### PR TITLE
Pin .NET SDK floor to 10.0.204 via global.json

### DIFF
--- a/.github/workflows/PullRequest.yml
+++ b/.github/workflows/PullRequest.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 10.x
+        global-json-file: global.json
     - name: Restore workloads
       run: dotnet workload restore EventLogExpert.slnx
     - name: Restore dependencies

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.204",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
## Why

SFI alert flagged that EventLogExpert ships a self-contained .NET application with an unpinned runtime version. The runtime baked into the published MSIX / EXE is whatever the active .NET SDK provides, and the repo had no `global.json` to enforce a secure minimum (the only build pipeline floated SDK via `dotnet-version: 10.x`). Alert recommendation: pin SDK floor to ≥ 10.0.204.

## What

- Add `global.json` at repo root pinning SDK floor to `10.0.204` with `rollForward: latestFeature`. This enforces the SFI floor on every build (local dev, PR CI, downstream release pipeline) while allowing newer 10.0.x patches without manual bumps and without silently jumping to .NET 11.
- Update `.github/workflows/PullRequest.yml` to source the SDK from `global.json` (`global-json-file: global.json`) instead of the floating `dotnet-version: 10.x`.

The downstream Azure DevOps release pipeline will be updated in a separate PR to consume the same `global.json`.

## Verification

- Locally: `dotnet --info` confirms `global.json` is detected at repo root and resolves to SDK `10.0.300` (satisfies the 10.0.204 floor via `latestFeature`).
- `dotnet build EventLogExpert.slnx -c Release` succeeds (41s, 0 warnings, 0 errors).
- All 2,175 unit tests pass: EventDbTool (8), Eventing (288), Filtering (869), Runtime (860), UI (150).
