### PR TITLE
Reduce unncessary re-filtering

### DIFF
--- a/src/EventLogExpert/Components/FilterPane.razor.cs
+++ b/src/EventLogExpert/Components/FilterPane.razor.cs
@@ -7,8 +7,8 @@ using EventLogExpert.Store.FilterPane;
 using EventLogExpert.Store.Settings;
 using Fluxor;
 using Microsoft.AspNetCore.Components;
+using System.Collections.Immutable;
 using System.Linq.Dynamic.Core;
-using System.Linq.Dynamic.Core.CustomTypeProviders;
 
 namespace EventLogExpert.Components;
 
@@ -193,9 +193,9 @@ public partial class FilterPane
     {
         return new EventLogState.EventFilter
         (
-            filterPaneState.IsAdvancedFilterEnabled ? filterPaneState.AdvancedFilter : null,
+            filterPaneState.IsAdvancedFilterEnabled ? filterPaneState.AdvancedFilter : "",
             filterPaneState.FilteredDateRange?.IsEnabled ?? false ? filterPaneState.FilteredDateRange : null,
-            filterPaneState.CurrentFilters.Any(f => f.IsEnabled) ? filterPaneState.CurrentFilters.Where(f => f.IsEnabled) : null
+            filterPaneState.CurrentFilters.Where(f => f.IsEnabled && f.Comparison.Any()).Select(f => f.Comparison.ToImmutableList()).ToImmutableList()
         );
     }
 }

--- a/src/EventLogExpert/Components/StatusBar.razor
+++ b/src/EventLogExpert/Components/StatusBar.razor
@@ -8,9 +8,9 @@
     @{
         var eventLogState = EventLogState.Value;
         var isAnyFilterApplied = 
-            eventLogState.AppliedFilter.AdvancedFilter != null ||
+            eventLogState.AppliedFilter.AdvancedFilter != "" ||
             eventLogState.AppliedFilter.DateFilter != null ||
-            eventLogState.AppliedFilter.Filters != null;
+            eventLogState.AppliedFilter.Filters.Any();
     }
 
     @foreach (var loadingProgress in eventLogState.EventsLoading)

--- a/src/EventLogExpert/Store/EventLog/EventLogState.cs
+++ b/src/EventLogExpert/Store/EventLog/EventLogState.cs
@@ -13,7 +13,7 @@ public record EventLogState
 {
     public record EventBuffer(ReadOnlyCollection<DisplayEventModel> Events, bool IsBufferFull);
 
-    public record EventFilter(string? AdvancedFilter, FilterDateModel? DateFilter, IEnumerable<FilterModel>? Filters);
+    public record EventFilter(string AdvancedFilter, FilterDateModel? DateFilter, ImmutableList<ImmutableList<Func<DisplayEventModel, bool>>> Filters);
 
     public enum LogType { Live, File }
 
@@ -30,7 +30,7 @@ public record EventLogState
 
     public ImmutableDictionary<string, EventLogData> ActiveLogs { get; init; } = ImmutableDictionary<string, EventLogData>.Empty;
 
-    public EventFilter AppliedFilter { get; init; } = new(null, null, null);
+    public EventFilter AppliedFilter { get; init; } = new("", null, ImmutableList<ImmutableList<Func<DisplayEventModel, bool>>>.Empty);
 
     public bool ContinuouslyUpdate { get; init; } = false;
 

--- a/src/EventLogExpert/Store/LoggingMiddleware.cs
+++ b/src/EventLogExpert/Store/LoggingMiddleware.cs
@@ -21,38 +21,33 @@ public class LoggingMiddleware : Middleware
 
     public override void BeforeDispatch(object action)
     {
-        if (action is EventLogAction.LoadEvents loadEventsAction)
+        switch (action)
         {
-            // We don't want to serialize all the events.
-            _debugLogger.Trace($"Action: EventLogAction.LoadEvents with {loadEventsAction.Events.Count} events.");
-        }
-        else if (action is EventLogAction.AddEvent addEventsAction)
-        {
-            _debugLogger.Trace($"Action: EventLogAction.AddEvent with {addEventsAction.NewEvent.Source} event ID {addEventsAction.NewEvent.Id}.");
-        }
-        else if (action is FilterPaneAction.SetFilter)
-        {
-            _debugLogger.Trace("Action: EventLogAction.SetFilter.");
-        }
-        else if (action is FilterPaneAction.RemoveFilter)
-        {
-            // We can't serialize a Func.
-            _debugLogger.Trace("Action: EventLogAction.FilterEventsAction.");
-        }
-        else if (action is EventLogAction.SelectEvent selectEventAction)
-        {
-            _debugLogger.Trace($"Action: EventLogAction.SelectEvent selected {selectEventAction?.SelectedEvent?.Source} event ID {selectEventAction?.SelectedEvent?.Id}.");
-        }
-        else
-        {
-            try
-            {
-                _debugLogger.Trace($"Action: {action.GetType()} {JsonSerializer.Serialize(action, _serializerOptions)}");
-            }
-            catch
-            {
-                _debugLogger.Trace($"Action: {action.GetType()}. Could not serialize payload.");
-            }
+            case EventLogAction.LoadEvents loadEventsAction:
+                _debugLogger.Trace($"Action: {action.GetType()} with {loadEventsAction.Events.Count} events.");
+                break;
+            case EventLogAction.AddEvent addEventsAction:
+                _debugLogger.Trace($"Action: {action.GetType()} with {addEventsAction.NewEvent.Source} event ID {addEventsAction.NewEvent.Id}.");
+                break;
+            case FilterPaneAction.SetFilter setFilterAction:
+            case EventLogAction.SetFilters setFiltersAction:
+            case FilterPaneAction.RemoveFilter removeFilterAction:
+                _debugLogger.Trace($"Action: {action.GetType()}.");
+                break;
+            case EventLogAction.SelectEvent selectEventAction:
+                _debugLogger.Trace($"Action: {nameof(EventLogAction.SelectEvent)} selected {selectEventAction?.SelectedEvent?.Source} event ID {selectEventAction?.SelectedEvent?.Id}.");
+                break;
+            default:
+                try
+                {
+                    _debugLogger.Trace($"Action: {action.GetType()} {JsonSerializer.Serialize(action, _serializerOptions)}");
+                }
+                catch
+                {
+                    _debugLogger.Trace($"Action: {action.GetType()}. Could not serialize payload.");
+                }
+
+                break;
         }
     }
 


### PR DESCRIPTION
Right now, clicking Add to add a new filter, or Edit to edit an existing filter, or Remove to remove a filter that was never saved, all these actions cause a re-filtering of the logs, because we fire EventLogAction.SetFilters on every state change.

I couldn't come up with a good way for the FilterPane itself to determine whether its own filters changed, so instead, the SetFilters reducer in EventLogState does equality checking. This approach of reference-checking the List<Func<>> solves the unnecessary re-filtering when:

* Add is clicked
* Remove is clicked for a filter that is already non-functional (like one that was just added)
* Edit is clicked

However, we still re-filter when Edit is clicked followed by Save, without actually changing the filter, because this produces a new Func reference. Solving that will require more work.

We no longer store FilterModel in EventLogState, because those objects are mutable, which broke equality checking between old state and new state (FilterPane would simply mutate the object we had already stored in the EventLogState).