### PR TITLE
Enabled event multi select support along with copying multiple events

### DIFF
--- a/src/EventLogExpert.UI/Store/EventLog/EventLogAction.cs
+++ b/src/EventLogExpert.UI/Store/EventLog/EventLogAction.cs
@@ -33,7 +33,12 @@ public sealed record EventLogAction
 
     public sealed record OpenLog(string LogName, LogType LogType, CancellationToken Token = default);
 
-    public sealed record SelectEvent(DisplayEventModel? SelectedEvent);
+    public sealed record SelectEvent(
+        DisplayEventModel SelectedEvent,
+        bool IsMultiSelect = false,
+        bool ShouldStaySelected = false);
+
+    public sealed record SelectEvents(IEnumerable<DisplayEventModel> SelectedEvents);
 
     public sealed record SetContinouslyUpdate(bool ContinuouslyUpdate);
 

--- a/src/EventLogExpert.UI/Store/EventLog/EventLogState.cs
+++ b/src/EventLogExpert.UI/Store/EventLog/EventLogState.cs
@@ -27,5 +27,5 @@ public sealed record EventLogState
 
     public bool NewEventBufferIsFull { get; init; }
 
-    public DisplayEventModel? SelectedEvent { get; init; }
+    public ImmutableList<DisplayEventModel> SelectedEvents { get; init; } = [];
 }

--- a/src/EventLogExpert.UI/Store/LoggingMiddleware.cs
+++ b/src/EventLogExpert.UI/Store/LoggingMiddleware.cs
@@ -69,6 +69,11 @@ public sealed class LoggingMiddleware(ITraceLogger debugLogger) : Middleware
                     $"{selectEventAction.SelectedEvent?.Source} event ID {selectEventAction.SelectedEvent?.Id}.");
 
                 break;
+            case EventLogAction.SelectEvents selectEventsAction:
+                _debugLogger.Trace($"Action: {nameof(EventLogAction.SelectEvents)} selected " +
+                    $"{selectEventsAction.SelectedEvents.Count()} events");
+
+                break;
             case StatusBarAction.SetEventsLoading:
                 _debugLogger.Trace($"Action: {action.GetType()} {JsonSerializer.Serialize(action, _serializerOptions)}", LogLevel.Debug);
                 break;

--- a/src/EventLogExpert/Components/DetailsPane.razor.cs
+++ b/src/EventLogExpert/Components/DetailsPane.razor.cs
@@ -9,6 +9,7 @@ using EventLogExpert.UI.Store.Settings;
 using Fluxor;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
+using System.Collections.Immutable;
 
 namespace EventLogExpert.Components;
 
@@ -26,7 +27,7 @@ public sealed partial class DetailsPane
 
     private DisplayEventModel? SelectedEvent { get; set; }
 
-    [Inject] private IStateSelection<EventLogState, DisplayEventModel?> SelectedEventSelection { get; init; } = null!;
+    [Inject] private IStateSelection<EventLogState, ImmutableList<DisplayEventModel>> SelectedEventSelection { get; init; } = null!;
 
     [Inject] private IState<SettingsState> SettingsState { get; init; } = null!;
 
@@ -42,11 +43,11 @@ public sealed partial class DetailsPane
 
     protected override void OnInitialized()
     {
-        SelectedEventSelection.Select(s => s.SelectedEvent);
+        SelectedEventSelection.Select(s => s.SelectedEvents);
 
-        SelectedEventSelection.SelectedValueChanged += (s, selectedEvent) =>
+        SelectedEventSelection.SelectedValueChanged += (s, selectedEvents) =>
         {
-            SelectedEvent = selectedEvent;
+            SelectedEvent = selectedEvents.LastOrDefault();
 
             if (SelectedEvent is not null &&
                 (!_hasOpened || SettingsState.Value.Config.ShowDisplayPaneOnSelectionChange))

--- a/src/EventLogExpert/Components/EventTable.razor
+++ b/src/EventLogExpert/Components/EventTable.razor
@@ -4,10 +4,10 @@
 <SplitLogTabPane />
 
 <div class="table-container">
-    <table id="eventTable" @onkeyup="HandleKeyUp">
+    <table id="eventTable" @onkeydown="HandleKeyDown">
         <thead @oncontextmenu="InvokeTableColumnMenu">
         <tr>
-            @foreach ((ColumnName column, bool _) in EventTableState.Value.Columns.Where(column => column.Value))
+            @foreach ((ColumnName column, bool _) in _eventTableState.Columns.Where(column => column.Value))
             {
                 <th class="@column.ToString().ToLower()">
                     @if (column == ColumnName.DateAndTime)
@@ -18,9 +18,9 @@
                     {
                         @column.ToFullString()
                     }
-                    @if (EventTableState.Value.OrderBy == column)
+                    @if (_eventTableState.OrderBy == column)
                     {
-                        <span class="menu-toggle" data-rotate="@EventTableState.Value.IsDescending.ToString().ToLower()" @onclick="ToggleSorting">
+                        <span class="menu-toggle" data-rotate="@_eventTableState.IsDescending.ToString().ToLower()" @onclick="ToggleSorting">
                             <i class="bi bi-caret-up"></i>
                         </span>
                     }
@@ -31,11 +31,12 @@
         </tr>
         </thead>
         <tbody @oncontextmenu="InvokeContextMenu">
-        @if (EventTableState.Value.ActiveEventLogId is not null)
+        @if (_currentTable is not null)
         {
-            <Virtualize Items="EventTableState.Value.EventTables.First(x => x.Id == EventTableState.Value.ActiveEventLogId).DisplayedEvents" Context="evt">
-                <tr @key="@($"{evt.OwningLog}_{evt.RecordId}")" class="@GetCss(evt)" @onfocus="() => SelectEvent(evt)" tabindex="0">
-                    @foreach ((ColumnName column, bool _) in EventTableState.Value.Columns.Where(column => column.Value))
+            <Virtualize Context="evt" Items="_currentTable.DisplayedEvents">
+                <tr class="@GetCss(evt)" @key="@($"{evt.OwningLog}_{evt.RecordId}")"
+                    @onmouseenter="args => DragSelectEvent(args, evt)" @onmousedown="args => SelectEvent(args, evt)" tabindex="0">
+                    @foreach ((ColumnName column, bool _) in _eventTableState.Columns.Where(column => column.Value))
                     {
                         <td>
                             @switch (column)
@@ -44,7 +45,7 @@
                                     <text><span class="@GetLevelClass(evt.Level)"></span> @evt.Level</text>
                                     break;
                                 case ColumnName.DateAndTime:
-                                    @evt.TimeCreated.ConvertTimeZone(TimeZoneSettings.Value)
+                                    @evt.TimeCreated.ConvertTimeZone(_timeZoneSettings)
                                     break;
                                 case ColumnName.ActivityId:
                                     @evt.ActivityId

--- a/src/EventLogExpert/Components/EventTable.razor.css
+++ b/src/EventLogExpert/Components/EventTable.razor.css
@@ -41,7 +41,10 @@ th, td {
     &:last-child { border-right: none; }
 }
 
-tr { height: 22px; }
+tr {
+    height: 22px;
+    user-select: none;
+}
 
 .error { color: var(--clr-red); }
 

--- a/src/EventLogExpert/Shared/Components/ContextMenu.razor.cs
+++ b/src/EventLogExpert/Shared/Components/ContextMenu.razor.cs
@@ -9,6 +9,7 @@ using EventLogExpert.UI.Store.EventLog;
 using EventLogExpert.UI.Store.FilterPane;
 using Fluxor;
 using Microsoft.AspNetCore.Components;
+using System.Collections.Immutable;
 using IDispatcher = Fluxor.IDispatcher;
 
 namespace EventLogExpert.Shared.Components;
@@ -20,11 +21,11 @@ public sealed partial class ContextMenu
     [Inject] private IDispatcher Dispatcher { get; init; } = null!;
 
     [Inject]
-    private IStateSelection<EventLogState, DisplayEventModel?> SelectedEventState { get; init; } = null!;
+    private IStateSelection<EventLogState, ImmutableList<DisplayEventModel>> SelectedEventState { get; init; } = null!;
 
     protected override void OnInitialized()
     {
-        SelectedEventState.Select(s => s.SelectedEvent);
+        SelectedEventState.Select(s => s.SelectedEvents);
 
         base.OnInitialized();
     }
@@ -33,17 +34,19 @@ public sealed partial class ContextMenu
 
     private void FilterEvent(FilterCategory filterType, bool shouldExclude = false)
     {
-        if (SelectedEventState.Value is null) { return; }
+        if (SelectedEventState.Value.IsEmpty) { return; }
+
+        var selectedEvent = SelectedEventState.Value.Last();
 
         string filterValue = filterType switch
         {
-            FilterCategory.Id => SelectedEventState.Value.Id.ToString(),
-            FilterCategory.ActivityId => SelectedEventState.Value.ActivityId.ToString()!,
-            FilterCategory.Level => SelectedEventState.Value.Level,
-            FilterCategory.KeywordsDisplayNames => SelectedEventState.Value.KeywordsDisplayNames.GetEventKeywords(),
-            FilterCategory.Source => SelectedEventState.Value.Source,
-            FilterCategory.TaskCategory => SelectedEventState.Value.TaskCategory,
-            FilterCategory.Description => SelectedEventState.Value.Description,
+            FilterCategory.Id => selectedEvent.Id.ToString(),
+            FilterCategory.ActivityId => selectedEvent.ActivityId.ToString()!,
+            FilterCategory.Level => selectedEvent.Level,
+            FilterCategory.KeywordsDisplayNames => selectedEvent.KeywordsDisplayNames.GetEventKeywords(),
+            FilterCategory.Source => selectedEvent.Source,
+            FilterCategory.TaskCategory => selectedEvent.TaskCategory,
+            FilterCategory.Description => selectedEvent.Description,
             _ => string.Empty,
         };
 

--- a/src/EventLogExpert/wwwroot/js/event_table.js
+++ b/src/EventLogExpert/wwwroot/js/event_table.js
@@ -62,10 +62,12 @@ window.enableColumnResize = (table) => {
 window.registerKeyHandlers = (table) => {
     const selectAdjacentRow = function(direction) {
         const tableRows = table.getElementsByTagName("tr");
-        const selectedRow = table.getElementsByClassName("selected")[0];
+        const focusedRow = document.activeElement;
+
+        if (focusedRow.tagName.toLowerCase() !== "tr") { return; }
 
         for (let i = 0; i < tableRows.length; i++) {
-            if (tableRows[i] === selectedRow) {
+            if (tableRows[i] === focusedRow) {
                 tableRows[i + direction].focus();
 
                 break;


### PR DESCRIPTION
Multi select support includes: Ctrl click to multi select, shift click to select a range of events and dragging to multi select.

Unfortunately, tab and arrow keys will no longer select the event but will still scroll event by event.

Resolves #335 