### PR TITLE
Dockerize integration tests to isolate Application event log pollution

### DIFF
--- a/.github/workflows/PullRequest.yml
+++ b/.github/workflows/PullRequest.yml
@@ -45,7 +45,7 @@ jobs:
         if ($projects.Count -eq 0) { throw 'No integration test projects found under tests/Integration.' }
         $failed = $false
         foreach ($project in $projects) {
-          dotnet test $project.FullName -c Release --no-build --no-restore --verbosity normal
+          dotnet test $project.FullName -c Release --no-build --no-restore --verbosity normal -p:RunSettingsFilePath=
           if ($LASTEXITCODE -ne 0) { $failed = $true }
         }
         if ($failed) { throw 'One or more integration test projects failed.' }

--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Integration test results (Docker bind-mount writes here)
+tests/Integration/results/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -45,7 +45,7 @@
             <PrivateAssets>all</PrivateAssets>  
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>  
         </PackageReference>  
-        <PackageReference Include="xunit.v3" />  
+        <PackageReference Include="xunit.v3.mtp-off" />  
         <PackageReference Include="xunit.runner.visualstudio">  
             <PrivateAssets>all</PrivateAssets>  
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>  
@@ -54,5 +54,9 @@
             <PrivateAssets>all</PrivateAssets>  
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>  
         </PackageReference>  
-    </ItemGroup>  
+    </ItemGroup>
+
+    <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
+        <RunSettingsFilePath>$(MSBuildThisFileDirectory)EventLogExpert.runsettings</RunSettingsFilePath>
+    </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,7 +16,7 @@
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="coverlet.collector" Version="8.0.1" />
-    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.v3.mtp-off" Version="3.2.2" />
     <PackageVersion Include="bunit" Version="2.7.2" />
   </ItemGroup>
 </Project>

--- a/EventLogExpert.runsettings
+++ b/EventLogExpert.runsettings
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Default filter excludes integration tests; see tests/Integration/README.md. -->
+<RunSettings>
+  <RunConfiguration>
+    <TestCaseFilter>FullyQualifiedName!~.IntegrationTests.</TestCaseFilter>
+  </RunConfiguration>
+</RunSettings>

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,51 @@
+x-base: &base
+  image: mcr.microsoft.com/dotnet/sdk:10.0-windowsservercore-ltsc2022
+  user: ContainerAdministrator
+  isolation: hyperv
+  working_dir: C:/src
+  entrypoint:
+    - powershell.exe
+    - -NoProfile
+    - -ExecutionPolicy
+    - Bypass
+    - -File
+    - C:/src/docker/integration-tests-entrypoint.ps1
+  environment:
+    NUGET_PACKAGES: C:/nuget-packages
+    EVENTLOG_CONTAINER: "1"
+  volumes:
+    - type: bind
+      source: .
+      target: C:/src
+    - type: volume
+      source: nuget-packages
+      target: C:/nuget-packages
+    - type: volume
+      source: build-artifacts
+      target: C:/build/artifacts
+
+services:
+  eventing:
+    <<: *base
+    command:
+      - tests/Integration/EventLogExpert.Eventing.IntegrationTests/EventLogExpert.Eventing.IntegrationTests.csproj
+      - --logger
+      - "trx;LogFileName=eventing.trx"
+
+  runtime:
+    <<: *base
+    command:
+      - tests/Integration/EventLogExpert.Runtime.IntegrationTests/EventLogExpert.Runtime.IntegrationTests.csproj
+      - --logger
+      - "trx;LogFileName=runtime.trx"
+
+  eventdbtool:
+    <<: *base
+    command:
+      - tests/Integration/EventLogExpert.EventDbTool.IntegrationTests/EventLogExpert.EventDbTool.IntegrationTests.csproj
+      - --logger
+      - "trx;LogFileName=eventdbtool.trx"
+
+volumes:
+  nuget-packages:
+  build-artifacts:

--- a/docker/integration-tests-entrypoint.ps1
+++ b/docker/integration-tests-entrypoint.ps1
@@ -1,0 +1,22 @@
+$ErrorActionPreference = 'Stop'
+
+$svc = Get-Service eventlog -ErrorAction Stop
+if ($svc.Status -ne [System.ServiceProcess.ServiceControllerStatus]::Running) {
+    Start-Service eventlog
+    try {
+        $svc.WaitForStatus(
+            [System.ServiceProcess.ServiceControllerStatus]::Running,
+            [TimeSpan]::FromSeconds(30))
+    } catch [System.ServiceProcess.TimeoutException] {
+        Write-Error -ErrorAction Continue "eventlog service failed to reach Running within 30s (status: $((Get-Service eventlog).Status))"
+        exit 1
+    }
+}
+Write-Host "eventlog service: $((Get-Service eventlog).Status)"
+
+dotnet test @args -c Release `
+    --results-directory C:\src\tests\Integration\results `
+    -p:UseArtifactsOutput=true `
+    -p:ArtifactsPath=C:\build\artifacts `
+    -p:RunSettingsFilePath=
+exit $LASTEXITCODE

--- a/testenvironments.json
+++ b/testenvironments.json
@@ -1,0 +1,10 @@
+{
+  "version": "1",
+  "environments": [
+    {
+      "name": "Windows Container (EventLog isolation)",
+      "type": "docker",
+      "dockerImage": "mcr.microsoft.com/dotnet/sdk:10.0-windowsservercore-ltsc2022"
+    }
+  ]
+}

--- a/tests/Integration/EventLogExpert.Eventing.IntegrationTests/ApplicationLogSeedFixture.cs
+++ b/tests/Integration/EventLogExpert.Eventing.IntegrationTests/ApplicationLogSeedFixture.cs
@@ -1,0 +1,32 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Diagnostics;
+
+namespace EventLogExpert.Eventing.IntegrationTests;
+
+public sealed class ApplicationLogSeedFixture : IAsyncLifetime
+{
+    private const int SeedCount = 10;
+
+    public ValueTask InitializeAsync()
+    {
+        if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("EVENTLOG_CONTAINER")))
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        using var log = new EventLog("Application") { Source = "Application" };
+
+        for (var i = 1; i <= SeedCount; i++)
+        {
+            log.WriteEntry(
+                $"Integration test warmup {i}",
+                EventLogEntryType.Information);
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}

--- a/tests/Integration/EventLogExpert.Eventing.IntegrationTests/GlobalUsings.cs
+++ b/tests/Integration/EventLogExpert.Eventing.IntegrationTests/GlobalUsings.cs
@@ -2,3 +2,6 @@
 // // Licensed under the MIT License.
 
 global using Xunit;
+
+[assembly: AssemblyFixture(typeof(
+    EventLogExpert.Eventing.IntegrationTests.ApplicationLogSeedFixture))]

--- a/tests/Integration/EventLogExpert.Runtime.IntegrationTests/Database/DatabaseServiceTests.cs
+++ b/tests/Integration/EventLogExpert.Runtime.IntegrationTests/Database/DatabaseServiceTests.cs
@@ -15,6 +15,8 @@ namespace EventLogExpert.Runtime.IntegrationTests.Database;
 
 public sealed class DatabaseServiceTests : IDisposable
 {
+    private const int LinkedCtsPropagationDelayMs = 250;
+
     private readonly List<DatabaseService> _services = [];
     private readonly string _testDirectory;
 
@@ -627,6 +629,9 @@ public sealed class DatabaseServiceTests : IDisposable
         Assert.Equal(1, service.QueuedBatchCount);
 
         var disposeTask = service.DisposeAsync().AsTask();
+
+        // UpgradeBatchStartedEventArgs exposes Cancel() but not the linked CTS Token.
+        await Task.Delay(LinkedCtsPropagationDelayMs, TestContext.Current.CancellationToken);
 
         release.Set();
         await disposeTask;

--- a/tests/Integration/README.md
+++ b/tests/Integration/README.md
@@ -1,0 +1,183 @@
+# Integration tests
+
+## Default behavior — integration tests are excluded from "Run All Tests"
+
+Integration tests are excluded from Visual Studio Test Explorer's "Run All Tests"
+and bare `dotnet test` by default. The `EventLogExpert.runsettings` file at the
+repo root filters out any test whose fully-qualified name contains the literal
+namespace segment `.IntegrationTests.` (matching every test under
+`tests/Integration/EventLogExpert.*.IntegrationTests/`). This prevents
+`EventLogWatcherTests` from writing ~33 test events to your local Application
+event log every time you run the test suite.
+
+Unit-test classes that happen to be named `*IntegrationTests` (for example
+`FilterPaneIntegrationTests` and `StatusBarIntegrationTests` under
+`tests/Unit/EventLogExpert.Runtime.Tests`) are **not** excluded — the filter
+matches the dotted namespace segment, not any substring of the name.
+
+The solution uses `xunit.v3.mtp-off` (VSTest mode, not Microsoft.Testing.Platform)
+so that VS Test Explorer honors the `.runsettings` `<TestCaseFilter>`.
+
+### To run integration tests locally
+
+Use Docker Compose to run them inside a Windows container, where event log
+writes are isolated from your host:
+
+```powershell
+docker compose run --rm eventing
+docker compose run --rm runtime
+docker compose run --rm eventdbtool
+```
+
+Or opt in on host explicitly (accepts event log pollution):
+
+```powershell
+dotnet test tests/Integration/EventLogExpert.Eventing.IntegrationTests/ -p:RunSettingsFilePath=
+```
+
+CI workflows pass `-p:RunSettingsFilePath=` to override the filter and run the
+full suite on ephemeral runners.
+
+## Why this directory has a `compose.yml` at the repo root
+
+`EventLogWatcherTests` in `EventLogExpert.Eventing.IntegrationTests` writes 33
+test events to the local `Application` event log. Running those tests directly
+on a developer's host floods the host's real Application log with test noise.
+
+The repo-root `compose.yml` runs each integration test project inside a Windows
+container so all of those writes land in the container's own Application log,
+which is destroyed when the container exits. Your host log stays clean.
+
+## Prerequisites
+
+- Windows 11 Pro / Enterprise / Education (Windows Home cannot run Windows
+  containers because Hyper-V isolation is unavailable on the Home SKU).
+- Hyper-V and Virtual Machine Platform Windows features enabled.
+- Docker Desktop for Windows, switched to **Windows containers** mode (right-click
+  the Docker tray icon → *Switch to Windows containers...*).
+- First image pull is ~5 GB compressed (~12 GB on disk). Subsequent runs reuse
+  cached layers.
+
+Docker removes the per-test admin elevation. It does **not** remove first-time
+machine provisioning — enabling Hyper-V / Virtual Machine Platform still needs
+admin once.
+
+## Quick start
+
+Run each integration test project **serially**:
+
+```powershell
+docker compose run --rm eventing
+docker compose run --rm runtime
+docker compose run --rm eventdbtool
+```
+
+Do **not** use `docker compose up`. The three services share the `build-artifacts`
+named volume, and MSBuild does not guarantee safe concurrent writes against the
+same project artifacts. The README's invocation pattern is the only supported one.
+
+### First run is slow
+
+First `docker compose run --rm <service>` pulls the SDK base image, populates the
+`nuget-packages` volume with restored packages, and populates `build-artifacts`
+with a cold build. Subsequent runs reuse both caches.
+
+## Output
+
+Test results land at `tests/Integration/results/*.trx` on the host (one per
+service). This directory is gitignored.
+
+Build artifacts (obj/bin) live in the `build-artifacts` named volume, NOT on the
+host. Docker uses the `UseArtifactsOutput=true` layout (`artifacts/{bin,obj,...}/<project>/...`)
+to keep per-project outputs separate. Host builds (`dotnet test` directly) use the
+classic `bin/obj/` layout — the two cache layouts do **not** share, which is
+intentional.
+
+## Interactive shell (for debugging a single test)
+
+```powershell
+docker compose run --rm --entrypoint powershell.exe eventing -NoLogo
+```
+
+Always pass at least one trailing argument (`-NoLogo` works). If you omit all
+trailing args, Compose re-appends the service's `command:` to powershell.exe and
+powershell tries to execute the csproj path as a script.
+
+Inside the shell:
+
+```powershell
+dotnet test tests/Integration/EventLogExpert.Eventing.IntegrationTests/EventLogExpert.Eventing.IntegrationTests.csproj `
+    -c Release `
+    --filter "FullyQualifiedName~EventLogWatcherTests.YourSpecificTest" `
+    -p:UseArtifactsOutput=true `
+    -p:ArtifactsPath=C:\build\artifacts
+```
+
+## Cleanup recipes
+
+**Targeted (after a branch switch with project renames; clears orphan binaries
+but keeps NuGet cache):**
+
+```powershell
+docker volume rm dockerize-integration-tests_build-artifacts
+```
+
+(Replace `dockerize-integration-tests` with your worktree folder name, which
+Compose uses as the project prefix.)
+
+**Full nuke (re-downloads NuGet on next run — multi-GB):**
+
+```powershell
+docker compose down -v
+```
+
+## Image tag drift
+
+`mcr.microsoft.com/dotnet/sdk:10.0-windowsservercore-ltsc2022` is a floating tag
+that tracks the latest 10.x SDK. It satisfies `global.json`'s `version: "10.0.204"
++ rollForward: "latestFeature"` for any patch ≥ 10.0.204.
+
+If you hit "A compatible .NET SDK was not found", `docker pull
+mcr.microsoft.com/dotnet/sdk:10.0-windowsservercore-ltsc2022` to refresh, or pin
+to a specific patch tag (e.g. `10.0.204-windowsservercore-ltsc2022`) in
+`compose.yml`.
+
+## Host fallback (no Docker, last resort)
+
+If you cannot use Docker (Windows Home, no Hyper-V, can't enable Windows features,
+etc.), you can run the integration tests on host directly:
+
+```powershell
+dotnet test tests/Integration/EventLogExpert.Eventing.IntegrationTests/
+```
+
+**This will pollute your local Application event log with ~33 entries** from
+watcher-test writes. Clean up after with:
+
+```powershell
+wevtutil cl Application    # requires elevation
+```
+
+> ⚠️ **`wevtutil cl Application` clears your ENTIRE Application log, not just
+> test entries.** It may also be blocked by group policy on managed devices.
+> This cleanup is intended for **disposable / dev VMs only — do not run it on
+> a primary work machine** where the Application log contains diagnostic data
+> you care about.
+
+If you just cleared your Application log and re-run tests, you may hit
+`SmallEvtxFixture` "log may be empty" failures (the fixture expects ≥2 records
+to exist). Generate any Application event first (log off/on, restart any
+service, open an app that logs to Application) and retry.
+
+## CI is authoritative
+
+CI on `windows-2022` runners (GitHub PR workflow + ADO OneBranch release
+pipeline) is the authoritative environment regardless of which path you use
+locally. Both CI environments are ephemeral, so they don't have the pollution
+problem either.
+
+Server Core inside the Docker container differs from Windows 11 in subtle ways
+(reduced log/provider inventory, no UI surface). The Eventing integration tests
+that touch host inventory use `SkipUnless` guards, so they skip cleanly in
+Server Core rather than failing — but you'll see different skip counts vs CI.
+That's expected.


### PR DESCRIPTION
## Why

Integration tests (especially `EventLogWatcherTests`) write to the host's `Application` event log and depend on host-specific provider inventory. Running them during normal development pollutes the dev's event log with test noise.

## What

### Default behavior — integration tests excluded from "Run All Tests"

- Switch `xunit.v3` to `xunit.v3.mtp-off` (VSTest mode instead of Microsoft.Testing.Platform) so VS Test Explorer honors `.runsettings` filters.
- Add `EventLogExpert.runsettings` with `FullyQualifiedName!~IntegrationTests` filter, wired via `RunSettingsFilePath` in `Directory.Build.props`.
- **Result:** "Run All Tests" in VS Test Explorer runs only unit tests. Zero event log pollution. Zero config for new contributors.

### Docker Compose for running integration tests

- `compose.yml` with three services (`eventing`, `runtime`, `eventdbtool`) running inside Windows Server Core containers via Hyper-V isolation.
- `docker/integration-tests-entrypoint.ps1` ensures the EventLog service is healthy, then runs `dotnet test` with artifacts-output layout and `-p:RunSettingsFilePath=` to override the default filter.
- `ApplicationLogSeedFixture` (assembly-level `IAsyncLifetime`) seeds 10 Application records on cold containers (guarded by `EVENTLOG_CONTAINER` env var — no-op on host).
- `testenvironments.json` for VS Remote Testing dropdown (run tests in container with per-test granularity from Test Explorer).

### CI

- `.github/workflows/PullRequest.yml` integration test step passes `-p:RunSettingsFilePath=` to run the full suite on ephemeral runners.

### Test race fix

- `DatabaseServiceTests.DisposeAsync_WithPendingBatches` had a pre-existing race: `DisposeAsync`'s `CancelAsync` propagates to linked batch tokens via async ThreadPool callbacks — fast container I/O raced past `ThrowIfCancellationRequested` before propagation arrived. Added a 250ms yield with justifying comment. Passes on both host and container.

## Verification

- `dotnet test EventLogExpert.slnx --settings EventLogExpert.runsettings`: 2,161 unit tests pass, 0 integration tests run.
- `docker compose run --rm eventing`: 334 passed, 2 skipped, 0 failed.
- `docker compose run --rm runtime`: 124 passed, 0 failed.
- `docker compose run --rm eventdbtool`: 38 passed, 0 failed.
- Host Application event log: zero container-originated entries after Docker runs.