### PR TITLE
Don't allow concurrent loading of multiple logs

### DIFF
--- a/src/EventLogExpert/Store/EventLog/EventLogEffects.cs
+++ b/src/EventLogExpert/Store/EventLog/EventLogEffects.cs
@@ -42,46 +42,49 @@ public class EventLogEffects
         // Do this on a background thread so we don't hang the UI
         await Task.Run(() =>
         {
-            var sw = new Stopwatch();
-            sw.Start();
-
-            List<DisplayEventModel> events = new();
-            HashSet<int> eventIdsAll = new();
-            HashSet<string> eventProviderNamesAll = new();
-            HashSet<string> eventTaskNamesAll = new();
-            EventRecord lastEvent = null!;
-
-            while (reader.ReadEvent() is { } e)
+            lock (_eventResolver)
             {
-                lastEvent = e;
-                var resolved = _eventResolver.Resolve(e, action.LogSpecifier.Name);
-                eventIdsAll.Add(resolved.Id);
-                eventProviderNamesAll.Add(resolved.Source);
-                eventTaskNamesAll.Add(resolved.TaskCategory);
+                var sw = new Stopwatch();
+                sw.Start();
 
-                events.Add(resolved);
+                List<DisplayEventModel> events = new();
+                HashSet<int> eventIdsAll = new();
+                HashSet<string> eventProviderNamesAll = new();
+                HashSet<string> eventTaskNamesAll = new();
+                EventRecord lastEvent = null!;
 
-                if (sw.ElapsedMilliseconds > 1000)
+                while (reader.ReadEvent() is { } e)
                 {
-                    sw.Restart();
-                    dispatcher.Dispatch(new EventLogAction.SetEventsLoading(events.Count));
+                    lastEvent = e;
+                    var resolved = _eventResolver.Resolve(e, action.LogSpecifier.Name);
+                    eventIdsAll.Add(resolved.Id);
+                    eventProviderNamesAll.Add(resolved.Source);
+                    eventTaskNamesAll.Add(resolved.TaskCategory);
+
+                    events.Add(resolved);
+
+                    if (sw.ElapsedMilliseconds > 1000)
+                    {
+                        sw.Restart();
+                        dispatcher.Dispatch(new EventLogAction.SetEventsLoading(events.Count));
+                    }
                 }
-            }
 
-            events.Reverse();
+                events.Reverse();
 
-            dispatcher.Dispatch(new EventLogAction.LoadEvents(
-                action.LogSpecifier.Name,
-                events,
-                eventIdsAll.ToImmutableList(),
-                eventProviderNamesAll.ToImmutableList(),
-                eventTaskNamesAll.ToImmutableList()));
+                dispatcher.Dispatch(new EventLogAction.LoadEvents(
+                    action.LogSpecifier.Name,
+                    events,
+                    eventIdsAll.ToImmutableList(),
+                    eventProviderNamesAll.ToImmutableList(),
+                    eventTaskNamesAll.ToImmutableList()));
 
-            dispatcher.Dispatch(new EventLogAction.SetEventsLoading(0));
+                dispatcher.Dispatch(new EventLogAction.SetEventsLoading(0));
 
-            if (action.LogSpecifier.LogType == EventLogState.LogType.Live)
-            {
-                _logWatcherService.AddLog(action.LogSpecifier.Name, lastEvent?.Bookmark);
+                if (action.LogSpecifier.LogType == EventLogState.LogType.Live)
+                {
+                    _logWatcherService.AddLog(action.LogSpecifier.Name, lastEvent?.Bookmark);
+                }
             }
         });
     }


### PR DESCRIPTION
If a user chooses to open another log while one is in progress, we can end up with two threads fighting over the DBContext, resulting in an exception.

With this change the user can still add logs while a log is loading, but they will be blocked until the first one is done.