### PR TITLE
Load XML from EventLogReader

### DIFF
--- a/src/EventLogExpert.Eventing/EventResolvers/EventProviderDatabaseEventResolver.cs
+++ b/src/EventLogExpert.Eventing/EventResolvers/EventProviderDatabaseEventResolver.cs
@@ -213,7 +213,8 @@ public class EventProviderDatabaseEventResolver : EventResolverBase, IEventResol
                 eventRecord.ThreadId,
                 eventRecord.LogName,
                 null,
-                OwningLogName);
+                OwningLogName,
+                eventRecord);
         }
 
         if (lastResult.Description == null)

--- a/src/EventLogExpert.Eventing/EventResolvers/EventProviderDatabaseEventResolver.cs
+++ b/src/EventLogExpert.Eventing/EventResolvers/EventProviderDatabaseEventResolver.cs
@@ -205,21 +205,18 @@ public class EventProviderDatabaseEventResolver : EventResolverBase, IEventResol
                 eventRecord.ProviderName,
                 "",
                 "Description not found. No provider available.",
-                eventProperties,
                 eventRecord.Qualifiers,
-                eventRecord.Keywords,
                 GetKeywordsFromBitmask(eventRecord.Keywords, null),
                 eventRecord.ProcessId,
                 eventRecord.ThreadId,
                 eventRecord.LogName,
-                null,
                 OwningLogName,
                 eventRecord);
         }
 
         if (lastResult.Description == null)
         {
-            lastResult = lastResult with { Description = "" };
+            lastResult.Description = "";
         }
 
         return lastResult;

--- a/src/EventLogExpert.Eventing/EventResolvers/EventReaderEventResolver.cs
+++ b/src/EventLogExpert.Eventing/EventResolvers/EventReaderEventResolver.cs
@@ -44,14 +44,11 @@ public class EventReaderEventResolver : IEventResolver
             eventRecord.ProviderName,
             eventRecord.Task is 0 or null ? "None" : TryGetValue(() => eventRecord.TaskDisplayName),
             string.IsNullOrEmpty(desc) ? string.Empty : desc,
-            eventRecord.Properties,
             eventRecord.Qualifiers,
-            eventRecord.Keywords,
             keywordsDisplayNames,
             eventRecord.ProcessId,
             eventRecord.ThreadId,
             eventRecord.LogName,
-            null,
             OwningLogName,
             eventRecord);
     }

--- a/src/EventLogExpert.Eventing/EventResolvers/EventReaderEventResolver.cs
+++ b/src/EventLogExpert.Eventing/EventResolvers/EventReaderEventResolver.cs
@@ -52,7 +52,8 @@ public class EventReaderEventResolver : IEventResolver
             eventRecord.ThreadId,
             eventRecord.LogName,
             null,
-            OwningLogName);
+            OwningLogName,
+            eventRecord);
     }
 
     private static T TryGetValue<T>(Func<T> func)

--- a/src/EventLogExpert.Eventing/EventResolvers/EventResolverBase.cs
+++ b/src/EventLogExpert.Eventing/EventResolvers/EventResolverBase.cs
@@ -295,14 +295,11 @@ public partial class EventResolverBase
             eventRecord.ProviderName,
             taskName?.TrimEnd('\0') ?? string.Empty,
             description?.TrimEnd('\0') ?? "Unable to format description",
-            eventProperties,
             eventRecord.Qualifiers,
-            eventRecord.Keywords,
             GetKeywordsFromBitmask(eventRecord.Keywords, providerDetails),
             eventRecord.ProcessId,
             eventRecord.ThreadId,
             eventRecord.LogName!,
-            template,
             owningLogName,
             eventRecord);
     }

--- a/src/EventLogExpert.Eventing/EventResolvers/EventResolverBase.cs
+++ b/src/EventLogExpert.Eventing/EventResolvers/EventResolverBase.cs
@@ -303,7 +303,8 @@ public partial class EventResolverBase
             eventRecord.ThreadId,
             eventRecord.LogName!,
             template,
-            owningLogName);
+            owningLogName,
+            eventRecord);
     }
 
     [GeneratedRegex("%+[0-9]+")]

--- a/src/EventLogExpert.Eventing/EventResolvers/LocalProviderEventResolver.cs
+++ b/src/EventLogExpert.Eventing/EventResolvers/LocalProviderEventResolver.cs
@@ -51,14 +51,11 @@ public class LocalProviderEventResolver : EventResolverBase, IEventResolver
                 eventRecord.ProviderName,
                 "",
                 "Description not found. No provider available.",
-                eventRecord.Properties,
                 eventRecord.Qualifiers,
-                eventRecord.Keywords,
                 GetKeywordsFromBitmask(eventRecord.Keywords, null),
                 eventRecord.ProcessId,
                 eventRecord.ThreadId,
                 eventRecord.LogName,
-                null,
                 OwningLogName,
                 eventRecord);
         }
@@ -71,7 +68,7 @@ public class LocalProviderEventResolver : EventResolverBase, IEventResolver
 
         if (result.Description == null)
         {
-            result = result with { Description = "" };
+            result.Description = "";
         }
 
         return result;

--- a/src/EventLogExpert.Eventing/EventResolvers/LocalProviderEventResolver.cs
+++ b/src/EventLogExpert.Eventing/EventResolvers/LocalProviderEventResolver.cs
@@ -59,7 +59,8 @@ public class LocalProviderEventResolver : EventResolverBase, IEventResolver
                 eventRecord.ThreadId,
                 eventRecord.LogName,
                 null,
-                OwningLogName);
+                OwningLogName,
+                eventRecord);
         }
 
         // The Properties getter is expensive, so we only call the getter once,

--- a/src/EventLogExpert.Eventing/Models/DisplayEventModel.cs
+++ b/src/EventLogExpert.Eventing/Models/DisplayEventModel.cs
@@ -92,7 +92,6 @@ public sealed class DisplayEventModel
                         _cachedXml = unformattedXml;
                     }
 
-                    _eventRecord.Dispose();
                     _eventRecord = null;
                 }
 

--- a/src/EventLogExpert.Eventing/Models/DisplayEventModel.cs
+++ b/src/EventLogExpert.Eventing/Models/DisplayEventModel.cs
@@ -5,50 +5,110 @@ using System.Diagnostics.Eventing.Reader;
 
 namespace EventLogExpert.Eventing.Models;
 
-public sealed record DisplayEventModel(
-    long? RecordId,
-    Guid? ActivityId,
-    DateTime TimeCreated,
-    int Id,
-    string ComputerName,
-    string Level,
-    string Source,
-    string TaskCategory,
-    string Description,
-    IList<EventProperty> Properties,
-    int? Qualifiers,
-    long? Keywords,
-    IEnumerable<string> KeywordsDisplayNames,
-    int? ProcessId,
-    int? ThreadId,
-    string LogName, // This is the log name from the event reader
-    string? Template,
-    string OwningLog, // This is the name of the log file or the live log, which we use internally
-    EventRecord EventRecord)
+public sealed class DisplayEventModel
 {
-    public EventRecord EventRecord { private get; init; } = EventRecord;
+    public Guid? ActivityId { get; }
+    public string ComputerName { get; }
+    public string Description { get; }
+    public int Id { get; }
+    public long? Keywords { get; }
+    public IEnumerable<string> KeywordsDisplayNames { get; }
+    public string Level { get; }
+    public string LogName { get; }
+    public string OwningLog { get; }
+    public int? ProcessId { get; }
+    public IList<EventProperty> Properties { get; }
+    public int? Qualifiers { get; }
+    public long? RecordId { get; }
+    public string Source { get; }
+    public string TaskCategory { get; }
+    public string? Template { get; }
+    public int? ThreadId { get; }
+    public DateTime TimeCreated { get; }
+
+    public DisplayEventModel(
+    long? recordId,
+    Guid? activityId,
+    DateTime timeCreated,
+    int id,
+    string computerName,
+    string level,
+    string source,
+    string taskCategory,
+    string description,
+    IList<EventProperty> properties,
+    int? qualifiers,
+    long? keywords,
+    IEnumerable<string> keywordsDisplayNames,
+    int? processId,
+    int? threadId,
+    string logName, // This is the log name from the event reader
+    string? template,
+    string owningLog, // This is the name of the log file or the live log, which we use internally
+    EventRecord eventRecord)
+    {
+        // Public immutable properties
+        ActivityId = activityId;
+        ComputerName = computerName;
+        Description = description;
+        Id = id;
+        Keywords = keywords;
+        KeywordsDisplayNames = keywordsDisplayNames;
+        Level = level;
+        LogName = logName;
+        OwningLog = owningLog;
+        ProcessId = processId;
+        Properties = properties;
+        Qualifiers = qualifiers;
+        RecordId = recordId;
+        Source = source;
+        TaskCategory = taskCategory;
+        Template = template;
+        ThreadId = threadId;
+        TimeCreated = timeCreated;
+
+        // Private properties
+        _eventRecord = eventRecord;
+    }
 
     public string Xml
     {
         get
         {
-            if (cachedXml is not null)
+            if (_cachedXml is not null)
             {
-                return cachedXml;
+                return _cachedXml;
             }
             
             lock (this)
             {
-                if (cachedXml is null)
+                if (_cachedXml is null)
                 {
-                    var unformattedXml = EventRecord.ToXml();
-                    cachedXml = System.Xml.Linq.XElement.Parse(unformattedXml).ToString();
+                    if (_eventRecord is null)
+                    {
+                        return "Unable to get XML. EventRecord is null.";
+                    }
+
+                    var unformattedXml = _eventRecord.ToXml();
+                    try
+                    {
+                        _cachedXml = System.Xml.Linq.XElement.Parse(unformattedXml).ToString();
+                    }
+                    catch
+                    {
+                        _cachedXml = unformattedXml;
+                    }
+
+                    _eventRecord.Dispose();
+                    _eventRecord = null;
                 }
 
-                return cachedXml;
+                return _cachedXml;
             }
         }
     }
 
-    private string? cachedXml = null;
+    private string? _cachedXml = null;
+
+    private EventRecord? _eventRecord;
 }

--- a/src/EventLogExpert.Eventing/Models/DisplayEventModel.cs
+++ b/src/EventLogExpert.Eventing/Models/DisplayEventModel.cs
@@ -9,20 +9,17 @@ public sealed class DisplayEventModel
 {
     public Guid? ActivityId { get; }
     public string ComputerName { get; }
-    public string Description { get; }
+    public string Description { get; set; }
     public int Id { get; }
-    public long? Keywords { get; }
     public IEnumerable<string> KeywordsDisplayNames { get; }
     public string Level { get; }
     public string LogName { get; }
     public string OwningLog { get; }
     public int? ProcessId { get; }
-    public IList<EventProperty> Properties { get; }
     public int? Qualifiers { get; }
     public long? RecordId { get; }
     public string Source { get; }
     public string TaskCategory { get; }
-    public string? Template { get; }
     public int? ThreadId { get; }
     public DateTime TimeCreated { get; }
 
@@ -36,36 +33,32 @@ public sealed class DisplayEventModel
     string source,
     string taskCategory,
     string description,
-    IList<EventProperty> properties,
     int? qualifiers,
-    long? keywords,
     IEnumerable<string> keywordsDisplayNames,
     int? processId,
     int? threadId,
     string logName, // This is the log name from the event reader
-    string? template,
     string owningLog, // This is the name of the log file or the live log, which we use internally
     EventRecord eventRecord)
     {
         // Public immutable properties
         ActivityId = activityId;
         ComputerName = computerName;
-        Description = description;
         Id = id;
-        Keywords = keywords;
         KeywordsDisplayNames = keywordsDisplayNames;
         Level = level;
         LogName = logName;
         OwningLog = owningLog;
         ProcessId = processId;
-        Properties = properties;
         Qualifiers = qualifiers;
         RecordId = recordId;
         Source = source;
         TaskCategory = taskCategory;
-        Template = template;
         ThreadId = threadId;
         TimeCreated = timeCreated;
+
+        // Public mutable properties
+        Description = description;
 
         // Private properties
         _eventRecord = eventRecord;

--- a/src/EventLogExpert.Eventing/Models/DisplayEventModel.cs
+++ b/src/EventLogExpert.Eventing/Models/DisplayEventModel.cs
@@ -2,7 +2,6 @@
 // // Licensed under the MIT License.
 
 using System.Diagnostics.Eventing.Reader;
-using System.Text;
 
 namespace EventLogExpert.Eventing.Models;
 
@@ -24,98 +23,32 @@ public sealed record DisplayEventModel(
     int? ThreadId,
     string LogName, // This is the log name from the event reader
     string? Template,
-    string OwningLog) // This is the name of the log file or the live log, which we use internally
+    string OwningLog, // This is the name of the log file or the live log, which we use internally
+    EventRecord EventRecord)
 {
+    public EventRecord EventRecord { private get; init; } = EventRecord;
+
     public string Xml
     {
         get
         {
-            StringBuilder sb = new();
+            if (cachedXml is not null)
+            {
+                return cachedXml;
+            }
+            
+            lock (this)
+            {
+                if (cachedXml is null)
+                {
+                    var unformattedXml = EventRecord.ToXml();
+                    cachedXml = System.Xml.Linq.XElement.Parse(unformattedXml).ToString();
+                }
 
-            sb.AppendLine($"""
-            <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
-                <System>
-                    <Provider Name="{Source}" />
-                    <EventID{(Qualifiers.HasValue ? $" Qualifiers=\"{Qualifiers.Value}\"" : "")}>{Id}</EventID>
-                    <Level>{Level}</Level>
-                    <Task>{TaskCategory}</Task>
-                    <Keywords>{(Keywords.HasValue ? "0x" + Keywords.Value.ToString("X") : "0x0")}</Keywords>
-                    <TimeCreated SystemTime="{TimeCreated.ToUniversalTime():o}" />
-                    <EventRecordID>{RecordId}</EventRecordID>
-                    {(ActivityId is null ? "<Correlation />" : $"<Correlation ActivityID=\"{ActivityId}\" />")}
-                    {(ProcessId is null && ThreadId is null ?
-                        "<Execution />" :
-                        $"<Execution ProcessID=\"{ProcessId}\" ThreadID=\"{ThreadId}\" />")}
-                    <Channel>{LogName}</Channel>
-                    <Computer>{ComputerName}</Computer>
-                </System>
-                <EventData>
-            """);
-
-            sb.Append(GetEventData());
-
-            sb.Append("""
-                </EventData>
-            </Event>
-            """);
-
-            return sb.ToString();
+                return cachedXml;
+            }
         }
     }
 
-    private string GetEventData()
-    {
-        StringBuilder sb = new();
-
-        if (!string.IsNullOrEmpty(Template))
-        {
-            try
-            {
-                List<string> propertyNames = [];
-                int index = -1;
-
-                while (-1 < (index = Template.IndexOf("name=", index + 1, StringComparison.Ordinal)))
-                {
-                    var nameStart = index + 6;
-                    var nameEnd = Template.IndexOf('"', nameStart);
-                    var name = Template[nameStart..nameEnd];
-                    propertyNames.Add(name);
-                }
-
-                for (var i = 0; i < Properties.Count; i++)
-                {
-                    if (i >= propertyNames.Count) { break; }
-
-                    if (Properties[i].Value is byte[] val)
-                    {
-                        sb.AppendLine($"           <Data Name=\"{propertyNames[i]}\">{Convert.ToHexString(val)}</Data>");
-                    }
-                    else
-                    {
-                        sb.AppendLine($"           <Data Name=\"{propertyNames[i]}\">{Properties[i].Value}</Data>");
-                    }
-                }
-
-                return sb.ToString();
-            }
-            catch
-            {
-                // No tracer available here
-            }
-        }
-
-        foreach (var p in Properties)
-        {
-            if (p.Value is byte[] bytes)
-            {
-                sb.AppendLine($"            <Data>{Convert.ToHexString(bytes)}</Data>");
-            }
-            else
-            {
-                sb.AppendLine($"            <Data>{p.Value}</Data>");
-            }
-        }
-
-        return sb.ToString();
-    }
+    private string? cachedXml = null;
 }

--- a/src/EventLogExpert.UI/Store/EventLog/EventLogAction.cs
+++ b/src/EventLogExpert.UI/Store/EventLog/EventLogAction.cs
@@ -46,5 +46,7 @@ public sealed record EventLogAction
     /// <param name="Count"></param>
     public sealed record SetEventsLoading(Guid ActivityId, int Count);
 
+    public sealed record SetXmlLoading(Guid ActivityId, int Count);
+
     public sealed record SetFilters(EventFilter EventFilter);
 }

--- a/src/EventLogExpert.UI/Store/EventLog/EventLogEffects.cs
+++ b/src/EventLogExpert.UI/Store/EventLog/EventLogEffects.cs
@@ -188,6 +188,22 @@ public sealed class EventLogEffects(
                     {
                         logWatcherService.AddLog(action.LogName, lastEvent?.Bookmark);
                     }
+
+                    sw.Restart();
+                    for (int i = 0; i < events.Count; i++)
+                    {
+                        if (sw.ElapsedMilliseconds > 1000)
+                        {
+                            sw.Restart();
+                            dispatcher.Dispatch(new EventLogAction.SetXmlLoading(activityId, i));
+                        }
+
+                        _ = events[i].Xml;
+                    }
+
+                    dispatcher.Dispatch(new EventLogAction.SetXmlLoading(activityId, 0));
+
+                    dispatcher.Dispatch(new StatusBarAction.SetResolverStatus($""));
                 }
                 finally
                 {

--- a/src/EventLogExpert.UI/Store/EventLog/EventLogReducers.cs
+++ b/src/EventLogExpert.UI/Store/EventLog/EventLogReducers.cs
@@ -4,6 +4,7 @@
 using EventLogExpert.Eventing.Models;
 using EventLogExpert.UI.Models;
 using Fluxor;
+using System;
 using System.Collections.Immutable;
 
 namespace EventLogExpert.UI.Store.EventLog;
@@ -95,19 +96,7 @@ public sealed class EventLogReducers
     [ReducerMethod]
     public static EventLogState ReduceSetEventsLoading(EventLogState state, EventLogAction.SetEventsLoading action)
     {
-        var newEventsLoading = state.EventsLoading;
-
-        if (newEventsLoading.ContainsKey(action.ActivityId))
-        {
-            newEventsLoading = newEventsLoading.Remove(action.ActivityId);
-        }
-
-        if (action.Count == 0)
-        {
-            return state with { EventsLoading = newEventsLoading };
-        }
-
-        return state with { EventsLoading = newEventsLoading.Add(action.ActivityId, action.Count) };
+        return state with { EventsLoading = CommonLoadingReducer(state.EventsLoading, action.ActivityId, action.Count) };
     }
 
     [ReducerMethod]
@@ -119,6 +108,27 @@ public sealed class EventLogReducers
         }
 
         return state with { AppliedFilter = action.EventFilter };
+    }
+
+    [ReducerMethod]
+    public static EventLogState ReduceSetXmlLoading(EventLogState state, EventLogAction.SetXmlLoading action)
+    {
+        return state with { XmlLoading = CommonLoadingReducer(state.XmlLoading, action.ActivityId, action.Count) };
+    }
+
+    private static ImmutableDictionary<Guid, int> CommonLoadingReducer(ImmutableDictionary<Guid, int> loadingEntries, Guid activityId, int count)
+    {
+        if (loadingEntries.ContainsKey(activityId))
+        {
+            loadingEntries = loadingEntries.Remove(activityId);
+        }
+
+        if (count == 0)
+        {
+            return loadingEntries;
+        }
+
+        return loadingEntries.Add(activityId, count);
     }
 
     private static EventLogData GetEmptyLogData(string logName, LogType logType) => new(

--- a/src/EventLogExpert.UI/Store/EventLog/EventLogState.cs
+++ b/src/EventLogExpert.UI/Store/EventLog/EventLogState.cs
@@ -30,4 +30,6 @@ public sealed record EventLogState
     public bool NewEventBufferIsFull { get; init; }
 
     public DisplayEventModel? SelectedEvent { get; init; }
+
+    public ImmutableDictionary<Guid, int> XmlLoading { get; init; } = ImmutableDictionary<Guid, int>.Empty;
 }

--- a/src/EventLogExpert.UI/Store/EventLog/LiveLogWatcherService.cs
+++ b/src/EventLogExpert.UI/Store/EventLog/LiveLogWatcherService.cs
@@ -166,6 +166,7 @@ public sealed class LiveLogWatcherService : ILogWatcherService
                     }
 
                     var resolved = _resolver.Resolve(eventArgs.EventRecord, logName);
+                    _ = resolved.Xml; // Immediately cache the ToXml() result.
                     _dispatcher.Dispatch(new EventLogAction.AddEvent(resolved));
                 }
             };

--- a/src/EventLogExpert/Components/StatusBar.razor
+++ b/src/EventLogExpert/Components/StatusBar.razor
@@ -16,6 +16,11 @@
         <span>Loading: @loadingProgress.Value</span>
     }
 
+    @foreach (var xmlProgress in EventLogState.Value.XmlLoading)
+    {
+        <span>Populating XML: @xmlProgress.Value</span>
+    }
+
     <span>Events Loaded: @EventLogState.Value.ActiveLogs.Values.Sum(log => log.Events.Count)</span>
 
     @if (EventTableState.Value.ActiveTableId is not null && FilterMethods.IsFilteringEnabled(EventLogState.Value.AppliedFilter))


### PR DESCRIPTION
With this change, we load the XML from the EventLogReader by calling ToXml() on the EventRecord, rather than generating our own XML from the Properties collection.

Pros:

* Full-fidelity XML instead of the partial XML we had before.

Cons:

* Loading the XML this way takes time. We do this in the background after the initial load, and the status is reflected in the status bar. Note the user can navigate to events and see XML immediately (we resolve it when they click on the event) even when this job is in progress.
* Storing these big XML strings take memory. With a set of 4 logs that caused EventLogExpert to use about 7 GB of memory before this change, we now use about 10.5 GB of memory for the same logs.