### PR TITLE
Allow loading logs with overlapping RecordId values

### DIFF
--- a/src/EventLogExpert/Components/EventTable.razor
+++ b/src/EventLogExpert/Components/EventTable.razor
@@ -92,7 +92,7 @@
         </thead>
         <tbody @oncontextmenu="InvokeContextMenu">
             <Virtualize Items="EventLogState.Value.CombinedEvents" Context="evt">
-                <tr class="@GetCss(evt)" @key="evt.RecordId" @onfocus="() => SelectEvent(evt)" tabindex="0">
+                <tr class="@GetCss(evt)" @onfocus="() => SelectEvent(evt)" tabindex="0">
                     <td hidden="@(IsColumnHidden(ColumnName.Level))">
                         <span class="@GetLevelClass(evt.Level)"></span>
                         @evt.Level
@@ -198,7 +198,7 @@
                 </thead>
                 <tbody @oncontextmenu="InvokeContextMenu">
                     <Virtualize Items="log.Value.FilteredEvents" Context="evt">
-                        <tr class="@GetCss(evt)" @key="evt.RecordId" @onfocus="() => SelectEvent(evt)" tabindex="0">
+                        <tr class="@GetCss(evt)" @onfocus="() => SelectEvent(evt)" tabindex="0">
                             <td hidden="@(IsColumnHidden(ColumnName.Level))">
                                 <span class="@GetLevelClass(evt.Level)"></span>
                                 @evt.Level


### PR DESCRIPTION
The `@key` attribute on the context menu created a situation where logs with the same RecordId values cannot be loaded simultaneously. This causes #252.

This PR fixes the problem by removing `@key` from the context menus. It's not clear if this is needed for anything, but in some quick testing it seems to work fine.

If this approach fails we will need to look at assigning all loaded events some sort of unique ID that we can use as a key.