### PR TITLE
Add typed launchers routing menu and FilterPane modal opens through coordinator

### DIFF
--- a/src/EventLogExpert.UI/FilterPane/FilterPane.razor.cs
+++ b/src/EventLogExpert.UI/FilterPane/FilterPane.razor.cs
@@ -14,8 +14,7 @@ using EventLogExpert.Runtime.FilterProgress;
 using EventLogExpert.Runtime.Menu;
 using EventLogExpert.Runtime.Modal;
 using EventLogExpert.Runtime.Settings;
-using EventLogExpert.UI.FilterCache;
-using EventLogExpert.UI.FilterGroup;
+using EventLogExpert.UI.Modal;
 using Fluxor;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
@@ -78,7 +77,7 @@ public sealed partial class FilterPane : IDisposable
 
     private string MenuState => HasFilters ? _isFilterListVisible.ToString().ToLower() : "false";
 
-    [Inject] private IModalService ModalService { get; init; } = null!;
+    [Inject] private IModalCoordinator ModalCoordinator { get; init; } = null!;
 
     [Inject] private ISettingsService Settings { get; init; } = null!;
 
@@ -284,7 +283,7 @@ public sealed partial class FilterPane : IDisposable
         StateHasChanged();
     }
 
-    private async Task OpenCachedFiltersModal() => await ModalService.Show<FilterCacheModal, bool>();
+    private Task OpenCachedFiltersModal() => ModalCoordinator.OpenFilterCacheAsync();
 
     private void OpenFilterGroupPicker()
     {
@@ -303,7 +302,7 @@ public sealed partial class FilterPane : IDisposable
         _isFilterListVisible = true;
     }
 
-    private async Task OpenFilterGroupsModal() => await ModalService.Show<FilterGroupModal, bool>();
+    private Task OpenFilterGroupsModal() => ModalCoordinator.OpenFilterGroupAsync();
 
     private void RemoveDateFilter()
     {

--- a/src/EventLogExpert.UI/Modal/ModalCoordinatorLaunchers.cs
+++ b/src/EventLogExpert.UI/Modal/ModalCoordinatorLaunchers.cs
@@ -1,0 +1,62 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.Modal;
+using EventLogExpert.Runtime.Update.ReleaseNotes;
+using EventLogExpert.UI.DatabaseTools;
+using EventLogExpert.UI.DebugLog;
+using EventLogExpert.UI.FilterCache;
+using EventLogExpert.UI.FilterGroup;
+using EventLogExpert.UI.Settings;
+using EventLogExpert.UI.Update;
+
+namespace EventLogExpert.UI.Modal;
+
+/// <summary>Typed launchers that route production modal opens through the coordinator's veto pipeline.</summary>
+public static class ModalCoordinatorLaunchers
+{
+    extension(IModalCoordinator coordinator)
+    {
+        public Task<ModalOpenResult<bool>> OpenDatabaseToolsAsync()
+        {
+            ArgumentNullException.ThrowIfNull(coordinator);
+
+            return coordinator.PushAsync<DatabaseToolsModal, bool>();
+        }
+
+        public Task<ModalOpenResult<bool>> OpenDebugLogsAsync()
+        {
+            ArgumentNullException.ThrowIfNull(coordinator);
+
+            return coordinator.PushAsync<DebugLogModal, bool>();
+        }
+
+        public Task<ModalOpenResult<bool>> OpenFilterCacheAsync()
+        {
+            ArgumentNullException.ThrowIfNull(coordinator);
+
+            return coordinator.PushAsync<FilterCacheModal, bool>();
+        }
+
+        public Task<ModalOpenResult<bool>> OpenFilterGroupAsync()
+        {
+            ArgumentNullException.ThrowIfNull(coordinator);
+
+            return coordinator.PushAsync<FilterGroupModal, bool>();
+        }
+
+        public Task<ModalOpenResult<bool>> OpenReleaseNotesAsync(ReleaseNotesContent content)
+        {
+            ArgumentNullException.ThrowIfNull(coordinator);
+
+            return coordinator.PushAsync<ReleaseNotesModal, bool>(new Dictionary<string, object?> { [nameof(ReleaseNotesModal.Content)] = content });
+        }
+
+        public Task<ModalOpenResult<bool>> OpenSettingsAsync()
+        {
+            ArgumentNullException.ThrowIfNull(coordinator);
+
+            return coordinator.PushAsync<SettingsModal, bool>();
+        }
+    }
+}

--- a/src/EventLogExpert/Adapters/Input/KeyboardShortcutService.cs
+++ b/src/EventLogExpert/Adapters/Input/KeyboardShortcutService.cs
@@ -15,11 +15,11 @@ namespace EventLogExpert.Adapters.Input;
 /// </summary>
 public sealed class KeyboardShortcutService(
     IMenuActionService actions,
-    IModalService modalService,
+    IModalCoordinator modalCoordinator,
     ISettingsService settings) : IAsyncDisposable
 {
     private readonly IMenuActionService _actions = actions;
-    private readonly IModalService _modalService = modalService;
+    private readonly IModalCoordinator _modalCoordinator = modalCoordinator;
     private readonly ISettingsService _settings = settings;
 
     private IJSRuntime? _jsRuntime;
@@ -75,7 +75,7 @@ public sealed class KeyboardShortcutService(
         if (!ctrl || alt || shift || meta) { return; }
 
         // Modal-gating happens here, not in JS, so a misbehaving (or stale) bridge can't bypass it.
-        if (_modalService.ActiveModalType is not null) { return; }
+        if (_modalCoordinator.ActiveSession is not null) { return; }
 
         switch (code)
         {

--- a/src/EventLogExpert/Adapters/Menu/MauiMenuActionService.cs
+++ b/src/EventLogExpert/Adapters/Menu/MauiMenuActionService.cs
@@ -16,10 +16,9 @@ using EventLogExpert.Runtime.Settings;
 using EventLogExpert.Runtime.Update;
 using EventLogExpert.UI.DatabaseTools;
 using EventLogExpert.UI.DebugLog;
+using EventLogExpert.UI.Modal;
 using EventLogExpert.UI.Settings;
-using EventLogExpert.UI.Update;
 using Fluxor;
-using Microsoft.AspNetCore.Components;
 using Application = Microsoft.Maui.Controls.Application;
 using IDispatcher = Fluxor.IDispatcher;
 
@@ -37,7 +36,7 @@ public sealed class MauiMenuActionService(
     IFilterPaneCommands filterPaneCommands,
     IClipboardService clipboardService,
     IAlertDialogService dialogService,
-    IModalService modalService,
+    IModalCoordinator modalCoordinator,
     ISettingsService settings,
     IUpdateService updateService,
     ICurrentVersionProvider currentVersionProvider,
@@ -54,7 +53,7 @@ public sealed class MauiMenuActionService(
     private readonly IFilterPaneCommands _filterPaneCommands = filterPaneCommands;
     private readonly IFolderPickerService _folderPickerService = folderPickerService;
     private readonly SemaphoreSlim _logNamesLock = new(1, 1);
-    private readonly IModalService _modalService = modalService;
+    private readonly IModalCoordinator _modalCoordinator = modalCoordinator;
     private readonly ISettingsService _settings = settings;
     private readonly ITraceLogger _traceLogger = traceLogger;
     private readonly IUpdateService _updateService = updateService;
@@ -141,7 +140,8 @@ public sealed class MauiMenuActionService(
 
     public void LoadNewEvents() => _eventLogCommands.LoadNewEvents();
 
-    public Task OpenDatabaseToolsAsync() => ShowModalAsync<DatabaseToolsModal>("database tools");
+    public Task OpenDatabaseToolsAsync() =>
+        TryOpenModalAsync(_modalCoordinator.OpenDatabaseToolsAsync, nameof(DatabaseToolsModal));
 
     public Task OpenDocsAsync() =>
         OpenBrowserAsync("https://github.com/microsoft/EventLogExpert/blob/main/docs/Home.md");
@@ -296,7 +296,8 @@ public sealed class MauiMenuActionService(
         }
     }
 
-    public Task<bool> OpenSettingsAsync() => ShowModalAsync<SettingsModal>("settings");
+    public Task<bool> OpenSettingsAsync() =>
+        TryOpenModalAsync(_modalCoordinator.OpenSettingsAsync, nameof(SettingsModal));
 
     public async Task SaveFiltersAsGroupAsync()
     {
@@ -313,7 +314,8 @@ public sealed class MauiMenuActionService(
     public void SetContinuouslyUpdate(bool value) =>
         _eventLogCommands.SetContinuouslyUpdate(value);
 
-    public Task ShowDebugLogsAsync() => ShowModalAsync<DebugLogModal>("debug logs");
+    public Task ShowDebugLogsAsync() =>
+        TryOpenModalAsync(_modalCoordinator.OpenDebugLogsAsync, nameof(DebugLogModal));
 
     public async Task ShowReleaseNotesAsync()
     {
@@ -323,8 +325,7 @@ public sealed class MauiMenuActionService(
 
             if (content is null) { return; }
 
-            await _modalService.Show<ReleaseNotesModal, bool>(
-                new Dictionary<string, object?> { ["Content"] = content.Value });
+            await _modalCoordinator.OpenReleaseNotesAsync(content.Value);
         }
         catch (Exception ex)
         {
@@ -355,18 +356,19 @@ public sealed class MauiMenuActionService(
         }
     }
 
-    private async Task<bool> ShowModalAsync<TModal>(string label)
-        where TModal : IComponent
+    private async Task<bool> TryOpenModalAsync(Func<Task<ModalOpenResult<bool>>> open, string modalName)
     {
         try
         {
-            await _modalService.Show<TModal, bool>();
+            ModalOpenResult<bool> result = await open();
+
+            if (!result.WasOpened) { _traceLogger.Trace($"{modalName} open preempted by an active modal."); }
 
             return true;
         }
         catch (Exception ex)
         {
-            _traceLogger.Error($"Failed to open {label} modal: {ex}");
+            _traceLogger.Error($"Failed to open {modalName}: {ex}");
 
             return false;
         }

--- a/src/EventLogExpert/MauiProgram.cs
+++ b/src/EventLogExpert/MauiProgram.cs
@@ -119,7 +119,6 @@ public static class MauiProgram
 
         builder.Services.AddSingleton<IAlertDialogService>(static provider =>
         {
-            var modalService = provider.GetRequiredService<IModalService>();
             var modalCoordinator = provider.GetRequiredService<IModalCoordinator>();
             var mainThreadService = provider.GetRequiredService<IMainThreadService>();
             var bannerService = provider.GetRequiredService<IBannerService>();
@@ -128,12 +127,19 @@ public static class MauiProgram
                 modalCoordinator,
                 mainThreadService,
                 bannerService,
-                parameters => modalService.Show<AlertModal, bool>(parameters.ToDictionary(static kvp => kvp.Key, static kvp => kvp.Value)),
                 async parameters =>
                 {
-                    string? result = await modalService.Show<PromptModal, string>(parameters.ToDictionary(static kvp => kvp.Key, static kvp => kvp.Value));
+                    ModalOpenResult<bool> result = await modalCoordinator.PushAsync<AlertModal, bool>(
+                        parameters as IDictionary<string, object?> ?? new Dictionary<string, object?>(parameters));
 
-                    return result ?? string.Empty;
+                    return result is { WasOpened: true, Result: true };
+                },
+                async parameters =>
+                {
+                    ModalOpenResult<string> result = await modalCoordinator.PushAsync<PromptModal, string>(
+                        parameters as IDictionary<string, object?> ?? new Dictionary<string, object?>(parameters));
+
+                    return result.WasOpened ? result.Result ?? string.Empty : string.Empty;
                 });
         });
 

--- a/tests/Unit/EventLogExpert.UI.Tests/Modal/ModalCoordinatorLaunchersTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Modal/ModalCoordinatorLaunchersTests.cs
@@ -1,0 +1,133 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.Modal;
+using EventLogExpert.Runtime.Update.ReleaseNotes;
+using EventLogExpert.UI.DatabaseTools;
+using EventLogExpert.UI.DebugLog;
+using EventLogExpert.UI.FilterCache;
+using EventLogExpert.UI.FilterGroup;
+using EventLogExpert.UI.Modal;
+using EventLogExpert.UI.Settings;
+using EventLogExpert.UI.Update;
+using NSubstitute;
+
+namespace EventLogExpert.UI.Tests.Modal;
+
+public sealed class ModalCoordinatorLaunchersTests
+{
+    [Fact]
+    public async Task OpenDatabaseToolsAsync_DelegatesToPushAsync()
+    {
+        // Arrange
+        var coordinator = Substitute.For<IModalCoordinator>();
+        coordinator.PushAsync<DatabaseToolsModal, bool>(Arg.Any<IDictionary<string, object?>?>())
+            .Returns(new ModalOpenResult<bool>(false, WasOpened: true));
+
+        // Act
+        await coordinator.OpenDatabaseToolsAsync();
+
+        // Assert
+        await coordinator.Received(1).PushAsync<DatabaseToolsModal, bool>(Arg.Any<IDictionary<string, object?>?>());
+    }
+
+    [Fact]
+    public async Task OpenDebugLogsAsync_DelegatesToPushAsync()
+    {
+        // Arrange
+        var coordinator = Substitute.For<IModalCoordinator>();
+        coordinator.PushAsync<DebugLogModal, bool>(Arg.Any<IDictionary<string, object?>?>())
+            .Returns(new ModalOpenResult<bool>(false, WasOpened: true));
+
+        // Act
+        await coordinator.OpenDebugLogsAsync();
+
+        // Assert
+        await coordinator.Received(1).PushAsync<DebugLogModal, bool>(Arg.Any<IDictionary<string, object?>?>());
+    }
+
+    [Fact]
+    public async Task OpenFilterCacheAsync_DelegatesToPushAsync()
+    {
+        // Arrange
+        var coordinator = Substitute.For<IModalCoordinator>();
+        coordinator.PushAsync<FilterCacheModal, bool>(Arg.Any<IDictionary<string, object?>?>())
+            .Returns(new ModalOpenResult<bool>(false, WasOpened: true));
+
+        // Act
+        await coordinator.OpenFilterCacheAsync();
+
+        // Assert
+        await coordinator.Received(1).PushAsync<FilterCacheModal, bool>(Arg.Any<IDictionary<string, object?>?>());
+    }
+
+    [Fact]
+    public async Task OpenFilterGroupAsync_DelegatesToPushAsync()
+    {
+        // Arrange
+        var coordinator = Substitute.For<IModalCoordinator>();
+        coordinator.PushAsync<FilterGroupModal, bool>(Arg.Any<IDictionary<string, object?>?>())
+            .Returns(new ModalOpenResult<bool>(false, WasOpened: true));
+
+        // Act
+        await coordinator.OpenFilterGroupAsync();
+
+        // Assert
+        await coordinator.Received(1).PushAsync<FilterGroupModal, bool>(Arg.Any<IDictionary<string, object?>?>());
+    }
+
+    [Fact]
+    public async Task OpenReleaseNotesAsync_PassesContentParameter()
+    {
+        // Arrange
+        var coordinator = Substitute.For<IModalCoordinator>();
+        coordinator.PushAsync<ReleaseNotesModal, bool>(Arg.Any<IDictionary<string, object?>?>())
+            .Returns(new ModalOpenResult<bool>(false, WasOpened: true));
+        var content = new ReleaseNotesContent("v1.0", "## Notes");
+
+        // Act
+        await coordinator.OpenReleaseNotesAsync(content);
+
+        // Assert
+        await coordinator.Received(1).PushAsync<ReleaseNotesModal, bool>(
+            Arg.Is<IDictionary<string, object?>?>(d => d != null && d.ContainsKey(nameof(ReleaseNotesModal.Content)) && content.Equals((ReleaseNotesContent)d[nameof(ReleaseNotesModal.Content)]!)));
+    }
+
+    [Fact]
+    public async Task OpenSettingsAsync_DelegatesToPushAsync()
+    {
+        // Arrange
+        var coordinator = Substitute.For<IModalCoordinator>();
+        coordinator.PushAsync<SettingsModal, bool>(Arg.Any<IDictionary<string, object?>?>())
+            .Returns(new ModalOpenResult<bool>(false, WasOpened: true));
+
+        // Act
+        await coordinator.OpenSettingsAsync();
+
+        // Assert
+        await coordinator.Received(1).PushAsync<SettingsModal, bool>(Arg.Any<IDictionary<string, object?>?>());
+    }
+
+    [Fact]
+    public void OpenSettingsAsync_NullCoordinator_ThrowsArgumentNullException()
+    {
+        // Arrange + Act + Assert — discard the Task to avoid xUnit2014; the throw happens synchronously in the guard.
+        Assert.Throws<ArgumentNullException>(static () => { _ = ModalCoordinatorLaunchers.OpenSettingsAsync(coordinator: null!); });
+    }
+
+    [Fact]
+    public async Task OpenSettingsAsync_WhenActiveModalVetoesPreemption_ReturnsNotOpened()
+    {
+        // Arrange — simulates PR 4's veto-preempt path: PushAsync returns WasOpened=false when the existing modal
+        // vetoes via OnRequestCloseAsync (e.g., SettingsModal IsCloseBlocked, DatabaseToolsModal AnyTabIsRunning).
+        var coordinator = Substitute.For<IModalCoordinator>();
+        coordinator.PushAsync<SettingsModal, bool>(Arg.Any<IDictionary<string, object?>?>())
+            .Returns(new ModalOpenResult<bool>(false, WasOpened: false));
+
+        // Act
+        ModalOpenResult<bool> result = await coordinator.OpenSettingsAsync();
+
+        // Assert
+        Assert.False(result.WasOpened);
+    }
+}


### PR DESCRIPTION
## Summary

PR 4 of the IModalCoordinator SoC refactor. Migrates 5 production modal-open call sites + 1 modal-state read from `IModalService.Show<>` (bypasses the close-veto pipeline) to `IModalCoordinator.PushAsync<>` (routes through it).

Stacks on top of #546 (PR 1+2+3 combined; PR 3 was merged in by the user).

## Behavior FIX (not just refactor)

PR 3 added `OnRequestCloseAsync` overrides to `SettingsModal` (vetoes when `IsCloseBlocked`) and `DatabaseToolsModal` (confirm prompt when `AnyTabIsRunning`). But until PR 4, all production callers still went through `IModalService.Show<>` — bypassing the new veto handlers. This PR routes them through `PushAsync<>`, which **fixes two pre-existing data-loss bugs**:

- Clicking Settings while Settings has unsaved changes (`IsCloseBlocked=true`) no longer silently nukes the existing modal.
- Clicking Database Tools mid-tab-operation now triggers the existing "An operation is running. Cancel and close anyway?" confirm prompt instead of silently orphaning the operation.

Both were broken since PR 3 landed; the veto handlers existed but no caller exercised them. Testers should verify both flows.

## New surface

`src/EventLogExpert.UI/Modal/ModalCoordinatorLaunchers.cs` — 6 extension methods on `IModalCoordinator`:

- `OpenSettingsAsync()`
- `OpenDatabaseToolsAsync()`
- `OpenDebugLogsAsync()`
- `OpenReleaseNotesAsync(ReleaseNotesContent)`
- `OpenFilterCacheAsync()`
- `OpenFilterGroupAsync()`

All return `Task<ModalOpenResult<bool>>`. Each null-guards the coordinator argument.

## Migrated callers

| Caller | Change |
|---|---|
| `MauiProgram.cs:120-145` `AlertDialogService` factory | Two inline closures rewritten to call `modalCoordinator.PushAsync<AlertModal/PromptModal, …>` directly; `IModalService` dependency removed from the factory |
| `MauiMenuActionService.cs` | Ctor injection swapped from `IModalService` to `IModalCoordinator`; `ShowModalAsync<T>` helper body changed from `Show<>; return true` to `_ = PushAsync<>; return true` (the helper covers Settings, DatabaseTools, DebugLogs); `ShowReleaseNotesAsync` uses the new extension method |
| `FilterPane.razor.cs` | `[Inject] IModalService ModalService` → `[Inject] IModalCoordinator ModalCoordinator`; `OpenCachedFiltersModal`/`OpenFilterGroupsModal` use extension methods |
| `KeyboardShortcutService.cs` | Ctor injection swapped + modal-gate read changed from `_modalService.ActiveModalType is not null` to `_modalCoordinator.ActiveSession is not null` (SoC consistency — it's a state-read, not a launcher) |

## Veto contract (preserved)

`MauiMenuActionService.ShowModalAsync<T>` helper:
- Opened normally → returns `true`
- Vetoed (user kept current modal) → returns `true` (non-error; consistent with "user state preserved")
- Exception → returns `false` (existing failure path; `BannerHost` shows the existing error banner)

`BannerHost.razor.cs:189-195`'s `if (!success)` only fires on actual exceptions, never on user-vetoed close.

`AlertDialogService` standalone closures:
- Alert: `r.WasOpened && r.Result` — veto-preempt collapses to `false` (caller interprets as "user dismissed")
- Prompt: `r.WasOpened ? r.Result ?? string.Empty : string.Empty` — veto returns `string.Empty` (existing "empty-on-cancel" contract)

## Tests

8 new tests in `ModalCoordinatorLaunchersTests`:
- 6 verify each extension method delegates to `PushAsync<TModal, bool>` via NSubstitute `Received(1)`
- 1 null-coordinator guard test
- 1 veto-preempt regression test: `OpenSettingsAsync` returns `WasOpened=false` when the coordinator vetoes

**918 Runtime + 158 UI = 1,076 tests passing**; build 0/0.

## Pre-implementation panel

4-slot panel (Opus xhigh + GPT-5.5 + GPT-5.4 + Opus 4.6) iterated R1→R3 to 4/4 unanimous READY. R2 surfaced a critical blind spot: Slot 3 caught that vetoes are reachable TODAY (not deferred to PR 5) because PR 3 added the `OnRequestCloseAsync` overrides. Three of four slots (and the agent) had missed this — tracked as a panel-miss for the post-PR-review feedback loop.

## Follow-up work this PR unblocks

- **PR 5**: `DatabaseRecoveryDialog` migrates to `ModalBase` with `ModalScope.Critical` — now that callers route through `PushAsync`, the Critical-scope policy actually fires.
- **PR 9**: re-apply banner #526 stash — workaround removed since cross-modal preemption is now properly vetoed at the production call sites.