### PR TITLE
Change db schema, load asynchronously, and report status to UI

### DIFF
--- a/src/EventLogExpert.EventDbTool/Program.cs
+++ b/src/EventLogExpert.EventDbTool/Program.cs
@@ -18,6 +18,8 @@ class Program
 
         rootCommand.AddCommand(DiffDatabaseCommand.GetCommand());
 
+        rootCommand.AddCommand(UpgradeDatabaseCommand.GetCommand());
+
         return await rootCommand.InvokeAsync(args);
     }
 }

--- a/src/EventLogExpert.EventDbTool/UpgradeDatabaseCommand.cs
+++ b/src/EventLogExpert.EventDbTool/UpgradeDatabaseCommand.cs
@@ -1,0 +1,56 @@
+﻿// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Library.EventProviderDatabase;
+using EventLogExpert.Library.Models;
+using EventLogExpert.Library.Providers;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using System.CommandLine;
+using System.Text.Json;
+
+namespace EventLogExpert.EventDbTool;
+
+public class UpgradeDatabaseCommand : DbToolCommand
+{
+    public static Command GetCommand()
+    {
+        var upgradeDatabaseCommand = new Command(
+            name: "upgrade",
+            description: "Upgrades the database schema");
+        var fileArgument = new Argument<string>(
+            name: "file",
+            description: "The database file to upgrade.");
+        var verboseOption = new Option<bool>(
+            name: "--verbose",
+            description: "Verbose logging. May be useful for troubleshooting.");
+        upgradeDatabaseCommand.AddArgument(fileArgument);
+        upgradeDatabaseCommand.AddOption(verboseOption);
+        upgradeDatabaseCommand.SetHandler((fileArgumentValue, verboseOptionValue) =>
+        {
+            UpgradeDatabase(fileArgumentValue, verboseOptionValue);
+        },
+        fileArgument, verboseOption);
+
+        return upgradeDatabaseCommand;
+    }
+
+    public static void UpgradeDatabase(string file, bool verbose)
+    {
+        if (!File.Exists(file))
+        {
+            Console.WriteLine($"File not found: {file}");
+            return;
+        }
+
+        using var dbContext = new EventProviderDbContext(file, readOnly: false);
+
+        if (!dbContext.IsUpgradeNeeded())
+        {
+            Console.WriteLine("This database does not need to be upgraded.");
+            return;
+        }
+
+        dbContext.PerformUpgradeIfNeeded();
+    }
+}

--- a/src/EventLogExpert.Library/EventProviderDatabase/CompressedJsonValueConverter.cs
+++ b/src/EventLogExpert.Library/EventProviderDatabase/CompressedJsonValueConverter.cs
@@ -1,0 +1,48 @@
+﻿// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using System.IO.Compression;
+using System.Text;
+using System.Text.Json;
+
+namespace EventLogExpert.Library.EventProviderDatabase;
+
+public class CompressedJsonValueConverter<T> : ValueConverter<T, byte[]> where T : class
+{
+    public CompressedJsonValueConverter() :
+      base(v => ConvertToCompressedJson(v), v => ConvertFromCompressedJson(v))
+    { }
+
+    private static byte[] ConvertToCompressedJson(T value)
+    {
+        var json = JsonSerializer.Serialize<T>(value);
+        var buffer = Encoding.UTF8.GetBytes(json);
+        MemoryStream memoryStream = new MemoryStream();
+        using (GZipStream gZipStream = new GZipStream(memoryStream, CompressionLevel.SmallestSize))
+        {
+            gZipStream.Write(buffer, 0, buffer.Length);
+        }
+
+        return memoryStream.ToArray();
+    }
+
+    private static T ConvertFromCompressedJson(byte[] value)
+    {
+        using (MemoryStream memoryStream = new MemoryStream(value))
+        {
+            using (GZipStream gZipStream = new GZipStream(memoryStream, CompressionMode.Decompress))
+            {
+                using (StreamReader streamReader = new StreamReader(gZipStream))
+                {
+                    return JsonSerializer.Deserialize<T>(streamReader.ReadToEnd());
+                }
+            }
+        }
+    }
+
+    private static T ConvertFromJson(string value)
+    {
+        return JsonSerializer.Deserialize<T>(value);
+    }
+}

--- a/src/EventLogExpert.Library/EventResolvers/EventProviderDatabaseEventResolver.cs
+++ b/src/EventLogExpert.Library/EventResolvers/EventProviderDatabaseEventResolver.cs
@@ -69,7 +69,8 @@ public class EventProviderDatabaseEventResolver : EventResolverBase, IEventResol
 
         foreach (var file in databasesToLoad)
         {
-            var c = new EventProviderDbContext(file, readOnly: true, _tracer);
+            var c = new EventProviderDbContext(file, readOnly: false, _tracer);
+            c.PerformUpgradeIfNeeded();
             c.ChangeTracker.QueryTrackingBehavior = Microsoft.EntityFrameworkCore.QueryTrackingBehavior.NoTracking;
             dbContexts.Add(c);
         }

--- a/src/EventLogExpert.Library/EventResolvers/EventReaderEventResolver.cs
+++ b/src/EventLogExpert.Library/EventResolvers/EventReaderEventResolver.cs
@@ -14,6 +14,10 @@ namespace EventLogExpert.Library.EventResolvers;
 /// </summary>
 public class EventReaderEventResolver : IEventResolver
 {
+    public string Status { get; private set; } = string.Empty;
+
+    public event EventHandler<string>? StatusChanged;
+
     public DisplayEventModel Resolve(EventRecord eventRecord)
     {
         var desc = eventRecord.FormatDescription();

--- a/src/EventLogExpert.Library/EventResolvers/EventResolverBase.cs
+++ b/src/EventLogExpert.Library/EventResolvers/EventResolverBase.cs
@@ -13,10 +13,6 @@ namespace EventLogExpert.Library.EventResolvers;
 
 public class EventResolverBase
 {
-    public event EventHandler<string>? StatusChanged;
-
-    public string Status { get; protected set; } = string.Empty;
-
     protected readonly Action<string> _tracer;
 
     private readonly Regex _formatRegex = new("%+[0-9]+");

--- a/src/EventLogExpert.Library/EventResolvers/EventResolverBase.cs
+++ b/src/EventLogExpert.Library/EventResolvers/EventResolverBase.cs
@@ -13,6 +13,10 @@ namespace EventLogExpert.Library.EventResolvers;
 
 public class EventResolverBase
 {
+    public event EventHandler<string>? StatusChanged;
+
+    public string Status { get; protected set; } = string.Empty;
+
     protected readonly Action<string> _tracer;
 
     private readonly Regex _formatRegex = new("%+[0-9]+");

--- a/src/EventLogExpert.Library/EventResolvers/IEventResolver.cs
+++ b/src/EventLogExpert.Library/EventResolvers/IEventResolver.cs
@@ -12,5 +12,9 @@ namespace EventLogExpert.Library.EventResolvers
     public interface IEventResolver
     {
         public DisplayEventModel Resolve(EventRecord eventRecord);
+
+        public string Status { get; }
+
+        public event EventHandler<string>? StatusChanged;
     }
 }

--- a/src/EventLogExpert.Library/EventResolvers/LocalProviderEventResolver.cs
+++ b/src/EventLogExpert.Library/EventResolvers/LocalProviderEventResolver.cs
@@ -15,6 +15,10 @@ namespace EventLogExpert.Library.EventResolvers;
 /// </summary>
 public class LocalProviderEventResolver : EventResolverBase, IEventResolver
 {
+    public string Status { get; private set; } = string.Empty;
+
+    public event EventHandler<string>? StatusChanged;
+
     private Dictionary<string, ProviderDetails?> _providerDetails = new();
 
     public LocalProviderEventResolver() : base(s => Debug.WriteLine(s)) { }

--- a/src/EventLogExpert.Test/EventResolverTests.cs
+++ b/src/EventLogExpert.Test/EventResolverTests.cs
@@ -17,6 +17,10 @@ public class EventResolverTests
 {
     internal class UnitTestEventResolver : EventResolverBase, IEventResolver
     {
+        public string Status { get; private set; } = string.Empty;
+
+        public event EventHandler<string>? StatusChanged;
+
         private readonly List<ProviderDetails> _providerDetailsList;
 
         internal UnitTestEventResolver(List<ProviderDetails> providerDetailsList) : base(s => Debug.WriteLine(s))

--- a/src/EventLogExpert/App.xaml.cs
+++ b/src/EventLogExpert/App.xaml.cs
@@ -1,17 +1,18 @@
 ﻿// // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Library.EventResolvers;
 using IDispatcher = Fluxor.IDispatcher;
 
 namespace EventLogExpert;
 
 public partial class App : Application
 {
-    public App(IDispatcher fluxorDispatcher)
+    public App(IDispatcher fluxorDispatcher, IEventResolver resolver)
     {
         InitializeComponent();
 
-        MainPage = new NavigationPage(new MainPage(fluxorDispatcher));
+        MainPage = new NavigationPage(new MainPage(fluxorDispatcher, resolver));
     }
 
     protected override Window CreateWindow(IActivationState? activationState)

--- a/src/EventLogExpert/Components/StatusBar.razor
+++ b/src/EventLogExpert/Components/StatusBar.razor
@@ -3,25 +3,31 @@
 @inject IState<EventLogState> EventLogState
 @inject IState<StatusBarState> StatusBarState
 
-@if (EventLogState.Value.Events.Count < 1 || EventLogState.Value.ActiveLog.LogType == EventLogExpert.Store.EventLog.EventLogState.LogType.File)
-{
-    <div class="status-bar">Events Loaded: @StatusBarState.Value.EventsLoaded</div>
-}
-else
-{
-    <div class="status-bar">
+<div class="status-bar">
+    @if (EventLogState.Value.Events.Count < 1 || EventLogState.Value.ActiveLog.LogType == EventLogExpert.Store.EventLog.EventLogState.LogType.File)
+    {
+        <span>Events Loaded: @StatusBarState.Value.EventsLoaded</span>
+    }
+    else
+    {
         <span>Events Loaded: @EventLogState.Value.Events.Count</span>
-        @if (EventLogState.Value.ContinuouslyUpdate)
+    }
+
+    @if (EventLogState.Value.ContinuouslyUpdate)
+    {
+        <span>Continuously Updating</span>
+    }
+    else
+    {
+        <span>New Events: @EventLogState.Value.NewEventBuffer.Events.Count</span>
+        @if (EventLogState.Value.NewEventBuffer.IsBufferFull)
         {
-            <span>Continuously Updating</span>
+            <span>Buffer Full</span>
         }
-        else
-        {
-            <span>New Events: @EventLogState.Value.NewEventBuffer.Events.Count</span>
-            @if (EventLogState.Value.NewEventBuffer.IsBufferFull)
-            {
-                <span>Buffer Full</span>
-            }
-        }
-    </div>
-}
+    }
+
+    @if (!string.IsNullOrEmpty(StatusBarState.Value.ResolverStatus))
+    {
+        <span>@StatusBarState.Value.ResolverStatus</span>
+    }
+</div>

--- a/src/EventLogExpert/MainPage.xaml.cs
+++ b/src/EventLogExpert/MainPage.xaml.cs
@@ -1,8 +1,10 @@
 ﻿// // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Library.EventResolvers;
 using EventLogExpert.Store.EventLog;
 using EventLogExpert.Store.Settings;
+using Microsoft.AspNetCore.Components;
 using System.Diagnostics.Eventing.Reader;
 using IDispatcher = Fluxor.IDispatcher;
 
@@ -11,6 +13,8 @@ namespace EventLogExpert;
 public partial class MainPage : ContentPage
 {
     private readonly IDispatcher _fluxorDispatcher;
+
+    [Inject] private IEventResolver _resolver { get; init; } = null!;
 
     public MainPage(IDispatcher fluxorDispatcher)
     {

--- a/src/EventLogExpert/Shared/NotificationService.cs
+++ b/src/EventLogExpert/Shared/NotificationService.cs
@@ -1,0 +1,29 @@
+﻿// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EventLogExpert.Shared;
+
+public interface INotificationService
+{
+    /// <summary>
+    /// Puts a notification in the status bar. There can be one
+    /// notification per owner. Calling Notify with the same owner
+    /// and a new message causes the old message to be replaced
+    /// with the new one. If message is null, the last notification
+    /// for that owner is removed.
+    /// </summary>
+    /// <param name="owner"></param>
+    /// <param name="message"></param>
+    public void Notify(string owner, string message);
+}
+
+public class NotificationService
+{
+
+}

--- a/src/EventLogExpert/Store/StatusBar/StatusBarAction.cs
+++ b/src/EventLogExpert/Store/StatusBar/StatusBarAction.cs
@@ -6,4 +6,6 @@ namespace EventLogExpert.Store.StatusBar;
 public record StatusBarAction
 {
     public record SetEventsLoaded(int EventCount);
+
+    public record SetResolverStatus(string ResolverStatus);
 }

--- a/src/EventLogExpert/Store/StatusBar/StatusBarReducers.cs
+++ b/src/EventLogExpert/Store/StatusBar/StatusBarReducers.cs
@@ -9,5 +9,9 @@ public class StatusBarReducers
 {
     [ReducerMethod]
     public static StatusBarState ReduceSetEventsLoaded(StatusBarState state, StatusBarAction.SetEventsLoaded action) =>
-        new() { EventsLoaded = action.EventCount };
+        new() { EventsLoaded = action.EventCount, ResolverStatus = state.ResolverStatus };
+
+    [ReducerMethod]
+    public static StatusBarState ReduceSetResolverStatus(StatusBarState state, StatusBarAction.SetResolverStatus action) =>
+        new() { EventsLoaded = state.EventsLoaded, ResolverStatus = action.ResolverStatus };
 }

--- a/src/EventLogExpert/Store/StatusBar/StatusBarState.cs
+++ b/src/EventLogExpert/Store/StatusBar/StatusBarState.cs
@@ -9,4 +9,6 @@ namespace EventLogExpert.Store.StatusBar;
 public record StatusBarState
 {
     public int EventsLoaded { get; init; }
+
+    public string ResolverStatus { get; init; } = string.Empty;
 }


### PR DESCRIPTION
A few changes here.

* The database schema now uses gzipped json instead of raw json. This makes the databases about 5% to 10% of their old sizes.
* When a user installs this update, the databases are upgraded in place on next launch.
* Loading an event log is blocked during the upgrade. Upgrade status is visible in the status bar:

![image](https://github.com/microsoft/EventLogExpert/assets/4518572/0e7b645f-9e85-4f9f-9551-05ce905fefb3)

* It will take about 2 minutes to upgrade the databases, depending on hardware.
* Local log names are now also loaded asynchronously to improve startup time.