### PR TITLE
Enable adding log to view via drag and drop

### DIFF
--- a/src/EventLogExpert/MainPage.xaml
+++ b/src/EventLogExpert/MainPage.xaml
@@ -40,7 +40,7 @@
         </MenuBarItem>
     </ContentPage.MenuBarItems>
 
-    <BlazorWebView HostPage="wwwroot/index.html">
+    <BlazorWebView HostPage="wwwroot/index.html" x:Name="WebView">
         <BlazorWebView.RootComponents>
             <RootComponent Selector="#app" ComponentType="{x:Type local:Main}" />
         </BlazorWebView.RootComponents>


### PR DESCRIPTION
Dragging an evtx file from explorer onto the EventLogExpert window now has the same behavior as choosing Add Another Log To This View.

Fixes #83.