### PR TITLE
Fix multi-log open race and debug log horizontal scrollbar

### DIFF
--- a/src/EventLogExpert.Components/Modals/DebugLogModal.razor
+++ b/src/EventLogExpert.Components/Modals/DebugLogModal.razor
@@ -1,4 +1,3 @@
-@using EventLogExpert.UI
 @using Microsoft.Extensions.Logging
 @inherits ModalBase<bool>
 
@@ -19,9 +18,9 @@
             <ValueSelect AriaLabel="Level operator"
                 CssClass="input filter-dropdown"
                 T="FilterEvaluator"
+                ToStringFunc="@(x => x.ToFullString())"
                 Value="_levelOperator"
-                ValueChanged="HandleLevelOperatorChanged"
-                ToStringFunc="@(x => x.ToFullString())">
+                ValueChanged="HandleLevelOperatorChanged">
                 <ValueSelectItem T="FilterEvaluator" Value="FilterEvaluator.Equals" />
                 <ValueSelectItem T="FilterEvaluator" Value="FilterEvaluator.NotEqual" />
                 <ValueSelectItem T="FilterEvaluator" Value="FilterEvaluator.MultiSelect" />
@@ -33,10 +32,10 @@
                     EmptyText="All"
                     IsMultiSelect
                     T="LogLevel"
+                    ToStringFunc="@(x => x.ToString())"
                     Values="_multiLevels"
-                    ValuesChanged="HandleMultiLevelsChanged"
-                    ToStringFunc="@(x => x.ToString())">
-                    <ValueSelectItem T="LogLevel" ClearItem>All</ValueSelectItem>
+                    ValuesChanged="HandleMultiLevelsChanged">
+                    <ValueSelectItem ClearItem T="LogLevel">All</ValueSelectItem>
                     @foreach (var level in s_logLevels)
                     {
                         <ValueSelectItem T="LogLevel" Value="level" />
@@ -48,10 +47,10 @@
                 <ValueSelect AriaLabel="Level"
                     CssClass="input filter-dropdown"
                     T="LogLevel?"
+                    ToStringFunc="@(x => x?.ToString() ?? "All")"
                     Value="_singleLevel"
-                    ValueChanged="HandleSingleLevelChanged"
-                    ToStringFunc="@(x => x?.ToString() ?? "All")">
-                    <ValueSelectItem T="LogLevel?" ClearItem>All</ValueSelectItem>
+                    ValueChanged="HandleSingleLevelChanged">
+                    <ValueSelectItem ClearItem T="LogLevel?">All</ValueSelectItem>
                     @foreach (var level in s_logLevels)
                     {
                         <ValueSelectItem T="LogLevel?" Value="level" />
@@ -59,16 +58,16 @@
                 </ValueSelect>
             }
             <input aria-label="Filter messages"
-                class="input debug-log-text-filter"
+                class="debug-log-text-filter input"
                 @oninput="HandleStringFilterInput"
                 placeholder="Filter messages..."
                 type="text"
                 value="@_pendingStringFilter" />
         </div>
         <div aria-busy="@(_hasLoaded ? "false" : "true")" aria-label="Debug log entries" class="debug-log-viewport" role="region" tabindex="0">
-            <Virtualize Items="_displayedView" Context="line" ItemSize="@RowHeightPx" OverscanCount="20">
+            <Virtualize Context="line" Items="_displayedView" ItemSize="@RowHeightPx" OverscanCount="20">
                 <ItemContent>
-                    <div class="debug-log-row">@line</div>
+                    <div class="debug-log-row" title="@line">@line</div>
                 </ItemContent>
                 <EmptyContent>
                     @if (_hasLoaded)

--- a/src/EventLogExpert.Components/Modals/DebugLogModal.razor.css
+++ b/src/EventLogExpert.Components/Modals/DebugLogModal.razor.css
@@ -4,14 +4,17 @@
     min-width: 0;
     flex: 1 1 auto;
     min-height: 0;
-    overflow-x: auto;
+    overflow-x: hidden;
     overflow-y: auto;
 }
 
 .debug-log-row {
     box-sizing: border-box;
+    width: 100%;
     height: 18px;
     padding: 0 0.25rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
 
     font-family: monospace;
     line-height: 18px;

--- a/src/EventLogExpert.UI/EventLog/Effects.cs
+++ b/src/EventLogExpert.UI/EventLog/Effects.cs
@@ -52,7 +52,6 @@ public sealed class Effects(
     private readonly IFilterService _filterService = filterService;
     private readonly Lock _globalCtsLock = new();
     private readonly ConcurrentDictionary<EventLogId, TaskCompletionSource> _logCloseCompletions = new();
-
     /// <summary>
     ///     Serializes <see cref="HandleSetFilters" />'s XML-reload path with
     ///     <see cref="PrepareForDatabaseRemovalAsync" />. Both write into <see cref="_logCloseCompletions" /> with raw
@@ -63,9 +62,8 @@ public sealed class Effects(
     ///     it.
     /// </summary>
     private readonly SemaphoreSlim _logCloseCoordinatorLock = new(1, 1);
-
     private readonly ConcurrentDictionary<EventLogId, CancellationTokenSource> _logCts = new();
-
+    private readonly ITraceLogger _logger = logger;
     /// <summary>
     ///     Tracks per-log load completion so <see cref="HandleCloseLog" /> can wait for the in-flight
     ///     <see cref="LoadLogAsync" /> service scope to dispose before draining the watcher. Without this, cts.Cancel() merely
@@ -73,16 +71,13 @@ public sealed class Effects(
     ///     disposes once HandleOpenLog's outer using/finally runs.
     /// </summary>
     private readonly ConcurrentDictionary<EventLogId, TaskCompletionSource> _logLoadCompletions = new();
-    private readonly ILogWatcherService _logWatcherService = logWatcherService;
-    private readonly ITraceLogger _logger = logger;
-
     /// <summary>
     ///     Tracks which currently-open logs (by <see cref="EventLogData.Id" />) were loaded with renderXml=true. A
     ///     reload-on-transition only re-opens logs that lack XML; logs that already have it are left alone. Removing or
     ///     disabling an XML filter never triggers a reload because the XML data is already in memory and harmless to keep.
     /// </summary>
     private readonly ConcurrentDictionary<EventLogId, byte> _logsLoadedWithXml = new();
-
+    private readonly ILogWatcherService _logWatcherService = logWatcherService;
     /// <summary>
     ///     Pending selection restore per log name, populated when a filter transition forces a reload. Consumed by
     ///     <see cref="HandleLoadEvents" /> when the reloaded log finishes loading. Carries both the selected record-ids and
@@ -146,8 +141,7 @@ public sealed class Effects(
     {
         CancelAllLoads();
 
-        await _logWatcherService.RemoveAllAsync();
-
+        // Sync prefix: subsequent OpenLogAction must see cleared LogTable.
         dispatcher.Dispatch(new LogTable.CloseAllAction());
         dispatcher.Dispatch(new StatusBar.CloseAllAction());
 
@@ -155,6 +149,8 @@ public sealed class Effects(
         _xmlResolver.ClearAll();
         _logsLoadedWithXml.Clear();
         _pendingSelectionRestore.Clear();
+
+        await _logWatcherService.RemoveAllAsync();
     }
 
     [EffectMethod]

--- a/tests/Unit/EventLogExpert.Components.Tests/Modals/DebugLogModalTests.cs
+++ b/tests/Unit/EventLogExpert.Components.Tests/Modals/DebugLogModalTests.cs
@@ -68,6 +68,26 @@ public sealed class DebugLogModalTests : BunitContext
     }
 
     [Fact]
+    public async Task DebugLogModal_AfterLoad_RowsCarryTitleAttributeMirroringText()
+    {
+        var firstHeader = DebugLogUtils.BuildLine(LogLevel.Information, Constants.DebugLogFirstMessage);
+        var secondHeader = DebugLogUtils.BuildLine(LogLevel.Information, Constants.DebugLogSecondMessage);
+
+        _fileLogger.LoadAsync(Arg.Any<CancellationToken>()).Returns(
+            DebugLogUtils.ToAsyncEnumerable([firstHeader, secondHeader]));
+
+        var component = Render<DebugLogModal>();
+
+        await component.WaitForAssertionAsync(() =>
+            Assert.Equal("2 of 2 entries", component.Find(".debug-log-footer-counter").TextContent.Trim()));
+
+        var rows = component.FindAll(".debug-log-row");
+        Assert.Equal(
+            rows.Select(row => row.TextContent).ToArray(),
+            rows.Select(row => row.GetAttribute("title")).ToArray());
+    }
+
+    [Fact]
     public async Task DebugLogModal_AfterLoad_ViewportHasRegionRoleWithoutAriaLiveAndIsKeyboardFocusable()
     {
         // Arrange

--- a/tests/Unit/EventLogExpert.UI.Tests/EventLog/EffectsTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/EventLog/EffectsTests.cs
@@ -139,6 +139,28 @@ public sealed class EffectsTests
     }
 
     [Fact]
+    public async Task HandleCloseAll_DispatchesStateClearsBeforeWatcherDrain()
+    {
+        var (effects, mockDispatcher, mockLogWatcher, mockResolverCache, _) = CreateEffectsWithServices();
+
+        var watcherTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        mockLogWatcher.RemoveAllAsync().Returns(watcherTcs.Task);
+
+        var closeTask = effects.HandleCloseAll(mockDispatcher);
+
+        Assert.False(closeTask.IsCompleted, "HandleCloseAll must still be awaiting RemoveAllAsync.");
+        mockDispatcher.Received(1).Dispatch(Arg.Any<CloseAllAction>());
+        mockDispatcher.Received(1).Dispatch(Arg.Any<UI.StatusBar.CloseAllAction>());
+        mockResolverCache.Received(1).ClearAll();
+
+        watcherTcs.SetResult();
+        await closeTask.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        Assert.True(closeTask.IsCompletedSuccessfully);
+        await mockLogWatcher.Received(1).RemoveAllAsync();
+    }
+
+    [Fact]
     public async Task HandleCloseAll_ShouldClearAllResolvedXml()
     {
         // Arrange
@@ -688,7 +710,7 @@ public sealed class EffectsTests
 
         var (effects, mockDispatcher, _, _, _) = CreateEffectsWithServices(activeLogs: activeLogs);
 
-        var filter = FilterUtils.CreateTestFilter(Constants.FilterIdEquals100, isEnabled: true);
+        var filter = FilterUtils.CreateTestFilter(isEnabled: true);
         var action = new SetFiltersAction(new EventFilter(null, [filter]));
 
         await effects.HandleSetFilters(action, mockDispatcher);
@@ -714,7 +736,7 @@ public sealed class EffectsTests
             .When(x => x.FilterActiveLogs(Arg.Any<IEnumerable<EventLogData>>(), Arg.Any<EventFilter>()))
             .Do(_ => throw new InvalidOperationException("boom"));
 
-        var filter = FilterUtils.CreateTestFilter(Constants.FilterIdEquals100, isEnabled: true);
+        var filter = FilterUtils.CreateTestFilter(isEnabled: true);
         var action = new SetFiltersAction(new EventFilter(null, [filter]));
 
         await Assert.ThrowsAsync<InvalidOperationException>(
@@ -763,7 +785,7 @@ public sealed class EffectsTests
                 return filterResult;
             });
 
-        var nonXmlFilter = FilterUtils.CreateTestFilter(Constants.FilterIdEquals100, isEnabled: true);
+        var nonXmlFilter = FilterUtils.CreateTestFilter(isEnabled: true);
         var action = new SetFiltersAction(new EventFilter(null, [nonXmlFilter]));
 
         // Act
@@ -827,7 +849,7 @@ public sealed class EffectsTests
                 },
                 _ => pass2Result);
 
-        var nonXmlFilter = FilterUtils.CreateTestFilter(Constants.FilterIdEquals100, isEnabled: true);
+        var nonXmlFilter = FilterUtils.CreateTestFilter(isEnabled: true);
         var action = new SetFiltersAction(new EventFilter(null, [nonXmlFilter]));
 
         // Act
@@ -914,7 +936,7 @@ public sealed class EffectsTests
                     return pass2Result;
                 });
 
-        var nonXmlFilter = FilterUtils.CreateTestFilter(Constants.FilterIdEquals100, isEnabled: true);
+        var nonXmlFilter = FilterUtils.CreateTestFilter(isEnabled: true);
         var action = new SetFiltersAction(new EventFilter(null, [nonXmlFilter]));
 
         // Act
@@ -952,7 +974,7 @@ public sealed class EffectsTests
         var staleStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var staleFilterModel = FilterUtils.CreateTestFilter(Constants.FilterIdEquals999, isEnabled: true);
-        var freshFilterModel = FilterUtils.CreateTestFilter(Constants.FilterIdEquals100, isEnabled: true);
+        var freshFilterModel = FilterUtils.CreateTestFilter(isEnabled: true);
 
         var staleFilter = new EventFilter(null, [staleFilterModel]);
         var freshFilter = new EventFilter(null, [freshFilterModel]);
@@ -1053,7 +1075,7 @@ public sealed class EffectsTests
 
         var (effects, mockDispatcher, _, _, _) = CreateEffectsWithServices(activeLogs: activeLogs);
 
-        var nonXmlFilter = FilterUtils.CreateTestFilter(Constants.FilterIdEquals100, isEnabled: true);
+        var nonXmlFilter = FilterUtils.CreateTestFilter(isEnabled: true);
         var eventFilter = new EventFilter(null, [nonXmlFilter]);
         var action = new SetFiltersAction(eventFilter);
 
@@ -1065,50 +1087,6 @@ public sealed class EffectsTests
         mockDispatcher.DidNotReceive().Dispatch(Arg.Any<CloseLogAction>());
         mockDispatcher.DidNotReceive().Dispatch(Arg.Any<OpenLogAction>());
         mockDispatcher.Received(1).Dispatch(Arg.Any<UpdateDisplayedEventsAction>());
-    }
-
-    [Fact]
-    public async Task HandleSetFilters_WhenFilterRequiresXmlAndLogLacksXml_ShouldCloseAndReopenLog()
-    {
-        // Arrange — active log has not been loaded with XML, so it must be re-read.
-        var logData = new EventLogData(Constants.LogNameTestLog, LogPathType.Channel, []);
-        var activeLogs = ImmutableDictionary<string, EventLogData>.Empty.Add(Constants.LogNameTestLog, logData);
-
-        var (effects, mockDispatcher, _, _, _) = CreateEffectsWithServices(activeLogs: activeLogs);
-
-        // Route CloseLog → HandleCloseLog so HandleSetFilters' await on the close-completion
-        // TCS resolves quickly (otherwise it hits LogCloseTimeout, 30s). Capture the routed
-        // tasks so any fault in HandleCloseLog surfaces at the end of the test instead of
-        // being swallowed by the discard.
-        var closeTasks = new List<Task>();
-        mockDispatcher
-            .When(d => d.Dispatch(Arg.Any<CloseLogAction>()))
-            .Do(callInfo =>
-            {
-                closeTasks.Add(effects.HandleCloseLog(callInfo.Arg<CloseLogAction>(), mockDispatcher));
-            });
-
-        var xmlFilter = FilterUtils.CreateTestFilter(Constants.FilterXmlContainsData, isEnabled: true);
-        var eventFilter = new EventFilter(null, [xmlFilter]);
-        var action = new SetFiltersAction(eventFilter);
-
-        // Act
-        await effects.HandleSetFilters(action, mockDispatcher);
-
-        // Assert
-        Assert.True(eventFilter.RequiresXml);
-
-        mockDispatcher.Received(1).Dispatch(Arg.Is<CloseLogAction>(a =>
-            a.LogName == Constants.LogNameTestLog && a.LogId == logData.Id));
-
-        mockDispatcher.Received(1).Dispatch(Arg.Is<OpenLogAction>(a =>
-            a.LogName == Constants.LogNameTestLog && a.LogPathType == LogPathType.Channel));
-
-        // Reload path returns early — no UpdateDisplayedEvents until LoadEvents fires.
-        mockDispatcher.DidNotReceive().Dispatch(Arg.Any<UpdateDisplayedEventsAction>());
-
-        // Surface any HandleCloseLog faults before exiting the test.
-        await Task.WhenAll(closeTasks);
     }
 
     [Fact]
@@ -1240,6 +1218,50 @@ public sealed class EffectsTests
         // Assert — SetSelectedEvents dispatched with exactly the restored event (RecordId=42).
         mockDispatcher.Received(1).Dispatch(Arg.Is<SetSelectedEventsAction>(a =>
             a.SelectedEvents.Count() == 1 && a.SelectedEvents.First().RecordId == 42));
+
+        // Surface any HandleCloseLog faults before exiting the test.
+        await Task.WhenAll(closeTasks);
+    }
+
+    [Fact]
+    public async Task HandleSetFilters_WhenFilterRequiresXmlAndLogLacksXml_ShouldCloseAndReopenLog()
+    {
+        // Arrange — active log has not been loaded with XML, so it must be re-read.
+        var logData = new EventLogData(Constants.LogNameTestLog, LogPathType.Channel, []);
+        var activeLogs = ImmutableDictionary<string, EventLogData>.Empty.Add(Constants.LogNameTestLog, logData);
+
+        var (effects, mockDispatcher, _, _, _) = CreateEffectsWithServices(activeLogs: activeLogs);
+
+        // Route CloseLog → HandleCloseLog so HandleSetFilters' await on the close-completion
+        // TCS resolves quickly (otherwise it hits LogCloseTimeout, 30s). Capture the routed
+        // tasks so any fault in HandleCloseLog surfaces at the end of the test instead of
+        // being swallowed by the discard.
+        var closeTasks = new List<Task>();
+        mockDispatcher
+            .When(d => d.Dispatch(Arg.Any<CloseLogAction>()))
+            .Do(callInfo =>
+            {
+                closeTasks.Add(effects.HandleCloseLog(callInfo.Arg<CloseLogAction>(), mockDispatcher));
+            });
+
+        var xmlFilter = FilterUtils.CreateTestFilter(Constants.FilterXmlContainsData, isEnabled: true);
+        var eventFilter = new EventFilter(null, [xmlFilter]);
+        var action = new SetFiltersAction(eventFilter);
+
+        // Act
+        await effects.HandleSetFilters(action, mockDispatcher);
+
+        // Assert
+        Assert.True(eventFilter.RequiresXml);
+
+        mockDispatcher.Received(1).Dispatch(Arg.Is<CloseLogAction>(a =>
+            a.LogName == Constants.LogNameTestLog && a.LogId == logData.Id));
+
+        mockDispatcher.Received(1).Dispatch(Arg.Is<OpenLogAction>(a =>
+            a.LogName == Constants.LogNameTestLog && a.LogPathType == LogPathType.Channel));
+
+        // Reload path returns early — no UpdateDisplayedEvents until LoadEvents fires.
+        mockDispatcher.DidNotReceive().Dispatch(Arg.Any<UpdateDisplayedEventsAction>());
 
         // Surface any HandleCloseLog faults before exiting the test.
         await Task.WhenAll(closeTasks);


### PR DESCRIPTION
Two unrelated runtime fixes off `main`.

## Bugs

- **Multi-log empty table:** opening a Live log immediately after another Live log left the table populated with the second log's rows briefly, then wiped to empty even though events had successfully arrived.
- **Debug log horizontal scrollbar:** long debug log lines re-introduced a horizontal scrollbar in the Debug Log modal viewport.

## Root cause

### CloseAll race

Commit `f046a07` flipped `EventLogExpertEffects.HandleCloseAll`'s `_logWatcherService.RemoveAll()` (sync) to `RemoveAllAsync()` (async). Pre-`f046a07` the entire effect body ran synchronously inside the `Dispatch(CloseAllAction)` frame; post-`f046a07` the dispatches that follow the await race against `HandleOpenLog`. Fluxor's `Dispatch` runs reducers synchronously and starts effects but does not await them. Callers (`MauiMenuActionService.OpenLogAsync`, `SettingsModal.ReloadOpenLogs`) dispatch `CloseAllAction` immediately followed by `OpenLogAction` back-to-back synchronously. With Live then Live, a Channel watcher is registered, `RemoveAllAsync` returns a non-completed Task, the await yields, `HandleOpenLog` populates the table via `AddTableAction` + `UpdateTableAction`, and the continuation then dispatches `LogTable.CloseAllAction` which wipes the freshly populated table.

### Debug log scrollbar

`.debug-log-viewport { overflow-x: auto }` combined with `.debug-log-row { white-space: pre }` on long lines (e.g., long stack traces or paths) re-introduced the horizontal scrollbar.

## Fix

- `HandleCloseAll`: dispatch `LogTable.CloseAllAction` / `StatusBar.CloseAllAction` and clear all in-memory bookkeeping (`_resolverCache`, `_xmlResolver`, `_logsLoadedWithXml`, `_pendingSelectionRestore`) BEFORE awaiting `_logWatcherService.RemoveAllAsync()`. The watcher drain is pure resource cleanup and does not read these caches, so flushing them up front is safe and ensures any caller-dispatched `OpenLogAction` runs against cleared state.
- New regression test `HandleCloseAll_DispatchesStateClearsBeforeWatcherDrain` uses a `TaskCompletionSource` to hold `RemoveAllAsync` and asserts every state-clearing call already happened during the synchronous prefix.
- Debug log modal: viewport `overflow-x: hidden`; rows get `width: 100%`, `overflow: hidden`, `text-overflow: ellipsis` (kept `white-space: pre` so leading indentation in stack traces still reads correctly). Each row gains a `title="@line"` attribute so users can hover to read the full clipped content as a native browser tooltip.
- New regression test `DebugLogModal_AfterLoad_RowsCarryTitleAttributeMirroringText` pins the title-mirror invariant.

## Verified

- `dotnet build EventLogExpert.slnx`: 0 warnings / 0 errors.
- `dotnet format whitespace --verify-no-changes`: clean.
- `dotnet format style --verify-no-changes --diagnostics IDE0005 IDE0065`: clean.
- `dotnet test EventLogExpert.slnx --no-build`: 1853 passed / 2 skipped / 0 failed across all 7 test projects.
- Manually confirmed Live then Live no longer empties the second log.
- Manually confirmed long debug-log lines now clip with ellipsis and reveal full content on hover.