### PR TITLE
Fixed race condition with EventLogState when loading multiple logs

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -142,7 +142,7 @@ csharp_new_line_before_catch = true
 csharp_new_line_before_else = true
 csharp_new_line_before_finally = true
 csharp_new_line_before_members_in_anonymous_types = true
-csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_object_initializers = false
 csharp_new_line_before_open_brace = all
 csharp_new_line_between_query_expression_clauses = true
 
@@ -202,26 +202,26 @@ dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
 
 dotnet_naming_symbols.interface.applicable_kinds = interface
 dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.interface.required_modifiers = 
+dotnet_naming_symbols.interface.required_modifiers =
 
 dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
 dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.types.required_modifiers = 
+dotnet_naming_symbols.types.required_modifiers =
 
 dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
 dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.non_field_members.required_modifiers = 
+dotnet_naming_symbols.non_field_members.required_modifiers =
 
 # Naming styles
 
-dotnet_naming_style.pascal_case.required_prefix = 
-dotnet_naming_style.pascal_case.required_suffix = 
-dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.required_prefix =
+dotnet_naming_style.pascal_case.required_suffix =
+dotnet_naming_style.pascal_case.word_separator =
 dotnet_naming_style.pascal_case.capitalization = pascal_case
 
 dotnet_naming_style.begins_with_i.required_prefix = I
-dotnet_naming_style.begins_with_i.required_suffix = 
-dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.required_suffix =
+dotnet_naming_style.begins_with_i.word_separator =
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
 
 [*.{cs,vb}]
@@ -241,3 +241,4 @@ dotnet_style_namespace_match_folder = true:suggestion
 
 [*.cs]
 file_header_template = // Copyright (c) Microsoft Corporation.\n// Licensed under the MIT License.
+csharp_style_prefer_primary_constructors = true:suggestion

--- a/src/EventLogExpert.UI/Models/FilterModel.cs
+++ b/src/EventLogExpert.UI/Models/FilterModel.cs
@@ -17,8 +17,10 @@ public sealed record FilterModel
     [JsonIgnore]
     public FilterData Data { get; set; } = new();
 
+    [JsonIgnore]
     public List<FilterModel> SubFilters { get; set; } = [];
 
+    [JsonIgnore]
     public bool ShouldCompareAny { get; set; }
 
     [JsonIgnore]

--- a/src/EventLogExpert.UI/Store/EventLog/EventLogAction.cs
+++ b/src/EventLogExpert.UI/Store/EventLog/EventLogAction.cs
@@ -32,21 +32,11 @@ public sealed record EventLogAction
 
     public sealed record LoadNewEvents;
 
-    public sealed record OpenLog(string LogName, LogType LogType);
+    public sealed record OpenLog(string LogName, LogType LogType, CancellationToken Token = default);
 
     public sealed record SelectEvent(DisplayEventModel? SelectedEvent);
 
     public sealed record SetContinouslyUpdate(bool ContinuouslyUpdate);
-
-    /// <summary>Used to indicate the progress of event logs being loaded.</summary>
-    /// <param name="ActivityId">
-    ///     A unique id that distinguishes this loading activity from others, since log names such as
-    ///     Application will be common and many file names will be the same.
-    /// </param>
-    /// <param name="Count"></param>
-    public sealed record SetEventsLoading(Guid ActivityId, int Count);
-
-    public sealed record SetXmlLoading(Guid ActivityId, int Count);
 
     public sealed record SetFilters(EventFilter EventFilter);
 }

--- a/src/EventLogExpert.UI/Store/EventLog/EventLogReducers.cs
+++ b/src/EventLogExpert.UI/Store/EventLog/EventLogReducers.cs
@@ -4,7 +4,6 @@
 using EventLogExpert.Eventing.Models;
 using EventLogExpert.UI.Models;
 using Fluxor;
-using System;
 using System.Collections.Immutable;
 
 namespace EventLogExpert.UI.Store.EventLog;
@@ -20,13 +19,14 @@ public sealed class EventLogReducers
         state with { ActiveLogs = action.ActiveLogs };
 
     [ReducerMethod(typeof(EventLogAction.CloseAll))]
-    public static EventLogState ReduceCloseAll(EventLogState state) => state with
-    {
-        ActiveLogs = ImmutableDictionary<string, EventLogData>.Empty,
-        SelectedEvent = null,
-        NewEventBuffer = new List<DisplayEventModel>().AsReadOnly(),
-        NewEventBufferIsFull = false
-    };
+    public static EventLogState ReduceCloseAll(EventLogState state) =>
+        state with
+        {
+            ActiveLogs = ImmutableDictionary<string, EventLogData>.Empty,
+            SelectedEvent = null,
+            NewEventBuffer = new List<DisplayEventModel>().AsReadOnly(),
+            NewEventBufferIsFull = false
+        };
 
     [ReducerMethod]
     public static EventLogState ReduceCloseLog(EventLogState state, EventLogAction.CloseLog action)
@@ -69,16 +69,16 @@ public sealed class EventLogReducers
                     action.AllActivityIds.ToImmutableHashSet(),
                     action.AllProviderNames.ToImmutableHashSet(),
                     action.AllTaskNames.ToImmutableHashSet(),
-                    action.AllKeywords.ToImmutableHashSet()
-                ))
+                    action.AllKeywords.ToImmutableHashSet()))
         };
     }
 
     [ReducerMethod]
-    public static EventLogState ReduceOpenLog(EventLogState state, EventLogAction.OpenLog action) => state with
-    {
-        ActiveLogs = state.ActiveLogs.Add(action.LogName, GetEmptyLogData(action.LogName, action.LogType))
-    };
+    public static EventLogState ReduceOpenLog(EventLogState state, EventLogAction.OpenLog action) =>
+        state with
+        {
+            ActiveLogs = state.ActiveLogs.Add(action.LogName, GetEmptyLogData(action.LogName, action.LogType))
+        };
 
     [ReducerMethod]
     public static EventLogState ReduceSelectEvent(EventLogState state, EventLogAction.SelectEvent action)
@@ -91,13 +91,8 @@ public sealed class EventLogReducers
     [ReducerMethod]
     public static EventLogState ReduceSetContinouslyUpdate(
         EventLogState state,
-        EventLogAction.SetContinouslyUpdate action) => state with { ContinuouslyUpdate = action.ContinuouslyUpdate };
-
-    [ReducerMethod]
-    public static EventLogState ReduceSetEventsLoading(EventLogState state, EventLogAction.SetEventsLoading action)
-    {
-        return state with { EventsLoading = CommonLoadingReducer(state.EventsLoading, action.ActivityId, action.Count) };
-    }
+        EventLogAction.SetContinouslyUpdate action) =>
+        state with { ContinuouslyUpdate = action.ContinuouslyUpdate };
 
     [ReducerMethod]
     public static EventLogState ReduceSetFilters(EventLogState state, EventLogAction.SetFilters action)
@@ -110,34 +105,6 @@ public sealed class EventLogReducers
         return state with { AppliedFilter = action.EventFilter };
     }
 
-    [ReducerMethod]
-    public static EventLogState ReduceSetXmlLoading(EventLogState state, EventLogAction.SetXmlLoading action)
-    {
-        return state with { XmlLoading = CommonLoadingReducer(state.XmlLoading, action.ActivityId, action.Count) };
-    }
-
-    private static ImmutableDictionary<Guid, int> CommonLoadingReducer(ImmutableDictionary<Guid, int> loadingEntries, Guid activityId, int count)
-    {
-        if (loadingEntries.ContainsKey(activityId))
-        {
-            loadingEntries = loadingEntries.Remove(activityId);
-        }
-
-        if (count == 0)
-        {
-            return loadingEntries;
-        }
-
-        return loadingEntries.Add(activityId, count);
-    }
-
-    private static EventLogData GetEmptyLogData(string logName, LogType logType) => new(
-        logName,
-        logType,
-        new List<DisplayEventModel>().AsReadOnly(),
-        ImmutableHashSet<int>.Empty,
-        ImmutableHashSet<Guid?>.Empty,
-        ImmutableHashSet<string>.Empty,
-        ImmutableHashSet<string>.Empty,
-        ImmutableHashSet<string>.Empty);
+    private static EventLogData GetEmptyLogData(string logName, LogType logType) =>
+        new(logName, logType, new List<DisplayEventModel>().AsReadOnly(), [], [], [], [], []);
 }

--- a/src/EventLogExpert.UI/Store/EventLog/EventLogState.cs
+++ b/src/EventLogExpert.UI/Store/EventLog/EventLogState.cs
@@ -22,14 +22,10 @@ public sealed record EventLogState
 
     public bool ContinuouslyUpdate { get; init; } = false;
 
-    public ImmutableDictionary<Guid, int> EventsLoading { get; init; } = ImmutableDictionary<Guid, int>.Empty;
-
     public ReadOnlyCollection<DisplayEventModel> NewEventBuffer { get; init; } =
         new List<DisplayEventModel>().AsReadOnly();
 
     public bool NewEventBufferIsFull { get; init; }
 
     public DisplayEventModel? SelectedEvent { get; init; }
-
-    public ImmutableDictionary<Guid, int> XmlLoading { get; init; } = ImmutableDictionary<Guid, int>.Empty;
 }

--- a/src/EventLogExpert.UI/Store/LoggingMiddleware.cs
+++ b/src/EventLogExpert.UI/Store/LoggingMiddleware.cs
@@ -5,6 +5,7 @@ using EventLogExpert.UI.Store.FilterCache;
 using EventLogExpert.UI.Store.FilterColor;
 using EventLogExpert.UI.Store.FilterGroup;
 using EventLogExpert.UI.Store.FilterPane;
+using EventLogExpert.UI.Store.StatusBar;
 using Fluxor;
 using System.Text.Json;
 using IDispatcher = Fluxor.IDispatcher;
@@ -87,8 +88,9 @@ public sealed class LoggingMiddleware(ITraceLogger debugLogger) : Middleware
             case EventLogAction.CloseLog :
             case EventLogAction.LoadNewEvents :
             case EventLogAction.SetContinouslyUpdate :
-            case EventLogAction.SetEventsLoading :
             case EventLogAction.SetFilters :
+            case StatusBarAction.SetEventsLoading :
+            case StatusBarAction.SetXmlLoading :
                 debugLogger.Trace($"Action: {action.GetType()}.");
                 break;
             case EventLogAction.SelectEvent selectEventAction :

--- a/src/EventLogExpert.UI/Store/StatusBar/StatusBarAction.cs
+++ b/src/EventLogExpert.UI/Store/StatusBar/StatusBarAction.cs
@@ -3,7 +3,19 @@
 
 namespace EventLogExpert.UI.Store.StatusBar;
 
-public record StatusBarAction
+public sealed record StatusBarAction
 {
-    public record SetResolverStatus(string ResolverStatus);
+    public sealed record CloseAll;
+
+    /// <summary>Used to indicate the progress of event logs being loaded.</summary>
+    /// <param name="ActivityId">
+    ///     A unique id that distinguishes this loading activity from others, since log names such as
+    ///     Application will be common and many file names will be the same.
+    /// </param>
+    /// <param name="Count"></param>
+    public sealed record SetEventsLoading(Guid ActivityId, int Count);
+
+    public sealed record SetResolverStatus(string ResolverStatus);
+
+    public sealed record SetXmlLoading(Guid ActivityId, int Count);
 }

--- a/src/EventLogExpert.UI/Store/StatusBar/StatusBarReducers.cs
+++ b/src/EventLogExpert.UI/Store/StatusBar/StatusBarReducers.cs
@@ -2,12 +2,45 @@
 // // Licensed under the MIT License.
 
 using Fluxor;
+using System.Collections.Immutable;
 
 namespace EventLogExpert.UI.Store.StatusBar;
 
-public class StatusBarReducers
+public sealed class StatusBarReducers
 {
+    [ReducerMethod(typeof(StatusBarAction.CloseAll))]
+    public static StatusBarState ReduceCloseAll(StatusBarState state) => new();
+
     [ReducerMethod]
-    public static StatusBarState ReduceSetResolverStatus(StatusBarState state, StatusBarAction.SetResolverStatus action) =>
+    public static StatusBarState ReduceSetEventsLoading(StatusBarState state, StatusBarAction.SetEventsLoading action)
+    {
+        return state with
+        {
+            EventsLoading = CommonLoadingReducer(state.EventsLoading, action.ActivityId, action.Count)
+        };
+    }
+
+    [ReducerMethod]
+    public static StatusBarState
+        ReduceSetResolverStatus(StatusBarState state, StatusBarAction.SetResolverStatus action) =>
         new() { ResolverStatus = action.ResolverStatus };
+
+    [ReducerMethod]
+    public static StatusBarState ReduceSetXmlLoading(StatusBarState state, StatusBarAction.SetXmlLoading action)
+    {
+        return state with { XmlLoading = CommonLoadingReducer(state.XmlLoading, action.ActivityId, action.Count) };
+    }
+
+    private static ImmutableDictionary<Guid, int> CommonLoadingReducer(
+        ImmutableDictionary<Guid, int> loadingEntries,
+        Guid activityId,
+        int count)
+    {
+        if (loadingEntries.ContainsKey(activityId))
+        {
+            loadingEntries = loadingEntries.Remove(activityId);
+        }
+
+        return count == 0 ? loadingEntries : loadingEntries.Add(activityId, count);
+    }
 }

--- a/src/EventLogExpert.UI/Store/StatusBar/StatusBarState.cs
+++ b/src/EventLogExpert.UI/Store/StatusBar/StatusBarState.cs
@@ -2,11 +2,16 @@
 // // Licensed under the MIT License.
 
 using Fluxor;
+using System.Collections.Immutable;
 
 namespace EventLogExpert.UI.Store.StatusBar;
 
 [FeatureState(MaximumStateChangedNotificationsPerSecond = 1)]
-public record StatusBarState
+public sealed record StatusBarState
 {
+    public ImmutableDictionary<Guid, int> EventsLoading { get; init; } = ImmutableDictionary<Guid, int>.Empty;
+
     public string ResolverStatus { get; init; } = string.Empty;
+
+    public ImmutableDictionary<Guid, int> XmlLoading { get; init; } = ImmutableDictionary<Guid, int>.Empty;
 }

--- a/src/EventLogExpert/Components/StatusBar.razor
+++ b/src/EventLogExpert/Components/StatusBar.razor
@@ -11,12 +11,12 @@
 @inject IState<StatusBarState> StatusBarState
 
 <div class="status-bar">
-    @foreach (var loadingProgress in EventLogState.Value.EventsLoading)
+    @foreach (var loadingProgress in StatusBarState.Value.EventsLoading)
     {
         <span>Loading: @loadingProgress.Value</span>
     }
 
-    @foreach (var xmlProgress in EventLogState.Value.XmlLoading)
+    @foreach (var xmlProgress in StatusBarState.Value.XmlLoading)
     {
         <span>Populating XML: @xmlProgress.Value</span>
     }


### PR DESCRIPTION
Calling CloseAll from file menu or closing application will not properly trigger the cancelation token to stop any event resolving