### PR TITLE
Moved copy shortcut handler back to event table

### DIFF
--- a/src/EventLogExpert/Components/EventTable.razor
+++ b/src/EventLogExpert/Components/EventTable.razor
@@ -6,7 +6,7 @@
 @foreach (var table in EventTableState.Value.EventTables)
 {
     <div class="table-container" hidden="@(!EventTableState.Value.ActiveTableId?.Equals(table.Id))">
-        <table id="@table.Id">
+        <table id="@table.Id" @onkeyup="HandleKeyUp">
             <thead @oncontextmenu="InvokeTableColumnMenu">
             <tr>
                 <th class="level" hidden="@(IsColumnHidden(ColumnName.Level))">

--- a/src/EventLogExpert/Components/EventTable.razor.cs
+++ b/src/EventLogExpert/Components/EventTable.razor.cs
@@ -3,6 +3,7 @@
 
 using EventLogExpert.Eventing.Helpers;
 using EventLogExpert.Eventing.Models;
+using EventLogExpert.Services;
 using EventLogExpert.UI;
 using EventLogExpert.UI.Store.EventLog;
 using EventLogExpert.UI.Store.EventTable;
@@ -18,6 +19,8 @@ namespace EventLogExpert.Components;
 
 public sealed partial class EventTable
 {
+    [Inject] private IClipboardService ClipboardService { get; init; } = null!;
+
     [Inject] private IDispatcher Dispatcher { get; init; } = null!;
 
     [Inject] private IState<EventTableState> EventTableState { get; init; } = null!;
@@ -60,6 +63,17 @@ public sealed partial class EventTable
         }
 
         return string.Empty;
+    }
+
+    private void HandleKeyUp(KeyboardEventArgs args)
+    {
+        // https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values
+        switch (args)
+        {
+            case { CtrlKey: true, Code: "KeyC" } :
+                ClipboardService.CopySelectedEvent();
+                break;
+        }
     }
 
     private async Task InvokeContextMenu(MouseEventArgs args) =>

--- a/src/EventLogExpert/Shared/MainLayout.razor.cs
+++ b/src/EventLogExpert/Shared/MainLayout.razor.cs
@@ -1,7 +1,6 @@
 ﻿// // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
-using EventLogExpert.Services;
 using EventLogExpert.UI.Services;
 using EventLogExpert.UI.Store.FilterPane;
 using EventLogExpert.UI.Store.Settings;
@@ -15,8 +14,6 @@ namespace EventLogExpert.Shared;
 public sealed partial class MainLayout
 {
     [Inject] private IAppTitleService AppTitleService { get; init; } = null!;
-
-    [Inject] private IClipboardService ClipboardService { get; init; } = null!;
 
     [Inject] private ICurrentVersionProvider CurrentVersionProvider { get; init; } = null!;
 
@@ -46,10 +43,6 @@ public sealed partial class MainLayout
         // https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values
         switch (args)
         {
-            case { CtrlKey: true, Code: "KeyC" } :
-                ClipboardService.CopySelectedEvent();
-                break;
-
             case { CtrlKey: true, Code: "KeyH" } :
                 Dispatcher.Dispatch(new FilterPaneAction.ToggleIsEnabled());
                 break;


### PR DESCRIPTION
Moved this back to the event table so it doesn't copy the selected event when trying to copy something from the details pane.

Resolves #296 