### PR TITLE
Revert to Moq 4.18 due to privacy issue

### DIFF
--- a/src/EventLogExpert.Test/EventLogExpert.Test.csproj
+++ b/src/EventLogExpert.Test/EventLogExpert.Test.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.6.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Moq 4.20 exfiltrates developer email addresses. See: https://github.com/devlooped/moq/issues/1372. This change reverts us to 4.18, which did not include this behavior.

Todo: Move to NSubstitute in a future PR.