### PR TITLE
Update status bar with total when load complete

### DIFF
--- a/src/EventLogExpert/Store/EventLog/EventLogEffects.cs
+++ b/src/EventLogExpert/Store/EventLog/EventLogEffects.cs
@@ -64,6 +64,8 @@ public class EventLogEffects
                 }
             }
 
+            dispatcher.Dispatch(new StatusBarAction.SetEventsLoaded(events.Count));
+
             events.Reverse();
 
             dispatcher.Dispatch(new EventLogAction.LoadEvents(events,


### PR DESCRIPTION
Status bar is not showing the total number of loaded events, because we only update it while loading is in progress, but not when done.