### PR TITLE
Added property count check in FormatDescription to prevent IndexOutOfRange error

### DIFF
--- a/src/EventLogExpert.Library/EventResolvers/EventResolverBase.cs
+++ b/src/EventLogExpert.Library/EventResolvers/EventResolverBase.cs
@@ -48,6 +48,9 @@ public class EventResolverBase
 
                 sb.Append(description.AsSpan(lastIndex, matches[i].Index - lastIndex));
                 var propIndex = int.Parse(matches[i].Value.Trim(new[] { '{', '}', '%' }));
+
+                if (propIndex - 1 >= eventRecord.Properties.Count) { return "Unable to format description"; }
+                
                 var propValue = eventRecord.Properties[propIndex - 1].Value;
                 if (propValue is DateTime)
                 {


### PR DESCRIPTION
May not best way to handle this but was a blocker with several exported evtx files I tried to load.

Schannel Id == 36871 appears to be the biggest offender for hitting this exception.
Also hit this with Microsoft-Windows-Wininit Id == 14.