### PR TITLE
Make canonical DisplayedEvents primary and drop per-table materialization

### DIFF
--- a/src/EventLogExpert.UI.Tests/Store/EventLog/EventLogEffectsTests.cs
+++ b/src/EventLogExpert.UI.Tests/Store/EventLog/EventLogEffectsTests.cs
@@ -552,6 +552,210 @@ public sealed class EventLogEffectsTests
     }
 
     [Fact]
+    public async Task HandleSetFilters_FilterBranch_WhenLogClosedDuringFilter_ShouldOmitStaleSliceFromDispatch()
+    {
+        // Arrange — log closes (ActiveLogs.Remove) while the filter task is running. The
+        // post-filter dispatch must omit the closed log's slice. (The reducer also skips
+        // unknown log ids, but checking at the effect keeps the dispatch minimal.)
+        var snapshotEvents = new List<DisplayEventModel> { EventUtils.CreateTestEvent(100) };
+        var snapshotData = new EventLogData(Constants.LogNameTestLog, PathType.LogName, snapshotEvents);
+
+        var snapshotState = new EventLogState
+        {
+            ContinuouslyUpdate = false,
+            ActiveLogs = ImmutableDictionary<string, EventLogData>.Empty.Add(Constants.LogNameTestLog, snapshotData),
+            NewEventBuffer = [],
+            AppliedFilter = new EventFilter(null, [])
+        };
+
+        var postCloseState = snapshotState with
+        {
+            ActiveLogs = ImmutableDictionary<string, EventLogData>.Empty
+        };
+
+        EventLogState volatileState = snapshotState;
+
+        var filterResult = new Dictionary<EventLogId, IReadOnlyList<DisplayEventModel>>
+        {
+            [snapshotData.Id] = snapshotEvents
+        };
+
+        var (effects, mockDispatcher, mockFilterService) = CreateEffectsWithMutableState(() => volatileState);
+
+        mockFilterService.FilterActiveLogs(Arg.Any<IEnumerable<EventLogData>>(), Arg.Any<EventFilter>())
+            .Returns(_ =>
+            {
+                volatileState = postCloseState;
+                return filterResult;
+            });
+
+        var nonXmlFilter = FilterUtils.CreateTestFilter(Constants.FilterIdEquals100, isEnabled: true);
+        var action = new EventLogAction.SetFilters(new EventFilter(null, [nonXmlFilter]));
+
+        // Act
+        await effects.HandleSetFilters(action, mockDispatcher);
+
+        // Assert — dispatched UpdateDisplayedEvents has no entry for the closed log id.
+        mockDispatcher.Received(1).Dispatch(Arg.Is<EventTableAction.UpdateDisplayedEvents>(
+            a => !a.ActiveLogs.ContainsKey(snapshotData.Id)));
+    }
+
+    [Fact]
+    public async Task HandleSetFilters_FilterBranch_WhenLogEventsChangeDuringFilter_ShouldRefilterFromCurrentState()
+    {
+        // Arrange — single open log; live event arrives during the first filter pass (Events ref
+        // changes). The new filter must be re-applied to the post-mutation rows in a single retry
+        // pass so the user sees the filter applied to the updated row set, not stale rows.
+        var snapshotEvents = new List<DisplayEventModel> { EventUtils.CreateTestEvent(100) };
+        var snapshotData = new EventLogData(Constants.LogNameTestLog, PathType.LogName, snapshotEvents);
+
+        var snapshotState = new EventLogState
+        {
+            ContinuouslyUpdate = false,
+            ActiveLogs = ImmutableDictionary<string, EventLogData>.Empty.Add(Constants.LogNameTestLog, snapshotData),
+            NewEventBuffer = [],
+            AppliedFilter = new EventFilter(null, [])
+        };
+
+        var liveTailEvents = new List<DisplayEventModel>
+        {
+            EventUtils.CreateTestEvent(100),
+            EventUtils.CreateTestEvent(101)
+        };
+
+        var postLiveTailState = snapshotState with
+        {
+            ActiveLogs = snapshotState.ActiveLogs.SetItem(
+                Constants.LogNameTestLog,
+                snapshotData with { Events = liveTailEvents })
+        };
+
+        EventLogState volatileState = snapshotState;
+
+        var pass1Result = new Dictionary<EventLogId, IReadOnlyList<DisplayEventModel>>
+        {
+            [snapshotData.Id] = snapshotEvents
+        };
+
+        var pass2Result = new Dictionary<EventLogId, IReadOnlyList<DisplayEventModel>>
+        {
+            [snapshotData.Id] = liveTailEvents
+        };
+
+        var (effects, mockDispatcher, mockFilterService) = CreateEffectsWithMutableState(() => volatileState);
+
+        mockFilterService.FilterActiveLogs(Arg.Any<IEnumerable<EventLogData>>(), Arg.Any<EventFilter>())
+            .Returns(
+                _ =>
+                {
+                    volatileState = postLiveTailState;
+                    return pass1Result;
+                },
+                _ => pass2Result);
+
+        var nonXmlFilter = FilterUtils.CreateTestFilter(Constants.FilterIdEquals100, isEnabled: true);
+        var action = new EventLogAction.SetFilters(new EventFilter(null, [nonXmlFilter]));
+
+        // Act
+        await effects.HandleSetFilters(action, mockDispatcher);
+
+        // Assert — FilterActiveLogs ran twice; the second call received the post-mutation
+        // EventLogData (proves pass 2 actually re-filtered from current state, not from the
+        // pass-1 snapshot). Dispatch contains the re-filtered slice, not the stale pass-1 result.
+        mockFilterService.Received(2).FilterActiveLogs(
+            Arg.Any<IEnumerable<EventLogData>>(),
+            Arg.Any<EventFilter>());
+
+        mockFilterService.Received(1).FilterActiveLogs(
+            Arg.Is<IEnumerable<EventLogData>>(logs => logs.Any(l => ReferenceEquals(l.Events, liveTailEvents))),
+            Arg.Any<EventFilter>());
+
+        mockDispatcher.Received(1).Dispatch(Arg.Is<EventTableAction.UpdateDisplayedEvents>(
+            a => a.ActiveLogs.ContainsKey(snapshotData.Id)
+                && ReferenceEquals(a.ActiveLogs[snapshotData.Id], liveTailEvents)));
+    }
+
+    [Fact]
+    public async Task HandleSetFilters_FilterBranch_WhenLogStillStaleAfterRetry_ShouldOmitStaleSliceFromDispatch()
+    {
+        // Arrange — events change during pass 1 AND again during pass 2. Single-retry semantics
+        // mean the pass-2 result is still stale; the slice must be omitted so the reducer's
+        // preserve-omitted fallback keeps the existing rows (avoids losing live events).
+        var snapshotEvents = new List<DisplayEventModel>();
+        var snapshotData = new EventLogData(Constants.LogNameTestLog, PathType.LogName, snapshotEvents);
+
+        var snapshotState = new EventLogState
+        {
+            ContinuouslyUpdate = false,
+            ActiveLogs = ImmutableDictionary<string, EventLogData>.Empty.Add(Constants.LogNameTestLog, snapshotData),
+            NewEventBuffer = [],
+            AppliedFilter = new EventFilter(null, [])
+        };
+
+        var pass1MutationEvents = new List<DisplayEventModel> { EventUtils.CreateTestEvent(100) };
+        var pass2MutationEvents = new List<DisplayEventModel>
+        {
+            EventUtils.CreateTestEvent(100),
+            EventUtils.CreateTestEvent(101)
+        };
+
+        var afterPass1State = snapshotState with
+        {
+            ActiveLogs = snapshotState.ActiveLogs.SetItem(
+                Constants.LogNameTestLog,
+                snapshotData with { Events = pass1MutationEvents })
+        };
+
+        var afterPass2State = snapshotState with
+        {
+            ActiveLogs = snapshotState.ActiveLogs.SetItem(
+                Constants.LogNameTestLog,
+                snapshotData with { Events = pass2MutationEvents })
+        };
+
+        EventLogState volatileState = snapshotState;
+
+        var pass1Result = new Dictionary<EventLogId, IReadOnlyList<DisplayEventModel>>
+        {
+            [snapshotData.Id] = []
+        };
+
+        var pass2Result = new Dictionary<EventLogId, IReadOnlyList<DisplayEventModel>>
+        {
+            [snapshotData.Id] = pass1MutationEvents
+        };
+
+        var (effects, mockDispatcher, mockFilterService) = CreateEffectsWithMutableState(() => volatileState);
+
+        mockFilterService.FilterActiveLogs(Arg.Any<IEnumerable<EventLogData>>(), Arg.Any<EventFilter>())
+            .Returns(
+                _ =>
+                {
+                    volatileState = afterPass1State;
+                    return pass1Result;
+                },
+                _ =>
+                {
+                    volatileState = afterPass2State;
+                    return pass2Result;
+                });
+
+        var nonXmlFilter = FilterUtils.CreateTestFilter(Constants.FilterIdEquals100, isEnabled: true);
+        var action = new EventLogAction.SetFilters(new EventFilter(null, [nonXmlFilter]));
+
+        // Act
+        await effects.HandleSetFilters(action, mockDispatcher);
+
+        // Assert — both filter passes ran; dispatch omits the still-stale log id.
+        mockFilterService.Received(2).FilterActiveLogs(
+            Arg.Any<IEnumerable<EventLogData>>(),
+            Arg.Any<EventFilter>());
+
+        mockDispatcher.Received(1).Dispatch(Arg.Is<EventTableAction.UpdateDisplayedEvents>(
+            a => !a.ActiveLogs.ContainsKey(snapshotData.Id)));
+    }
+
+    [Fact]
     public async Task HandleSetFilters_FilterBranch_WhenSupersededByNewerFilter_ShouldDropStaleResults()
     {
         var logData = new EventLogData(Constants.LogNameTestLog, PathType.LogName, []);
@@ -841,6 +1045,46 @@ public sealed class EventLogEffectsTests
         var mockDispatcher = Substitute.For<IDispatcher>();
 
         return (effects, mockDispatcher);
+    }
+
+    private static (EventLogEffects effects,
+        IDispatcher mockDispatcher,
+        IFilterService mockFilterService) CreateEffectsWithMutableState(Func<EventLogState> stateProvider)
+    {
+        var mockEventLogState = Substitute.For<IState<EventLogState>>();
+        mockEventLogState.Value.Returns(_ => stateProvider());
+
+        var mockFilterService = Substitute.For<IFilterService>();
+
+        mockFilterService.FilterActiveLogs(Arg.Any<IEnumerable<EventLogData>>(), Arg.Any<EventFilter>())
+            .Returns(new Dictionary<EventLogId, IReadOnlyList<DisplayEventModel>>());
+
+        mockFilterService.GetFilteredEvents(Arg.Any<IEnumerable<DisplayEventModel>>(), Arg.Any<EventFilter>())
+            .Returns(callInfo => callInfo.Arg<IEnumerable<DisplayEventModel>>().ToList());
+
+        var mockLogger = Substitute.For<ITraceLogger>();
+        var mockLogWatcherService = Substitute.For<ILogWatcherService>();
+        var mockResolverCache = Substitute.For<IEventResolverCache>();
+
+        var mockServiceScopeFactory = Substitute.For<IServiceScopeFactory>();
+        var mockServiceScope = Substitute.For<IServiceScope>();
+        var mockServiceProvider = Substitute.For<IServiceProvider>();
+
+        mockServiceScopeFactory.CreateScope().Returns(mockServiceScope);
+        mockServiceScope.ServiceProvider.Returns(mockServiceProvider);
+
+        var effects = new EventLogEffects(
+            mockEventLogState,
+            mockFilterService,
+            mockLogger,
+            mockLogWatcherService,
+            mockResolverCache,
+            Substitute.For<IEventXmlResolver>(),
+            mockServiceScopeFactory);
+
+        var mockDispatcher = Substitute.For<IDispatcher>();
+
+        return (effects, mockDispatcher, mockFilterService);
     }
 
     private static (EventLogEffects effects,

--- a/src/EventLogExpert.UI.Tests/Store/EventTable/EventTableEffectsTests.cs
+++ b/src/EventLogExpert.UI.Tests/Store/EventTable/EventTableEffectsTests.cs
@@ -383,32 +383,6 @@ public sealed class EventTableEffectsTests
                 columns.Count() == 2);
     }
 
-    [Fact]
-    public async Task HandleUpdateDisplayedEvents_ShouldDispatchUpdateCombinedEvents()
-    {
-        // Arrange
-        var mockDispatcher = Substitute.For<IDispatcher>();
-
-        // Act
-        await EventTableEffects.HandleUpdateDisplayedEvents(mockDispatcher);
-
-        // Assert
-        mockDispatcher.Received(1).Dispatch(Arg.Any<EventTableAction.UpdateCombinedEvents>());
-    }
-
-    [Fact]
-    public async Task HandleUpdateTable_ShouldDispatchUpdateCombinedEvents()
-    {
-        // Arrange
-        var mockDispatcher = Substitute.For<IDispatcher>();
-
-        // Act
-        await EventTableEffects.HandleUpdateTable(mockDispatcher);
-
-        // Assert
-        mockDispatcher.Received(1).Dispatch(Arg.Any<EventTableAction.UpdateCombinedEvents>());
-    }
-
     private static (EventTableEffects effects, IDispatcher mockDispatcher, IPreferencesProvider mockPreferencesProvider)
         CreateEffects(List<ColumnName>? enabledColumns = null, EventTableState? state = null)
     {

--- a/src/EventLogExpert.UI.Tests/Store/EventTable/EventTableStoreTests.cs
+++ b/src/EventLogExpert.UI.Tests/Store/EventTable/EventTableStoreTests.cs
@@ -163,25 +163,59 @@ public sealed class EventTableStoreTests
     }
 
     [Fact]
-    public void EventTableModel_ComputerName_ShouldReturnFirstEventComputer()
+    public void EventTableModel_ComputerName_AfterFirstEventArrives_ShouldBeStoredOnTable()
     {
         // Arrange
-        var events = new List<DisplayEventModel>
+        var logData = new EventLogData(Constants.LogNameTestLog, PathType.LogName, []);
+        var state = new EventTableState();
+        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData));
+
+        var firstBatch = new List<DisplayEventModel>
         {
-            EventUtils.CreateTestEvent(100, computerName: Constants.EventComputerServer01),
-            EventUtils.CreateTestEvent(200, computerName: Constants.EventComputerServer02)
+            new(Constants.LogNameTestLog, PathType.LogName) { Id = 10, RecordId = 1, ComputerName = Constants.EventComputerServer01 }
         };
 
-        var model = new EventTableModel(EventLogId.Create())
+        state = EventTableReducers.ReduceAppendTableEvents(
+            state,
+            new EventTableAction.AppendTableEvents(logData.Id, firstBatch));
+
+        var secondBatch = new List<DisplayEventModel>
         {
-            DisplayedEvents = events
+            new(Constants.LogNameTestLog, PathType.LogName) { Id = 11, RecordId = 2, ComputerName = Constants.EventComputerServer02 }
+        };
+
+        // Act — second batch with a different ComputerName must not overwrite the latched value
+        state = EventTableReducers.ReduceAppendTableEvents(
+            state,
+            new EventTableAction.AppendTableEvents(logData.Id, secondBatch));
+
+        // Assert — ComputerName latches to the first non-empty observed value
+        var table = state.EventTables.First(t => t.Id == logData.Id);
+        Assert.Equal(Constants.EventComputerServer01, table.ComputerName);
+    }
+
+    [Fact]
+    public void EventTableModel_ComputerName_WhenFirstEventHasEmptyComputerName_ShouldUseLaterEventInBatch()
+    {
+        // Arrange — first event has an empty ComputerName (resolver miss); second carries the name
+        var logData = new EventLogData(Constants.LogNameTestLog, PathType.LogName, []);
+        var state = new EventTableState();
+        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData));
+
+        var batch = new List<DisplayEventModel>
+        {
+            new(Constants.LogNameTestLog, PathType.LogName) { Id = 10, RecordId = 1, ComputerName = string.Empty },
+            new(Constants.LogNameTestLog, PathType.LogName) { Id = 11, RecordId = 2, ComputerName = Constants.EventComputerServer01 }
         };
 
         // Act
-        var computerName = model.ComputerName;
+        state = EventTableReducers.ReduceAppendTableEvents(
+            state,
+            new EventTableAction.AppendTableEvents(logData.Id, batch));
 
-        // Assert
-        Assert.Equal(Constants.EventComputerServer01, computerName);
+        // Assert — reducer scans past the empty leading event and latches the first non-empty value
+        var table = state.EventTables.First(t => t.Id == logData.Id);
+        Assert.Equal(Constants.EventComputerServer01, table.ComputerName);
     }
 
     [Fact]
@@ -270,7 +304,7 @@ public sealed class EventTableStoreTests
 
         // Assert
         Assert.False(state.EventTables.First().IsLoading);
-        Assert.Equal(2, state.EventTables.First().DisplayedEvents.Count);
+        Assert.Equal(2, state.DisplayedEvents.Count);
     }
 
     [Fact]
@@ -456,7 +490,8 @@ public sealed class EventTableStoreTests
 
         // Assert
         var updatedTable = newState.EventTables.First(t => t.Id == logData.Id);
-        Assert.Equal(4, updatedTable.DisplayedEvents.Count);
+        Assert.Equal(4, newState.DisplayedEvents.Count);
+        Assert.Equal(4, newState.EventCountByLog[updatedTable.Id]);
     }
 
     [Fact]
@@ -480,7 +515,7 @@ public sealed class EventTableStoreTests
         // Assert - IsLoading should still be true (partial update doesn't complete loading)
         var updatedTable = newState.EventTables.First(t => t.Id == logData.Id);
         Assert.True(updatedTable.IsLoading);
-        Assert.Single(updatedTable.DisplayedEvents);
+        Assert.Single(newState.DisplayedEvents);
     }
 
     [Fact]
@@ -515,7 +550,7 @@ public sealed class EventTableStoreTests
 
         // Assert - sort is by DateAndTime descending; ties on TimeCreated fall through
         // to the RecordId tiebreaker, which preserves descending RecordId order here.
-        var displayedEvents = newState.EventTables.First(t => t.Id == logData.Id).DisplayedEvents;
+        var displayedEvents = newState.DisplayedEvents;
         Assert.Equal(4, displayedEvents.Count);
 
         var recordIds = displayedEvents.Select(e => e.RecordId).ToList();
@@ -544,6 +579,33 @@ public sealed class EventTableStoreTests
     }
 
     [Fact]
+    public void ReduceAppendTableEventsBatch_WhenBatchTargetsClosedLog_ShouldSkipThatBatch()
+    {
+        // Arrange — open log plus a stale log id whose tab no longer exists (race: closed mid-flight)
+        var openLog = new EventLogData(Constants.LogNameLog1, PathType.LogName, []);
+        var state = new EventTableState();
+        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(openLog));
+
+        var staleLogId = EventLogId.Create();
+        var batches = new Dictionary<EventLogId, IReadOnlyList<DisplayEventModel>>
+        {
+            { openLog.Id, [new(Constants.LogNameLog1, PathType.LogName) { Id = 10, RecordId = 1 }] },
+            { staleLogId, [new("ClosedLog", PathType.LogName) { Id = 99, RecordId = 99 }] }
+        };
+
+        // Act
+        var newState = EventTableReducers.ReduceAppendTableEventsBatch(
+            state,
+            new EventTableAction.AppendTableEventsBatch(batches));
+
+        // Assert — stale batch is skipped; canonical and EventCountByLog only reflect the open log
+        Assert.Single(newState.DisplayedEvents);
+        Assert.Equal(1L, newState.DisplayedEvents[0].RecordId);
+        Assert.False(newState.EventCountByLog.ContainsKey(staleLogId));
+        Assert.Equal(1, newState.EventCountByLog[openLog.Id]);
+    }
+
+    [Fact]
     public void ReduceCloseAll_ShouldClearAllTables()
     {
         // Arrange
@@ -557,6 +619,86 @@ public sealed class EventTableStoreTests
         // Assert
         Assert.Empty(newState.EventTables);
         Assert.Null(newState.ActiveEventLogId);
+    }
+
+    [Fact]
+    public void ReduceCloseLog_ShouldScrubCanonicalRowsAndCountForClosedLog()
+    {
+        // Arrange — three logs with canonical rows; close the middle one. Canonical must lose
+        // only the closed log's rows, and EventCountByLog must drop the closed log's id.
+        var logData1 = new EventLogData(Constants.LogNameLog1, PathType.LogName, []);
+        var logData2 = new EventLogData(Constants.LogNameLog2, PathType.LogName, []);
+        var logData3 = new EventLogData(Constants.LogNameLog3, PathType.LogName, []);
+        var state = new EventTableState();
+        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData1));
+        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData2));
+        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData3));
+
+        var log1Events = new List<DisplayEventModel>
+        {
+            new(Constants.LogNameLog1, PathType.LogName) { Id = 100, RecordId = 1 }
+        };
+
+        var log2Events = new List<DisplayEventModel>
+        {
+            new(Constants.LogNameLog2, PathType.LogName) { Id = 200, RecordId = 1 },
+            new(Constants.LogNameLog2, PathType.LogName) { Id = 201, RecordId = 2 }
+        };
+
+        var log3Events = new List<DisplayEventModel>
+        {
+            new(Constants.LogNameLog3, PathType.LogName) { Id = 300, RecordId = 1 }
+        };
+
+        state = EventTableReducers.ReduceUpdateTable(state, new EventTableAction.UpdateTable(logData1.Id, log1Events));
+        state = EventTableReducers.ReduceUpdateTable(state, new EventTableAction.UpdateTable(logData2.Id, log2Events));
+        state = EventTableReducers.ReduceUpdateTable(state, new EventTableAction.UpdateTable(logData3.Id, log3Events));
+
+        // Act
+        var newState = EventTableReducers.ReduceCloseLog(state, new EventTableAction.CloseLog(logData2.Id));
+
+        // Assert — canonical loses only logData2's rows; count map drops only logData2's id.
+        Assert.Equal(2, newState.DisplayedEvents.Count);
+        Assert.DoesNotContain(newState.DisplayedEvents, e => e.OwningLog == Constants.LogNameLog2);
+        Assert.False(newState.EventCountByLog.ContainsKey(logData2.Id));
+        Assert.Equal(1, newState.EventCountByLog[logData1.Id]);
+        Assert.Equal(1, newState.EventCountByLog[logData3.Id]);
+    }
+
+    [Fact]
+    public void ReduceCloseLog_WhenClosingDownToOneLog_ShouldKeepOnlySoleRemainingLogRows()
+    {
+        // Arrange — two logs with canonical rows; close one. The Combined table is removed and
+        // canonical is filtered down to just the remaining log's rows. Exercises the case-1
+        // branch (which uses FilterByOwningLog rather than FilterOutOwningLog).
+        var logData1 = new EventLogData(Constants.LogNameLog1, PathType.LogName, []);
+        var logData2 = new EventLogData(Constants.LogNameLog2, PathType.LogName, []);
+        var state = new EventTableState();
+        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData1));
+        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData2));
+
+        var log1Events = new List<DisplayEventModel>
+        {
+            new(Constants.LogNameLog1, PathType.LogName) { Id = 100, RecordId = 1 }
+        };
+
+        var log2Events = new List<DisplayEventModel>
+        {
+            new(Constants.LogNameLog2, PathType.LogName) { Id = 200, RecordId = 1 },
+            new(Constants.LogNameLog2, PathType.LogName) { Id = 201, RecordId = 2 }
+        };
+
+        state = EventTableReducers.ReduceUpdateTable(state, new EventTableAction.UpdateTable(logData1.Id, log1Events));
+        state = EventTableReducers.ReduceUpdateTable(state, new EventTableAction.UpdateTable(logData2.Id, log2Events));
+
+        // Act
+        var newState = EventTableReducers.ReduceCloseLog(state, new EventTableAction.CloseLog(logData1.Id));
+
+        // Assert — only logData2's rows remain; logData1 dropped from count map.
+        Assert.Equal(2, newState.DisplayedEvents.Count);
+        Assert.All(newState.DisplayedEvents, e => Assert.Equal(Constants.LogNameLog2, e.OwningLog));
+        Assert.False(newState.EventCountByLog.ContainsKey(logData1.Id));
+        Assert.Equal(2, newState.EventCountByLog[logData2.Id]);
     }
 
     [Fact]
@@ -877,7 +1019,7 @@ public sealed class EventTableStoreTests
         // RecordId=2 (+20s) before RecordId=1 (+40s)).
         Assert.Null(toggledState.OrderBy);
         Assert.True(toggledState.IsDescending);
-        var sortedEvents = toggledState.EventTables.First(table => table.Id == logData.Id).DisplayedEvents;
+        var sortedEvents = toggledState.DisplayedEvents;
         Assert.Equal(baseTime.AddSeconds(40), sortedEvents[0].TimeCreated);
         Assert.Equal(baseTime.AddSeconds(20), sortedEvents[1].TimeCreated);
     }
@@ -983,263 +1125,36 @@ public sealed class EventTableStoreTests
         // Assert
         Assert.Null(toggledState.OrderBy);
         Assert.True(toggledState.IsDescending);
-        var sortedEvents = toggledState.EventTables.First(table => table.Id == logData.Id).DisplayedEvents;
+        var sortedEvents = toggledState.DisplayedEvents;
         Assert.Equal(baseTime.AddSeconds(40), sortedEvents[0].TimeCreated);
         Assert.Equal(baseTime.AddSeconds(20), sortedEvents[1].TimeCreated);
     }
 
     [Fact]
-    public void ReduceUpdateCombinedEvents_WhenAllTablesAreLoading_ShouldReturnSameState()
+    public void ReduceUpdateDisplayedEvents_ShouldUpdateSlicesForLogsInActiveLogs()
     {
-        // Arrange
+        // Arrange — two logs added, then a filter-driven UpdateDisplayedEvents arrives with
+        // post-filter results for both logs.
         var logData1 = new EventLogData(Constants.LogNameLog1, PathType.LogName, []);
         var logData2 = new EventLogData(Constants.LogNameLog2, PathType.LogName, []);
         var state = new EventTableState();
         state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData1));
         state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData2));
-
-        // Act
-        var newState = EventTableReducers.ReduceUpdateCombinedEvents(state);
-
-        // Assert
-        Assert.Same(state, newState);
-    }
-
-    [Fact]
-    public void ReduceUpdateCombinedEvents_WhenDescendingOrderRequested_ShouldMergeInDescendingOrder()
-    {
-        // Arrange — two logs, descending sort
-        var logData1 = new EventLogData(Constants.LogNameLog1, PathType.LogName, []);
-        var logData2 = new EventLogData(Constants.LogNameLog2, PathType.LogName, []);
-        var state = new EventTableState { IsDescending = true };
-        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData1));
-        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData2));
-
-        var eventsLog1 = new List<DisplayEventModel>
-        {
-            new(Constants.LogNameLog1, PathType.LogName) { Id = 10, RecordId = 1 },
-            new(Constants.LogNameLog1, PathType.LogName) { Id = 11, RecordId = 3 }
-        };
-
-        var eventsLog2 = new List<DisplayEventModel>
-        {
-            new(Constants.LogNameLog2, PathType.LogName) { Id = 20, RecordId = 2 },
-            new(Constants.LogNameLog2, PathType.LogName) { Id = 21, RecordId = 4 }
-        };
-
-        state = EventTableReducers.ReduceUpdateTable(state, new EventTableAction.UpdateTable(logData1.Id, eventsLog1));
-        state = EventTableReducers.ReduceUpdateTable(state, new EventTableAction.UpdateTable(logData2.Id, eventsLog2));
-
-        // Act
-        var newState = EventTableReducers.ReduceUpdateCombinedEvents(state);
-
-        // Assert — combined view in descending RecordId order
-        var combinedTable = newState.EventTables.First(table => table.IsCombined);
-        Assert.Equal(4, combinedTable.DisplayedEvents.Count);
-        Assert.Equal(4L, combinedTable.DisplayedEvents[0].RecordId);
-        Assert.Equal(3L, combinedTable.DisplayedEvents[1].RecordId);
-        Assert.Equal(2L, combinedTable.DisplayedEvents[2].RecordId);
-        Assert.Equal(1L, combinedTable.DisplayedEvents[3].RecordId);
-    }
-
-    [Fact]
-    public void ReduceUpdateCombinedEvents_WhenMultipleTablesPopulated_ShouldMergeInSortedOrder()
-    {
-        // Arrange — two logs with interleaved RecordIds, ascending RecordId order
-        var logData1 = new EventLogData(Constants.LogNameLog1, PathType.LogName, []);
-        var logData2 = new EventLogData(Constants.LogNameLog2, PathType.LogName, []);
-        var state = new EventTableState { IsDescending = false };
-        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData1));
-        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData2));
-
-        var eventsLog1 = new List<DisplayEventModel>
-        {
-            new(Constants.LogNameLog1, PathType.LogName) { Id = 10, RecordId = 1 },
-            new(Constants.LogNameLog1, PathType.LogName) { Id = 11, RecordId = 3 }
-        };
-
-        var eventsLog2 = new List<DisplayEventModel>
-        {
-            new(Constants.LogNameLog2, PathType.LogName) { Id = 20, RecordId = 2 },
-            new(Constants.LogNameLog2, PathType.LogName) { Id = 21, RecordId = 4 }
-        };
-
-        state = EventTableReducers.ReduceUpdateTable(state, new EventTableAction.UpdateTable(logData1.Id, eventsLog1));
-        state = EventTableReducers.ReduceUpdateTable(state, new EventTableAction.UpdateTable(logData2.Id, eventsLog2));
-
-        // Act
-        var newState = EventTableReducers.ReduceUpdateCombinedEvents(state);
-
-        // Assert — combined view must interleave both logs in RecordId order
-        var combinedTable = newState.EventTables.First(table => table.IsCombined);
-        Assert.Equal(4, combinedTable.DisplayedEvents.Count);
-        Assert.Equal(1L, combinedTable.DisplayedEvents[0].RecordId);
-        Assert.Equal(2L, combinedTable.DisplayedEvents[1].RecordId);
-        Assert.Equal(3L, combinedTable.DisplayedEvents[2].RecordId);
-        Assert.Equal(4L, combinedTable.DisplayedEvents[3].RecordId);
-        Assert.Equal(Constants.LogNameLog1, combinedTable.DisplayedEvents[0].OwningLog);
-        Assert.Equal(Constants.LogNameLog2, combinedTable.DisplayedEvents[1].OwningLog);
-    }
-
-    [Fact]
-    public void ReduceUpdateCombinedEvents_WhenOneTable_ShouldReturnSameState()
-    {
-        // Arrange
-        var logData = new EventLogData(Constants.LogNameTestLog, PathType.LogName, []);
-        var state = new EventTableState();
-        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData));
-
-        // Act
-        var newState = EventTableReducers.ReduceUpdateCombinedEvents(state);
-
-        // Assert
-        Assert.Same(state, newState);
-    }
-
-    [Fact]
-    public void ReduceUpdateCombinedEvents_WhenRecordIdsCollideAcrossLogs_ShouldDetectContentChangeViaOwningLog()
-    {
-        // Arrange — two logs with disjoint RecordIds initially, ascending RecordId order
-        var logData1 = new EventLogData(Constants.LogNameLog1, PathType.LogName, []);
-        var logData2 = new EventLogData(Constants.LogNameLog2, PathType.LogName, []);
-        var state = new EventTableState { IsDescending = false };
-        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData1));
-        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData2));
-
-        var initialLog1Events = new List<DisplayEventModel>
-        {
-            new(Constants.LogNameLog1, PathType.LogName) { Id = 10, RecordId = 1 },
-            new(Constants.LogNameLog1, PathType.LogName) { Id = 11, RecordId = 3 }
-        };
-
-        var initialLog2Events = new List<DisplayEventModel>
-        {
-            new(Constants.LogNameLog2, PathType.LogName) { Id = 20, RecordId = 2 },
-            new(Constants.LogNameLog2, PathType.LogName) { Id = 21, RecordId = 4 }
-        };
-
-        state = EventTableReducers.ReduceUpdateTable(state, new EventTableAction.UpdateTable(logData1.Id, initialLog1Events));
-        state = EventTableReducers.ReduceUpdateTable(state, new EventTableAction.UpdateTable(logData2.Id, initialLog2Events));
-        state = EventTableReducers.ReduceUpdateCombinedEvents(state);
-
-        // Swap which log owns which RecordIds — keeps the combined RecordId sequence [1,2,3,4]
-        // identical, but flips the OwningLog at each position. The pre-fix equality check (RecordId-only)
-        // would falsely short-circuit; the (OwningLog, RecordId) check correctly detects the change.
-        var swappedLog1Events = new List<DisplayEventModel>
-        {
-            new(Constants.LogNameLog1, PathType.LogName) { Id = 12, RecordId = 2 },
-            new(Constants.LogNameLog1, PathType.LogName) { Id = 13, RecordId = 4 }
-        };
-
-        var swappedLog2Events = new List<DisplayEventModel>
-        {
-            new(Constants.LogNameLog2, PathType.LogName) { Id = 22, RecordId = 1 },
-            new(Constants.LogNameLog2, PathType.LogName) { Id = 23, RecordId = 3 }
-        };
-
-        state = EventTableReducers.ReduceUpdateTable(state, new EventTableAction.UpdateTable(logData1.Id, swappedLog1Events));
-        state = EventTableReducers.ReduceUpdateTable(state, new EventTableAction.UpdateTable(logData2.Id, swappedLog2Events));
-
-        // Act
-        var newState = EventTableReducers.ReduceUpdateCombinedEvents(state);
-
-        // Assert — combined view reflects the swapped ownership at each position
-        var combinedTable = newState.EventTables.First(table => table.IsCombined);
-        Assert.Equal(4, combinedTable.DisplayedEvents.Count);
-        Assert.Equal(Constants.LogNameLog2, combinedTable.DisplayedEvents[0].OwningLog);
-        Assert.Equal(Constants.LogNameLog1, combinedTable.DisplayedEvents[1].OwningLog);
-        Assert.Equal(Constants.LogNameLog2, combinedTable.DisplayedEvents[2].OwningLog);
-        Assert.Equal(Constants.LogNameLog1, combinedTable.DisplayedEvents[3].OwningLog);
-    }
-
-    [Fact]
-    public void ReduceUpdateCombinedEvents_WhenSomeTablesAreEmpty_ShouldMergeOnlyNonEmptyTables()
-    {
-        // Arrange — one log populated, one log empty (but not loading), ascending RecordId order
-        var logData1 = new EventLogData(Constants.LogNameLog1, PathType.LogName, []);
-        var logData2 = new EventLogData(Constants.LogNameLog2, PathType.LogName, []);
-        var state = new EventTableState { IsDescending = false };
-        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData1));
-        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData2));
-
-        var eventsLog1 = new List<DisplayEventModel>
-        {
-            new(Constants.LogNameLog1, PathType.LogName) { Id = 10, RecordId = 5 },
-            new(Constants.LogNameLog1, PathType.LogName) { Id = 11, RecordId = 7 }
-        };
-
-        state = EventTableReducers.ReduceUpdateTable(state, new EventTableAction.UpdateTable(logData1.Id, eventsLog1));
-        state = EventTableReducers.ReduceUpdateTable(state, new EventTableAction.UpdateTable(logData2.Id, []));
-
-        // Act
-        var newState = EventTableReducers.ReduceUpdateCombinedEvents(state);
-
-        // Assert — combined view contains only the populated log's events
-        var combinedTable = newState.EventTables.First(table => table.IsCombined);
-        Assert.Equal(2, combinedTable.DisplayedEvents.Count);
-        Assert.Equal(5L, combinedTable.DisplayedEvents[0].RecordId);
-        Assert.Equal(7L, combinedTable.DisplayedEvents[1].RecordId);
-    }
-
-    [Fact]
-    public void ReduceUpdateCombinedEvents_WhenTimeCreatedDivergesFromRecordId_ShouldMergeByTimeCreated()
-    {
-        // Per-log lists are stored sorted by the same comparator the combined merge uses
-        // (DateAndTime when OrderBy is null). This test pins that contract by giving each log
-        // ascending RecordIds whose TimeCreated values descend, so a RecordId-based merge would
-        // emit events out of chronological order. The combined view must come out time-ordered.
-        var baseTime = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
 
         var log1Events = new List<DisplayEventModel>
         {
-            new(Constants.LogNameLog1, PathType.LogName) { Id = 10, RecordId = 1, TimeCreated = baseTime.AddSeconds(40) },
-            new(Constants.LogNameLog1, PathType.LogName) { Id = 11, RecordId = 2, TimeCreated = baseTime.AddSeconds(20) }
+            new(Constants.LogNameLog1, PathType.LogName) { Id = 10, RecordId = 1 }
         };
 
         var log2Events = new List<DisplayEventModel>
         {
-            new(Constants.LogNameLog2, PathType.LogName) { Id = 20, RecordId = 1, TimeCreated = baseTime.AddSeconds(30) },
-            new(Constants.LogNameLog2, PathType.LogName) { Id = 21, RecordId = 2, TimeCreated = baseTime.AddSeconds(10) }
+            new(Constants.LogNameLog2, PathType.LogName) { Id = 20, RecordId = 2 }
         };
-
-        var logData1 = new EventLogData(Constants.LogNameLog1, PathType.LogName, []);
-        var logData2 = new EventLogData(Constants.LogNameLog2, PathType.LogName, []);
-        var state = new EventTableState { IsDescending = false };
-        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData1));
-        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData2));
-        state = EventTableReducers.ReduceUpdateTable(state, new EventTableAction.UpdateTable(logData1.Id, log1Events));
-        state = EventTableReducers.ReduceUpdateTable(state, new EventTableAction.UpdateTable(logData2.Id, log2Events));
-
-        var newState = EventTableReducers.ReduceUpdateCombinedEvents(state);
-
-        var combinedTable = newState.EventTables.First(table => table.IsCombined);
-        var actualTimes = combinedTable.DisplayedEvents.Select(e => e.TimeCreated).ToList();
-        var expectedTimes = new List<DateTime>
-        {
-            baseTime.AddSeconds(10),
-            baseTime.AddSeconds(20),
-            baseTime.AddSeconds(30),
-            baseTime.AddSeconds(40)
-        };
-        Assert.Equal(expectedTimes, actualTimes);
-    }
-
-    [Fact]
-    public void ReduceUpdateDisplayedEvents_ShouldUpdateNonCombinedTables()
-    {
-        // Arrange
-        var logData1 = new EventLogData(Constants.LogNameLog1, PathType.LogName, []);
-        var logData2 = new EventLogData(Constants.LogNameLog2, PathType.LogName, []);
-        var state = new EventTableState();
-        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData1));
-        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData2));
-
-        var events = new List<DisplayEventModel> { EventUtils.CreateTestEvent(100) };
 
         var activeLogs = new Dictionary<EventLogId, IReadOnlyList<DisplayEventModel>>
         {
-            { logData1.Id, events },
-            { logData2.Id, events }
+            { logData1.Id, log1Events },
+            { logData2.Id, log2Events }
         };
 
         var action = new EventTableAction.UpdateDisplayedEvents(activeLogs);
@@ -1247,27 +1162,205 @@ public sealed class EventTableStoreTests
         // Act
         var newState = EventTableReducers.ReduceUpdateDisplayedEvents(state, action);
 
-        // Assert
-        Assert.All(newState.EventTables.Where(t => !t.IsCombined),
-            table => Assert.Single(table.DisplayedEvents));
+        // Assert — canonical contains both logs' filtered events; per-log counts updated.
+        Assert.Equal(2, newState.DisplayedEvents.Count);
+        Assert.Equal(1, newState.EventCountByLog[logData1.Id]);
+        Assert.Equal(1, newState.EventCountByLog[logData2.Id]);
     }
 
     [Fact]
-    public void ReduceUpdateDisplayedEvents_WhenTableNotInActiveLogs_ShouldPreserveTable()
+    public void ReduceUpdateDisplayedEvents_WhenActiveLogsContainsClosedLogId_ShouldSkipIt()
     {
-        // Arrange — add a table but provide ActiveLogs that don't include it
+        // Arrange — filter result includes a log id whose tab was closed mid-flight
+        var openLog = new EventLogData(Constants.LogNameLog1, PathType.LogName, []);
+        var state = new EventTableState();
+        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(openLog));
+
+        var staleLogId = EventLogId.Create();
+        var openLogEvents = new List<DisplayEventModel>
+        {
+            new(Constants.LogNameLog1, PathType.LogName) { Id = 10, RecordId = 1 }
+        };
+
+        var staleEvents = new List<DisplayEventModel>
+        {
+            new("ClosedLog", PathType.LogName) { Id = 99, RecordId = 99 }
+        };
+
+        var activeLogs = new Dictionary<EventLogId, IReadOnlyList<DisplayEventModel>>
+        {
+            { openLog.Id, openLogEvents },
+            { staleLogId, staleEvents }
+        };
+
+        // Act
+        var newState = EventTableReducers.ReduceUpdateDisplayedEvents(
+            state,
+            new EventTableAction.UpdateDisplayedEvents(activeLogs));
+
+        // Assert — closed log id contributes nothing to canonical or to the count map
+        Assert.Single(newState.DisplayedEvents);
+        Assert.Equal(1L, newState.DisplayedEvents[0].RecordId);
+        Assert.False(newState.EventCountByLog.ContainsKey(staleLogId));
+    }
+
+    [Fact]
+    public void ReduceUpdateDisplayedEvents_WhenLogIsNotInActiveLogs_ShouldPreserveExistingCanonicalRows()
+    {
+        // Arrange — log A has rows in canonical (live-load via UpdateTable); a filter dispatch
+        // then arrives with empty ActiveLogs (e.g. log opened mid-filter so the snapshot did
+        // not include it). The omitted log's rows must stay in canonical — otherwise a fresh
+        // load could be silently scrubbed by a stale filter result.
         var logData = new EventLogData(Constants.LogNameTestLog, PathType.LogName, []);
         var state = new EventTableState();
         state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData));
 
+        var loadedEvents = new List<DisplayEventModel>
+        {
+            new(Constants.LogNameTestLog, PathType.LogName) { Id = 10, RecordId = 1 },
+            new(Constants.LogNameTestLog, PathType.LogName) { Id = 11, RecordId = 2 }
+        };
+
+        state = EventTableReducers.ReduceUpdateTable(state, new EventTableAction.UpdateTable(logData.Id, loadedEvents));
+
         var emptyActiveLogs = new Dictionary<EventLogId, IReadOnlyList<DisplayEventModel>>();
         var action = new EventTableAction.UpdateDisplayedEvents(emptyActiveLogs);
 
-        // Act — table not in ActiveLogs should be preserved as-is
+        // Act
         var newState = EventTableReducers.ReduceUpdateDisplayedEvents(state, action);
 
-        // Assert — table still exists, events unchanged
+        // Assert — table still exists, canonical rows preserved, count map preserved.
         Assert.Single(newState.EventTables);
+        Assert.Equal(2, newState.DisplayedEvents.Count);
+        Assert.Equal(2, newState.EventCountByLog[logData.Id]);
+    }
+
+    [Fact]
+    public void ReduceUpdateDisplayedEvents_WhenSomeLogsOmitted_ShouldReplaceIncludedAndPreserveOmitted()
+    {
+        // Arrange — two logs, both populated via UpdateTable. Filter dispatch arrives for log A
+        // only (e.g. log B opened or finished loading after the snapshot). Log A's rows must be
+        // replaced by the filter result; log B's rows must be preserved untouched.
+        var logData1 = new EventLogData(Constants.LogNameLog1, PathType.LogName, []);
+        var logData2 = new EventLogData(Constants.LogNameLog2, PathType.LogName, []);
+        var state = new EventTableState();
+        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData1));
+        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData2));
+
+        var log1Loaded = new List<DisplayEventModel>
+        {
+            new(Constants.LogNameLog1, PathType.LogName) { Id = 100, RecordId = 1 },
+            new(Constants.LogNameLog1, PathType.LogName) { Id = 101, RecordId = 2 }
+        };
+
+        var log2Loaded = new List<DisplayEventModel>
+        {
+            new(Constants.LogNameLog2, PathType.LogName) { Id = 200, RecordId = 1 },
+            new(Constants.LogNameLog2, PathType.LogName) { Id = 201, RecordId = 2 },
+            new(Constants.LogNameLog2, PathType.LogName) { Id = 202, RecordId = 3 }
+        };
+
+        state = EventTableReducers.ReduceUpdateTable(state, new EventTableAction.UpdateTable(logData1.Id, log1Loaded));
+        state = EventTableReducers.ReduceUpdateTable(state, new EventTableAction.UpdateTable(logData2.Id, log2Loaded));
+
+        var log1Filtered = new List<DisplayEventModel>
+        {
+            new(Constants.LogNameLog1, PathType.LogName) { Id = 100, RecordId = 1 }
+        };
+
+        var activeLogs = new Dictionary<EventLogId, IReadOnlyList<DisplayEventModel>>
+        {
+            { logData1.Id, log1Filtered }
+        };
+
+        // Act
+        var newState = EventTableReducers.ReduceUpdateDisplayedEvents(
+            state,
+            new EventTableAction.UpdateDisplayedEvents(activeLogs));
+
+        // Assert — log A reduced from 2 to 1, log B's 3 rows untouched; counts reflect both.
+        Assert.Equal(4, newState.DisplayedEvents.Count);
+        Assert.Equal(1, newState.DisplayedEvents.Count(e => e.OwningLog == Constants.LogNameLog1));
+        Assert.Equal(3, newState.DisplayedEvents.Count(e => e.OwningLog == Constants.LogNameLog2));
+        Assert.Equal(1, newState.EventCountByLog[logData1.Id]);
+        Assert.Equal(3, newState.EventCountByLog[logData2.Id]);
+    }
+
+    [Fact]
+    public void ReduceUpdateDisplayedEvents_WhenTableComputerNameEmpty_ShouldLatchFromFirstNonEmptyEvent()
+    {
+        // Arrange — log first becomes visible via UpdateDisplayedEvents (filter clear), not via append
+        var logData = new EventLogData(Constants.LogNameLog1, PathType.LogName, []);
+        var state = new EventTableState();
+        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData));
+
+        var revealedEvents = new List<DisplayEventModel>
+        {
+            new(Constants.LogNameLog1, PathType.LogName) { Id = 10, RecordId = 1, ComputerName = string.Empty },
+            new(Constants.LogNameLog1, PathType.LogName) { Id = 11, RecordId = 2, ComputerName = Constants.EventComputerServer01 }
+        };
+
+        var activeLogs = new Dictionary<EventLogId, IReadOnlyList<DisplayEventModel>>
+        {
+            { logData.Id, revealedEvents }
+        };
+
+        // Act
+        var newState = EventTableReducers.ReduceUpdateDisplayedEvents(
+            state,
+            new EventTableAction.UpdateDisplayedEvents(activeLogs));
+
+        // Assert — UpdateDisplayedEvents also latches ComputerName, not just the append paths
+        var updatedTable = newState.EventTables.First(t => t.Id == logData.Id);
+        Assert.Equal(Constants.EventComputerServer01, updatedTable.ComputerName);
+    }
+
+    [Fact]
+    public void ReduceUpdateTable_AfterPartialAppends_ShouldReplaceNotMergeWithPartials()
+    {
+        // Arrange — partial AppendTableEvents land first (live-load deltas), then UpdateTable arrives with the full filtered list
+        var logData = new EventLogData(Constants.LogNameTestLog, PathType.LogName, []);
+        var state = new EventTableState { IsDescending = false };
+        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData));
+
+        var partial1 = new List<DisplayEventModel>
+        {
+            new(Constants.LogNameTestLog, PathType.LogName) { Id = 10, RecordId = 1 },
+            new(Constants.LogNameTestLog, PathType.LogName) { Id = 11, RecordId = 2 }
+        };
+
+        state = EventTableReducers.ReduceAppendTableEvents(
+            state,
+            new EventTableAction.AppendTableEvents(logData.Id, partial1));
+
+        var partial2 = new List<DisplayEventModel>
+        {
+            new(Constants.LogNameTestLog, PathType.LogName) { Id = 12, RecordId = 3 }
+        };
+
+        state = EventTableReducers.ReduceAppendTableEvents(
+            state,
+            new EventTableAction.AppendTableEvents(logData.Id, partial2));
+
+        Assert.Equal(3, state.DisplayedEvents.Count);
+
+        var fullLoad = new List<DisplayEventModel>
+        {
+            new(Constants.LogNameTestLog, PathType.LogName) { Id = 20, RecordId = 1 },
+            new(Constants.LogNameTestLog, PathType.LogName) { Id = 21, RecordId = 2 },
+            new(Constants.LogNameTestLog, PathType.LogName) { Id = 22, RecordId = 3 },
+            new(Constants.LogNameTestLog, PathType.LogName) { Id = 23, RecordId = 4 }
+        };
+
+        // Act
+        state = EventTableReducers.ReduceUpdateTable(
+            state,
+            new EventTableAction.UpdateTable(logData.Id, fullLoad));
+
+        // Assert — partials are dropped before merging the full slice; canonical is exactly the full load
+        Assert.Equal(4, state.DisplayedEvents.Count);
+        Assert.Equal(state.DisplayedEvents.Select(e => e.RecordId), [1L, 2L, 3L, 4L]);
+        Assert.Equal(4, state.EventCountByLog[logData.Id]);
     }
 
     [Fact]
@@ -1291,8 +1384,138 @@ public sealed class EventTableStoreTests
 
         // Assert
         var updatedTable = newState.EventTables.First(t => t.Id == logData.Id);
-        Assert.Equal(2, updatedTable.DisplayedEvents.Count);
+        Assert.Equal(2, newState.DisplayedEvents.Count);
+        Assert.Equal(2, newState.EventCountByLog[updatedTable.Id]);
         Assert.False(updatedTable.IsLoading);
+    }
+
+    [Fact]
+    public void ReduceUpdateTable_WhenCalledTwiceForSameLog_ShouldReplaceNotDuplicate()
+    {
+        // Arrange — first UpdateTable populates canonical with two events
+        var logData = new EventLogData(Constants.LogNameTestLog, PathType.LogName, []);
+        var state = new EventTableState { IsDescending = false };
+        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData));
+
+        var firstLoad = new List<DisplayEventModel>
+        {
+            new(Constants.LogNameTestLog, PathType.LogName) { Id = 10, RecordId = 1 },
+            new(Constants.LogNameTestLog, PathType.LogName) { Id = 11, RecordId = 2 }
+        };
+
+        state = EventTableReducers.ReduceUpdateTable(state, new EventTableAction.UpdateTable(logData.Id, firstLoad));
+        Assert.Equal(2, state.DisplayedEvents.Count);
+
+        var secondLoad = new List<DisplayEventModel>
+        {
+            new(Constants.LogNameTestLog, PathType.LogName) { Id = 12, RecordId = 3 },
+            new(Constants.LogNameTestLog, PathType.LogName) { Id = 13, RecordId = 4 },
+            new(Constants.LogNameTestLog, PathType.LogName) { Id = 14, RecordId = 5 }
+        };
+
+        // Act — second UpdateTable for the same log (e.g., filter-driven reload)
+        state = EventTableReducers.ReduceUpdateTable(state, new EventTableAction.UpdateTable(logData.Id, secondLoad));
+
+        // Assert — canonical reflects only the second load; first load is replaced, not appended
+        Assert.Equal(3, state.DisplayedEvents.Count);
+        Assert.Equal(state.DisplayedEvents.Select(e => e.RecordId), [3L, 4L, 5L]);
+        Assert.Equal(3, state.EventCountByLog[logData.Id]);
+    }
+
+    [Fact]
+    public void ReduceUpdateTable_WhenDescendingOrderRequested_ShouldMergeInDescendingOrder()
+    {
+        // Arrange — two logs, descending sort
+        var logData1 = new EventLogData(Constants.LogNameLog1, PathType.LogName, []);
+        var logData2 = new EventLogData(Constants.LogNameLog2, PathType.LogName, []);
+        var state = new EventTableState { IsDescending = true };
+        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData1));
+        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData2));
+
+        var eventsLog1 = new List<DisplayEventModel>
+        {
+            new(Constants.LogNameLog1, PathType.LogName) { Id = 10, RecordId = 1 },
+            new(Constants.LogNameLog1, PathType.LogName) { Id = 11, RecordId = 3 }
+        };
+
+        var eventsLog2 = new List<DisplayEventModel>
+        {
+            new(Constants.LogNameLog2, PathType.LogName) { Id = 20, RecordId = 2 },
+            new(Constants.LogNameLog2, PathType.LogName) { Id = 21, RecordId = 4 }
+        };
+
+        // Act
+        state = EventTableReducers.ReduceUpdateTable(state, new EventTableAction.UpdateTable(logData1.Id, eventsLog1));
+        state = EventTableReducers.ReduceUpdateTable(state, new EventTableAction.UpdateTable(logData2.Id, eventsLog2));
+
+        // Assert — canonical view in descending RecordId order
+        Assert.Equal(4, state.DisplayedEvents.Count);
+        Assert.Equal(4L, state.DisplayedEvents[0].RecordId);
+        Assert.Equal(3L, state.DisplayedEvents[1].RecordId);
+        Assert.Equal(2L, state.DisplayedEvents[2].RecordId);
+        Assert.Equal(1L, state.DisplayedEvents[3].RecordId);
+    }
+
+    [Fact]
+    public void ReduceUpdateTable_WhenSecondLogIsEmpty_ShouldKeepFirstLogEvents()
+    {
+        // Arrange — one log populated, one log empty (but not loading), ascending RecordId order
+        var logData1 = new EventLogData(Constants.LogNameLog1, PathType.LogName, []);
+        var logData2 = new EventLogData(Constants.LogNameLog2, PathType.LogName, []);
+        var state = new EventTableState { IsDescending = false };
+        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData1));
+        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData2));
+
+        var eventsLog1 = new List<DisplayEventModel>
+        {
+            new(Constants.LogNameLog1, PathType.LogName) { Id = 10, RecordId = 5 },
+            new(Constants.LogNameLog1, PathType.LogName) { Id = 11, RecordId = 7 }
+        };
+
+        // Act
+        state = EventTableReducers.ReduceUpdateTable(state, new EventTableAction.UpdateTable(logData1.Id, eventsLog1));
+        state = EventTableReducers.ReduceUpdateTable(state, new EventTableAction.UpdateTable(logData2.Id, []));
+
+        // Assert — canonical view contains only the populated log's events
+        Assert.Equal(2, state.DisplayedEvents.Count);
+        Assert.Equal(5L, state.DisplayedEvents[0].RecordId);
+        Assert.Equal(7L, state.DisplayedEvents[1].RecordId);
+    }
+
+    [Fact]
+    public void ReduceUpdateTable_WhenSecondLogPopulated_ShouldMergeIntoCanonicalInSortedOrder()
+    {
+        // Arrange — two logs with interleaved RecordIds, ascending RecordId order
+        var logData1 = new EventLogData(Constants.LogNameLog1, PathType.LogName, []);
+        var logData2 = new EventLogData(Constants.LogNameLog2, PathType.LogName, []);
+        var state = new EventTableState { IsDescending = false };
+        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData1));
+        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData2));
+
+        var eventsLog1 = new List<DisplayEventModel>
+        {
+            new(Constants.LogNameLog1, PathType.LogName) { Id = 10, RecordId = 1 },
+            new(Constants.LogNameLog1, PathType.LogName) { Id = 11, RecordId = 3 }
+        };
+
+        var eventsLog2 = new List<DisplayEventModel>
+        {
+            new(Constants.LogNameLog2, PathType.LogName) { Id = 20, RecordId = 2 },
+            new(Constants.LogNameLog2, PathType.LogName) { Id = 21, RecordId = 4 }
+        };
+
+        // Act — UpdateTable maintains the canonical view atomically; no follow-up call needed.
+        state = EventTableReducers.ReduceUpdateTable(state, new EventTableAction.UpdateTable(logData1.Id, eventsLog1));
+        state = EventTableReducers.ReduceUpdateTable(state, new EventTableAction.UpdateTable(logData2.Id, eventsLog2));
+
+        // Assert — canonical view interleaves both logs in RecordId order
+        Assert.Equal(4, state.DisplayedEvents.Count);
+        Assert.Equal(1L, state.DisplayedEvents[0].RecordId);
+        Assert.Equal(2L, state.DisplayedEvents[1].RecordId);
+        Assert.Equal(3L, state.DisplayedEvents[2].RecordId);
+        Assert.Equal(4L, state.DisplayedEvents[3].RecordId);
+        Assert.Equal(Constants.LogNameLog1, state.DisplayedEvents[0].OwningLog);
+        Assert.Equal(Constants.LogNameLog2, state.DisplayedEvents[1].OwningLog);
     }
 
     [Fact]
@@ -1309,5 +1532,45 @@ public sealed class EventTableStoreTests
 
         // Assert — state unchanged, no exception thrown
         Assert.Same(state, newState);
+    }
+
+    [Fact]
+    public void ReduceUpdateTable_WhenTimeCreatedDivergesFromRecordId_ShouldMergeByTimeCreated()
+    {
+        // Arrange — RecordIds ascending but TimeCreated descending: verifies sort is by timestamp
+        var baseTime = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        var log1Events = new List<DisplayEventModel>
+        {
+            new(Constants.LogNameLog1, PathType.LogName) { Id = 10, RecordId = 1, TimeCreated = baseTime.AddSeconds(40) },
+            new(Constants.LogNameLog1, PathType.LogName) { Id = 11, RecordId = 2, TimeCreated = baseTime.AddSeconds(20) }
+        };
+
+        var log2Events = new List<DisplayEventModel>
+        {
+            new(Constants.LogNameLog2, PathType.LogName) { Id = 20, RecordId = 1, TimeCreated = baseTime.AddSeconds(30) },
+            new(Constants.LogNameLog2, PathType.LogName) { Id = 21, RecordId = 2, TimeCreated = baseTime.AddSeconds(10) }
+        };
+
+        var logData1 = new EventLogData(Constants.LogNameLog1, PathType.LogName, []);
+        var logData2 = new EventLogData(Constants.LogNameLog2, PathType.LogName, []);
+        var state = new EventTableState { IsDescending = false };
+        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData1));
+        state = EventTableReducers.ReduceAddTable(state, new EventTableAction.AddTable(logData2));
+
+        // Act
+        state = EventTableReducers.ReduceUpdateTable(state, new EventTableAction.UpdateTable(logData1.Id, log1Events));
+        state = EventTableReducers.ReduceUpdateTable(state, new EventTableAction.UpdateTable(logData2.Id, log2Events));
+
+        // Assert — canonical comes out time-ordered, not RecordId-ordered
+        var actualTimes = state.DisplayedEvents.Select(e => e.TimeCreated).ToList();
+        var expectedTimes = new List<DateTime>
+        {
+            baseTime.AddSeconds(10),
+            baseTime.AddSeconds(20),
+            baseTime.AddSeconds(30),
+            baseTime.AddSeconds(40)
+        };
+        Assert.Equal(expectedTimes, actualTimes);
     }
 }

--- a/src/EventLogExpert.UI/Models/EventTableModel.cs
+++ b/src/EventLogExpert.UI/Models/EventTableModel.cs
@@ -2,7 +2,6 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Eventing.Helpers;
-using EventLogExpert.Eventing.Models;
 
 namespace EventLogExpert.UI.Models;
 
@@ -10,13 +9,11 @@ public sealed record EventTableModel(EventLogId Id)
 {
     public string? FileName { get; init; }
 
-    public string ComputerName => DisplayedEvents.FirstOrDefault()?.ComputerName ?? string.Empty;
+    public string ComputerName { get; init; } = string.Empty;
 
     public string LogName { get; init; } = string.Empty;
 
     public PathType PathType { get; init; }
-
-    public IReadOnlyList<DisplayEventModel> DisplayedEvents { get; init; } = [];
 
     public bool IsCombined { get; init; }
 

--- a/src/EventLogExpert.UI/Store/EventLog/EventLogEffects.cs
+++ b/src/EventLogExpert.UI/Store/EventLog/EventLogEffects.cs
@@ -359,10 +359,59 @@ public sealed class EventLogEffects(
             var filteredActiveLogs = await Task.Run(
                 () => _filterService.FilterActiveLogs(activeLogsSnapshot, action.EventFilter));
 
-            if (Interlocked.Read(ref _filterGeneration) == generation)
+            if (Interlocked.Read(ref _filterGeneration) != generation) { return; }
+
+            // Pass 1: keep slices whose source Events ref is still current. Logs whose
+            // Events ref changed (live event arrived during the filter run) get re-filtered
+            // once below so the new filter is applied to the post-mutation rows too.
+            var snapshotById = activeLogsSnapshot.ToDictionary(d => d.Id);
+            var currentByName = _eventLogState.Value.ActiveLogs;
+            var fresh = new Dictionary<EventLogId, IReadOnlyList<DisplayEventModel>>(filteredActiveLogs.Count);
+            var staleLogs = new List<EventLogData>();
+
+            foreach (var (logId, filteredEvents) in filteredActiveLogs)
             {
-                dispatcher.Dispatch(new EventTableAction.UpdateDisplayedEvents(filteredActiveLogs));
+                if (!snapshotById.TryGetValue(logId, out var snapshotData)) { continue; }
+
+                if (!currentByName.TryGetValue(snapshotData.Name, out var currentData)) { continue; }
+
+                if (ReferenceEquals(snapshotData.Events, currentData.Events))
+                {
+                    fresh[logId] = filteredEvents;
+                }
+                else
+                {
+                    staleLogs.Add(currentData);
+                }
             }
+
+            // Pass 2: single retry. If a log is still stale after this pass, leave it omitted —
+            // the reducer preserves existing rows so live events are not lost.
+            if (staleLogs.Count > 0)
+            {
+                var refiltered = await Task.Run(
+                    () => _filterService.FilterActiveLogs(staleLogs, action.EventFilter));
+
+                if (Interlocked.Read(ref _filterGeneration) != generation) { return; }
+
+                var pass2InputById = staleLogs.ToDictionary(d => d.Id);
+                currentByName = _eventLogState.Value.ActiveLogs;
+
+                foreach (var (logId, filteredEvents) in refiltered)
+                {
+                    if (!pass2InputById.TryGetValue(logId, out var pass2Input)) { continue; }
+
+                    if (!currentByName.TryGetValue(pass2Input.Name, out var nowCurrent)) { continue; }
+
+                    // pass2Input.Events IS the list ref pass 2 consumed; new ref = stale.
+                    if (ReferenceEquals(pass2Input.Events, nowCurrent.Events))
+                    {
+                        fresh[logId] = filteredEvents;
+                    }
+                }
+            }
+
+            dispatcher.Dispatch(new EventTableAction.UpdateDisplayedEvents(fresh));
         }
         finally
         {
@@ -376,6 +425,8 @@ public sealed class EventLogEffects(
     /// <summary>Adds new events to the currently opened log</summary>
     private static EventLogData AddEventsToOneLog(EventLogData logData, List<DisplayEventModel> eventsToAdd)
     {
+        if (eventsToAdd.Count == 0) { return logData; }
+
         eventsToAdd.AddRange(logData.Events);
 
         return logData with { Events = eventsToAdd.AsReadOnly() };

--- a/src/EventLogExpert.UI/Store/EventTable/EventTableAction.cs
+++ b/src/EventLogExpert.UI/Store/EventTable/EventTableAction.cs
@@ -42,8 +42,6 @@ public sealed record EventTableAction
 
     public sealed record ToggleSorting;
 
-    public sealed record UpdateCombinedEvents;
-
     public sealed record UpdateDisplayedEvents(
         IReadOnlyDictionary<EventLogId, IReadOnlyList<DisplayEventModel>> ActiveLogs);
 

--- a/src/EventLogExpert.UI/Store/EventTable/EventTableEffects.cs
+++ b/src/EventLogExpert.UI/Store/EventTable/EventTableEffects.cs
@@ -1,4 +1,4 @@
-﻿// // Copyright (c) Microsoft Corporation.
+// // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
 using EventLogExpert.UI.Interfaces;
@@ -11,38 +11,6 @@ public sealed class EventTableEffects(IPreferencesProvider preferencesProvider, 
 {
     private readonly IState<EventTableState> _eventTableState = eventTableState;
     private readonly IPreferencesProvider _preferencesProvider = preferencesProvider;
-
-    [EffectMethod(typeof(EventTableAction.AppendTableEvents))]
-    public static Task HandleAppendTableEvents(IDispatcher dispatcher)
-    {
-        dispatcher.Dispatch(new EventTableAction.UpdateCombinedEvents());
-
-        return Task.CompletedTask;
-    }
-
-    [EffectMethod(typeof(EventTableAction.AppendTableEventsBatch))]
-    public static Task HandleAppendTableEventsBatch(IDispatcher dispatcher)
-    {
-        dispatcher.Dispatch(new EventTableAction.UpdateCombinedEvents());
-
-        return Task.CompletedTask;
-    }
-
-    [EffectMethod(typeof(EventTableAction.UpdateDisplayedEvents))]
-    public static Task HandleUpdateDisplayedEvents(IDispatcher dispatcher)
-    {
-        dispatcher.Dispatch(new EventTableAction.UpdateCombinedEvents());
-
-        return Task.CompletedTask;
-    }
-
-    [EffectMethod(typeof(EventTableAction.UpdateTable))]
-    public static Task HandleUpdateTable(IDispatcher dispatcher)
-    {
-        dispatcher.Dispatch(new EventTableAction.UpdateCombinedEvents());
-
-        return Task.CompletedTask;
-    }
 
     [EffectMethod(typeof(EventTableAction.LoadColumns))]
     public Task HandleLoadColumns(IDispatcher dispatcher)

--- a/src/EventLogExpert.UI/Store/EventTable/EventTableReducers.cs
+++ b/src/EventLogExpert.UI/Store/EventTable/EventTableReducers.cs
@@ -22,11 +22,14 @@ public sealed class EventTableReducers
             IsLoading = true
         };
 
+        var counts = state.EventCountByLog.SetItem(newTable.Id, 0);
+
         if (state.EventTables.IsEmpty)
         {
             return state with
             {
                 EventTables = state.EventTables.Add(newTable),
+                EventCountByLog = counts,
                 ActiveEventLogId = newTable.Id
             };
         }
@@ -35,7 +38,11 @@ public sealed class EventTableReducers
 
         if (combinedTable is not null)
         {
-            return state with { EventTables = state.EventTables.Add(newTable) };
+            return state with
+            {
+                EventTables = state.EventTables.Add(newTable),
+                EventCountByLog = counts
+            };
         }
 
         combinedTable = new EventTableModel(EventLogId.Create()) { IsCombined = true };
@@ -45,6 +52,7 @@ public sealed class EventTableReducers
             EventTables = state.EventTables
                 .Add(combinedTable)
                 .Add(newTable),
+            EventCountByLog = counts,
             ActiveEventLogId = combinedTable.Id
         };
     }
@@ -54,20 +62,24 @@ public sealed class EventTableReducers
     {
         var table = state.EventTables.FirstOrDefault(t => action.LogId == t.Id);
 
-        if (table is null) { return state; }
+        if (table is null || table.IsCombined || action.Events.Count == 0) { return state; }
 
         var merged = FilterMethods.MergeSorted(
-            table.DisplayedEvents,
+            state.DisplayedEvents,
             action.Events,
             GetEffectiveOrderBy(state.OrderBy),
             state.IsDescending);
 
+        var updatedTable = SetComputerNameIfFirstEvent(table, action.Events);
+        var counts = IncrementCount(state.EventCountByLog, table.Id, action.Events.Count);
+
         return state with
         {
-            EventTables = state.EventTables.Replace(table, table with
-            {
-                DisplayedEvents = merged
-            })
+            DisplayedEvents = merged,
+            EventTables = ReferenceEquals(updatedTable, table) ?
+                state.EventTables :
+                state.EventTables.Replace(table, updatedTable),
+            EventCountByLog = counts
         };
     }
 
@@ -78,70 +90,108 @@ public sealed class EventTableReducers
     {
         if (action.EventsByLog.Count == 0) { return state; }
 
-        var updatedTables = new List<EventTableModel>(state.EventTables.Count);
-        var changed = false;
+        // Skip batches for closed logs: avoid resurrecting events and stale counts.
+        int totalNew = 0;
+        var combinedBatch = new List<DisplayEventModel>();
+        var counts = state.EventCountByLog;
+        var updatedTables = state.EventTables;
 
-        foreach (var table in state.EventTables)
+        foreach (var (logId, events) in action.EventsByLog)
         {
-            if (!action.EventsByLog.TryGetValue(table.Id, out var newEvents) || newEvents.Count == 0)
+            if (events.Count == 0) { continue; }
+
+            var table = updatedTables.FirstOrDefault(t => t.Id == logId);
+
+            if (table is null || table.IsCombined) { continue; }
+
+            combinedBatch.AddRange(events);
+            counts = IncrementCount(counts, logId, events.Count);
+            totalNew += events.Count;
+
+            var updatedTable = SetComputerNameIfFirstEvent(table, events);
+
+            if (!ReferenceEquals(updatedTable, table))
             {
-                updatedTables.Add(table);
-
-                continue;
+                updatedTables = updatedTables.Replace(table, updatedTable);
             }
-
-            var merged = FilterMethods.MergeSorted(
-                table.DisplayedEvents,
-                newEvents,
-                GetEffectiveOrderBy(state.OrderBy),
-                state.IsDescending);
-
-            updatedTables.Add(table with { DisplayedEvents = merged });
-            changed = true;
         }
 
-        if (!changed) { return state; }
+        if (totalNew == 0) { return state; }
 
-        return state with { EventTables = [.. updatedTables] };
+        var merged = FilterMethods.MergeSorted(
+            state.DisplayedEvents,
+            combinedBatch,
+            GetEffectiveOrderBy(state.OrderBy),
+            state.IsDescending);
+
+        return state with
+        {
+            DisplayedEvents = merged,
+            EventTables = updatedTables,
+            EventCountByLog = counts
+        };
     }
 
     [ReducerMethod(typeof(EventTableAction.CloseAll))]
     public static EventTableState ReduceCloseAll(EventTableState state) =>
-        state with { EventTables = [], ActiveEventLogId = null };
+        state with
+        {
+            EventTables = [],
+            DisplayedEvents = [],
+            EventCountByLog = ImmutableDictionary<EventLogId, int>.Empty,
+            ActiveEventLogId = null
+        };
 
     [ReducerMethod]
     public static EventTableState ReduceCloseLog(EventTableState state, EventTableAction.CloseLog action)
     {
-        var updatedTables = state.EventTables
+        var closingTable = state.EventTables.FirstOrDefault(table => table.Id == action.LogId);
+
+        if (closingTable is null || closingTable.IsCombined) { return state; }
+
+        var remainingPerLogTables = state.EventTables
             .Where(table => table.Id != action.LogId && !table.IsCombined)
             .ToImmutableList();
 
-        switch (updatedTables.Count)
-        {
-            case <= 0: return state with { EventTables = [], ActiveEventLogId = null };
-            case <= 1:
-                return state with
-                {
-                    EventTables = updatedTables,
-                    ActiveEventLogId = updatedTables.First().Id
-                };
-            default:
-                var combinedTable = new EventTableModel(EventLogId.Create())
-                {
-                    IsCombined = true,
-                    DisplayedEvents = GetCombinedEvents(
-                        updatedTables.Select(log => log.DisplayedEvents),
-                        GetEffectiveOrderBy(state.OrderBy),
-                        state.IsDescending)
-                };
+        var counts = state.EventCountByLog.Remove(action.LogId);
 
+        switch (remainingPerLogTables.Count)
+        {
+            case <= 0:
                 return state with
                 {
-                    EventTables = updatedTables.Add(combinedTable),
-                    ActiveEventLogId =
-                    updatedTables.FirstOrDefault(table => table.Id == state.ActiveEventLogId) is not null ?
-                        state.ActiveEventLogId : combinedTable.Id
+                    EventTables = [],
+                    DisplayedEvents = [],
+                    EventCountByLog = ImmutableDictionary<EventLogId, int>.Empty,
+                    ActiveEventLogId = null
                 };
+            case 1:
+                {
+                    var soleRemaining = remainingPerLogTables[0];
+                    var filtered = FilterByOwningLog(state.DisplayedEvents, soleRemaining.LogName);
+
+                    return state with
+                    {
+                        EventTables = remainingPerLogTables,
+                        DisplayedEvents = filtered,
+                        EventCountByLog = counts,
+                        ActiveEventLogId = soleRemaining.Id
+                    };
+                }
+            default:
+                {
+                    var combinedTable = new EventTableModel(EventLogId.Create()) { IsCombined = true };
+                    var filtered = FilterOutOwningLog(state.DisplayedEvents, closingTable.LogName);
+
+                    return state with
+                    {
+                        EventTables = remainingPerLogTables.Insert(0, combinedTable),
+                        DisplayedEvents = filtered,
+                        EventCountByLog = counts,
+                        ActiveEventLogId = remainingPerLogTables.Any(t => t.Id == state.ActiveEventLogId) ?
+                            state.ActiveEventLogId : combinedTable.Id
+                    };
+                }
         }
     }
 
@@ -214,71 +264,95 @@ public sealed class EventTableReducers
     public static EventTableState ReduceToggleSorting(EventTableState state) =>
         SortDisplayEvents(state, state.OrderBy, !state.IsDescending);
 
-    [ReducerMethod(typeof(EventTableAction.UpdateCombinedEvents))]
-    public static EventTableState ReduceUpdateCombinedEvents(EventTableState state)
-    {
-        if (state.EventTables.Count <= 1) { return state; }
-
-        var nonCombinedTables = state.EventTables.Where(table => !table.IsCombined);
-
-        if (nonCombinedTables.All(table => table.IsLoading)) { return state; }
-
-        var existingCombinedTable = state.EventTables.FirstOrDefault(table => table.IsCombined);
-
-        if (existingCombinedTable is null) { return state; }
-
-        var combinedEvents = GetCombinedEvents(
-            state.EventTables
-                .Where(table => !table.IsCombined)
-                .Select(table => table.DisplayedEvents),
-            GetEffectiveOrderBy(state.OrderBy),
-            state.IsDescending);
-
-        if (combinedEvents.Count == existingCombinedTable.DisplayedEvents.Count &&
-            combinedEvents.Select(e => (e.OwningLog, e.RecordId))
-                .SequenceEqual(existingCombinedTable.DisplayedEvents.Select(e => (e.OwningLog, e.RecordId))))
-        {
-            return state;
-        }
-
-        return state with
-        {
-            EventTables = state.EventTables
-                .Remove(existingCombinedTable)
-                .Add(existingCombinedTable with { DisplayedEvents = combinedEvents })
-        };
-    }
-
     [ReducerMethod]
     public static EventTableState ReduceUpdateDisplayedEvents(
         EventTableState state,
         EventTableAction.UpdateDisplayedEvents action)
     {
-        List<EventTableModel> updatedTables = [];
+        // Skip log ids absent from EventTables: log closed while filter ran.
+        var tablesById = state.EventTables
+            .Where(table => !table.IsCombined)
+            .ToDictionary(table => table.Id);
 
-        foreach (var table in state.EventTables)
+        // Logs absent from ActiveLogs keep their current rows (stale-snapshot protection).
+        var logNamesBeingReplaced = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var (logId, _) in action.ActiveLogs)
         {
-            if (table.IsCombined)
+            if (tablesById.TryGetValue(logId, out var table))
             {
-                updatedTables.Add(table);
-
-                continue;
+                logNamesBeingReplaced.Add(table.LogName);
             }
-
-            if (!action.ActiveLogs.TryGetValue(table.Id, out var currentActiveLog))
-            {
-                updatedTables.Add(table);
-
-                continue;
-            }
-
-            updatedTables.Add(table with
-            {
-                DisplayedEvents = currentActiveLog.SortEvents(GetEffectiveOrderBy(state.OrderBy), state.IsDescending)
-            });
         }
 
-        return state with { EventTables = [.. updatedTables] };
+        // Defensive: orphan rows whose OwningLog has no current table get dropped.
+        var currentLogNames = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var table in tablesById.Values)
+        {
+            currentLogNames.Add(table.LogName);
+        }
+
+        int preservedCount = 0;
+
+        for (int eventIndex = 0; eventIndex < state.DisplayedEvents.Count; eventIndex++)
+        {
+            var existing = state.DisplayedEvents[eventIndex];
+
+            if (currentLogNames.Contains(existing.OwningLog) &&
+                !logNamesBeingReplaced.Contains(existing.OwningLog))
+            {
+                preservedCount++;
+            }
+        }
+
+        int totalCount = preservedCount;
+
+        foreach (var (logId, events) in action.ActiveLogs)
+        {
+            if (tablesById.ContainsKey(logId)) { totalCount += events.Count; }
+        }
+
+        var concatenated = new List<DisplayEventModel>(totalCount);
+
+        for (int eventIndex = 0; eventIndex < state.DisplayedEvents.Count; eventIndex++)
+        {
+            var existing = state.DisplayedEvents[eventIndex];
+
+            if (currentLogNames.Contains(existing.OwningLog) &&
+                !logNamesBeingReplaced.Contains(existing.OwningLog))
+            {
+                concatenated.Add(existing);
+            }
+        }
+
+        var counts = state.EventCountByLog;
+        var tables = state.EventTables;
+
+        foreach (var (logId, events) in action.ActiveLogs)
+        {
+            if (!tablesById.TryGetValue(logId, out var table)) { continue; }
+
+            concatenated.AddRange(events);
+            counts = counts.SetItem(logId, events.Count);
+
+            // Filter-clear may be the first event-bearing path for a log; latch ComputerName.
+            var updatedTable = SetComputerNameIfFirstEvent(table, events);
+
+            if (!ReferenceEquals(updatedTable, table))
+            {
+                tables = tables.Replace(table, updatedTable);
+            }
+        }
+
+        var sorted = concatenated.SortEvents(GetEffectiveOrderBy(state.OrderBy), state.IsDescending);
+
+        return state with
+        {
+            DisplayedEvents = sorted,
+            EventTables = tables,
+            EventCountByLog = counts
+        };
     }
 
     [ReducerMethod]
@@ -286,45 +360,107 @@ public sealed class EventTableReducers
     {
         var table = state.EventTables.FirstOrDefault(t => action.LogId == t.Id);
 
-        if (table is null) { return state; }
+        if (table is null || table.IsCombined) { return state; }
+
+        // UpdateTable carries the full slice; drop existing rows before merging.
+        bool hasExistingRowsForLog = state.EventCountByLog.TryGetValue(table.Id, out int existingCount) && existingCount > 0;
+
+        var existing = hasExistingRowsForLog
+            ? FilterOutOwningLog(state.DisplayedEvents, table.LogName)
+            : state.DisplayedEvents;
+
+        var merged = FilterMethods.MergeSorted(
+            existing,
+            action.Events,
+            GetEffectiveOrderBy(state.OrderBy),
+            state.IsDescending);
+
+        var updatedTable = SetComputerNameIfFirstEvent(table, action.Events) with { IsLoading = false };
+        var counts = state.EventCountByLog.SetItem(table.Id, action.Events.Count);
 
         return state with
         {
-            EventTables = state.EventTables.Replace(table, table with
-            {
-                DisplayedEvents = action.Events.SortEvents(GetEffectiveOrderBy(state.OrderBy), state.IsDescending),
-                IsLoading = false
-            })
+            DisplayedEvents = merged,
+            EventTables = state.EventTables.Replace(table, updatedTable),
+            EventCountByLog = counts
         };
     }
 
-    private static IReadOnlyList<DisplayEventModel> GetCombinedEvents(
-        IEnumerable<IReadOnlyList<DisplayEventModel>> sortedEventLists,
-        ColumnName orderBy,
-        bool isDescending) =>
-        FilterMethods.MergeSorted([.. sortedEventLists], orderBy, isDescending);
+    private static IReadOnlyList<DisplayEventModel> FilterByOwningLog(
+        IReadOnlyList<DisplayEventModel> events,
+        string owningLog)
+    {
+        var filtered = new List<DisplayEventModel>(events.Count);
 
-    // The k-way merge in GetCombinedEvents requires every per-log list to have been sorted with
-    // the same comparator. Funnel all per-log sort and combined-merge call sites through this
-    // helper so the effective default (DateAndTime) is applied consistently in both directions.
+        for (int eventIndex = 0; eventIndex < events.Count; eventIndex++)
+        {
+            var current = events[eventIndex];
+
+            if (string.Equals(current.OwningLog, owningLog, StringComparison.Ordinal))
+            {
+                filtered.Add(current);
+            }
+        }
+
+        return filtered.AsReadOnly();
+    }
+
+    private static IReadOnlyList<DisplayEventModel> FilterOutOwningLog(
+        IReadOnlyList<DisplayEventModel> events,
+        string owningLog)
+    {
+        var filtered = new List<DisplayEventModel>(events.Count);
+
+        for (int eventIndex = 0; eventIndex < events.Count; eventIndex++)
+        {
+            var current = events[eventIndex];
+
+            if (!string.Equals(current.OwningLog, owningLog, StringComparison.Ordinal))
+            {
+                filtered.Add(current);
+            }
+        }
+
+        return filtered.AsReadOnly();
+    }
+
     private static ColumnName GetEffectiveOrderBy(ColumnName? orderBy) =>
         orderBy ?? ColumnName.DateAndTime;
 
+    private static ImmutableDictionary<EventLogId, int> IncrementCount(
+        ImmutableDictionary<EventLogId, int> counts,
+        EventLogId logId,
+        int delta)
+    {
+        int current = counts.TryGetValue(logId, out int existing) ? existing : 0;
+        return counts.SetItem(logId, current + delta);
+    }
+
+    private static EventTableModel SetComputerNameIfFirstEvent(EventTableModel table, IReadOnlyList<DisplayEventModel> newEvents)
+    {
+        if (!string.IsNullOrEmpty(table.ComputerName) || newEvents.Count == 0) { return table; }
+
+        // events[0].ComputerName may be empty (resolver miss); scan for first non-empty.
+        for (int i = 0; i < newEvents.Count; i++)
+        {
+            var candidate = newEvents[i];
+
+            if (!string.IsNullOrEmpty(candidate.ComputerName))
+            {
+                return table with { ComputerName = candidate.ComputerName };
+            }
+        }
+
+        return table;
+    }
+
     private static EventTableState SortDisplayEvents(EventTableState state, ColumnName? orderBy, bool isDescending)
     {
-        List<EventTableModel> updatedTables = [];
         var effectiveOrderBy = GetEffectiveOrderBy(orderBy);
-
-        updatedTables.AddRange(
-            state.EventTables.Select(
-                logData => logData with
-                {
-                    DisplayedEvents = logData.DisplayedEvents.SortEvents(effectiveOrderBy, isDescending)
-                }));
 
         return state with
         {
-            EventTables = [.. updatedTables],
+            DisplayedEvents = state.DisplayedEvents.SortEvents(effectiveOrderBy, isDescending),
             OrderBy = orderBy,
             IsDescending = isDescending
         };

--- a/src/EventLogExpert.UI/Store/EventTable/EventTableState.cs
+++ b/src/EventLogExpert.UI/Store/EventTable/EventTableState.cs
@@ -1,6 +1,7 @@
-﻿// // Copyright (c) Microsoft Corporation.
+// // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Eventing.Models;
 using EventLogExpert.UI.Models;
 using Fluxor;
 using System.Collections.Immutable;
@@ -11,6 +12,11 @@ namespace EventLogExpert.UI.Store.EventTable;
 public sealed record EventTableState
 {
     public ImmutableList<EventTableModel> EventTables { get; init; } = [];
+
+    public IReadOnlyList<DisplayEventModel> DisplayedEvents { get; init; } = [];
+
+    public ImmutableDictionary<EventLogId, int> EventCountByLog { get; init; } =
+        ImmutableDictionary<EventLogId, int>.Empty;
 
     public EventLogId? ActiveEventLogId { get; init; }
 

--- a/src/EventLogExpert/Components/EventTable.razor
+++ b/src/EventLogExpert/Components/EventTable.razor
@@ -7,7 +7,7 @@
 <div aria-labelledby="eventTable" class="table-container" @onkeydown="HandleKeyDown" role="region" tabindex="0">
     <table aria-label="Event Log Table"
         aria-multiselectable="true"
-        aria-rowcount="@(_currentTable?.DisplayedEvents.Count + 1 ?? 1)"
+        aria-rowcount="@(_activeDisplayedEvents.Count + 1)"
         id="eventTable"
         role="grid">
         <thead @oncontextmenu="InvokeTableColumnMenu" @oncontextmenu:preventDefault="true" @oncontextmenu:stopPropagation="true">
@@ -48,7 +48,7 @@
         <tbody @oncontextmenu="InvokeContextMenu" @oncontextmenu:preventDefault="true" @oncontextmenu:stopPropagation="true">
         @if (_currentTable is not null)
         {
-            <Virtualize Context="evt" Items="@(_currentTable.DisplayedEvents as ICollection<DisplayEventModel> ?? [])">
+            <Virtualize Context="evt" Items="@(_activeDisplayedEvents as ICollection<DisplayEventModel> ?? [])">
                 <tr aria-rowindex="@GetRowIndex(evt)"
                     aria-selected="@(_selectedSet.Contains(evt).ToString().ToLower())"
                     class="@GetCss(evt)"

--- a/src/EventLogExpert/Components/EventTable.razor.cs
+++ b/src/EventLogExpert/Components/EventTable.razor.cs
@@ -36,6 +36,10 @@ public sealed partial class EventTable
 
     private readonly Dictionary<DisplayEventModel, string?> _highlightCache = new(ReferenceEqualityComparer.Instance);
 
+    private IReadOnlyList<DisplayEventModel> _activeDisplayedEvents = [];
+    private IReadOnlyList<DisplayEventModel>? _cachedFilteredCanonical;
+    private EventLogId? _cachedFilteredTableId;
+    private IReadOnlyList<DisplayEventModel>? _cachedFilteredView;
     private EventTableModel? _currentTable;
     private DotNetObjectReference<EventTable>? _dotNetRef;
     private ColumnName[] _enabledColumns = null!;
@@ -43,7 +47,7 @@ public sealed partial class EventTable
     private ImmutableList<FilterModel> _filters = [];
     private bool _focusActiveOnNextRender;
     private string _headerName = string.Empty;
-    private IReadOnlyList<DisplayEventModel>? _lastDisplayedEvents;
+    private IReadOnlyList<DisplayEventModel>? _lastIndexedDisplayedEvents;
     // View-local cursor: the row that is the moving end of a range selection within the
     // current table. May briefly diverge from _selectedEvent during local keyboard nav
     // (advanced before the dispatch round-trip) and after RebuildRowIndexMap rebinds it
@@ -174,8 +178,10 @@ public sealed partial class EventTable
         SelectedEvents.Select(s => s.SelectedEvents);
 
         SubscribeToAction<EventTableAction.SetActiveTable>(OnSetActiveTable);
-        SubscribeToAction<EventTableAction.UpdateCombinedEvents>(OnUpdateCombinedEvents);
-        SubscribeToAction<EventTableAction.UpdateDisplayedEvents>(OnUpdateDisplayedEvents);
+        SubscribeToAction<EventTableAction.UpdateDisplayedEvents>(_ => RescrollToSelected());
+        SubscribeToAction<EventTableAction.AppendTableEvents>(_ => RescrollToSelected());
+        SubscribeToAction<EventTableAction.AppendTableEventsBatch>(_ => RescrollToSelected());
+        SubscribeToAction<EventTableAction.UpdateTable>(_ => RescrollToSelected());
 
         _eventTableState = EventTableState.Value;
 
@@ -502,9 +508,9 @@ public sealed partial class EventTable
 
     private async Task HandleKeyDown(KeyboardEventArgs args)
     {
-        var displayedEvents = _currentTable?.DisplayedEvents;
+        var displayedEvents = _activeDisplayedEvents;
 
-        if (displayedEvents is null || displayedEvents.Count == 0) { return; }
+        if (displayedEvents.Count == 0) { return; }
 
         // Ctrl+C copies the active selection regardless of focused row.
         if (args is { CtrlKey: true, Code: "KeyC" })
@@ -642,19 +648,7 @@ public sealed partial class EventTable
         }
     }
 
-    private async void OnUpdateCombinedEvents(EventTableAction.UpdateCombinedEvents action)
-    {
-        try
-        {
-            await InvokeAsync(ScrollToSelectedEvent);
-        }
-        catch (Exception e)
-        {
-            TraceLogger.Error($"Failed to scroll to selected event: {e}");
-        }
-    }
-
-    private async void OnUpdateDisplayedEvents(EventTableAction.UpdateDisplayedEvents action)
+    private async void RescrollToSelected()
     {
         try
         {
@@ -668,17 +662,18 @@ public sealed partial class EventTable
 
     private void RebuildRowIndexMap()
     {
-        var displayedEvents = _currentTable?.DisplayedEvents;
+        var displayedEvents = ResolveActiveDisplayedEvents();
+        _activeDisplayedEvents = displayedEvents;
 
-        if (ReferenceEquals(displayedEvents, _lastDisplayedEvents)) { return; }
+        if (ReferenceEquals(displayedEvents, _lastIndexedDisplayedEvents)) { return; }
 
-        _lastDisplayedEvents = displayedEvents;
-        _rowIndexMap = new(displayedEvents?.Count ?? 0, ReferenceEqualityComparer.Instance);
+        _lastIndexedDisplayedEvents = displayedEvents;
+        _rowIndexMap = new(displayedEvents.Count, ReferenceEqualityComparer.Instance);
         // New event-list reference means stored DisplayEventModel instances
         // are stale; clearing prevents memory growth across log reloads.
         _highlightCache.Clear();
 
-        if (displayedEvents is null)
+        if (displayedEvents.Count == 0)
         {
             _selectionAnchor = null;
             _localCursor = null;
@@ -708,6 +703,45 @@ public sealed partial class EventTable
         }
     }
 
+    private IReadOnlyList<DisplayEventModel> ResolveActiveDisplayedEvents()
+    {
+        if (_currentTable is null) { return []; }
+
+        if (_currentTable.IsCombined) { return _eventTableState.DisplayedEvents; }
+
+        var canonical = _eventTableState.DisplayedEvents;
+
+        if (_cachedFilteredView is not null &&
+            ReferenceEquals(canonical, _cachedFilteredCanonical) &&
+            _cachedFilteredTableId == _currentTable.Id)
+        {
+            return _cachedFilteredView;
+        }
+
+        int expectedCapacity = _eventTableState.EventCountByLog.TryGetValue(_currentTable.Id, out int trackedCount)
+            ? trackedCount
+            : 0;
+
+        var filtered = new List<DisplayEventModel>(expectedCapacity);
+
+        for (int eventIndex = 0; eventIndex < canonical.Count; eventIndex++)
+        {
+            var current = canonical[eventIndex];
+
+            if (string.Equals(current.OwningLog, _currentTable.LogName, StringComparison.Ordinal))
+            {
+                filtered.Add(current);
+            }
+        }
+
+        var result = filtered.AsReadOnly();
+        _cachedFilteredCanonical = canonical;
+        _cachedFilteredTableId = _currentTable.Id;
+        _cachedFilteredView = result;
+
+        return result;
+    }
+
     private void ResortSelectionForCurrentTable()
     {
         // Re-publish the current selection in the new sort order. The dispatch
@@ -726,9 +760,9 @@ public sealed partial class EventTable
 
         if (target is null) { return; }
 
-        var displayedEvents = _currentTable?.DisplayedEvents;
+        var displayedEvents = _activeDisplayedEvents;
 
-        if (displayedEvents is null) { return; }
+        if (displayedEvents.Count == 0) { return; }
 
         // Match on OwningLog (the per-source identifier — file path for
         // exported logs, channel name for live logs) in addition to LogName
@@ -755,11 +789,11 @@ public sealed partial class EventTable
 
     private void SelectEvent(MouseEventArgs args, DisplayEventModel @event)
     {
-        var displayedEvents = _currentTable?.DisplayedEvents;
+        var displayedEvents = _activeDisplayedEvents;
 
         switch (args)
         {
-            case { ShiftKey: true } when displayedEvents is not null:
+            case { ShiftKey: true } when displayedEvents.Count > 0:
                 // Shift+Click: range from anchor to clicked. Anchor stays put.
                 // Without an anchor (first interaction), treat as a plain
                 // click so we have something to extend from on the next click.

--- a/src/EventLogExpert/Components/SplitLogTabPane.razor.cs
+++ b/src/EventLogExpert/Components/SplitLogTabPane.razor.cs
@@ -51,7 +51,7 @@ public sealed partial class SplitLogTabPane
         return true;
     }
 
-    private static string GetTabName(EventTableModel table)
+    private string GetTabName(EventTableModel table)
     {
         if (table.IsCombined) { return "Combined"; }
 
@@ -59,7 +59,11 @@ public sealed partial class SplitLogTabPane
             Path.GetFileNameWithoutExtension(table.FileName)!.Split("\\").Last() :
             $"{table.LogName} - {table.ComputerName}";
 
-        return table.DisplayedEvents.Count <= 0 && !table.IsLoading ? $"(Empty) {tabName}" : tabName;
+        if (table.IsLoading) { return tabName; }
+
+        int count = _eventTableState.EventCountByLog.GetValueOrDefault(table.Id, 0);
+
+        return count <= 0 ? $"(Empty) {tabName}" : tabName;
     }
 
     private static string GetTabTooltip(EventTableModel table)

--- a/src/EventLogExpert/Components/StatusBar.razor
+++ b/src/EventLogExpert/Components/StatusBar.razor
@@ -22,9 +22,13 @@
 
         var totalEvents = activeTable.IsCombined ?
             _eventLogState.ActiveLogs.Sum(l => l.Value.Events.Count) :
-            _eventLogState.ActiveLogs[activeTable.LogName].Events.Count;
+            _eventLogState.ActiveLogs.TryGetValue(activeTable.LogName, out var activeLogData)
+                ? activeLogData.Events.Count
+                : 0;
 
-        var filteredEvents = activeTable.DisplayedEvents.Count;
+        var filteredEvents = activeTable.IsCombined ?
+            _eventTableState.DisplayedEvents.Count :
+            _eventTableState.EventCountByLog.GetValueOrDefault(activeTable.Id, 0);
 
         <span>Visible: @(filteredEvents) Hidden by filter: @(totalEvents - filteredEvents)</span>
     }


### PR DESCRIPTION
## Problem

The "Combined" view is the user's primary view when ≥2 logs are open, but the architecture inverts this: it materializes a `DisplayedEvents` list **per log** (treated as primary), then maintains an *additional* materialized list for Combined that is rebuilt **from scratch on every event-flow tick** via `ReduceUpdateCombinedEvents` (a full k-way merge plus an O(N) `SequenceEqual` sanity check). The merge work is paid even when nothing changed, dispatched after every `AppendTableEvents`, `AppendTableEventsBatch`, `UpdateDisplayedEvents`, and `UpdateTable`.

## Approach

Make Combined the **single canonical materialized view**, maintained incrementally. Drop per-log `DisplayedEvents` materialization. Per-log tabs derive their view by `OwningLog` filter on demand when activated.

- `EventTableState` gains a canonical `IReadOnlyList<DisplayEventModel> DisplayedEvents`.
- `EventTableModel` becomes metadata-only (no per-log `DisplayedEvents`).
- `EventTableReducers` maintains the canonical list incrementally on append / batch / filter / sort / close paths.
- `ReduceUpdateCombinedEvents` (and its action) deleted entirely along with the four effects that dispatched it.
- `EventTable.razor.cs` reads from `state.DisplayedEvents`, applying a per-log filter only when a per-log tab is active (with a 1-entry cache keyed by table id + canonical reference).
- `StatusBar` and `SplitLogTabPane` updated to read counts and ComputerName from the canonical list.

## Performance (benchmarks captured pre/post; project not landed in this PR)

Host: AMD EPYC 7763 2.44GHz (Hyper-V VM), .NET 10.0.7, BenchmarkDotNet v0.15.4, RunStrategy=Throughput.

| Scenario | K | N/log | Baseline | Refactor | Δ Mean | Baseline Alloc | Refactor Alloc | Δ Alloc |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| AppendTableEvents (live-tail) | 2 | 100k | 11.60 ms | **0.94 ms** | **−92%** | 2.29 MB | 1.53 MB | −33% |
| AppendTableEvents (live-tail) | 5 | 100k | 34.21 ms | **2.22 ms** | **−94%** | 4.58 MB | 3.82 MB | −17% |
| AppendTableEventsBatch | 2 | 100k | 11.98 ms | **0.95 ms** | **−92%** | 3.05 MB | 1.53 MB | −50% |
| AppendTableEventsBatch | 5 | 100k | 37.00 ms | **2.21 ms** | **−94%** | 7.63 MB | 3.82 MB | −50% |
| UpdateDisplayedEvents (filter) | 5 | 100k | 71.46 ms | **55.76 ms** | −22% | 7.63 MB | 7.63 MB | 0% |
| Sequential UpdateTable per log (load) | 5 | 100k | 107.20 ms | **64.74 ms** | −40% | 15.27 MB | 14.5 MB | −5% |
| CloseLog | 5 | 100k | 25.11 ms | **13.08 ms** | −48% | 3.05 MB | 3.82 MB | +25% |

The hot live-tail path (every event tick) is **92–94% faster and uses ~17–50% less memory** — that's what dominates real-world usage. Cold paths (filter change, load completion, close log) are 22–48% faster with neutral or slight allocation deltas.

## Verification

- 880 UI unit tests pass (rewrites of `EventTableStoreTests` for the new shape; `EventTableEffectsTests` shrunk by 26 lines as the deleted action removed test surface).
- MAUI app builds clean (0 warnings, 0 errors).
- Multiple rubber-duck and code-review passes (Claude Opus + GPT-5) during development.
- Strict comment-hygiene audit applied across every touched file.
