### PR TITLE
Revert "Last part of version must be 4 digits for consistent sort on GitHub"

### DIFF
--- a/azure-pipeline-merge.yml
+++ b/azure-pipeline-merge.yml
@@ -19,7 +19,7 @@ steps:
 
 - pwsh: |
     $now = [DateTime]::UtcNow
-    $versionString = "$($now.ToString(`"y.M.d`")).$(($now.Hour * 60 + $now.Minute).ToString("D4"))"
+    $versionString = "$($now.ToString(`"y.M.d`")).$($now.Hour * 60 + $now.Minute)"
     Write-Host "##vso[task.setvariable variable=ReleaseVersion]$versionString"
     Write-Host $versionString
   displayName: 'create version string'

--- a/azure-pipeline-release.yml
+++ b/azure-pipeline-release.yml
@@ -20,7 +20,7 @@ steps:
 
 - pwsh: |
     $now = [DateTime]::UtcNow
-    $versionString = "$($now.ToString(`"y.M.d`")).$(($now.Hour * 60 + $now.Minute).ToString("D4"))"
+    $versionString = "$($now.ToString(`"y.M.d`")).$($now.Hour * 60 + $now.Minute)"
     Write-Host "##vso[task.setvariable variable=ReleaseVersion]$versionString"
     Write-Host $versionString
   displayName: 'create version string'


### PR DESCRIPTION
Reverts microsoft/EventLogExpert#172

MakeAppx doesn't support a leading 0. This change made our builds fail:

MakeAppx : error : Error info: error C00CE169: App manifest validation error: The app manifest must be valid as per schema: Line 10, Column 128, Reason: '23.6.3.0426' violates pattern constraint of '(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(\.(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])){3}'. [D:\a\1\s\src\EventLogExpert\EventLogExpert.csproj::TargetFramework=net7.0-windows10.0.19041.0]
