### PR TITLE
Fixes ToString calls with LINQ dynamic parser

### DIFF
--- a/src/EventLogExpert.UI/Models/FilterComparison.cs
+++ b/src/EventLogExpert.UI/Models/FilterComparison.cs
@@ -17,7 +17,7 @@ public sealed record FilterComparison
         set
         {
             Expression = DynamicExpressionParser
-                .ParseLambda<DisplayEventModel, bool>(ParsingConfig.Default, false, value)
+                .ParseLambda<DisplayEventModel, bool>(new ParsingConfig { AllowEqualsAndToStringMethodsOnObject = true }, false, value)
                 .Compile();
 
             _value = value;


### PR DESCRIPTION
Vulnerability fix for LINQ dynamic parser removed the ability to use ToString on objects but added a parameter that we needed to enable to restore functionality.

Resolves #410 