### PR TITLE
Use IStateSelection instead of hooking StateChanged

### DIFF
--- a/src/EventLogExpert/Components/DetailsPane.razor.cs
+++ b/src/EventLogExpert/Components/DetailsPane.razor.cs
@@ -4,12 +4,15 @@
 using EventLogExpert.Library.Models;
 using EventLogExpert.Store.EventLog;
 using Fluxor;
+using Microsoft.AspNetCore.Components;
 using System.Text;
 
 namespace EventLogExpert.Components;
 
 public partial class DetailsPane
 {
+    [Inject] private IStateSelection<EventLogState, DisplayEventModel?> selectedEventSelection { get; set; } = null!;
+
     private bool _expandMenu = false;
     private bool _expandXml = false;
 
@@ -18,16 +21,14 @@ public partial class DetailsPane
     protected override void OnInitialized()
     {
         base.OnInitialized();
-        EventLogState.StateChanged += (s, e) =>
+
+        selectedEventSelection.Select(s => s.SelectedEvent);
+        selectedEventSelection.SelectedValueChanged += (s, v) =>
         {
-            if (s is State<EventLogState> state)
+            if (v != null)
             {
-                if (state.Value.SelectedEvent != Event)
-                {
-                    Event = state.Value.SelectedEvent;
-                    _expandMenu = true;
-                    _expandXml = false;
-                }
+                _expandMenu = true;
+                _expandXml = false;
             }
         };
     }

--- a/src/EventLogExpert/Components/EventTable.razor
+++ b/src/EventLogExpert/Components/EventTable.razor
@@ -17,7 +17,7 @@
             </tr>
         </thead>
         <tbody>
-            <Virtualize Items="@GetFilteredEvents()" Context="evt" @ref="_virtualizeComponent">
+            <Virtualize Items="@GetFilteredEvents()" Context="evt">
                 <tr class="@GetCss(evt)" @key="evt.RecordId" @onfocus="() => SelectEvent(evt)" tabindex="0">
                     <td>@evt.Level</td>
                     <td>@evt.TimeCreated?.ConvertTimeZone(SettingsState.Value.TimeZone)</td>

--- a/src/EventLogExpert/Components/EventTable.razor.cs
+++ b/src/EventLogExpert/Components/EventTable.razor.cs
@@ -3,17 +3,13 @@
 
 using EventLogExpert.Library.Models;
 using EventLogExpert.Store.EventLog;
-using Fluxor;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web.Virtualization;
 using Microsoft.JSInterop;
 
 namespace EventLogExpert.Components;
 
 public partial class EventTable
 {
-    private Virtualize<DisplayEventModel>? _virtualizeComponent;
-
     [Inject] private IJSRuntime JSRuntime { get; set; } = null!;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -28,17 +24,6 @@ public partial class EventTable
 
     protected override void OnInitialized()
     {
-        IList<DisplayEventModel> lastEventList = EventLogState.Value.Events;
-
-        EventLogState.StateChanged += (s, e) =>
-        {
-            if (s is State<EventLogState> state && !Equals(state.Value.Events, lastEventList))
-            {
-                lastEventList = state.Value.Events;
-                _virtualizeComponent?.RefreshDataAsync();
-            }
-        };
-
         base.OnInitialized();
     }
 


### PR DESCRIPTION
Use the correct pattern for watching a piece of state for changes in the component.

Also, somehow Virtualize is updating itself when Items changes just like it was always supposed to. I'm not sure why I couldn't get it working before, but it's working now, so we no longer need to manually call RefreshDataAsync in that component.