### PR TITLE
Include Parameters in provider details

### DIFF
--- a/src/EventLogExpert.EventDbTool/DbToolCommand.cs
+++ b/src/EventLogExpert.EventDbTool/DbToolCommand.cs
@@ -29,8 +29,8 @@ public class DbToolCommand
     {
         var maxNameLength = providerNames.Any() ? providerNames.Max(p => p.Length) : 14;
         if (maxNameLength < 14) maxNameLength = 14;
-        _providerDetailFormat = "{0, -" + maxNameLength + "} {1, 8} {2, 8} {3, 8} {4, 8} {5, 8}";
-        Console.WriteLine(string.Format(_providerDetailFormat, "Provider Name", "Events", "Keywords", "Opcodes", "Tasks", "Messages"));
+        _providerDetailFormat = "{0, -" + maxNameLength + "} {1, 8} {2, 8} {3, 8} {4, 8} {5, 8} {6, 8}";
+        Console.WriteLine(string.Format(_providerDetailFormat, "Provider Name", "Events", "Parameters", "Keywords", "Opcodes", "Tasks", "Messages"));
     }
 
     public static void LogProviderDetails(ProviderDetails details)
@@ -39,6 +39,7 @@ public class DbToolCommand
             _providerDetailFormat,
             details.ProviderName,
             details.Events.Count,
+            details.Parameters.Count,
             details.Keywords.Count,
             details.Opcodes.Count,
             details.Tasks.Count,

--- a/src/EventLogExpert.EventDbTool/MergeDatabaseCommand.cs
+++ b/src/EventLogExpert.EventDbTool/MergeDatabaseCommand.cs
@@ -108,6 +108,7 @@ public class MergeDatabaseCommand : DbToolCommand
             {
                 ProviderName = provider.ProviderName,
                 Events = provider.Events,
+                Parameters = provider.Parameters,
                 Keywords = provider.Keywords,
                 Messages = provider.Messages,
                 Opcodes = provider.Opcodes,

--- a/src/EventLogExpert.EventDbTool/UpgradeDatabaseCommand.cs
+++ b/src/EventLogExpert.EventDbTool/UpgradeDatabaseCommand.cs
@@ -45,7 +45,9 @@ public class UpgradeDatabaseCommand : DbToolCommand
 
         using var dbContext = new EventProviderDbContext(file, readOnly: false);
 
-        if (!dbContext.IsUpgradeNeeded())
+        var (needsV2, needsV3) = dbContext.IsUpgradeNeeded();
+
+        if (!(needsV2 || needsV3))
         {
             Console.WriteLine("This database does not need to be upgraded.");
             return;

--- a/src/EventLogExpert.Library/EventProviderDatabase/CompressedJsonValueConverter.cs
+++ b/src/EventLogExpert.Library/EventProviderDatabase/CompressedJsonValueConverter.cs
@@ -14,7 +14,7 @@ public class CompressedJsonValueConverter<T> : ValueConverter<T, byte[]> where T
       base(v => ConvertToCompressedJson(v), v => ConvertFromCompressedJson(v))
     { }
 
-    private static byte[] ConvertToCompressedJson(T value)
+    public static byte[] ConvertToCompressedJson(T value)
     {
         var json = JsonSerializer.Serialize<T>(value);
         var buffer = Encoding.UTF8.GetBytes(json);
@@ -27,7 +27,7 @@ public class CompressedJsonValueConverter<T> : ValueConverter<T, byte[]> where T
         return memoryStream.ToArray();
     }
 
-    private static T ConvertFromCompressedJson(byte[] value)
+    public static T ConvertFromCompressedJson(byte[] value)
     {
         using (MemoryStream memoryStream = new MemoryStream(value))
         {

--- a/src/EventLogExpert.Library/EventResolvers/EventProviderDatabaseEventResolver.cs
+++ b/src/EventLogExpert.Library/EventResolvers/EventProviderDatabaseEventResolver.cs
@@ -74,7 +74,8 @@ public class EventProviderDatabaseEventResolver : EventResolverBase, IDatabaseEv
             foreach (var file in databasesToLoad)
             {
                 var c = new EventProviderDbContext(file, readOnly: false, _tracer);
-                if (c.IsUpgradeNeeded())
+                var (needsv2, needsv3) = c.IsUpgradeNeeded();
+                if (needsv2 || needsv3)
                 {
                     UpdateStatus($"Upgrading database {c.Name}. Please wait...");
                     c.PerformUpgradeIfNeeded();

--- a/src/EventLogExpert.Library/Providers/ProviderDetails.cs
+++ b/src/EventLogExpert.Library/Providers/ProviderDetails.cs
@@ -12,6 +12,9 @@ public class ProviderDetails
     /// <summary>Messages from legacy provider</summary>
     public List<MessageModel> Messages { get; set; } = new List<MessageModel>();
 
+    /// <summary>Parameter strings from legacy provider</summary>
+    public List<MessageModel> Parameters { get; set; } = new List<MessageModel>();
+
     /// <summary>Events and related items from modern provider</summary>
     public List<EventModel> Events { get; set; } = new List<EventModel>();
 

--- a/src/EventLogExpert.Library/Providers/RegistryProvider.cs
+++ b/src/EventLogExpert.Library/Providers/RegistryProvider.cs
@@ -103,7 +103,7 @@ public class RegistryProvider
         }
 
         hklm.Close();
-        return null;
+        return new List<string>();
     }
 
     private IEnumerable<string> GetExpandedFilePaths(IEnumerable<string> paths)


### PR DESCRIPTION
This change fixes #92. However, note that FindResource fails in some cases when running from within the EventLogExpert UI:

![image](https://github.com/microsoft/EventLogExpert/assets/4518572/8c173d74-f6ff-48af-a07f-ab20f786a36b)

Meanwhile, it works when the same call is made (literally by calling the same method the UI is calling) when run from a unit test or EventDbTool. This means we can produce event databases that contain messages which are not accessible when the UI is attempting to use local providers (when all databases are disabled or not present).

Ultimately this means that, when using local providers, events in the Security log will have these placeholders (this example is from event 4663):

![image](https://github.com/microsoft/EventLogExpert/assets/4518572/514d190e-cede-4cfa-8707-e03c0efc40f8)

But if you have databases that contain the appropriate strings, we can resolve these:

![image](https://github.com/microsoft/EventLogExpert/assets/4518572/034cdcd8-c1bb-4854-81c9-02753400e4a0)

I'm guessing this is due to the restricted permissions around modern apps? In any case, the answer is to use event databases if you want to resolve these placeholders.