### PR TITLE
Don't render bookmarks unnecessarily

### DIFF
--- a/src/EventLogExpert/Store/EventLog/EventLogEffects.cs
+++ b/src/EventLogExpert/Store/EventLog/EventLogEffects.cs
@@ -50,11 +50,11 @@ public class EventLogEffects
             HashSet<int> eventIdsAll = new();
             HashSet<string> eventProviderNamesAll = new();
             HashSet<string> eventTaskNamesAll = new();
-            EventBookmark lastEventBookmark = null!;
+            EventRecord lastEvent = null!;
 
             while (reader.ReadEvent() is { } e)
             {
-                lastEventBookmark = e.Bookmark;
+                lastEvent = e;
                 var resolved = _eventResolver.Resolve(e);
                 eventIdsAll.Add(resolved.Id);
                 eventProviderNamesAll.Add(resolved.Source);
@@ -79,9 +79,9 @@ public class EventLogEffects
             {
                 var query = new EventLogQuery(action.LogSpecifier.Name, PathType.LogName);
 
-                if (lastEventBookmark != null)
+                if (lastEvent != null)
                 {
-                    watcher = new EventLogWatcher(query, lastEventBookmark);
+                    watcher = new EventLogWatcher(query, lastEvent.Bookmark);
                 }
                 else
                 {


### PR DESCRIPTION
It turns out that bookmarks are something that have to "rendered", and we're spending a lot of time doing it.

This change significantly improves load times.