### PR TITLE
Throttle state updates per second in EventTable

### DIFF
--- a/src/EventLogExpert/Components/EventTable.razor.cs
+++ b/src/EventLogExpert/Components/EventTable.razor.cs
@@ -22,6 +22,12 @@ public partial class EventTable
         await base.OnAfterRenderAsync(firstRender);
     }
 
+    protected override void OnInitialized()
+    {
+        MaximumStateChangedNotificationsPerSecond = 2;
+        base.OnInitialized();
+    }
+
     private string GetCss(DisplayEventModel @event) => EventLogState.Value.SelectedEvent?.RecordId == @event.RecordId ?
         "table-row selected" : "table-row";
 

--- a/src/EventLogExpert/Store/EventLog/EventLogReducers.cs
+++ b/src/EventLogExpert/Store/EventLog/EventLogReducers.cs
@@ -13,7 +13,7 @@ public class EventLogReducers
     /// The maximum number of new events we will hold in the state
     /// before we turn off the watcher.
     /// </summary>
-    private static readonly int MaxNewEvents = 5000;
+    private static readonly int MaxNewEvents = 1000;
 
     [ReducerMethod]
     public static EventLogState ReduceAddEvent(EventLogState state, EventLogAction.AddEvent action)


### PR DESCRIPTION
ImmutableList was not the whole problem, and not even really the main problem. The main problem with Load New Events is the rapid-fire state changes which cause us to re-filter on every single new event, which means re-filtering 5000 times when we load a full buffer. Throttling the state changes fixes this.

Also reduced the new event buffer to 1000. That should be plenty, and it prevents us from dealing with a massive buffer on slower machines.