### PR TITLE
Switch to LocalProviderEventResolver

### DIFF
--- a/src/EventLogExpert.Library/EventResolvers/LocalProviderEventResolver.cs
+++ b/src/EventLogExpert.Library/EventResolvers/LocalProviderEventResolver.cs
@@ -3,6 +3,8 @@ using EventLogExpert.Library.Models;
 using EventLogExpert.Library.Providers;
 using System.Diagnostics;
 using System.Diagnostics.Eventing.Reader;
+using System.Text;
+using System.Text.RegularExpressions;
 
 namespace EventLogExpert.Library.EventResolvers;
 
@@ -12,8 +14,9 @@ namespace EventLogExpert.Library.EventResolvers;
 /// </summary>
 public class LocalProviderEventResolver : IEventResolver
 {
-    private Dictionary<string, EventMessageProvider> _messageProviders = new();
+    private Dictionary<string, ProviderDetails> _providerDetails = new();
     private Action<string> _tracer;
+    private Regex _formatRegex = new("%+[0-9]+");
 
     public LocalProviderEventResolver()
     {
@@ -27,16 +30,15 @@ public class LocalProviderEventResolver : IEventResolver
 
     public DisplayEventModel Resolve(EventRecord eventRecord)
     {
-        _messageProviders.TryGetValue(eventRecord.ProviderName, out EventMessageProvider provider);
-
-        if (provider == null)
+        _providerDetails.TryGetValue(eventRecord.ProviderName, out ProviderDetails providerDetails);
+        if (providerDetails == null)
         {
-            provider = new EventMessageProvider(eventRecord.ProviderName, _tracer);
-            provider.LoadProviderDetails();
-            _messageProviders.Add(eventRecord.ProviderName, provider);
+            var provider = new EventMessageProvider(eventRecord.ProviderName, _tracer);
+            providerDetails = provider.LoadProviderDetails();
+            _providerDetails.Add(eventRecord.ProviderName, providerDetails);
         }
 
-        if (provider == null)
+        if (providerDetails == null)
         {
             return new DisplayEventModel(
                 eventRecord.RecordId,
@@ -49,7 +51,149 @@ public class LocalProviderEventResolver : IEventResolver
                 "Description not found. No provider available.");
         }
 
-        // TODO: Implement this
-        return null;
+        string description = null;
+        string taskName = null;
+
+        if (eventRecord.Version != null && eventRecord.LogName != null)
+        {
+            var modernEvents = providerDetails.Events?.Where(e => e.Id == eventRecord.Id && e.Version == eventRecord.Version && e.LogName == eventRecord.LogName).ToList();
+            if (modernEvents != null && modernEvents.Count == 0)
+            {
+                // Try again forcing the long to a short and with no log name. This is needed for providers such as Microsoft-Windows-Complus
+                modernEvents = providerDetails.Events?.Where(e => (short)e.Id == eventRecord.Id && e.Version == eventRecord.Version).ToList();
+            }
+
+            if (modernEvents != null && modernEvents.Any())
+            {
+                if (modernEvents.Count > 1)
+                {
+                    _tracer("Ambiguous modern event found:");
+                    foreach (var modernEvent in modernEvents)
+                    {
+                        _tracer($"  Version: {modernEvent.Version} Id: {modernEvent.Id} LogName: {modernEvent.LogName} Description: {modernEvent.Description}");
+                    }
+                }
+
+                var e = modernEvents[0];
+
+                taskName = providerDetails.Tasks.FirstOrDefault(t => t.Value == e.Task)?.Name;
+
+                // If we don't have a description template
+                if (string.IsNullOrEmpty(e.Description))
+                {
+                    // And we have exactly one property
+                    if (eventRecord.Properties.Count == 1)
+                    {
+                        // Return that property as the description. This is what certain EventRecords look like
+                        // when the entire description is a string literal, and there is no provider DLL needed.
+                        description = eventRecord.Properties[0].ToString();
+                    }
+                    else
+                    {
+                        description = "This event record is missing a template. The following information was included with the event:\n\n" +
+                            string.Join("\n", eventRecord.Properties);
+                    }
+                }
+                else
+                {
+                    description = FormatDescription(eventRecord, e.Description);
+                }
+            }
+        }
+
+        if (description == null)
+        {
+            var potentialTaskNames = providerDetails.Messages?.Where(m => m.ShortId == eventRecord.Task && m.LogLink != null && m.LogLink == eventRecord.LogName).ToList();
+            if (potentialTaskNames != null && potentialTaskNames.Any())
+            {
+                taskName = potentialTaskNames[0].Text;
+
+                if (potentialTaskNames.Count > 1)
+                {
+                    _tracer("More than one matching task ID was found.");
+                    _tracer($"  eventRecord.Task: {eventRecord.Task}");
+                    _tracer("   Potential matches:");
+                    potentialTaskNames.ForEach(t => _tracer($"    {t.LogLink} {t.Text}"));
+                }
+            }
+            else
+            {
+                taskName = eventRecord.Task == null | eventRecord.Task == 0 ? "None" : $"({eventRecord.Task}";
+            }
+
+            description = providerDetails.Messages?.FirstOrDefault(m => m.ShortId == eventRecord.Id)?.Text;
+            description = FormatDescription(eventRecord, description);
+        }
+
+        if (description == null)
+        {
+            description = "";
+        }
+
+        return new DisplayEventModel(
+                eventRecord.RecordId,
+                eventRecord.TimeCreated,
+                eventRecord.Id,
+                eventRecord.MachineName,
+                (SeverityLevel?)eventRecord.Level,
+                eventRecord.ProviderName,
+                taskName,
+                description);
+    }
+
+    private string FormatDescription(EventRecord eventRecord, string descriptionTemplate)
+    {
+        if (descriptionTemplate == null)
+        {
+            return null;
+        }
+
+        string description = descriptionTemplate
+            .Replace("\r\n%n", " \r\n")
+            .Replace("%n\r\n", "\r\n ")
+            .Replace("%n", "\r\n");
+        var matches = _formatRegex.Matches(description);
+        if (matches.Count > 0)
+        {
+            var sb = new StringBuilder();
+            var lastIndex = 0;
+            for (var i = 0; i < matches.Count; i++)
+            {
+                if (matches[i].Value.StartsWith("%%"))
+                {
+                    // The % is escaped, so skip it.
+                    continue;
+                }
+
+                sb.Append(description.AsSpan(lastIndex, matches[i].Index - lastIndex));
+                var propIndex = int.Parse(matches[i].Value.Trim(new[] { '{', '}', '%' }));
+                var propValue = eventRecord.Properties[propIndex - 1].Value;
+                if (propValue is DateTime)
+                {
+                    // Exactly match the format produced by EventRecord.FormatMessage(). I have no idea why it includes Unicode LRM marks, but it does.
+                    sb.Append(((DateTime)propValue).ToUniversalTime().ToString("\u200Eyyyy\u200E-\u200EMM\u200E-\u200EddTHH:mm:ss.fffffff00K"));
+                }
+                else
+                {
+                    sb.Append(propValue);
+                }
+
+                lastIndex = matches[i].Index + matches[i].Length;
+            }
+
+            if (lastIndex < description.Length)
+            {
+                sb.Append(description.Substring(lastIndex));
+            }
+
+            description = sb.ToString();
+        }
+
+        while (description.EndsWith("\r\n"))
+        {
+            description = description.Remove(description.Length - "\r\n".Length);
+        }
+
+        return description;
     }
 }

--- a/src/EventLogExpert.Library/Helpers/NativeMethods.cs
+++ b/src/EventLogExpert.Library/Helpers/NativeMethods.cs
@@ -13,11 +13,36 @@ public class NativeMethods
     [DllImport("kernel32.dll", SetLastError = true)]
     public static extern IntPtr LoadLibrary(string fileName);
 
+    [Flags]
+    public enum LoadLibraryFlags : uint
+    {
+        None = 0,
+        DONT_RESOLVE_DLL_REFERENCES = 0x00000001,
+        LOAD_IGNORE_CODE_AUTHZ_LEVEL = 0x00000010,
+        LOAD_LIBRARY_AS_DATAFILE = 0x00000002,
+        LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE = 0x00000040,
+        LOAD_LIBRARY_AS_IMAGE_RESOURCE = 0x00000020,
+        LOAD_LIBRARY_SEARCH_APPLICATION_DIR = 0x00000200,
+        LOAD_LIBRARY_SEARCH_DEFAULT_DIRS = 0x00001000,
+        LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR = 0x00000100,
+        LOAD_LIBRARY_SEARCH_SYSTEM32 = 0x00000800,
+        LOAD_LIBRARY_SEARCH_USER_DIRS = 0x00000400,
+        LOAD_WITH_ALTERED_SEARCH_PATH = 0x00000008
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern IntPtr LoadLibraryEx(string lpFileName, IntPtr hReservedNull, LoadLibraryFlags dwFlags);
+
     [DllImport("kernel32.dll", SetLastError = true)]
     public static extern bool FreeLibrary(IntPtr hModule);
 
     [DllImport("kernel32.dll", SetLastError = true)]
     public static extern IntPtr FindResource(IntPtr hModule, int lpID, int lpType);
+
+    public delegate bool EnumResTypeProc(IntPtr hModule, string lpszType, IntPtr lParam);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern bool EnumResourceTypes(IntPtr hModule, EnumResTypeProc lpEnumFunc, IntPtr lParam);
 
     [DllImport("kernel32.dll", SetLastError = true)]
     public static extern IntPtr LoadResource(IntPtr hModule, IntPtr hResInfo);

--- a/src/EventLogExpert.Test/EventLogExpert.Test.csproj
+++ b/src/EventLogExpert.Test/EventLogExpert.Test.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EventLogExpert.Library\EventLogExpert.Library.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/EventLogExpert.Test/UnitTest1.cs
+++ b/src/EventLogExpert.Test/UnitTest1.cs
@@ -1,0 +1,94 @@
+using EventLogExpert.Library.EventResolvers;
+using System.Diagnostics;
+using System.Diagnostics.Eventing.Reader;
+using Xunit.Abstractions;
+
+namespace EventLogExpert.Test;
+
+public class UnitTest1
+{
+    private readonly ITestOutputHelper _outputHelper;
+
+    public UnitTest1(ITestOutputHelper outputHelper)
+    {
+        _outputHelper = outputHelper;
+    }
+
+    [Fact]
+    public void Test1()
+    {
+        var eventLogReader = new EventLogReader("Application", PathType.LogName);
+
+        var resolvers = new List<IEventResolver>()
+        {
+            new EventReaderEventResolver(),
+            new LocalProviderEventResolver(s => { _outputHelper.WriteLine(s); Debug.WriteLine(s); Debug.Flush(); })
+        };
+
+        EventRecord er;
+        HashSet<string> uniqueDescriptions = new();
+
+        var totalCount = 0;
+        var mismatchCount = 0;
+        var mismatches = new List<List<string>>();
+        while (null != (er = eventLogReader.ReadEvent()))
+        {
+            uniqueDescriptions.Clear();
+
+            foreach (var r in resolvers)
+            {
+                uniqueDescriptions.Add(r.Resolve(er).Description
+                    .Replace("\r", "")  // I can't figure out the logic of FormatMessage() for when it leaves
+                    .Replace("\n", "")  // CRLFs and spaces in or takes them out, so I'm just giving up for now.
+                    .Replace(" ", "")   // If we're this close to matching FormatMessage() then we're close enough.
+                    .Trim());
+            }
+
+            if (uniqueDescriptions.Count > 1)
+            {
+                mismatchCount++;
+                mismatches.Add(uniqueDescriptions.ToList());
+            }
+
+            totalCount++;
+        }
+
+        Assert.Equal(0, mismatchCount);
+    }
+
+    [Fact]
+    public void PerformanceTestEventReaderEventResolver()
+    {
+        var sw = new System.Diagnostics.Stopwatch();
+        sw.Start();
+
+        var eventLogReader = new EventLogReader("Application", PathType.LogName);
+        var resolver = new EventReaderEventResolver();
+        EventRecord er;
+        while (null != (er = eventLogReader.ReadEvent()))
+        {
+            resolver.Resolve(er);
+        }
+
+        sw.Stop();
+        _outputHelper.WriteLine($"Elapsed: {sw.ElapsedMilliseconds}");
+    }
+
+    [Fact]
+    public void PerformanceTestLocalProviderEventResolver()
+    {
+        var sw = new System.Diagnostics.Stopwatch();
+        sw.Start();
+
+        var eventLogReader = new EventLogReader("Application", PathType.LogName);
+        var resolver = new LocalProviderEventResolver();
+        EventRecord er;
+        while (null != (er = eventLogReader.ReadEvent()))
+        {
+            resolver.Resolve(er);
+        }
+
+        sw.Stop();
+        _outputHelper.WriteLine($"Elapsed: {sw.ElapsedMilliseconds}");
+    }
+}

--- a/src/EventLogExpert.Test/Usings.cs
+++ b/src/EventLogExpert.Test/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/src/EventLogExpert.sln
+++ b/src/EventLogExpert.sln
@@ -13,6 +13,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventLogExpert.Test", "EventLogExpert.Test\EventLogExpert.Test.csproj", "{E5D3A2A2-6001-452F-8ECE-7263D72C9438}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{2524E3CE-D95D-4C70-9614-47906411FBD7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2524E3CE-D95D-4C70-9614-47906411FBD7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2524E3CE-D95D-4C70-9614-47906411FBD7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E5D3A2A2-6001-452F-8ECE-7263D72C9438}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E5D3A2A2-6001-452F-8ECE-7263D72C9438}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E5D3A2A2-6001-452F-8ECE-7263D72C9438}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E5D3A2A2-6001-452F-8ECE-7263D72C9438}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/EventLogExpert/MauiProgram.cs
+++ b/src/EventLogExpert/MauiProgram.cs
@@ -30,7 +30,7 @@ public static class MauiProgram
             options.ScanAssemblies(typeof(EventLogState).Assembly).WithLifetime(StoreLifetime.Singleton);
         });
 
-        builder.Services.AddSingleton<IEventResolver, EventReaderEventResolver>();
+        builder.Services.AddSingleton<IEventResolver, LocalProviderEventResolver>();
 
         return builder.Build();
     }


### PR DESCRIPTION
* Switch over to LocalProviderEventResolver. Instead of using FormatMessage(), this uses our own logic to resolve event descriptions from the available providers.
* The test project currently has no actual unit tests, just stuff I'm using to compare the two event resolvers and test performance.

* Next step will be to add the third resolver and the one we will actually use in the released tool - DatabaseEventResolver, which will resolve event descriptions from our own database.
* Would also be good to flesh out the test project to have actual unit tests around the descriptions produced by the three providers.

The new event resolver is _much_ faster than calling FormatMessage(). On my workstation I see 3 seconds vs 17 seconds:

![image](https://user-images.githubusercontent.com/4518572/197314969-bf15eb30-2406-4a40-b817-75c8b014c2b1.png)

The event descriptions produced by the new resolver are very close to what FormatMessage produces. I had trouble with CRLFs and spaces, so my test for a match ignores those for now: 

![image](https://user-images.githubusercontent.com/4518572/197315016-b01e5c68-19c9-4924-af9d-3fefeb430219.png)

Allowing for those difference, we match the FormatMessage() output 99% of the time on my workstation:

![image](https://user-images.githubusercontent.com/4518572/197315048-440f11c7-0a53-44d7-8e24-404a92ba751b.png)

Most of the ones that don't match look like this, where FormatMessage() is somehow replacing the number (the number 1 on the end in this case) with a text error code. I haven't figured out how that works yet, but it seems to be a small minority of events (at least in my test log) that behave this way.

Anyway, if we're matching 99%, this is a pretty good starting point, and likely better than the old version of EventLogExpert.