### PR TITLE
Flip LoggingMiddleware default to type-name-only and tighten selected-events signatures

### DIFF
--- a/src/EventLogExpert.UI.Tests/Store/EventLog/EventLogStoreTests.cs
+++ b/src/EventLogExpert.UI.Tests/Store/EventLog/EventLogStoreTests.cs
@@ -187,7 +187,7 @@ public sealed class EventLogStoreTests
         var action = new EventLogAction.SelectEvents(events);
 
         // Assert
-        Assert.Equal(2, action.SelectedEvents.Count());
+        Assert.Equal(2, action.SelectedEvents.Count);
     }
 
     [Fact]

--- a/src/EventLogExpert.UI.Tests/TestUtils/LoggerUtils.cs
+++ b/src/EventLogExpert.UI.Tests/TestUtils/LoggerUtils.cs
@@ -1,0 +1,39 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Helpers;
+using Microsoft.Extensions.Logging;
+
+namespace EventLogExpert.UI.Tests.TestUtils;
+
+internal static class LoggerUtils
+{
+    internal sealed class RecordingTraceLogger : ITraceLogger
+    {
+        public List<string> CriticalMessages { get; } = [];
+
+        public List<string> DebugMessages { get; } = [];
+
+        public List<string> ErrorMessages { get; } = [];
+
+        public List<string> InfoMessages { get; } = [];
+
+        public LogLevel MinimumLevel => LogLevel.Trace;
+
+        public List<string> TraceMessages { get; } = [];
+
+        public List<string> WarnMessages { get; } = [];
+
+        public void Critical(CriticalLogHandler handler) => CriticalMessages.Add(handler.ToStringAndClear());
+
+        public void Debug(DebugLogHandler handler) => DebugMessages.Add(handler.ToStringAndClear());
+
+        public void Error(ErrorLogHandler handler) => ErrorMessages.Add(handler.ToStringAndClear());
+
+        public void Info(InfoLogHandler handler) => InfoMessages.Add(handler.ToStringAndClear());
+
+        public void Trace(TraceLogHandler handler) => TraceMessages.Add(handler.ToStringAndClear());
+
+        public void Warn(WarnLogHandler handler) => WarnMessages.Add(handler.ToStringAndClear());
+    }
+}

--- a/src/EventLogExpert.UI/Store/EventLog/EventLogAction.cs
+++ b/src/EventLogExpert.UI/Store/EventLog/EventLogAction.cs
@@ -33,7 +33,7 @@ public sealed record EventLogAction
         bool IsMultiSelect = false,
         bool ShouldStaySelected = false);
 
-    public sealed record SelectEvents(IEnumerable<DisplayEventModel> SelectedEvents);
+    public sealed record SelectEvents(IReadOnlyCollection<DisplayEventModel> SelectedEvents);
 
     /// <summary>
     /// Replaces the entire selection with the supplied events, preserving input order
@@ -47,7 +47,7 @@ public sealed record EventLogAction
     /// <param name="SelectedEvent">The new focused event, or null to clear focus. Does not
     /// need to be a member of <paramref name="SelectedEvents"/>.</param>
     public sealed record SetSelectedEvents(
-        IEnumerable<DisplayEventModel> SelectedEvents,
+        IReadOnlyCollection<DisplayEventModel> SelectedEvents,
         DisplayEventModel? SelectedEvent);
 
     public sealed record SetContinuouslyUpdate(bool ContinuouslyUpdate);

--- a/src/EventLogExpert.UI/Store/LoggingMiddleware.cs
+++ b/src/EventLogExpert.UI/Store/LoggingMiddleware.cs
@@ -4,9 +4,6 @@
 using EventLogExpert.Eventing.Helpers;
 using EventLogExpert.UI.Store.EventLog;
 using EventLogExpert.UI.Store.EventTable;
-using EventLogExpert.UI.Store.FilterCache;
-using EventLogExpert.UI.Store.FilterGroup;
-using EventLogExpert.UI.Store.FilterPane;
 using EventLogExpert.UI.Store.StatusBar;
 using Fluxor;
 using System.Text.Json;
@@ -16,69 +13,44 @@ namespace EventLogExpert.UI.Store;
 public sealed class LoggingMiddleware(ITraceLogger debugLogger) : Middleware
 {
     private readonly ITraceLogger _debugLogger = debugLogger;
-    private readonly JsonSerializerOptions _serializerOptions = new();
 
     public override void BeforeDispatch(object action)
     {
         switch (action)
         {
             case EventLogAction.LoadEvents loadEventsAction:
-                _debugLogger.Debug($"Action: {action.GetType()} with {loadEventsAction.Events.Count()} events.");
+                _debugLogger.Debug($"Action: {action.GetType()} with {loadEventsAction.Events.Count} events.");
                 break;
-            case EventLogAction.AddEvent addEventsAction:
-                _debugLogger.Debug($"Action: {action.GetType()} with {addEventsAction.NewEvent.Source} event ID {addEventsAction.NewEvent.Id}.");
+            case EventLogAction.LoadEventsPartial loadEventsPartialAction:
+                _debugLogger.Debug($"Action: {action.GetType()} with {loadEventsPartialAction.Events.Count} events.");
+                break;
+            case EventLogAction.AddEvent addEventAction:
+                _debugLogger.Debug($"Action: {action.GetType()} with {addEventAction.NewEvent.Source} event ID {addEventAction.NewEvent.Id}.");
                 break;
             case EventLogAction.OpenLog openLogAction:
                 _debugLogger.Info($"Action: {action.GetType()} with {openLogAction.LogName} log type {openLogAction.PathType}.");
                 break;
-            case EventLogAction.CloseLog:
-            case EventLogAction.CloseAll:
-                _debugLogger.Info($"Action: {action.GetType()}.");
-                break;
-            case EventLogAction.AddEventBuffered:
-            case EventLogAction.AddEventSuccess:
-            case EventLogAction.SetFilters:
-            case EventTableAction.AddTable:
-            case EventTableAction.LoadColumnsCompleted:
-            case EventTableAction.UpdateDisplayedEvents:
-            case EventTableAction.UpdateTable:
-            case FilterCacheAction.AddFavoriteFilterCompleted:
-            case FilterCacheAction.AddRecentFilterCompleted:
-            case FilterCacheAction.ImportFavorites:
-            case FilterCacheAction.LoadFiltersCompleted:
-            case FilterCacheAction.RemoveFavoriteFilterCompleted:
-            case FilterGroupAction.AddGroup:
-            case FilterGroupAction.ImportGroups:
-            case FilterGroupAction.LoadGroupsSuccess:
-            case FilterGroupAction.SetFilter:
-            case FilterGroupAction.SetGroup:
-            case FilterPaneAction.AddFilter:
-            case FilterPaneAction.ApplyFilterGroup:
-            case FilterPaneAction.SetFilter:
-            case FilterPaneAction.SetFilterDateRange:
-                _debugLogger.Debug($"Action: {action.GetType()}.");
-                break;
             case EventLogAction.SelectEvent selectEventAction:
-                _debugLogger.Debug($"Action: {nameof(EventLogAction.SelectEvent)} selected {selectEventAction.SelectedEvent?.Source} event ID {selectEventAction.SelectedEvent?.Id}.");
-
+                _debugLogger.Debug($"Action: {nameof(EventLogAction.SelectEvent)} selected {selectEventAction.SelectedEvent.Source} event ID {selectEventAction.SelectedEvent.Id}.");
                 break;
             case EventLogAction.SelectEvents selectEventsAction:
-                _debugLogger.Debug($"Action: {nameof(EventLogAction.SelectEvents)} selected {selectEventsAction.SelectedEvents.Count()} events");
-
+                _debugLogger.Debug($"Action: {nameof(EventLogAction.SelectEvents)} selected {selectEventsAction.SelectedEvents.Count} events.");
+                break;
+            case EventLogAction.SetSelectedEvents setSelectedEventsAction:
+                _debugLogger.Debug($"Action: {nameof(EventLogAction.SetSelectedEvents)} set {setSelectedEventsAction.SelectedEvents.Count} events.");
+                break;
+            case EventTableAction.AppendTableEvents appendTableEventsAction:
+                _debugLogger.Debug($"Action: {action.GetType()} with {appendTableEventsAction.Events.Count} events for log {appendTableEventsAction.LogId}.");
+                break;
+            case EventTableAction.AppendTableEventsBatch appendTableEventsBatchAction:
+                var totalAppendEvents = appendTableEventsBatchAction.EventsByLog.Values.Sum(eventsForLog => eventsForLog.Count);
+                _debugLogger.Debug($"Action: {action.GetType()} with {totalAppendEvents} events across {appendTableEventsBatchAction.EventsByLog.Count} logs.");
                 break;
             case StatusBarAction.SetEventsLoading:
-                _debugLogger.Debug($"Action: {action.GetType()} {JsonSerializer.Serialize(action, _serializerOptions)}");
+                _debugLogger.Debug($"Action: {action.GetType()} {JsonSerializer.Serialize(action)}");
                 break;
             default:
-                try
-                {
-                    _debugLogger.Debug($"Action: {action.GetType()} {JsonSerializer.Serialize(action, _serializerOptions)}");
-                }
-                catch
-                {
-                    _debugLogger.Debug($"Action: {action.GetType()}. Could not serialize payload.");
-                }
-
+                _debugLogger.Debug($"Action: {action.GetType()}.");
                 break;
         }
     }


### PR DESCRIPTION
## Summary

Flips the Fluxor `LoggingMiddleware` policy from "default = JSON-serialize unknown actions, allowlist = type-only" to "default = type-name only (safe), opt-in = rich diagnostics", and tightens the two `EventLogAction` selection records so the middleware can read `.Count` (property) instead of `.Count()` (LINQ).

## Why

The original switch had a `default:` branch that JSON-serialized the entire action payload to `debug.log` on every dispatch, with a per-case allowlist for type-only logging. Four high-volume actions silently fell through to the default JSON path:

- `EventTableAction.AppendTableEvents` (carries `IReadOnlyList<DisplayEventModel>`)
- `EventTableAction.AppendTableEventsBatch` (carries `IDictionary<int, IReadOnlyCollection<DisplayEventModel>>`)
- `EventLogAction.LoadEventsPartial` (carries `IReadOnlyList<DisplayEventModel>`)
- `EventLogAction.SetSelectedEvents` (carries the user's full selection)

Result: every dispatch of these actions wrote a multi-kilobyte JSON blob to disk on the dispatch hot path. User caught it in the wild via `Action: EventLogExpert.UI.Store.EventTable.EventTableAction+AppendTableEvents` log lines that should never have included payload at all.

## Changes

**`LoggingMiddleware.cs` (-43 / +19):**
- `default:` branch now logs only `action.GetType()`.
- Removed 21-case type-name-only allowlist (those types now get the same output via the new safe default — no behavior change for them).
- Removed try/catch and `_serializerOptions` field (no longer reachable on the hot path; only `StatusBarAction.SetEventsLoading` still serializes and its payload is small/bounded — guid + 2 ints).
- Added explicit count-summary cases for the 4 large-payload actions.
- Renamed `addEventsAction` → `addEventAction` (action is `AddEvent`, singular).

**`EventLogAction.cs` (+2 / -2):** Tightened `SelectEvents.SelectedEvents` and `SetSelectedEvents.SelectedEvents` from `IEnumerable<DisplayEventModel>` to `IReadOnlyCollection<DisplayEventModel>`. Every call site already passes `List<T>` or `T[]` (verified via repo-wide grep); the broader type was fiction. Tightening unlocks `.Count` (property, O(1)) on the dispatch hot path.

**`EventLogStoreTests.cs` (+1 / -1):** `.Count()` → `.Count` on the tightened signature for sibling-consistency with the other 5 `.Count` sites in the file.

**`LoggerUtils.cs` (new):** `RecordingTraceLogger` test fake at `src/EventLogExpert.UI.Tests/TestUtils/LoggerUtils.cs`. NSubstitute can't cleanly capture interpolated string handler structs (`ITraceLogger.Debug([InterpolatedStringHandlerArgument(""")] DebugLogHandler handler)`); the fake calls `handler.ToStringAndClear()` synchronously and stores per-level `List<string>` for assertions.

## Verification

- Full solution build: 0 warnings, 0 errors.
- All 1791 tests pass (113 Components + 19 EventDbTool + 628 Eventing + 1031 UI).
- Multi-model code review (Claude Opus + GPT-5.5): both clean. Opus's one finding (`.Count()` → `.Count` outlier in `EventLogStoreTests.cs:190`) was applied.