### PR TITLE
PR 10 Commit A: AttentionBanner label + Settings focus ring + inline-alert z-index

### DIFF
--- a/src/EventLogExpert.UI/Modal/ModalChrome.razor.css
+++ b/src/EventLogExpert.UI/Modal/ModalChrome.razor.css
@@ -61,6 +61,7 @@ dialog:not(:modal) {
 .inline-alert-overlay {
     position: absolute;
     inset: 0;
+    z-index: 2;
 
     background-color: var(--overlay-dim);
 }
@@ -70,6 +71,7 @@ dialog:not(:modal) {
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
+    z-index: 3;
 
     display: flex;
     flex-direction: column;

--- a/src/EventLogExpert.UI/Settings/SettingsModal.razor.css
+++ b/src/EventLogExpert.UI/Settings/SettingsModal.razor.css
@@ -6,6 +6,11 @@
     height: 100%;
 }
 
+/* Padding so :focus-visible rings are not clipped by the ancestor overflow-hidden utility. */
+.settings-form > .flex-column-scroll {
+    padding: .5rem;
+}
+
 .tz-row { margin-bottom: .5rem; }
 
 .fixed-width { width: 50px; }


### PR DESCRIPTION
Polish on top of #553 stack: small fixes addressed across 3 cosmetic surfaces.

## Changes
- `AttentionBanner` action text: `Open Settings` → `Open Databases` (and flipped `IMenuActionService.OpenDatabaseToolsAsync()` signature from `Task` → `Task<bool>` so MauiMenuActionService surfaces the previously-discarded bool)
- Settings ValueSelect `:focus-visible` rings no longer clipped (added .5rem padding on `.settings-form > .flex-column-scroll`)
- Inline-alert overlay paired z-index (overlay:2 + alert:3) above sticky save-strip (z-index:1)

## Stack
This PR is the first of three stacked on top of #553. Order:
1. #553 (foundation: IA + DatabaseToolsModal extraction)
2. **This PR** (polish — Commit A)
3. PR for Commits B+C+D (banners — closes #526)
4. PR for Commits E+F (database row UX — closes #525)

## Tests
- UI: 253 (existing AttentionBanner / BannerHost tests renamed)
- All green