### PR TITLE
Add close-veto pipeline with ModalScope.Critical and ModalOpenResult

### DIFF
--- a/src/EventLogExpert.Runtime/Modal/IModalCoordinator.cs
+++ b/src/EventLogExpert.Runtime/Modal/IModalCoordinator.cs
@@ -18,18 +18,29 @@ public interface IModalCoordinator
 
     void ForceCloseActive();
 
-    Task<TResult?> PushAsync<TModal, TResult>(IDictionary<string, object?>? parameters = null)
-        where TModal : IComponent;
+    /// <summary>Returns the active modal's scope, or <see langword="null" /> if no modal is active.</summary>
+    ModalScope? GetActiveModalScope();
 
     /// <summary>
-    ///     Register <paramref name="host" /> as the inline-alert host for the modal identified by
-    ///     <paramref name="modalId" />. Stale ids are ignored.
+    ///     Opens <typeparamref name="TModal" />. If an active modal exists, asks it to close via the veto pipeline first;
+    ///     if vetoed, returns a result with <see cref="ModalOpenResult{TResult}.WasOpened" /> set to <see langword="false" />.
     /// </summary>
-    void RegisterInlineAlertHost(ModalId modalId, IInlineAlertHost host);
+    Task<ModalOpenResult<TResult>> PushAsync<TModal, TResult>(IDictionary<string, object?>? parameters = null)
+        where TModal : IComponent;
 
-    /// <summary>Returns the registered inline-alert host for the active modal, if any.</summary>
+    /// <summary>Register a modal's close handler, scope, and optional inline-alert host. Stale ids are ignored.</summary>
+    void RegisterModal(ModalRegistration registration);
+
+    /// <summary>
+    ///     Asks the active modal to close. Coalesces concurrent calls; the first verdict wins. Critical-scoped modals
+    ///     reject <see cref="ModalCloseReason.OtherModalActivation" /> immediately, regardless of in-flight state.
+    ///     If a close handler throws <see cref="OperationCanceledException" /> (e.g., from a force-close race), the
+    ///     close is treated as accepted so coalesced awaiters resolve successfully.
+    /// </summary>
+    Task<bool> RequestCloseActiveAsync(ModalCloseReason reason);
+
     bool TryGetInlineAlertHost([NotNullWhen(true)] out IInlineAlertHost? host);
 
-    void UnregisterInlineAlertHost(ModalId modalId);
+    void UnregisterModal(ModalId modalId);
 }
 

--- a/src/EventLogExpert.Runtime/Modal/ModalCloseReason.cs
+++ b/src/EventLogExpert.Runtime/Modal/ModalCloseReason.cs
@@ -1,0 +1,13 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Modal;
+
+public enum ModalCloseReason
+{
+    UserDismiss,
+    EscKey,
+    OutsideClick,
+    ProgrammaticCancel,
+    OtherModalActivation
+}

--- a/src/EventLogExpert.Runtime/Modal/ModalCloseRequest.cs
+++ b/src/EventLogExpert.Runtime/Modal/ModalCloseRequest.cs
@@ -1,0 +1,6 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Modal;
+
+public readonly record struct ModalCloseRequest(ModalCloseReason Reason);

--- a/src/EventLogExpert.Runtime/Modal/ModalCoordinator.cs
+++ b/src/EventLogExpert.Runtime/Modal/ModalCoordinator.cs
@@ -12,10 +12,10 @@ internal sealed class ModalCoordinator : IModalCoordinator, IDisposable
     private readonly IModalService _modalService;
     private readonly Lock _stateLock = new();
 
+    private ModalRegistration? _activeRegistration;
     private ModalSession? _activeSession;
     private bool _disposed;
-    private IInlineAlertHost? _host;
-    private ModalId _hostModalId;
+    private TaskCompletionSource<bool>? _inFlightCloseTcs;
 
     public ModalCoordinator(IModalService modalService)
     {
@@ -46,20 +46,96 @@ internal sealed class ModalCoordinator : IModalCoordinator, IDisposable
 
     public void ForceCloseActive() => _modalService.CancelActive();
 
-    public Task<TResult?> PushAsync<TModal, TResult>(IDictionary<string, object?>? parameters = null)
-        where TModal : IComponent
-        => _modalService.Show<TModal, TResult>(parameters);
-
-    public void RegisterInlineAlertHost(ModalId modalId, IInlineAlertHost host)
+    public ModalScope? GetActiveModalScope()
     {
-        ArgumentNullException.ThrowIfNull(host);
+        lock (_stateLock) { return GetActiveRegistration()?.Scope; }
+    }
+
+    public async Task<ModalOpenResult<TResult>> PushAsync<TModal, TResult>(IDictionary<string, object?>? parameters = null)
+        where TModal : IComponent
+    {
+        // Use the service-derived active id (immediately available) rather than _activeRegistration
+        // (component-lifecycle gap between Show and OnInitialized's RegisterModal).
+        if (_modalService.ActiveModalId != ModalId.None)
+        {
+            bool accepted = await RequestCloseActiveAsync(ModalCloseReason.OtherModalActivation);
+            if (!accepted) { return new ModalOpenResult<TResult>(default, WasOpened: false); }
+        }
+
+        TResult? result = await _modalService.Show<TModal, TResult>(parameters);
+        return new ModalOpenResult<TResult>(result, WasOpened: true);
+    }
+
+    public void RegisterModal(ModalRegistration registration)
+    {
+        ArgumentNullException.ThrowIfNull(registration);
 
         lock (_stateLock)
         {
-            if (modalId != _modalService.ActiveModalId) { return; }
+            if (registration.ModalId.IsNone || registration.ModalId != _modalService.ActiveModalId) { return; }
 
-            _hostModalId = modalId;
-            _host = host;
+            _activeRegistration = registration;
+        }
+    }
+
+    public async Task<bool> RequestCloseActiveAsync(ModalCloseReason reason)
+    {
+        ModalRegistration? snapshot = null;
+        TaskCompletionSource<bool>? newTcs = null;
+        Task<bool>? inFlight = null;
+
+        lock (_stateLock)
+        {
+            ModalRegistration? activeRegistration = GetActiveRegistration();
+
+            // Scope policy FIRST (before coalescing) so Critical+OtherModalActivation is always rejected.
+            if (activeRegistration is not null
+                && activeRegistration.Scope == ModalScope.Critical
+                && reason == ModalCloseReason.OtherModalActivation)
+            {
+                return false;
+            }
+
+            if (_inFlightCloseTcs is not null)
+            {
+                inFlight = _inFlightCloseTcs.Task;
+            }
+            else if (activeRegistration is null)
+            {
+                // Init-window guard: the service may publish ActiveModalId before OnInitialized's RegisterModal lands.
+                // Reject OtherModalActivation during the gap so a not-yet-registered modal can't be preempted past its scope policy.
+                return reason != ModalCloseReason.OtherModalActivation || _modalService.ActiveModalId == ModalId.None;
+            }
+            else
+            {
+                snapshot = activeRegistration;
+                newTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                _inFlightCloseTcs = newTcs;
+            }
+        }
+
+        if (inFlight is not null) { return await inFlight; }
+
+        try
+        {
+            bool accepted = await snapshot!.RequestClose(new ModalCloseRequest(reason));
+            newTcs!.TrySetResult(accepted);
+            return accepted;
+        }
+        catch (OperationCanceledException)
+        {
+            // Modal is gone via ForceCloseActive race; treat as accepted so coalesced callers can proceed.
+            newTcs!.TrySetResult(true);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            newTcs!.TrySetException(ex);
+            throw;
+        }
+        finally
+        {
+            lock (_stateLock) { _inFlightCloseTcs = null; }
         }
     }
 
@@ -67,26 +143,39 @@ internal sealed class ModalCoordinator : IModalCoordinator, IDisposable
     {
         lock (_stateLock)
         {
-            if (_hostModalId != _modalService.ActiveModalId)
-            {
-                _host = null;
-                _hostModalId = ModalId.None;
-            }
+            host = GetActiveRegistration()?.InlineAlertHost;
 
-            host = _host;
             return host is not null;
         }
     }
 
-    public void UnregisterInlineAlertHost(ModalId modalId)
+    public void UnregisterModal(ModalId modalId)
     {
         lock (_stateLock)
         {
-            if (_hostModalId != modalId) { return; }
-
-            _host = null;
-            _hostModalId = ModalId.None;
+            if (_activeRegistration?.ModalId == modalId)
+            {
+                _activeRegistration = null;
+            }
         }
+    }
+
+    // Stale-clear inside the read path: ModalService publishes ActiveModalId changes BEFORE firing StateChanged,
+    // so reads via _activeRegistration can race the registration's modal being cancelled/completed. If the
+    // stored registration's id no longer matches the service, drop it and return null — the next OnInitialized
+    // (or OnModalServiceStateChanged backstop) will install the correct successor.
+    private ModalRegistration? GetActiveRegistration()
+    {
+        if (_activeRegistration is null) { return null; }
+
+        if (_activeRegistration.ModalId == _modalService.ActiveModalId)
+        {
+            return _activeRegistration;
+        }
+
+        _activeRegistration = null;
+
+        return null;
     }
 
     private void OnModalServiceStateChanged()
@@ -106,10 +195,10 @@ internal sealed class ModalCoordinator : IModalCoordinator, IDisposable
             changed = !Equals(_activeSession, newSession);
             _activeSession = newSession;
 
-            if (_hostModalId != id)
+            // Stale-clear: drop _activeRegistration if the active id moved past it.
+            if (_activeRegistration is not null && _activeRegistration.ModalId != id)
             {
-                _host = null;
-                _hostModalId = ModalId.None;
+                _activeRegistration = null;
             }
         }
 

--- a/src/EventLogExpert.Runtime/Modal/ModalOpenResult.cs
+++ b/src/EventLogExpert.Runtime/Modal/ModalOpenResult.cs
@@ -1,0 +1,10 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Modal;
+
+/// <summary>
+///     Result of <see cref="IModalCoordinator.PushAsync{TModal,TResult}" />. <c>WasOpened</c> distinguishes
+///     user-completion-with-default from preempt-veto.
+/// </summary>
+public sealed record ModalOpenResult<TResult>(TResult? Result, bool WasOpened);

--- a/src/EventLogExpert.Runtime/Modal/ModalRegistration.cs
+++ b/src/EventLogExpert.Runtime/Modal/ModalRegistration.cs
@@ -1,0 +1,31 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.Alerts;
+
+namespace EventLogExpert.Runtime.Modal;
+
+public sealed class ModalRegistration
+{
+    public ModalRegistration(
+        ModalId modalId,
+        Func<ModalCloseRequest, Task<bool>> requestClose,
+        ModalScope scope,
+        IInlineAlertHost? inlineAlertHost)
+    {
+        ArgumentNullException.ThrowIfNull(requestClose);
+
+        ModalId = modalId;
+        RequestClose = requestClose;
+        Scope = scope;
+        InlineAlertHost = inlineAlertHost;
+    }
+
+    public IInlineAlertHost? InlineAlertHost { get; }
+
+    public ModalId ModalId { get; }
+
+    public Func<ModalCloseRequest, Task<bool>> RequestClose { get; }
+
+    public ModalScope Scope { get; }
+}

--- a/src/EventLogExpert.Runtime/Modal/ModalScope.cs
+++ b/src/EventLogExpert.Runtime/Modal/ModalScope.cs
@@ -1,0 +1,10 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Modal;
+
+public enum ModalScope
+{
+    Standard,
+    Critical
+}

--- a/src/EventLogExpert.UI/DatabaseTools/DatabaseToolsModal.razor
+++ b/src/EventLogExpert.UI/DatabaseTools/DatabaseToolsModal.razor
@@ -7,8 +7,8 @@
     InlineAlert="@CurrentInlineAlert"
     MaxWidth="min(80rem, calc(100vw - 2rem))"
     MinWidth="min(80rem, calc(100vw - 2rem))"
-    OnCancel="OnCancelAsync"
-    OnClose="OnCancelAsync"
+    OnCancel="HandleCancelButtonClickAsync"
+    OnClose="HandleCancelButtonClickAsync"
     OnDialogClosedByUser="HandleDialogClosedByUserAsync"
     OnInlineAlertResolved="HandleInlineAlertResolvedAsync"
     @ref="ChromeRef">

--- a/src/EventLogExpert.UI/DatabaseTools/DatabaseToolsModal.razor.cs
+++ b/src/EventLogExpert.UI/DatabaseTools/DatabaseToolsModal.razor.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Runtime.Alerts;
+using EventLogExpert.Runtime.Modal;
 using EventLogExpert.UI.DatabaseTools.Tabs;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
@@ -88,31 +89,33 @@ public sealed partial class DatabaseToolsModal
         await base.OnAfterRenderAsync(firstRender);
     }
 
-    protected override async Task OnCancelAsync()
+    protected override async Task OnClosingAsync()
     {
-        if (AnyTabIsRunning)
-        {
-            var confirm = await ShowInlineAlertAsync(
-                new InlineAlertRequest(
-                    Title: "Operation in progress",
-                    Message: "An operation is running. Cancel and close anyway?",
-                    AcceptLabel: "Cancel and close",
-                    CancelLabel: "Continue running",
-                    IsPrompt: false,
-                    PromptInitialValue: null),
-                CancellationToken.None);
+        // CancelIfRunning is a no-op when not running; safe to call from all close paths.
+        _showTab?.CancelIfRunning();
+        _createTab?.CancelIfRunning();
+        _mergeTab?.CancelIfRunning();
+        _diffTab?.CancelIfRunning();
+        _upgradeTab?.CancelIfRunning();
 
-            if (!confirm.Accepted) { return; }
+        await base.OnClosingAsync();
+    }
 
-            // Best-effort: cancel running tabs before closing.
-            _showTab?.CancelIfRunning();
-            _createTab?.CancelIfRunning();
-            _mergeTab?.CancelIfRunning();
-            _diffTab?.CancelIfRunning();
-            _upgradeTab?.CancelIfRunning();
-        }
+    protected override async Task<bool> OnRequestCloseAsync(ModalCloseRequest request)
+    {
+        if (!AnyTabIsRunning) { return true; }
 
-        await base.OnCancelAsync();
+        var confirm = await ShowInlineAlertAsync(
+            new InlineAlertRequest(
+                Title: "Operation in progress",
+                Message: "An operation is running. Cancel and close anyway?",
+                AcceptLabel: "Cancel and close",
+                CancelLabel: "Continue running",
+                IsPrompt: false,
+                PromptInitialValue: null),
+            CancellationToken.None);
+
+        return confirm.Accepted;
     }
 
     private static DatabaseToolsTab NextTab(DatabaseToolsTab current)

--- a/src/EventLogExpert.UI/Modal/ModalBase.cs
+++ b/src/EventLogExpert.UI/Modal/ModalBase.cs
@@ -28,6 +28,9 @@ public abstract class ModalBase<TResult> : FluxorComponent, IInlineAlertHost
 
     protected InlineAlertRequest? CurrentInlineAlert => _activeInlineAlert?.Request;
 
+    /// <summary>Override to mark the modal as Critical (rejects cross-modal cancel via the veto pipeline).</summary>
+    protected virtual ModalScope Scope => ModalScope.Standard;
+
     public Task CloseAsync() => CompleteAsync(default);
 
     /// <inheritdoc />
@@ -69,6 +72,17 @@ public abstract class ModalBase<TResult> : FluxorComponent, IInlineAlertHost
         return await tcs.Task;
     }
 
+    // Called by ModalCoordinator. Runs the veto check, then routes to OnCancelAsync (which derived
+    // modals may override for cancel-default-value semantics like PromptModal's string.Empty).
+    internal async Task<bool> RequestCloseAsync(ModalCloseRequest request)
+    {
+        bool accepted = await OnRequestCloseAsync(request);
+
+        if (accepted) { await OnCancelAsync(); }
+
+        return accepted;
+    }
+
     protected async Task CompleteAsync(TResult? result)
     {
         await OnClosingAsync();
@@ -100,7 +114,7 @@ public abstract class ModalBase<TResult> : FluxorComponent, IInlineAlertHost
                 pending.Tcs.TrySetCanceled();
             }
 
-            ModalCoordinator.UnregisterInlineAlertHost(_modalId);
+            ModalCoordinator.UnregisterModal(_modalId);
 
             // Defensive: complete the task if we were torn down without an explicit close path.
             // Stale ids are ignored, so this is a no-op when Complete already ran.
@@ -110,10 +124,14 @@ public abstract class ModalBase<TResult> : FluxorComponent, IInlineAlertHost
         await base.DisposeAsyncCore(disposing);
     }
 
-    // Route Esc/native-close through OnCancelAsync so all close paths share the same pipeline.
-    // Protected so derived modals' .razor markup can wire OnDialogClosedByUser="HandleDialogClosedByUserAsync"
-    // even when the derived class lives in a different assembly than ModalBase.
-    protected Task HandleDialogClosedByUserAsync() => OnCancelAsync();
+    /// <summary>UI button (Cancel/Close) entry point — routes through the coordinator's veto pipeline.</summary>
+    protected Task HandleCancelButtonClickAsync() =>
+        ModalCoordinator.RequestCloseActiveAsync(ModalCloseReason.UserDismiss);
+
+    // Route Esc/native-close through the coordinator's veto pipeline. The native dialog handler
+    // can't distinguish Esc from backdrop click, so UserDismiss (generic) is the right reason.
+    protected Task HandleDialogClosedByUserAsync() =>
+        ModalCoordinator.RequestCloseActiveAsync(ModalCloseReason.UserDismiss);
 
     protected async Task HandleInlineAlertResolvedAsync(InlineAlertResult result)
     {
@@ -147,9 +165,18 @@ public abstract class ModalBase<TResult> : FluxorComponent, IInlineAlertHost
     {
         // Capture the active id so a stale modal can never complete a successor's task.
         _modalId = ModalService.ActiveModalId;
-        ModalCoordinator.RegisterInlineAlertHost(_modalId, this);
+        var registration = new ModalRegistration(_modalId, RequestCloseAsync, Scope, this);
+        ModalCoordinator.RegisterModal(registration);
         base.OnInitialized();
     }
+
+    /// <summary>Veto hook for modal close requests. Override to block close conditionally (return <see langword="false" />).</summary>
+    /// <remarks>
+    ///     Calling <see cref="IModalCoordinator.RequestCloseActiveAsync" /> from inside this method is unsupported and
+    ///     will deadlock on the coordinator's in-flight close TCS. Throwing <see cref="OperationCanceledException" />
+    ///     from this method is interpreted by the coordinator as accepting the close.
+    /// </remarks>
+    protected virtual Task<bool> OnRequestCloseAsync(ModalCloseRequest request) => Task.FromResult(true);
 
     protected virtual Task OnSaveAsync() => CompleteAsync(default);
 

--- a/src/EventLogExpert.UI/Settings/SettingsModal.razor
+++ b/src/EventLogExpert.UI/Settings/SettingsModal.razor
@@ -8,7 +8,7 @@
     FooterDisabled="@IsCloseBlocked"
     Height="60%"
     InlineAlert="@CurrentInlineAlert"
-    OnCancel="OnCancelAsync"
+    OnCancel="HandleCancelButtonClickAsync"
     OnDialogClosedByUser="HandleDialogClosedByUserAsync"
     OnInlineAlertResolved="HandleInlineAlertResolvedAsync"
     OnSave="OnSaveAsync"

--- a/src/EventLogExpert.UI/Settings/SettingsModal.razor.cs
+++ b/src/EventLogExpert.UI/Settings/SettingsModal.razor.cs
@@ -9,6 +9,7 @@ using EventLogExpert.Runtime.Database;
 using EventLogExpert.Runtime.Database.Upgrade;
 using EventLogExpert.Runtime.DetailsPane;
 using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.Modal;
 using EventLogExpert.Runtime.Settings;
 using EventLogExpert.UI.Modal;
 using Fluxor;
@@ -75,10 +76,8 @@ public sealed partial class SettingsModal : ModalBase<bool>
         await base.DisposeAsyncCore(disposing);
     }
 
-    protected override Task OnCancelAsync() =>
-        IsCloseBlocked
-            ? Task.CompletedTask
-            : base.OnCancelAsync();
+    protected override Task<bool> OnRequestCloseAsync(ModalCloseRequest request) =>
+        Task.FromResult(!IsCloseBlocked);
 
     protected override async Task OnClosingAsync()
     {

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Modal/ModalCoordinatorCloseTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Modal/ModalCoordinatorCloseTests.cs
@@ -1,0 +1,479 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.Alerts;
+using EventLogExpert.Runtime.Modal;
+using Microsoft.AspNetCore.Components;
+using NSubstitute;
+
+namespace EventLogExpert.Runtime.Tests.Modal;
+
+public sealed class ModalCoordinatorCloseTests
+{
+    [Fact]
+    public void GetActiveModalScope_CriticalModal_ReturnsCritical()
+    {
+        // Arrange
+        var service = new ModalService();
+        using var sut = new ModalCoordinator(service);
+        _ = sut.PushAsync<DummyModal, bool>();
+        ModalId id = service.ActiveModalId;
+        sut.RegisterModal(TestRegistration(id, scope: ModalScope.Critical));
+
+        // Act + Assert
+        Assert.Equal(ModalScope.Critical, sut.GetActiveModalScope());
+    }
+
+    [Fact]
+    public void GetActiveModalScope_NoModal_ReturnsNull()
+    {
+        // Arrange
+        var service = new ModalService();
+        using var sut = new ModalCoordinator(service);
+
+        // Act + Assert
+        Assert.Null(sut.GetActiveModalScope());
+    }
+
+    [Fact]
+    public void GetActiveModalScope_StaleRegistrationAfterCancel_ReturnsNull()
+    {
+        // Arrange — register a modal, then cancel via the service (ModalService publishes ActiveModalId changes before
+        // firing StateChanged, so a read can race the backstop in OnModalServiceStateChanged).
+        var service = new ModalService();
+        using var sut = new ModalCoordinator(service);
+        _ = sut.PushAsync<DummyModal, bool>();
+        ModalId id = service.ActiveModalId;
+        sut.RegisterModal(TestRegistration(id, scope: ModalScope.Critical));
+        service.CancelActive();
+
+        // Act
+        ModalScope? scope = sut.GetActiveModalScope();
+
+        // Assert
+        Assert.Null(scope);
+    }
+
+    [Fact]
+    public void GetActiveModalScope_StandardModal_ReturnsStandard()
+    {
+        // Arrange
+        var service = new ModalService();
+        using var sut = new ModalCoordinator(service);
+        _ = sut.PushAsync<DummyModal, bool>();
+        ModalId id = service.ActiveModalId;
+        sut.RegisterModal(TestRegistration(id, scope: ModalScope.Standard));
+
+        // Act + Assert
+        Assert.Equal(ModalScope.Standard, sut.GetActiveModalScope());
+    }
+
+    [Fact]
+    public void ModalRegistration_NullRequestClose_ThrowsArgumentNullException()
+    {
+        // Arrange + Act + Assert
+        Assert.Throws<ArgumentNullException>(() => new ModalRegistration(new ModalId(1L), null!, ModalScope.Standard, inlineAlertHost: null));
+    }
+
+    [Fact]
+    public async Task PushAsync_ActiveModalAcceptsPreemption_ReturnsOpened()
+    {
+        // Arrange
+        var service = new ModalService();
+        using var sut = new ModalCoordinator(service);
+        _ = sut.PushAsync<DummyModal, bool>();
+        ModalId firstId = service.ActiveModalId;
+        sut.RegisterModal(TestRegistration(firstId, _ => Task.FromResult(true)));
+
+        // Act
+        Task<ModalOpenResult<bool>> secondShow = sut.PushAsync<OtherModal, bool>();
+        ModalId secondId = service.ActiveModalId;
+        sut.ForceCloseActive();
+
+        // Assert
+        ModalOpenResult<bool> result = await secondShow;
+        Assert.True(result.WasOpened);
+        Assert.NotEqual(firstId, secondId);
+    }
+
+    [Fact]
+    public async Task PushAsync_ActiveModalVetoesPreemption_ReturnsNotOpened()
+    {
+        // Arrange
+        var service = new ModalService();
+        using var sut = new ModalCoordinator(service);
+        _ = sut.PushAsync<DummyModal, bool>();
+        ModalId firstId = service.ActiveModalId;
+        sut.RegisterModal(TestRegistration(firstId, _ => Task.FromResult(false)));
+
+        // Act
+        ModalOpenResult<bool> result = await sut.PushAsync<OtherModal, bool>();
+
+        // Assert
+        Assert.False(result.WasOpened);
+        Assert.Equal(default, result.Result);
+        Assert.Equal(firstId, service.ActiveModalId);
+    }
+
+    [Fact]
+    public void RegisterModal_ModalIdNone_RejectsRegistrationToAvoidGhostState()
+    {
+        // Arrange — caller passes a ModalId.None registration (e.g., default-constructed); coordinator must not store it.
+        var service = new ModalService();
+        using var sut = new ModalCoordinator(service);
+
+        // Act
+        sut.RegisterModal(TestRegistration(ModalId.None));
+
+        // Assert
+        Assert.Null(sut.GetActiveModalScope());
+        Assert.False(sut.TryGetInlineAlertHost(out _));
+    }
+
+    [Fact]
+    public async Task RequestCloseActiveAsync_ConcurrentCalls_ShareResult()
+    {
+        // Arrange
+        var service = new ModalService();
+        using var sut = new ModalCoordinator(service);
+        _ = sut.PushAsync<DummyModal, bool>();
+        ModalId id = service.ActiveModalId;
+        var handlerReached = new TaskCompletionSource();
+        var releaseHandler = new TaskCompletionSource<bool>();
+        sut.RegisterModal(TestRegistration(id, async _ =>
+        {
+            handlerReached.SetResult();
+            return await releaseHandler.Task;
+        }));
+
+        // Act — first call enters handler; second call coalesces.
+        Task<bool> firstCall = sut.RequestCloseActiveAsync(ModalCloseReason.UserDismiss);
+        await handlerReached.Task;
+        Task<bool> secondCall = sut.RequestCloseActiveAsync(ModalCloseReason.EscKey);
+        releaseHandler.SetResult(true);
+
+        // Assert
+        bool firstResult = await firstCall;
+        bool secondResult = await secondCall;
+        Assert.True(firstResult);
+        Assert.True(secondResult);
+    }
+
+    [Fact]
+    public async Task RequestCloseActiveAsync_CriticalScope_RejectsOtherModalActivationEvenWithEscInFlight()
+    {
+        // Arrange — scope policy fires per-call BEFORE coalescing, so Critical+OtherModalActivation is rejected
+        // even when an Esc close is already in flight.
+        var service = new ModalService();
+        using var sut = new ModalCoordinator(service);
+        _ = sut.PushAsync<DummyModal, bool>();
+        ModalId id = service.ActiveModalId;
+        var handlerReached = new TaskCompletionSource();
+        var releaseHandler = new TaskCompletionSource<bool>();
+        sut.RegisterModal(TestRegistration(id, async _ =>
+        {
+            handlerReached.SetResult();
+            return await releaseHandler.Task;
+        }, ModalScope.Critical));
+
+        Task<bool> escCall = sut.RequestCloseActiveAsync(ModalCloseReason.EscKey);
+        await handlerReached.Task;
+
+        // Act
+        bool omaResult = await sut.RequestCloseActiveAsync(ModalCloseReason.OtherModalActivation);
+
+        // Assert
+        Assert.False(omaResult);
+
+        releaseHandler.SetResult(true);
+        await escCall;
+    }
+
+    [Fact]
+    public async Task RequestCloseActiveAsync_CriticalScopeAndOtherModalActivation_RejectsWithoutCallingHandler()
+    {
+        // Arrange
+        var service = new ModalService();
+        using var sut = new ModalCoordinator(service);
+        _ = sut.PushAsync<DummyModal, bool>();
+        ModalId id = service.ActiveModalId;
+        int handlerCallCount = 0;
+        sut.RegisterModal(TestRegistration(id, _ =>
+        {
+            handlerCallCount++;
+            return Task.FromResult(true);
+        }, ModalScope.Critical));
+
+        // Act
+        bool result = await sut.RequestCloseActiveAsync(ModalCloseReason.OtherModalActivation);
+
+        // Assert
+        Assert.False(result);
+        Assert.Equal(0, handlerCallCount);
+    }
+
+    [Fact]
+    public async Task RequestCloseActiveAsync_CriticalScopeAndUserDismiss_DelegatesToHandler()
+    {
+        // Arrange — Critical scope only blocks OtherModalActivation; user gestures still delegate.
+        var service = new ModalService();
+        using var sut = new ModalCoordinator(service);
+        _ = sut.PushAsync<DummyModal, bool>();
+        ModalId id = service.ActiveModalId;
+        int handlerCallCount = 0;
+        sut.RegisterModal(TestRegistration(id, _ =>
+        {
+            handlerCallCount++;
+            return Task.FromResult(true);
+        }, ModalScope.Critical));
+
+        // Act
+        bool result = await sut.RequestCloseActiveAsync(ModalCloseReason.UserDismiss);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(1, handlerCallCount);
+    }
+
+    [Fact]
+    public async Task RequestCloseActiveAsync_HandlerAccepts_ReturnsTrue()
+    {
+        // Arrange
+        var service = new ModalService();
+        using var sut = new ModalCoordinator(service);
+        _ = sut.PushAsync<DummyModal, bool>();
+        ModalId id = service.ActiveModalId;
+        sut.RegisterModal(TestRegistration(id, _ => Task.FromResult(true)));
+
+        // Act
+        bool result = await sut.RequestCloseActiveAsync(ModalCloseReason.UserDismiss);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task RequestCloseActiveAsync_HandlerCanceled_AwaitersReceiveAccepted()
+    {
+        // Arrange — OperationCanceledException from a force-close race is treated as accepted=true so
+        // coalesced PushAsync callers don't blow up with unhandled OCE.
+        var service = new ModalService();
+        using var sut = new ModalCoordinator(service);
+        _ = sut.PushAsync<DummyModal, bool>();
+        ModalId id = service.ActiveModalId;
+        sut.RegisterModal(TestRegistration(id, _ => throw new OperationCanceledException()));
+
+        // Act
+        bool result = await sut.RequestCloseActiveAsync(ModalCloseReason.UserDismiss);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task RequestCloseActiveAsync_HandlerThrows_CoalescedAwaitersSeeException()
+    {
+        // Arrange
+        var service = new ModalService();
+        using var sut = new ModalCoordinator(service);
+        _ = sut.PushAsync<DummyModal, bool>();
+        ModalId id = service.ActiveModalId;
+        var handlerReached = new TaskCompletionSource();
+        var releaseHandler = new TaskCompletionSource<bool>();
+        sut.RegisterModal(TestRegistration(id, async _ =>
+        {
+            handlerReached.SetResult();
+            await releaseHandler.Task;
+            throw new InvalidOperationException("handler failure");
+        }));
+
+        Task<bool> firstCall = sut.RequestCloseActiveAsync(ModalCloseReason.UserDismiss);
+        await handlerReached.Task;
+        Task<bool> secondCall = sut.RequestCloseActiveAsync(ModalCloseReason.EscKey);
+
+        // Act
+        releaseHandler.SetResult(true);
+
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() => firstCall);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => secondCall);
+    }
+
+    [Fact]
+    public async Task RequestCloseActiveAsync_HandlerThrows_PropagatesException()
+    {
+        // Arrange
+        var service = new ModalService();
+        using var sut = new ModalCoordinator(service);
+        _ = sut.PushAsync<DummyModal, bool>();
+        ModalId id = service.ActiveModalId;
+        sut.RegisterModal(TestRegistration(id, _ => throw new InvalidOperationException("handler failure")));
+
+        // Act
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.RequestCloseActiveAsync(ModalCloseReason.UserDismiss));
+
+        // Assert
+        Assert.Equal("handler failure", ex.Message);
+
+        // Subsequent call should not be stuck on the previous TCS — _inFlightCloseTcs cleared in finally.
+        sut.UnregisterModal(id);
+        bool followup = await sut.RequestCloseActiveAsync(ModalCloseReason.UserDismiss);
+        Assert.True(followup);
+    }
+
+    [Fact]
+    public async Task RequestCloseActiveAsync_HandlerVetoes_ReturnsFalse()
+    {
+        // Arrange
+        var service = new ModalService();
+        using var sut = new ModalCoordinator(service);
+        _ = sut.PushAsync<DummyModal, bool>();
+        ModalId id = service.ActiveModalId;
+        sut.RegisterModal(TestRegistration(id, _ => Task.FromResult(false)));
+
+        // Act
+        bool result = await sut.RequestCloseActiveAsync(ModalCloseReason.UserDismiss);
+
+        // Assert
+        Assert.False(result);
+        Assert.NotNull(sut.ActiveSession);
+    }
+
+    [Fact]
+    public async Task RequestCloseActiveAsync_HandlerVetoes_SecondCallCanSucceedAfterHandlerSwitches()
+    {
+        // Arrange — first call vetoed; the captured flag toggles to accept and the next call should succeed
+        // (verifies _inFlightCloseTcs is cleared in finally after a veto, not stuck holding the false result).
+        var service = new ModalService();
+        using var sut = new ModalCoordinator(service);
+        _ = sut.PushAsync<DummyModal, bool>();
+        ModalId id = service.ActiveModalId;
+        bool acceptNext = false;
+        sut.RegisterModal(TestRegistration(id, _ => Task.FromResult(acceptNext)));
+
+        // Act
+        bool first = await sut.RequestCloseActiveAsync(ModalCloseReason.UserDismiss);
+        acceptNext = true;
+        bool second = await sut.RequestCloseActiveAsync(ModalCloseReason.UserDismiss);
+
+        // Assert
+        Assert.False(first);
+        Assert.True(second);
+    }
+
+    [Fact]
+    public async Task RequestCloseActiveAsync_InitWindowOtherModalActivation_RejectsToProtectScopePolicy()
+    {
+        // Arrange — service has ActiveModalId published but RegisterModal hasn't fired yet (OnInitialized gap).
+        // OtherModalActivation must be rejected so a not-yet-registered Critical modal can't be preempted.
+        var service = new ModalService();
+        using var sut = new ModalCoordinator(service);
+        _ = sut.PushAsync<DummyModal, bool>();
+        Assert.NotEqual(ModalId.None, service.ActiveModalId);
+        Assert.Null(sut.GetActiveModalScope());
+
+        // Act
+        bool result = await sut.RequestCloseActiveAsync(ModalCloseReason.OtherModalActivation);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task RequestCloseActiveAsync_InitWindowUserDismiss_ReturnsTrue()
+    {
+        // Arrange — non-preemption reasons during init window still return true (idempotent no-op equivalent).
+        var service = new ModalService();
+        using var sut = new ModalCoordinator(service);
+        _ = sut.PushAsync<DummyModal, bool>();
+        Assert.NotEqual(ModalId.None, service.ActiveModalId);
+        Assert.Null(sut.GetActiveModalScope());
+
+        // Act
+        bool result = await sut.RequestCloseActiveAsync(ModalCloseReason.UserDismiss);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task RequestCloseActiveAsync_NoActiveModal_ReturnsTrue()
+    {
+        // Arrange
+        var service = new ModalService();
+        using var sut = new ModalCoordinator(service);
+
+        // Act
+        bool result = await sut.RequestCloseActiveAsync(ModalCloseReason.UserDismiss);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task RequestCloseActiveAsync_StaleCriticalRegistrationAfterCancel_DoesNotVetoOtherModalActivation()
+    {
+        // Arrange — register a Critical modal, then cancel via the service. A subsequent OtherModalActivation must
+        // NOT see the stale Critical scope (which would incorrectly veto a legitimate preemption).
+        var service = new ModalService();
+        using var sut = new ModalCoordinator(service);
+        _ = sut.PushAsync<DummyModal, bool>();
+        ModalId id = service.ActiveModalId;
+        int handlerCallCount = 0;
+        sut.RegisterModal(TestRegistration(id, _ =>
+        {
+            handlerCallCount++;
+            return Task.FromResult(true);
+        }, ModalScope.Critical));
+        service.CancelActive();
+
+        // Act — service has no active modal anymore; OMA should fall through, not be vetoed by stale Critical scope.
+        bool result = await sut.RequestCloseActiveAsync(ModalCloseReason.OtherModalActivation);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(0, handlerCallCount);
+    }
+
+    [Fact]
+    public void TryGetInlineAlertHost_StaleRegistrationAfterCancel_ReturnsFalse()
+    {
+        // Arrange — register a modal with an inline-alert host, then cancel; the stored host must not be returned.
+        var service = new ModalService();
+        using var sut = new ModalCoordinator(service);
+        _ = sut.PushAsync<DummyModal, bool>();
+        ModalId id = service.ActiveModalId;
+        var host = Substitute.For<IInlineAlertHost>();
+        sut.RegisterModal(new ModalRegistration(id, _ => Task.FromResult(true), ModalScope.Standard, host));
+        service.CancelActive();
+
+        // Act
+        bool found = sut.TryGetInlineAlertHost(out IInlineAlertHost? resolved);
+
+        // Assert
+        Assert.False(found);
+        Assert.Null(resolved);
+    }
+
+    private static ModalRegistration TestRegistration(
+        ModalId id,
+        Func<ModalCloseRequest, Task<bool>>? requestClose = null,
+        ModalScope scope = ModalScope.Standard,
+        IInlineAlertHost? host = null) =>
+        new(id, requestClose ?? (_ => Task.FromResult(true)), scope, host);
+
+    private sealed class DummyModal : IComponent
+    {
+        public void Attach(RenderHandle renderHandle) { }
+
+        public Task SetParametersAsync(ParameterView parameters) => Task.CompletedTask;
+    }
+
+    private sealed class OtherModal : IComponent
+    {
+        public void Attach(RenderHandle renderHandle) { }
+
+        public Task SetParametersAsync(ParameterView parameters) => Task.CompletedTask;
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Modal/ModalCoordinatorTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Modal/ModalCoordinatorTests.cs
@@ -16,7 +16,7 @@ public sealed class ModalCoordinatorTests
         // Arrange
         var service = new ModalService();
         using var sut = new ModalCoordinator(service);
-        Task<bool> showTask = sut.PushAsync<DummyModal, bool>();
+        Task<ModalOpenResult<bool>> showTask = sut.PushAsync<DummyModal, bool>();
         ModalId activeId = service.ActiveModalId;
         Assert.NotNull(sut.ActiveSession);
 
@@ -37,7 +37,9 @@ public sealed class ModalCoordinatorTests
         ModalSession? sessionAtResume = await resumeSnapshot.Task;
         Assert.Null(sessionAtResume);
         await observer;
-        Assert.True(await showTask);
+        ModalOpenResult<bool> result = await showTask;
+        Assert.True(result.WasOpened);
+        Assert.True(result.Result);
         Assert.Null(sut.ActiveSession);
     }
 
@@ -113,9 +115,10 @@ public sealed class ModalCoordinatorTests
         using var sut = new ModalCoordinator(service);
 
         // Act
-        Task<bool> firstShow = sut.PushAsync<DummyModal, bool>();
+        Task<ModalOpenResult<bool>> firstShow = sut.PushAsync<DummyModal, bool>();
         ModalId firstId = service.ActiveModalId;
-        Task<bool> secondShow = sut.PushAsync<OtherModal, bool>();
+        sut.RegisterModal(TestRegistration(firstId, _ => Task.FromResult(true)));
+        Task<ModalOpenResult<bool>> secondShow = sut.PushAsync<OtherModal, bool>();
         ModalId secondId = service.ActiveModalId;
 
         // Assert
@@ -123,14 +126,18 @@ public sealed class ModalCoordinatorTests
         Assert.NotNull(sut.ActiveSession);
         Assert.Equal(secondId, sut.ActiveSession.Id);
         Assert.Equal(typeof(OtherModal), sut.ActiveSession.ComponentType);
-        Assert.False(await firstShow);
+        ModalOpenResult<bool> firstResult = await firstShow;
+        Assert.True(firstResult.WasOpened);
+        Assert.False(firstResult.Result);
 
         sut.ForceCloseActive();
-        Assert.False(await secondShow);
+        ModalOpenResult<bool> secondResult = await secondShow;
+        Assert.True(secondResult.WasOpened);
+        Assert.False(secondResult.Result);
     }
 
     [Fact]
-    public void RegisterInlineAlertHost_ActiveId_RegistersAndIsReadable()
+    public void RegisterModal_ActiveId_RegistersAndInlineAlertHostIsReadable()
     {
         // Arrange
         var service = new ModalService();
@@ -140,7 +147,7 @@ public sealed class ModalCoordinatorTests
         var host = Substitute.For<IInlineAlertHost>();
 
         // Act
-        sut.RegisterInlineAlertHost(id, host);
+        sut.RegisterModal(TestRegistration(id, host));
 
         // Assert
         Assert.True(sut.TryGetInlineAlertHost(out var resolved));
@@ -148,7 +155,7 @@ public sealed class ModalCoordinatorTests
     }
 
     [Fact]
-    public void RegisterInlineAlertHost_StaleId_IsNoOp()
+    public void RegisterModal_StaleId_IsNoOp()
     {
         // Arrange
         var service = new ModalService();
@@ -156,7 +163,7 @@ public sealed class ModalCoordinatorTests
         var host = Substitute.For<IInlineAlertHost>();
 
         // Act
-        sut.RegisterInlineAlertHost(new ModalId(999L), host);
+        sut.RegisterModal(TestRegistration(new ModalId(999L), host));
 
         // Assert
         Assert.False(sut.TryGetInlineAlertHost(out _));
@@ -194,7 +201,7 @@ public sealed class ModalCoordinatorTests
         _ = sut.PushAsync<DummyModal, bool>();
         ModalId firstId = service.ActiveModalId;
         var host = Substitute.For<IInlineAlertHost>();
-        sut.RegisterInlineAlertHost(firstId, host);
+        sut.RegisterModal(TestRegistration(firstId, host));
         Assert.True(sut.TryGetInlineAlertHost(out _));
 
         // Act — successor preempts prior; the host is now stale.
@@ -207,24 +214,25 @@ public sealed class ModalCoordinatorTests
     }
 
     [Fact]
-    public void UnregisterInlineAlertHost_MatchingId_ClearsHost()
+    public void UnregisterModal_MatchingId_ClearsRegistration()
     {
         // Arrange
         var service = new ModalService();
         using var sut = new ModalCoordinator(service);
         _ = sut.PushAsync<DummyModal, bool>();
         ModalId id = service.ActiveModalId;
-        sut.RegisterInlineAlertHost(id, Substitute.For<IInlineAlertHost>());
+        sut.RegisterModal(TestRegistration(id, Substitute.For<IInlineAlertHost>()));
 
         // Act
-        sut.UnregisterInlineAlertHost(id);
+        sut.UnregisterModal(id);
 
         // Assert
         Assert.False(sut.TryGetInlineAlertHost(out _));
+        Assert.Null(sut.GetActiveModalScope());
     }
 
     [Fact]
-    public void UnregisterInlineAlertHost_StaleId_IsNoOp()
+    public void UnregisterModal_StaleId_IsNoOp()
     {
         // Arrange
         var service = new ModalService();
@@ -232,15 +240,21 @@ public sealed class ModalCoordinatorTests
         _ = sut.PushAsync<DummyModal, bool>();
         ModalId id = service.ActiveModalId;
         var host = Substitute.For<IInlineAlertHost>();
-        sut.RegisterInlineAlertHost(id, host);
+        sut.RegisterModal(TestRegistration(id, host));
 
         // Act
-        sut.UnregisterInlineAlertHost(new ModalId(id.Value + 99));
+        sut.UnregisterModal(new ModalId(id.Value + 99));
 
         // Assert
         Assert.True(sut.TryGetInlineAlertHost(out var resolved));
         Assert.Same(host, resolved);
     }
+
+    private static ModalRegistration TestRegistration(ModalId id, IInlineAlertHost? host = null, ModalScope scope = ModalScope.Standard) =>
+        new(id, _ => Task.FromResult(true), scope, host);
+
+    private static ModalRegistration TestRegistration(ModalId id, Func<ModalCloseRequest, Task<bool>> requestClose, ModalScope scope = ModalScope.Standard) =>
+        new(id, requestClose, scope, inlineAlertHost: null);
 
     private sealed class DummyModal : IComponent
     {


### PR DESCRIPTION
## Summary

PR 3 of the IModalCoordinator SoC refactor. Adds the close-veto pipeline + Critical scope policy that PR 5 (DatabaseRecoveryDialog) and PR 9 (banner #526 stash re-apply) will consume.

Stacks on top of #546 (PR 1+2). Merge order: #546 first, then this.

## New surface

5 new public types in `EventLogExpert.Runtime.Modal`:

| Type | Purpose |
|---|---|
| `ModalScope` (enum) | `Standard` (default) or `Critical` (rejects `OtherModalActivation`) |
| `ModalCloseReason` (enum) | `UserDismiss`, `EscKey`, `OutsideClick`, `ProgrammaticCancel`, `OtherModalActivation` |
| `ModalCloseRequest` (readonly record struct) | Carries the reason into the close handler |
| `ModalRegistration` (sealed class) | `ModalId` + `RequestClose` delegate + `Scope` + optional `IInlineAlertHost` |
| `ModalOpenResult<TResult>` (record) | `Result` + `WasOpened` so callers can distinguish vetoed-preempt from real cancel |

## Breaking changes to `IModalCoordinator` (vs PR 1+2)

- `RegisterInlineAlertHost(IInlineAlertHost)` + `UnregisterInlineAlertHost(IInlineAlertHost)` **replaced with** `RegisterModal(ModalRegistration)` + `UnregisterModal(ModalId)`
- `PushAsync<TModal, TResult>` return type changed from `Task<TResult?>` to `Task<ModalOpenResult<TResult>>`
- New: `GetActiveModalScope()` returns `ModalScope?`
- New: `RequestCloseActiveAsync(ModalCloseReason)` returns `Task<bool>`

## Implementation highlights

- **Scope policy fires FIRST** (before coalescing): `Critical + OtherModalActivation` is always rejected, regardless of in-flight Esc.
- **Init-window guard**: when `_activeRegistration is null` but `ActiveModalId != None` (between `Show` and `OnInitialized.RegisterModal`), `OtherModalActivation` is rejected so a not-yet-registered Critical modal cannot be bypassed.
- **Stale-clear inside reads**: `GetActiveModalScope` / `TryGetInlineAlertHost` / `RequestCloseActiveAsync` route through `GetActiveRegistration()` which validates `_activeRegistration.ModalId == _modalService.ActiveModalId` inside the lock and self-heals on mismatch. Closes the race between `ModalService` publishing `ActiveModalId` changes and `StateChanged` firing.
- **Capture-then-await coalescing**: concurrent `RequestCloseActiveAsync` calls share the first call's TCS; the verdict is published outside the lock.
- **OCE-as-accepted**: if a close handler throws `OperationCanceledException` (force-close race), coalesced awaiters resolve to `true` so PushAsync callers don't blow up.
- **`HandleCancelButtonClickAsync`** on `ModalBase`: razor cancel/close buttons route here, which calls the coordinator's veto pipeline. `OnCancelAsync` is reserved as the post-veto terminal hook (preserves PromptModal's `string.Empty` non-null contract).
- **`ModalRegistration` invariants**: `sealed class` with get-only properties + ctor `ArgumentNullException.ThrowIfNull(requestClose)`. Get-only props (not `init`) prevent `with`-expression bypass of the null-check.

## Migrated modals

- **`SettingsModal`**: `OnCancelAsync` override removed; new `OnRequestCloseAsync => Task.FromResult(!IsCloseBlocked)`. Razor wired to `HandleCancelButtonClickAsync`.
- **`DatabaseToolsModal`**: confirm-prompt moved to `OnRequestCloseAsync` (veto decision); `CancelIfRunning()` calls moved to `OnClosingAsync` (cleanup side effects). Both `OnCancel` and `OnClose` razor wirings updated.

`PromptModal` unchanged - its `OnCancelAsync => CompleteAsync(string.Empty)` override stays as the post-veto terminal step.

## Tests

- 21+ new tests in `ModalCoordinatorCloseTests` covering scope policy, coalescing, exception propagation, OCE-as-accepted, init-window guard, retry-after-veto, stale-clear on reads + scope policy, ghost-registration rejection (ModalId.None), and `ModalRegistration` null-check
- `ModalCoordinatorTests` updated for the new `RegisterModal` / `PushAsync` signatures
- `PushAsync_PreemptsPriorModal_CoordinatorMirrorsLatest` now registers the first modal between the two pushes (it was previously passing because of the init-window bypass - caught by the pre-PR panel)

**918 Runtime + 150 UI = 1,068 tests passing**; build 0/0.

## Follow-up work this PR unblocks

- **PR 4**: typed launchers (`OpenSettingsAsync`, `OpenDatabaseToolsAsync`) using the new `ModalOpenResult<TResult>` return
- **PR 5**: `DatabaseRecoveryDialog` migrates to `ModalBase` with `ModalScope.Critical`
- **PR 9**: re-apply banner #526 stash (workaround removed since cross-modal preemption is now properly vetoed)