### PR TITLE
Enable watcher on background thread

### DIFF
--- a/src/EventLogExpert/Store/EventLog/EventLogReducers.cs
+++ b/src/EventLogExpert/Store/EventLog/EventLogReducers.cs
@@ -96,6 +96,11 @@ public class EventLogReducers
                 Events = state.NewEventBuffer.Events.Concat(state.Events).ToList().AsReadOnly(),
                 NewEventBuffer = new(new List<DisplayEventModel>().AsReadOnly(), false)
             };
+
+            if (state.Watcher != null && !state.Watcher.IsWatching)
+            {
+                state.Watcher.StartWatching();
+            }
         }
 
         return newState;

--- a/src/EventLogExpert/Store/EventLog/LiveLogWatcher.cs
+++ b/src/EventLogExpert/Store/EventLog/LiveLogWatcher.cs
@@ -64,9 +64,15 @@ public class LiveLogWatcher
             }
         };
 
-        _watcher.Enabled = true;
+        // When the watcher is enabled, it reads all the events since the
+        // last bookmark. Do this on a background thread so we don't tie
+        // up the UI.
+        Task.Run(() =>
+        {
+            _watcher.Enabled = true;
 
-        _debugLogger.Trace("LiveLogWatcher started watching.");
+            _debugLogger.Trace("LiveLogWatcher started watching.");
+        });
     }
 
     public void StopWatching()


### PR DESCRIPTION
* Enable the watcher on a background thread so the UI thread is not tied up while reading large numbers of new events.
* Make sure the watcher is enabled when ContinuouslyUpdate is set to true.