### PR TITLE
Converted disabled database information to be stored in local preferences

### DIFF
--- a/src/EventLogExpert.Library/Models/SettingsModel.cs
+++ b/src/EventLogExpert.Library/Models/SettingsModel.cs
@@ -12,7 +12,8 @@ public record SettingsModel
     [JsonIgnore]
     public TimeZoneInfo TimeZoneInfo => TimeZoneInfo.FindSystemTimeZoneById(TimeZoneId);
 
-    public IList<string>? DisabledDatabases { get; set; }
+    [JsonIgnore]
+    public IList<string> DisabledDatabases { get; set; } = new List<string>();
 
     public bool IsPrereleaseEnabled { get; set; }
 }

--- a/src/EventLogExpert/Shared/Components/SettingsModal.razor
+++ b/src/EventLogExpert/Shared/Components/SettingsModal.razor
@@ -19,7 +19,7 @@
         </div>
 
         <div class="database-list">
-            @if (_databases?.Any() is true)
+            @if (_databases.Any())
             {
                 @foreach (var database in _databases)
                 {
@@ -38,7 +38,7 @@
             }
         </div>
         
-        @if (_request.DisabledDatabases?.Any() is true)
+        @if (_request.DisabledDatabases.Any())
         {
             <div class="database-row">
                 <div>Disabled Databases: </div>

--- a/src/EventLogExpert/Shared/Components/SettingsModal.razor.cs
+++ b/src/EventLogExpert/Shared/Components/SettingsModal.razor.cs
@@ -15,8 +15,8 @@ namespace EventLogExpert.Shared.Components;
 
 public partial class SettingsModal
 {
-    private List<string>? _databases;
-    private bool _databasesHasChanged;
+    private List<string> _databases = new();
+    private bool _hasDatabasesChanged;
     private SettingsModel _request = new();
 
     [Inject] private IJSRuntime JSRuntime { get; set; } = null!;
@@ -40,20 +40,18 @@ public partial class SettingsModal
 
     private void DisableDatabase(string database)
     {
-        _request.DisabledDatabases ??= new List<string>();
+        _request.DisabledDatabases.Add(database);
+        _databases.Remove(database);
 
-        _request.DisabledDatabases?.Add(database);
-        _databases?.Remove(database);
-
-        _databasesHasChanged = true;
+        _hasDatabasesChanged = true;
     }
 
     private void EnableDatabase(string database)
     {
-        _request.DisabledDatabases?.Remove(database);
-        _databases?.Add(database);
+        _request.DisabledDatabases.Remove(database);
+        _databases.Add(database);
 
-        _databasesHasChanged = true;
+        _hasDatabasesChanged = true;
     }
 
     private async void ImportDatabase()
@@ -162,9 +160,8 @@ public partial class SettingsModal
     private void ResetSettingsModel()
     {
         _request = SettingsState.Value.Config with { };
-
         _databases = SettingsState.Value.LoadedDatabases.ToList();
-        _databasesHasChanged = false;
+        _hasDatabasesChanged = false;
 
         StateHasChanged();
     }
@@ -172,7 +169,7 @@ public partial class SettingsModal
     private void Save()
     {
 
-        if (_databasesHasChanged)
+        if (_hasDatabasesChanged)
         {
             Dispatcher.Dispatch(new SettingsAction.Save(_request));
             Dispatcher.Dispatch(new SettingsAction.LoadDatabases());


### PR DESCRIPTION
Don't see a need that disabled database information needs to be saved to the local settings file so moving it to local preference storage.

This will also be where previous filters will be stored so laying the groundwork in preparation for that change.