### PR TITLE
Fix weird stretchy table issue

### DIFF
--- a/src/EventLogExpert/Components/EventTable.razor
+++ b/src/EventLogExpert/Components/EventTable.razor
@@ -6,43 +6,43 @@
     <table>
         <thead>
         <tr>
-            <th nowrap width="@(_colWidths["RecordId"])px">Rec</th>
+            <th style="@GetInlineStyle("RecordId")">Rec</th>
             <th class="table-divider"></th>
-            <th nowrap width="@(_colWidths["TimeCreated"])px">Time</th>
+            <th style="@GetInlineStyle("TimeCreated")">Time</th>
             <th class="table-divider"></th>
-            <th nowrap width="@(_colWidths["Id"])px">Id</th>
+            <th style="@GetInlineStyle("Id")x">Id</th>
             <th class="table-divider"></th>
-            <th nowrap width="@(_colWidths["MachineName"])px">Machine</th>
+            <th style="@GetInlineStyle("MachineName")">Machine</th>
             <th class="table-divider"></th>
-            <th nowrap width="@(_colWidths["Level"])px">Level</th>
+            <th style="@GetInlineStyle("Level")">Level</th>
             <th class="table-divider"></th>
-            <th nowrap width="@(_colWidths["ProviderName"])px">Source</th>
+            <th style="@GetInlineStyle("ProviderName")">Source</th>
             <th class="table-divider"></th>
-            <th nowrap width="@(_colWidths["Task"])px">Task</th>
+            <th style="@GetInlineStyle("Task")">Task</th>
             <th class="table-divider"></th>
-            <th nowrap width="@(_colWidths["Description"])px">Description</th>
+            <th style="@GetDescriptionStyle()">Description</th>
         </tr>
         </thead>
         <tbody>
-        <Virtualize Items="@EventLogState.Value.EventsToDisplay" Context="evt">
-            <tr>
-                <td nowrap>@evt.RecordId</td>
-                <th class="table-divider"></th>
-                <td nowrap>@evt.TimeCreated</td>
-                <th class="table-divider"></th>
-                <td nowrap>@evt.Id</td>
-                <th class="table-divider"></th>
-                <td nowrap>@evt.MachineName</td>
-                <th class="table-divider"></th>
-                <td nowrap>@evt.Level</td>
-                <th class="table-divider"></th>
-                <td nowrap>@evt.ProviderName</td>
-                <th class="table-divider"></th>
-                <td nowrap>@evt.TaskDisplayName</td>
-                <th class="table-divider"></th>
-                <td nowrap>@evt.Description</td>
-            </tr>
-        </Virtualize>
+            <Virtualize Items="@EventLogState.Value.EventsToDisplay" Context="evt">
+                <tr>
+                    <td style="@GetInlineStyle("RecordId")">@evt.RecordId</td>
+                    <th class="table-divider"></th>
+                    <td style="@GetInlineStyle("TimeCreated")">@evt.TimeCreated</td>
+                    <th class="table-divider"></th>
+                    <td style="@GetInlineStyle("Id")">@evt.Id</td>
+                    <th class="table-divider"></th>
+                    <td style="@GetInlineStyle("MachineName")">@evt.MachineName</td>
+                    <th class="table-divider"></th>
+                    <td style="@GetInlineStyle("Level")">@evt.Level</td>
+                    <th class="table-divider"></th>
+                    <td style="@GetInlineStyle("ProviderName")">@evt.ProviderName</td>
+                    <th class="table-divider"></th>
+                    <td style="@GetInlineStyle("Task")">@evt.TaskDisplayName</td>
+                    <th class="table-divider"></th>
+                    <td style="@GetDescriptionStyle()">@evt.Description</td>
+                </tr>
+            </Virtualize>
         </tbody>
     </table>
 </div>

--- a/src/EventLogExpert/Components/EventTable.razor.cs
+++ b/src/EventLogExpert/Components/EventTable.razor.cs
@@ -7,13 +7,27 @@ public partial class EventTable
 {
     private readonly Dictionary<string, int> _colWidths = new()
     {
-        { "RecordId", 10 },
-        { "TimeCreated", 25 },
-        { "Id", 10 },
-        { "MachineName", 10 },
-        { "Level", 15 },
-        { "ProviderName", 25 },
-        { "Task", 20 },
-        { "Description", 200 }
+        { "RecordId", 75 },
+        { "TimeCreated", 165 },
+        { "Id", 50 },
+        { "MachineName", 100 },
+        { "Level", 100 },
+        { "ProviderName", 250 },
+        { "Task", 150 }
     };
+
+    private const int TableDividerWidth = 4;
+
+    private const int ScrollBarWidth = 18;
+
+    private string GetDescriptionStyle()
+    {
+        var total = _colWidths.Values.Sum() + (TableDividerWidth * _colWidths.Count) + ScrollBarWidth;
+        return $"min-width: calc(100vw - {total}px); max-width: calc(100vw - {total}px);";
+    }
+
+    private string GetInlineStyle(string colName)
+    {
+        return $"min-width: {_colWidths[colName]}px; max-width: {_colWidths[colName]}px;";
+    }
 }

--- a/src/EventLogExpert/Components/EventTable.razor.css
+++ b/src/EventLogExpert/Components/EventTable.razor.css
@@ -7,8 +7,6 @@
 
 table {
     border-spacing: 0;
-    width: calc(100% - 10px);
-    table-layout: fixed;
 }
 
 tr:nth-child(odd) {
@@ -16,18 +14,21 @@ tr:nth-child(odd) {
 }
 
 th {
+    white-space: nowrap;
+    overflow: hidden;
     position: sticky;
     top: 0;
     background-color: var(--background-darkgray);
-    z-index: 2;
 }
 
 td {
+    white-space: nowrap;
     overflow: hidden;
 }
 
 .table-divider {
-    width: 1px;
+    min-width: 4px;
+    max-width: 4px;
     margin: 0;
     padding: 0;
     background: var(--clr-black);


### PR DESCRIPTION
The web view was not honoring the specified column widths, and enlarging the window would make the problem even more apparent. As the window got larger, all the columns and even the dividers stretched to be far larger than they should be.

I couldn't find any explanation for this. Removing `Virtualize` did not fix it. However, I did find a way around it, by removing `table-layout: fixed` and `width: 100%` from the table, then being very specific about how wide everything should be, setting minimums and maximums everywhere.