### PR TITLE
Do not use ImmutableList for Events collections

### DIFF
--- a/src/EventLogExpert/MainPage.xaml.cs
+++ b/src/EventLogExpert/MainPage.xaml.cs
@@ -43,7 +43,6 @@ public partial class MainPage : ContentPage
                         fileName,
                         EventLogState.LogType.File)));
 
-
         Utils.UpdateAppTitle(fileName);
     }
 

--- a/src/EventLogExpert/Store/EventLog/EventLogReducers.cs
+++ b/src/EventLogExpert/Store/EventLog/EventLogReducers.cs
@@ -27,11 +27,11 @@ public class EventLogReducers
 
         if (state.ContinuouslyUpdate)
         {
-            newState = newState with { Events = newEvent.Concat(state.Events).ToImmutableList() };
+            newState = newState with { Events = newEvent.Concat(state.Events).ToList().AsReadOnly() };
         }
         else
         {
-            var updatedBuffer = newEvent.Concat(state.NewEventBuffer.Events).ToImmutableList();
+            var updatedBuffer = newEvent.Concat(state.NewEventBuffer.Events).ToList().AsReadOnly();
             var full = updatedBuffer.Count >= MaxNewEvents;
             newState = newState with { NewEventBuffer = new(updatedBuffer, full) };
 
@@ -46,19 +46,19 @@ public class EventLogReducers
 
     [ReducerMethod(typeof(EventLogAction.ClearEvents))]
     public static EventLogState ReduceClearEvents(EventLogState state) => 
-        state with { Events = ImmutableList<DisplayEventModel>.Empty };
+        state with { Events = new List<DisplayEventModel>().AsReadOnly() };
 
     [ReducerMethod]
     public static EventLogState ReduceLoadEvents(EventLogState state, EventLogAction.LoadEvents action) =>
-        state with { Events = action.Events.ToImmutableList(), Watcher = action.Watcher };
+        state with { Events = action.Events.ToList().AsReadOnly(), Watcher = action.Watcher };
 
     [ReducerMethod]
     public static EventLogState ReduceLoadNewEvents(EventLogState state, EventLogAction.LoadNewEvents action)
     {
         var newState = state with
         {
-            Events = state.NewEventBuffer.Events.Concat(state.Events).ToImmutableList(),
-            NewEventBuffer = new(ImmutableList<DisplayEventModel>.Empty, false)
+            Events = state.NewEventBuffer.Events.Concat(state.Events).ToList().AsReadOnly(),
+            NewEventBuffer = new(new List<DisplayEventModel>().AsReadOnly(), false)
         };
 
         if (state.Watcher != null && !state.Watcher.IsWatching)
@@ -93,8 +93,8 @@ public class EventLogReducers
         {
             newState = newState with
             {
-                Events = state.NewEventBuffer.Events.Concat(state.Events).ToImmutableList(),
-                NewEventBuffer = new(ImmutableList<DisplayEventModel>.Empty, false)
+                Events = state.NewEventBuffer.Events.Concat(state.Events).ToList().AsReadOnly(),
+                NewEventBuffer = new(new List<DisplayEventModel>().AsReadOnly(), false)
             };
         }
 

--- a/src/EventLogExpert/Store/EventLog/EventLogState.cs
+++ b/src/EventLogExpert/Store/EventLog/EventLogState.cs
@@ -4,13 +4,14 @@
 using EventLogExpert.Library.Models;
 using Fluxor;
 using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 
 namespace EventLogExpert.Store.EventLog;
 
 [FeatureState]
 public record EventLogState
 {
-    public record EventBuffer(ImmutableList<DisplayEventModel> Events, bool IsBufferFull);
+    public record EventBuffer(ReadOnlyCollection<DisplayEventModel> Events, bool IsBufferFull);
 
     public record LogSpecifier(string Name, LogType? LogType);
 
@@ -20,9 +21,9 @@ public record EventLogState
 
     public bool ContinuouslyUpdate { get; init; } = false;
 
-    public ImmutableList<DisplayEventModel> Events { get; init; } = ImmutableList<DisplayEventModel>.Empty;
+    public ReadOnlyCollection<DisplayEventModel> Events { get; init; } = new List<DisplayEventModel>().AsReadOnly();
 
-    public EventBuffer NewEventBuffer { get; init; } = new (ImmutableList<DisplayEventModel>.Empty, false);
+    public EventBuffer NewEventBuffer { get; init; } = new (new List<DisplayEventModel>().AsReadOnly(), false);
 
     public DisplayEventModel? SelectedEvent { get; init; }
 


### PR DESCRIPTION
I noticed in my lab, which is a VM with limited CPUs, that if I open a large event log (~500,000 events) which is also very busy adding new events, choosing Load New Events from the view menu can make the app hang for several seconds. After doing some testing, I believe this is due to the use of ImmutableList.

Our Fluxor Store needs to produce immutable state, so ImmutableList seems like a natural choice for our event collections. We can't use IEnumerable, because we need to be able to index into the collection, and anyway, IEnumerable leaves it possible to modify the underlying collection.

ImmutableList would be fine for 100 or 1000 items, but when we have 500,000 events and we now need to concatenate two ImmutableLists to produce a new one for the state, it gets very expensive and very slow.

I compared Concat() performance between List<>, ImmutableList<>, and ReadOnlyCollection<>. This is starting with a collection of 50,000 items and then calling Concat 10,000 times to add 10,000 new items:

```
❯ dotnet run
ReadOnlyCollection: 94ms
ImmutableList: 4758ms
List: 99ms
```

This is too high of a performance price to pay in a critical UI path, even if it might save us from accidentally modifying the underlying collection. We can use ReadOnlyCollection, which at least limits mutability somewhat, and as long as we are disciplined about making sure the Reducers always produce a new collection and don't mutate the old one, we should be fine.

Therefore, this PR drops ImmutableList for ReadOnlyCollection in the EventLogState.