### PR TITLE
Fixed a few minor issues

### DIFF
--- a/src/EventLogExpert/Components/DetailsPane.razor
+++ b/src/EventLogExpert/Components/DetailsPane.razor
@@ -19,6 +19,10 @@
     {
         <div class="details-group" data-toggle="@_isXmlVisible.ToString().ToLower()">
             <div class="d-flex flex-row">
+                @if (EventLogState.Value.ActiveLogs.Count > 1)
+                {
+                    <div>Log Name: @Event.LogName</div>
+                }
                 <div>Source: @Event.Source</div>
                 <div>Event Id: @Event.Id</div>
                 <div>Level: @Event.Level</div>

--- a/src/EventLogExpert/Components/EventTable.razor
+++ b/src/EventLogExpert/Components/EventTable.razor
@@ -37,7 +37,7 @@
                         @evt.Level
                     </td>
                     <td>@evt.TimeCreated.ConvertTimeZone(SettingsState.Value.Config.TimeZoneInfo)</td>
-                    <td hidden="@(!SettingsState.Value.ShowLogName)">@evt.OwningLog</td>
+                    <td hidden="@(!SettingsState.Value.ShowLogName)">@evt.OwningLog.Split("\\").Last()</td>
                     <td hidden="@(!SettingsState.Value.ShowComputerName)">@evt.ComputerName</td>
                     <td>@evt.Source</td>
                     <td>@evt.Id</td>

--- a/src/EventLogExpert/Components/EventTable.razor.css
+++ b/src/EventLogExpert/Components/EventTable.razor.css
@@ -20,6 +20,7 @@ th {
     top: 0;
     background-color: var(--background-darkgray);
     cursor: default;
+    user-select: none;
 
     & > span {
         position: absolute;

--- a/src/EventLogExpert/Components/SplitLogTabPane.razor.cs
+++ b/src/EventLogExpert/Components/SplitLogTabPane.razor.cs
@@ -36,19 +36,15 @@ public partial class SplitLogTabPane
     private static string GetTabName(EventLogData log)
     {
         var firstEvent = log.Events.FirstOrDefault();
-        if (firstEvent != null)
-        {
-            return firstEvent.ComputerName + " - " + firstEvent.LogName;
-        }
-        else
-        {
-            return Path.GetFileNameWithoutExtension(log.Name);
-        }
+
+        return firstEvent is not null ?
+            $"{firstEvent.LogName} - {firstEvent.ComputerName}" :
+            Path.GetFileNameWithoutExtension(log.Name);
     }
 
     private static string GetTabTooltip(EventLogData log)
     {
-        return $"{(log.Type == LogType.File ? $"Log File: " : "Live Log: ")} {log.Name}\n" +
+        return $"{(log.Type == LogType.File ? "Log File: " : "Live Log: ")} {log.Name}\n" +
             $"Log Name: {log.Events.FirstOrDefault()?.LogName ?? ""}\n" +
             $"Computer Name: {log.Events.FirstOrDefault()?.ComputerName ?? ""}";
     }

--- a/src/EventLogExpert/MainPage.xaml
+++ b/src/EventLogExpert/MainPage.xaml
@@ -24,6 +24,7 @@
                 </MenuFlyoutSubItem>
             </MenuFlyoutSubItem>
             <MenuFlyoutItem Text="Close All Open Logs" x:Name="CloseAllOpenLogs" Clicked="CloseAll_Clicked" />
+            <MenuFlyoutItem Text="Exit" Clicked="Exit_Clicked" />
         </MenuBarItem>
         <MenuBarItem Text="View">
             <MenuFlyoutItem Text="Load New Events" Clicked="LoadNewEvents_Clicked" />

--- a/src/EventLogExpert/MainPage.xaml.cs
+++ b/src/EventLogExpert/MainPage.xaml.cs
@@ -171,6 +171,8 @@ public partial class MainPage : ContentPage
         }
     }
 
+    private void Exit_Clicked(object sender, EventArgs e) => Application.Current?.CloseWindow(Application.Current.MainPage!.Window);
+
     private void LoadNewEvents_Clicked(object sender, EventArgs e)
     {
         _fluxorDispatcher.Dispatch(new EventLogAction.LoadNewEvents(_traceLogger));

--- a/src/EventLogExpert/Shared/Components/Filters/SubFilterRow.razor
+++ b/src/EventLogExpert/Shared/Components/Filters/SubFilterRow.razor
@@ -3,18 +3,18 @@
 <div class="flex-center-aligned-row px-4">
     <div class="flex-align-center">
         <span>Join On: </span>
-        <ValueSelect CssClass="input filter-dropdown" T="FilterType" @bind-Value="Value.FilterType">
+        <ValueSelect CssClass="input filter-dropdown" T="FilterType" @bind-Value="Value.FilterType" ToStringFunc="x => x.ToFullString()">
             @foreach (FilterType item in Enum.GetValues(typeof(FilterType)))
             {
-                <ValueSelectItem T="FilterType" Value="item">@item.ToFullString()</ValueSelectItem>
+                <ValueSelectItem T="FilterType" Value="item" />
             }
         </ValueSelect>
 
         <span>Comparison: </span>
-        <ValueSelect CssClass="input filter-dropdown" T="FilterComparison" @bind-Value="Value.FilterComparison">
+        <ValueSelect CssClass="input filter-dropdown" T="FilterComparison" @bind-Value="Value.FilterComparison" ToStringFunc="x => x.ToFullString()">
             @foreach (FilterComparison item in Enum.GetValues(typeof(FilterComparison)))
             {
-                <ValueSelectItem T="FilterComparison" Value="item">@item.ToFullString()</ValueSelectItem>
+                <ValueSelectItem T="FilterComparison" Value="item" />
             }
         </ValueSelect>
 

--- a/src/EventLogExpert/Shared/Components/SettingsModal.razor
+++ b/src/EventLogExpert/Shared/Components/SettingsModal.razor
@@ -29,7 +29,7 @@
             <div class="flex-column-scroll">
                 @if (_databases.Any())
                 {
-                    @foreach (var database in _databases)
+                    @foreach (var database in _databases.OrderBy(x => x.Key))
                     {
                         <div class="flex-space-between">
                             <span>@database.Key</span>

--- a/src/EventLogExpert/Shared/Components/SettingsModal.razor.cs
+++ b/src/EventLogExpert/Shared/Components/SettingsModal.razor.cs
@@ -17,7 +17,7 @@ namespace EventLogExpert.Shared.Components;
 public partial class SettingsModal
 {
     private Dictionary<string, bool> _databases = new();
-    private bool _hasDatabasesChanged;
+    private bool _hasDatabasesChanged = false;
     private SettingsModel _request = new();
 
     [Inject] private IAlertDialogService AlertDialogService { get; set; } = null!;
@@ -157,13 +157,13 @@ public partial class SettingsModal
         {
             Dispatcher.Dispatch(new SettingsAction.Save(_request));
             Dispatcher.Dispatch(new SettingsAction.LoadDatabases());
+            
+            await ReloadOpenLogs();
         }
         else
         {
             Dispatcher.Dispatch(new SettingsAction.Save(_request));
         }
-
-        await ReloadOpenLogs();
 
         Close();
     }


### PR DESCRIPTION
Switched Log Name and Computer Name in tab pane
- Long FQDN made it look like a bunch of computer name tabs
Added log name to detail pane when more than 1 log is loaded
Removed folder path from LogName column
Fixed an issue that was triggering log reload whenever settings were saved, even if databases were not changed
Added an Exit option to File menu since Close button can get hidden with multiple logs open and long file paths