### PR TITLE
Added divider line above XML section

### DIFF
--- a/src/EventLogExpert/Components/DetailsPane.razor
+++ b/src/EventLogExpert/Components/DetailsPane.razor
@@ -33,6 +33,8 @@
             <p class="details-description">@SelectedEvent.Description</p>
         </div>
 
+        <hr />
+
         <div class="details-row-xml" @onclick="ToggleXml">
             <div>XML:</div>
             <div class="justify-self-center">

--- a/src/EventLogExpert/Components/DetailsPane.razor.css
+++ b/src/EventLogExpert/Components/DetailsPane.razor.css
@@ -61,3 +61,5 @@
 }
 
     .details-xml[data-toggle="false"] { display: none; }
+
+hr { margin: 1px 0; }


### PR DESCRIPTION
This should make the bottom row with XML and Copy Event stand out more that it is a clickable section and not just floating text.