### PR TITLE
Refactored DetailsPane and increased large log performance while reducing memory usage

### DIFF
--- a/src/EventLogExpert.Eventing/EventResolvers/EventProviderDatabaseEventResolver.cs
+++ b/src/EventLogExpert.Eventing/EventResolvers/EventProviderDatabaseEventResolver.cs
@@ -27,7 +27,7 @@ public class EventProviderDatabaseEventResolver : EventResolverBase, IEventResol
 
     private bool disposedValue;
 
-    public EventProviderDatabaseEventResolver(IDatabaseCollectionProvider dbCollection) : this(dbCollection, (s,log) => { }) { }
+    public EventProviderDatabaseEventResolver(IDatabaseCollectionProvider dbCollection) : this(dbCollection, (s, log) => { }) { }
 
     public EventProviderDatabaseEventResolver(IDatabaseCollectionProvider dbCollection, Action<string, LogLevel> tracer) : base(tracer)
     {
@@ -146,7 +146,7 @@ public class EventProviderDatabaseEventResolver : EventResolverBase, IEventResol
 
     public DisplayEventModel Resolve(EventRecord eventRecord, string OwningLogName)
     {
-        DisplayEventModel lastResult = null!;
+        DisplayEventModel? lastResult = null;
 
         // The Properties getter is expensive, so we only call the getter once,
         // and we pass this value separately from the eventRecord so it can be reused.
@@ -177,6 +177,7 @@ public class EventProviderDatabaseEventResolver : EventResolverBase, IEventResol
                         {
                             _tracer($"Resolved {eventRecord.ProviderName} provider from database {dbContext.Name}.", LogLevel.Information);
                             _providerDetails.TryAdd(eventRecord.ProviderName, providerDetails);
+
                             return lastResult;
                         }
                     }
@@ -211,12 +212,12 @@ public class EventProviderDatabaseEventResolver : EventResolverBase, IEventResol
                 eventRecord.ThreadId,
                 eventRecord.LogName,
                 OwningLogName,
-                eventRecord);
+                eventRecord.ToXml());
         }
 
         if (lastResult.Description == null)
         {
-            lastResult = lastResult with { Description = ""};
+            lastResult = lastResult with { Description = "" };
         }
 
         return lastResult;

--- a/src/EventLogExpert.Eventing/EventResolvers/EventReaderEventResolver.cs
+++ b/src/EventLogExpert.Eventing/EventResolvers/EventReaderEventResolver.cs
@@ -50,7 +50,7 @@ public class EventReaderEventResolver : IEventResolver
             eventRecord.ThreadId,
             eventRecord.LogName,
             OwningLogName,
-            eventRecord);
+            eventRecord.ToXml());
     }
 
     private static T TryGetValue<T>(Func<T> func)

--- a/src/EventLogExpert.Eventing/EventResolvers/EventResolverBase.cs
+++ b/src/EventLogExpert.Eventing/EventResolvers/EventResolverBase.cs
@@ -301,7 +301,7 @@ public partial class EventResolverBase
             eventRecord.ThreadId,
             eventRecord.LogName!,
             owningLogName,
-            eventRecord);
+            eventRecord.ToXml());
     }
 
     [GeneratedRegex("%+[0-9]+")]

--- a/src/EventLogExpert.Eventing/EventResolvers/LocalProviderEventResolver.cs
+++ b/src/EventLogExpert.Eventing/EventResolvers/LocalProviderEventResolver.cs
@@ -57,7 +57,7 @@ public class LocalProviderEventResolver : EventResolverBase, IEventResolver
                 eventRecord.ThreadId,
                 eventRecord.LogName,
                 OwningLogName,
-                eventRecord);
+                eventRecord.ToXml());
         }
 
         // The Properties getter is expensive, so we only call the getter once,

--- a/src/EventLogExpert.Eventing/Models/DisplayEventModel.cs
+++ b/src/EventLogExpert.Eventing/Models/DisplayEventModel.cs
@@ -1,9 +1,6 @@
 ﻿// // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
-using System.Diagnostics.Eventing.Reader;
-using System.Xml.Linq;
-
 namespace EventLogExpert.Eventing.Models;
 
 public sealed record DisplayEventModel(
@@ -22,42 +19,4 @@ public sealed record DisplayEventModel(
     int? ThreadId,
     string LogName, // This is the log name from the event reader
     string OwningLog, // This is the name of the log file or the live log, which we use internally
-    EventRecord EventRecord)
-{
-    private EventRecord? EventRecord { get; set; } = EventRecord;
-
-    public string Xml
-    {
-        get
-        {
-            if (_cachedXml is not null) { return _cachedXml; }
-
-            lock (this)
-            {
-                if (_cachedXml is not null) { return _cachedXml; }
-
-                if (EventRecord is null)
-                {
-                    return "Unable to get XML. EventRecord is null.";
-                }
-
-                var unformattedXml = EventRecord.ToXml();
-
-                try
-                {
-                    _cachedXml = XElement.Parse(unformattedXml).ToString();
-                }
-                catch
-                {
-                    _cachedXml = unformattedXml;
-                }
-
-                EventRecord = null;
-
-                return _cachedXml;
-            }
-        }
-    }
-
-    private string? _cachedXml;
-}
+    string Xml);

--- a/src/EventLogExpert.UI/Store/EventLog/EventLogEffects.cs
+++ b/src/EventLogExpert.UI/Store/EventLog/EventLogEffects.cs
@@ -173,27 +173,6 @@ public sealed class EventLogEffects(
             {
                 logWatcherService.AddLog(action.LogName, lastEvent?.Bookmark);
             }
-
-            sw.Restart();
-
-            await Task.Run(() =>
-                {
-                    for (int i = 0; i < events.Count; i++)
-                    {
-                        action.Token.ThrowIfCancellationRequested();
-
-                        if (sw.ElapsedMilliseconds > 1000)
-                        {
-                            sw.Restart();
-                            dispatcher.Dispatch(new StatusBarAction.SetXmlLoading(activityId, i));
-                        }
-
-                        _ = events[i].Xml;
-                    }
-                },
-                action.Token);
-
-            dispatcher.Dispatch(new StatusBarAction.SetXmlLoading(activityId, 0));
         }
         catch (TaskCanceledException)
         {

--- a/src/EventLogExpert.UI/Store/LoggingMiddleware.cs
+++ b/src/EventLogExpert.UI/Store/LoggingMiddleware.cs
@@ -1,4 +1,7 @@
-﻿using EventLogExpert.Eventing.Helpers;
+﻿// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Helpers;
 using EventLogExpert.UI.Store.EventLog;
 using EventLogExpert.UI.Store.EventTable;
 using EventLogExpert.UI.Store.FilterCache;
@@ -23,56 +26,55 @@ public sealed class LoggingMiddleware(ITraceLogger debugLogger) : Middleware
     {
         switch (action)
         {
-            case EventLogAction.LoadEvents loadEventsAction :
+            case EventLogAction.LoadEvents loadEventsAction:
                 debugLogger.Trace($"Action: {action.GetType()} with {loadEventsAction.Events.Count} events.");
                 break;
-            case EventLogAction.AddEvent addEventsAction :
+            case EventLogAction.AddEvent addEventsAction:
                 debugLogger.Trace($"Action: {action.GetType()} with {addEventsAction.NewEvent.Source} event ID {addEventsAction.NewEvent.Id}.");
                 break;
-            case EventLogAction.OpenLog openLogAction :
+            case EventLogAction.OpenLog openLogAction:
                 debugLogger.Trace($"Action: {action.GetType()} with {openLogAction.LogName} log type {openLogAction.LogType}.");
                 break;
-            case EventLogAction.AddEventBuffered :
-            case EventLogAction.AddEventSuccess :
-            case EventLogAction.SetFilters :
-            case EventTableAction.AddTable :
-            case EventTableAction.LoadColumnsCompleted :
-            case EventTableAction.UpdateDisplayedEvents :
-            case FilterCacheAction.AddFavoriteFilterCompleted :
-            case FilterCacheAction.AddRecentFilterCompleted :
-            case FilterCacheAction.ImportFavorites :
-            case FilterCacheAction.LoadFiltersCompleted :
-            case FilterCacheAction.RemoveFavoriteFilterCompleted :
-            case FilterGroupAction.AddGroup :
-            case FilterGroupAction.ImportGroups :
-            case FilterGroupAction.LoadGroupsSuccess :
-            case FilterGroupAction.SetFilter :
-            case FilterGroupAction.SetGroup :
-            case FilterGroupAction.UpdateDisplayGroups :
-            case FilterPaneAction.AddAdvancedFilter :
-            case FilterPaneAction.AddBasicFilter :
-            case FilterPaneAction.AddCachedFilter :
-            case FilterPaneAction.ApplyFilterGroup :
-            case FilterPaneAction.SetAdvancedFilter :
-            case FilterPaneAction.SetBasicFilter :
-            case FilterPaneAction.SetCachedFilter :
-            case FilterPaneAction.SetFilterDateRange :
-            case SettingsAction.LoadDatabasesCompleted :
-            case SettingsAction.LoadSettingsCompleted :
+            case EventLogAction.AddEventBuffered:
+            case EventLogAction.AddEventSuccess:
+            case EventLogAction.SetFilters:
+            case EventTableAction.AddTable:
+            case EventTableAction.LoadColumnsCompleted:
+            case EventTableAction.UpdateDisplayedEvents:
+            case FilterCacheAction.AddFavoriteFilterCompleted:
+            case FilterCacheAction.AddRecentFilterCompleted:
+            case FilterCacheAction.ImportFavorites:
+            case FilterCacheAction.LoadFiltersCompleted:
+            case FilterCacheAction.RemoveFavoriteFilterCompleted:
+            case FilterGroupAction.AddGroup:
+            case FilterGroupAction.ImportGroups:
+            case FilterGroupAction.LoadGroupsSuccess:
+            case FilterGroupAction.SetFilter:
+            case FilterGroupAction.SetGroup:
+            case FilterGroupAction.UpdateDisplayGroups:
+            case FilterPaneAction.AddAdvancedFilter:
+            case FilterPaneAction.AddBasicFilter:
+            case FilterPaneAction.AddCachedFilter:
+            case FilterPaneAction.ApplyFilterGroup:
+            case FilterPaneAction.SetAdvancedFilter:
+            case FilterPaneAction.SetBasicFilter:
+            case FilterPaneAction.SetCachedFilter:
+            case FilterPaneAction.SetFilterDateRange:
+            case SettingsAction.LoadDatabasesCompleted:
+            case SettingsAction.LoadSettingsCompleted:
             case SettingsAction.Save:
-            case SettingsAction.SaveCompleted :
+            case SettingsAction.SaveCompleted:
                 debugLogger.Trace($"Action: {action.GetType()}.");
                 break;
-            case EventLogAction.SelectEvent selectEventAction :
+            case EventLogAction.SelectEvent selectEventAction:
                 debugLogger.Trace($"Action: {nameof(EventLogAction.SelectEvent)} selected " +
                     $"{selectEventAction.SelectedEvent?.Source} event ID {selectEventAction.SelectedEvent?.Id}.");
 
                 break;
-            case StatusBarAction.SetEventsLoading :
-            case StatusBarAction.SetXmlLoading :
+            case StatusBarAction.SetEventsLoading:
                 debugLogger.Trace($"Action: {action.GetType()} {JsonSerializer.Serialize(action, _serializerOptions)}", LogLevel.Debug);
                 break;
-            default :
+            default:
                 try
                 {
                     debugLogger.Trace($"Action: {action.GetType()} {JsonSerializer.Serialize(action, _serializerOptions)}");

--- a/src/EventLogExpert.UI/Store/LoggingMiddleware.cs
+++ b/src/EventLogExpert.UI/Store/LoggingMiddleware.cs
@@ -18,6 +18,7 @@ namespace EventLogExpert.UI.Store;
 
 public sealed class LoggingMiddleware(ITraceLogger debugLogger) : Middleware
 {
+    private readonly ITraceLogger _debugLogger = debugLogger;
     private readonly JsonSerializerOptions _serializerOptions = new();
 
     private IStore? _store;
@@ -27,13 +28,13 @@ public sealed class LoggingMiddleware(ITraceLogger debugLogger) : Middleware
         switch (action)
         {
             case EventLogAction.LoadEvents loadEventsAction:
-                debugLogger.Trace($"Action: {action.GetType()} with {loadEventsAction.Events.Count} events.");
+                _debugLogger.Trace($"Action: {action.GetType()} with {loadEventsAction.Events.Count} events.");
                 break;
             case EventLogAction.AddEvent addEventsAction:
-                debugLogger.Trace($"Action: {action.GetType()} with {addEventsAction.NewEvent.Source} event ID {addEventsAction.NewEvent.Id}.");
+                _debugLogger.Trace($"Action: {action.GetType()} with {addEventsAction.NewEvent.Source} event ID {addEventsAction.NewEvent.Id}.");
                 break;
             case EventLogAction.OpenLog openLogAction:
-                debugLogger.Trace($"Action: {action.GetType()} with {openLogAction.LogName} log type {openLogAction.LogType}.");
+                _debugLogger.Trace($"Action: {action.GetType()} with {openLogAction.LogName} log type {openLogAction.LogType}.");
                 break;
             case EventLogAction.AddEventBuffered:
             case EventLogAction.AddEventSuccess:
@@ -64,24 +65,24 @@ public sealed class LoggingMiddleware(ITraceLogger debugLogger) : Middleware
             case SettingsAction.LoadSettingsCompleted:
             case SettingsAction.Save:
             case SettingsAction.SaveCompleted:
-                debugLogger.Trace($"Action: {action.GetType()}.");
+                _debugLogger.Trace($"Action: {action.GetType()}.");
                 break;
             case EventLogAction.SelectEvent selectEventAction:
-                debugLogger.Trace($"Action: {nameof(EventLogAction.SelectEvent)} selected " +
+                _debugLogger.Trace($"Action: {nameof(EventLogAction.SelectEvent)} selected " +
                     $"{selectEventAction.SelectedEvent?.Source} event ID {selectEventAction.SelectedEvent?.Id}.");
 
                 break;
             case StatusBarAction.SetEventsLoading:
-                debugLogger.Trace($"Action: {action.GetType()} {JsonSerializer.Serialize(action, _serializerOptions)}", LogLevel.Debug);
+                _debugLogger.Trace($"Action: {action.GetType()} {JsonSerializer.Serialize(action, _serializerOptions)}", LogLevel.Debug);
                 break;
             default:
                 try
                 {
-                    debugLogger.Trace($"Action: {action.GetType()} {JsonSerializer.Serialize(action, _serializerOptions)}");
+                    _debugLogger.Trace($"Action: {action.GetType()} {JsonSerializer.Serialize(action, _serializerOptions)}");
                 }
                 catch
                 {
-                    debugLogger.Trace($"Action: {action.GetType()}. Could not serialize payload.");
+                    _debugLogger.Trace($"Action: {action.GetType()}. Could not serialize payload.");
                 }
 
                 break;

--- a/src/EventLogExpert.UI/Store/StatusBar/StatusBarAction.cs
+++ b/src/EventLogExpert.UI/Store/StatusBar/StatusBarAction.cs
@@ -18,6 +18,4 @@ public sealed record StatusBarAction
     public sealed record SetEventsLoading(Guid ActivityId, int Count);
 
     public sealed record SetResolverStatus(string ResolverStatus);
-
-    public sealed record SetXmlLoading(Guid ActivityId, int Count);
 }

--- a/src/EventLogExpert.UI/Store/StatusBar/StatusBarReducers.cs
+++ b/src/EventLogExpert.UI/Store/StatusBar/StatusBarReducers.cs
@@ -18,11 +18,6 @@ public sealed class StatusBarReducers
             updatedState = updatedState with { EventsLoading = updatedState.EventsLoading.Remove(action.ActivityId) };
         }
 
-        if (state.XmlLoading.ContainsKey(action.ActivityId))
-        {
-            updatedState = updatedState with { XmlLoading = updatedState.XmlLoading.Remove(action.ActivityId) };
-        }
-
         return updatedState;
     }
 
@@ -42,12 +37,6 @@ public sealed class StatusBarReducers
     public static StatusBarState
         ReduceSetResolverStatus(StatusBarState state, StatusBarAction.SetResolverStatus action) =>
         new() { ResolverStatus = action.ResolverStatus };
-
-    [ReducerMethod]
-    public static StatusBarState ReduceSetXmlLoading(StatusBarState state, StatusBarAction.SetXmlLoading action)
-    {
-        return state with { XmlLoading = CommonLoadingReducer(state.XmlLoading, action.ActivityId, action.Count) };
-    }
 
     private static ImmutableDictionary<Guid, int> CommonLoadingReducer(
         ImmutableDictionary<Guid, int> loadingEntries,

--- a/src/EventLogExpert.UI/Store/StatusBar/StatusBarState.cs
+++ b/src/EventLogExpert.UI/Store/StatusBar/StatusBarState.cs
@@ -12,6 +12,4 @@ public sealed record StatusBarState
     public ImmutableDictionary<Guid, int> EventsLoading { get; init; } = ImmutableDictionary<Guid, int>.Empty;
 
     public string ResolverStatus { get; init; } = string.Empty;
-
-    public ImmutableDictionary<Guid, int> XmlLoading { get; init; } = ImmutableDictionary<Guid, int>.Empty;
 }

--- a/src/EventLogExpert/Components/DetailsPane.razor
+++ b/src/EventLogExpert/Components/DetailsPane.razor
@@ -1,14 +1,10 @@
-﻿@using EventLogExpert.UI.Store.EventLog
-@using EventLogExpert.UI.Store.Settings
+﻿@using System.Xml.Linq
 @inherits FluxorComponent
 
-@inject IState<EventLogState> EventLogState
-@inject IState<SettingsState> SettingsState
-
-<div id="details-pane" data-toggle="@IsVisible" hidden="@(EventLogState.Value.SelectedEvent is null)">
+<div data-toggle="@IsVisible" hidden="@(SelectedEvent is null)" id="details-pane">
     <div id="details-resizer"></div>
 
-    <div id="details-header" class="flex-space-between" @onclick="ToggleMenu">
+    <div class="flex-space-between" id="details-header" @onclick="ToggleMenu">
         <div>Details</div>
 
         <span class="menu-toggle" data-rotate="@IsVisible">
@@ -16,28 +12,25 @@
         </span>
     </div>
 
-    @if (Event is not null)
+    @if (SelectedEvent is not null)
     {
         <div class="details-group" data-toggle="@_isXmlVisible.ToString().ToLower()">
             <div class="d-flex flex-row">
-                @if (EventLogState.Value.ActiveLogs.Count > 1)
-                {
-                    <div>Log Name: @Event.LogName</div>
-                }
-                <div>Source: @Event.Source</div>
-                <div>Event Id: @Event.Id</div>
-                <div>Level: @Event.Level</div>
-                @if (Event.KeywordsDisplayNames.Any())
+                <div>Log Name: @SelectedEvent.LogName</div>
+                <div>Source: @SelectedEvent.Source</div>
+                <div>Event Id: @SelectedEvent.Id</div>
+                <div>Level: @SelectedEvent.Level</div>
+                @if (SelectedEvent.KeywordsDisplayNames.Any())
                 {
                     <div>
-                        @Event.KeywordsDisplayNames.GetEventKeywords()
+                        @SelectedEvent.KeywordsDisplayNames.GetEventKeywords()
                     </div>
                 }
-                <div>Date and Time: @Event.TimeCreated.ConvertTimeZone(SettingsState.Value.Config.TimeZoneInfo)</div>
+                <div>Date and Time: @SelectedEvent.TimeCreated.ConvertTimeZone(SettingsState.Value.Config.TimeZoneInfo)</div>
             </div>
 
             <div>Description:</div>
-            <p class="details-description">@Event.Description</p>
+            <p class="details-description">@SelectedEvent.Description</p>
         </div>
 
         <div class="details-row-xml" @onclick="ToggleXml">
@@ -50,6 +43,6 @@
             </span>
         </div>
 
-        <p class="details-xml" data-toggle="@_isXmlVisible.ToString().ToLower()">@Event.Xml</p>
+        <p class="details-xml" data-toggle="@_isXmlVisible.ToString().ToLower()">@XElement.Parse(SelectedEvent.Xml)</p>
     }
 </div>

--- a/src/EventLogExpert/Components/DetailsPane.razor.cs
+++ b/src/EventLogExpert/Components/DetailsPane.razor.cs
@@ -1,5 +1,6 @@
 ﻿// // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
+
 using EventLogExpert.Eventing.Models;
 using EventLogExpert.Services;
 using EventLogExpert.UI;

--- a/src/EventLogExpert/Components/DetailsPane.razor.css
+++ b/src/EventLogExpert/Components/DetailsPane.razor.css
@@ -10,7 +10,7 @@
 
     border-top: solid var(--background-darkgray);
 
-    &[data-toggle="false"] { 
+    &[data-toggle="false"] {
         height: auto !important;
         min-height: 0 !important;
 
@@ -55,6 +55,8 @@
     margin: 0;
     height: 100%;
     overflow-y: auto;
+    overflow-x: hidden;
+    text-wrap: pretty;
     white-space: pre-wrap;
 }
 

--- a/src/EventLogExpert/Components/StatusBar.razor
+++ b/src/EventLogExpert/Components/StatusBar.razor
@@ -16,11 +16,6 @@
         <span>Loading: @loadingProgress.Value</span>
     }
 
-    @foreach (var xmlProgress in StatusBarState.Value.XmlLoading)
-    {
-        <span>Populating XML: @xmlProgress.Value</span>
-    }
-
     <span>Events Loaded: @EventLogState.Value.ActiveLogs.Values.Sum(log => log.Events.Count)</span>
 
     @if (EventTableState.Value.ActiveEventLogId is not null && FilterMethods.IsFilteringEnabled(EventLogState.Value.AppliedFilter))


### PR DESCRIPTION
Removed the horizontal scroll bar when viewing XML in details pane.

Since details pane and copying is the only place we care about formatted XML, it made sense to just keep the raw XML in the DisplayEventModel similar to how we were doing it before changing to ToXml. The side effect to this is that we get back all the memory we spent on caching the XML results, but the downside is we don't get the performance benefit of offloading the XML resolution.

To combat this performance hit, I have changed OpenLog to resolve events on multiple threads. This brings load speed back to what they were before the change with the reduction in memory usage. In my testing, larger log files had a much faster load time (1.4m events loaded 20 seconds faster, 40 seconds faster with database enabled).