### PR TITLE
Store log data separately in the state

### DIFF
--- a/src/EventLogExpert/App.xaml.cs
+++ b/src/EventLogExpert/App.xaml.cs
@@ -5,6 +5,7 @@ using EventLogExpert.Library.EventResolvers;
 using EventLogExpert.Store.EventLog;
 using EventLogExpert.Store.Settings;
 using Fluxor;
+using System.Collections.Immutable;
 using static EventLogExpert.Store.EventLog.EventLogState;
 using IDispatcher = Fluxor.IDispatcher;
 
@@ -13,7 +14,7 @@ namespace EventLogExpert;
 public partial class App : Application
 {
     public App(IDispatcher fluxorDispatcher, IEventResolver resolver,
-        IStateSelection<EventLogState, IEnumerable<LogSpecifier>> activeLogsState,
+        IStateSelection<EventLogState, ImmutableDictionary<string, EventLogData>> activeLogsState,
         IStateSelection<EventLogState, bool> continuouslyUpdateState,
         IStateSelection<SettingsState, bool> showLogState,
         IStateSelection<SettingsState,bool> showComputerState)

--- a/src/EventLogExpert/Components/EventTable.razor.cs
+++ b/src/EventLogExpert/Components/EventTable.razor.cs
@@ -40,9 +40,11 @@ public partial class EventTable
 
     private IList<DisplayEventModel> GetFilteredEvents()
     {
+        var allEventsCombined = EventLogState.Value.ActiveLogs.Values.SelectMany(l => l.Events);
+
         int numberOfFilteredEvents = 0;
-        int initialNumberOfEvents = EventLogState.Value.Events.Count;
-        var filteredEvents = EventLogState.Value.Events.AsQueryable();
+        int initialNumberOfEvents = allEventsCombined.Count();
+        var filteredEvents = allEventsCombined.AsQueryable();
 
         if (FilterPaneState.Value.FilteredDateRange is not null && FilterPaneState.Value.FilteredDateRange.IsEnabled)
         {
@@ -68,6 +70,13 @@ public partial class EventTable
         if (!_isDateTimeDescending)
         {
             filteredEvents = filteredEvents.OrderBy(x => x.TimeCreated);
+        }
+        else if (EventLogState.Value.ActiveLogs.Count > 1)
+        {
+            // If we only have one log open, the allEventsCombined enumerable already
+            // has them all in descending order. However, if there's more than one,
+            // we need to order them here.
+            filteredEvents = filteredEvents.OrderByDescending(x => x.TimeCreated);
         }
 
         if (filteredEvents.Count() != initialNumberOfEvents)

--- a/src/EventLogExpert/Components/FilterPane.razor.cs
+++ b/src/EventLogExpert/Components/FilterPane.razor.cs
@@ -63,13 +63,21 @@ public partial class FilterPane
 
         // Offset by 1 minute to make sure we don't drop events
         // since HTML input DateTime does not go lower than minutes
-        _model.Before = EventLogState.Value.Events.FirstOrDefault()?.TimeCreated
-                .AddMinutes(1).ConvertTimeZone(_model.TimeZoneInfo) ??
-            DateTime.Now;
+        _model.Before = EventLogState.Value.ActiveLogs.Values
+            .Where(log => log.Events.Any())
+            .Select(log => log.Events.First().TimeCreated)
+            .OrderBy(t => t)
+            .DefaultIfEmpty(DateTime.UtcNow)
+            .First()
+            .AddMinutes(1).ConvertTimeZone(_model.TimeZoneInfo);
 
-        _model.After = EventLogState.Value.Events.LastOrDefault()?.TimeCreated
-                .AddMinutes(-1).ConvertTimeZone(_model.TimeZoneInfo) ??
-            DateTime.Now;
+        _model.After = EventLogState.Value.ActiveLogs.Values
+            .Where(log => log.Events.Any())
+            .Select(log => log.Events.Last().TimeCreated)
+            .OrderBy(t => t)
+            .DefaultIfEmpty(DateTime.UtcNow)
+            .Last()
+            .AddMinutes(-1).ConvertTimeZone(_model.TimeZoneInfo);
 
         _isDateFilterVisible = true;
     }

--- a/src/EventLogExpert/Components/StatusBar.razor
+++ b/src/EventLogExpert/Components/StatusBar.razor
@@ -17,17 +17,22 @@
         <span>Filtered Events: @FilterPaneState.Value.NumberOfFilteredEvents</span>
     }
 
-    @if (EventLogState.Value.ContinuouslyUpdate)
+    @if (EventLogState.Value.ActiveLogs.Values.Any(l => l.Type == EventLogExpert.Store.EventLog.EventLogState.LogType.Live))
     {
-        <span>Continuously Updating</span>
-    }
-    else
-    {
-        <span>New Events: @EventLogState.Value.NewEventBuffer.Count</span>
-        @if (EventLogState.Value.NewEventBufferIsFull)
+        @if (EventLogState.Value.ContinuouslyUpdate)
         {
-            <span>Buffer Full</span>
+            <span>Continuously Updating</span>
         }
+        else
+        {
+            <span>New Events: @EventLogState.Value.NewEventBuffer.Count</span>
+            @if (EventLogState.Value.NewEventBufferIsFull)
+            {
+                <span>Buffer Full</span>
+            }
+
+        }
+
     }
 
     @if (!string.IsNullOrEmpty(StatusBarState.Value.ResolverStatus))

--- a/src/EventLogExpert/Components/StatusBar.razor
+++ b/src/EventLogExpert/Components/StatusBar.razor
@@ -10,7 +10,7 @@
         <span>Loading Progress: @EventLogState.Value.EventsLoading</span>
     }
     
-    <span>Events Loaded: @EventLogState.Value.Events.Count</span>
+    <span>Events Loaded: @EventLogState.Value.ActiveLogs.Values.Sum(log => log.Events.Count)</span>
     
     @if (FilterPaneState.Value.CurrentFilters.Any())
     {

--- a/src/EventLogExpert/MainPage.xaml.cs
+++ b/src/EventLogExpert/MainPage.xaml.cs
@@ -6,7 +6,7 @@ using EventLogExpert.Store.EventLog;
 using EventLogExpert.Store.Settings;
 using EventLogExpert.Store.StatusBar;
 using Fluxor;
-using Microsoft.Maui.Storage;
+using System.Collections.Immutable;
 using System.Diagnostics.Eventing.Reader;
 using static EventLogExpert.Store.EventLog.EventLogState;
 using IDispatcher = Fluxor.IDispatcher;
@@ -20,7 +20,7 @@ public partial class MainPage : ContentPage
     private readonly IEventResolver _resolver;
 
     public MainPage(IDispatcher fluxorDispatcher, IEventResolver resolver,
-        IStateSelection<EventLogState, IEnumerable<LogSpecifier>> activeLogsState,
+        IStateSelection<EventLogState, ImmutableDictionary<string, EventLogData>> activeLogsState,
         IStateSelection<EventLogState, bool> continuouslyUpdateState,
         IStateSelection<SettingsState, bool> showLogNameState,
         IStateSelection<SettingsState, bool> showComputerNameState)
@@ -32,7 +32,7 @@ public partial class MainPage : ContentPage
         _resolver = resolver;
 
         activeLogsState.Select(e => e.ActiveLogs);
-        activeLogsState.SelectedValueChanged += (sender, activeLogs) => Utils.UpdateAppTitle(string.Join(" ", activeLogs.Select(l => l.Name)));
+        activeLogsState.SelectedValueChanged += (sender, activeLogs) => Utils.UpdateAppTitle(string.Join(" ", activeLogs.Values.Select(l => l.Name)));
 
         continuouslyUpdateState.Select(e => e.ContinuouslyUpdate);
         continuouslyUpdateState.SelectedValueChanged += (sender, continuouslyUpdate) => ContinuouslyUpdateMenuItem.Text = $"Continuously Update{(continuouslyUpdate ? " ✓" : "")}";
@@ -58,9 +58,8 @@ public partial class MainPage : ContentPage
     {
         _fluxorDispatcher.Dispatch(
                 new EventLogAction.OpenLog(
-                    new EventLogState.LogSpecifier(
-                        fileName,
-                        EventLogState.LogType.File)));
+                    fileName,
+                    LogType.File));
     }
 
     public async void OpenFile_Clicked(object sender, EventArgs e)
@@ -131,9 +130,8 @@ public partial class MainPage : ContentPage
 
         _fluxorDispatcher.Dispatch(
             new EventLogAction.OpenLog(
-                new EventLogState.LogSpecifier(
-                    logName,
-                    EventLogState.LogType.Live)));
+                logName,
+                LogType.Live));
     }
 
     private void CloseAll_Clicked(object? sender, EventArgs e)

--- a/src/EventLogExpert/Shared/Components/FilterValueSelect.razor.cs
+++ b/src/EventLogExpert/Shared/Components/FilterValueSelect.razor.cs
@@ -41,7 +41,7 @@ public partial class FilterValueSelect
         switch (Type)
         {
             case FilterType.EventId :
-                _items = EventLogState.Value.EventIds.Select(x => x.ToString()).ToList();
+                _items = EventLogState.Value.ActiveLogs.Values.SelectMany(log => log.EventIds).Select(id => id.ToString()).ToList();
                 break;
             case FilterType.Level :
                 _items = new List<string>();
@@ -53,11 +53,11 @@ public partial class FilterValueSelect
 
                 break;
             case FilterType.Source :
-                _items = EventLogState.Value.EventProviderNames.ToList();
+                _items = EventLogState.Value.ActiveLogs.Values.SelectMany(log => log.EventProviderNames).Select(name => name.ToString()).ToList();
 
                 break;
             case FilterType.Task :
-                _items = EventLogState.Value.TaskNames.ToList();
+                _items = EventLogState.Value.ActiveLogs.Values.SelectMany(log => log.TaskNames).Select(name => name.ToString()).ToList();
 
                 break;
             case FilterType.Description :

--- a/src/EventLogExpert/Store/EventLog/EventLogAction.cs
+++ b/src/EventLogExpert/Store/EventLog/EventLogAction.cs
@@ -12,9 +12,9 @@ public record EventLogAction
     public record LoadEvents(
         string LogName,
         List<DisplayEventModel> Events,
-        IReadOnlyList<int> AllEventIds,
-        IReadOnlyList<string> AllProviderNames,
-        IReadOnlyList<string> AllTaskNames
+        IEnumerable<int> AllEventIds,
+        IEnumerable<string> AllProviderNames,
+        IEnumerable<string> AllTaskNames
     ) : EventLogAction;
 
     public record LoadNewEvents() : EventLogAction;

--- a/src/EventLogExpert/Store/EventLog/EventLogAction.cs
+++ b/src/EventLogExpert/Store/EventLog/EventLogAction.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Library.Models;
+using static EventLogExpert.Store.EventLog.EventLogState;
 
 namespace EventLogExpert.Store.EventLog;
 
@@ -11,6 +12,7 @@ public record EventLogAction
 
     public record LoadEvents(
         string LogName,
+        EventLogState.LogType Type,
         List<DisplayEventModel> Events,
         IEnumerable<int> AllEventIds,
         IEnumerable<string> AllProviderNames,
@@ -19,7 +21,7 @@ public record EventLogAction
 
     public record LoadNewEvents() : EventLogAction;
 
-    public record OpenLog(EventLogState.LogSpecifier LogSpecifier) : EventLogAction;
+    public record OpenLog(string LogName, LogType LogType) : EventLogAction;
 
     public record CloseLog(string LogName) : EventLogAction;
 

--- a/src/EventLogExpert/Store/EventLog/EventLogEffects.cs
+++ b/src/EventLogExpert/Store/EventLog/EventLogEffects.cs
@@ -30,13 +30,13 @@ public class EventLogEffects
     {
         EventLogReader reader;
 
-        if (action.LogSpecifier.LogType == EventLogState.LogType.Live)
+        if (action.LogType == EventLogState.LogType.Live)
         {
-            reader = new EventLogReader(action.LogSpecifier.Name, PathType.LogName);
+            reader = new EventLogReader(action.LogName, PathType.LogName);
         }
         else
         {
-            reader = new EventLogReader(action.LogSpecifier.Name, PathType.FilePath);
+            reader = new EventLogReader(action.LogName, PathType.FilePath);
         }
 
         // Do this on a background thread so we don't hang the UI
@@ -56,7 +56,7 @@ public class EventLogEffects
                 while (reader.ReadEvent() is { } e)
                 {
                     lastEvent = e;
-                    var resolved = _eventResolver.Resolve(e, action.LogSpecifier.Name);
+                    var resolved = _eventResolver.Resolve(e, action.LogName);
                     eventIdsAll.Add(resolved.Id);
                     eventProviderNamesAll.Add(resolved.Source);
                     eventTaskNamesAll.Add(resolved.TaskCategory);
@@ -73,7 +73,8 @@ public class EventLogEffects
                 events.Reverse();
 
                 dispatcher.Dispatch(new EventLogAction.LoadEvents(
-                    action.LogSpecifier.Name,
+                    action.LogName,
+                    action.LogType,
                     events,
                     eventIdsAll.ToImmutableList(),
                     eventProviderNamesAll.ToImmutableList(),
@@ -81,9 +82,9 @@ public class EventLogEffects
 
                 dispatcher.Dispatch(new EventLogAction.SetEventsLoading(0));
 
-                if (action.LogSpecifier.LogType == EventLogState.LogType.Live)
+                if (action.LogType == EventLogState.LogType.Live)
                 {
-                    _logWatcherService.AddLog(action.LogSpecifier.Name, lastEvent?.Bookmark);
+                    _logWatcherService.AddLog(action.LogName, lastEvent?.Bookmark);
                 }
             }
         });

--- a/src/EventLogExpert/Store/EventLog/EventLogState.cs
+++ b/src/EventLogExpert/Store/EventLog/EventLogState.cs
@@ -13,21 +13,20 @@ public record EventLogState
 {
     public record EventBuffer(ReadOnlyCollection<DisplayEventModel> Events, bool IsBufferFull);
 
-    public record LogSpecifier(string Name, LogType? LogType);
-
     public enum LogType { Live, File }
 
-    public ImmutableList<LogSpecifier> ActiveLogs { get; init; } = ImmutableList<LogSpecifier>.Empty;
+    public record EventLogData(
+        string Name,
+        LogType Type,
+        ReadOnlyCollection<DisplayEventModel> Events,
+        ImmutableHashSet<int> EventIds,
+        ImmutableHashSet<string> EventProviderNames,
+        ImmutableHashSet<string> TaskNames
+        );
 
-    public ImmutableHashSet<int> EventIds { get; init; } = ImmutableHashSet<int>.Empty;
-
-    public ImmutableHashSet<string> EventProviderNames { get; init; } = ImmutableHashSet<string>.Empty;
-
-    public ImmutableHashSet<string> TaskNames { get; init;} = ImmutableHashSet<string>.Empty;
+    public ImmutableDictionary<string, EventLogData> ActiveLogs { get; init; } = ImmutableDictionary<string, EventLogData>.Empty;
 
     public bool ContinuouslyUpdate { get; init; } = false;
-
-    public ReadOnlyCollection<DisplayEventModel> Events { get; init; } = new List<DisplayEventModel>().AsReadOnly();
 
     public int EventsLoading { get; set; } = 0;
 

--- a/src/EventLogExpert/Store/EventLog/EventLogState.cs
+++ b/src/EventLogExpert/Store/EventLog/EventLogState.cs
@@ -3,6 +3,7 @@
 
 using EventLogExpert.Library.Models;
 using Fluxor;
+using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 
 namespace EventLogExpert.Store.EventLog;
@@ -16,13 +17,13 @@ public record EventLogState
 
     public enum LogType { Live, File }
 
-    public ReadOnlyCollection<LogSpecifier> ActiveLogs { get; init; } = new List<LogSpecifier>().AsReadOnly();
+    public ImmutableList<LogSpecifier> ActiveLogs { get; init; } = ImmutableList<LogSpecifier>.Empty;
 
-    public ReadOnlyCollection<int> EventIds { get; init; } = new List<int>().AsReadOnly();
+    public ImmutableHashSet<int> EventIds { get; init; } = ImmutableHashSet<int>.Empty;
 
-    public ReadOnlyCollection<string> EventProviderNames { get; init; } = new List<string>().AsReadOnly();
+    public ImmutableHashSet<string> EventProviderNames { get; init; } = ImmutableHashSet<string>.Empty;
 
-    public ReadOnlyCollection<string> TaskNames { get; init;} = new List<string>().AsReadOnly();
+    public ImmutableHashSet<string> TaskNames { get; init;} = ImmutableHashSet<string>.Empty;
 
     public bool ContinuouslyUpdate { get; init; } = false;
 


### PR DESCRIPTION
With this change, we store the events collection, unique event ids, unique provider names, etc, separately for each log in the state. It's up to the view to combine them if it wants - or not. This will allow for additional views that show individual logs on separate tabs or side-by-side for comparison, etc.