### PR TITLE
Make IEventResolvers transient

### DIFF
--- a/src/EventLogExpert.Library/EventResolvers/DatabaseCollectionProvider.cs
+++ b/src/EventLogExpert.Library/EventResolvers/DatabaseCollectionProvider.cs
@@ -1,0 +1,25 @@
+﻿// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Library.Helpers;
+using System.Collections.Immutable;
+
+namespace EventLogExpert.Library.EventResolvers;
+
+public class DatabaseCollectionProvider : IDatabaseCollectionProvider
+{
+    private readonly ITraceLogger _logger;
+
+    public DatabaseCollectionProvider(ITraceLogger traceLogger)
+    {
+        _logger = traceLogger;
+    }
+
+    public ImmutableList<string> ActiveDatabases { get; private set; } = ImmutableList<string>.Empty;
+
+    public void SetActiveDatabases(IEnumerable<string> activeDatabases)
+    {
+        _logger.Trace($"{nameof(SetActiveDatabases)} was called with {activeDatabases.Count()} databases.");
+        ActiveDatabases = activeDatabases.ToImmutableList();
+    }
+}

--- a/src/EventLogExpert.Library/EventResolvers/EventReaderEventResolver.cs
+++ b/src/EventLogExpert.Library/EventResolvers/EventReaderEventResolver.cs
@@ -14,6 +14,8 @@ namespace EventLogExpert.Library.EventResolvers;
 /// </summary>
 public class EventReaderEventResolver : IEventResolver
 {
+    private bool disposedValue;
+
     public string Status { get; private set; } = string.Empty;
 
     public event EventHandler<string>? StatusChanged;
@@ -61,5 +63,19 @@ public class EventReaderEventResolver : IEventResolver
         {
             return default;
         }
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!disposedValue)
+        {
+            disposedValue = true;
+        }
+    }
+
+    public void Dispose()
+    {
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
     }
 }

--- a/src/EventLogExpert.Library/EventResolvers/IDatabaseCollectionProvider.cs
+++ b/src/EventLogExpert.Library/EventResolvers/IDatabaseCollectionProvider.cs
@@ -1,0 +1,13 @@
+﻿// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Collections.Immutable;
+
+namespace EventLogExpert.Library.EventResolvers;
+
+public interface IDatabaseCollectionProvider
+{
+    ImmutableList<string> ActiveDatabases { get; }
+
+    void SetActiveDatabases(IEnumerable<string> activeDatabases);
+}

--- a/src/EventLogExpert.Library/EventResolvers/IEventResolver.cs
+++ b/src/EventLogExpert.Library/EventResolvers/IEventResolver.cs
@@ -9,7 +9,7 @@ namespace EventLogExpert.Library.EventResolvers
     /// <summary>
     /// Turns a System.Diagnostics.Eventing.Reader.EventRecord into an EventLogExpert.Library.Models.DisplayEventModel.
     /// </summary>
-    public interface IEventResolver
+    public interface IEventResolver : IDisposable
     {
         public DisplayEventModel Resolve(EventRecord eventRecord, string OwningLogName);
 

--- a/src/EventLogExpert.Library/EventResolvers/LocalProviderEventResolver.cs
+++ b/src/EventLogExpert.Library/EventResolvers/LocalProviderEventResolver.cs
@@ -22,6 +22,8 @@ public class LocalProviderEventResolver : EventResolverBase, IEventResolver
 
     private readonly ConcurrentDictionary<string, ProviderDetails?> _providerDetails = new();
 
+    private bool disposedValue;
+
     public LocalProviderEventResolver() : base(s => Debug.WriteLine(s)) { }
 
     public LocalProviderEventResolver(Action<string> tracer) : base(tracer) { }
@@ -68,5 +70,21 @@ public class LocalProviderEventResolver : EventResolverBase, IEventResolver
         }
 
         return result;
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!disposedValue)
+        {
+            _providerDetails.Clear();
+
+            disposedValue = true;
+        }
+    }
+
+    public void Dispose()
+    {
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
     }
 }

--- a/src/EventLogExpert.Test/EventResolverTests.cs
+++ b/src/EventLogExpert.Test/EventResolverTests.cs
@@ -32,6 +32,10 @@ public class EventResolverTests
         {
             return ResolveFromProviderDetails(eventRecord, eventRecord.Properties, _providerDetailsList[0], OwningLog);
         }
+
+        public void Dispose()
+        {
+        }
     }
 
     private readonly ITestOutputHelper _outputHelper;

--- a/src/EventLogExpert/App.xaml.cs
+++ b/src/EventLogExpert/App.xaml.cs
@@ -15,7 +15,7 @@ public partial class App : Application
 {
 
     public App(IDispatcher fluxorDispatcher,
-        IEventResolver resolver,
+        IDatabaseCollectionProvider databaseCollectionProvider,
         IStateSelection<EventLogState, ImmutableDictionary<string, EventLogData>> activeLogsState,
         IStateSelection<EventLogState, bool> continuouslyUpdateState,
         IStateSelection<SettingsState, bool> showLogState,
@@ -27,7 +27,7 @@ public partial class App : Application
 
         MainPage = new NavigationPage(
             new MainPage(fluxorDispatcher,
-                resolver,
+                databaseCollectionProvider,
                 activeLogsState,
                 continuouslyUpdateState,
                 showLogState,

--- a/src/EventLogExpert/MauiProgram.cs
+++ b/src/EventLogExpert/MauiProgram.cs
@@ -37,13 +37,11 @@ public static class MauiProgram
 
         Directory.CreateDirectory(Utils.DatabasePath);
 
-        var dbResolver = new EventProviderDatabaseEventResolver(Utils.Trace);
-        var localResolver = new LocalProviderEventResolver(Utils.Trace);
-        var versEventResolver = new VersatileEventResolver(localResolver, dbResolver, Utils.Trace);
+        builder.Services.AddSingleton<IDatabaseCollectionProvider, DatabaseCollectionProvider>();
 
-        builder.Services.AddSingleton<IEventResolver>(versEventResolver);
+        builder.Services.AddTransient<IEventResolver, VersatileEventResolver>();
 
-        builder.Services.AddSingleton<ILogWatcherService, LiveLogWatcher>();
+        builder.Services.AddSingleton<ILogWatcherService, LiveLogWatcherService>();
 
         return builder.Build();
     }

--- a/src/EventLogExpert/Store/EventLog/LiveLogWatcherService.cs
+++ b/src/EventLogExpert/Store/EventLog/LiveLogWatcherService.cs
@@ -200,12 +200,10 @@ public class LiveLogWatcherService : ILogWatcherService
 
             if (_watchers.Count < 1)
             {
-                _debugLogger.Trace($"{nameof(LiveLogWatcherService)} That was the last watcher, so we are letting go of the IEventResolver instance.");
-
                 if (_resolver is IDisposable disposableResolver)
                 {
                     disposableResolver.Dispose();
-                    _debugLogger.Trace($"{nameof(LiveLogWatcherService)} The IEventResolver was disposable, so we have disposed it.");
+                    _debugLogger.Trace($"{nameof(LiveLogWatcherService)} Disposed the IEventResolver.");
                 }
 
                 _resolver = null;

--- a/src/EventLogExpert/Store/EventLog/LiveLogWatcherService.cs
+++ b/src/EventLogExpert/Store/EventLog/LiveLogWatcherService.cs
@@ -17,20 +17,21 @@ public interface ILogWatcherService
     void RemoveAll();
 }
 
-public class LiveLogWatcher : ILogWatcherService
+public class LiveLogWatcherService : ILogWatcherService
 {
     private readonly ITraceLogger _debugLogger;
-    private readonly IEventResolver _resolver;
+    private IEventResolver? _resolver = null;
+    private readonly IServiceProvider _serviceProvider;
     private readonly Fluxor.IDispatcher _dispatcher;
     private List<string> _logsToWatch = new();
     private Dictionary<string, EventBookmark?> _bookmarks = new();
     private Dictionary<string, EventLogWatcher> _watchers = new();
 
-    public LiveLogWatcher(ITraceLogger DebugLogger, IEventResolver Resolver, Fluxor.IDispatcher Dispatcher, IStateSelection<EventLogState, bool> bufferFullStateSelection)
+    public LiveLogWatcherService(ITraceLogger DebugLogger, IServiceProvider serviceProvider, Fluxor.IDispatcher Dispatcher, IStateSelection<EventLogState, bool> bufferFullStateSelection)
     {
         _debugLogger = DebugLogger;
-        _resolver = Resolver;
         _dispatcher = Dispatcher;
+        _serviceProvider = serviceProvider;
         bufferFullStateSelection.Select(s => s.NewEventBufferIsFull);
         bufferFullStateSelection.SelectedValueChanged += (sender, isFull) =>
         {
@@ -95,13 +96,7 @@ public class LiveLogWatcher : ILogWatcherService
         {
             _logsToWatch.Remove(LogName);
             _bookmarks.Remove(LogName);
-            if (_watchers.ContainsKey(LogName))
-            {
-                var watcher = _watchers[LogName];
-                _watchers.Remove(LogName);
-                watcher.Dispose();
-                _debugLogger.Trace($"Disposed watcher for log {LogName}.");
-            }
+            StopWatching(LogName);
         }
     }
 
@@ -131,6 +126,12 @@ public class LiveLogWatcher : ILogWatcherService
     {
         lock (this)
         {
+            if (_resolver == null)
+            {
+                _debugLogger.Trace($"{nameof(LiveLogWatcherService)} Getting a new IEventResolver so we can start watching.");
+                _resolver = _serviceProvider.GetService<IEventResolver>();
+            }
+
             if (_watchers.ContainsKey(LogName)) return;
 
             var query = new EventLogQuery(LogName, PathType.LogName);
@@ -154,6 +155,12 @@ public class LiveLogWatcher : ILogWatcherService
                 {
                     _debugLogger.Trace("EventRecordWritten callback was called.");
                     _bookmarks[LogName] = eventArgs.EventRecord.Bookmark;
+                    if (_resolver == null)
+                    {
+                        _debugLogger.Trace($"{nameof(LiveLogWatcherService)} _resolver is null in EventRecordWritten callback.");
+                        return;
+                    }
+
                     var resolved = _resolver.Resolve(eventArgs.EventRecord, LogName);
                     _dispatcher.Dispatch(new EventLogAction.AddEvent(resolved));
                 }
@@ -166,7 +173,7 @@ public class LiveLogWatcher : ILogWatcherService
             {
                 watcher.Enabled = true;
 
-                _debugLogger.Trace($"LiveLogWatcher started watching {LogName}.");
+                _debugLogger.Trace($"{nameof(LiveLogWatcherService)} started watching {LogName}.");
             });
         }
     }
@@ -185,12 +192,24 @@ public class LiveLogWatcher : ILogWatcherService
             _watchers.Remove(LogName);
             Task.Run(() =>
             {
-                oldWatcher.Enabled = false;
                 oldWatcher.Dispose();
-                _debugLogger.Trace($"LiveLogWatcher disposed the old watcher for log {LogName}.");
+                _debugLogger.Trace($"{nameof(LiveLogWatcherService)} disposed the old watcher for log {LogName}.");
             });
 
-            _debugLogger.Trace($"LiveLogWatcher dispatched a task to stop the watcher for log {LogName}.");
+            _debugLogger.Trace($"{nameof(LiveLogWatcherService)} dispatched a task to stop the watcher for log {LogName}.");
+
+            if (_watchers.Count < 1)
+            {
+                _debugLogger.Trace($"{nameof(LiveLogWatcherService)} That was the last watcher, so we are letting go of the IEventResolver instance.");
+
+                if (_resolver is IDisposable disposableResolver)
+                {
+                    disposableResolver.Dispose();
+                    _debugLogger.Trace($"{nameof(LiveLogWatcherService)} The IEventResolver was disposable, so we have disposed it.");
+                }
+
+                _resolver = null;
+            }
         }
     }
 }


### PR DESCRIPTION
We are thread-safe, but DbContext isn't. So we need to limit concurrent access to the DbContexts inside
EventProviderDatabaseEventResolver. For max concurrency, provide a brand new EventProviderDatabaseEventResolver per thread, so each thread has its own set of DbContexts.

A nice side effect is that it should now be possible to go to Tools -> Options immediately upon launch and import new databases that overwrite old ones. Previously, they were always locked. With the new approach, DbContexts are not instantiated until we're about to use them.