### PR TITLE
Refactored EventTable to reduce and speed up rendering updates

### DIFF
--- a/src/EventLogExpert.UI/Models/FilterModel.cs
+++ b/src/EventLogExpert.UI/Models/FilterModel.cs
@@ -17,8 +17,10 @@ public sealed record FilterModel
     [JsonIgnore]
     public FilterData Data { get; set; } = new();
 
+    [JsonIgnore]
     public List<FilterModel> SubFilters { get; set; } = [];
 
+    [JsonIgnore]
     public bool ShouldCompareAny { get; set; }
 
     [JsonIgnore]

--- a/src/EventLogExpert.UI/Store/EventLog/EventLogAction.cs
+++ b/src/EventLogExpert.UI/Store/EventLog/EventLogAction.cs
@@ -32,21 +32,11 @@ public sealed record EventLogAction
 
     public sealed record LoadNewEvents;
 
-    public sealed record OpenLog(string LogName, LogType LogType);
+    public sealed record OpenLog(string LogName, LogType LogType, CancellationToken Token = default);
 
     public sealed record SelectEvent(DisplayEventModel? SelectedEvent);
 
     public sealed record SetContinouslyUpdate(bool ContinuouslyUpdate);
-
-    /// <summary>Used to indicate the progress of event logs being loaded.</summary>
-    /// <param name="ActivityId">
-    ///     A unique id that distinguishes this loading activity from others, since log names such as
-    ///     Application will be common and many file names will be the same.
-    /// </param>
-    /// <param name="Count"></param>
-    public sealed record SetEventsLoading(Guid ActivityId, int Count);
-
-    public sealed record SetXmlLoading(Guid ActivityId, int Count);
 
     public sealed record SetFilters(EventFilter EventFilter);
 }

--- a/src/EventLogExpert.UI/Store/EventLog/EventLogReducers.cs
+++ b/src/EventLogExpert.UI/Store/EventLog/EventLogReducers.cs
@@ -4,7 +4,6 @@
 using EventLogExpert.Eventing.Models;
 using EventLogExpert.UI.Models;
 using Fluxor;
-using System;
 using System.Collections.Immutable;
 
 namespace EventLogExpert.UI.Store.EventLog;
@@ -20,13 +19,14 @@ public sealed class EventLogReducers
         state with { ActiveLogs = action.ActiveLogs };
 
     [ReducerMethod(typeof(EventLogAction.CloseAll))]
-    public static EventLogState ReduceCloseAll(EventLogState state) => state with
-    {
-        ActiveLogs = ImmutableDictionary<string, EventLogData>.Empty,
-        SelectedEvent = null,
-        NewEventBuffer = new List<DisplayEventModel>().AsReadOnly(),
-        NewEventBufferIsFull = false
-    };
+    public static EventLogState ReduceCloseAll(EventLogState state) =>
+        state with
+        {
+            ActiveLogs = ImmutableDictionary<string, EventLogData>.Empty,
+            SelectedEvent = null,
+            NewEventBuffer = new List<DisplayEventModel>().AsReadOnly(),
+            NewEventBufferIsFull = false
+        };
 
     [ReducerMethod]
     public static EventLogState ReduceCloseLog(EventLogState state, EventLogAction.CloseLog action)
@@ -69,16 +69,16 @@ public sealed class EventLogReducers
                     action.AllActivityIds.ToImmutableHashSet(),
                     action.AllProviderNames.ToImmutableHashSet(),
                     action.AllTaskNames.ToImmutableHashSet(),
-                    action.AllKeywords.ToImmutableHashSet()
-                ))
+                    action.AllKeywords.ToImmutableHashSet()))
         };
     }
 
     [ReducerMethod]
-    public static EventLogState ReduceOpenLog(EventLogState state, EventLogAction.OpenLog action) => state with
-    {
-        ActiveLogs = state.ActiveLogs.Add(action.LogName, GetEmptyLogData(action.LogName, action.LogType))
-    };
+    public static EventLogState ReduceOpenLog(EventLogState state, EventLogAction.OpenLog action) =>
+        state with
+        {
+            ActiveLogs = state.ActiveLogs.Add(action.LogName, GetEmptyLogData(action.LogName, action.LogType))
+        };
 
     [ReducerMethod]
     public static EventLogState ReduceSelectEvent(EventLogState state, EventLogAction.SelectEvent action)
@@ -91,13 +91,8 @@ public sealed class EventLogReducers
     [ReducerMethod]
     public static EventLogState ReduceSetContinouslyUpdate(
         EventLogState state,
-        EventLogAction.SetContinouslyUpdate action) => state with { ContinuouslyUpdate = action.ContinuouslyUpdate };
-
-    [ReducerMethod]
-    public static EventLogState ReduceSetEventsLoading(EventLogState state, EventLogAction.SetEventsLoading action)
-    {
-        return state with { EventsLoading = CommonLoadingReducer(state.EventsLoading, action.ActivityId, action.Count) };
-    }
+        EventLogAction.SetContinouslyUpdate action) =>
+        state with { ContinuouslyUpdate = action.ContinuouslyUpdate };
 
     [ReducerMethod]
     public static EventLogState ReduceSetFilters(EventLogState state, EventLogAction.SetFilters action)
@@ -110,34 +105,6 @@ public sealed class EventLogReducers
         return state with { AppliedFilter = action.EventFilter };
     }
 
-    [ReducerMethod]
-    public static EventLogState ReduceSetXmlLoading(EventLogState state, EventLogAction.SetXmlLoading action)
-    {
-        return state with { XmlLoading = CommonLoadingReducer(state.XmlLoading, action.ActivityId, action.Count) };
-    }
-
-    private static ImmutableDictionary<Guid, int> CommonLoadingReducer(ImmutableDictionary<Guid, int> loadingEntries, Guid activityId, int count)
-    {
-        if (loadingEntries.ContainsKey(activityId))
-        {
-            loadingEntries = loadingEntries.Remove(activityId);
-        }
-
-        if (count == 0)
-        {
-            return loadingEntries;
-        }
-
-        return loadingEntries.Add(activityId, count);
-    }
-
-    private static EventLogData GetEmptyLogData(string logName, LogType logType) => new(
-        logName,
-        logType,
-        new List<DisplayEventModel>().AsReadOnly(),
-        ImmutableHashSet<int>.Empty,
-        ImmutableHashSet<Guid?>.Empty,
-        ImmutableHashSet<string>.Empty,
-        ImmutableHashSet<string>.Empty,
-        ImmutableHashSet<string>.Empty);
+    private static EventLogData GetEmptyLogData(string logName, LogType logType) =>
+        new(logName, logType, new List<DisplayEventModel>().AsReadOnly(), [], [], [], [], []);
 }

--- a/src/EventLogExpert.UI/Store/EventLog/EventLogState.cs
+++ b/src/EventLogExpert.UI/Store/EventLog/EventLogState.cs
@@ -22,14 +22,10 @@ public sealed record EventLogState
 
     public bool ContinuouslyUpdate { get; init; } = false;
 
-    public ImmutableDictionary<Guid, int> EventsLoading { get; init; } = ImmutableDictionary<Guid, int>.Empty;
-
     public ReadOnlyCollection<DisplayEventModel> NewEventBuffer { get; init; } =
         new List<DisplayEventModel>().AsReadOnly();
 
     public bool NewEventBufferIsFull { get; init; }
 
     public DisplayEventModel? SelectedEvent { get; init; }
-
-    public ImmutableDictionary<Guid, int> XmlLoading { get; init; } = ImmutableDictionary<Guid, int>.Empty;
 }

--- a/src/EventLogExpert.UI/Store/EventTable/EventTableAction.cs
+++ b/src/EventLogExpert.UI/Store/EventTable/EventTableAction.cs
@@ -21,5 +21,7 @@ public sealed record EventTableAction
 
     public sealed record ToggleSorting;
 
+    public sealed record UpdateCombinedEvents;
+
     public sealed record UpdateDisplayedEvents(IDictionary<string, IEnumerable<DisplayEventModel>> ActiveLogs);
 }

--- a/src/EventLogExpert.UI/Store/EventTable/EventTableEffects.cs
+++ b/src/EventLogExpert.UI/Store/EventTable/EventTableEffects.cs
@@ -1,0 +1,22 @@
+﻿// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Fluxor;
+
+namespace EventLogExpert.UI.Store.EventTable;
+
+public sealed class EventTableEffects(IState<EventTableState> eventTableState)
+{
+    [EffectMethod(typeof(EventTableAction.UpdateDisplayedEvents))]
+    public Task HandleUpdateDisplayedEvents(IDispatcher dispatcher)
+    {
+        if (eventTableState.Value.EventTables.Any(table => table.IsLoading))
+        {
+            return Task.CompletedTask;
+        }
+
+        dispatcher.Dispatch(new EventTableAction.UpdateCombinedEvents());
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/EventLogExpert.UI/Store/LoggingMiddleware.cs
+++ b/src/EventLogExpert.UI/Store/LoggingMiddleware.cs
@@ -5,6 +5,7 @@ using EventLogExpert.UI.Store.FilterCache;
 using EventLogExpert.UI.Store.FilterColor;
 using EventLogExpert.UI.Store.FilterGroup;
 using EventLogExpert.UI.Store.FilterPane;
+using EventLogExpert.UI.Store.StatusBar;
 using Fluxor;
 using System.Text.Json;
 using IDispatcher = Fluxor.IDispatcher;
@@ -87,8 +88,9 @@ public sealed class LoggingMiddleware(ITraceLogger debugLogger) : Middleware
             case EventLogAction.CloseLog :
             case EventLogAction.LoadNewEvents :
             case EventLogAction.SetContinouslyUpdate :
-            case EventLogAction.SetEventsLoading :
             case EventLogAction.SetFilters :
+            case StatusBarAction.SetEventsLoading :
+            case StatusBarAction.SetXmlLoading :
                 debugLogger.Trace($"Action: {action.GetType()}.");
                 break;
             case EventLogAction.SelectEvent selectEventAction :

--- a/src/EventLogExpert.UI/Store/LoggingMiddleware.cs
+++ b/src/EventLogExpert.UI/Store/LoggingMiddleware.cs
@@ -5,7 +5,6 @@ using EventLogExpert.UI.Store.FilterCache;
 using EventLogExpert.UI.Store.FilterColor;
 using EventLogExpert.UI.Store.FilterGroup;
 using EventLogExpert.UI.Store.FilterPane;
-using EventLogExpert.UI.Store.StatusBar;
 using Fluxor;
 using System.Text.Json;
 using IDispatcher = Fluxor.IDispatcher;
@@ -29,68 +28,34 @@ public sealed class LoggingMiddleware(ITraceLogger debugLogger) : Middleware
                 debugLogger.Trace($"Action: {action.GetType()} with {addEventsAction.NewEvent.Source} event ID {addEventsAction.NewEvent.Id}.");
 
                 break;
-            case EventTableAction.AddTable :
-            case EventTableAction.CloseAll :
-            case EventTableAction.CloseLog :
-            case EventTableAction.SetActiveTable :
-            case EventTableAction.SetOrderBy :
-            case EventTableAction.ToggleLoading :
-            case EventTableAction.ToggleSorting :
+            case EventLogAction.OpenLog openLogAction :
+                debugLogger.Trace($"Action: {action.GetType()} with {openLogAction.LogName} log type {openLogAction.LogType}.");
+                break;
+            case EventLogAction.AddEventBuffered :
+            case EventLogAction.AddEventSuccess :
+            case EventLogAction.SetFilters :
             case EventTableAction.UpdateDisplayedEvents :
-            case FilterCacheAction.AddFavoriteFilter :
             case FilterCacheAction.AddFavoriteFilterCompleted :
-            case FilterCacheAction.AddRecentFilter :
             case FilterCacheAction.AddRecentFilterCompleted :
-            case FilterCacheAction.RemoveFavoriteFilter :
-            case FilterCacheAction.RemoveFavoriteFilterCompleted :
+            case FilterCacheAction.ImportFavorites :
             case FilterCacheAction.LoadFiltersCompleted :
-            case FilterColorAction.ClearAllFilters :
-            case FilterColorAction.RemoveFilter :
+            case FilterCacheAction.RemoveFavoriteFilterCompleted :
             case FilterColorAction.SetFilter :
-            case FilterGroupAction.AddFilter :
+            case FilterColorAction.SetFilters :
             case FilterGroupAction.AddGroup :
-            case FilterGroupAction.LoadGroups :
+            case FilterGroupAction.ImportGroups :
             case FilterGroupAction.LoadGroupsSuccess :
-            case FilterGroupAction.OpenMenu :
-            case FilterGroupAction.RemoveFilter :
-            case FilterGroupAction.RemoveGroup :
             case FilterGroupAction.SetFilter :
             case FilterGroupAction.SetGroup :
-            case FilterGroupAction.ToggleFilter :
-            case FilterGroupAction.ToggleGroup :
+            case FilterGroupAction.UpdateDisplayGroups :
             case FilterPaneAction.AddAdvancedFilter :
             case FilterPaneAction.AddBasicFilter :
             case FilterPaneAction.AddCachedFilter :
-            case FilterPaneAction.AddSubFilter :
             case FilterPaneAction.ApplyFilterGroup :
-            case FilterPaneAction.ClearAllFilters :
-            case FilterPaneAction.RemoveAdvancedFilter :
-            case FilterPaneAction.RemoveBasicFilter :
-            case FilterPaneAction.RemoveCachedFilter :
-            case FilterPaneAction.RemoveSubFilter :
-            case FilterPaneAction.SaveFilterGroup :
             case FilterPaneAction.SetAdvancedFilter :
             case FilterPaneAction.SetBasicFilter :
             case FilterPaneAction.SetCachedFilter :
             case FilterPaneAction.SetFilterDateRange :
-            case FilterPaneAction.ToggleAdvancedFilterEditing :
-            case FilterPaneAction.ToggleAdvancedFilterEnabled :
-            case FilterPaneAction.ToggleBasicFilterEditing :
-            case FilterPaneAction.ToggleBasicFilterEnabled :
-            case FilterPaneAction.ToggleCachedFilterEditing :
-            case FilterPaneAction.ToggleCachedFilterEnabled :
-            case FilterPaneAction.ToggleFilterDate :
-            case FilterPaneAction.ToggleIsEnabled :
-            case FilterPaneAction.ToggleIsLoading :
-            case EventLogAction.AddEventBuffered :
-            case EventLogAction.AddEventSuccess :
-            case EventLogAction.CloseAll :
-            case EventLogAction.CloseLog :
-            case EventLogAction.LoadNewEvents :
-            case EventLogAction.SetContinouslyUpdate :
-            case EventLogAction.SetFilters :
-            case StatusBarAction.SetEventsLoading :
-            case StatusBarAction.SetXmlLoading :
                 debugLogger.Trace($"Action: {action.GetType()}.");
                 break;
             case EventLogAction.SelectEvent selectEventAction :

--- a/src/EventLogExpert.UI/Store/StatusBar/StatusBarAction.cs
+++ b/src/EventLogExpert.UI/Store/StatusBar/StatusBarAction.cs
@@ -5,6 +5,8 @@ namespace EventLogExpert.UI.Store.StatusBar;
 
 public sealed record StatusBarAction
 {
+    public sealed record ClearStatus(Guid ActivityId);
+
     public sealed record CloseAll;
 
     /// <summary>Used to indicate the progress of event logs being loaded.</summary>

--- a/src/EventLogExpert.UI/Store/StatusBar/StatusBarAction.cs
+++ b/src/EventLogExpert.UI/Store/StatusBar/StatusBarAction.cs
@@ -3,7 +3,19 @@
 
 namespace EventLogExpert.UI.Store.StatusBar;
 
-public record StatusBarAction
+public sealed record StatusBarAction
 {
-    public record SetResolverStatus(string ResolverStatus);
+    public sealed record CloseAll;
+
+    /// <summary>Used to indicate the progress of event logs being loaded.</summary>
+    /// <param name="ActivityId">
+    ///     A unique id that distinguishes this loading activity from others, since log names such as
+    ///     Application will be common and many file names will be the same.
+    /// </param>
+    /// <param name="Count"></param>
+    public sealed record SetEventsLoading(Guid ActivityId, int Count);
+
+    public sealed record SetResolverStatus(string ResolverStatus);
+
+    public sealed record SetXmlLoading(Guid ActivityId, int Count);
 }

--- a/src/EventLogExpert.UI/Store/StatusBar/StatusBarReducers.cs
+++ b/src/EventLogExpert.UI/Store/StatusBar/StatusBarReducers.cs
@@ -2,12 +2,45 @@
 // // Licensed under the MIT License.
 
 using Fluxor;
+using System.Collections.Immutable;
 
 namespace EventLogExpert.UI.Store.StatusBar;
 
-public class StatusBarReducers
+public sealed class StatusBarReducers
 {
+    [ReducerMethod(typeof(StatusBarAction.CloseAll))]
+    public static StatusBarState ReduceCloseAll(StatusBarState state) => new();
+
     [ReducerMethod]
-    public static StatusBarState ReduceSetResolverStatus(StatusBarState state, StatusBarAction.SetResolverStatus action) =>
+    public static StatusBarState ReduceSetEventsLoading(StatusBarState state, StatusBarAction.SetEventsLoading action)
+    {
+        return state with
+        {
+            EventsLoading = CommonLoadingReducer(state.EventsLoading, action.ActivityId, action.Count)
+        };
+    }
+
+    [ReducerMethod]
+    public static StatusBarState
+        ReduceSetResolverStatus(StatusBarState state, StatusBarAction.SetResolverStatus action) =>
         new() { ResolverStatus = action.ResolverStatus };
+
+    [ReducerMethod]
+    public static StatusBarState ReduceSetXmlLoading(StatusBarState state, StatusBarAction.SetXmlLoading action)
+    {
+        return state with { XmlLoading = CommonLoadingReducer(state.XmlLoading, action.ActivityId, action.Count) };
+    }
+
+    private static ImmutableDictionary<Guid, int> CommonLoadingReducer(
+        ImmutableDictionary<Guid, int> loadingEntries,
+        Guid activityId,
+        int count)
+    {
+        if (loadingEntries.ContainsKey(activityId))
+        {
+            loadingEntries = loadingEntries.Remove(activityId);
+        }
+
+        return count == 0 ? loadingEntries : loadingEntries.Add(activityId, count);
+    }
 }

--- a/src/EventLogExpert.UI/Store/StatusBar/StatusBarReducers.cs
+++ b/src/EventLogExpert.UI/Store/StatusBar/StatusBarReducers.cs
@@ -8,6 +8,24 @@ namespace EventLogExpert.UI.Store.StatusBar;
 
 public sealed class StatusBarReducers
 {
+    [ReducerMethod]
+    public static StatusBarState ReduceCloseAll(StatusBarState state, StatusBarAction.ClearStatus action)
+    {
+        var updatedState = state with { };
+
+        if (state.EventsLoading.ContainsKey(action.ActivityId))
+        {
+            updatedState = updatedState with { EventsLoading = updatedState.EventsLoading.Remove(action.ActivityId) };
+        }
+
+        if (state.XmlLoading.ContainsKey(action.ActivityId))
+        {
+            updatedState = updatedState with { XmlLoading = updatedState.XmlLoading.Remove(action.ActivityId) };
+        }
+
+        return updatedState;
+    }
+
     [ReducerMethod(typeof(StatusBarAction.CloseAll))]
     public static StatusBarState ReduceCloseAll(StatusBarState state) => new();
 

--- a/src/EventLogExpert.UI/Store/StatusBar/StatusBarState.cs
+++ b/src/EventLogExpert.UI/Store/StatusBar/StatusBarState.cs
@@ -2,11 +2,16 @@
 // // Licensed under the MIT License.
 
 using Fluxor;
+using System.Collections.Immutable;
 
 namespace EventLogExpert.UI.Store.StatusBar;
 
 [FeatureState(MaximumStateChangedNotificationsPerSecond = 1)]
-public record StatusBarState
+public sealed record StatusBarState
 {
+    public ImmutableDictionary<Guid, int> EventsLoading { get; init; } = ImmutableDictionary<Guid, int>.Empty;
+
     public string ResolverStatus { get; init; } = string.Empty;
+
+    public ImmutableDictionary<Guid, int> XmlLoading { get; init; } = ImmutableDictionary<Guid, int>.Empty;
 }

--- a/src/EventLogExpert/App.xaml.cs
+++ b/src/EventLogExpert/App.xaml.cs
@@ -3,7 +3,6 @@
 
 using EventLogExpert.Eventing.EventResolvers;
 using EventLogExpert.Eventing.Helpers;
-using EventLogExpert.Eventing.Models;
 using EventLogExpert.Services;
 using EventLogExpert.UI.Models;
 using EventLogExpert.UI.Options;

--- a/src/EventLogExpert/Components/EventTable.razor
+++ b/src/EventLogExpert/Components/EventTable.razor
@@ -3,91 +3,91 @@
 
 <SplitLogTabPane />
 
-@foreach (var table in EventTableState.Value.EventTables)
-{
-    <div class="table-container" hidden="@(!EventTableState.Value.ActiveTableId?.Equals(table.Id))">
-        <table id="@table.Id" @onkeyup="HandleKeyUp">
-            <thead @oncontextmenu="InvokeTableColumnMenu">
-            <tr>
-                <th class="level" hidden="@(IsColumnHidden(ColumnName.Level))">
-                    Level
+<div class="table-container">
+    <table id="eventTable" @onkeyup="HandleKeyUp">
+        <thead @oncontextmenu="InvokeTableColumnMenu">
+        <tr>
+            <th class="level" hidden="@(IsColumnHidden(ColumnName.Level))">
+                Level
                     @if (EventTableState.Value.OrderBy == ColumnName.Level)
-                    {
+                {
                         <span class="menu-toggle" data-rotate="@EventTableState.Value.IsDescending.ToString().ToLower()" @onclick="ToggleSorting">
-                            <i class="bi bi-caret-up"></i>
-                        </span>
-                    }
-                </th>
-                <th class="time" hidden="@(IsColumnHidden(ColumnName.DateAndTime))">
-                    @GetDateColumnHeader()
+                        <i class="bi bi-caret-up"></i>
+                    </span>
+                }
+            </th>
+            <th class="time" hidden="@(IsColumnHidden(ColumnName.DateAndTime))">
+                @GetDateColumnHeader()
 
                     @if (EventTableState.Value.OrderBy == ColumnName.DateAndTime)
-                    {
+                {
                         <span class="menu-toggle" data-rotate="@EventTableState.Value.IsDescending.ToString().ToLower()" @onclick="ToggleSorting">
-                            <i class="bi bi-caret-up"></i>
-                        </span>
-                    }
-                </th>
-                <th class="activity-id" hidden="@(IsColumnHidden(ColumnName.ActivityId))">
-                    Activity ID
+                        <i class="bi bi-caret-up"></i>
+                    </span>
+                }
+            </th>
+            <th class="activity-id" hidden="@(IsColumnHidden(ColumnName.ActivityId))">
+                Activity ID
                     @if (EventTableState.Value.OrderBy == ColumnName.ActivityId)
-                    {
+                {
                         <span class="menu-toggle" data-rotate="@EventTableState.Value.IsDescending.ToString().ToLower()" @onclick="ToggleSorting">
-                            <i class="bi bi-caret-up"></i>
-                        </span>
-                    }
-                </th>
-                <th class="logname" hidden="@(IsColumnHidden(ColumnName.LogName))">
-                    Log Name
+                        <i class="bi bi-caret-up"></i>
+                    </span>
+                }
+            </th>
+            <th class="logname" hidden="@(IsColumnHidden(ColumnName.LogName))">
+                Log Name
                     @if (EventTableState.Value.OrderBy == ColumnName.LogName)
-                    {
+                {
                         <span class="menu-toggle" data-rotate="@EventTableState.Value.IsDescending.ToString().ToLower()" @onclick="ToggleSorting">
-                            <i class="bi bi-caret-up"></i>
-                        </span>
-                    }
-                </th>
-                <th class="computername" hidden="@(IsColumnHidden(ColumnName.ComputerName))">
-                    Computer
+                        <i class="bi bi-caret-up"></i>
+                    </span>
+                }
+            </th>
+            <th class="computername" hidden="@(IsColumnHidden(ColumnName.ComputerName))">
+                Computer
                     @if (EventTableState.Value.OrderBy == ColumnName.ComputerName)
-                    {
+                {
                         <span class="menu-toggle" data-rotate="@EventTableState.Value.IsDescending.ToString().ToLower()" @onclick="ToggleSorting">
-                            <i class="bi bi-caret-up"></i>
-                        </span>
-                    }
-                </th>
-                <th class="source" hidden="@(IsColumnHidden(ColumnName.Source))">
-                    Source
+                        <i class="bi bi-caret-up"></i>
+                    </span>
+                }
+            </th>
+            <th class="source" hidden="@(IsColumnHidden(ColumnName.Source))">
+                Source
                     @if (EventTableState.Value.OrderBy == ColumnName.Source)
-                    {
+                {
                         <span class="menu-toggle" data-rotate="@EventTableState.Value.IsDescending.ToString().ToLower()" @onclick="ToggleSorting">
-                            <i class="bi bi-caret-up"></i>
-                        </span>
-                    }
-                </th>
-                <th class="id" hidden="@(IsColumnHidden(ColumnName.EventId))">
-                    Event ID
+                        <i class="bi bi-caret-up"></i>
+                    </span>
+                }
+            </th>
+            <th class="id" hidden="@(IsColumnHidden(ColumnName.EventId))">
+                Event ID
                     @if (EventTableState.Value.OrderBy == ColumnName.EventId)
-                    {
+                {
                         <span class="menu-toggle" data-rotate="@EventTableState.Value.IsDescending.ToString().ToLower()" @onclick="ToggleSorting">
-                            <i class="bi bi-caret-up"></i>
-                        </span>
-                    }
-                </th>
-                <th class="task" hidden="@(IsColumnHidden(ColumnName.TaskCategory))">
-                    Task Category
+                        <i class="bi bi-caret-up"></i>
+                    </span>
+                }
+            </th>
+            <th class="task" hidden="@(IsColumnHidden(ColumnName.TaskCategory))">
+                Task Category
                     @if (EventTableState.Value.OrderBy == ColumnName.TaskCategory)
-                    {
+                {
                         <span class="menu-toggle" data-rotate="@EventTableState.Value.IsDescending.ToString().ToLower()" @onclick="ToggleSorting">
-                            <i class="bi bi-caret-up"></i>
-                        </span>
-                    }
-                </th>
-                <th class="description">Description</th>
-            </tr>
-            </thead>
-            <tbody @oncontextmenu="InvokeContextMenu">
-            <Virtualize Items="table.DisplayedEvents" Context="evt">
-                <tr @key="@($"{table.Id}_{evt.RecordId}")" class="@GetCss(evt)" @onfocus="() => SelectEvent(evt)" tabindex="0">
+                        <i class="bi bi-caret-up"></i>
+                    </span>
+                }
+            </th>
+            <th class="description">Description</th>
+        </tr>
+        </thead>
+        <tbody @oncontextmenu="InvokeContextMenu">
+        @if (EventTableState.Value.ActiveTableId is not null)
+        {
+            <Virtualize Items="EventTableState.Value.EventTables.First(x => x.Id == EventTableState.Value.ActiveTableId).DisplayedEvents" Context="evt">
+                <tr @key="@($"{evt.LogName}_{evt.RecordId}")" class="@GetCss(evt)" @onfocus="() => SelectEvent(evt)" tabindex="0">
                     <td hidden="@(IsColumnHidden(ColumnName.Level))">
                         <span class="@GetLevelClass(evt.Level)"></span>
                         @evt.Level
@@ -104,7 +104,7 @@
                     <td>@evt.Description</td>
                 </tr>
             </Virtualize>
-            </tbody>
-        </table>
-    </div>
-}
+        }
+        </tbody>
+    </table>
+</div>

--- a/src/EventLogExpert/Components/EventTable.razor
+++ b/src/EventLogExpert/Components/EventTable.razor
@@ -87,7 +87,7 @@
         @if (EventTableState.Value.ActiveTableId is not null)
         {
             <Virtualize Items="EventTableState.Value.EventTables.First(x => x.Id == EventTableState.Value.ActiveTableId).DisplayedEvents" Context="evt">
-                <tr @key="@($"{evt.LogName}_{evt.RecordId}")" class="@GetCss(evt)" @onfocus="() => SelectEvent(evt)" tabindex="0">
+                <tr @key="@($"{evt.OwningLog}_{evt.RecordId}")" class="@GetCss(evt)" @onfocus="() => SelectEvent(evt)" tabindex="0">
                     <td hidden="@(IsColumnHidden(ColumnName.Level))">
                         <span class="@GetLevelClass(evt.Level)"></span>
                         @evt.Level

--- a/src/EventLogExpert/Components/StatusBar.razor
+++ b/src/EventLogExpert/Components/StatusBar.razor
@@ -11,12 +11,12 @@
 @inject IState<StatusBarState> StatusBarState
 
 <div class="status-bar">
-    @foreach (var loadingProgress in EventLogState.Value.EventsLoading)
+    @foreach (var loadingProgress in StatusBarState.Value.EventsLoading)
     {
         <span>Loading: @loadingProgress.Value</span>
     }
 
-    @foreach (var xmlProgress in EventLogState.Value.XmlLoading)
+    @foreach (var xmlProgress in StatusBarState.Value.XmlLoading)
     {
         <span>Populating XML: @xmlProgress.Value</span>
     }

--- a/src/EventLogExpert/wwwroot/js/event_table.js
+++ b/src/EventLogExpert/wwwroot/js/event_table.js
@@ -1,5 +1,7 @@
-window.registerTableEvents = (id) => {
-    const table = document.getElementById(id);
+window.registerTableEvents = () => {
+    const table = document.getElementById("eventTable");
+
+    if (!table) { return; }
 
     deleteColumnResize(table);
     enableColumnResize(table);
@@ -86,8 +88,8 @@ window.registerKeyHandlers = (table) => {
     table.addEventListener("keydown", keyDownHandler);
 };
 
-window.scrollToRow = (id, offset) => {
-    const table = document.getElementById(id);
+window.scrollToRow = (offset) => {
+    const table = document.getElementById("eventTable");
     const row = table.getElementsByTagName("tr")[0];
 
     table.parentNode.scrollTo({


### PR DESCRIPTION
Tabs can be changed while events are loading and won't force back to combined view.

This should finally resolve the duplicate table row key thrown from the UI.

Cleaned up state middleware so only things that we don't want serialized are manually added.

Also updated CancellationTokens to interrupt event and xml resolving if CloseAll is called from the file menu or if the app is closed.