### PR TITLE
Right-align modal footer buttons and stack Settings extra row

### DIFF
--- a/src/EventLogExpert.Components/Base/ModalChrome.razor
+++ b/src/EventLogExpert.Components/Base/ModalChrome.razor
@@ -35,7 +35,7 @@
         <div class="footer-group" inert="@HasInlineAlert">
             @if (ExtraFooterContent is not null)
             {
-                <div class="footer-extra">
+                <div class="footer-extra@(StackFooterExtra ? " footer-extra-stacked" : null)">
                     @ExtraFooterContent
                 </div>
             }

--- a/src/EventLogExpert.Components/Base/ModalChrome.razor.cs
+++ b/src/EventLogExpert.Components/Base/ModalChrome.razor.cs
@@ -75,6 +75,12 @@ public sealed partial class ModalChrome : ComponentBase, IAsyncDisposable
 
     [Parameter] public bool ShowCloseButton { get; set; }
 
+    /// <summary>Opt the footer-extra slot into a full-width row above the action
+    /// buttons, instead of sharing the row with them. Use when the extra content
+    /// is a label/control pair that should align with the dialog body rather than
+    /// compete with the button row for horizontal space.</summary>
+    [Parameter] public bool StackFooterExtra { get; set; }
+
     [Parameter] public string? Title { get; set; }
 
     private string? DialogInlineStyle

--- a/src/EventLogExpert.Components/Modals/SettingsModal.razor
+++ b/src/EventLogExpert.Components/Modals/SettingsModal.razor
@@ -14,7 +14,8 @@
     OnInlineAlertResolved="HandleInlineAlertResolvedAsync"
     OnSave="OnSaveAsync"
     @ref="ChromeRef"
-    SaveLabel="Save">
+    SaveLabel="Save"
+    StackFooterExtra="true">
     <ChildContent>
         <div class="settings-form">
             <div class="flex-column-scroll">

--- a/src/EventLogExpert/wwwroot/css/app.css
+++ b/src/EventLogExpert/wwwroot/css/app.css
@@ -162,16 +162,25 @@ html, body {
 
 .footer-group {
     display: flex;
-    justify-content: space-between;
+    flex-wrap: wrap;
+    justify-content: flex-end;
     align-items: center;
     gap: 0.5rem;
 
     margin-top: .5rem;
 }
 
-    .footer-group.align-right { justify-content: flex-end; }
-
     .footer-group .footer-extra { flex: 1 1 auto; min-width: 0; }
+
+    /* Opt-in: force the extra slot onto its own full-width row so the action
+       buttons wrap to a second row beneath it. Used when the extra content is a
+       label/control pair that should align with the dialog body. */
+    .footer-group .footer-extra.footer-extra-stacked { flex: 0 0 100%; }
+
+    /* Preserve the "secondary actions on the left, primary on the right" split
+       used by FooterPreset.ImportExportClose. The non-final .button-group is
+       pushed left while the trailing primary button stays at flex-end. */
+    .footer-group > .button-group:not(:last-child) { margin-right: auto; }
 
 a { color: var(--clr-lightblue); }
 


### PR DESCRIPTION
Fixes modal footer alignment across all dialogs.

## Bugs
- **Settings:** Save/Exit buttons rendered inline with the "Pre-release Builds" toggle on the same row.
- **Release Notes:** Close button left-aligned instead of right.
- General: several modals had buttons at the wrong edge of the footer.

## Root cause
`.footer-group { justify-content: space-between; }` left single-button footers pinned to the left and split paired buttons. With `ExtraFooterContent` it forced the toggle and the action buttons to share one row.

## Fix
- `.footer-group` now uses `flex-wrap: wrap` + `justify-content: flex-end` so buttons right-align by default.
- New opt-in `StackFooterExtra` parameter on `ModalChrome` adds `footer-extra-stacked` to the extra slot so it consumes a full row above the buttons. Settings opts in; DebugLog stays inline (its custom grid keeps the Exit button next to Refresh/Clear).
- Added `.footer-group > .button-group:not(:last-child) { margin-right: auto; }` to preserve the Import/Export-left + Close-right split for `FooterPreset.ImportExportClose` (FilterCacheModal, FilterGroupModal).
- Removed the unused `.footer-group.align-right` selector.

## Verified
- Build clean.
- `EventLogExpert.Components.Tests` and `EventLogExpert.UI.Tests` pass.
- Visually confirmed in the running MAUI app: Settings, Release Notes, Saved Filters, Filter Groups, Debug Log, and alert/prompt modals all render footers as expected.