### PR TITLE
Move filtering and sorting into the Store

### DIFF
--- a/src/EventLogExpert/Components/EventTable.razor
+++ b/src/EventLogExpert/Components/EventTable.razor
@@ -13,7 +13,7 @@
                 <th class="level">Level</th>
                 <th class="time">
                     Date and Time
-                    <span class="button-toggle" data-rotate="@IsDateTimeDescending" @onclick="ToggleDateTime">
+                    <span class="button-toggle" data-rotate="@EventLogState.Value.SortDescending.ToString().ToLower()" @onclick="ToggleDateTime">
                         <i class="bi bi-caret-up"></i>
                     </span>
                 </th>
@@ -26,7 +26,7 @@
             </tr>
         </thead>
         <tbody>
-            <Virtualize Items="GetFilteredEvents(null)" Context="evt">
+            <Virtualize Items="EventLogState.Value.CombinedEvents" Context="evt">
                 <tr class="@GetCss(evt)" @key="evt.RecordId" @onfocus="() => SelectEvent(evt)" tabindex="0">
                     <td>
                         <span class="@GetLevelClass(evt.Level)"></span>
@@ -45,9 +45,9 @@
     </table>
 </div>
 
-@if (EventLogState.Value.ActiveLogs.Count > 1)
+@if (ActiveLogState.Value.Count > 1)
 {
-    @foreach (var log in EventLogState.Value.ActiveLogs)
+    @foreach (var log in ActiveLogState.Value)
     {
         <div class="table-container" hidden="@(_activeLog != log.Key)">
             <table>
@@ -56,7 +56,7 @@
                         <th class="level">Level</th>
                         <th class="time">
                             Date and Time
-                            <span class="button-toggle" data-rotate="@IsDateTimeDescending" @onclick="ToggleDateTime">
+                            <span class="button-toggle" data-rotate="@EventLogState.Value.SortDescending.ToString().ToLower()" @onclick="ToggleDateTime">
                                 <i class="bi bi-caret-up"></i>
                             </span>
                         </th>
@@ -69,7 +69,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <Virtualize Items="GetFilteredEvents(log.Key)" Context="evt">
+                    <Virtualize Items="log.Value.FilteredEvents" Context="evt">
                         <tr class="@GetCss(evt)" @key="evt.RecordId" @onfocus="() => SelectEvent(evt)" tabindex="0">
                             <td>
                                 <span class="@GetLevelClass(evt.Level)"></span>

--- a/src/EventLogExpert/Components/EventTable.razor.cs
+++ b/src/EventLogExpert/Components/EventTable.razor.cs
@@ -4,12 +4,10 @@
 using EventLogExpert.Library.Helpers;
 using EventLogExpert.Library.Models;
 using EventLogExpert.Store.EventLog;
-using EventLogExpert.Store.FilterPane;
 using Fluxor;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 using System.Collections.Immutable;
-using System.Linq.Dynamic.Core;
 using static EventLogExpert.Store.EventLog.EventLogState;
 
 namespace EventLogExpert.Components;
@@ -17,12 +15,12 @@ namespace EventLogExpert.Components;
 public partial class EventTable
 {
     private string? _activeLog;
-    private bool _isDateTimeDescending = true;
 
     [Inject] private IStateSelection<EventLogState, IImmutableDictionary<string, EventLogData>>
         ActiveLogState { get; set; } = null!;
 
-    private string IsDateTimeDescending => _isDateTimeDescending.ToString().ToLower();
+    [Inject]
+    private IStateSelection<EventLogState, DisplayEventModel?> SelectedEventState { get; set; } = null!;
 
     [Inject] private IJSRuntime JSRuntime { get; set; } = null!;
 
@@ -47,74 +45,13 @@ public partial class EventTable
             await JSRuntime.InvokeVoidAsync("registerTableColumnResizers");
         };
 
+        SelectedEventState.Select(s => s.SelectedEvent);
+
         base.OnInitialized();
     }
 
-    private string GetCss(DisplayEventModel @event) => EventLogState.Value.SelectedEvent?.RecordId == @event.RecordId ?
+    private string GetCss(DisplayEventModel @event) => SelectedEventState.Value?.RecordId == @event.RecordId ?
         "table-row selected" : "table-row";
-
-    private IList<DisplayEventModel> GetFilteredEvents(string? logName)
-    {
-        IQueryable<DisplayEventModel> filteredEvents = logName is null
-            ? EventLogState.Value.ActiveLogs.Values.SelectMany(l => l.Events).AsQueryable()
-            : EventLogState.Value.ActiveLogs.Values.Where(l => l.Name == logName).SelectMany(l => l.Events)
-                .AsQueryable();
-
-        int numberOfFilteredEvents = 0;
-        int initialNumberOfEvents = filteredEvents.Count();
-
-        if (FilterPaneState.Value.FilteredDateRange is not null && FilterPaneState.Value.FilteredDateRange.IsEnabled)
-        {
-            filteredEvents = filteredEvents.Where(e =>
-                e.TimeCreated >= FilterPaneState.Value.FilteredDateRange.After &&
-                e.TimeCreated <= FilterPaneState.Value.FilteredDateRange.Before);
-        }
-
-        if (FilterPaneState.Value.CurrentFilters.Any())
-        {
-            filteredEvents = filteredEvents.AsParallel()
-                .Where(e => FilterPaneState.Value.CurrentFilters
-                    .Where(filter => filter is { IsEnabled: true, IsEditing: false })
-                    .All(filter => filter.Comparison
-                        .Any(comp => comp(e))))
-                .AsQueryable();
-        }
-
-        if (!string.IsNullOrEmpty(FilterPaneState.Value.AdvancedFilter) &&
-            FilterPaneState.Value.IsAdvancedFilterEnabled)
-        {
-            filteredEvents = filteredEvents.Where(FilterPaneState.Value.AdvancedFilter);
-        }
-
-        if (!_isDateTimeDescending)
-        {
-            filteredEvents = filteredEvents.OrderBy(x => x.TimeCreated);
-        }
-        else if (EventLogState.Value.ActiveLogs.Count > 1)
-        {
-            // If more than one log is loaded we need to make sure they are orderd by date and not record id
-            filteredEvents = filteredEvents.OrderByDescending(x => x.TimeCreated);
-        }
-        else
-        {
-            // AsParallel puts events out of order so make sure we are still in order
-            filteredEvents = filteredEvents.OrderByDescending(x => x.RecordId);
-        }
-
-        var returnList = filteredEvents.ToList();
-
-        if (returnList.Count != initialNumberOfEvents)
-        {
-            numberOfFilteredEvents = returnList.Count - initialNumberOfEvents + initialNumberOfEvents;
-        }
-
-        if (_activeLog == logName && numberOfFilteredEvents != FilterPaneState.Value.NumberOfFilteredEvents)
-        {
-            Dispatcher.Dispatch(new FilterPaneAction.SetNumberOfFilteredEvents(numberOfFilteredEvents));
-        }
-
-        return returnList;
-    }
 
     private string GetLevelClass(SeverityLevel? level)
     {
@@ -133,5 +70,5 @@ public partial class EventTable
 
     private void SelectEvent(DisplayEventModel @event) => Dispatcher.Dispatch(new EventLogAction.SelectEvent(@event));
 
-    private void ToggleDateTime() => _isDateTimeDescending = !_isDateTimeDescending;
+    private void ToggleDateTime() => Dispatcher.Dispatch(new EventLogAction.SetSortDescending(!EventLogState.Value.SortDescending));
 }

--- a/src/EventLogExpert/Components/SplitLogTabPane.razor.cs
+++ b/src/EventLogExpert/Components/SplitLogTabPane.razor.cs
@@ -30,13 +30,6 @@ public partial class SplitLogTabPane
         base.OnInitialized();
     }
 
-    private static IEnumerable<EventLogData> GetLogsTabSorted(Dictionary<string, EventLogData> activeLogs)
-    {
-        return activeLogs.Values
-            .OrderBy(l => l.Events.FirstOrDefault()?.ComputerName)
-            .ThenBy(l => l.Events.FirstOrDefault()?.LogName);
-    }
-
     private static string GetTabName(EventLogData log)
     {
         var firstEvent = log.Events.FirstOrDefault();
@@ -61,5 +54,6 @@ public partial class SplitLogTabPane
     {
         ActiveLog = activeLog;
         await ActiveLogChanged.InvokeAsync(ActiveLog);
+        Dispatcher.Dispatch(new EventLogAction.SelectLog(activeLog));
     }
 }

--- a/src/EventLogExpert/Components/StatusBar.razor
+++ b/src/EventLogExpert/Components/StatusBar.razor
@@ -5,16 +5,25 @@
 @inject IState<StatusBarState> StatusBarState
 
 <div class="status-bar">
-    @foreach (var loadingProgress in EventLogState.Value.EventsLoading)
+    @{
+        var eventLogState = EventLogState.Value;
+        var isAnyFilterApplied = 
+            eventLogState.AppliedFilter.AdvancedFilter != null ||
+            eventLogState.AppliedFilter.DateFilter != null ||
+            eventLogState.AppliedFilter.Filters != null;
+    }
+
+    @foreach (var loadingProgress in eventLogState.EventsLoading)
     {
         <span>Loading: @loadingProgress.Value</span>
     }
     
-    <span>Events Loaded: @EventLogState.Value.ActiveLogs.Values.Sum(log => log.Events.Count)</span>
-    
-    @if (FilterPaneState.Value.CurrentFilters.Any())
+    <span>Events Loaded: @eventLogState.ActiveLogs.Values.Sum(log => log.Events.Count)</span>
+    @if (isAnyFilterApplied)
     {
-        <span>Filtered Events: @FilterPaneState.Value.NumberOfFilteredEvents</span>
+        var totalEvents = eventLogState.SelectedLogName == null ? eventLogState.ActiveLogs.Values.Sum(l => l.Events.Count) : eventLogState.ActiveLogs[eventLogState.SelectedLogName].Events.Count;
+        var filteredEvents = eventLogState.SelectedLogName == null ? eventLogState.CombinedEvents.Count : eventLogState.ActiveLogs[eventLogState.SelectedLogName].FilteredEvents.Count;
+        <span>Visible: @(filteredEvents) Hidden by filter: @(totalEvents - filteredEvents)</span>
     }
 
     @if (EventLogState.Value.ActiveLogs.Values.Any(l => l.Type == EventLogExpert.Store.EventLog.EventLogState.LogType.Live))
@@ -25,8 +34,8 @@
         }
         else
         {
-            <span>New Events: @EventLogState.Value.NewEventBuffer.Count</span>
-            @if (EventLogState.Value.NewEventBufferIsFull)
+                <span>New Events: @eventLogState.NewEventBuffer.Count</span>
+                    @if (eventLogState.NewEventBufferIsFull)
             {
                 <span>Buffer Full</span>
             }

--- a/src/EventLogExpert/Store/EventLog/EventLogAction.cs
+++ b/src/EventLogExpert/Store/EventLog/EventLogAction.cs
@@ -30,6 +30,12 @@ public record EventLogAction
 
     public record SelectEvent(DisplayEventModel? SelectedEvent) : EventLogAction;
 
+    /// <summary>
+    /// This action only has meaning for the UI.
+    /// </summary>
+    /// <param name="LogName"></param>
+    public record SelectLog(string? LogName) : EventLogAction;
+
     public record SetContinouslyUpdate(bool ContinuouslyUpdate) : EventLogAction;
 
     /// <summary>
@@ -41,4 +47,8 @@ public record EventLogAction
     /// </param>
     /// <param name="Count"></param>
     public record SetEventsLoading(Guid ActivityId, int Count) : EventLogAction;
+
+    public record SetFilters(EventFilter EventFilter) : EventLogAction;
+
+    public record SetSortDescending(bool SortDescending) : EventLogAction;
 }

--- a/src/EventLogExpert/Store/EventLog/EventLogEffects.cs
+++ b/src/EventLogExpert/Store/EventLog/EventLogEffects.cs
@@ -18,7 +18,6 @@ public class EventLogEffects
     private readonly ITraceLogger _debugLogger;
     private readonly ILogWatcherService _logWatcherService;
     private readonly IServiceProvider _serviceProvider;
-    private bool disposedValue;
 
     public EventLogEffects(IServiceProvider serviceProvider, ITraceLogger debugLogger, ILogWatcherService logWatcherService)
     {
@@ -93,8 +92,6 @@ public class EventLogEffects
                         dispatcher.Dispatch(new EventLogAction.SetEventsLoading(activityId, events.Count));
                     }
                 }
-
-                events.Reverse();
 
                 dispatcher.Dispatch(new EventLogAction.LoadEvents(
                     action.LogName,

--- a/src/EventLogExpert/Store/EventLog/EventLogState.cs
+++ b/src/EventLogExpert/Store/EventLog/EventLogState.cs
@@ -13,12 +13,15 @@ public record EventLogState
 {
     public record EventBuffer(ReadOnlyCollection<DisplayEventModel> Events, bool IsBufferFull);
 
+    public record EventFilter(string? AdvancedFilter, FilterDateModel? DateFilter, IEnumerable<FilterModel>? Filters);
+
     public enum LogType { Live, File }
 
     public record EventLogData(
         string Name,
         LogType Type,
         ReadOnlyCollection<DisplayEventModel> Events,
+        ReadOnlyCollection<DisplayEventModel> FilteredEvents,
         ImmutableHashSet<int> EventIds,
         ImmutableHashSet<string> EventProviderNames,
         ImmutableHashSet<string> TaskNames,
@@ -27,7 +30,11 @@ public record EventLogState
 
     public ImmutableDictionary<string, EventLogData> ActiveLogs { get; init; } = ImmutableDictionary<string, EventLogData>.Empty;
 
+    public EventFilter AppliedFilter { get; init; } = new(null, null, null);
+
     public bool ContinuouslyUpdate { get; init; } = false;
+
+    public ReadOnlyCollection<DisplayEventModel> CombinedEvents { get; init; } = new List<DisplayEventModel>().AsReadOnly();
 
     public ImmutableDictionary<Guid, int> EventsLoading { get; set; } = ImmutableDictionary<Guid, int>.Empty;
 
@@ -36,4 +43,8 @@ public record EventLogState
     public bool NewEventBufferIsFull { get; set; }
 
     public DisplayEventModel? SelectedEvent { get; init; }
+
+    public string? SelectedLogName { get; init; } = null;
+
+    public bool SortDescending { get; init; } = true;
 }

--- a/src/EventLogExpert/Store/FilterPane/FilterPaneReducers.cs
+++ b/src/EventLogExpert/Store/FilterPane/FilterPaneReducers.cs
@@ -97,11 +97,6 @@ public class FilterPaneReducers
         ReduceSetFilterDateRange(FilterPaneState state, FilterPaneAction.SetFilterDateRange action) =>
         state with { FilteredDateRange = action.FilterDateModel };
 
-    [ReducerMethod]
-    public static FilterPaneState ReduceSetNumberOfFilteredEvents(FilterPaneState state,
-        FilterPaneAction.SetNumberOfFilteredEvents action) =>
-        state with { NumberOfFilteredEvents = action.NumberOfFilteredEvents };
-
     [ReducerMethod(typeof(FilterPaneAction.ToggleAdvancedFilter))]
     public static FilterPaneState ReduceToggleAdvancedFilter(FilterPaneState state) =>
         state with { IsAdvancedFilterEnabled = !state.IsAdvancedFilterEnabled };

--- a/src/EventLogExpert/Store/FilterPane/FilterPaneState.cs
+++ b/src/EventLogExpert/Store/FilterPane/FilterPaneState.cs
@@ -18,6 +18,4 @@ public record FilterPaneState
     public string AdvancedFilter { get; init; } = string.Empty;
 
     public bool IsAdvancedFilterEnabled { get; set; } = true;
-
-    public int NumberOfFilteredEvents { get; set; }
 }


### PR DESCRIPTION
We were paying a performance penalty for trying to keep the Store slim and letting the view do the sorting and filtering. Nearly any state update, such as selecting an event, was causing the view to re-filter and re-sort all the events, which became slow with large event logs loaded.

With this change, all that work is done inside the reducers and is exposed as part of the EventLogState. The reducers are able to make better decisions on whether any large collections need to be modified.