### PR TITLE
Improve watcher logic

### DIFF
--- a/src/EventLogExpert/Store/EventLog/EventLogAction.cs
+++ b/src/EventLogExpert/Store/EventLog/EventLogAction.cs
@@ -2,7 +2,6 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Library.Models;
-using System.Diagnostics.Eventing.Reader;
 
 namespace EventLogExpert.Store.EventLog;
 
@@ -14,7 +13,7 @@ public record EventLogAction
 
     public record LoadEvents(
         List<DisplayEventModel> Events,
-        EventLogWatcher Watcher,
+        LiveLogWatcher Watcher,
         IReadOnlyList<int> AllEventIds,
         IReadOnlyList<string> AllProviderNames,
         IReadOnlyList<string> AllTaskNames

--- a/src/EventLogExpert/Store/EventLog/EventLogReducers.cs
+++ b/src/EventLogExpert/Store/EventLog/EventLogReducers.cs
@@ -34,14 +34,9 @@ public class EventLogReducers
             newState = newState with { NewEvents = newEvent.Concat(state.NewEvents).ToImmutableList() };
         }
 
-        if (newState.NewEvents.Count >= MaxNewEvents && state.Watcher != null && state.Watcher.Enabled)
+        if (newState.NewEvents.Count >= MaxNewEvents && state.Watcher != null && state.Watcher.IsWatching)
         {
-            newState = newState with { Watcher = null };
-
-            // This must run on a different thread to avoid a deadlock. This causes
-            // the EventLogWatcher to block until other callbacks complete, and they
-            // cannot complete if we are tying up the Store by blocking on this thread.
-            Task.Run(() => state.Watcher.Enabled = false);
+            state.Watcher.StopWatching();
         }
 
         return newState;
@@ -59,9 +54,9 @@ public class EventLogReducers
     public static EventLogState ReduceLoadNewEvents(EventLogState state, EventLogAction.LoadNewEvents action)
     {
         var newState = state with { Events = state.NewEvents.Concat(state.Events).ToImmutableList(), NewEvents = ImmutableList<DisplayEventModel>.Empty };
-        if (state.Watcher != null && !state.Watcher.Enabled)
+        if (state.Watcher != null && !state.Watcher.IsWatching)
         {
-            state.Watcher.Enabled = true;
+            state.Watcher.StartWatching();
         }
 
         return newState;
@@ -70,10 +65,7 @@ public class EventLogReducers
     [ReducerMethod]
     public static EventLogState ReduceOpenLog(EventLogState state, EventLogAction.OpenLog action)
     {
-        if (state.Watcher != null)
-        {
-            state.Watcher.Dispose();
-        }
+        state.Watcher?.StopWatching();
 
         return new() { ActiveLog = action.LogSpecifier, ContinuouslyUpdate = state.ContinuouslyUpdate };
     }

--- a/src/EventLogExpert/Store/EventLog/EventLogState.cs
+++ b/src/EventLogExpert/Store/EventLog/EventLogState.cs
@@ -4,7 +4,6 @@
 using EventLogExpert.Library.Models;
 using Fluxor;
 using System.Collections.Immutable;
-using System.Diagnostics.Eventing.Reader;
 
 namespace EventLogExpert.Store.EventLog;
 
@@ -25,5 +24,5 @@ public record EventLogState
 
     public DisplayEventModel? SelectedEvent { get; init; }
 
-    public EventLogWatcher? Watcher { get; init; } = null!;
+    public LiveLogWatcher? Watcher { get; init; } = null!;
 }

--- a/src/EventLogExpert/Store/EventLog/LiveLogWatcher.cs
+++ b/src/EventLogExpert/Store/EventLog/LiveLogWatcher.cs
@@ -1,0 +1,91 @@
+﻿// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Library.EventResolvers;
+using EventLogExpert.Library.Helpers;
+using Microsoft.Extensions.FileSystemGlobbing;
+using System;
+using System.Diagnostics.Eventing.Reader;
+
+namespace EventLogExpert.Store.EventLog;
+
+/// <summary>
+///   This class is a wrapper around EventLogWatcher so we can maintain
+///   state as we create and destroy multiple EventLogWatchers without dumping
+///   all that state at the top level of EventLogState. Most importantly:
+///   - Keep track of the last bookmark so we can stop watching and start watching again later
+///     with a new EventLogWatcher.
+///   - Hold on to the resolver and the debug logger so we can create callbacks
+///     for new EventLogWatchers.
+/// </summary>
+public class LiveLogWatcher
+{
+    private readonly string _logName;
+    private readonly ITraceLogger _debugLogger;
+    private readonly IEventResolver _resolver;
+    private readonly Fluxor.IDispatcher _dispatcher;
+    private EventBookmark? _bookmark;
+    private EventLogWatcher? _watcher;
+
+    public LiveLogWatcher(string LogName, EventBookmark? Bookmark, ITraceLogger DebugLogger, IEventResolver Resolver, Fluxor.IDispatcher Dispatcher)
+    {
+        _logName = LogName;
+        _bookmark = Bookmark;
+        _debugLogger = DebugLogger;
+        _resolver = Resolver;
+        _dispatcher = Dispatcher;
+    }
+
+    public bool IsWatching => _watcher != null;
+
+    public void StartWatching()
+    {
+        if (_watcher != null) return;
+
+        var query = new EventLogQuery(_logName, PathType.LogName);
+
+        if (_bookmark != null)
+        {
+            _watcher = new EventLogWatcher(query, _bookmark);
+        }
+        else
+        {
+            _watcher = new EventLogWatcher(query);
+        }
+
+        _watcher.EventRecordWritten += (watcher, eventArgs) =>
+        {
+            lock (this)
+            {
+                _debugLogger.Trace("EventRecordWritten callback was called.");
+                _bookmark = eventArgs.EventRecord.Bookmark;
+                var resolved = _resolver.Resolve(eventArgs.EventRecord);
+                _dispatcher.Dispatch(new EventLogAction.AddEvent(resolved));
+            }
+        };
+
+        _watcher.Enabled = true;
+
+        _debugLogger.Trace("LiveLogWatcher started watching.");
+    }
+
+    public void StopWatching()
+    {
+        if (_watcher == null) return;
+
+        // Always do this on a background thread to avoid a deadlock
+        // if this is called on the UI thread. EventLogWatcher.Enabled = false
+        // will cause the thread to block until all outstanding callbacks
+        // have completed.
+        var oldWatcher = _watcher;
+        _watcher = null;
+        Task.Run(() =>
+            {
+                oldWatcher.Enabled = false;
+                oldWatcher.Dispose();
+                _debugLogger.Trace("LiveLogWatcher disposed the old watcher.");
+            });
+
+        _debugLogger.Trace("LiveLogWatcher dispatched a task to stop the watcher.");
+    }
+}


### PR DESCRIPTION
Wrap the EventLogWatcher in a new class which tracks the bookmark and the watcher state, and keep that in the EventLogState instead of the bare EventLogWatcher.

Fixes #79. A good way to test this is to set the limit very low, like 5, and then open a busy log and watch the debug output while you repeatedly choose to load new events. You can see it creating and disposing watchers successfully as the limit is quickly flooded with new events.