### PR TITLE
Support concurrent loading of multiple logs

### DIFF
--- a/src/EventLogExpert.Library/EventResolvers/EventResolverBase.cs
+++ b/src/EventLogExpert.Library/EventResolvers/EventResolverBase.cs
@@ -122,7 +122,6 @@ public class EventResolverBase
     protected DisplayEventModel ResolveFromProviderDetails(EventRecord eventRecord, IList<EventProperty> eventProperties, ProviderDetails providerDetails, string owningLogName)
     {
         string? description = null;
-        string? xml = null;
         string? taskName = null;
         string? template = null;
 
@@ -224,7 +223,7 @@ public class EventResolverBase
                 owningLogName);
     }
 
-    protected IEnumerable<string> GetKeywordsFromBitmask(long? bitmask, ProviderDetails? providerDetails)
+    protected static IEnumerable<string> GetKeywordsFromBitmask(long? bitmask, ProviderDetails? providerDetails)
     {
         if (!bitmask.HasValue || bitmask.Value == 0) return Enumerable.Empty<string>();
         var returnValue = new List<string>();
@@ -255,7 +254,7 @@ public class EventResolverBase
     /// However, the names there do not match what is normally displayed in Event Viewer. We
     /// redefine them here so we can use our own strings.
     /// </summary>
-    private Dictionary<long, string> StandardKeywords = new()
+    private static readonly Dictionary<long, string> StandardKeywords = new()
     {
         { 0x1000000000000, "Response Time" },
         { 0x2000000000000, "Wdi Context"},

--- a/src/EventLogExpert.Library/EventResolvers/LocalProviderEventResolver.cs
+++ b/src/EventLogExpert.Library/EventResolvers/LocalProviderEventResolver.cs
@@ -4,6 +4,7 @@
 using EventLogExpert.Library.Helpers;
 using EventLogExpert.Library.Models;
 using EventLogExpert.Library.Providers;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.Eventing.Reader;
 
@@ -19,7 +20,7 @@ public class LocalProviderEventResolver : EventResolverBase, IEventResolver
 
     public event EventHandler<string>? StatusChanged;
 
-    private Dictionary<string, ProviderDetails?> _providerDetails = new();
+    private readonly ConcurrentDictionary<string, ProviderDetails?> _providerDetails = new();
 
     public LocalProviderEventResolver() : base(s => Debug.WriteLine(s)) { }
 
@@ -30,7 +31,7 @@ public class LocalProviderEventResolver : EventResolverBase, IEventResolver
         if (!_providerDetails.ContainsKey(eventRecord.ProviderName))
         {
             var provider = new EventMessageProvider(eventRecord.ProviderName, _tracer);
-            _providerDetails.Add(eventRecord.ProviderName, provider.LoadProviderDetails());
+            _providerDetails.TryAdd(eventRecord.ProviderName, provider.LoadProviderDetails());
         }
 
         _providerDetails.TryGetValue(eventRecord.ProviderName, out var providerDetails);

--- a/src/EventLogExpert/Components/StatusBar.razor
+++ b/src/EventLogExpert/Components/StatusBar.razor
@@ -5,9 +5,9 @@
 @inject IState<StatusBarState> StatusBarState
 
 <div class="status-bar">
-    @if (EventLogState.Value.EventsLoading > 0)
+    @foreach (var loadingProgress in EventLogState.Value.EventsLoading)
     {
-        <span>Loading Progress: @EventLogState.Value.EventsLoading</span>
+        <span>Loading: @loadingProgress.Value</span>
     }
     
     <span>Events Loaded: @EventLogState.Value.ActiveLogs.Values.Sum(log => log.Events.Count)</span>

--- a/src/EventLogExpert/Store/EventLog/EventLogAction.cs
+++ b/src/EventLogExpert/Store/EventLog/EventLogAction.cs
@@ -32,5 +32,13 @@ public record EventLogAction
 
     public record SetContinouslyUpdate(bool ContinuouslyUpdate) : EventLogAction;
 
-    public record SetEventsLoading(int Count) : EventLogAction;
+    /// <summary>
+    /// Used to indicate the progress of event logs being loaded.
+    /// </summary>
+    /// <param name="ActivityId">
+    ///     A unique id that distinguishes this loading activity from others, since log names such as
+    ///     Application will be common and many file names will be the same.
+    /// </param>
+    /// <param name="Count"></param>
+    public record SetEventsLoading(Guid ActivityId, int Count) : EventLogAction;
 }

--- a/src/EventLogExpert/Store/EventLog/EventLogReducers.cs
+++ b/src/EventLogExpert/Store/EventLog/EventLogReducers.cs
@@ -164,8 +164,24 @@ public class EventLogReducers
     }
 
     [ReducerMethod]
-    public static EventLogState ReduceSetEventsLoading(EventLogState state, EventLogAction.SetEventsLoading action) =>
-        state with { EventsLoading = action.Count };
+    public static EventLogState ReduceSetEventsLoading(EventLogState state, EventLogAction.SetEventsLoading action)
+    {
+        var newEventsLoading = state.EventsLoading;
+
+        if (newEventsLoading.ContainsKey(action.ActivityId))
+        {
+            newEventsLoading = newEventsLoading.Remove(action.ActivityId);
+        }
+
+        if (action.Count == 0)
+        {
+            return state with { EventsLoading = newEventsLoading };
+        }
+        else
+        {
+            return state with { EventsLoading = newEventsLoading.Add(action.ActivityId, action.Count) };
+        }
+    }
 
     private static EventLogData AddEventsToLogData(EventLogData logData, IEnumerable<DisplayEventModel> eventsToAdd)
     {

--- a/src/EventLogExpert/Store/EventLog/EventLogState.cs
+++ b/src/EventLogExpert/Store/EventLog/EventLogState.cs
@@ -29,7 +29,7 @@ public record EventLogState
 
     public bool ContinuouslyUpdate { get; init; } = false;
 
-    public int EventsLoading { get; set; } = 0;
+    public ImmutableDictionary<Guid, int> EventsLoading { get; set; } = ImmutableDictionary<Guid, int>.Empty;
 
     public ReadOnlyCollection<DisplayEventModel> NewEventBuffer { get; init; } = new List<DisplayEventModel>().AsReadOnly();
 


### PR DESCRIPTION
With this change, our IEventResolvers are intended to be thread-safe, which means we can now load multiple logs concurrently.