### PR TITLE
Show hex representation for any byte[] values

### DIFF
--- a/src/EventLogExpert.Eventing/EventResolvers/EventResolverBase.cs
+++ b/src/EventLogExpert.Eventing/EventResolvers/EventResolverBase.cs
@@ -80,7 +80,14 @@ public class EventResolverBase
 
                     if (!valueFormatted)
                     {
-                        sb.Append(propValue);
+                        if (propValue is byte[] bytes)
+                        {
+                            sb.Append(Convert.ToHexString(bytes));
+                        }
+                        else
+                        {
+                            sb.Append(propValue);
+                        }
                     }
 
                     lastIndex = matches[i].Index + matches[i].Length;

--- a/src/EventLogExpert.Eventing/Models/DisplayEventModel.cs
+++ b/src/EventLogExpert.Eventing/Models/DisplayEventModel.cs
@@ -68,12 +68,9 @@ public record DisplayEventModel(
                             break;
                         }
 
-                        if (propertyNames[i] == "__binLength" && propertyNames[i + 1] == "BinaryData" && Properties[i].Value is byte[] val)
+                        if (Properties[i].Value is byte[] val)
                         {
-                            // Handle event 7036 from Service Control Manager binary data
-                            templateBuilder.Append($"    <Data Name=\"{propertyNames[i]}\">{val.Length}</Data>\r\n");
-                            templateBuilder.Append($"    <Data Name=\"{propertyNames[i + 1]}\">{Convert.ToHexString(val)}</Data>\r\n");
-                            i++;
+                            templateBuilder.Append($"    <Data Name=\"{propertyNames[i]}\">{Convert.ToHexString(val)}</Data>\r\n");
                         }
                         else
                         {


### PR DESCRIPTION
Previously we were very selective about what byte[] values to convert to hex string. All others would show up as "byte[]" in both the description and the XML. With this change, we always convert byte[] to a hex string.

Fixes #230