### PR TITLE
Performance optimizations based on previous copilot recommendations

### DIFF
--- a/src/EventLogExpert.Eventing.Tests/EventResolvers/EventResolverBaseTests.cs
+++ b/src/EventLogExpert.Eventing.Tests/EventResolvers/EventResolverBaseTests.cs
@@ -411,7 +411,7 @@ public sealed class EventResolverBaseTests
 
         // Assert
         Assert.NotNull(displayEvent);
-        Assert.Empty(displayEvent.KeywordsDisplayNames);
+        Assert.Empty(displayEvent.Keywords);
     }
 
     [Fact]
@@ -513,8 +513,8 @@ public sealed class EventResolverBaseTests
 
         // Assert
         Assert.NotNull(displayEvent);
-        Assert.Contains("CustomKeyword1", displayEvent.KeywordsDisplayNames);
-        Assert.Contains("CustomKeyword2", displayEvent.KeywordsDisplayNames);
+        Assert.Contains("CustomKeyword1", displayEvent.Keywords);
+        Assert.Contains("CustomKeyword2", displayEvent.Keywords);
     }
 
     [Fact]
@@ -599,7 +599,7 @@ public sealed class EventResolverBaseTests
 
         // Assert
         Assert.NotNull(displayEvent);
-        Assert.Contains("Classic", displayEvent.KeywordsDisplayNames);
+        Assert.Contains("Classic", displayEvent.Keywords);
     }
 
     [Fact]
@@ -729,7 +729,7 @@ public sealed class EventResolverBaseTests
 
         // Assert
         Assert.NotNull(displayEvent);
-        Assert.Empty(displayEvent.KeywordsDisplayNames);
+        Assert.Empty(displayEvent.Keywords);
     }
 
     private class TestEventResolver : EventResolverBase, IEventResolver

--- a/src/EventLogExpert.Eventing.Tests/Readers/EventLogReaderTests.cs
+++ b/src/EventLogExpert.Eventing.Tests/Readers/EventLogReaderTests.cs
@@ -130,20 +130,16 @@ public sealed class EventLogReaderTests
     }
 
     [Fact]
-    public void Dispose_AfterDispose_TryGetEventsStillWorks()
+    public void Dispose_AfterDispose_TryGetEventsShouldThrow()
     {
         // Arrange
         var reader = new EventLogReader(Constants.ApplicationLogName, PathType.LogName);
 
         // Act
         reader.Dispose();
-        bool success = reader.TryGetEvents(out var events);
 
-        // Assert
-        // The Dispose method only acts during finalization (disposing: false)
-        // Direct calls with disposing: true return immediately, so TryGetEvents still works
-        Assert.True(success);
-        Assert.NotNull(events);
+        // Assert - After Dispose, the handle is disposed and TryGetEvents should throw
+        Assert.Throws<ObjectDisposedException>(() => reader.TryGetEvents(out _));
     }
 
     [Fact]

--- a/src/EventLogExpert.Eventing/EventResolvers/EventResolverBase.cs
+++ b/src/EventLogExpert.Eventing/EventResolvers/EventResolverBase.cs
@@ -73,13 +73,16 @@ public partial class EventResolverBase : IDisposable
     {
         ObjectDisposedException.ThrowIf(disposed, this);
 
+        var keywords = GetKeywordsFromBitmask(eventRecord);
+
         return new DisplayEventModel(eventRecord.PathName, eventRecord.PathType)
         {
             ActivityId = eventRecord.ActivityId,
             ComputerName = _cache?.GetOrAddValue(eventRecord.ComputerName) ?? eventRecord.ComputerName,
             Description = ResolveDescription(eventRecord),
             Id = eventRecord.Id,
-            KeywordsDisplayNames = GetKeywordsFromBitmask(eventRecord),
+            Keywords = keywords,
+            KeywordsDisplayName = string.Join(", ", keywords),
             Level = Severity.GetString(eventRecord.Level),
             LogName = _cache?.GetOrAddValue(eventRecord.LogName) ?? eventRecord.LogName,
             ProcessId = eventRecord.ProcessId,
@@ -313,11 +316,7 @@ public partial class EventResolverBase : IDisposable
             return modernEvent;
         }
 
-        var matchingEvents = details.Events
-            .Where(e => e.Id == eventRecord.Id && e.LogName == eventRecord.LogName)
-            .ToList();
-
-        foreach (var @event in matchingEvents)
+        foreach (var @event in details.Events.Where(e => e.Id == eventRecord.Id && e.LogName == eventRecord.LogName))
         {
             if (DoesTemplateMatchPropertyCount(@event.Template, eventPropertyCount))
             {
@@ -327,11 +326,7 @@ public partial class EventResolverBase : IDisposable
 
         // Try again forcing the long to a short and with no log name.
         // This is needed for providers such as Microsoft-Windows-Complus
-        var shortIdEvents = details.Events
-            .Where(e => (short)e.Id == eventRecord.Id && e.Version == eventRecord.Version)
-            .ToList();
-
-        foreach (var @event in shortIdEvents)
+        foreach (var @event in details.Events.Where(e => (short)e.Id == eventRecord.Id && e.Version == eventRecord.Version))
         {
             if (DoesTemplateMatchPropertyCount(@event.Template, eventPropertyCount))
             {

--- a/src/EventLogExpert.Eventing/EventResolvers/EventResolverCache.cs
+++ b/src/EventLogExpert.Eventing/EventResolvers/EventResolverCache.cs
@@ -1,102 +1,24 @@
 ﻿// // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using System.Collections.Concurrent;
+
 namespace EventLogExpert.Eventing.EventResolvers;
 
 public sealed class EventResolverCache : IEventResolverCache
 {
-    private readonly HashSet<string> _descriptionCache = [];
-    private readonly ReaderWriterLockSlim _descriptionCacheLock = new();
-    private readonly HashSet<string> _valueCache = [];
-    private readonly ReaderWriterLockSlim _valueCacheLock = new();
+    private readonly ConcurrentDictionary<string, string> _descriptionCache = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, string> _valueCache = new(StringComparer.Ordinal);
 
     public void ClearAll()
     {
-        _descriptionCacheLock.EnterWriteLock();
-        _valueCacheLock.EnterWriteLock();
-
-        try
-        {
-            _descriptionCache.Clear();
-            _valueCache.Clear();
-        }
-        finally
-        {
-            _descriptionCacheLock.ExitWriteLock();
-            _valueCacheLock.ExitWriteLock();
-        }
+        _descriptionCache.Clear();
+        _valueCache.Clear();
     }
 
     /// <summary>Returns the description if it exists in the cache, otherwise adds it to the cache and returns it.</summary>
-    public string GetOrAddDescription(string description)
-    {
-        _descriptionCacheLock.EnterUpgradeableReadLock();
-
-        try
-        {
-            if (_descriptionCache.TryGetValue(description, out string? result))
-            {
-                return result;
-            }
-
-            _descriptionCacheLock.EnterWriteLock();
-
-            try
-            {
-                if (_descriptionCache.TryGetValue(description, out result))
-                {
-                    return result;
-                }
-
-                _descriptionCache.Add(description);
-
-                return description;
-            }
-            finally
-            {
-                _descriptionCacheLock.ExitWriteLock();
-            }
-        }
-        finally
-        {
-            _descriptionCacheLock.ExitUpgradeableReadLock();
-        }
-    }
+    public string GetOrAddDescription(string description) => _descriptionCache.GetOrAdd(description, static key => key);
 
     /// <summary>Returns the value if it exists in the cache, otherwise adds it to the cache and returns it.</summary>
-    public string GetOrAddValue(string value)
-    {
-        _valueCacheLock.EnterUpgradeableReadLock();
-
-        try
-        {
-            if (_valueCache.TryGetValue(value, out string? result))
-            {
-                return result;
-            }
-
-            _valueCacheLock.EnterWriteLock();
-
-            try
-            {
-                // Double-check if the value was added by another thread
-                if (_valueCache.TryGetValue(value, out result))
-                {
-                    return result;
-                }
-
-                _valueCache.Add(value);
-
-                return value;
-            }
-            finally
-            {
-                _valueCacheLock.ExitWriteLock();
-            }
-        }
-        finally
-        {
-            _valueCacheLock.ExitUpgradeableReadLock();
-        }
-    }
+    public string GetOrAddValue(string value) => _valueCache.GetOrAdd(value, static key => key);
 }

--- a/src/EventLogExpert.Eventing/Helpers/EventMethods.cs
+++ b/src/EventLogExpert.Eventing/Helpers/EventMethods.cs
@@ -617,7 +617,7 @@ internal static partial class EventMethods
         }
     }
 
-    internal static IList<object> RenderEventProperties(EvtHandle eventHandle)
+    internal static IReadOnlyList<object> RenderEventProperties(EvtHandle eventHandle)
     {
         bool success = EvtRender(
             EventLogSession.GlobalSession.UserRenderContext,
@@ -676,7 +676,9 @@ internal static partial class EventMethods
             }
         }
 
-        return properties.AsReadOnly();
+        // Dropping AsReadOnly since this is a hot path and since this is only used internally,
+        // we can ensure immutability through documentation and code reviews
+        return properties;
     }
 
     internal static string? RenderEventXml(EvtHandle eventHandle)

--- a/src/EventLogExpert.Eventing/Helpers/EventMethods.cs
+++ b/src/EventLogExpert.Eventing/Helpers/EventMethods.cs
@@ -659,9 +659,9 @@ internal static partial class EventMethods
             ThrowEventLogException(error);
         }
 
-        List<object> properties = [];
+        if (propertyCount <= 0) { return []; }
 
-        if (propertyCount <= 0) { return properties; }
+        var properties = new object[propertyCount];
 
         for (int i = 0; i < propertyCount; i++)
         {
@@ -671,13 +671,11 @@ internal static partial class EventMethods
                 {
                     var property = Marshal.PtrToStructure<EvtVariant>((IntPtr)bufferPtr + (i * Marshal.SizeOf<EvtVariant>()));
 
-                    properties.Add(ConvertVariant(property) ?? throw new InvalidDataException());
+                    properties[i] = ConvertVariant(property) ?? throw new InvalidDataException();
                 }
             }
         }
 
-        // Dropping AsReadOnly since this is a hot path and since this is only used internally,
-        // we can ensure immutability through documentation and code reviews
         return properties;
     }
 

--- a/src/EventLogExpert.Eventing/Models/DisplayEventModel.cs
+++ b/src/EventLogExpert.Eventing/Models/DisplayEventModel.cs
@@ -21,7 +21,9 @@ public sealed record DisplayEventModel(
 
     public int Id { get; init; }
 
-    public IEnumerable<string> KeywordsDisplayNames { get; init; } = [];
+    public IReadOnlyList<string> Keywords { get; init; } = [];
+
+    public string KeywordsDisplayName { get; init; } = string.Empty;
 
     public string Level { get; init; } = string.Empty;
 

--- a/src/EventLogExpert.Eventing/Models/EventRecord.cs
+++ b/src/EventLogExpert.Eventing/Models/EventRecord.cs
@@ -28,7 +28,7 @@ public sealed record EventRecord
 
     public long? RecordId { get; set; }
 
-    public IEnumerable<object> Properties { get; set; } = [];
+    public IReadOnlyList<object> Properties { get; set; } = [];
 
     public string ProviderName { get; set; } = string.Empty;
 

--- a/src/EventLogExpert.Eventing/Readers/EventLogReader.cs
+++ b/src/EventLogExpert.Eventing/Readers/EventLogReader.cs
@@ -13,6 +13,8 @@ public sealed partial class EventLogReader(string path, PathType pathType, bool 
     private readonly EvtHandle _handle =
         EventMethods.EvtQuery(EventLogSession.GlobalSession.Handle, path, null, pathType);
 
+    private bool _disposed;
+
     ~EventLogReader()
     {
         Dispose(disposing: false);
@@ -143,11 +145,16 @@ public sealed partial class EventLogReader(string path, PathType pathType, bool 
 
     private void Dispose(bool disposing)
     {
-        if (disposing) { return; }
+        if (_disposed) { return; }
 
-        if (_handle is { IsInvalid: false })
+        if (disposing)
         {
-            _handle.Dispose();
+            if (_handle is { IsInvalid: false })
+            {
+                _handle.Dispose();
+            }
         }
+
+        _disposed = true;
     }
 }

--- a/src/EventLogExpert.Eventing/Readers/EventLogReader.cs
+++ b/src/EventLogExpert.Eventing/Readers/EventLogReader.cs
@@ -15,17 +15,18 @@ public sealed partial class EventLogReader(string path, PathType pathType, bool 
 
     private bool _disposed;
 
-    ~EventLogReader()
-    {
-        Dispose(disposing: false);
-    }
-
     public string? LastBookmark { get; private set; }
 
     public void Dispose()
     {
-        Dispose(disposing: true);
-        GC.SuppressFinalize(this);
+        if (_disposed) { return; }
+
+        if (_handle is { IsInvalid: false })
+        {
+            _handle.Dispose();
+        }
+
+        _disposed = true;
     }
 
     // Pre-Windows 11, a batch being returned can be maximum of (2 MB of data, batchSize count of events).
@@ -141,20 +142,5 @@ public sealed partial class EventLogReader(string path, PathType pathType, bool 
         }
 
         return bufferUsed - 1 <= 0 ? null : new string(buffer[..^1]);
-    }
-
-    private void Dispose(bool disposing)
-    {
-        if (_disposed) { return; }
-
-        if (disposing)
-        {
-            if (_handle is { IsInvalid: false })
-            {
-                _handle.Dispose();
-            }
-        }
-
-        _disposed = true;
     }
 }

--- a/src/EventLogExpert.UI/Enums.cs
+++ b/src/EventLogExpert.UI/Enums.cs
@@ -72,7 +72,7 @@ public enum FilterCategory
     [EnumMember(Value = "Event ID")] Id,
     [EnumMember(Value = "Activity ID")] ActivityId,
     Level,
-    [EnumMember(Value = "Keywords")] KeywordsDisplayNames,
+    Keywords,
     Source,
     [EnumMember(Value = "Task Category")] TaskCategory,
     [EnumMember(Value = "Process ID")] ProcessId,

--- a/src/EventLogExpert.UI/FilterMethods.cs
+++ b/src/EventLogExpert.UI/FilterMethods.cs
@@ -89,8 +89,8 @@ public static class FilterMethods
                 events.OrderByDescending(e => e.TaskCategory) :
                 events.OrderBy(e => e.TaskCategory),
             ColumnName.Keywords => isDescending ?
-                events.OrderByDescending(e => e.Keywords) :
-                events.OrderBy(e => e.Keywords),
+                events.OrderByDescending(e => e.KeywordsDisplayName) :
+                events.OrderBy(e => e.KeywordsDisplayName),
             ColumnName.ProcessId => isDescending ?
                 events.OrderByDescending(e => e.ProcessId) :
                 events.OrderBy(e => e.ProcessId),

--- a/src/EventLogExpert.UI/FilterMethods.cs
+++ b/src/EventLogExpert.UI/FilterMethods.cs
@@ -106,8 +106,8 @@ public static class FilterMethods
                 events.OrderByDescending(e => e.TaskCategory) :
                 events.OrderBy(e => e.TaskCategory),
             ColumnName.Keywords => isDescending ?
-                events.OrderByDescending(e => e.KeywordsDisplayNames) :
-                events.OrderBy(e => e.KeywordsDisplayNames),
+                events.OrderByDescending(e => e.Keywords) :
+                events.OrderBy(e => e.Keywords),
             ColumnName.ProcessId => isDescending ?
                 events.OrderByDescending(e => e.ProcessId) :
                 events.OrderBy(e => e.ProcessId),

--- a/src/EventLogExpert.UI/FilterMethods.cs
+++ b/src/EventLogExpert.UI/FilterMethods.cs
@@ -3,7 +3,6 @@
 
 using EventLogExpert.Eventing.Models;
 using EventLogExpert.UI.Models;
-using System.Collections.ObjectModel;
 
 namespace EventLogExpert.UI;
 
@@ -43,46 +42,30 @@ public static class FilterMethods
         return group;
     }
 
-    public static bool Filter(this DisplayEventModel? @event, IEnumerable<FilterModel> filters, bool isXmlEnabled)
-    {
-        if (@event is null) { return false; }
-
-        bool isEmpty = true;
-        bool isFiltered = false;
-
-        foreach (var filter in filters)
-        {
-            if (!isXmlEnabled && filter.Comparison.Value.Contains("xml.", StringComparison.OrdinalIgnoreCase)) { return false; }
-
-            if (filter.IsExcluded && filter.Comparison.Expression(@event)) { return false; }
-
-            if (!filter.IsExcluded) { isEmpty = false; }
-
-            if (!filter.IsExcluded && filter.Comparison.Expression(@event)) { isFiltered = true; }
-        }
-
-        return isEmpty || isFiltered;
-    }
-
-    public static DisplayEventModel? FilterByDate(this DisplayEventModel? @event, FilterDateModel? dateFilter)
-    {
-        if (@event is null) { return null; }
-
-        if (dateFilter is null) { return @event; }
-
-        return @event.TimeCreated >= dateFilter.After && @event.TimeCreated <= dateFilter.Before ? @event : null;
-    }
-
     public static bool HasFilteringChanged(EventFilter updated, EventFilter original) =>
         updated.DateFilter?.Equals(original.DateFilter) is false ||
         updated.Filters.Equals(original.Filters) is false;
+
+    /// <summary>Returns the index of the specified item in the list, or -1 if not found.</summary>
+    public static int IndexOf<T>(this IReadOnlyList<T> list, T item)
+    {
+        for (int i = 0; i < list.Count; i++)
+        {
+            if (EqualityComparer<T>.Default.Equals(list[i], item))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
 
     public static bool IsFilteringEnabled(EventFilter eventFilter) =>
         eventFilter.DateFilter?.IsEnabled is true ||
         eventFilter.Filters.IsEmpty is false;
 
     /// <summary>Sorts events by RecordId if no order is specified</summary>
-    public static ReadOnlyCollection<DisplayEventModel> SortEvents(
+    public static IReadOnlyList<DisplayEventModel> SortEvents(
         this IEnumerable<DisplayEventModel> events,
         ColumnName? orderBy = null,
         bool isDescending = false)
@@ -118,6 +101,39 @@ public static class FilterMethods
             _ => isDescending ? events.OrderByDescending(e => e.RecordId) : events.OrderBy(e => e.RecordId)
         };
 
-        return sortedEvents.ToList().AsReadOnly();
+        return [.. sortedEvents];
+    }
+
+    extension(DisplayEventModel? @event)
+    {
+        public bool Filter(IEnumerable<FilterModel> filters, bool isXmlEnabled)
+        {
+            if (@event is null) { return false; }
+
+            bool isEmpty = true;
+            bool isFiltered = false;
+
+            foreach (var filter in filters)
+            {
+                if (!isXmlEnabled && filter.Comparison.Value.Contains("xml.", StringComparison.OrdinalIgnoreCase)) { return false; }
+
+                if (filter.IsExcluded && filter.Comparison.Expression(@event)) { return false; }
+
+                if (!filter.IsExcluded) { isEmpty = false; }
+
+                if (!filter.IsExcluded && filter.Comparison.Expression(@event)) { isFiltered = true; }
+            }
+
+            return isEmpty || isFiltered;
+        }
+
+        public DisplayEventModel? FilterByDate(FilterDateModel? dateFilter)
+        {
+            if (@event is null) { return null; }
+
+            if (dateFilter is null) { return @event; }
+
+            return @event.TimeCreated >= dateFilter.After && @event.TimeCreated <= dateFilter.Before ? @event : null;
+        }
     }
 }

--- a/src/EventLogExpert.UI/Interfaces/IFilterService.cs
+++ b/src/EventLogExpert.UI/Interfaces/IFilterService.cs
@@ -12,11 +12,11 @@ public interface IFilterService
 {
     bool IsXmlEnabled { get; }
 
-    IDictionary<EventLogId, IEnumerable<DisplayEventModel>> FilterActiveLogs(
+    IReadOnlyDictionary<EventLogId, IReadOnlyList<DisplayEventModel>> FilterActiveLogs(
         IEnumerable<EventLogData> logData,
         EventFilter eventFilter);
 
-    IEnumerable<DisplayEventModel> GetFilteredEvents(IEnumerable<DisplayEventModel> events, EventFilter eventFilter);
+    IReadOnlyList<DisplayEventModel> GetFilteredEvents(IEnumerable<DisplayEventModel> events, EventFilter eventFilter);
 
     bool TryParse(FilterModel filterModel, out string comparison);
 

--- a/src/EventLogExpert.UI/Models/EventLogData.cs
+++ b/src/EventLogExpert.UI/Models/EventLogData.cs
@@ -20,7 +20,7 @@ public sealed record EventLogData(
             FilterCategory.Id => Events.Select(e => e.Id.ToString()).Distinct(),
             FilterCategory.ActivityId => Events.Select(e => e.ActivityId?.ToString() ?? string.Empty).Distinct(),
             FilterCategory.Level => Enum.GetNames<SeverityLevel>(),
-            FilterCategory.KeywordsDisplayNames => Events.SelectMany(e => e.Keywords).Distinct(),
+            FilterCategory.Keywords => Events.SelectMany(e => e.Keywords).Distinct(),
             FilterCategory.Source => Events.Select(e => e.Source).Distinct(),
             FilterCategory.TaskCategory => Events.Select(e => e.TaskCategory).Distinct(),
             _ => [],

--- a/src/EventLogExpert.UI/Models/EventLogData.cs
+++ b/src/EventLogExpert.UI/Models/EventLogData.cs
@@ -21,7 +21,7 @@ public sealed record EventLogData(
             FilterCategory.Id => Events.Select(e => e.Id.ToString()).Distinct(),
             FilterCategory.ActivityId => Events.Select(e => e.ActivityId?.ToString() ?? string.Empty).Distinct(),
             FilterCategory.Level => Enum.GetNames<SeverityLevel>(),
-            FilterCategory.KeywordsDisplayNames => Events.SelectMany(e => e.KeywordsDisplayNames).Distinct(),
+            FilterCategory.KeywordsDisplayNames => Events.SelectMany(e => e.Keywords).Distinct(),
             FilterCategory.Source => Events.Select(e => e.Source).Distinct(),
             FilterCategory.TaskCategory => Events.Select(e => e.TaskCategory).Distinct(),
             _ => [],

--- a/src/EventLogExpert.UI/Models/EventLogData.cs
+++ b/src/EventLogExpert.UI/Models/EventLogData.cs
@@ -3,14 +3,13 @@
 
 using EventLogExpert.Eventing.Helpers;
 using EventLogExpert.Eventing.Models;
-using System.Collections.ObjectModel;
 
 namespace EventLogExpert.UI.Models;
 
 public sealed record EventLogData(
     string Name,
     PathType Type,
-    ReadOnlyCollection<DisplayEventModel> Events)
+    IReadOnlyList<DisplayEventModel> Events)
 {
     public EventLogId Id { get; } = EventLogId.Create();
 

--- a/src/EventLogExpert.UI/Models/EventTableModel.cs
+++ b/src/EventLogExpert.UI/Models/EventTableModel.cs
@@ -3,7 +3,6 @@
 
 using EventLogExpert.Eventing.Helpers;
 using EventLogExpert.Eventing.Models;
-using System.Collections.ObjectModel;
 
 namespace EventLogExpert.UI.Models;
 
@@ -17,8 +16,7 @@ public sealed record EventTableModel(EventLogId Id)
 
     public PathType PathType { get; init; }
 
-    public ReadOnlyCollection<DisplayEventModel> DisplayedEvents { get; init; } =
-        new List<DisplayEventModel>().AsReadOnly();
+    public IReadOnlyList<DisplayEventModel> DisplayedEvents { get; init; } = [];
 
     public bool IsCombined { get; init; }
 

--- a/src/EventLogExpert.UI/Models/FilterGroupModel.cs
+++ b/src/EventLogExpert.UI/Models/FilterGroupModel.cs
@@ -15,7 +15,7 @@ public sealed record FilterGroupModel
     [JsonIgnore]
     public string DisplayName => Name.Split('\\').Last();
 
-    public IEnumerable<FilterModel> Filters { get; init; } = [];
+    public IReadOnlyList<FilterModel> Filters { get; init; } = [];
 
     [JsonIgnore]
     public bool IsEditing { get; init; }

--- a/src/EventLogExpert.UI/Services/FilterService.cs
+++ b/src/EventLogExpert.UI/Services/FilterService.cs
@@ -35,7 +35,10 @@ public sealed class FilterService(IState<FilterPaneState> filterPaneState) : IFi
         IEnumerable<DisplayEventModel> events,
         EventFilter eventFilter)
     {
-        if (!FilterMethods.IsFilteringEnabled(eventFilter)) { return [.. events]; }
+        if (!FilterMethods.IsFilteringEnabled(eventFilter))
+        {
+            return events as IReadOnlyList<DisplayEventModel> ?? [.. events];
+        }
 
         return events.AsParallel()
             .Where(e => e.FilterByDate(eventFilter.DateFilter)
@@ -61,7 +64,7 @@ public sealed class FilterService(IState<FilterPaneState> filterPaneState) : IFi
         StringBuilder stringBuilder = new();
 
         if (filterModel.Data.Evaluator != FilterEvaluator.MultiSelect ||
-            filterModel.Data.Category is FilterCategory.KeywordsDisplayNames)
+            filterModel.Data.Category is FilterCategory.Keywords)
         {
             stringBuilder.Append(GetComparisonString(filterModel.Data.Category, filterModel.Data.Evaluator));
         }
@@ -70,7 +73,7 @@ public sealed class FilterService(IState<FilterPaneState> filterPaneState) : IFi
         {
             case FilterEvaluator.Equals:
             case FilterEvaluator.NotEqual:
-                if (filterModel.Data.Category is FilterCategory.KeywordsDisplayNames)
+                if (filterModel.Data.Category is FilterCategory.Keywords)
                 {
                     stringBuilder.Append($"\"{filterModel.Data.Value?.Replace("\"", "\'")}\", StringComparison.OrdinalIgnoreCase))");
                 }
@@ -82,7 +85,7 @@ public sealed class FilterService(IState<FilterPaneState> filterPaneState) : IFi
                 break;
             case FilterEvaluator.Contains:
             case FilterEvaluator.NotContains:
-                if (filterModel.Data.Category is FilterCategory.KeywordsDisplayNames)
+                if (filterModel.Data.Category is FilterCategory.Keywords)
                 {
                     stringBuilder.Append($"(\"{filterModel.Data.Value?.Replace("\"", "\'")}\", StringComparison.OrdinalIgnoreCase))");
                 }
@@ -93,7 +96,7 @@ public sealed class FilterService(IState<FilterPaneState> filterPaneState) : IFi
 
                 break;
             case FilterEvaluator.MultiSelect:
-                if (filterModel.Data.Category is FilterCategory.KeywordsDisplayNames)
+                if (filterModel.Data.Category is FilterCategory.Keywords)
                 {
                     stringBuilder.Append($"(e => (new[] {{\"{string.Join("\", \"", filterModel.Data.Values)}\"}}).Contains(e))");
                 }
@@ -106,7 +109,7 @@ public sealed class FilterService(IState<FilterPaneState> filterPaneState) : IFi
             default: return false;
         }
 
-        if (filterModel.Data is { Evaluator: FilterEvaluator.MultiSelect, Category: not FilterCategory.KeywordsDisplayNames })
+        if (filterModel.Data is { Evaluator: FilterEvaluator.MultiSelect, Category: not FilterCategory.Keywords })
         {
             stringBuilder.Append(GetComparisonString(filterModel.Data.Category, filterModel.Data.Evaluator));
         }
@@ -158,34 +161,34 @@ public sealed class FilterService(IState<FilterPaneState> filterPaneState) : IFi
     {
         FilterEvaluator.Equals => type switch
         {
-            FilterCategory.KeywordsDisplayNames => $"{type}.Any(e => string.Equals(e, ",
+            FilterCategory.Keywords => $"{type}.Any(e => string.Equals(e, ",
             FilterCategory.UserId => $"{type} != null && {type}.Value == ",
             _ => $"{type} == "
         },
         FilterEvaluator.Contains => type switch
         {
             FilterCategory.Id or FilterCategory.ActivityId => $"{type}.ToString().Contains",
-            FilterCategory.KeywordsDisplayNames => $"{type}.Any(e => e.Contains",
+            FilterCategory.Keywords => $"{type}.Any(e => e.Contains",
             FilterCategory.UserId => $"{type} != null && {type}.Value.Contains",
             _ => $"{type}.Contains"
         },
         FilterEvaluator.NotEqual => type switch
         {
-            FilterCategory.KeywordsDisplayNames => $"!{type}.Any(e => string.Equals(e, ",
+            FilterCategory.Keywords => $"!{type}.Any(e => string.Equals(e, ",
             FilterCategory.UserId => $"{type} != null && {type}.Value != ",
             _ => $"{type} != ",
         },
         FilterEvaluator.NotContains => type switch
         {
             FilterCategory.Id or FilterCategory.ActivityId => $"!{type}.ToString().Contains",
-            FilterCategory.KeywordsDisplayNames => $"!{type}.Any(e => e.Contains",
+            FilterCategory.Keywords => $"!{type}.Any(e => e.Contains",
             FilterCategory.UserId => $"{type} != null && !{type}.Value.Contains",
             _ => $"!{type}.Contains"
         },
         FilterEvaluator.MultiSelect => type switch
         {
             FilterCategory.Id or FilterCategory.Level => $"{type}.ToString())",
-            FilterCategory.KeywordsDisplayNames => $"{type}.Any",
+            FilterCategory.Keywords => $"{type}.Any",
             _ => $"{type})"
         },
         _ => string.Empty
@@ -202,7 +205,7 @@ public sealed class FilterService(IState<FilterPaneState> filterPaneState) : IFi
         StringBuilder stringBuilder = new(subFilter.ShouldCompareAny ? " || " : " && ");
 
         if (subFilter.Data.Evaluator != FilterEvaluator.MultiSelect ||
-            subFilter.Data.Category is FilterCategory.KeywordsDisplayNames)
+            subFilter.Data.Category is FilterCategory.Keywords)
         {
             stringBuilder.Append(GetComparisonString(subFilter.Data.Category, subFilter.Data.Evaluator));
         }
@@ -211,7 +214,7 @@ public sealed class FilterService(IState<FilterPaneState> filterPaneState) : IFi
         {
             case FilterEvaluator.Equals:
             case FilterEvaluator.NotEqual:
-                if (subFilter.Data.Category is FilterCategory.KeywordsDisplayNames)
+                if (subFilter.Data.Category is FilterCategory.Keywords)
                 {
                     stringBuilder.Append($"\"{subFilter.Data.Value?.Replace("\"", "\\\"")}\", StringComparison.OrdinalIgnoreCase))");
                 }
@@ -223,7 +226,7 @@ public sealed class FilterService(IState<FilterPaneState> filterPaneState) : IFi
                 break;
             case FilterEvaluator.Contains:
             case FilterEvaluator.NotContains:
-                if (subFilter.Data.Category is FilterCategory.KeywordsDisplayNames)
+                if (subFilter.Data.Category is FilterCategory.Keywords)
                 {
                     stringBuilder.Append($"(\"{subFilter.Data.Value?.Replace("\"", "\'")}\", StringComparison.OrdinalIgnoreCase))");
                 }
@@ -234,7 +237,7 @@ public sealed class FilterService(IState<FilterPaneState> filterPaneState) : IFi
 
                 break;
             case FilterEvaluator.MultiSelect:
-                if (subFilter.Data.Category is FilterCategory.KeywordsDisplayNames)
+                if (subFilter.Data.Category is FilterCategory.Keywords)
                 {
                     stringBuilder.Append($"(e => (new[] {{\"{string.Join("\", \"", subFilter.Data.Values)}\"}}).Contains(e))");
                 }
@@ -247,7 +250,7 @@ public sealed class FilterService(IState<FilterPaneState> filterPaneState) : IFi
             default: return null;
         }
 
-        if (subFilter.Data is { Evaluator: FilterEvaluator.MultiSelect, Category: not FilterCategory.KeywordsDisplayNames })
+        if (subFilter.Data is { Evaluator: FilterEvaluator.MultiSelect, Category: not FilterCategory.Keywords })
         {
             stringBuilder.Append(GetComparisonString(subFilter.Data.Category, subFilter.Data.Evaluator));
         }

--- a/src/EventLogExpert.UI/Services/FilterService.cs
+++ b/src/EventLogExpert.UI/Services/FilterService.cs
@@ -17,11 +17,11 @@ public sealed class FilterService(IState<FilterPaneState> filterPaneState) : IFi
 
     public bool IsXmlEnabled => _filterPaneState.Value.IsXmlEnabled;
 
-    public IDictionary<EventLogId, IEnumerable<DisplayEventModel>> FilterActiveLogs(
+    public IReadOnlyDictionary<EventLogId, IReadOnlyList<DisplayEventModel>> FilterActiveLogs(
         IEnumerable<EventLogData> logData,
         EventFilter eventFilter)
     {
-        Dictionary<EventLogId, IEnumerable<DisplayEventModel>> activeLogsFiltered = [];
+        Dictionary<EventLogId, IReadOnlyList<DisplayEventModel>> activeLogsFiltered = [];
 
         foreach (var data in logData)
         {
@@ -31,15 +31,16 @@ public sealed class FilterService(IState<FilterPaneState> filterPaneState) : IFi
         return activeLogsFiltered;
     }
 
-    public IEnumerable<DisplayEventModel> GetFilteredEvents(
+    public IReadOnlyList<DisplayEventModel> GetFilteredEvents(
         IEnumerable<DisplayEventModel> events,
         EventFilter eventFilter)
     {
-        if (!FilterMethods.IsFilteringEnabled(eventFilter)) { return events; }
+        if (!FilterMethods.IsFilteringEnabled(eventFilter)) { return [.. events]; }
 
         return events.AsParallel()
             .Where(e => e.FilterByDate(eventFilter.DateFilter)
-                .Filter(eventFilter.Filters, IsXmlEnabled));
+                .Filter(eventFilter.Filters, IsXmlEnabled))
+            .ToList();
     }
 
     public bool TryParse(FilterModel filterModel, out string comparison)

--- a/src/EventLogExpert.UI/Store/EventLog/EventLogAction.cs
+++ b/src/EventLogExpert.UI/Store/EventLog/EventLogAction.cs
@@ -12,7 +12,7 @@ public sealed record EventLogAction
 {
     public sealed record AddEvent(DisplayEventModel NewEvent);
 
-    public sealed record AddEventBuffered(IEnumerable<DisplayEventModel> UpdatedBuffer, bool IsFull);
+    public sealed record AddEventBuffered(IReadOnlyList<DisplayEventModel> UpdatedBuffer, bool IsFull);
 
     public sealed record AddEventSuccess(ImmutableDictionary<string, EventLogData> ActiveLogs);
 

--- a/src/EventLogExpert.UI/Store/EventLog/EventLogEffects.cs
+++ b/src/EventLogExpert.UI/Store/EventLog/EventLogEffects.cs
@@ -57,8 +57,8 @@ public sealed class EventLogEffects(
         }
         else
         {
-            var updatedBuffer = newEvent.Concat(_eventLogState.Value.NewEventBuffer);
-            var full = updatedBuffer.Count() >= EventLogState.MaxNewEvents;
+            var updatedBuffer = newEvent.Concat(_eventLogState.Value.NewEventBuffer).ToList();
+            var full = updatedBuffer.Count >= EventLogState.MaxNewEvents;
 
             dispatcher.Dispatch(new EventLogAction.AddEventBuffered(updatedBuffer, full));
         }
@@ -233,9 +233,9 @@ public sealed class EventLogEffects(
     /// <summary>Adds new events to the currently opened log</summary>
     private static EventLogData AddEventsToOneLog(EventLogData logData, IEnumerable<DisplayEventModel> eventsToAdd)
     {
-        var newEvents = eventsToAdd.Concat(logData.Events);
+        var newEvents = eventsToAdd.Concat(logData.Events).ToList();
 
-        var updatedLogData = logData with { Events = newEvents.ToList().AsReadOnly() };
+        var updatedLogData = logData with { Events = newEvents };
 
         return updatedLogData;
     }
@@ -267,6 +267,6 @@ public sealed class EventLogEffects(
 
         dispatcher.Dispatch(new EventTableAction.UpdateDisplayedEvents(filteredActiveLogs));
         dispatcher.Dispatch(new EventLogAction.AddEventSuccess(activeLogs));
-        dispatcher.Dispatch(new EventLogAction.AddEventBuffered(new List<DisplayEventModel>().AsReadOnly(), false));
+        dispatcher.Dispatch(new EventLogAction.AddEventBuffered([], false));
     }
 }

--- a/src/EventLogExpert.UI/Store/EventLog/EventLogReducers.cs
+++ b/src/EventLogExpert.UI/Store/EventLog/EventLogReducers.cs
@@ -13,7 +13,7 @@ public sealed class EventLogReducers
 {
     [ReducerMethod]
     public static EventLogState ReduceAddEventBuffered(EventLogState state, EventLogAction.AddEventBuffered action) =>
-        state with { NewEventBuffer = action.UpdatedBuffer.ToList().AsReadOnly(), NewEventBufferIsFull = action.IsFull };
+        state with { NewEventBuffer = action.UpdatedBuffer, NewEventBufferIsFull = action.IsFull };
 
     [ReducerMethod]
     public static EventLogState ReduceAddEventSuccess(EventLogState state, EventLogAction.AddEventSuccess action) =>
@@ -25,7 +25,7 @@ public sealed class EventLogReducers
         {
             ActiveLogs = ImmutableDictionary<string, EventLogData>.Empty,
             SelectedEvents = [],
-            NewEventBuffer = new List<DisplayEventModel>().AsReadOnly(),
+            NewEventBuffer = [],
             NewEventBufferIsFull = false
         };
 
@@ -34,8 +34,7 @@ public sealed class EventLogReducers
     {
         var newEventBuffer = state.NewEventBuffer
             .Where(e => e.OwningLog != action.LogName)
-            .ToList()
-            .AsReadOnly();
+            .ToList();
 
         return state with
         {
@@ -54,7 +53,7 @@ public sealed class EventLogReducers
         {
             ActiveLogs = newLogsCollection.Add(
                 action.LogData.Name,
-                action.LogData with { Events = action.Events.ToList().AsReadOnly() })
+                action.LogData with { Events = [.. action.Events] })
         };
     }
 

--- a/src/EventLogExpert.UI/Store/EventLog/EventLogState.cs
+++ b/src/EventLogExpert.UI/Store/EventLog/EventLogState.cs
@@ -5,7 +5,6 @@ using EventLogExpert.Eventing.Models;
 using EventLogExpert.UI.Models;
 using Fluxor;
 using System.Collections.Immutable;
-using System.Collections.ObjectModel;
 
 namespace EventLogExpert.UI.Store.EventLog;
 
@@ -22,8 +21,7 @@ public sealed record EventLogState
 
     public bool ContinuouslyUpdate { get; init; } = false;
 
-    public ReadOnlyCollection<DisplayEventModel> NewEventBuffer { get; init; } =
-        new List<DisplayEventModel>().AsReadOnly();
+    public IReadOnlyList<DisplayEventModel> NewEventBuffer { get; init; } = [];
 
     public bool NewEventBufferIsFull { get; init; }
 

--- a/src/EventLogExpert.UI/Store/EventTable/EventTableAction.cs
+++ b/src/EventLogExpert.UI/Store/EventTable/EventTableAction.cs
@@ -30,7 +30,7 @@ public sealed record EventTableAction
 
     public sealed record UpdateCombinedEvents;
 
-    public sealed record UpdateDisplayedEvents(IDictionary<EventLogId, IEnumerable<DisplayEventModel>> ActiveLogs);
+    public sealed record UpdateDisplayedEvents(IReadOnlyDictionary<EventLogId, IReadOnlyList<DisplayEventModel>> ActiveLogs);
 
-    public sealed record UpdateTable(EventLogId LogId, IEnumerable<DisplayEventModel> Events);
+    public sealed record UpdateTable(EventLogId LogId, IReadOnlyList<DisplayEventModel> Events);
 }

--- a/src/EventLogExpert.UI/Store/EventTable/EventTableReducers.cs
+++ b/src/EventLogExpert.UI/Store/EventTable/EventTableReducers.cs
@@ -6,7 +6,6 @@ using EventLogExpert.Eventing.Models;
 using EventLogExpert.UI.Models;
 using Fluxor;
 using System.Collections.Immutable;
-using System.Collections.ObjectModel;
 
 namespace EventLogExpert.UI.Store.EventTable;
 
@@ -198,7 +197,7 @@ public sealed class EventTableReducers
         };
     }
 
-    private static ReadOnlyCollection<DisplayEventModel> GetCombinedEvents(
+    private static List<DisplayEventModel> GetCombinedEvents(
         IEnumerable<IEnumerable<DisplayEventModel>> eventLists)
     {
         List<DisplayEventModel> combinedEvents = [];
@@ -208,7 +207,7 @@ public sealed class EventTableReducers
             combinedEvents.AddRange(eventList);
         }
 
-        return combinedEvents.AsReadOnly();
+        return combinedEvents;
     }
 
     private static EventTableState SortDisplayEvents(EventTableState state, ColumnName? orderBy, bool isDescending)

--- a/src/EventLogExpert.UI/Store/FilterGroup/FilterGroupReducers.cs
+++ b/src/EventLogExpert.UI/Store/FilterGroup/FilterGroupReducers.cs
@@ -19,7 +19,7 @@ public sealed class FilterGroupReducers
         {
             Groups = state.Groups
                 .Remove(group)
-                .Add(group with { Filters = group.Filters.Concat([new FilterModel { IsEditing = true }]) })
+                .Add(group with { Filters = [.. group.Filters, new FilterModel { IsEditing = true }] })
         };
     }
 

--- a/src/EventLogExpert.UI/Store/FilterGroup/FilterGroupState.cs
+++ b/src/EventLogExpert.UI/Store/FilterGroup/FilterGroupState.cs
@@ -4,7 +4,6 @@
 using EventLogExpert.UI.Models;
 using Fluxor;
 using System.Collections.Immutable;
-using System.Collections.ObjectModel;
 
 namespace EventLogExpert.UI.Store.FilterGroup;
 
@@ -13,6 +12,6 @@ public sealed record FilterGroupState
 {
     public ImmutableList<FilterGroupModel> Groups { get; init; } = [];
 
-    public ReadOnlyDictionary<string, FilterGroupData> DisplayGroups { get; init; } =
-        new Dictionary<string, FilterGroupData>().AsReadOnly();
+    public IReadOnlyDictionary<string, FilterGroupData> DisplayGroups { get; init; } =
+        ImmutableDictionary<string, FilterGroupData>.Empty;
 }

--- a/src/EventLogExpert/Components/DetailsPane.razor
+++ b/src/EventLogExpert/Components/DetailsPane.razor
@@ -23,9 +23,7 @@
                 <div>Level: @SelectedEvent.Level</div>
                 @if (SelectedEvent.Keywords.Any())
                 {
-                    <div>
-                        "Keywords: @SelectedEvent.KeywordsDisplayName"
-                    </div>
+                    <div>Keywords: @SelectedEvent.KeywordsDisplayName</div>
                 }
                 <div>Date and Time: @SelectedEvent.TimeCreated.ConvertTimeZone(Settings.TimeZoneInfo)</div>
             </div>

--- a/src/EventLogExpert/Components/DetailsPane.razor
+++ b/src/EventLogExpert/Components/DetailsPane.razor
@@ -21,10 +21,10 @@
                 <div>Source: @SelectedEvent.Source</div>
                 <div>Event Id: @SelectedEvent.Id</div>
                 <div>Level: @SelectedEvent.Level</div>
-                @if (SelectedEvent.KeywordsDisplayNames.Any())
+                @if (SelectedEvent.Keywords.Any())
                 {
                     <div>
-                        @SelectedEvent.KeywordsDisplayNames.GetEventKeywords()
+                        "Keywords: @SelectedEvent.KeywordsDisplayName"
                     </div>
                 }
                 <div>Date and Time: @SelectedEvent.TimeCreated.ConvertTimeZone(Settings.TimeZoneInfo)</div>

--- a/src/EventLogExpert/Components/EventTable.razor
+++ b/src/EventLogExpert/Components/EventTable.razor
@@ -71,7 +71,7 @@
                                     @evt.TaskCategory
                                     break;
                                 case ColumnName.Keywords:
-                                    <text>@string.Join(", ", evt.KeywordsDisplayNames)</text>
+                                    @evt.KeywordsDisplayName
                                     break;
                                 case ColumnName.ProcessId:
                                     @evt.ProcessId

--- a/src/EventLogExpert/Components/EventTable.razor
+++ b/src/EventLogExpert/Components/EventTable.razor
@@ -1,10 +1,11 @@
-﻿@using EventLogExpert.UI
+﻿@using EventLogExpert.Eventing.Models
+@using EventLogExpert.UI
 @inherits FluxorComponent
 
 <SplitLogTabPane />
 
 <div class="table-container">
-    <table aria-label="Event Log Table" id="eventTable" @onkeydown="HandleKeyDown" role="grid">
+    <table aria-label="Event Log Table" aria-rowcount="@(_currentTable?.DisplayedEvents.Count + 1 ?? 1)" id="eventTable" @onkeydown="HandleKeyDown" role="grid">
         <thead @oncontextmenu="InvokeTableColumnMenu">
         <tr role="row">
             @for (int columnIndex = 0; columnIndex < _enabledColumns.Length; columnIndex++)
@@ -37,7 +38,7 @@
         <tbody @oncontextmenu="InvokeContextMenu">
         @if (_currentTable is not null)
         {
-            <Virtualize Context="evt" Items="_currentTable.DisplayedEvents">
+            <Virtualize Context="evt" Items="@((_currentTable.DisplayedEvents as ICollection<DisplayEventModel>) ?? [])">
                 @{ _rowIndex = _currentTable.DisplayedEvents.IndexOf(evt); }
                     <tr aria-rowindex="@(_rowIndex + 2)" aria-selected="@(_selectedEventState.Contains(evt).ToString().ToLower())"
                         class="@GetCss(evt)" @key="@($"{evt.OwningLog}_{evt.RecordId}")" @onmousedown="args => SelectEvent(args, evt)" role="row" tabindex="0">

--- a/src/EventLogExpert/ExtensionMethods.cs
+++ b/src/EventLogExpert/ExtensionMethods.cs
@@ -33,15 +33,6 @@ internal static class ExtensionMethods
     internal static DateTime ConvertTimeZoneToUtc(this DateTime time, TimeZoneInfo? destinationTime) =>
         destinationTime is null ? time : TimeZoneInfo.ConvertTimeToUtc(time, destinationTime);
 
-    internal static string GetEventKeywords(this IEnumerable<string> keywords)
-    {
-        StringBuilder sb = new("Keywords:");
-
-        foreach (var keyword in keywords) { sb.Append($" {keyword}"); }
-
-        return sb.ToString();
-    }
-
     internal static string ToFullString(this Enum value)
     {
         var memberAttribute = value.GetType().GetField(value.ToString())?

--- a/src/EventLogExpert/Services/ClipboardService.cs
+++ b/src/EventLogExpert/Services/ClipboardService.cs
@@ -94,7 +94,7 @@ public sealed class ClipboardService : IClipboardService
                             defaultEvent.Append($"\"{@event.TaskCategory}\" ");
                             break;
                         case ColumnName.Keywords:
-                            defaultEvent.Append($"\"{string.Join(", ", @event.KeywordsDisplayNames)}\" ");
+                            defaultEvent.Append($"\"{@event.KeywordsDisplayName}\" ");
                             break;
                         case ColumnName.ProcessId:
                             defaultEvent.Append($"\"{@event.ProcessId}\" ");
@@ -133,7 +133,7 @@ public sealed class ClipboardService : IClipboardService
                 fullEvent.AppendLine($"Event ID: {@event.Id}");
                 fullEvent.AppendLine($"Task Category: {@event.TaskCategory}");
                 fullEvent.AppendLine($"Level: {@event.Level}");
-                fullEvent.AppendLine(@event.KeywordsDisplayNames.GetEventKeywords());
+                fullEvent.AppendLine($"Keywords: {@event.KeywordsDisplayName}");
                 fullEvent.AppendLine($"User: {@event.UserId}");
                 fullEvent.AppendLine($"Computer: {@event.ComputerName}");
                 fullEvent.AppendLine("Description:");

--- a/src/EventLogExpert/Shared/Components/ContextMenu.razor.cs
+++ b/src/EventLogExpert/Shared/Components/ContextMenu.razor.cs
@@ -56,7 +56,7 @@ public sealed partial class ContextMenu
             FilterCategory.Id => selectedEvent.Id.ToString(),
             FilterCategory.ActivityId => selectedEvent.ActivityId.ToString()!,
             FilterCategory.Level => selectedEvent.Level,
-            FilterCategory.KeywordsDisplayNames => selectedEvent.KeywordsDisplayName,
+            FilterCategory.Keywords => selectedEvent.KeywordsDisplayName,
             FilterCategory.Source => selectedEvent.Source,
             FilterCategory.TaskCategory => selectedEvent.TaskCategory,
             _ => string.Empty,

--- a/src/EventLogExpert/Shared/Components/ContextMenu.razor.cs
+++ b/src/EventLogExpert/Shared/Components/ContextMenu.razor.cs
@@ -56,7 +56,7 @@ public sealed partial class ContextMenu
             FilterCategory.Id => selectedEvent.Id.ToString(),
             FilterCategory.ActivityId => selectedEvent.ActivityId.ToString()!,
             FilterCategory.Level => selectedEvent.Level,
-            FilterCategory.KeywordsDisplayNames => selectedEvent.KeywordsDisplayNames.GetEventKeywords(),
+            FilterCategory.KeywordsDisplayNames => selectedEvent.KeywordsDisplayName,
             FilterCategory.Source => selectedEvent.Source,
             FilterCategory.TaskCategory => selectedEvent.TaskCategory,
             _ => string.Empty,

--- a/src/EventLogExpert/Shared/Components/Filters/FilterRow.razor.cs
+++ b/src/EventLogExpert/Shared/Components/Filters/FilterRow.razor.cs
@@ -42,8 +42,8 @@ public sealed partial class FilterRow
                 .SelectMany(log => log.GetCategoryValues(FilterCategory.ActivityId))
                 .Distinct().Order()],
             FilterCategory.Level => [.. Enum.GetNames<SeverityLevel>()],
-            FilterCategory.KeywordsDisplayNames => [.. EventLogState.Value.ActiveLogs.Values
-                .SelectMany(log => log.GetCategoryValues(FilterCategory.KeywordsDisplayNames))
+            FilterCategory.Keywords => [.. EventLogState.Value.ActiveLogs.Values
+                .SelectMany(log => log.GetCategoryValues(FilterCategory.Keywords))
                 .Distinct().Order()],
             FilterCategory.Source => [.. EventLogState.Value.ActiveLogs.Values
                 .SelectMany(log => log.GetCategoryValues(FilterCategory.Source))

--- a/src/EventLogExpert/Shared/Components/Filters/SubFilterRow.razor.cs
+++ b/src/EventLogExpert/Shared/Components/Filters/SubFilterRow.razor.cs
@@ -41,8 +41,8 @@ public sealed partial class SubFilterRow
                 .SelectMany(log => log.GetCategoryValues(FilterCategory.ActivityId))
                 .Distinct().Order()],
             FilterCategory.Level => [.. Enum.GetNames<SeverityLevel>()],
-            FilterCategory.KeywordsDisplayNames => [.. EventLogState.Value.ActiveLogs.Values
-                .SelectMany(log => log.GetCategoryValues(FilterCategory.KeywordsDisplayNames))
+            FilterCategory.Keywords => [.. EventLogState.Value.ActiveLogs.Values
+                .SelectMany(log => log.GetCategoryValues(FilterCategory.Keywords))
                 .Distinct().Order()],
             FilterCategory.Source => [.. EventLogState.Value.ActiveLogs.Values
                 .SelectMany(log => log.GetCategoryValues(FilterCategory.Source))


### PR DESCRIPTION
Method	Change	Why
CacheStringInterning	-19% faster ✅	Directly tests the simplified EventResolverCache
ResolveEvents	-1.8% faster ✅	Uses the cache and resolver logic
ReadEvents	No change	Doesn't use cache or collections with AsReadOnly
FullPipeline	Mostly API calls	Dominated by ReadEvents overhead

Biggest potential issue with this change is the removal of AsReadonly from several hot paths but since these are private and internal methods then we can keep this under control by making sure there is no List casts in PR reviews.