### PR TITLE
Always provide a ParserConfig when using Dynamic LINQ

### DIFF
--- a/src/EventLogExpert/Components/FilterPane.razor.cs
+++ b/src/EventLogExpert/Components/FilterPane.razor.cs
@@ -8,6 +8,7 @@ using EventLogExpert.Store.Settings;
 using Fluxor;
 using Microsoft.AspNetCore.Components;
 using System.Linq.Dynamic.Core;
+using System.Linq.Dynamic.Core.CustomTypeProviders;
 
 namespace EventLogExpert.Components;
 
@@ -169,7 +170,7 @@ public partial class FilterPane
 
         try
         {
-            var result = testQueryable.AsQueryable().Where(expression).ToList();
+            var result = testQueryable.AsQueryable().Where(EventLogExpertCustomTypeProvider.ParsingConfig, expression).ToList();
             return true;
         }
         catch (Exception ex)

--- a/src/EventLogExpert/EventLogExpertCustomTypeProvider.cs
+++ b/src/EventLogExpert/EventLogExpertCustomTypeProvider.cs
@@ -1,0 +1,18 @@
+﻿// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Library.Models;
+using System.Linq.Dynamic.Core;
+using System.Linq.Dynamic.Core.CustomTypeProviders;
+
+namespace EventLogExpert;
+
+public class EventLogExpertCustomTypeProvider : DefaultDynamicLinqCustomTypeProvider
+{
+    public override HashSet<Type> GetCustomTypes() => new[] { typeof(DisplayEventModel) }.ToHashSet();
+
+    public static ParsingConfig ParsingConfig => new ParsingConfig
+    {
+        CustomTypeProvider = new EventLogExpertCustomTypeProvider()
+    };
+}

--- a/src/EventLogExpert/Store/EventLog/EventLogReducers.cs
+++ b/src/EventLogExpert/Store/EventLog/EventLogReducers.cs
@@ -404,7 +404,7 @@ public class EventLogReducers
 
         if (!string.IsNullOrEmpty(eventFilter.AdvancedFilter))
         {
-            filteredEvents = filteredEvents.Where(eventFilter.AdvancedFilter);
+            filteredEvents = filteredEvents.Where(EventLogExpertCustomTypeProvider.ParsingConfig, eventFilter.AdvancedFilter);
         }
 
         return filteredEvents;


### PR DESCRIPTION
If we don't provider a ParserConfig, Dynamic LINQ uses a default which performs an exhaustive search of binaries using reflection trying to find custom types. This is not only slow but actually breaks the application if it happens early enough in the lifecycle.

Providing a ParserConfig avoids all that.

Fixes #190.