### PR TITLE
Implement updating live logs

### DIFF
--- a/src/EventLogExpert/Components/EventTable.razor
+++ b/src/EventLogExpert/Components/EventTable.razor
@@ -17,7 +17,7 @@
             </tr>
         </thead>
         <tbody>
-            <Virtualize Items="@GetFilteredEvents()" Context="evt" @ref="virtualizeComponent">
+            <Virtualize Items="@GetFilteredEvents()" Context="evt" @ref="_virtualizeComponent">
                 <tr class="@GetCss(evt)" @key="evt.RecordId" @onfocus="() => SelectEvent(evt)" tabindex="0">
                     <td>@evt.Level</td>
                     <td>@evt.TimeCreated?.ConvertTimeZone(SettingsState.Value.TimeZone)</td>

--- a/src/EventLogExpert/Components/EventTable.razor
+++ b/src/EventLogExpert/Components/EventTable.razor
@@ -1,6 +1,7 @@
 ﻿@inherits FluxorComponent
 
 @inject IState<EventLogState> EventLogState
+@inject IState<FilterPaneState> FilterPaneState
 @inject IState<SettingsState> SettingsState
 
 <div class="table-container">
@@ -16,7 +17,7 @@
             </tr>
         </thead>
         <tbody>
-            <Virtualize Items="@EventLogState.Value.EventsToDisplay" Context="evt">
+            <Virtualize Items="@GetFilteredEvents()" Context="evt" @ref="virtualizeComponent">
                 <tr class="@GetCss(evt)" @key="evt.RecordId" @onfocus="() => SelectEvent(evt)" tabindex="0">
                     <td>@evt.Level</td>
                     <td>@evt.TimeCreated?.ConvertTimeZone(SettingsState.Value.TimeZone)</td>

--- a/src/EventLogExpert/Components/EventTable.razor.cs
+++ b/src/EventLogExpert/Components/EventTable.razor.cs
@@ -3,14 +3,20 @@
 
 using EventLogExpert.Library.Models;
 using EventLogExpert.Store.EventLog;
+using Fluxor;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web.Virtualization;
+using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
+using System;
 
 namespace EventLogExpert.Components;
 
 public partial class EventTable
 {
     [Inject] private IJSRuntime JSRuntime { get; set; } = null!;
+
+    private Virtualize<DisplayEventModel>? virtualizeComponent;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -20,6 +26,38 @@ public partial class EventTable
         }
 
         await base.OnAfterRenderAsync(firstRender);
+    }
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+
+        IList<DisplayEventModel> lastEventList = EventLogState.Value.Events;
+        EventLogState.StateChanged += (s, e) =>
+        {
+            if (s is State<EventLogState> state)
+            {
+                if (state.Value.Events != lastEventList)
+                {
+                    lastEventList = state.Value.Events;
+                    virtualizeComponent?.RefreshDataAsync();
+                }
+            }
+        };
+    }
+
+    private IList<DisplayEventModel> GetFilteredEvents()
+    {
+        if (!FilterPaneState.Value.AppliedFilters.Any())
+        {
+            return EventLogState.Value.Events;
+        }
+
+        return EventLogState.Value.Events
+            .Where(e => FilterPaneState.Value.AppliedFilters
+                .All(filter => filter.Comparison
+                    .Any(comp => comp(e))))
+            .ToList();
     }
 
     private string GetCss(DisplayEventModel @event) => EventLogState.Value.SelectedEvent?.RecordId == @event.RecordId ?

--- a/src/EventLogExpert/Components/StatusBar.razor
+++ b/src/EventLogExpert/Components/StatusBar.razor
@@ -1,5 +1,16 @@
 ﻿@inherits FluxorComponent
 
+@inject IState<EventLogState> EventLogState
 @inject IState<StatusBarState> StatusBarState
 
-<div class="status-bar">Events Loaded: @StatusBarState.Value.EventsLoaded</div>
+@if (EventLogState.Value.Events.Count < 1 || EventLogState.Value.ActiveLog.LogType == EventLogExpert.Store.EventLog.EventLogState.LogType.File)
+{
+    <div class="status-bar">Events Loaded: @StatusBarState.Value.EventsLoaded</div>
+}
+else
+{
+    <div class="status-bar">
+        <span>Events Loaded: @EventLogState.Value.Events.Count</span>
+        <span>New Events: @EventLogState.Value.NewEvents.Count</span>
+    </div>
+}

--- a/src/EventLogExpert/Components/StatusBar.razor
+++ b/src/EventLogExpert/Components/StatusBar.razor
@@ -11,6 +11,13 @@ else
 {
     <div class="status-bar">
         <span>Events Loaded: @EventLogState.Value.Events.Count</span>
-        <span>New Events: @EventLogState.Value.NewEvents.Count</span>
+        @if (EventLogState.Value.ContinuouslyUpdate)
+        {
+            <span>Continuously Updating</span>
+        }
+        else
+        {
+            <span>New Events: @EventLogState.Value.NewEvents.Count</span>
+        }
     </div>
 }

--- a/src/EventLogExpert/Components/StatusBar.razor.css
+++ b/src/EventLogExpert/Components/StatusBar.razor.css
@@ -2,3 +2,7 @@
     background-color: var(--clr-statusbar);
     color: white;
 }
+
+.status-bar > span {
+    margin-right: 10px;
+}

--- a/src/EventLogExpert/MainPage.xaml
+++ b/src/EventLogExpert/MainPage.xaml
@@ -19,6 +19,10 @@
             <!-- Option to export providers? -->
             <!-- Manual check for updates option or an about page with option to check for updates? -->
         </MenuBarItem>
+        <MenuBarItem Text="View">
+            <MenuFlyoutItem Text="Load New Events" Clicked="LoadNewEvents_Clicked"></MenuFlyoutItem>
+            <MenuFlyoutItem Text="Continuously Update" Clicked="ContinuouslyUpdate_Clicked"></MenuFlyoutItem>
+        </MenuBarItem>
     </ContentPage.MenuBarItems>
 
     <BlazorWebView HostPage="wwwroot/index.html">

--- a/src/EventLogExpert/MainPage.xaml.cs
+++ b/src/EventLogExpert/MainPage.xaml.cs
@@ -82,4 +82,23 @@ public partial class MainPage : ContentPage
             OtherLogsFlyoutSubitem.Add(m);
         }
     }
+
+    private void LoadNewEvents_Clicked(object sender, EventArgs e)
+    {
+        _fluxorDispatcher.Dispatch(new EventLogAction.LoadNewEvents());
+    }
+
+    private void ContinuouslyUpdate_Clicked(object sender, EventArgs e)
+    {
+        if (((MenuFlyoutItem)sender).Text == "Continuously Update")
+        {
+            _fluxorDispatcher.Dispatch(new EventLogAction.SetContinouslyUpdate(true));
+            ((MenuFlyoutItem)sender).Text = "Continuously Update ✓";
+        }
+        else
+        {
+            _fluxorDispatcher.Dispatch(new EventLogAction.SetContinouslyUpdate(false));
+            ((MenuFlyoutItem)sender).Text = "Continuously Update";
+        }
+    }
 }

--- a/src/EventLogExpert/Store/EventLog/EventLogAction.cs
+++ b/src/EventLogExpert/Store/EventLog/EventLogAction.cs
@@ -26,5 +26,5 @@ public record EventLogAction
 
     public record SelectEvent(DisplayEventModel? SelectedEvent) : EventLogAction;
 
-    public record SetContinouslyUpdate(bool continuouslyUpdate) : EventLogAction;
+    public record SetContinouslyUpdate(bool ContinuouslyUpdate) : EventLogAction;
 }

--- a/src/EventLogExpert/Store/EventLog/EventLogAction.cs
+++ b/src/EventLogExpert/Store/EventLog/EventLogAction.cs
@@ -2,25 +2,29 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Library.Models;
+using System.Diagnostics.Eventing.Reader;
 
 namespace EventLogExpert.Store.EventLog;
 
 public record EventLogAction
 {
-    public record OpenLog(EventLogState.LogSpecifier LogSpecifier) : EventLogAction;
+    public record AddEvent(DisplayEventModel NewEvent) : EventLogAction;
 
     public record ClearEvents : EventLogAction;
 
     public record LoadEvents(
         List<DisplayEventModel> Events,
+        EventLogWatcher Watcher,
         IReadOnlyList<int> AllEventIds,
         IReadOnlyList<string> AllProviderNames,
         IReadOnlyList<string> AllTaskNames
     ) : EventLogAction;
 
-    public record ClearFilters : EventLogAction;
+    public record LoadNewEvents() : EventLogAction;
 
-    public record FilterEvents(IEnumerable<FilterModel> Filters) : EventLogAction;
+    public record OpenLog(EventLogState.LogSpecifier LogSpecifier) : EventLogAction;
 
     public record SelectEvent(DisplayEventModel? SelectedEvent) : EventLogAction;
+
+    public record SetContinouslyUpdate(bool continuouslyUpdate) : EventLogAction;
 }

--- a/src/EventLogExpert/Store/EventLog/EventLogReducers.cs
+++ b/src/EventLogExpert/Store/EventLog/EventLogReducers.cs
@@ -77,8 +77,8 @@ public class EventLogReducers
     [ReducerMethod]
     public static EventLogState ReduceSetContinouslyUpdate(EventLogState state, EventLogAction.SetContinouslyUpdate action)
     {
-        var newState = state with { ContinuouslyUpdate = action.continuouslyUpdate };
-        if (action.continuouslyUpdate)
+        var newState = state with { ContinuouslyUpdate = action.ContinuouslyUpdate };
+        if (action.ContinuouslyUpdate)
         {
             newState = newState with
             {

--- a/src/EventLogExpert/Store/EventLog/EventLogReducers.cs
+++ b/src/EventLogExpert/Store/EventLog/EventLogReducers.cs
@@ -3,43 +3,64 @@
 
 using EventLogExpert.Library.Models;
 using Fluxor;
+using System.Collections.Immutable;
 
 namespace EventLogExpert.Store.EventLog;
 
 public class EventLogReducers
 {
-    [ReducerMethod(typeof(EventLogAction.ClearEvents))]
-    public static EventLogState ReduceClearEvents(EventLogState state) => state with
-    {
-        Events = new List<DisplayEventModel>(), EventsToDisplay = new List<DisplayEventModel>()
-    };
-
-    [ReducerMethod(typeof(EventLogAction.ClearFilters))]
-    public static EventLogState ReduceClearFilters(EventLogState state) =>
-        state with { EventsToDisplay = state.Events };
+    /// <summary>
+    /// The maximum number of new events we will hold in the state
+    /// before we turn off the watcher.
+    /// </summary>
+    private static readonly int MaxNewEvents = 5000;
 
     [ReducerMethod]
-    public static EventLogState ReduceFilterEvents(EventLogState state, EventLogAction.FilterEvents action)
+    public static EventLogState ReduceAddEvent(EventLogState state, EventLogAction.AddEvent action)
     {
-        if (!state.Events.Any()) { return state; }
-
-        if (!action.Filters.Any()) { return state with { EventsToDisplay = state.Events }; }
-
-        var events = state.Events.AsEnumerable();
-
-        foreach (var filter in action.Filters)
+        var newEvent = new List<DisplayEventModel>
         {
-            events = events.Where(ev => filter.Comparison.Any(f => f(ev)));
+            action.NewEvent
+        };
+
+        var newState = state;
+
+        if (state.ContinuouslyUpdate)
+        {
+            newState = newState with { Events = newEvent.Concat(state.Events).ToImmutableList() };
+        }
+        else
+        {
+            newState = newState with { NewEvents = newEvent.Concat(state.NewEvents).ToImmutableList() };
         }
 
-        var filteredEvents = events.DistinctBy(ev => ev.RecordId).OrderByDescending(ev => ev.RecordId).ToList();
+        if (newState.NewEvents.Count >= MaxNewEvents && state.Watcher != null)
+        {
+            state.Watcher.Enabled = false;
+        }
 
-        return state with { EventsToDisplay = filteredEvents };
+        return newState;
     }
+
+    [ReducerMethod(typeof(EventLogAction.ClearEvents))]
+    public static EventLogState ReduceClearEvents(EventLogState state) => 
+        state with { Events = ImmutableList<DisplayEventModel>.Empty };
 
     [ReducerMethod]
     public static EventLogState ReduceLoadEvents(EventLogState state, EventLogAction.LoadEvents action) =>
-        state with { Events = action.Events, EventsToDisplay = action.Events };
+        state with { Events = action.Events.ToImmutableList(), Watcher = action.Watcher };
+
+    [ReducerMethod]
+    public static EventLogState ReduceLoadNewEvents(EventLogState state, EventLogAction.LoadNewEvents action)
+    {
+        var newState = state with { Events = state.NewEvents.Concat(state.Events).ToImmutableList(), NewEvents = ImmutableList<DisplayEventModel>.Empty };
+        if (state.Watcher != null && !state.Watcher.Enabled)
+        {
+            state.Watcher.Enabled = true;
+        }
+
+        return newState;
+    }
 
     [ReducerMethod]
     public static EventLogState ReduceOpenLog(EventLogState state, EventLogAction.OpenLog action) =>
@@ -51,5 +72,21 @@ public class EventLogReducers
         if (state.SelectedEvent == action.SelectedEvent) { return state; }
 
         return state with { SelectedEvent = action.SelectedEvent };
+    }
+
+    [ReducerMethod]
+    public static EventLogState ReduceSetContinouslyUpdate(EventLogState state, EventLogAction.SetContinouslyUpdate action)
+    {
+        var newState = state with { ContinuouslyUpdate = action.continuouslyUpdate };
+        if (action.continuouslyUpdate)
+        {
+            newState = newState with
+            {
+                Events = state.NewEvents.Concat(state.Events).ToImmutableList(),
+                NewEvents = ImmutableList<DisplayEventModel>.Empty
+            };
+        }
+
+        return newState;
     }
 }

--- a/src/EventLogExpert/Store/EventLog/EventLogState.cs
+++ b/src/EventLogExpert/Store/EventLog/EventLogState.cs
@@ -23,7 +23,7 @@ public record EventLogState
 
     public ImmutableList<DisplayEventModel> NewEvents { get; init; } = ImmutableList<DisplayEventModel>.Empty;
 
-    public DisplayEventModel? SelectedEvent { get; set; }
+    public DisplayEventModel? SelectedEvent { get; init; }
 
     public EventLogWatcher? Watcher { get; init; } = null!;
 }

--- a/src/EventLogExpert/Store/EventLog/EventLogState.cs
+++ b/src/EventLogExpert/Store/EventLog/EventLogState.cs
@@ -3,14 +3,11 @@
 
 using EventLogExpert.Library.Models;
 using Fluxor;
+using System.Collections.Immutable;
+using System.Diagnostics.Eventing.Reader;
 
 namespace EventLogExpert.Store.EventLog;
 
-/// <summary>
-///     NOTE: Because Virtualize requires an ICollection<T>, we have to use
-///     some sort of mutable collection for EventsToDisplay, unfortunately.
-///     If that ever changes we should consider making these immutable.
-/// </summary>
 [FeatureState]
 public record EventLogState
 {
@@ -18,11 +15,15 @@ public record EventLogState
 
     public LogSpecifier ActiveLog { get; init; } = null!;
 
-    public List<DisplayEventModel> Events { get; init; } = new();
+    public bool ContinuouslyUpdate { get; init; } = false;
 
-    public List<DisplayEventModel> EventsToDisplay { get; init; } = new();
+    public ImmutableList<DisplayEventModel> Events { get; init; } = ImmutableList<DisplayEventModel>.Empty;
+
+    public record LogSpecifier(string Name, LogType? LogType);
+
+    public ImmutableList<DisplayEventModel> NewEvents { get; init; } = ImmutableList<DisplayEventModel>.Empty;
 
     public DisplayEventModel? SelectedEvent { get; set; }
 
-    public record LogSpecifier(string Name, LogType? LogType);
+    public EventLogWatcher? Watcher { get; init; } = null!;
 }

--- a/src/EventLogExpert/Store/FilterPane/FilterPaneEffects.cs
+++ b/src/EventLogExpert/Store/FilterPane/FilterPaneEffects.cs
@@ -13,19 +13,4 @@ public class FilterPaneEffects
     private readonly IState<FilterPaneState> _state;
 
     public FilterPaneEffects(IState<FilterPaneState> state) => _state = state;
-
-    [EffectMethod(typeof(FilterPaneAction.ApplyFilters))]
-    public Task HandleApplyFiltersAction(IDispatcher dispatcher)
-    {
-        List<FilterModel> filters = new();
-
-        foreach (var filterModel in _state.Value.CurrentFilters)
-        {
-            if (filterModel.Comparison.Any()) { filters.Add(filterModel); }
-        }
-
-        dispatcher.Dispatch(new EventLogAction.FilterEvents(filters));
-
-        return Task.CompletedTask;
-    }
 }

--- a/src/EventLogExpert/Store/FilterPane/FilterPaneState.cs
+++ b/src/EventLogExpert/Store/FilterPane/FilterPaneState.cs
@@ -10,4 +10,6 @@ namespace EventLogExpert.Store.FilterPane;
 public record FilterPaneState
 {
     public IEnumerable<FilterModel> CurrentFilters { get; init; } = Enumerable.Empty<FilterModel>();
+
+    public IEnumerable<FilterModel> AppliedFilters { get; init; } = Enumerable.Empty<FilterModel>();
 }

--- a/src/EventLogExpert/Store/LoggingMiddleware.cs
+++ b/src/EventLogExpert/Store/LoggingMiddleware.cs
@@ -26,7 +26,7 @@ public class LoggingMiddleware : Middleware
             // We don't want to serialize all the events.
             _debugLogger.Trace($"Action: EventLogAction.LoadEvents with {loadEventsAction.Events.Count} events.");
         }
-        else if (action is EventLogAction.FilterEvents or FilterPaneAction.RemoveFilter)
+        else if (action is FilterPaneAction.RemoveFilter)
         {
             // We can't serialize a Func.
             _debugLogger.Trace("Action: EventLogAction.FilterEventsAction.");


### PR DESCRIPTION
Overview:

When the user chooses Live Event Log, we now watch the log for new events. This can be seen in the status bar when this type of log is loaded:

![image](https://github.com/microsoft/EventLogExpert/assets/4518572/ba7fc41e-0df1-4e41-9f6a-6446ce1443e6)

When new events are available, they can be loaded from the View menu:

![image](https://github.com/microsoft/EventLogExpert/assets/4518572/c82e8385-a917-41a7-a5f3-69d6f78f0702)

Load New Events adds the new events to the loaded events, and the status bar will reflect the change.

Continuously Update will not only load any new events already read, but will instantly load any new events that are detected, updating the view in real time. When this mode is activated, the menu item shows a checkmark:

![image](https://github.com/microsoft/EventLogExpert/assets/4518572/e8f2cbf5-6d8f-4f27-8573-3d962b625393)

These two menu items do nothing when a file is loaded. We may want to consider disabling them in that scenario in a future PR.

Other notes:

This PR removes the filtering implementation from the EventLogState store. The interplay between FilterState and EventLogState felt weird when we were loading new events that needed to be filtered. It's not really necessary for these two separate components to have knowledge of each other, and clearly separating them made the loading of new events a bit cleaner. The EventTable component now applies the filters to produce the filtered view.

