### PR TITLE
Only re-filter if the filters actually changed

### DIFF
--- a/src/EventLogExpert/Store/LoggingMiddleware.cs
+++ b/src/EventLogExpert/Store/LoggingMiddleware.cs
@@ -21,38 +21,33 @@ public class LoggingMiddleware : Middleware
 
     public override void BeforeDispatch(object action)
     {
-        if (action is EventLogAction.LoadEvents loadEventsAction)
+        switch (action)
         {
-            // We don't want to serialize all the events.
-            _debugLogger.Trace($"Action: EventLogAction.LoadEvents with {loadEventsAction.Events.Count} events.");
-        }
-        else if (action is EventLogAction.AddEvent addEventsAction)
-        {
-            _debugLogger.Trace($"Action: EventLogAction.AddEvent with {addEventsAction.NewEvent.Source} event ID {addEventsAction.NewEvent.Id}.");
-        }
-        else if (action is FilterPaneAction.SetFilter)
-        {
-            _debugLogger.Trace("Action: EventLogAction.SetFilter.");
-        }
-        else if (action is FilterPaneAction.RemoveFilter)
-        {
-            // We can't serialize a Func.
-            _debugLogger.Trace("Action: EventLogAction.FilterEventsAction.");
-        }
-        else if (action is EventLogAction.SelectEvent selectEventAction)
-        {
-            _debugLogger.Trace($"Action: EventLogAction.SelectEvent selected {selectEventAction?.SelectedEvent?.Source} event ID {selectEventAction?.SelectedEvent?.Id}.");
-        }
-        else
-        {
-            try
-            {
-                _debugLogger.Trace($"Action: {action.GetType()} {JsonSerializer.Serialize(action, _serializerOptions)}");
-            }
-            catch
-            {
-                _debugLogger.Trace($"Action: {action.GetType()}. Could not serialize payload.");
-            }
+            case EventLogAction.LoadEvents loadEventsAction:
+                _debugLogger.Trace($"Action: {action.GetType()} with {loadEventsAction.Events.Count} events.");
+                break;
+            case EventLogAction.AddEvent addEventsAction:
+                _debugLogger.Trace($"Action: {action.GetType()} with {addEventsAction.NewEvent.Source} event ID {addEventsAction.NewEvent.Id}.");
+                break;
+            case FilterPaneAction.SetFilter setFilterAction:
+            case EventLogAction.SetFilters setFiltersAction:
+            case FilterPaneAction.RemoveFilter removeFilterAction:
+                _debugLogger.Trace($"Action: {action.GetType()}.");
+                break;
+            case EventLogAction.SelectEvent selectEventAction:
+                _debugLogger.Trace($"Action: {nameof(EventLogAction.SelectEvent)} selected {selectEventAction?.SelectedEvent?.Source} event ID {selectEventAction?.SelectedEvent?.Id}.");
+                break;
+            default:
+                try
+                {
+                    _debugLogger.Trace($"Action: {action.GetType()} {JsonSerializer.Serialize(action, _serializerOptions)}");
+                }
+                catch
+                {
+                    _debugLogger.Trace($"Action: {action.GetType()}. Could not serialize payload.");
+                }
+
+                break;
         }
     }
 


### PR DESCRIPTION
Currently, every time you click Add Filter, or enable/disable a filter, or start editing or stop editing a filter, all of these state changes to the dropdown-style filters cause the EventLogState reducer to re-filter the logs. This makes the filter UI rather slow when several large logs are open.

This PR implements a FilterModel equality comparison inside the EventLogState reducer. This is not the greatest place for this to live. I would rather have equality be the concern of the FilterModel itself. However, FilterModel has things that we don't care about for the purpose of filtering - for example, whether the filter is currently being edited.

If an enabled filter is currently being edited, EventLogState should not care - we should still filter on it. But that would definitely make it not equal from FilterModel's point of view. EventLogState's equality concerns are different.

In the long run this probably means we need a different class for modeling filters inside of EventLogState, so this PR may just be a short-term solution.