### PR TITLE
Extract database operation orchestration from SettingsModal

### DIFF
--- a/scripts/run-tests.ps1
+++ b/scripts/run-tests.ps1
@@ -69,10 +69,24 @@ function Switch-DockerDaemon([string]$targetOS) {
         throw "docker is not on PATH. Install Docker Desktop and ensure it is available."
     }
 
-    $dockerCli = Join-Path (Split-Path (Split-Path $dockerCmd.Source)) "DockerCli.exe"
+    # Docker Desktop layout has changed across versions: newer installs put DockerCli.exe at
+    # 'C:\Program Files\Docker\Docker\DockerCli.exe', older installs at '...\resources\DockerCli.exe'.
+    # Try the canonical sibling-of-resources path first (newer layout), then the older
+    # resources-relative path, then a recursive scan.
+    $resourcesDir = Split-Path (Split-Path $dockerCmd.Source)
+    $dockerCli = Join-Path (Split-Path $resourcesDir) "DockerCli.exe"
 
     if (-not (Test-Path $dockerCli)) {
-        throw "DockerCli.exe not found at '$dockerCli'. Cannot switch Docker daemon mode."
+        $dockerCli = Join-Path $resourcesDir "DockerCli.exe"
+    }
+
+    if (-not (Test-Path $dockerCli)) {
+        $found = Get-ChildItem (Split-Path $resourcesDir) -Recurse -Filter "DockerCli.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($found) { $dockerCli = $found.FullName }
+    }
+
+    if (-not (Test-Path $dockerCli)) {
+        throw "DockerCli.exe not found near '$resourcesDir'. Cannot switch Docker daemon mode."
     }
 
     & $dockerCli -SwitchDaemon 2>$null

--- a/src/EventLogExpert.Runtime/Database/DatabaseOperationCoordinator.cs
+++ b/src/EventLogExpert.Runtime/Database/DatabaseOperationCoordinator.cs
@@ -1,0 +1,409 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.Banner;
+using EventLogExpert.Runtime.Common.Files;
+using EventLogExpert.Runtime.Database.Upgrade;
+using EventLogExpert.Runtime.EventLog;
+
+namespace EventLogExpert.Runtime.Database;
+
+internal sealed class DatabaseOperationCoordinator(
+    IDatabaseService databases,
+    IInfoBannerService infoBanners,
+    IErrorBannerService errorBanners,
+    IFilePickerService filePicker,
+    ILogReloadCoordinator logReload,
+    ITraceLogger logger) : IDatabaseOperationCoordinator
+{
+    private readonly IDatabaseService _databases = databases;
+    private readonly IErrorBannerService _errorBanners = errorBanners;
+    private readonly IFilePickerService _filePicker = filePicker;
+    private readonly IInfoBannerService _infoBanners = infoBanners;
+    private readonly ITraceLogger _logger = logger;
+    private readonly ILogReloadCoordinator _logReload = logReload;
+    private readonly Lock _upgradeGate = new();
+    private readonly HashSet<string> _upgradesInFlight = new(StringComparer.OrdinalIgnoreCase);
+
+    public event Action? UpgradeStateChanged;
+
+    internal enum ResultSeverity
+    {
+        Info,
+        Warning,
+        Error,
+    }
+
+    public bool IsAnyUpgradeInFlight
+    {
+        get { using (_upgradeGate.EnterScope()) { return _upgradesInFlight.Count > 0; } }
+    }
+
+    public async Task ApplyPendingTogglesAsync(
+        IReadOnlyCollection<string> fileNames,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(fileNames);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        foreach (var fileName in fileNames)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            await RunOperationAsync(
+                operationName: "toggle",
+                failureTitle: "Failed to Update Database",
+                operationNoun: $"updating '{fileName}'",
+                body: () =>
+                {
+                    _databases.Toggle(fileName);
+
+                    return Task.CompletedTask;
+                });
+        }
+    }
+
+    public async Task<ImportOutcome> ImportAsync(
+        Func<string, CancellationToken, Task<bool>>? askOverwriteAsync = null,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return await RunOperationAsync(
+            operationName: "import",
+            failureTitle: "Import Failed",
+            operationNoun: "importing provider databases",
+            fallbackOutcome: ImportOutcome.None,
+            body: async () =>
+            {
+                var sourcePaths = await _filePicker.PickMultipleAsync(
+                    "Please select database files to import",
+                    FilePickerFileTypes.Database);
+
+                if (sourcePaths.Count == 0) { return ImportOutcome.None; }
+
+                var skip = await ResolveImportConflictsAsync(sourcePaths, askOverwriteAsync, cancellationToken);
+                var result = await _databases.ImportAsync(sourcePaths, skip, cancellationToken);
+                var (title, message, severity) = BuildImportSummary(result);
+
+                ReportPostOperationResult(title, message, severity);
+
+                return new ImportOutcome(result.Imported, result.Failures, result.UpgradeFailures);
+            });
+    }
+
+    public bool IsUpgradeInFlight(string fileName)
+    {
+        ArgumentNullException.ThrowIfNull(fileName);
+
+        using (_upgradeGate.EnterScope()) { return _upgradesInFlight.Contains(fileName); }
+    }
+
+    public async Task<RemoveOutcome> RemoveDatabaseAsync(
+        string fileName,
+        Func<bool, CancellationToken, Task<bool>> confirmRemoveAsync,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(fileName);
+        ArgumentNullException.ThrowIfNull(confirmRemoveAsync);
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var entry = _databases.Entries.FirstOrDefault(e =>
+            string.Equals(e.FileName, fileName, StringComparison.OrdinalIgnoreCase));
+
+        if (entry is null) { return RemoveOutcome.NotFound; }
+
+        var isReadyAndEnabled = entry is { IsEnabled: true, Status: DatabaseStatus.Ready };
+        var showCloseReopenWarning = isReadyAndEnabled && _logReload.HasActiveLogs;
+
+        bool confirmed;
+
+        try
+        {
+            confirmed = await confirmRemoveAsync(showCloseReopenWarning, cancellationToken);
+        }
+        catch (OperationCanceledException) { return RemoveOutcome.NotConfirmed; }
+        catch (Exception ex)
+        {
+            _logger.Warning($"{nameof(RemoveDatabaseAsync)} confirm callback threw: {ex}");
+
+            return RemoveOutcome.NotConfirmed;
+        }
+
+        if (!confirmed) { return RemoveOutcome.NotConfirmed; }
+
+        // Remove is bespoke (not via RunOperationAsync) because of the snapshot-reopen-on-failure semantic:
+        // if RemoveAsync throws after populating snapshot.Items, logs that were closed must still reopen.
+        var snapshot = new LogReopenSnapshot();
+        bool removed = false;
+
+        try
+        {
+            await _databases.RemoveAsync(
+                fileName,
+                ct => _logReload.PrepareForDatabaseRemovalAsync(snapshot, ct),
+                cancellationToken);
+
+            removed = true;
+        }
+        catch (OperationCanceledException)
+        {
+            // Cancellation is silent.
+        }
+        catch (Exception ex)
+        {
+            _logger.Warning($"{nameof(RemoveDatabaseAsync)} remove failed: {ex}");
+            _errorBanners.ReportError(
+                "Failed to Remove Database",
+                $"An exception occurred while removing '{fileName}': {ex.Message}");
+        }
+
+        bool logsReopened = false;
+
+        if (snapshot.Items.Count > 0)
+        {
+            _logReload.ReopenAfterDatabaseRemoval(snapshot.Items);
+            logsReopened = true;
+        }
+
+        return new RemoveOutcome(RemoveOutcomeStatus.Confirmed, removed, logsReopened);
+    }
+
+    public async Task UpgradeDatabaseAsync(
+        string fileName,
+        UpgradeProgressScope scope = UpgradeProgressScope.SettingsTriggered,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(fileName);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        using (_upgradeGate.EnterScope())
+        {
+            if (_upgradesInFlight.Contains(fileName)) { return; }
+
+            if (_upgradesInFlight.Count > 0) { return; }
+
+            _upgradesInFlight.Add(fileName);
+        }
+
+        try
+        {
+            RaiseUpgradeStateChangedSafely();
+
+            await RunOperationAsync(
+                operationName: "upgrade",
+                failureTitle: "Database Upgrade Failed",
+                operationNoun: $"upgrading '{fileName}'",
+                body: async () =>
+                {
+                    var result = await _databases.UpgradeBatchAsync([fileName], scope, cancellationToken);
+
+                    foreach (var failure in result.Failed)
+                    {
+                        _errorBanners.ReportError(
+                            "Database Upgrade Failed",
+                            $"Failed to upgrade '{failure.FileName}': {failure.Message}");
+                    }
+                });
+        }
+        finally
+        {
+            using (_upgradeGate.EnterScope()) { _upgradesInFlight.Remove(fileName); }
+
+            RaiseUpgradeStateChangedSafely();
+        }
+    }
+
+    internal static (string Title, string Message, ResultSeverity Severity) BuildImportSummary(ImportResult importResult)
+    {
+        ArgumentNullException.ThrowIfNull(importResult);
+
+        var imported = importResult.Imported;
+        var failures = importResult.Failures;
+        var upgradeFailures = importResult.UpgradeFailures;
+
+        if (failures.Count == 0 && upgradeFailures.Count == 0)
+        {
+            if (imported == 0) { return ("Import Successful", "No databases were imported.", ResultSeverity.Info); }
+
+            var successMessage = imported > 1
+                ? $"{imported} databases have successfully been imported"
+                : "1 database has successfully been imported";
+
+            return ("Import Successful", successMessage, ResultSeverity.Info);
+        }
+
+        var failureSummary = FormatFailureSummary(failures, upgradeFailures);
+
+        if (imported == 0)
+        {
+            return ("Import Failed", $"No databases were imported; {failureSummary}", ResultSeverity.Error);
+        }
+
+        var partialMessage = imported > 1
+            ? $"{imported} databases imported"
+            : "1 database imported";
+
+        return ("Import Completed with Errors", $"{partialMessage}; {failureSummary}", ResultSeverity.Warning);
+    }
+
+    private static string FormatFailureSummary(
+        IReadOnlyList<ImportFailure> failures,
+        IReadOnlyList<ImportFailure> upgradeFailures)
+    {
+        var parts = new List<string>(failures.Count + upgradeFailures.Count);
+
+        foreach (var entry in failures) { parts.Add($"{entry.FileName} ({entry.Reason})"); }
+
+        foreach (var entry in upgradeFailures) { parts.Add($"{entry.FileName} upgrade ({entry.Reason})"); }
+
+        return $"failed: {string.Join(", ", parts)}";
+    }
+
+    private void RaiseUpgradeStateChangedSafely()
+    {
+        var handler = UpgradeStateChanged;
+
+        if (handler is null) { return; }
+
+        foreach (var subscriber in handler.GetInvocationList())
+        {
+            try { ((Action)subscriber).Invoke(); }
+            catch (Exception ex)
+            {
+                _logger.Warning($"{nameof(RaiseUpgradeStateChangedSafely)} subscriber threw: {ex}");
+            }
+        }
+    }
+
+    private void ReportPostOperationResult(string title, string message, ResultSeverity severity)
+    {
+        switch (severity)
+        {
+            case ResultSeverity.Info:
+                _infoBanners.ReportInfoBanner(title, message, BannerSeverity.Info);
+
+                break;
+            case ResultSeverity.Warning:
+                _infoBanners.ReportInfoBanner(title, message, BannerSeverity.Warning);
+
+                break;
+            case ResultSeverity.Error:
+                _errorBanners.ReportError(title, message);
+
+                break;
+        }
+    }
+
+    private async Task<IReadOnlySet<string>> ResolveImportConflictsAsync(
+        IReadOnlyList<string> sourcePaths,
+        Func<string, CancellationToken, Task<bool>>? askOverwriteAsync,
+        CancellationToken cancellationToken)
+    {
+        var existingNames = _databases.Entries
+            .Select(entry => entry.FileName)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        if (existingNames.Count == 0) { return new HashSet<string>(StringComparer.OrdinalIgnoreCase); }
+
+        var skip = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var resolved = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var sourcePath in sourcePaths)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (string.IsNullOrEmpty(sourcePath)) { continue; }
+
+            IReadOnlyList<string> candidateNames;
+
+            if (Path.GetExtension(sourcePath).Equals(".zip", StringComparison.OrdinalIgnoreCase))
+            {
+                candidateNames = await _databases.EnumerateZipDbEntryNamesAsync(sourcePath, cancellationToken);
+            }
+            else
+            {
+                var name = Path.GetFileName(sourcePath);
+
+                candidateNames = string.IsNullOrEmpty(name) ? [] : [name];
+            }
+
+            foreach (var candidateName in candidateNames)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (string.IsNullOrEmpty(candidateName)) { continue; }
+
+                if (!existingNames.Contains(candidateName)) { continue; }
+
+                if (!resolved.Add(candidateName)) { continue; }
+
+                if (askOverwriteAsync is null)
+                {
+                    skip.Add(candidateName);
+
+                    continue;
+                }
+
+                bool overwrite;
+
+                try { overwrite = await askOverwriteAsync(candidateName, cancellationToken); }
+                catch (OperationCanceledException) { throw; }
+                catch (Exception ex)
+                {
+                    // Defensive: unexpected callback exception → treat as Skip and log.
+                    _logger.Warning($"{nameof(ResolveImportConflictsAsync)} overwrite callback threw for '{candidateName}': {ex}");
+                    skip.Add(candidateName);
+
+                    continue;
+                }
+
+                if (!overwrite) { skip.Add(candidateName); }
+            }
+        }
+
+        return skip;
+    }
+
+    private async Task<T> RunOperationAsync<T>(
+        string operationName,
+        string failureTitle,
+        string operationNoun,
+        T fallbackOutcome,
+        Func<Task<T>> body)
+    {
+        try { return await body(); }
+        catch (OperationCanceledException) { return fallbackOutcome; }
+        catch (Exception ex)
+        {
+            _logger.Warning($"{operationName} failed: {ex}");
+            _errorBanners.ReportError(
+                failureTitle,
+                $"An exception occurred while {operationNoun}: {ex.Message}");
+
+            return fallbackOutcome;
+        }
+    }
+
+    private async Task RunOperationAsync(
+        string operationName,
+        string failureTitle,
+        string operationNoun,
+        Func<Task> body)
+    {
+        try { await body(); }
+        catch (OperationCanceledException)
+        {
+            // Cancellation is silent.
+        }
+        catch (Exception ex)
+        {
+            _logger.Warning($"{operationName} failed: {ex}");
+            _errorBanners.ReportError(
+                failureTitle,
+                $"An exception occurred while {operationNoun}: {ex.Message}");
+        }
+    }
+}

--- a/src/EventLogExpert.Runtime/Database/IDatabaseOperationCoordinator.cs
+++ b/src/EventLogExpert.Runtime/Database/IDatabaseOperationCoordinator.cs
@@ -1,0 +1,33 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.Database.Upgrade;
+
+namespace EventLogExpert.Runtime.Database;
+
+public interface IDatabaseOperationCoordinator
+{
+    event Action? UpgradeStateChanged;
+
+    bool IsAnyUpgradeInFlight { get; }
+
+    Task ApplyPendingTogglesAsync(
+        IReadOnlyCollection<string> fileNames,
+        CancellationToken cancellationToken = default);
+
+    Task<ImportOutcome> ImportAsync(
+        Func<string, CancellationToken, Task<bool>>? askOverwriteAsync = null,
+        CancellationToken cancellationToken = default);
+
+    bool IsUpgradeInFlight(string fileName);
+
+    Task<RemoveOutcome> RemoveDatabaseAsync(
+        string fileName,
+        Func<bool, CancellationToken, Task<bool>> confirmRemoveAsync,
+        CancellationToken cancellationToken = default);
+
+    Task UpgradeDatabaseAsync(
+        string fileName,
+        UpgradeProgressScope scope = UpgradeProgressScope.SettingsTriggered,
+        CancellationToken cancellationToken = default);
+}

--- a/src/EventLogExpert.Runtime/Database/ImportOutcome.cs
+++ b/src/EventLogExpert.Runtime/Database/ImportOutcome.cs
@@ -1,0 +1,14 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Database;
+
+public readonly record struct ImportOutcome(
+    int ImportedCount,
+    IReadOnlyList<ImportFailure> Failures,
+    IReadOnlyList<ImportFailure> UpgradeFailures)
+{
+    public static ImportOutcome None { get; } = new(0, [], []);
+
+    public bool DatabaseStateChanged => ImportedCount > 0;
+}

--- a/src/EventLogExpert.Runtime/Database/RemoveOutcome.cs
+++ b/src/EventLogExpert.Runtime/Database/RemoveOutcome.cs
@@ -1,0 +1,16 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Database;
+
+public readonly record struct RemoveOutcome(
+    RemoveOutcomeStatus Status,
+    bool Removed,
+    bool LogsReopened)
+{
+    public static RemoveOutcome NotFound { get; } = new(RemoveOutcomeStatus.NotFound, false, false);
+
+    public static RemoveOutcome NotConfirmed { get; } = new(RemoveOutcomeStatus.NotConfirmed, false, false);
+
+    public bool Confirmed => Status == RemoveOutcomeStatus.Confirmed;
+}

--- a/src/EventLogExpert.Runtime/Database/RemoveOutcomeStatus.cs
+++ b/src/EventLogExpert.Runtime/Database/RemoveOutcomeStatus.cs
@@ -1,0 +1,11 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Database;
+
+public enum RemoveOutcomeStatus
+{
+    NotFound,
+    NotConfirmed,
+    Confirmed,
+}

--- a/src/EventLogExpert.Runtime/DependencyInjection/RuntimeServiceCollectionExtensions.cs
+++ b/src/EventLogExpert.Runtime/DependencyInjection/RuntimeServiceCollectionExtensions.cs
@@ -38,6 +38,10 @@ public static class RuntimeServiceCollectionExtensions
     ///             <c>AddEventLogProviderDatabase()</c> — database sub-services depend on
     ///             <c>IProviderDatabaseMaintenance</c>.
     ///         </item>
+    ///         <item>
+    ///             <c>IFilePickerService</c> — <c>DatabaseOperationCoordinator</c> depends on it for Import.
+    ///             Host registers a concrete implementation (e.g., <c>MauiFilePickerService</c>).
+    ///         </item>
     ///     </list>
     ///     Omitting any of these produces a DI resolution failure when the dependent services are first activated.
     /// </summary>
@@ -131,5 +135,7 @@ public static class RuntimeServiceCollectionExtensions
         services.AddSingleton<DatabaseService>();
         services.AddSingleton<IDatabaseService>(static sp => sp.GetRequiredService<DatabaseService>());
         services.AddSingleton<IActiveDatabases>(static sp => sp.GetRequiredService<DatabaseService>());
+
+        services.AddSingleton<IDatabaseOperationCoordinator, DatabaseOperationCoordinator>();
     }
 }

--- a/src/EventLogExpert.Runtime/EventLog/DatabaseCoordinationEffects.cs
+++ b/src/EventLogExpert.Runtime/EventLog/DatabaseCoordinationEffects.cs
@@ -5,6 +5,7 @@ using EventLogExpert.Eventing.Common.Channels;
 using EventLogExpert.Eventing.Common.EventLogs;
 using EventLogExpert.Logging.Abstractions;
 using Fluxor;
+using System.Runtime.ExceptionServices;
 using IDispatcher = Fluxor.IDispatcher;
 
 namespace EventLogExpert.Runtime.EventLog;
@@ -13,18 +14,24 @@ internal sealed class DatabaseCoordinationEffects(
     IState<EventLogState> eventLogState,
     ITraceLogger logger,
     LogCloseCoordinator closeCoordinator,
-    IDispatcher dispatcher) : ILogReloadCoordinator
+    IDispatcher dispatcher,
+    IEventLogCommands eventLogCommands) : ILogReloadCoordinator
 {
     private readonly LogCloseCoordinator _closeCoordinator = closeCoordinator;
     private readonly IDispatcher _dispatcher = dispatcher;
+    private readonly IEventLogCommands _eventLogCommands = eventLogCommands;
     private readonly IState<EventLogState> _eventLogState = eventLogState;
     private readonly ITraceLogger _logger = logger;
+
+    public bool HasActiveLogs => !_eventLogState.Value.ActiveLogs.IsEmpty;
 
     public async Task PrepareForDatabaseRemovalAsync(
         LogReopenSnapshot snapshot,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(snapshot);
+
+        cancellationToken.ThrowIfCancellationRequested();
 
         var activeLogs = _eventLogState.Value.ActiveLogs.Values.ToList();
 
@@ -66,7 +73,7 @@ internal sealed class DatabaseCoordinationEffects(
                 _dispatcher.Dispatch(new CloseLogAction(id, name));
             }
 
-            foreach (var (id, name, type, task) in waiters)
+            foreach (var (_, name, type, task) in waiters)
             {
                 try
                 {
@@ -76,7 +83,22 @@ internal sealed class DatabaseCoordinationEffects(
                 }
                 catch (Exception ex) when (ex is TimeoutException or OperationCanceledException)
                 {
-                    _closeCoordinator.RemoveStrandedCompletion(id);
+                    foreach (var (strandedId, _, _, _) in waiters)
+                    {
+                        _closeCoordinator.RemoveStrandedCompletion(strandedId);
+                    }
+
+                    var alreadySnapshotted = new HashSet<string>(
+                        snapshot.Items.Select(i => i.Name),
+                        StringComparer.Ordinal);
+
+                    foreach (var (_, dispatchedName, dispatchedType, _) in waiters)
+                    {
+                        if (alreadySnapshotted.Add(dispatchedName))
+                        {
+                            snapshot.Add(new LogReopenInfo(dispatchedName, dispatchedType));
+                        }
+                    }
 
                     _logger.Trace(
                         $"{nameof(PrepareForDatabaseRemovalAsync)}: close for log '{name}' did not complete: {ex.GetType().Name}");
@@ -97,6 +119,68 @@ internal sealed class DatabaseCoordinationEffects(
         {
             _closeCoordinator.ReleaseCoordinatorLock();
         }
+    }
+
+    public async Task ReloadAllActiveLogsAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var activeLogsBeforeClose = _eventLogState.Value.ActiveLogs.Values.ToArray();
+        if (activeLogsBeforeClose.Length == 0) { return; }
+
+        await _closeCoordinator.AcquireCoordinatorLockAsync(cancellationToken);
+
+        ExceptionDispatchInfo? deferredCloseFailure = null;
+
+        try
+        {
+            var waiters = new List<(EventLogId Id, string Name, Task Task)>(activeLogsBeforeClose.Length);
+
+            foreach (var log in activeLogsBeforeClose)
+            {
+                var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                _closeCoordinator.RegisterCloseCompletion(log.Id, tcs);
+                waiters.Add((log.Id, log.Name, tcs.Task));
+            }
+
+            foreach (var (id, name, _) in waiters)
+            {
+                _dispatcher.Dispatch(new CloseLogAction(id, name));
+            }
+
+            foreach (var (_, name, task) in waiters)
+            {
+                try
+                {
+                    await task.WaitAsync(LogCloseCoordinator.LogCloseTimeout, cancellationToken);
+                }
+                catch (Exception ex) when (ex is TimeoutException or OperationCanceledException)
+                {
+                    foreach (var (strandedId, _, _) in waiters)
+                    {
+                        _closeCoordinator.RemoveStrandedCompletion(strandedId);
+                    }
+
+                    _logger.Trace(
+                        $"{nameof(ReloadAllActiveLogsAsync)}: close for log '{name}' did not complete: {ex.GetType().Name}");
+
+                    deferredCloseFailure = ExceptionDispatchInfo.Capture(ex);
+
+                    break;
+                }
+            }
+        }
+        finally
+        {
+            _closeCoordinator.ReleaseCoordinatorLock();
+        }
+
+        foreach (var log in activeLogsBeforeClose)
+        {
+            _eventLogCommands.OpenLog(log.Name, log.Type, CancellationToken.None);
+        }
+
+        deferredCloseFailure?.Throw();
     }
 
     public void ReopenAfterDatabaseRemoval(IReadOnlyList<LogReopenInfo> snapshot)

--- a/src/EventLogExpert.Runtime/EventLog/ILogReloadCoordinator.cs
+++ b/src/EventLogExpert.Runtime/EventLog/ILogReloadCoordinator.cs
@@ -3,15 +3,14 @@
 
 namespace EventLogExpert.Runtime.EventLog;
 
-/// <summary>
-///     Bridges DatabaseService delete operations and the EventLog Effects log lifecycle. Lets the database layer ask
-///     the log layer to close every active log (so SQLite handles are released) and later reopen exactly the logs that
-///     closed cleanly. Implemented by EventLog Effects so close/open dispatches share the same TCS dictionaries that
-///     already track per-log load and close completion.
-/// </summary>
+/// <summary>Coordinates log reload and database-removal lifecycle: query active presence, reload all, close-for-removal.</summary>
 public interface ILogReloadCoordinator
 {
+    bool HasActiveLogs { get; }
+
     Task PrepareForDatabaseRemovalAsync(LogReopenSnapshot snapshot, CancellationToken cancellationToken = default);
+
+    Task ReloadAllActiveLogsAsync(CancellationToken cancellationToken = default);
 
     void ReopenAfterDatabaseRemoval(IReadOnlyList<LogReopenInfo> snapshot);
 }

--- a/src/EventLogExpert.UI/Settings/SettingsModal.razor
+++ b/src/EventLogExpert.UI/Settings/SettingsModal.razor
@@ -12,9 +12,9 @@
     OnDialogClosedByUser="HandleDialogClosedByUserAsync"
     OnInlineAlertResolved="HandleInlineAlertResolvedAsync"
     OnSave="OnSaveAsync"
+    @ref="ChromeRef"
     SaveLabel="Save"
-    StackFooterExtra="true"
-    @ref="ChromeRef">
+    StackFooterExtra="true">
     <ChildContent>
         <div class="settings-form">
             <div class="flex-column-scroll">
@@ -22,7 +22,7 @@
 
                 <div class="flex-center-aligned-row tz-row">
                     <text>Time Zone:</text>
-                    <ValueSelect AriaLabel="Time Zone" CssClass="input timezone-dropdown" T="string" @bind-Value="_timeZoneId">
+                    <ValueSelect AriaLabel="Time Zone" @bind-Value="_timeZoneId" CssClass="input timezone-dropdown" T="string">
                         @foreach (var item in TimeZoneInfo.GetSystemTimeZones())
                         {
                             <ValueSelectItem T="string" Value="item.Id">@item.DisplayName</ValueSelectItem>
@@ -54,12 +54,12 @@
                             <DatabaseEntryRow EffectiveEnabled="GetEffectiveEnabled(entry)"
                                 Entry="@entry"
                                 IsClassificationPending="@IsClassificationPending"
-                                IsUpgradeBlocked="@(IsAnyUpgradeInFlight && !_entriesUpgrading.Contains(entry.FileName))"
-                                IsUpgrading="@_entriesUpgrading.Contains(entry.FileName)"
+                                IsUpgradeBlocked="@(IsAnyUpgradeInFlight && !Coordinator.IsUpgradeInFlight(entry.FileName))"
+                                IsUpgrading="@Coordinator.IsUpgradeInFlight(entry.FileName)"
+                                @key="entry.FileName"
                                 OnRemove="@(() => RemoveDatabase(entry))"
                                 OnToggle="@(() => ToggleDatabase(entry.FileName))"
-                                OnUpgrade="@(() => UpgradeEntry(entry.FileName))"
-                                @key="entry.FileName" />
+                                OnUpgrade="@(() => UpgradeEntry(entry.FileName))" />
                         }
                     }
                     else
@@ -75,7 +75,7 @@
 
                 <div class="flex-center-aligned-row">
                     <text>Theme:</text>
-                    <ValueSelect AriaLabel="Theme" CssClass="input filter-dropdown" T="Theme" @bind-Value="_theme">
+                    <ValueSelect AriaLabel="Theme" @bind-Value="_theme" CssClass="input filter-dropdown" T="Theme">
                         @foreach (Theme item in Enum.GetValues(typeof(Theme)))
                         {
                             <ValueSelectItem T="Theme" Value="item">@(item == Theme.System ? "Follow System" : item.ToString())</ValueSelectItem>
@@ -85,7 +85,7 @@
 
                 <div class="flex-center-aligned-row">
                     <text>Keyboard Copy Behavior:</text>
-                    <ValueSelect AriaLabel="Keyboard Copy Behavior" CssClass="input filter-dropdown" T="EventCopyFormat" @bind-Value="_copyFormat">
+                    <ValueSelect AriaLabel="Keyboard Copy Behavior" @bind-Value="_copyFormat" CssClass="input filter-dropdown" T="EventCopyFormat">
                         @foreach (EventCopyFormat item in Enum.GetValues(typeof(EventCopyFormat)))
                         {
                             <ValueSelectItem T="EventCopyFormat" Value="item" />
@@ -95,7 +95,7 @@
 
                 <div class="flex-center-aligned-row">
                     <text>Logging Level:</text>
-                    <ValueSelect AriaLabel="Logging Level" CssClass="input filter-dropdown" T="LogLevel" @bind-Value="_logLevel">
+                    <ValueSelect AriaLabel="Logging Level" @bind-Value="_logLevel" CssClass="input filter-dropdown" T="LogLevel">
                         @foreach (LogLevel item in Enum.GetValues(typeof(LogLevel)))
                         {
                             <ValueSelectItem T="LogLevel" Value="item" />

--- a/src/EventLogExpert.UI/Settings/SettingsModal.razor.cs
+++ b/src/EventLogExpert.UI/Settings/SettingsModal.razor.cs
@@ -1,28 +1,23 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Runtime.Alerts;
 using EventLogExpert.Runtime.Banner;
 using EventLogExpert.Runtime.Common.Clipboard;
-using EventLogExpert.Runtime.Common.Files;
 using EventLogExpert.Runtime.Database;
-using EventLogExpert.Runtime.Database.Upgrade;
 using EventLogExpert.Runtime.DetailsPane;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.Runtime.Modal;
 using EventLogExpert.Runtime.Settings;
 using EventLogExpert.UI.Modal;
-using Fluxor;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
-using System.Text;
-using IDispatcher = Fluxor.IDispatcher;
 
 namespace EventLogExpert.UI.Settings;
 
 public sealed partial class SettingsModal : ModalBase<bool>
 {
-    private readonly HashSet<string> _entriesUpgrading = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, bool> _pendingToggles = new(StringComparer.OrdinalIgnoreCase);
 
     private CancellationTokenSource? _classificationCts;
@@ -35,23 +30,14 @@ public sealed partial class SettingsModal : ModalBase<bool>
     private Theme _theme;
     private string _timeZoneId = string.Empty;
 
-    [Inject] private IAlertDialogService AlertDialogService { get; init; } = null!;
-
-    [Inject] private IProgressBannerService ProgressBannerService { get; init; } = null!;
+    [Inject] private IDatabaseOperationCoordinator Coordinator { get; init; } = null!;
 
     [Inject] private IDatabaseService DatabaseService { get; init; } = null!;
 
     [Inject] private IDetailsPanePreferencesProvider DetailsPanePreferences { get; init; } = null!;
 
-    [Inject] private IDispatcher Dispatcher { get; init; } = null!;
-
-    [Inject] private IEventLogCommands EventLogCommands { get; init; } = null!;
-
-    [Inject] private IState<EventLogState> EventLogState { get; init; } = null!;
-
-    [Inject] private IFilePickerService FilePickerService { get; init; } = null!;
-
-    private bool IsAnyUpgradeInFlight => _entriesUpgrading.Count > 0 || ProgressBannerService.SettingsProgress is not null;
+    private bool IsAnyUpgradeInFlight =>
+        Coordinator.IsAnyUpgradeInFlight || ProgressBannerService.SettingsProgress is not null;
 
     private bool IsClassificationPending => !DatabaseService.InitialClassificationTask.IsCompleted;
 
@@ -59,7 +45,11 @@ public sealed partial class SettingsModal : ModalBase<bool>
 
     [Inject] private ILogReloadCoordinator LogReloadCoordinator { get; init; } = null!;
 
+    [Inject] private IProgressBannerService ProgressBannerService { get; init; } = null!;
+
     [Inject] private ISettingsService Settings { get; init; } = null!;
+
+    [Inject] private ITraceLogger TraceLogger { get; init; } = null!;
 
     protected override async ValueTask DisposeAsyncCore(bool disposing)
     {
@@ -71,19 +61,17 @@ public sealed partial class SettingsModal : ModalBase<bool>
             _classificationCts = null;
             DatabaseService.EntriesChanged -= OnDatabaseEntriesChanged;
             ProgressBannerService.StateChanged -= OnBannerStateChanged;
+            Coordinator.UpgradeStateChanged -= OnCoordinatorStateChanged;
         }
 
         await base.DisposeAsyncCore(disposing);
     }
 
-    protected override Task<bool> OnRequestCloseAsync(ModalCloseRequest request) =>
-        Task.FromResult(!IsCloseBlocked);
-
     protected override async Task OnClosingAsync()
     {
         if (_databaseStateChanged)
         {
-            await ReloadOpenLogs();
+            await PromptAndReloadOpenLogs();
 
             _databaseStateChanged = false;
         }
@@ -95,6 +83,7 @@ public sealed partial class SettingsModal : ModalBase<bool>
 
         DatabaseService.EntriesChanged += OnDatabaseEntriesChanged;
         ProgressBannerService.StateChanged += OnBannerStateChanged;
+        Coordinator.UpgradeStateChanged += OnCoordinatorStateChanged;
 
         if (!DatabaseService.InitialClassificationTask.IsCompleted)
         {
@@ -105,11 +94,19 @@ public sealed partial class SettingsModal : ModalBase<bool>
         base.OnInitialized();
     }
 
+    protected override Task<bool> OnRequestCloseAsync(ModalCloseRequest request) =>
+        Task.FromResult(!IsCloseBlocked);
+
     protected override async Task OnSaveAsync()
     {
         if (IsCloseBlocked) { return; }
 
-        await ApplyPendingToggles();
+        var snapshot = _pendingToggles.Keys.ToArray();
+        _pendingToggles.Clear();
+
+        await Coordinator.ApplyPendingTogglesAsync(snapshot);
+
+        if (_disposed) { return; }
 
         Settings.CopyFormat = _copyFormat;
         Settings.IsPreReleaseEnabled = _isPreReleaseEnabled;
@@ -121,80 +118,25 @@ public sealed partial class SettingsModal : ModalBase<bool>
         await CompleteAsync(true);
     }
 
-    private static void AppendImportFailureSection(
-        StringBuilder builder,
-        string heading,
-        IReadOnlyList<ImportFailure> entries)
+    private async Task<bool> AskOverwriteAsync(string fileName, CancellationToken cancellationToken)
     {
-        builder.AppendLine();
-        builder.AppendLine();
-        builder.Append(heading);
+        if (_disposed) { return false; }
 
-        foreach (var entry in entries)
+        try
         {
-            builder.AppendLine();
-            builder.Append("\u2022 ");
-            builder.Append(entry.FileName);
-            builder.Append(": ");
-            builder.Append(entry.Reason);
+            var result = await ShowInlineAlertAsync(
+                new InlineAlertRequest(
+                    Title: "Database already exists",
+                    Message: $"{fileName} already exists. Overwrite?",
+                    AcceptLabel: "Overwrite",
+                    CancelLabel: "Skip",
+                    IsPrompt: false,
+                    PromptInitialValue: null),
+                cancellationToken);
+
+            return result.Accepted;
         }
-    }
-
-    private static (string Title, string Message) BuildImportSummary(ImportResult importResult)
-    {
-        var imported = importResult.Imported;
-        var failures = importResult.Failures;
-        var upgradeFailures = importResult.UpgradeFailures;
-
-        if (failures.Count == 0 && upgradeFailures.Count == 0)
-        {
-            if (imported == 0) { return ("Import Successful", "No databases were imported."); }
-
-            var successMessage = imported > 1
-                ? $"{imported} databases have successfully been imported"
-                : "1 database has successfully been imported";
-
-            return ("Import Successful", successMessage);
-        }
-
-        var detail = new StringBuilder();
-
-        if (failures.Count > 0) { AppendImportFailureSection(detail, "Failed:", failures); }
-
-        if (upgradeFailures.Count > 0) { AppendImportFailureSection(detail, "Upgrade failures:", upgradeFailures); }
-
-        if (imported == 0)
-        {
-            return ("Import Failed", $"No databases were imported.{detail}");
-        }
-
-        var partialMessage = imported > 1
-            ? $"{imported} databases imported successfully."
-            : "1 database imported successfully.";
-
-        return ("Import Completed with Errors", $"{partialMessage}{detail}");
-    }
-
-    private async Task ApplyPendingToggles()
-    {
-        if (_pendingToggles.Count == 0) { return; }
-
-        var toApply = _pendingToggles.ToArray();
-        _pendingToggles.Clear();
-
-        foreach (var (fileName, _) in toApply)
-        {
-            try
-            {
-                DatabaseService.Toggle(fileName);
-            }
-            catch (Exception ex)
-            {
-                await AlertDialogService.ShowAlert("Failed to Update Database",
-                    $"An exception occurred while updating '{fileName}': {ex.Message}",
-                    "OK");
-            }
-        }
+        catch (ObjectDisposedException) { return false; }
     }
 
     private bool GetEffectiveEnabled(DatabaseEntry entry) =>
@@ -202,31 +144,26 @@ public sealed partial class SettingsModal : ModalBase<bool>
 
     private async Task ImportDatabase()
     {
-        try
+        var outcome = await Coordinator.ImportAsync(AskOverwriteAsync);
+
+        if (_disposed) { return; }
+
+        if (outcome.DatabaseStateChanged)
         {
-            var sourcePaths = await FilePickerService.PickMultipleAsync(
-                "Please select database files to import",
-                FilePickerFileTypes.Database);
-
-            if (sourcePaths.Count == 0) { return; }
-
-            var skipFileNames = await ResolveImportConflictsAsync(sourcePaths, CancellationToken.None);
-
-            var importResult = await DatabaseService.ImportAsync(sourcePaths, skipFileNames, CancellationToken.None);
-
-            var (title, message) = BuildImportSummary(importResult);
-            await AlertDialogService.ShowAlert(title, message, "OK");
-
-            if (importResult.Imported > 0)
+            try { await InvokeAsync(OnSaveAsync); }
+            catch (ObjectDisposedException)
             {
-                await InvokeAsync(OnSaveAsync);
+                // Modal torn down between the _disposed check and the dispatcher call; safe to ignore.
             }
         }
-        catch (Exception ex)
+    }
+
+    private async Task InvokeAsyncSafe()
+    {
+        try { await InvokeAsync(StateHasChanged); }
+        catch (ObjectDisposedException)
         {
-            await AlertDialogService.ShowAlert("Import Failed",
-                $"An exception occurred while importing provider databases: {ex.Message}",
-                "OK");
+            // Renderer disposed concurrently with this dispatch; safe to ignore during teardown.
         }
     }
 
@@ -258,147 +195,100 @@ public sealed partial class SettingsModal : ModalBase<bool>
 
         if (_disposed) { return; }
 
-        try
-        {
-            await InvokeAsync(StateHasChanged);
-        }
-        catch (ObjectDisposedException)
-        {
-            // Modal was torn down between the _disposed check and the dispatcher call; safe to ignore.
-        }
+        await InvokeAsyncSafe();
     }
 
-    private void OnBannerStateChanged() => _ = InvokeAsync(StateHasChanged);
+    private void OnBannerStateChanged() => _ = InvokeAsyncSafe();
+
+    private void OnCoordinatorStateChanged() => _ = InvokeAsyncSafe();
 
     private void OnDatabaseEntriesChanged(object? sender, EventArgs e)
     {
         _databaseStateChanged = true;
-        _ = InvokeAsync(StateHasChanged);
+        _ = InvokeAsyncSafe();
     }
 
-    private async Task ReloadOpenLogs()
+    private async Task PromptAndReloadOpenLogs()
     {
-        if (EventLogState.Value.ActiveLogs.IsEmpty) { return; }
+        if (!LogReloadCoordinator.HasActiveLogs) { return; }
 
-        bool answer = await AlertDialogService.ShowAlert("Reload Open Logs Now?",
-            "In order for these changes to take effect, all currently open logs must be reloaded. Would you like to reload all open logs now?",
-            "Yes",
-            "No");
+        if (_disposed) { return; }
 
-        if (!answer) { return; }
+        bool yes;
 
-        var logsToReopen = EventLogState.Value.ActiveLogs.Values;
-
-        Dispatcher.Dispatch(new CloseAllLogsAction());
-
-        foreach (var log in logsToReopen)
+        try
         {
-            EventLogCommands.OpenLog(log.Name, log.Type);
+            var result = await ShowInlineAlertAsync(
+                new InlineAlertRequest(
+                    Title: "Reload Open Logs Now?",
+                    Message: "In order for these changes to take effect, all currently open logs must be reloaded. " +
+                        "Would you like to reload all open logs now?",
+                    AcceptLabel: "Yes",
+                    CancelLabel: "No",
+                    IsPrompt: false,
+                    PromptInitialValue: null),
+                CancellationToken.None);
+
+            yes = result.Accepted;
+        }
+        catch (ObjectDisposedException) { return; }
+        catch (OperationCanceledException) { return; }
+
+        if (yes)
+        {
+            try { await LogReloadCoordinator.ReloadAllActiveLogsAsync(); }
+            catch (OperationCanceledException) { }
+            catch (TimeoutException ex)
+            {
+                TraceLogger.Warning(
+                    $"{nameof(SettingsModal)}.{nameof(PromptAndReloadOpenLogs)}: reload did not complete within timeout: {ex}");
+            }
         }
     }
 
     private async Task RemoveDatabase(DatabaseEntry entry)
     {
         var fileName = entry.FileName;
-        var isReadyAndEnabled = entry is { IsEnabled: true, Status: DatabaseStatus.Ready };
-        var hasOpenLogs = !EventLogState.Value.ActiveLogs.IsEmpty;
 
-        var message = (isReadyAndEnabled && hasOpenLogs)
-            ? $"{fileName} is currently enabled. Removing will close and reopen any affected log views. Are you sure?"
-            : $"Are you sure you want to remove {fileName}?";
-
-        var confirmed = await AlertDialogService.ShowAlert("Remove Database",
-            message,
-            "Remove",
-            "Cancel");
-
-        if (!confirmed) { return; }
-
-        // Sink populated incrementally as the coordinator closes each log; the finally
-        // block reopens every log that successfully closed regardless of whether the
-        // delete succeeded or threw downstream.
-        var snapshot = new LogReopenSnapshot();
-
-        try
-        {
-            await DatabaseService.RemoveAsync(
-                fileName,
-                ct =>
-                    LogReloadCoordinator.PrepareForDatabaseRemovalAsync(snapshot, ct));
-        }
-        catch (Exception ex)
-        {
-            await AlertDialogService.ShowAlert("Failed to Remove Database",
-                $"An exception occurred while removing provider databases: {ex.Message}",
-                "OK");
-        }
-        finally
-        {
-            if (snapshot.Items.Count > 0)
+        var outcome = await Coordinator.RemoveDatabaseAsync(
+            fileName,
+            async (showCloseReopenWarning, cancellationToken) =>
             {
-                LogReloadCoordinator.ReopenAfterDatabaseRemoval(snapshot.Items);
+                if (_disposed) { return false; }
 
-                // Coordinator just rebuilt the resolver scopes for these logs against the
-                // current enabled-database set, which subsumes any prior dirty state from
-                // earlier modal actions. Suppress the modal-close global reload prompt so
-                // the user isn't asked twice. When no logs were reopened we leave the flag
-                // alone so unrelated prior mutations (e.g., a toggle earlier in the same
-                // modal session) still trigger their pending reload on close.
-                _databaseStateChanged = false;
-            }
+                var message = showCloseReopenWarning
+                    ? $"{fileName} is currently enabled. Removing will close and reopen any affected log views. Are you sure?"
+                    : $"Are you sure you want to remove {fileName}?";
 
-            _pendingToggles.Remove(fileName);
-        }
-    }
+                try
+                {
+                    var result = await ShowInlineAlertAsync(
+                        new InlineAlertRequest(
+                            Title: "Remove Database",
+                            Message: message,
+                            AcceptLabel: "Remove",
+                            CancelLabel: "Cancel",
+                            IsPrompt: false,
+                            PromptInitialValue: null),
+                        cancellationToken);
 
-    private async Task<IReadOnlySet<string>> ResolveImportConflictsAsync(
-        IReadOnlyList<string> sourcePaths,
-        CancellationToken cancellationToken)
-    {
-        var existingNames = DatabaseService.Entries
-            .Select(entry => entry.FileName)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+                    return result.Accepted;
+                }
+                catch (ObjectDisposedException) { return false; }
+            });
 
-        if (existingNames.Count == 0) { return new HashSet<string>(StringComparer.OrdinalIgnoreCase); }
+        if (_disposed) { return; }
 
-        var skip = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var resolved = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (outcome.Confirmed) { _pendingToggles.Remove(fileName); }
 
-        foreach (var sourcePath in sourcePaths)
+        if (outcome.LogsReopened)
         {
-            if (string.IsNullOrEmpty(sourcePath)) { continue; }
-
-            IReadOnlyList<string> candidateNames;
-
-            if (Path.GetExtension(sourcePath).Equals(".zip", StringComparison.OrdinalIgnoreCase))
-            {
-                candidateNames = await DatabaseService.EnumerateZipDbEntryNamesAsync(sourcePath, cancellationToken);
-            }
-            else
-            {
-                var name = Path.GetFileName(sourcePath);
-                candidateNames = string.IsNullOrEmpty(name) ? [] : [name];
-            }
-
-            foreach (var candidateName in candidateNames)
-            {
-                if (string.IsNullOrEmpty(candidateName)) { continue; }
-
-                if (!existingNames.Contains(candidateName)) { continue; }
-
-                if (!resolved.Add(candidateName)) { continue; }
-
-                var overwrite = await AlertDialogService.ShowAlert(
-                    "Database already exists",
-                    $"{candidateName} already exists. Overwrite?",
-                    "Overwrite",
-                    "Skip");
-
-                if (!overwrite) { skip.Add(candidateName); }
-            }
+            _databaseStateChanged = false;
         }
-
-        return skip;
+        else if (outcome.Removed)
+        {
+            _databaseStateChanged = true;
+        }
     }
 
     private void ToggleDatabase(string fileName)
@@ -422,69 +312,10 @@ public sealed partial class SettingsModal : ModalBase<bool>
 
     private async Task UpgradeEntry(string fileName)
     {
-        if (IsAnyUpgradeInFlight && !_entriesUpgrading.Contains(fileName)) { return; }
+        await Coordinator.UpgradeDatabaseAsync(fileName);
 
-        if (!_entriesUpgrading.Add(fileName)) { return; }
+        if (_disposed) { return; }
 
-        try
-        {
-            UpgradeBatchResult result;
-
-            try
-            {
-                result = await DatabaseService.UpgradeBatchAsync(
-                    [fileName],
-                    UpgradeProgressScope.SettingsTriggered);
-            }
-            catch (Exception ex)
-            {
-                if (_disposed) { return; }
-
-                try
-                {
-                    await AlertDialogService.ShowAlert("Database Upgrade Failed",
-                        $"An exception occurred while upgrading '{fileName}': {ex.Message}",
-                        "OK");
-                }
-                catch (ObjectDisposedException)
-                {
-                    // Alert dialog service was torn down with the modal; nothing to surface to.
-                }
-
-                return;
-            }
-
-            if (_disposed) { return; }
-
-            foreach (var failure in result.Failed)
-            {
-                try
-                {
-                    await AlertDialogService.ShowErrorAlert(
-                        "Database Upgrade Failed",
-                        $"Failed to upgrade '{failure.FileName}': {failure.Message}");
-                }
-                catch (ObjectDisposedException)
-                {
-                    return;
-                }
-            }
-        }
-        finally
-        {
-            _entriesUpgrading.Remove(fileName);
-
-            if (!_disposed)
-            {
-                try
-                {
-                    await InvokeAsync(StateHasChanged);
-                }
-                catch (ObjectDisposedException)
-                {
-                    // Modal was torn down between the _disposed check and the dispatcher call; safe to ignore.
-                }
-            }
-        }
+        await InvokeAsyncSafe();
     }
 }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Database/DatabaseOperationCoordinatorTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Database/DatabaseOperationCoordinatorTests.cs
@@ -1,0 +1,731 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.Banner;
+using EventLogExpert.Runtime.Common.Files;
+using EventLogExpert.Runtime.Database;
+using EventLogExpert.Runtime.Database.Upgrade;
+using EventLogExpert.Runtime.EventLog;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace EventLogExpert.Runtime.Tests.Database;
+
+public sealed class DatabaseOperationCoordinatorTests
+{
+    private readonly IDatabaseService _databases = Substitute.For<IDatabaseService>();
+    private readonly IErrorBannerService _errorBanners = Substitute.For<IErrorBannerService>();
+    private readonly IFilePickerService _filePicker = Substitute.For<IFilePickerService>();
+    private readonly IInfoBannerService _infoBanners = Substitute.For<IInfoBannerService>();
+    private readonly ITraceLogger _logger = Substitute.For<ITraceLogger>();
+    private readonly ILogReloadCoordinator _logReload = Substitute.For<ILogReloadCoordinator>();
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    [Fact]
+    public async Task ApplyPendingTogglesAsync_CancelledMidIteration_ThrowsAndDoesNotSilentlyApplyPrefix()
+    {
+        using var cts = new CancellationTokenSource();
+
+        _databases.When(x => x.Toggle("a.db")).Do(_ => cts.Cancel());
+
+        var sut = CreateSut();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            sut.ApplyPendingTogglesAsync(["a.db", "b.db", "c.db"], cts.Token));
+
+        _databases.Received(1).Toggle("a.db");
+        _databases.DidNotReceive().Toggle("b.db");
+        _databases.DidNotReceive().Toggle("c.db");
+    }
+
+    [Fact]
+    public async Task ApplyPendingTogglesAsync_EmptyInput_NoToggleCallsAndNoBanners()
+    {
+        var sut = CreateSut();
+        await sut.ApplyPendingTogglesAsync([], Ct);
+
+        _databases.DidNotReceiveWithAnyArgs().Toggle(null!);
+        _errorBanners.DidNotReceiveWithAnyArgs().ReportError(null!, null!);
+    }
+
+    [Fact]
+    public async Task ApplyPendingTogglesAsync_FiveFilesWithTwoFailures_AllAttemptedAndOneBannerPerFailure()
+    {
+        _databases.When(x => x.Toggle("c.db")).Do(_ => throw new InvalidOperationException("c failed"));
+        _databases.When(x => x.Toggle("e.db")).Do(_ => throw new InvalidOperationException("e failed"));
+
+        var sut = CreateSut();
+        await sut.ApplyPendingTogglesAsync(["a.db", "b.db", "c.db", "d.db", "e.db"], Ct);
+
+        _databases.Received(1).Toggle("a.db");
+        _databases.Received(1).Toggle("b.db");
+        _databases.Received(1).Toggle("c.db");
+        _databases.Received(1).Toggle("d.db");
+        _databases.Received(1).Toggle("e.db");
+        _errorBanners.Received(1).ReportError("Failed to Update Database", Arg.Is<string>(m => m.Contains("c.db", StringComparison.Ordinal)));
+        _errorBanners.Received(1).ReportError("Failed to Update Database", Arg.Is<string>(m => m.Contains("e.db", StringComparison.Ordinal)));
+        _errorBanners.Received(2).ReportError("Failed to Update Database", Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task ApplyPendingTogglesAsync_PreCancelledToken_ThrowsBeforeAnyToggleCall()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var sut = CreateSut();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            sut.ApplyPendingTogglesAsync(["a.db", "b.db"], cts.Token));
+
+        _databases.DidNotReceiveWithAnyArgs().Toggle(null!);
+        _errorBanners.DidNotReceiveWithAnyArgs().ReportError(null!, null!);
+    }
+
+    [Fact]
+    public void BuildImportSummary_AllFailedZeroImported_MessageJoinsWithSemicolonNotPeriodToPreserveLowercaseFragment()
+    {
+        var failures = new[] { new ImportFailure("A.db", "bad") };
+        var result = new ImportResult(0, failures, []);
+
+        var (_, message, _) = DatabaseOperationCoordinator.BuildImportSummary(result);
+
+        Assert.Contains("No databases were imported;", message, StringComparison.Ordinal);
+        Assert.DoesNotContain("imported. failed", message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData(0, 0, 0, (int)DatabaseOperationCoordinator.ResultSeverity.Info, "Import Successful")]
+    [InlineData(1, 0, 0, (int)DatabaseOperationCoordinator.ResultSeverity.Info, "Import Successful")]
+    [InlineData(3, 0, 0, (int)DatabaseOperationCoordinator.ResultSeverity.Info, "Import Successful")]
+    [InlineData(2, 1, 0, (int)DatabaseOperationCoordinator.ResultSeverity.Warning, "Import Completed with Errors")]
+    [InlineData(2, 0, 1, (int)DatabaseOperationCoordinator.ResultSeverity.Warning, "Import Completed with Errors")]
+    [InlineData(0, 1, 0, (int)DatabaseOperationCoordinator.ResultSeverity.Error, "Import Failed")]
+    public void BuildImportSummary_MapsSeverityCorrectly(
+        int imported, int failureCount, int upgradeFailureCount,
+        int expectedSeverityAsInt,
+        string expectedTitle)
+    {
+        var expectedSeverity = (DatabaseOperationCoordinator.ResultSeverity)expectedSeverityAsInt;
+        var failures = Enumerable.Range(0, failureCount)
+            .Select(i => new ImportFailure($"f{i}.db", "reason")).ToList();
+        var upgradeFailures = Enumerable.Range(0, upgradeFailureCount)
+            .Select(i => new ImportFailure($"u{i}.db", "reason")).ToList();
+        var result = new ImportResult(imported, failures, upgradeFailures);
+
+        var (title, _, severity) = DatabaseOperationCoordinator.BuildImportSummary(result);
+
+        Assert.Equal(expectedSeverity, severity);
+        Assert.Equal(expectedTitle, title);
+    }
+
+    [Fact]
+    public async Task ImportAsync_CallbackReturnsTrue_FileNotAddedToSkipSet()
+    {
+        _filePicker.PickMultipleAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>())
+            .Returns(["/path/exists.db"]);
+        _databases.Entries.Returns([CreateEntry("exists.db")]);
+        _databases.ImportAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<IReadOnlySet<string>>(), Arg.Any<CancellationToken>())
+            .Returns(new ImportResult(1, [], []));
+
+        var sut = CreateSut();
+        await sut.ImportAsync((_, _) => Task.FromResult(true), Ct);
+
+        await _databases.Received(1).ImportAsync(
+            Arg.Any<IEnumerable<string>>(),
+            Arg.Is<IReadOnlySet<string>>(s => !s.Contains("exists.db")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ImportAsync_CallbackThrowsNonCancellation_DefensiveSkipAndImportProceeds()
+    {
+        _filePicker.PickMultipleAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>())
+            .Returns(["/path/exists.db"]);
+        _databases.Entries.Returns([CreateEntry("exists.db")]);
+        _databases.ImportAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<IReadOnlySet<string>>(), Arg.Any<CancellationToken>())
+            .Returns(new ImportResult(0, [], []));
+
+        Task<bool> ThrowingCallback(string _, CancellationToken __) =>
+            Task.FromException<bool>(new InvalidOperationException("ui callback failed"));
+
+        var sut = CreateSut();
+        await sut.ImportAsync(ThrowingCallback, Ct);
+
+        // Conflict defaults to Skip (safer than overwrite); import still proceeds.
+        await _databases.Received(1).ImportAsync(
+            Arg.Any<IEnumerable<string>>(),
+            Arg.Is<IReadOnlySet<string>>(s => s.Contains("exists.db")),
+            Arg.Any<CancellationToken>());
+        _errorBanners.DidNotReceiveWithAnyArgs().ReportError(null!, null!);
+    }
+
+    [Fact]
+    public async Task ImportAsync_DatabaseServiceThrows_RoutesErrorBannerAndReturnsNone()
+    {
+        _filePicker.PickMultipleAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>())
+            .Returns(["/path/A.db"]);
+        _databases.Entries.Returns([]);
+        _databases.ImportAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<IReadOnlySet<string>>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("boom"));
+
+        var sut = CreateSut();
+        var outcome = await sut.ImportAsync(cancellationToken: Ct);
+
+        _errorBanners.Received(1).ReportError("Import Failed", Arg.Is<string>(m => m.Contains("boom", StringComparison.Ordinal)));
+        _infoBanners.DidNotReceiveWithAnyArgs().ReportInfoBanner(null!, null!, default);
+        Assert.Equal(ImportOutcome.None, outcome);
+    }
+
+    [Fact]
+    public async Task ImportAsync_DatabaseServiceThrowsOperationCanceled_NoBannerAndReturnsNone()
+    {
+        _filePicker.PickMultipleAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>())
+            .Returns(["/path/A.db"]);
+        _databases.Entries.Returns([]);
+        _databases.ImportAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<IReadOnlySet<string>>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException());
+
+        var sut = CreateSut();
+        var outcome = await sut.ImportAsync(cancellationToken: Ct);
+
+        _infoBanners.DidNotReceiveWithAnyArgs().ReportInfoBanner(null!, null!, default);
+        _errorBanners.DidNotReceiveWithAnyArgs().ReportError(null!, null!);
+        Assert.Equal(ImportOutcome.None, outcome);
+    }
+
+    [Fact]
+    public async Task ImportAsync_LongRunningImport_PostOpRoutesDirectlyToInfoBannerRegardlessOfCallerLifetime()
+    {
+        // Empty-body bug regression: the coordinator awaits the import then routes the summary
+        // directly to IInfoBannerService.ReportInfoBanner. No host lookup, no alert dialog service,
+        // so post-op routing is deterministic regardless of any modal lifetime.
+        var importTcs = new TaskCompletionSource<ImportResult>();
+        _filePicker.PickMultipleAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>())
+            .Returns(["/path/A.db"]);
+        _databases.Entries.Returns([]);
+        _databases.ImportAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<IReadOnlySet<string>>(), Arg.Any<CancellationToken>())
+            .Returns(importTcs.Task);
+
+        var sut = CreateSut();
+        var importTask = sut.ImportAsync(cancellationToken: Ct);
+        Assert.False(importTask.IsCompleted);
+        _infoBanners.DidNotReceiveWithAnyArgs().ReportInfoBanner(null!, null!, default);
+
+        importTcs.SetResult(new ImportResult(1, [], []));
+        var outcome = await importTask;
+
+        _infoBanners.Received(1).ReportInfoBanner(
+            "Import Successful",
+            Arg.Is<string>(m => m.Contains("1 database has successfully been imported", StringComparison.Ordinal)),
+            BannerSeverity.Info);
+        Assert.Equal(1, outcome.ImportedCount);
+    }
+
+    [Fact]
+    public async Task ImportAsync_NoFilesPicked_ReturnsNoneAndDoesNotInvokeDatabaseOrBanners()
+    {
+        _filePicker.PickMultipleAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>())
+            .Returns([]);
+
+        var sut = CreateSut();
+        var outcome = await sut.ImportAsync(cancellationToken: Ct);
+
+        Assert.Equal(ImportOutcome.None, outcome);
+        await _databases.DidNotReceive().ImportAsync(
+            Arg.Any<IEnumerable<string>>(), Arg.Any<IReadOnlySet<string>>(), Arg.Any<CancellationToken>());
+        _infoBanners.DidNotReceiveWithAnyArgs().ReportInfoBanner(null!, null!, default);
+        _errorBanners.DidNotReceiveWithAnyArgs().ReportError(null!, null!);
+    }
+
+    [Fact]
+    public async Task ImportAsync_NullCallbackWithExistingConflict_FileAddedToSkipSet()
+    {
+        _filePicker.PickMultipleAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>())
+            .Returns(["/path/exists.db"]);
+        _databases.Entries.Returns([CreateEntry("exists.db")]);
+        _databases.ImportAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<IReadOnlySet<string>>(), Arg.Any<CancellationToken>())
+            .Returns(new ImportResult(0, [], []));
+
+        var sut = CreateSut();
+        await sut.ImportAsync(askOverwriteAsync: null, cancellationToken: Ct);
+
+        await _databases.Received(1).ImportAsync(
+            Arg.Any<IEnumerable<string>>(),
+            Arg.Is<IReadOnlySet<string>>(s => s.Contains("exists.db")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ImportAsync_OverwriteCallbackThrowsOperationCanceled_AbortsImportNoBannerAndReturnsNone()
+    {
+        _filePicker.PickMultipleAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>())
+            .Returns(["/path/exists.db"]);
+        _databases.Entries.Returns([CreateEntry("exists.db")]);
+
+        Task<bool> CancellingCallback(string _, CancellationToken __) =>
+            Task.FromException<bool>(new OperationCanceledException());
+
+        var sut = CreateSut();
+        var outcome = await sut.ImportAsync(CancellingCallback, Ct);
+
+        await _databases.DidNotReceiveWithAnyArgs().ImportAsync(null!, null!, Ct);
+        _errorBanners.DidNotReceiveWithAnyArgs().ReportError(null!, null!);
+        _infoBanners.DidNotReceiveWithAnyArgs().ReportInfoBanner(null!, null!, default);
+        Assert.Equal(ImportOutcome.None, outcome);
+    }
+
+    [Fact]
+    public async Task ImportAsync_PreCancelledToken_ThrowsBeforeFilePickerOrConflictResolution()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var sut = CreateSut();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => sut.ImportAsync(cancellationToken: cts.Token));
+
+        await _filePicker.DidNotReceiveWithAnyArgs().PickMultipleAsync(null!, null!);
+        await _databases.DidNotReceiveWithAnyArgs().ImportAsync(null!, null!, Ct);
+        _infoBanners.DidNotReceiveWithAnyArgs().ReportInfoBanner(null!, null!, default);
+        _errorBanners.DidNotReceiveWithAnyArgs().ReportError(null!, null!);
+    }
+
+    [Theory]
+    [InlineData(1, 0, 0, "Import Successful", BannerSeverity.Info)]
+    [InlineData(3, 0, 0, "Import Successful", BannerSeverity.Info)]
+    [InlineData(2, 1, 0, "Import Completed with Errors", BannerSeverity.Warning)]
+    [InlineData(2, 0, 1, "Import Completed with Errors", BannerSeverity.Warning)]
+    public async Task ImportAsync_SuccessAndPartial_RoutesInfoBannerWithExpectedSeverity(
+        int imported, int failureCount, int upgradeFailureCount,
+        string expectedTitle, BannerSeverity expectedSeverity)
+    {
+        _filePicker.PickMultipleAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>())
+            .Returns(["/path/A.db"]);
+        _databases.Entries.Returns([]);
+        var failures = Enumerable.Range(0, failureCount).Select(i => new ImportFailure($"f{i}.db", "x")).ToList();
+        var upgradeFailures = Enumerable.Range(0, upgradeFailureCount).Select(i => new ImportFailure($"u{i}.db", "x")).ToList();
+        _databases.ImportAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<IReadOnlySet<string>>(), Arg.Any<CancellationToken>())
+            .Returns(new ImportResult(imported, failures, upgradeFailures));
+
+        var sut = CreateSut();
+        var outcome = await sut.ImportAsync(cancellationToken: Ct);
+
+        _infoBanners.Received(1).ReportInfoBanner(expectedTitle, Arg.Any<string>(), expectedSeverity);
+        _errorBanners.DidNotReceiveWithAnyArgs().ReportError(null!, null!);
+        Assert.Equal(imported, outcome.ImportedCount);
+        Assert.True(outcome.DatabaseStateChanged);
+    }
+
+    [Fact]
+    public async Task ImportAsync_TokenCancelledDuringConflictResolution_AbortsBeforeReachingDatabaseImport()
+    {
+        _filePicker.PickMultipleAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>())
+            .Returns(["/path/exists1.db", "/path/exists2.db", "/path/exists3.db"]);
+        _databases.Entries.Returns(
+        [
+            CreateEntry("exists1.db"),
+            CreateEntry("exists2.db"),
+            CreateEntry("exists3.db"),
+        ]);
+
+        using var cts = new CancellationTokenSource();
+
+        var promptedNames = new List<string>();
+        Task<bool> CancelOnFirstPrompt(string candidateName, CancellationToken _)
+        {
+            promptedNames.Add(candidateName);
+            cts.Cancel();
+
+            return Task.FromResult(false);
+        }
+
+        var sut = CreateSut();
+        var outcome = await sut.ImportAsync(CancelOnFirstPrompt, cts.Token);
+
+        await _databases.DidNotReceiveWithAnyArgs().ImportAsync(null!, null!, Ct);
+        Assert.Equal(ImportOutcome.None, outcome);
+        Assert.Single(promptedNames);
+    }
+
+    [Fact]
+    public async Task ImportAsync_ZeroImportedWithFailures_RoutesErrorBannerNotInfoBanner()
+    {
+        _filePicker.PickMultipleAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>())
+            .Returns(["/path/A.db"]);
+        _databases.Entries.Returns([]);
+        _databases.ImportAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<IReadOnlySet<string>>(), Arg.Any<CancellationToken>())
+            .Returns(new ImportResult(0, [new ImportFailure("A.db", "bad")], []));
+
+        var sut = CreateSut();
+        var outcome = await sut.ImportAsync(cancellationToken: Ct);
+
+        _errorBanners.Received(1).ReportError("Import Failed", Arg.Is<string>(m => m.Contains("A.db (bad)", StringComparison.Ordinal)));
+        _infoBanners.DidNotReceiveWithAnyArgs().ReportInfoBanner(null!, null!, default);
+        Assert.Equal(0, outcome.ImportedCount);
+        Assert.False(outcome.DatabaseStateChanged);
+    }
+
+    [Fact]
+    public async Task RemoveDatabaseAsync_DatabaseThrowsAfterSnapshotPopulated_SnapshotReopensAndErrorBannerReports()
+    {
+        // This is the R3-BLOCKER-fix invariant: even though the helper would swallow the exception,
+        // the bespoke RemoveDatabaseAsync executes the reopen path AFTER both catches.
+        _databases.Entries.Returns([CreateEntry("a.db")]);
+        _databases.RemoveAsync("a.db", Arg.Any<Func<CancellationToken, Task>?>(), Arg.Any<CancellationToken>())
+            .Returns(async call =>
+            {
+                var prepare = call.ArgAt<Func<CancellationToken, Task>?>(1);
+                if (prepare is not null) { await prepare(CancellationToken.None); }
+                throw new InvalidOperationException("removal failed mid-flight");
+            });
+        _logReload
+            .When(x => x.PrepareForDatabaseRemovalAsync(Arg.Any<LogReopenSnapshot>(), Arg.Any<CancellationToken>()))
+            .Do(call => call.ArgAt<LogReopenSnapshot>(0).Add(new LogReopenInfo("App", LogPathType.Channel)));
+
+        var sut = CreateSut();
+        var outcome = await sut.RemoveDatabaseAsync("a.db", (_, _) => Task.FromResult(true), Ct);
+
+        Assert.Equal(RemoveOutcomeStatus.Confirmed, outcome.Status);
+        Assert.False(outcome.Removed);
+        Assert.True(outcome.LogsReopened);
+        _logReload.Received(1).ReopenAfterDatabaseRemoval(Arg.Any<IReadOnlyList<LogReopenInfo>>());
+        _errorBanners.Received(1).ReportError(
+            "Failed to Remove Database",
+            Arg.Is<string>(m => m.Contains("removal failed mid-flight", StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public async Task RemoveDatabaseAsync_DatabaseThrowsOperationCanceledAfterSnapshotPopulated_SnapshotReopensWithoutErrorBanner()
+    {
+        _databases.Entries.Returns([CreateEntry("a.db")]);
+        _databases.RemoveAsync("a.db", Arg.Any<Func<CancellationToken, Task>?>(), Arg.Any<CancellationToken>())
+            .Returns(async call =>
+            {
+                var prepare = call.ArgAt<Func<CancellationToken, Task>?>(1);
+                if (prepare is not null) { await prepare(CancellationToken.None); }
+                throw new OperationCanceledException();
+            });
+        _logReload
+            .When(x => x.PrepareForDatabaseRemovalAsync(Arg.Any<LogReopenSnapshot>(), Arg.Any<CancellationToken>()))
+            .Do(call => call.ArgAt<LogReopenSnapshot>(0).Add(new LogReopenInfo("App", LogPathType.Channel)));
+
+        var sut = CreateSut();
+        var outcome = await sut.RemoveDatabaseAsync("a.db", (_, _) => Task.FromResult(true), Ct);
+
+        Assert.False(outcome.Removed);
+        Assert.True(outcome.LogsReopened);
+        _logReload.Received(1).ReopenAfterDatabaseRemoval(Arg.Any<IReadOnlyList<LogReopenInfo>>());
+        _errorBanners.DidNotReceiveWithAnyArgs().ReportError(null!, null!);
+    }
+
+    [Fact]
+    public async Task RemoveDatabaseAsync_FileNotInRegistry_ReturnsNotFoundWithoutDatabaseCall()
+    {
+        _databases.Entries.Returns([]);
+
+        var sut = CreateSut();
+        var outcome = await sut.RemoveDatabaseAsync("missing.db", (_, _) => Task.FromResult(true), Ct);
+
+        Assert.Equal(RemoveOutcomeStatus.NotFound, outcome.Status);
+        Assert.False(outcome.Confirmed);
+        Assert.False(outcome.Removed);
+        await _databases.DidNotReceiveWithAnyArgs().RemoveAsync(null!, null, Ct);
+    }
+
+    [Fact]
+    public async Task RemoveDatabaseAsync_NullCallback_ThrowsArgumentNullException()
+    {
+        var sut = CreateSut();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            sut.RemoveDatabaseAsync("a.db", null!, Ct));
+    }
+
+    [Fact]
+    public async Task RemoveDatabaseAsync_PreCancelledToken_ThrowsBeforeInvokingConfirmCallback()
+    {
+        _databases.Entries.Returns([CreateEntry("a.db")]);
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var callbackInvocations = 0;
+
+        var sut = CreateSut();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            sut.RemoveDatabaseAsync(
+                "a.db",
+                (_, _) =>
+                {
+                    callbackInvocations++;
+                    return Task.FromResult(true);
+                },
+                cts.Token));
+
+        Assert.Equal(0, callbackInvocations);
+        await _databases.DidNotReceiveWithAnyArgs().RemoveAsync(null!, null, Ct);
+        _errorBanners.DidNotReceiveWithAnyArgs().ReportError(null!, null!);
+    }
+
+    [Theory]
+    [InlineData("callback-false")]
+    [InlineData("callback-oce")]
+    [InlineData("callback-throws-non-oce")]
+    public async Task RemoveDatabaseAsync_RefusedConfirmation_ReturnsNotConfirmedAndDoesNotCallDatabase(string scenario)
+    {
+        _databases.Entries.Returns([CreateEntry("a.db")]);
+
+        Func<bool, CancellationToken, Task<bool>> callback = scenario switch
+        {
+            "callback-false" => (_, _) => Task.FromResult(false),
+            "callback-oce" => (_, _) => Task.FromException<bool>(new OperationCanceledException()),
+            "callback-throws-non-oce" => (_, _) => Task.FromException<bool>(new InvalidOperationException("ui failed")),
+            _ => throw new InvalidOperationException(scenario),
+        };
+
+        var sut = CreateSut();
+        var outcome = await sut.RemoveDatabaseAsync("a.db", callback, Ct);
+
+        Assert.Equal(RemoveOutcomeStatus.NotConfirmed, outcome.Status);
+        await _databases.DidNotReceiveWithAnyArgs().RemoveAsync(null!, null, Ct);
+        _logReload.DidNotReceiveWithAnyArgs().ReopenAfterDatabaseRemoval(null!);
+        _errorBanners.DidNotReceiveWithAnyArgs().ReportError(null!, null!);
+    }
+
+    [Fact]
+    public async Task RemoveDatabaseAsync_SuccessNoClosedLogs_ReturnsRemovedNoReopen()
+    {
+        _databases.Entries.Returns([CreateEntry("a.db")]);
+        _databases.RemoveAsync("a.db", Arg.Any<Func<CancellationToken, Task>?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        var sut = CreateSut();
+        var outcome = await sut.RemoveDatabaseAsync("a.db", (_, _) => Task.FromResult(true), Ct);
+
+        Assert.Equal(RemoveOutcomeStatus.Confirmed, outcome.Status);
+        Assert.True(outcome.Removed);
+        Assert.False(outcome.LogsReopened);
+        await _databases.Received(1).RemoveAsync("a.db", Arg.Any<Func<CancellationToken, Task>?>(), Arg.Any<CancellationToken>());
+        _logReload.DidNotReceiveWithAnyArgs().ReopenAfterDatabaseRemoval(null!);
+    }
+
+    [Fact]
+    public async Task RemoveDatabaseAsync_SuccessWithClosedLogs_ReopensLogsAndReportsReopened()
+    {
+        _databases.Entries.Returns([CreateEntry("a.db")]);
+        _databases.RemoveAsync("a.db", Arg.Any<Func<CancellationToken, Task>?>(), Arg.Any<CancellationToken>())
+            .Returns(async call =>
+            {
+                var prepare = call.ArgAt<Func<CancellationToken, Task>?>(1);
+                if (prepare is not null) { await prepare(CancellationToken.None); }
+            });
+        _logReload
+            .When(x => x.PrepareForDatabaseRemovalAsync(Arg.Any<LogReopenSnapshot>(), Arg.Any<CancellationToken>()))
+            .Do(call => call.ArgAt<LogReopenSnapshot>(0).Add(new LogReopenInfo("Application", LogPathType.Channel)));
+
+        var sut = CreateSut();
+        var outcome = await sut.RemoveDatabaseAsync("a.db", (_, _) => Task.FromResult(true), Ct);
+
+        Assert.True(outcome.Removed);
+        Assert.True(outcome.LogsReopened);
+        _logReload.Received(1).ReopenAfterDatabaseRemoval(
+            Arg.Is<IReadOnlyList<LogReopenInfo>>(l => l.Count == 1 && l[0].Name == "Application"));
+        _errorBanners.DidNotReceiveWithAnyArgs().ReportError(null!, null!);
+    }
+
+    [Theory]
+    [InlineData(true, DatabaseStatus.Ready, true, true)]     // enabled+ready+activeLogs → warning
+    [InlineData(true, DatabaseStatus.Ready, false, false)]   // enabled+ready, no activeLogs → no warning
+    [InlineData(false, DatabaseStatus.Ready, true, false)]   // disabled+activeLogs → no warning
+    [InlineData(true, DatabaseStatus.UpgradeRequired, true, false)] // enabled but not-ready+activeLogs → no warning
+    public async Task RemoveDatabaseAsync_WarningFlag_DerivesFromEnabledStatusAndActiveLogs(
+        bool isEnabled, DatabaseStatus status, bool hasActiveLogs, bool expectedWarning)
+    {
+        _databases.Entries.Returns([CreateEntry("a.db", isEnabled, status)]);
+        _logReload.HasActiveLogs.Returns(hasActiveLogs);
+
+        bool? receivedFlag = null;
+
+        var sut = CreateSut();
+        await sut.RemoveDatabaseAsync("a.db", (showWarning, _) =>
+        {
+            receivedFlag = showWarning;
+            return Task.FromResult(false);
+        }, Ct);
+
+        Assert.Equal(expectedWarning, receivedFlag);
+    }
+
+    [Fact]
+    public async Task UpgradeDatabaseAsync_DatabaseThrows_ReportsErrorBannerAndClearsStateAndRaisesExit()
+    {
+        _databases.UpgradeBatchAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<UpgradeProgressScope>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("upgrade body failed"));
+
+        var sut = CreateSut();
+        int stateChangeCount = 0;
+        sut.UpgradeStateChanged += () => stateChangeCount++;
+
+        await sut.UpgradeDatabaseAsync("a.db", cancellationToken: Ct);
+
+        Assert.False(sut.IsAnyUpgradeInFlight);
+        Assert.Equal(2, stateChangeCount);
+        _errorBanners.Received(1).ReportError(
+            "Database Upgrade Failed",
+            Arg.Is<string>(m => m.Contains("upgrade body failed", StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public async Task UpgradeDatabaseAsync_OperationCancelled_NoBannerAndStateCleared()
+    {
+        _databases.UpgradeBatchAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<UpgradeProgressScope>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException());
+
+        var sut = CreateSut();
+        await sut.UpgradeDatabaseAsync("a.db", cancellationToken: Ct);
+
+        Assert.False(sut.IsAnyUpgradeInFlight);
+        _errorBanners.DidNotReceiveWithAnyArgs().ReportError(null!, null!);
+    }
+
+    [Fact]
+    public async Task UpgradeDatabaseAsync_PreCancelledToken_ThrowsBeforeAcquiringLockOrRaisingEvents()
+    {
+        using var cts = new CancellationTokenSource();
+
+        cts.Cancel();
+
+        var sut = CreateSut();
+        int stateChangeCount = 0;
+        sut.UpgradeStateChanged += () => stateChangeCount++;
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            sut.UpgradeDatabaseAsync("a.db", cancellationToken: cts.Token));
+
+        Assert.Equal(0, stateChangeCount);
+        Assert.False(sut.IsAnyUpgradeInFlight);
+        await _databases.DidNotReceiveWithAnyArgs().UpgradeBatchAsync(default!, default, Ct);
+    }
+
+    [Fact]
+    public async Task UpgradeDatabaseAsync_ResultFailedPopulated_ReportsOneErrorBannerPerFailure()
+    {
+        _databases.UpgradeBatchAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<UpgradeProgressScope>(), Arg.Any<CancellationToken>())
+            .Returns(new UpgradeBatchResult([], [], [
+                new UpgradeFailure("a.db", "schema-mismatch"),
+                new UpgradeFailure("b.db", "io-error"),
+            ]));
+
+        var sut = CreateSut();
+        await sut.UpgradeDatabaseAsync("a.db", cancellationToken: Ct);
+
+        _errorBanners.Received(1).ReportError("Database Upgrade Failed", Arg.Is<string>(m => m.Contains("a.db", StringComparison.Ordinal) && m.Contains("schema-mismatch", StringComparison.Ordinal)));
+        _errorBanners.Received(1).ReportError("Database Upgrade Failed", Arg.Is<string>(m => m.Contains("b.db", StringComparison.Ordinal) && m.Contains("io-error", StringComparison.Ordinal)));
+    }
+
+    [Theory]
+    [InlineData("a.db")]   // re-entrant same file
+    [InlineData("b.db")]   // different file (current behavior: block)
+    public async Task UpgradeDatabaseAsync_SecondCallWhileFirstInFlight_NoOpsAndDoesNotInvokeDatabase(string secondFile)
+    {
+        var upgradeTcs = new TaskCompletionSource<UpgradeBatchResult>();
+        _databases.UpgradeBatchAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<UpgradeProgressScope>(), Arg.Any<CancellationToken>())
+            .Returns(upgradeTcs.Task);
+
+        var sut = CreateSut();
+        var firstCall = sut.UpgradeDatabaseAsync("a.db", cancellationToken: Ct);
+        Assert.True(sut.IsUpgradeInFlight("a.db"));
+
+        await sut.UpgradeDatabaseAsync(secondFile, cancellationToken: Ct);
+
+        Assert.True(sut.IsUpgradeInFlight("a.db"));
+        if (secondFile != "a.db") { Assert.False(sut.IsUpgradeInFlight(secondFile)); }
+
+        upgradeTcs.SetResult(new UpgradeBatchResult([], [], []));
+        await firstCall;
+
+        await _databases.Received(1).UpgradeBatchAsync(
+            Arg.Any<IReadOnlyList<string>>(), Arg.Any<UpgradeProgressScope>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpgradeDatabaseAsync_StateChangedSubscriberThrows_StateStillClearedAndUpgradeBodyRan()
+    {
+        // RaiseSafely invariant (parallels BannerService.RaiseSafely): one bad subscriber must not
+        // wedge the upgrade-in-flight HashSet and must not skip the upgrade body.
+        _databases.UpgradeBatchAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<UpgradeProgressScope>(), Arg.Any<CancellationToken>())
+            .Returns(new UpgradeBatchResult([], [], []));
+
+        var sut = CreateSut();
+        sut.UpgradeStateChanged += () => throw new InvalidOperationException("subscriber threw");
+
+        await sut.UpgradeDatabaseAsync("a.db", cancellationToken: Ct);
+
+        Assert.False(sut.IsAnyUpgradeInFlight);
+        Assert.False(sut.IsUpgradeInFlight("a.db"));
+        await _databases.Received(1).UpgradeBatchAsync(
+            Arg.Is<IReadOnlyList<string>>(l => l.Count == 1 && l[0] == "a.db"),
+            Arg.Any<UpgradeProgressScope>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ===== UpgradeDatabaseAsync =====
+    //
+    // The behavioral contract:
+    // - Upgrade success → IsUpgradeInFlight(file) true during, false after; UpgradeStateChanged fires enter+exit.
+    // - Re-entrant same-file → second call no-ops (no DB call).
+    // - Different-file while one in-flight → second call no-ops (preserve current global-block).
+    // - DB throws → ErrorBanner; state cleared; subscriber-safe; event still fires exit.
+    // - DB throws OCE → silent (no banner); state cleared.
+    // - Result.Failed → one ErrorBanner per failure.
+    // - Throwing subscriber → state still cleared; upgrade body still ran (BannerService.RaiseSafely parity).
+
+    [Fact]
+    public async Task UpgradeDatabaseAsync_Success_TracksInFlightStateAndRaisesEnterExitEvents()
+    {
+        _databases.UpgradeBatchAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<UpgradeProgressScope>(), Arg.Any<CancellationToken>())
+            .Returns(new UpgradeBatchResult([], [], []));
+
+        var sut = CreateSut();
+        bool wasInFlightDuringEnter = false;
+        bool wasInFlightDuringExit = false;
+        bool enterFired = false;
+        sut.UpgradeStateChanged += () =>
+        {
+            if (!enterFired)
+            {
+                enterFired = true;
+                wasInFlightDuringEnter = sut.IsUpgradeInFlight("a.db");
+            }
+            else
+            {
+                wasInFlightDuringExit = sut.IsUpgradeInFlight("a.db");
+            }
+        };
+
+        await sut.UpgradeDatabaseAsync("a.db", cancellationToken: Ct);
+
+        Assert.True(wasInFlightDuringEnter, "Enter event should fire while file is in-flight");
+        Assert.False(wasInFlightDuringExit, "Exit event should fire after file is removed");
+        Assert.False(sut.IsAnyUpgradeInFlight);
+        await _databases.Received(1).UpgradeBatchAsync(
+            Arg.Is<IReadOnlyList<string>>(l => l.Count == 1 && l[0] == "a.db"),
+            UpgradeProgressScope.SettingsTriggered,
+            Arg.Any<CancellationToken>());
+    }
+
+    private static DatabaseEntry CreateEntry(
+        string fileName,
+        bool isEnabled = true,
+        DatabaseStatus status = DatabaseStatus.Ready) =>
+        new(fileName, $"C:/db/{fileName}", isEnabled, status);
+
+    private DatabaseOperationCoordinator CreateSut() =>
+        new(_databases, _infoBanners, _errorBanners, _filePicker, _logReload, _logger);
+}
+

--- a/tests/Unit/EventLogExpert.Runtime.Tests/DependencyInjection/RuntimeServiceCollectionExtensionsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/DependencyInjection/RuntimeServiceCollectionExtensionsTests.cs
@@ -117,6 +117,7 @@ public sealed class RuntimeServiceCollectionExtensionsTests
     [InlineData(typeof(IInfoBannerService))]
     [InlineData(typeof(IDatabaseService))]
     [InlineData(typeof(IActiveDatabases))]
+    [InlineData(typeof(IDatabaseOperationCoordinator))]
     [InlineData(typeof(IModalCoordinator))]
     [InlineData(typeof(ILogWatcherService))]
     [InlineData(typeof(IMenuService))]
@@ -148,6 +149,7 @@ public sealed class RuntimeServiceCollectionExtensionsTests
         services.AddSingleton(Substitute.For<ITitleProvider>());
         services.AddSingleton(Substitute.For<IMainThreadService>());
         services.AddSingleton(Substitute.For<IWindowsIdentityProvider>());
+        services.AddSingleton(Substitute.For<IFilePickerService>());
         services.AddSingleton(Substitute.For<IState<EventLogState>>());
         services.AddSingleton(Substitute.For<IStateSelection<EventLogState, bool>>());
         services.AddSingleton(new FileLocationOptions(Path.Combine(Path.GetTempPath(), "EventLogExpertTests")));
@@ -178,6 +180,7 @@ public sealed class RuntimeServiceCollectionExtensionsTests
         services.AddSingleton(Substitute.For<ITitleProvider>());
         services.AddSingleton(Substitute.For<IMainThreadService>());
         services.AddSingleton(Substitute.For<IWindowsIdentityProvider>());
+        services.AddSingleton(Substitute.For<IFilePickerService>());
         services.AddSingleton(Substitute.For<IState<EventLogState>>());
         services.AddSingleton(Substitute.For<IStateSelection<EventLogState, bool>>());
         services.AddSingleton(new FileLocationOptions(Path.Combine(Path.GetTempPath(), "EventLogExpertTests")));

--- a/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/DatabaseCoordinationEffectsReloadTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/DatabaseCoordinationEffectsReloadTests.cs
@@ -1,0 +1,251 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.EventLog;
+using Fluxor;
+using NSubstitute;
+using System.Collections.Immutable;
+using IDispatcher = Fluxor.IDispatcher;
+
+namespace EventLogExpert.Runtime.Tests.EventLog;
+
+public sealed class DatabaseCoordinationEffectsReloadTests
+{
+    private readonly LogCloseCoordinator _closeCoordinator = new();
+    private readonly IDispatcher _dispatcher = Substitute.For<IDispatcher>();
+    private readonly IEventLogCommands _eventLogCommands = Substitute.For<IEventLogCommands>();
+    private readonly IState<EventLogState> _eventLogState = Substitute.For<IState<EventLogState>>();
+    private readonly ITraceLogger _logger = Substitute.For<ITraceLogger>();
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    [Fact]
+    public void HasActiveLogs_NoActiveLogs_ReturnsFalse()
+    {
+        _eventLogState.Value.Returns(new EventLogState { ActiveLogs = ImmutableDictionary<string, EventLogData>.Empty });
+
+        var sut = CreateSut();
+
+        Assert.False(sut.HasActiveLogs);
+    }
+
+    [Fact]
+    public void HasActiveLogs_OneActiveLog_ReturnsTrue()
+    {
+        var log = new EventLogData("Application", LogPathType.Channel, []);
+        _eventLogState.Value.Returns(new EventLogState
+        {
+            ActiveLogs = ImmutableDictionary<string, EventLogData>.Empty.Add("Application", log),
+        });
+
+        var sut = CreateSut();
+
+        Assert.True(sut.HasActiveLogs);
+    }
+
+    [Fact]
+    public async Task PrepareForDatabaseRemovalAsync_CancelledBeforeEntry_ThrowsAndDoesNotMutateSnapshot()
+    {
+        var logA = new EventLogData("Application", LogPathType.Channel, []);
+        _eventLogState.Value.Returns(new EventLogState
+        {
+            ActiveLogs = ImmutableDictionary<string, EventLogData>.Empty.Add("Application", logA),
+        });
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var snapshot = new LogReopenSnapshot();
+        var sut = CreateSut();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            sut.PrepareForDatabaseRemovalAsync(snapshot, cts.Token));
+
+        Assert.Empty(snapshot.Items);
+        _dispatcher.DidNotReceiveWithAnyArgs().Dispatch(null!);
+    }
+
+    [Fact]
+    public async Task PrepareForDatabaseRemovalAsync_CloseFailureMidwayDispatchesAllAndSnapshotsAllDispatchedLogsForCallerReopen()
+    {
+        var logA = new EventLogData("Application", LogPathType.Channel, []);
+        var logB = new EventLogData("Security", LogPathType.Channel, []);
+        var logC = new EventLogData("System", LogPathType.Channel, []);
+        _eventLogState.Value.Returns(new EventLogState
+        {
+            ActiveLogs = ImmutableDictionary<string, EventLogData>.Empty
+                .Add("Application", logA)
+                .Add("Security", logB)
+                .Add("System", logC),
+        });
+
+        using var cts = new CancellationTokenSource();
+        _dispatcher.When(d => d.Dispatch(Arg.Any<CloseLogAction>())).Do(call =>
+        {
+            var action = (CloseLogAction)call.Args()[0];
+
+            if (action.LogName == "Application")
+            {
+                _closeCoordinator.CompleteCloseFor(action.LogId);
+
+                return;
+            }
+
+            if (action.LogName == "Security") { cts.Cancel(); }
+        });
+
+        var snapshot = new LogReopenSnapshot();
+        var sut = CreateSut();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            sut.PrepareForDatabaseRemovalAsync(snapshot, cts.Token));
+
+        var snapshotNames = snapshot.Items.Select(i => i.Name).ToHashSet();
+        Assert.Contains("Application", snapshotNames);
+        Assert.Contains("Security", snapshotNames);
+        Assert.Contains("System", snapshotNames);
+        Assert.Equal(3, snapshot.Items.Count);
+    }
+
+    [Fact]
+    public async Task ReloadAllActiveLogsAsync_CalledSequentiallyTwice_CoordinatorLockReleasedBetweenCallsAndBothComplete()
+    {
+        var logA = new EventLogData("Application", LogPathType.Channel, []);
+        _eventLogState.Value.Returns(new EventLogState
+        {
+            ActiveLogs = ImmutableDictionary<string, EventLogData>.Empty.Add("Application", logA),
+        });
+
+        _dispatcher.When(d => d.Dispatch(Arg.Any<CloseLogAction>())).Do(call =>
+        {
+            var action = (CloseLogAction)call.Args()[0];
+            _closeCoordinator.CompleteCloseFor(action.LogId);
+        });
+
+        var sut = CreateSut();
+        await sut.ReloadAllActiveLogsAsync(Ct);
+        await sut.ReloadAllActiveLogsAsync(Ct).WaitAsync(TimeSpan.FromSeconds(5), Ct);
+
+        _dispatcher.Received(2).Dispatch(Arg.Any<CloseLogAction>());
+        _eventLogCommands.Received(2).OpenLog("Application", LogPathType.Channel, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ReloadAllActiveLogsAsync_CancelledBeforeEntry_ThrowsAndDoesNotMutateLogState()
+    {
+        var logA = new EventLogData("Application", LogPathType.Channel, []);
+        _eventLogState.Value.Returns(new EventLogState
+        {
+            ActiveLogs = ImmutableDictionary<string, EventLogData>.Empty.Add("Application", logA),
+        });
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var sut = CreateSut();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => sut.ReloadAllActiveLogsAsync(cts.Token));
+
+        _dispatcher.DidNotReceiveWithAnyArgs().Dispatch(null!);
+        _eventLogCommands.DidNotReceiveWithAnyArgs().OpenLog(null!, default, Ct);
+    }
+
+    [Fact]
+    public async Task ReloadAllActiveLogsAsync_CloseCompletionNeverSignaledAndTokenCancelled_ThrowsAfterBestEffortReopen()
+    {
+        var logA = new EventLogData("Application", LogPathType.Channel, []);
+        _eventLogState.Value.Returns(new EventLogState
+        {
+            ActiveLogs = ImmutableDictionary<string, EventLogData>.Empty.Add("Application", logA),
+        });
+
+        using var cts = new CancellationTokenSource();
+        _dispatcher.When(d => d.Dispatch(Arg.Any<CloseLogAction>())).Do(_ => cts.Cancel());
+
+        var sut = CreateSut();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => sut.ReloadAllActiveLogsAsync(cts.Token));
+
+        _eventLogCommands.Received(1).OpenLog("Application", LogPathType.Channel, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ReloadAllActiveLogsAsync_CloseThrowsThenSubsequentCallProceeds_LockReleasedOnFailurePath()
+    {
+        var logA = new EventLogData("Application", LogPathType.Channel, []);
+        _eventLogState.Value.Returns(new EventLogState
+        {
+            ActiveLogs = ImmutableDictionary<string, EventLogData>.Empty.Add("Application", logA),
+        });
+
+        var signalCompletionOnDispatch = false;
+
+        _dispatcher.When(d => d.Dispatch(Arg.Any<CloseLogAction>())).Do(call =>
+        {
+            if (!signalCompletionOnDispatch) { return; }
+
+            var action = (CloseLogAction)call.Args()[0];
+            _closeCoordinator.CompleteCloseFor(action.LogId);
+        });
+
+        var sut = CreateSut();
+
+        using (var cts = new CancellationTokenSource())
+        {
+            cts.CancelAfter(TimeSpan.FromMilliseconds(50));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => sut.ReloadAllActiveLogsAsync(cts.Token));
+        }
+
+        signalCompletionOnDispatch = true;
+        await sut.ReloadAllActiveLogsAsync(Ct).WaitAsync(TimeSpan.FromSeconds(5), Ct);
+
+        _eventLogCommands.Received(2).OpenLog("Application", LogPathType.Channel, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ReloadAllActiveLogsAsync_NoActiveLogs_DoesNotDispatchOrOpen()
+    {
+        _eventLogState.Value.Returns(new EventLogState { ActiveLogs = ImmutableDictionary<string, EventLogData>.Empty });
+
+        var sut = CreateSut();
+        await sut.ReloadAllActiveLogsAsync(Ct);
+
+        _dispatcher.DidNotReceiveWithAnyArgs().Dispatch(null!);
+        _eventLogCommands.DidNotReceiveWithAnyArgs().OpenLog(null!, default, Ct);
+    }
+
+    [Fact]
+    public async Task ReloadAllActiveLogsAsync_TwoActiveLogs_DispatchesPerLogCloseAndAwaitsCompletionBeforeOpening()
+    {
+        var logA = new EventLogData("Application", LogPathType.Channel, []);
+        var logB = new EventLogData("C:/path/security.evtx", LogPathType.File, []);
+        _eventLogState.Value.Returns(new EventLogState
+        {
+            ActiveLogs = ImmutableDictionary<string, EventLogData>.Empty
+                .Add("Application", logA)
+                .Add("C:/path/security.evtx", logB),
+        });
+
+        _dispatcher.When(d => d.Dispatch(Arg.Any<CloseLogAction>())).Do(call =>
+        {
+            var action = (CloseLogAction)call.Args()[0];
+            _closeCoordinator.CompleteCloseFor(action.LogId);
+        });
+
+        var sut = CreateSut();
+        await sut.ReloadAllActiveLogsAsync(Ct);
+
+        _dispatcher.Received(1).Dispatch(Arg.Is<CloseLogAction>(a => a.LogName == "Application"));
+        _dispatcher.Received(1).Dispatch(Arg.Is<CloseLogAction>(a => a.LogName == "C:/path/security.evtx"));
+        _dispatcher.DidNotReceive().Dispatch(Arg.Any<CloseAllLogsAction>());
+        _eventLogCommands.Received(1).OpenLog("Application", LogPathType.Channel, Arg.Any<CancellationToken>());
+        _eventLogCommands.Received(1).OpenLog("C:/path/security.evtx", LogPathType.File, Arg.Any<CancellationToken>());
+    }
+
+    private DatabaseCoordinationEffects CreateSut() =>
+        new(_eventLogState, _logger, _closeCoordinator, _dispatcher, _eventLogCommands);
+}
+

--- a/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EffectsTests.cs
@@ -1719,7 +1719,8 @@ public sealed class EffectsTests
             eventLogState,
             logger,
             closeCoordinator,
-            dispatcher);
+            dispatcher,
+            Substitute.For<IEventLogCommands>());
 
         return new EffectsHarness(
             filtering,


### PR DESCRIPTION
Extracts `ImportDatabase` / `RemoveDatabase` / upgrade orchestration out of `SettingsModal` into a new runtime-tier `IDatabaseOperationCoordinator`. Fixes the empty-body alert bug (Settings closes before import completes → result rendered into stale inline-host) by routing post-operation summaries directly to banner facets (no host lookup, no popup fallback).

**PR 8 of 9** in the IModalCoordinator SoC refactor series. Strict-SoC scope per user direction.

## Highlights

- New `IDatabaseOperationCoordinator` (Runtime tier, singleton, `internal sealed` impl) owns Import / Remove / Upgrade / ApplyPendingToggles.
- Modal becomes a thin delegating shell with `_disposed` guards and `ObjectDisposedException`-tolerant `InvokeAsyncSafe()` helper.
- Interactive prompts (overwrite, remove confirm, reload prompt) use inherited `ModalBase.ShowInlineAlertAsync` directly — wrong-modal risk eliminated by construction.
- Both callback parameters (`askOverwriteAsync`, `confirmRemoveAsync`) defensively catch non-OCE exceptions (Skip / NotConfirmed) — symmetric pattern across both call sites.
- Upgrade in-flight tracking via `lock + HashSet` preserves current global-block; `RaiseUpgradeStateChangedSafely` mirrors `BannerService.RaiseSafely` so a throwing subscriber cannot wedge state.
- `ILogReloadCoordinator` extended with `HasActiveLogs` + `ReloadAllActiveLogsAsync` (snapshot-before-close); `DatabaseCoordinationEffects` accepts `IEventLogCommands`.
- `ImportOutcome` / `RemoveOutcome` (record structs) with static factories (`None`, `NotFound`, `NotConfirmed`) + `RemoveOutcomeStatus` enum.
- `RunOperationAsync<T>` + non-generic `Task` overload covers Import / Upgrade / Toggle. `RemoveDatabaseAsync` deviates with bespoke try/catch — documented inline; snapshot-reopen-on-failure must execute outside the helper's swallowing catch.

## Tests

- Unit: 2,321 passing (+31 net new — coordinator, summary, effects, DI smoke)
- Integration: Runtime 124, EventDbTool 0 (no tests), Eventing 303 (+2 skipped)

## Out of scope (deferred)

41 non-lifetime Settings UI findings surfaced by the 4-slot UI panel (IA reorganization, empty state, row affordances, spacing, a11y plumbing). Tracked as PR 10 in the session plan.
