### PR TITLE
Test surface hardening for filter-slice-rework SUTs

### DIFF
--- a/src/EventLogExpert.Runtime/FilterGroup/FilterGroupExtensions.cs
+++ b/src/EventLogExpert.Runtime/FilterGroup/FilterGroupExtensions.cs
@@ -1,45 +1,42 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using System.Collections.Immutable;
+
 using EventLogExpert.Filtering.Persistence;
 
 namespace EventLogExpert.Runtime.FilterGroup;
 
 internal static class FilterGroupExtensions
 {
-    extension(Dictionary<string, FilterGroupNode> group)
+    extension(ImmutableDictionary<string, FilterGroupNode> group)
     {
-        public Dictionary<string, FilterGroupNode> AddFilterGroup(
+        public ImmutableDictionary<string, FilterGroupNode> AddFilterGroup(
             string[] groupNames,
             SavedFilterGroup data)
         {
+            ArgumentNullException.ThrowIfNull(groupNames);
+
             var root = groupNames.Length <= 1 ? string.Empty : groupNames.First();
-            groupNames = [.. groupNames.Skip(1)];
+            var remaining = groupNames.Length <= 1 ? [] : groupNames.Skip(1).ToArray();
 
             if (group.TryGetValue(root, out var node))
             {
-                if (groupNames.Length > 1)
-                {
-                    node.ChildNodes.AddFilterGroup(groupNames, data);
-                }
-                else
-                {
-                    node.Groups.Add(data);
-                }
-            }
-            else
-            {
-                group.Add(root,
-                    groupNames.Length > 1 ?
-                        new FilterGroupNode
-                        {
-                            ChildNodes = new Dictionary<string, FilterGroupNode>()
-                                .AddFilterGroup(groupNames, data)
-                        } :
-                        new FilterGroupNode { Groups = [data] });
+                var updated = remaining.Length > 1
+                    ? node with { ChildNodes = node.ChildNodes.AddFilterGroup(remaining, data) }
+                    : node with { Groups = node.Groups.Add(data) };
+
+                return group.SetItem(root, updated);
             }
 
-            return group;
+            var newNode = remaining.Length > 1
+                ? new FilterGroupNode
+                {
+                    ChildNodes = ImmutableDictionary<string, FilterGroupNode>.Empty.AddFilterGroup(remaining, data)
+                }
+                : new FilterGroupNode { Groups = ImmutableList.Create(data) };
+
+            return group.Add(root, newNode);
         }
     }
 }

--- a/src/EventLogExpert.Runtime/FilterGroup/FilterGroupNode.cs
+++ b/src/EventLogExpert.Runtime/FilterGroup/FilterGroupNode.cs
@@ -1,13 +1,16 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using System.Collections.Immutable;
+
 using EventLogExpert.Filtering.Persistence;
 
 namespace EventLogExpert.Runtime.FilterGroup;
 
 public sealed record FilterGroupNode
 {
-    public Dictionary<string, FilterGroupNode> ChildNodes { get; init; } = [];
+    public ImmutableDictionary<string, FilterGroupNode> ChildNodes { get; init; } =
+        ImmutableDictionary<string, FilterGroupNode>.Empty;
 
-    public List<SavedFilterGroup> Groups { get; init; } = [];
+    public ImmutableList<SavedFilterGroup> Groups { get; init; } = ImmutableList<SavedFilterGroup>.Empty;
 }

--- a/src/EventLogExpert.Runtime/FilterGroup/Reducers.cs
+++ b/src/EventLogExpert.Runtime/FilterGroup/Reducers.cs
@@ -137,16 +137,16 @@ internal sealed class Reducers
     private static IReadOnlyDictionary<string, FilterGroupNode> BuildDisplayGroups(
         IEnumerable<SavedFilterGroup> groups)
     {
-        Dictionary<string, FilterGroupNode> displayGroups = [];
+        var displayGroups = ImmutableDictionary<string, FilterGroupNode>.Empty;
 
         foreach (var group in groups)
         {
             var folders = group.Name.Split('\\');
 
-            displayGroups.AddFilterGroup(folders, group);
+            displayGroups = displayGroups.AddFilterGroup(folders, group);
         }
 
-        return displayGroups.AsReadOnly();
+        return displayGroups;
     }
 
     private static IReadOnlyList<SavedFilter> ReplaceFilterById(

--- a/src/EventLogExpert.Runtime/LogTable/ResolvedEventOrdering.cs
+++ b/src/EventLogExpert.Runtime/LogTable/ResolvedEventOrdering.cs
@@ -97,53 +97,6 @@ internal static class ResolvedEventOrdering
             };
 
     internal static IReadOnlyList<ResolvedEvent> MergeSorted(
-        IReadOnlyList<IReadOnlyList<ResolvedEvent>> sortedLists,
-        ColumnName orderBy,
-        bool isDescending)
-    {
-        switch (sortedLists.Count)
-        {
-            case 0: return [];
-            case 1: return sortedLists[0];
-        }
-
-        int totalCount = 0;
-
-        foreach (var list in sortedLists) { totalCount += list.Count; }
-
-        if (totalCount == 0) { return []; }
-
-        var comparer = GetComparer(orderBy, isDescending);
-        var result = new List<ResolvedEvent>(totalCount);
-        var heap = new PriorityQueue<int, ResolvedEvent>(
-            sortedLists.Count,
-            Comparer<ResolvedEvent>.Create(comparer));
-        var positions = new int[sortedLists.Count];
-
-        for (int listIndex = 0; listIndex < sortedLists.Count; listIndex++)
-        {
-            if (sortedLists[listIndex].Count <= 0) { continue; }
-
-            heap.Enqueue(listIndex, sortedLists[listIndex][0]);
-            positions[listIndex] = 1;
-        }
-
-        while (heap.TryDequeue(out int sourceListIndex, out ResolvedEvent? currentEvent))
-        {
-            result.Add(currentEvent);
-
-            int nextPosition = positions[sourceListIndex];
-
-            if (nextPosition >= sortedLists[sourceListIndex].Count) { continue; }
-
-            heap.Enqueue(sourceListIndex, sortedLists[sourceListIndex][nextPosition]);
-            positions[sourceListIndex] = nextPosition + 1;
-        }
-
-        return result.AsReadOnly();
-    }
-
-    internal static IReadOnlyList<ResolvedEvent> MergeSorted(
         IReadOnlyList<ResolvedEvent> existing,
         IReadOnlyList<ResolvedEvent> batch,
         ColumnName? orderBy,

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterGroup/FilterGroupExtensionsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterGroup/FilterGroupExtensionsTests.cs
@@ -60,6 +60,39 @@ public sealed class FilterGroupExtensionsTests
     }
 
     [Fact]
+    public void AddFilterGroup_WhenGroupNamesIsNull_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        var dictionary = ImmutableDictionary<string, FilterGroupNode>.Empty;
+        var filterGroup = new SavedFilterGroup { Name = "Anything" };
+
+        // Act + Assert
+        Assert.Throws<ArgumentNullException>(() => dictionary.AddFilterGroup(null!, filterGroup));
+    }
+
+    [Fact]
+    public void AddFilterGroup_WhenMixedShape_ShouldBucketByPathArity()
+    {
+        // Arrange
+        var dictionary = ImmutableDictionary<string, FilterGroupNode>.Empty;
+        var solo = new SavedFilterGroup { Name = "Solo" };
+        var twoSegment = new SavedFilterGroup { Name = "Section\\Leaf" };
+        var threeSegment = new SavedFilterGroup { Name = "Branch\\Sub\\Leaf" };
+
+        // Act
+        dictionary = dictionary.AddFilterGroup(["Solo"], solo);
+        dictionary = dictionary.AddFilterGroup("Section\\Leaf".Split('\\'), twoSegment);
+        dictionary = dictionary.AddFilterGroup("Branch\\Sub\\Leaf".Split('\\'), threeSegment);
+
+        // Assert
+        Assert.Single(dictionary[string.Empty].Groups);
+        Assert.Single(dictionary["Section"].Groups);
+        Assert.True(dictionary["Branch"].ChildNodes.ContainsKey("Sub"));
+        Assert.True(dictionary["Branch"].ChildNodes["Sub"].ChildNodes.IsEmpty is false
+            || dictionary["Branch"].ChildNodes["Sub"].Groups.Count > 0);
+    }
+
+    [Fact]
     public void AddFilterGroup_WhenNestedGroupNames_ShouldCreateHierarchy()
     {
         // Arrange
@@ -76,6 +109,51 @@ public sealed class FilterGroupExtensionsTests
     }
 
     [Fact]
+    public void AddFilterGroup_WhenPathHasEmptySegment_ShouldDescendThroughEmptyKey()
+    {
+        // Arrange
+        var dictionary = ImmutableDictionary<string, FilterGroupNode>.Empty;
+        var filterGroup = new SavedFilterGroup { Name = "Section\\\\Leaf" };
+
+        // Act
+        dictionary = dictionary.AddFilterGroup("Section\\\\Leaf".Split('\\'), filterGroup);
+
+        // Assert
+        Assert.True(dictionary["Section"].ChildNodes.ContainsKey(string.Empty));
+    }
+
+    [Fact]
+    public void AddFilterGroup_WhenSameInstanceReAdded_ShouldDuplicateInGroupsBucket()
+    {
+        // Arrange
+        var dictionary = ImmutableDictionary<string, FilterGroupNode>.Empty;
+        var filterGroup = new SavedFilterGroup { Name = "Section\\Leaf" };
+
+        // Act
+        dictionary = dictionary.AddFilterGroup("Section\\Leaf".Split('\\'), filterGroup);
+        dictionary = dictionary.AddFilterGroup("Section\\Leaf".Split('\\'), filterGroup);
+
+        // Assert
+        Assert.Equal(2, dictionary["Section"].Groups.Count);
+    }
+
+    [Fact]
+    public void AddFilterGroup_WhenSameNameSiblings_ShouldKeepBothEntriesUnderTheSameKey()
+    {
+        // Arrange
+        var dictionary = ImmutableDictionary<string, FilterGroupNode>.Empty;
+        var first = new SavedFilterGroup { Name = "Section\\Leaf" };
+        var second = new SavedFilterGroup { Name = "Section\\Leaf" };
+
+        // Act
+        dictionary = dictionary.AddFilterGroup("Section\\Leaf".Split('\\'), first);
+        dictionary = dictionary.AddFilterGroup("Section\\Leaf".Split('\\'), second);
+
+        // Assert
+        Assert.Equal(2, dictionary["Section"].Groups.Count);
+    }
+
+    [Fact]
     public void AddFilterGroup_WhenSingleGroupName_ShouldAddToRoot()
     {
         // Arrange
@@ -89,5 +167,20 @@ public sealed class FilterGroupExtensionsTests
         // Assert
         Assert.True(dictionary.ContainsKey(string.Empty));
         Assert.Single(dictionary[string.Empty].Groups);
+    }
+
+    [Fact]
+    public void AddFilterGroup_WhenThreeLevelNesting_ShouldDescendFullPath()
+    {
+        // Arrange
+        var dictionary = ImmutableDictionary<string, FilterGroupNode>.Empty;
+        var filterGroup = new SavedFilterGroup { Name = "Root\\Mid\\Leaf" };
+
+        // Act
+        dictionary = dictionary.AddFilterGroup("Root\\Mid\\Leaf".Split('\\'), filterGroup);
+
+        // Assert
+        Assert.True(dictionary.ContainsKey("Root"));
+        Assert.True(dictionary["Root"].ChildNodes.ContainsKey("Mid"));
     }
 }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterGroup/FilterGroupExtensionsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterGroup/FilterGroupExtensionsTests.cs
@@ -4,6 +4,7 @@
 using EventLogExpert.Filtering.Persistence;
 using EventLogExpert.Runtime.FilterGroup;
 using EventLogExpert.Runtime.Tests.TestUtils.Constants;
+using System.Collections.Immutable;
 
 namespace EventLogExpert.Runtime.Tests.FilterGroup;
 
@@ -13,7 +14,7 @@ public sealed class FilterGroupExtensionsTests
     public void AddFilterGroup_WhenAddingToEmptyDictionary_ShouldCreateNewEntry()
     {
         // Arrange
-        var dictionary = new Dictionary<string, FilterGroupNode>();
+        var dictionary = ImmutableDictionary<string, FilterGroupNode>.Empty;
         var filterGroup = new SavedFilterGroup { Name = Constants.FilterGroupName };
         var groupNames = Constants.FilterGroupName.Split('\\');
 
@@ -29,13 +30,13 @@ public sealed class FilterGroupExtensionsTests
     public void AddFilterGroup_WhenAddingToExistingSection_ShouldAppendFilterGroup()
     {
         // Arrange
-        var dictionary = new Dictionary<string, FilterGroupNode>();
+        var dictionary = ImmutableDictionary<string, FilterGroupNode>.Empty;
         var filterGroup1 = new SavedFilterGroup { Name = Constants.FilterGroupName };
         var filterGroup2 = new SavedFilterGroup { Name = "TestSection\\AnotherGroup" };
 
         // Act
-        dictionary.AddFilterGroup(Constants.FilterGroupName.Split('\\'), filterGroup1);
-        dictionary.AddFilterGroup("TestSection\\AnotherGroup".Split('\\'), filterGroup2);
+        dictionary = dictionary.AddFilterGroup(Constants.FilterGroupName.Split('\\'), filterGroup1);
+        dictionary = dictionary.AddFilterGroup("TestSection\\AnotherGroup".Split('\\'), filterGroup2);
 
         // Assert
         Assert.Single(dictionary);
@@ -43,29 +44,31 @@ public sealed class FilterGroupExtensionsTests
     }
 
     [Fact]
-    public void AddFilterGroup_WhenCalled_ShouldReturnSameDictionary()
+    public void AddFilterGroup_WhenCalled_ShouldReturnUpdatedDictionary()
     {
         // Arrange
-        var dictionary = new Dictionary<string, FilterGroupNode>();
+        var dictionary = ImmutableDictionary<string, FilterGroupNode>.Empty;
         var filterGroup = new SavedFilterGroup { Name = Constants.FilterGroupName };
 
         // Act
         var result = dictionary.AddFilterGroup(Constants.FilterGroupName.Split('\\'), filterGroup);
 
         // Assert
-        Assert.Same(dictionary, result);
+        Assert.NotSame(dictionary, result);
+        Assert.Empty(dictionary);
+        Assert.Single(result);
     }
 
     [Fact]
     public void AddFilterGroup_WhenNestedGroupNames_ShouldCreateHierarchy()
     {
         // Arrange
-        var dictionary = new Dictionary<string, FilterGroupNode>();
+        var dictionary = ImmutableDictionary<string, FilterGroupNode>.Empty;
         var filterGroup = new SavedFilterGroup { Name = Constants.FilterGroupNameNested };
         var groupNames = Constants.FilterGroupNameNested.Split('\\');
 
         // Act
-        dictionary.AddFilterGroup(groupNames, filterGroup);
+        dictionary = dictionary.AddFilterGroup(groupNames, filterGroup);
 
         // Assert
         Assert.True(dictionary.ContainsKey(Constants.FilterGroupSection));
@@ -76,12 +79,12 @@ public sealed class FilterGroupExtensionsTests
     public void AddFilterGroup_WhenSingleGroupName_ShouldAddToRoot()
     {
         // Arrange
-        var dictionary = new Dictionary<string, FilterGroupNode>();
+        var dictionary = ImmutableDictionary<string, FilterGroupNode>.Empty;
         var filterGroup = new SavedFilterGroup { Name = "SingleGroup" };
         var groupNames = new[] { "SingleGroup" };
 
         // Act
-        dictionary.AddFilterGroup(groupNames, filterGroup);
+        dictionary = dictionary.AddFilterGroup(groupNames, filterGroup);
 
         // Assert
         Assert.True(dictionary.ContainsKey(string.Empty));

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Filters/FilterExtensionsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Filters/FilterExtensionsTests.cs
@@ -12,7 +12,23 @@ namespace EventLogExpert.Runtime.Tests.Filters;
 public sealed class FilterExtensionsTests
 {
     [Fact]
-    public void HasFilteringChanged_WhenBothEmpty_ShouldReportNoChange()
+    public void HasFilteringChangedFrom_WhenArgsSwapped_ShouldReportSameChange()
+    {
+        // Arrange
+        var first = new Filter(null, ImmutableList.Create(CreateFilter(Constants.FilterIdEquals100)));
+        var second = new Filter(null, ImmutableList.Create(CreateFilter(Constants.FilterIdEquals200)));
+
+        // Act
+        var forward = first.HasFilteringChangedFrom(second);
+        var reverse = second.HasFilteringChangedFrom(first);
+
+        // Assert
+        Assert.True(forward);
+        Assert.Equal(forward, reverse);
+    }
+
+    [Fact]
+    public void HasFilteringChangedFrom_WhenBothEmpty_ShouldReportNoChange()
     {
         // Arrange
         var original = new Filter(null, []);
@@ -26,7 +42,20 @@ public sealed class FilterExtensionsTests
     }
 
     [Fact]
-    public void HasFilteringChanged_WhenComparisonTextChanges_ShouldReportChange()
+    public void HasFilteringChangedFrom_WhenBothSnapshotsAreDefault_ShouldReportNoChange()
+    {
+        // Arrange
+        var defaultFilter = default(Filter);
+
+        // Act
+        var result = defaultFilter.HasFilteringChangedFrom(default);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void HasFilteringChangedFrom_WhenComparisonTextChanges_ShouldReportChange()
     {
         // Arrange
         var first = FilterUtils.CreateTestFilter();
@@ -43,7 +72,7 @@ public sealed class FilterExtensionsTests
     }
 
     [Fact]
-    public void HasFilteringChanged_WhenDateFilterAdded_ShouldReportChange()
+    public void HasFilteringChangedFrom_WhenDateFilterAdded_ShouldReportChange()
     {
         // Arrange
         var original = new Filter(null, []);
@@ -58,7 +87,7 @@ public sealed class FilterExtensionsTests
     }
 
     [Fact]
-    public void HasFilteringChanged_WhenDateFilterRangeChanges_ShouldReportChange()
+    public void HasFilteringChangedFrom_WhenDateFilterRangeChanges_ShouldReportChange()
     {
         // Arrange
         var dateFilter1 = new DateFilter { After = DateTime.Now.AddDays(-1), Before = DateTime.Now };
@@ -74,7 +103,7 @@ public sealed class FilterExtensionsTests
     }
 
     [Fact]
-    public void HasFilteringChanged_WhenDateFilterRemoved_ShouldReportChange()
+    public void HasFilteringChangedFrom_WhenDateFilterRemoved_ShouldReportChange()
     {
         // Arrange
         var dateFilter = new DateFilter { After = DateTime.Now.AddDays(-1), Before = DateTime.Now };
@@ -89,7 +118,7 @@ public sealed class FilterExtensionsTests
     }
 
     [Fact]
-    public void HasFilteringChanged_WhenEquivalentFiltersFromDifferentInstances_ShouldReportNoChange()
+    public void HasFilteringChangedFrom_WhenEquivalentFiltersFromDifferentInstances_ShouldReportNoChange()
     {
         // Arrange
         var original = new Filter(
@@ -108,7 +137,24 @@ public sealed class FilterExtensionsTests
     }
 
     [Fact]
-    public void HasFilteringChanged_WhenFiltersAdded_ShouldReportChange()
+    public void HasFilteringChangedFrom_WhenFilterOrderSwaps_ShouldReportChange()
+    {
+        // Arrange
+        var first = CreateFilter(Constants.FilterIdEquals100);
+        var second = CreateFilter(Constants.FilterIdEquals200);
+
+        var original = new Filter(null, ImmutableList.Create(first, second));
+        var updated = new Filter(null, ImmutableList.Create(second, first));
+
+        // Act
+        var result = updated.HasFilteringChangedFrom(original);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void HasFilteringChangedFrom_WhenFiltersAdded_ShouldReportChange()
     {
         // Arrange
         var original = new Filter(null, []);
@@ -123,7 +169,7 @@ public sealed class FilterExtensionsTests
     }
 
     [Fact]
-    public void HasFilteringChanged_WhenFiltersRemoved_ShouldReportChange()
+    public void HasFilteringChangedFrom_WhenFiltersRemoved_ShouldReportChange()
     {
         // Arrange
         var filter = CreateFilter(Constants.FilterIdEquals100);
@@ -138,7 +184,7 @@ public sealed class FilterExtensionsTests
     }
 
     [Fact]
-    public void HasFilteringChanged_WhenIsExcludedDiffers_ShouldReportChange()
+    public void HasFilteringChangedFrom_WhenIsExcludedDiffers_ShouldReportChange()
     {
         // Arrange
         var original = new Filter(
@@ -157,7 +203,7 @@ public sealed class FilterExtensionsTests
     }
 
     [Fact]
-    public void HasFilteringChanged_WhenOnlyColorDiffers_ShouldReportNoChange()
+    public void HasFilteringChangedFrom_WhenOnlyColorDiffers_ShouldReportNoChange()
     {
         // Arrange
         var redFilter = FilterUtils.CreateTestFilter(Constants.FilterIdEquals100, HighlightColor.Red);
@@ -174,7 +220,7 @@ public sealed class FilterExtensionsTests
     }
 
     [Fact]
-    public void HasFilteringChanged_WhenOnlyDateFilterIsEnabledToggles_ShouldReportChange()
+    public void HasFilteringChangedFrom_WhenOnlyDateFilterIsEnabledToggles_ShouldReportChange()
     {
         // Arrange
         var bounds = (After: DateTime.Now.AddDays(-1), Before: DateTime.Now);
@@ -191,7 +237,22 @@ public sealed class FilterExtensionsTests
     }
 
     [Fact]
-    public void HasFilteringChanged_WhenSameFilters_ShouldReportNoChange()
+    public void HasFilteringChangedFrom_WhenOnlyOneSnapshotIsDefault_ShouldReportChange()
+    {
+        // Arrange
+        var initialized = new Filter(null, []);
+
+        // Act
+        var forward = initialized.HasFilteringChangedFrom(default);
+        var reverse = default(Filter).HasFilteringChangedFrom(initialized);
+
+        // Assert
+        Assert.True(forward);
+        Assert.True(reverse);
+    }
+
+    [Fact]
+    public void HasFilteringChangedFrom_WhenSameFilters_ShouldReportNoChange()
     {
         // Arrange
         var filters = ImmutableList.Create(CreateFilter(Constants.FilterIdEquals100));

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Filters/FilterExtensionsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Filters/FilterExtensionsTests.cs
@@ -2,7 +2,6 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Filtering.Persistence;
-using EventLogExpert.Filtering.Runtime;
 using EventLogExpert.Runtime.Filters;
 using EventLogExpert.Runtime.Tests.TestUtils;
 using EventLogExpert.Runtime.Tests.TestUtils.Constants;
@@ -35,20 +34,6 @@ public sealed class FilterExtensionsTests
 
         var original = new Filter(null, ImmutableList.Create(first));
         var updated = new Filter(null, ImmutableList.Create(second));
-
-        // Act
-        var result = updated.HasFilteringChangedFrom(original);
-
-        // Assert
-        Assert.True(result);
-    }
-
-    [Fact]
-    public void HasFilteringChanged_WhenComparisonValueDiffers_ShouldReportChange()
-    {
-        // Arrange
-        var original = new Filter(null, ImmutableList.Create(CreateFilter(Constants.FilterIdEquals100)));
-        var updated = new Filter(null, ImmutableList.Create(CreateFilter(Constants.FilterIdEquals200)));
 
         // Act
         var result = updated.HasFilteringChangedFrom(original);

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Filters/ResolvedEventExtensionsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Filters/ResolvedEventExtensionsTests.cs
@@ -3,7 +3,6 @@
 
 using EventLogExpert.Eventing.Common.Events;
 using EventLogExpert.Filtering.Persistence;
-using EventLogExpert.Filtering.Runtime;
 using EventLogExpert.Runtime.Filters;
 using EventLogExpert.Runtime.Tests.TestUtils;
 using EventLogExpert.Runtime.Tests.TestUtils.Constants;
@@ -12,6 +11,27 @@ namespace EventLogExpert.Runtime.Tests.Filters;
 
 public sealed class ResolvedEventExtensionsTests
 {
+    [Fact]
+    public void MatchesDateFilter_WhenAfterIsAfterBefore_ShouldFailDateConstraint()
+    {
+        // Arrange
+        var @event = EventUtils.CreateTestEvent(100,
+            timeCreated: new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc));
+
+        var dateFilter = new DateFilter
+        {
+            IsEnabled = true,
+            After = new DateTime(2024, 1, 2, 0, 0, 0, DateTimeKind.Utc),
+            Before = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+        // Act
+        var result = @event.MatchesDateFilter(dateFilter);
+
+        // Assert
+        Assert.False(result);
+    }
+
     [Fact]
     public void MatchesDateFilter_WhenDateFilterDisabled_ShouldNotConstrainEvent()
     {
@@ -273,6 +293,24 @@ public sealed class ResolvedEventExtensionsTests
     }
 
     [Fact]
+    public void MatchesFilters_WhenIncludeFilterHasNullCompiled_ShouldSkipNullCompiledFilter()
+    {
+        // Arrange
+        var @event = EventUtils.CreateTestEvent(100);
+        var filters = new List<SavedFilter>
+        {
+            SavedFilter.Empty,
+            CreateFilter(Constants.FilterIdEquals100)
+        };
+
+        // Act
+        var result = @event.MatchesFilters(filters);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
     public void MatchesFilters_WhenIncludeFilterMatches_ShouldIncludeEvent()
     {
         // Arrange
@@ -284,6 +322,60 @@ public sealed class ResolvedEventExtensionsTests
 
         // Assert
         Assert.True(result);
+    }
+
+    [Fact]
+    public void MatchesFilters_WhenIncludeMatchesAndExcludeDoesNot_ShouldIncludeEvent()
+    {
+        // Arrange
+        var @event = EventUtils.CreateTestEvent(100);
+        var filters = new List<SavedFilter>
+        {
+            CreateFilter(Constants.FilterIdEquals100),
+            CreateFilter(Constants.FilterIdEquals200, true)
+        };
+
+        // Act
+        var result = @event.MatchesFilters(filters);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void MatchesFilters_WhenMultipleExcludesAndNoneMatch_ShouldIncludeEvent()
+    {
+        // Arrange
+        var @event = EventUtils.CreateTestEvent(300);
+        var filters = new List<SavedFilter>
+        {
+            CreateFilter(Constants.FilterIdEquals100, true),
+            CreateFilter(Constants.FilterIdEquals200, true)
+        };
+
+        // Act
+        var result = @event.MatchesFilters(filters);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void MatchesFilters_WhenMultipleExcludesAndOneMatches_ShouldExcludeEvent()
+    {
+        // Arrange
+        var @event = EventUtils.CreateTestEvent(100);
+        var filters = new List<SavedFilter>
+        {
+            CreateFilter(Constants.FilterIdEquals100, true),
+            CreateFilter(Constants.FilterIdEquals200, true)
+        };
+
+        // Act
+        var result = @event.MatchesFilters(filters);
+
+        // Assert
+        Assert.False(result);
     }
 
     [Fact]
@@ -321,14 +413,29 @@ public sealed class ResolvedEventExtensionsTests
     }
 
     [Fact]
-    public void MatchesFilters_WhenXmlFilterDoesNotMatch_ShouldExcludeEvent()
+    public void MatchesFilters_WhenOnlyFilterHasNullCompiled_ShouldIncludeEvent()
     {
         // Arrange
         var @event = EventUtils.CreateTestEvent(100);
-        var filters = new List<SavedFilter> { CreateFilter(Constants.FilterXmlContainsData) };
+        var filters = new List<SavedFilter> { SavedFilter.Empty };
 
         // Act
         var result = @event.MatchesFilters(filters);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void MatchesFilters_WhenXmlFilterDoesNotMatch_ShouldExcludeEvent()
+    {
+        // Arrange
+        var eventWithoutXml = EventUtils.CreateTestEvent(100);
+        var xmlContainsDataFilter = CreateFilter(Constants.FilterXmlContainsData);
+        var filters = new List<SavedFilter> { xmlContainsDataFilter };
+
+        // Act
+        var result = eventWithoutXml.MatchesFilters(filters);
 
         // Assert
         Assert.False(result);

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/ResolvedEventOrderingTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/ResolvedEventOrderingTests.cs
@@ -4,11 +4,155 @@
 using EventLogExpert.Eventing.Common.Events;
 using EventLogExpert.Runtime.LogTable;
 using EventLogExpert.Runtime.Tests.TestUtils;
+using System.Security.Principal;
 
 namespace EventLogExpert.Runtime.Tests.LogTable;
 
 public sealed class ResolvedEventOrderingTests
 {
+    [Fact]
+    public void MergeSorted_WhenBatchIsEmpty_ShouldReturnExistingUnchanged()
+    {
+        var existing = new List<ResolvedEvent>
+        {
+            EventUtils.CreateTestEvent(100),
+            EventUtils.CreateTestEvent(200)
+        }.AsReadOnly();
+        var batch = new List<ResolvedEvent>().AsReadOnly();
+
+        var result = ResolvedEventOrdering.MergeSorted(existing, batch, ColumnName.EventId, false);
+
+        Assert.Same(existing, result);
+    }
+
+    [Fact]
+    public void MergeSorted_WhenDescending_ShouldMergeInDescendingOrder()
+    {
+        var existing = new List<ResolvedEvent>
+        {
+            EventUtils.CreateTestEvent(400),
+            EventUtils.CreateTestEvent(200)
+        }.AsReadOnly();
+        var batch = new List<ResolvedEvent>
+        {
+            EventUtils.CreateTestEvent(300),
+            EventUtils.CreateTestEvent(100)
+        }.AsReadOnly();
+
+        var result = ResolvedEventOrdering.MergeSorted(existing, batch, ColumnName.EventId, true);
+
+        Assert.Equal(new[] { 400, 300, 200, 100 }, result.Select(e => e.Id));
+    }
+
+    [Fact]
+    public void MergeSorted_WhenExistingIsEmpty_ShouldReturnSortedBatch()
+    {
+        var existing = new List<ResolvedEvent>().AsReadOnly();
+        var batch = new List<ResolvedEvent>
+        {
+            EventUtils.CreateTestEvent(300),
+            EventUtils.CreateTestEvent(100),
+            EventUtils.CreateTestEvent(200)
+        }.AsReadOnly();
+
+        var result = ResolvedEventOrdering.MergeSorted(existing, batch, ColumnName.EventId, false);
+
+        Assert.Equal(3, result.Count);
+        Assert.Equal(100, result[0].Id);
+        Assert.Equal(200, result[1].Id);
+        Assert.Equal(300, result[2].Id);
+    }
+
+    [Fact]
+    public void MergeSorted_WhenKeysInterleave_ShouldMergeInOrder()
+    {
+        var existing = new List<ResolvedEvent>
+        {
+            EventUtils.CreateTestEvent(100),
+            EventUtils.CreateTestEvent(300)
+        }.AsReadOnly();
+        var batch = new List<ResolvedEvent>
+        {
+            EventUtils.CreateTestEvent(200),
+            EventUtils.CreateTestEvent(400)
+        }.AsReadOnly();
+
+        var result = ResolvedEventOrdering.MergeSorted(existing, batch, ColumnName.EventId, false);
+
+        Assert.Equal(new[] { 100, 200, 300, 400 }, result.Select(e => e.Id));
+    }
+
+    [Fact]
+    public void MergeSorted_WhenKeysTie_ShouldPlaceExistingBeforeBatchForStability()
+    {
+        var existingA = EventUtils.CreateTestEvent(100, recordId: 10);
+        var batchB = EventUtils.CreateTestEvent(100, recordId: 11);
+
+        var existing = new List<ResolvedEvent> { existingA }.AsReadOnly();
+        var batch = new List<ResolvedEvent> { batchB }.AsReadOnly();
+
+        var result = ResolvedEventOrdering.MergeSorted(existing, batch, ColumnName.EventId, false);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(10L, result[0].RecordId);
+        Assert.Equal(11L, result[1].RecordId);
+    }
+
+    [Fact]
+    public void MergeSorted_WhenOrderingByComputerName_ShouldUseSelectedColumnComparer()
+    {
+        var existing = new List<ResolvedEvent>
+        {
+            EventUtils.CreateTestEvent(computerName: "Alpha"),
+            EventUtils.CreateTestEvent(computerName: "Charlie")
+        }.AsReadOnly();
+        var batch = new List<ResolvedEvent>
+        {
+            EventUtils.CreateTestEvent(computerName: "Bravo"),
+            EventUtils.CreateTestEvent(computerName: "Delta")
+        }.AsReadOnly();
+
+        var result = ResolvedEventOrdering.MergeSorted(existing, batch, ColumnName.ComputerName, false);
+
+        Assert.Equal(new[] { "Alpha", "Bravo", "Charlie", "Delta" }, result.Select(e => e.ComputerName));
+    }
+
+    [Fact]
+    public void MergeSorted_WhenRangesAreDisjoint_ShouldMergeInOrder()
+    {
+        var existing = new List<ResolvedEvent>
+        {
+            EventUtils.CreateTestEvent(100),
+            EventUtils.CreateTestEvent(200)
+        }.AsReadOnly();
+        var batch = new List<ResolvedEvent>
+        {
+            EventUtils.CreateTestEvent(300),
+            EventUtils.CreateTestEvent(400)
+        }.AsReadOnly();
+
+        var result = ResolvedEventOrdering.MergeSorted(existing, batch, ColumnName.EventId, false);
+
+        Assert.Equal(new[] { 100, 200, 300, 400 }, result.Select(e => e.Id));
+    }
+
+    [Fact]
+    public void SortEvents_WhenComputerNameContainsNull_ShouldOrderNullsBeforeValues()
+    {
+        var events = new List<ResolvedEvent>
+        {
+            EventUtils.CreateTestEvent(computerName: "Server02"),
+            EventUtils.CreateTestEvent(computerName: null!),
+            EventUtils.CreateTestEvent(computerName: "Server01")
+        };
+
+        var result = events.SortEvents(ColumnName.ComputerName);
+
+        Assert.Null(result[0].ComputerName);
+        Assert.Equal("Server01", result[1].ComputerName);
+        Assert.Equal("Server02", result[2].ComputerName);
+    }
+
     [Fact]
     public void SortEvents_WhenDescendingTrue_ShouldSortInDescendingOrder()
     {
@@ -43,23 +187,41 @@ public sealed class ResolvedEventOrderingTests
     }
 
     [Fact]
-    public void SortEvents_WhenNoOrderSpecifiedDescending_ShouldSortByRecordIdDescending()
+    public void SortEvents_WhenInputMutatedAfterCall_ShouldReturnIndependentList()
     {
-        // Arrange
         var events = new List<ResolvedEvent>
         {
-            EventUtils.CreateTestEvent(recordId: 1),
-            EventUtils.CreateTestEvent(recordId: 3),
-            EventUtils.CreateTestEvent(recordId: 2)
+            EventUtils.CreateTestEvent(300),
+            EventUtils.CreateTestEvent(100),
+            EventUtils.CreateTestEvent(200)
         };
 
-        // Act
-        var result = events.SortEvents(isDescending: true);
+        var result = events.SortEvents(ColumnName.EventId);
 
-        // Assert
-        Assert.Equal(3L, result[0].RecordId);
-        Assert.Equal(2L, result[1].RecordId);
-        Assert.Equal(1L, result[2].RecordId);
+        events.Clear();
+        events.Add(EventUtils.CreateTestEvent(999));
+
+        Assert.Equal(3, result.Count);
+        Assert.Equal(100, result[0].Id);
+        Assert.Equal(200, result[1].Id);
+        Assert.Equal(300, result[2].Id);
+    }
+
+    [Fact]
+    public void SortEvents_WhenKeywordsContainsNull_ShouldOrderNullsBeforeValues()
+    {
+        var events = new List<ResolvedEvent>
+        {
+            EventUtils.CreateTestEvent(keywords: ["BKeyword"]),
+            EventUtils.CreateTestEvent(),
+            EventUtils.CreateTestEvent(keywords: ["AKeyword"])
+        };
+
+        var result = events.SortEvents(ColumnName.Keywords);
+
+        Assert.True(string.IsNullOrEmpty(result[0].KeywordsDisplayName));
+        Assert.Equal("AKeyword", result[1].KeywordsDisplayName);
+        Assert.Equal("BKeyword", result[2].KeywordsDisplayName);
     }
 
     [Fact]
@@ -80,6 +242,26 @@ public sealed class ResolvedEventOrderingTests
         Assert.Equal(1L, result[0].RecordId);
         Assert.Equal(2L, result[1].RecordId);
         Assert.Equal(3L, result[2].RecordId);
+    }
+
+    [Fact]
+    public void SortEvents_WhenNoOrderSpecifiedDescending_ShouldSortByRecordIdDescending()
+    {
+        // Arrange
+        var events = new List<ResolvedEvent>
+        {
+            EventUtils.CreateTestEvent(recordId: 1),
+            EventUtils.CreateTestEvent(recordId: 3),
+            EventUtils.CreateTestEvent(recordId: 2)
+        };
+
+        // Act
+        var result = events.SortEvents(isDescending: true);
+
+        // Assert
+        Assert.Equal(3L, result[0].RecordId);
+        Assert.Equal(2L, result[1].RecordId);
+        Assert.Equal(1L, result[2].RecordId);
     }
 
     [Fact]
@@ -107,6 +289,27 @@ public sealed class ResolvedEventOrderingTests
     }
 
     [Fact]
+    public void SortEvents_WhenOrderByActivityIdDescending_ShouldSortByActivityIdDescending()
+    {
+        var guid1 = Guid.Parse("00000000-0000-0000-0000-000000000001");
+        var guid2 = Guid.Parse("00000000-0000-0000-0000-000000000002");
+        var guid3 = Guid.Parse("00000000-0000-0000-0000-000000000003");
+
+        var events = new List<ResolvedEvent>
+        {
+            EventUtils.CreateTestEvent(activityId: guid1),
+            EventUtils.CreateTestEvent(activityId: guid3),
+            EventUtils.CreateTestEvent(activityId: guid2)
+        };
+
+        var result = events.SortEvents(ColumnName.ActivityId, true);
+
+        Assert.Equal(guid3, result[0].ActivityId);
+        Assert.Equal(guid2, result[1].ActivityId);
+        Assert.Equal(guid1, result[2].ActivityId);
+    }
+
+    [Fact]
     public void SortEvents_WhenOrderByComputerName_ShouldSortByComputerName()
     {
         // Arrange
@@ -127,10 +330,26 @@ public sealed class ResolvedEventOrderingTests
     }
 
     [Fact]
+    public void SortEvents_WhenOrderByComputerNameDescending_ShouldSortByComputerNameDescending()
+    {
+        var events = new List<ResolvedEvent>
+        {
+            EventUtils.CreateTestEvent(computerName: "Server01"),
+            EventUtils.CreateTestEvent(computerName: "Server03"),
+            EventUtils.CreateTestEvent(computerName: "Server02")
+        };
+
+        var result = events.SortEvents(ColumnName.ComputerName, true);
+
+        Assert.Equal("Server03", result[0].ComputerName);
+        Assert.Equal("Server02", result[1].ComputerName);
+        Assert.Equal("Server01", result[2].ComputerName);
+    }
+
+    [Fact]
     public void SortEvents_WhenOrderByDateAndTime_ShouldSortByTimeCreated()
     {
-        // Arrange
-        var baseTime = DateTime.Now;
+        var baseTime = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
         var events = new List<ResolvedEvent>
         {
@@ -146,6 +365,25 @@ public sealed class ResolvedEventOrderingTests
         Assert.Equal(baseTime, result[0].TimeCreated);
         Assert.Equal(baseTime.AddHours(1), result[1].TimeCreated);
         Assert.Equal(baseTime.AddHours(2), result[2].TimeCreated);
+    }
+
+    [Fact]
+    public void SortEvents_WhenOrderByDateAndTimeDescending_ShouldSortByTimeCreatedDescending()
+    {
+        var baseTime = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        var events = new List<ResolvedEvent>
+        {
+            EventUtils.CreateTestEvent(timeCreated: baseTime),
+            EventUtils.CreateTestEvent(timeCreated: baseTime.AddHours(2)),
+            EventUtils.CreateTestEvent(timeCreated: baseTime.AddHours(1))
+        };
+
+        var result = events.SortEvents(ColumnName.DateAndTime, true);
+
+        Assert.Equal(baseTime.AddHours(2), result[0].TimeCreated);
+        Assert.Equal(baseTime.AddHours(1), result[1].TimeCreated);
+        Assert.Equal(baseTime, result[2].TimeCreated);
     }
 
     [Fact]
@@ -189,6 +427,23 @@ public sealed class ResolvedEventOrderingTests
     }
 
     [Fact]
+    public void SortEvents_WhenOrderByKeywordsDescending_ShouldSortByKeywordsDisplayNameDescending()
+    {
+        var events = new List<ResolvedEvent>
+        {
+            EventUtils.CreateTestEvent(keywords: ["Apple"]),
+            EventUtils.CreateTestEvent(keywords: ["Zebra"]),
+            EventUtils.CreateTestEvent(keywords: ["Mango"])
+        };
+
+        var result = events.SortEvents(ColumnName.Keywords, true);
+
+        Assert.Equal("Zebra", result[0].KeywordsDisplayName);
+        Assert.Equal("Mango", result[1].KeywordsDisplayName);
+        Assert.Equal("Apple", result[2].KeywordsDisplayName);
+    }
+
+    [Fact]
     public void SortEvents_WhenOrderByLevel_ShouldSortByLevel()
     {
         // Arrange
@@ -206,6 +461,23 @@ public sealed class ResolvedEventOrderingTests
         Assert.Equal("Error", result[0].Level);
         Assert.Equal("Information", result[1].Level);
         Assert.Equal("Warning", result[2].Level);
+    }
+
+    [Fact]
+    public void SortEvents_WhenOrderByLevelDescending_ShouldSortByLevelDescending()
+    {
+        var events = new List<ResolvedEvent>
+        {
+            EventUtils.CreateTestEvent(level: "Information"),
+            EventUtils.CreateTestEvent(level: "Warning"),
+            EventUtils.CreateTestEvent(level: "Error")
+        };
+
+        var result = events.SortEvents(ColumnName.Level, true);
+
+        Assert.Equal("Warning", result[0].Level);
+        Assert.Equal("Information", result[1].Level);
+        Assert.Equal("Error", result[2].Level);
     }
 
     [Fact]
@@ -229,6 +501,23 @@ public sealed class ResolvedEventOrderingTests
     }
 
     [Fact]
+    public void SortEvents_WhenOrderByLogDescending_ShouldSortByLogNameDescending()
+    {
+        var events = new List<ResolvedEvent>
+        {
+            EventUtils.CreateTestEvent(logName: "Application"),
+            EventUtils.CreateTestEvent(logName: "System"),
+            EventUtils.CreateTestEvent(logName: "Security")
+        };
+
+        var result = events.SortEvents(ColumnName.Log, true);
+
+        Assert.Equal("System", result[0].LogName);
+        Assert.Equal("Security", result[1].LogName);
+        Assert.Equal("Application", result[2].LogName);
+    }
+
+    [Fact]
     public void SortEvents_WhenOrderByProcessId_ShouldSortByProcessId()
     {
         // Arrange
@@ -246,6 +535,23 @@ public sealed class ResolvedEventOrderingTests
         Assert.Equal(100, result[0].ProcessId);
         Assert.Equal(200, result[1].ProcessId);
         Assert.Equal(300, result[2].ProcessId);
+    }
+
+    [Fact]
+    public void SortEvents_WhenOrderByProcessIdDescending_ShouldSortByProcessIdDescending()
+    {
+        var events = new List<ResolvedEvent>
+        {
+            EventUtils.CreateTestEvent(processId: 100),
+            EventUtils.CreateTestEvent(processId: 300),
+            EventUtils.CreateTestEvent(processId: 200)
+        };
+
+        var result = events.SortEvents(ColumnName.ProcessId, true);
+
+        Assert.Equal(300, result[0].ProcessId);
+        Assert.Equal(200, result[1].ProcessId);
+        Assert.Equal(100, result[2].ProcessId);
     }
 
     [Fact]
@@ -269,6 +575,23 @@ public sealed class ResolvedEventOrderingTests
     }
 
     [Fact]
+    public void SortEvents_WhenOrderBySourceDescending_ShouldSortBySourceDescending()
+    {
+        var events = new List<ResolvedEvent>
+        {
+            EventUtils.CreateTestEvent(source: "ASource"),
+            EventUtils.CreateTestEvent(source: "ZSource"),
+            EventUtils.CreateTestEvent(source: "MSource")
+        };
+
+        var result = events.SortEvents(ColumnName.Source, true);
+
+        Assert.Equal("ZSource", result[0].Source);
+        Assert.Equal("MSource", result[1].Source);
+        Assert.Equal("ASource", result[2].Source);
+    }
+
+    [Fact]
     public void SortEvents_WhenOrderByTaskCategory_ShouldSortByTaskCategory()
     {
         // Arrange
@@ -286,6 +609,23 @@ public sealed class ResolvedEventOrderingTests
         Assert.Equal("ACategory", result[0].TaskCategory);
         Assert.Equal("MCategory", result[1].TaskCategory);
         Assert.Equal("ZCategory", result[2].TaskCategory);
+    }
+
+    [Fact]
+    public void SortEvents_WhenOrderByTaskCategoryDescending_ShouldSortByTaskCategoryDescending()
+    {
+        var events = new List<ResolvedEvent>
+        {
+            EventUtils.CreateTestEvent(taskCategory: "ACategory"),
+            EventUtils.CreateTestEvent(taskCategory: "ZCategory"),
+            EventUtils.CreateTestEvent(taskCategory: "MCategory")
+        };
+
+        var result = events.SortEvents(ColumnName.TaskCategory, true);
+
+        Assert.Equal("ZCategory", result[0].TaskCategory);
+        Assert.Equal("MCategory", result[1].TaskCategory);
+        Assert.Equal("ACategory", result[2].TaskCategory);
     }
 
     [Fact]
@@ -309,6 +649,65 @@ public sealed class ResolvedEventOrderingTests
     }
 
     [Fact]
+    public void SortEvents_WhenOrderByThreadIdDescending_ShouldSortByThreadIdDescending()
+    {
+        var events = new List<ResolvedEvent>
+        {
+            EventUtils.CreateTestEvent(threadId: 10),
+            EventUtils.CreateTestEvent(threadId: 30),
+            EventUtils.CreateTestEvent(threadId: 20)
+        };
+
+        var result = events.SortEvents(ColumnName.ThreadId, true);
+
+        Assert.Equal(30, result[0].ThreadId);
+        Assert.Equal(20, result[1].ThreadId);
+        Assert.Equal(10, result[2].ThreadId);
+    }
+
+    [Fact]
+    public void SortEvents_WhenOrderByUser_ShouldSortByUserIdValue()
+    {
+        var sid1 = new SecurityIdentifier("S-1-5-18"); // LocalSystem
+        var sid2 = new SecurityIdentifier("S-1-5-19"); // LocalService
+        var sid3 = new SecurityIdentifier("S-1-5-20"); // NetworkService
+
+        var events = new List<ResolvedEvent>
+        {
+            EventUtils.CreateTestEvent(userId: sid3),
+            EventUtils.CreateTestEvent(userId: sid1),
+            EventUtils.CreateTestEvent(userId: sid2)
+        };
+
+        var result = events.SortEvents(ColumnName.User);
+
+        Assert.Equal(sid1.Value, result[0].UserId?.Value);
+        Assert.Equal(sid2.Value, result[1].UserId?.Value);
+        Assert.Equal(sid3.Value, result[2].UserId?.Value);
+    }
+
+    [Fact]
+    public void SortEvents_WhenOrderByUserDescending_ShouldSortByUserIdValueDescending()
+    {
+        var sid1 = new SecurityIdentifier("S-1-5-18");
+        var sid2 = new SecurityIdentifier("S-1-5-19");
+        var sid3 = new SecurityIdentifier("S-1-5-20");
+
+        var events = new List<ResolvedEvent>
+        {
+            EventUtils.CreateTestEvent(userId: sid1),
+            EventUtils.CreateTestEvent(userId: sid3),
+            EventUtils.CreateTestEvent(userId: sid2)
+        };
+
+        var result = events.SortEvents(ColumnName.User, true);
+
+        Assert.Equal(sid3.Value, result[0].UserId?.Value);
+        Assert.Equal(sid2.Value, result[1].UserId?.Value);
+        Assert.Equal(sid1.Value, result[2].UserId?.Value);
+    }
+
+    [Fact]
     public void SortEvents_WhenSingleItem_ShouldReturnSingleItem()
     {
         // Arrange
@@ -323,23 +722,37 @@ public sealed class ResolvedEventOrderingTests
     }
 
     [Fact]
-    public void SortEvents_WhenTiedOnPrimaryKeyDescending_ShouldBreakTieByRecordIdDescending()
+    public void SortEvents_WhenStringValuesDifferOnlyInCase_ShouldOrderByOrdinalCodepoint()
     {
-        // Arrange
         var events = new List<ResolvedEvent>
         {
-            EventUtils.CreateTestEvent(100, recordId: 1),
-            EventUtils.CreateTestEvent(100, recordId: 3),
-            EventUtils.CreateTestEvent(100, recordId: 2)
+            EventUtils.CreateTestEvent(source: "apple"),
+            EventUtils.CreateTestEvent(source: "Apple"),
+            EventUtils.CreateTestEvent(source: "Banana")
         };
 
-        // Act
-        var result = events.SortEvents(ColumnName.EventId, true);
+        var result = events.SortEvents(ColumnName.Source);
 
-        // Assert - tied on Id, should fall back to RecordId descending
-        Assert.Equal(3L, result[0].RecordId);
-        Assert.Equal(2L, result[1].RecordId);
-        Assert.Equal(1L, result[2].RecordId);
+        Assert.Equal("Apple", result[0].Source);
+        Assert.Equal("Banana", result[1].Source);
+        Assert.Equal("apple", result[2].Source);
+    }
+
+    [Fact]
+    public void SortEvents_WhenTaskCategoryContainsNull_ShouldOrderNullsBeforeValues()
+    {
+        var events = new List<ResolvedEvent>
+        {
+            EventUtils.CreateTestEvent(taskCategory: "BCategory"),
+            EventUtils.CreateTestEvent(taskCategory: null!),
+            EventUtils.CreateTestEvent(taskCategory: "ACategory")
+        };
+
+        var result = events.SortEvents(ColumnName.TaskCategory);
+
+        Assert.Null(result[0].TaskCategory);
+        Assert.Equal("ACategory", result[1].TaskCategory);
+        Assert.Equal("BCategory", result[2].TaskCategory);
     }
 
     [Fact]
@@ -362,5 +775,25 @@ public sealed class ResolvedEventOrderingTests
         Assert.Equal(1L, result[0].RecordId);
         Assert.Equal(2L, result[1].RecordId);
         Assert.Equal(3L, result[2].RecordId);
+    }
+
+    [Fact]
+    public void SortEvents_WhenTiedOnPrimaryKeyDescending_ShouldBreakTieByRecordIdDescending()
+    {
+        // Arrange
+        var events = new List<ResolvedEvent>
+        {
+            EventUtils.CreateTestEvent(100, recordId: 1),
+            EventUtils.CreateTestEvent(100, recordId: 3),
+            EventUtils.CreateTestEvent(100, recordId: 2)
+        };
+
+        // Act
+        var result = events.SortEvents(ColumnName.EventId, true);
+
+        // Assert - tied on Id, should fall back to RecordId descending
+        Assert.Equal(3L, result[0].RecordId);
+        Assert.Equal(2L, result[1].RecordId);
+        Assert.Equal(1L, result[2].RecordId);
     }
 }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/TestUtils/EventUtils.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/TestUtils/EventUtils.cs
@@ -3,6 +3,7 @@
 
 using EventLogExpert.Eventing.Common.Channels;
 using EventLogExpert.Eventing.Common.Events;
+using System.Security.Principal;
 
 namespace EventLogExpert.Runtime.Tests.TestUtils;
 
@@ -21,6 +22,7 @@ internal static class EventUtils
         Guid? activityId = null,
         int? processId = null,
         int? threadId = null,
+        SecurityIdentifier? userId = null,
         IReadOnlyList<string>? keywords = null) =>
         new("TestLog", LogPathType.Channel)
         {
@@ -36,6 +38,7 @@ internal static class EventUtils
             ActivityId = activityId,
             ProcessId = processId,
             ThreadId = threadId,
+            UserId = userId,
             Keywords = keywords ?? []
         };
 }


### PR DESCRIPTION
Test surface hardening for filter-slice-rework SUTs (HasFilteringChangedFrom, SortEvents, MergeSorted, MatchesFilters, MatchesDateFilter, AddFilterGroup).

## Outcomes
- 40 new tests + 12 HasFilteringChanged_* test renames to HasFilteringChangedFrom_*.
- Production cleanup: dead 3-arg MergeSorted overload removed, AddFilterGroup null guard added, FilterGroupNode switched to ImmutableDictionary/ImmutableList so record value-equality works.

## Tests
2,671 passing (was 2,632 baseline). Runtime.Tests went from 1,087 -> 1,126.

## Commits
- b500a8b8 Clean up FilterGroup state mutation, dead MergeSorted overload, and duplicate filter-change test
- 9fde4467 Backfill missing test coverage for the 6 SUTs listed above