### PR TITLE
Fix banner selection drift, priority watermark, and per-row Remove guard for pre-progress and queued upgrade batches

### DIFF
--- a/src/EventLogExpert.Runtime/Banner/BannerProgressEntry.cs
+++ b/src/EventLogExpert.Runtime/Banner/BannerProgressEntry.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Runtime.Database.Upgrade;
+using System.Collections.Frozen;
 
 namespace EventLogExpert.Runtime.Banner;
 
@@ -13,4 +14,10 @@ public sealed record BannerProgressEntry(
     string CurrentEntryName,
     UpgradePhase CurrentPhase,
     int QueuedBatchesAfter,
-    Action Cancel);
+    Action Cancel)
+{
+    private static readonly FrozenSet<string> s_emptyCaseInsensitive =
+        FrozenSet.ToFrozenSet<string>([], StringComparer.OrdinalIgnoreCase);
+
+    public IReadOnlySet<string> BatchFileNames { get; init; } = s_emptyCaseInsensitive;
+}

--- a/src/EventLogExpert.Runtime/Banner/BannerService.cs
+++ b/src/EventLogExpert.Runtime/Banner/BannerService.cs
@@ -4,6 +4,7 @@
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Runtime.Database;
 using EventLogExpert.Runtime.Database.Upgrade;
+using System.Collections.Frozen;
 using System.Collections.Immutable;
 
 namespace EventLogExpert.Runtime.Banner;
@@ -433,7 +434,10 @@ internal sealed class BannerService
             string.Empty,
             UpgradePhase.BackingUp,
             _databaseService.QueuedBatchCount,
-            args.Cancel);
+            args.Cancel)
+        {
+            BatchFileNames = args.FileNames.ToFrozenSet(StringComparer.OrdinalIgnoreCase)
+        };
 
         lock (_stateLock)
         {

--- a/src/EventLogExpert.Runtime/Database/DatabaseService.cs
+++ b/src/EventLogExpert.Runtime/Database/DatabaseService.cs
@@ -100,6 +100,9 @@ internal sealed class DatabaseService(
     public Task RetryClassificationAsync(string fileName, CancellationToken cancellationToken = default) =>
         _classificationService.RetryClassificationAsync(fileName, cancellationToken);
 
+    public IReadOnlyList<QueuedBatchInfo> SnapshotQueuedBatches() =>
+        _upgradeService.SnapshotQueuedBatches();
+
     public void Toggle(string fileName) => _registry.Toggle(fileName);
 
     public Task<UpgradeBatchResult> UpgradeBatchAsync(

--- a/src/EventLogExpert.Runtime/Database/DatabaseUpgradeService.cs
+++ b/src/EventLogExpert.Runtime/Database/DatabaseUpgradeService.cs
@@ -5,6 +5,8 @@ using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Provider.Maintenance;
 using EventLogExpert.Provider.Schema;
 using EventLogExpert.Runtime.Database.Upgrade;
+using System.Collections.Concurrent;
+using System.Collections.Frozen;
 using System.Threading.Channels;
 
 namespace EventLogExpert.Runtime.Database;
@@ -15,6 +17,7 @@ internal sealed class DatabaseUpgradeService : IAsyncDisposable
     private readonly CancellationTokenSource _disposeCts = new();
     private readonly Task _initialClassificationTask;
     private readonly IProviderDatabaseMaintenance _maintenance;
+    private readonly ConcurrentDictionary<UpgradeBatchId, UpgradeBatch> _queuedBatches = new();
     private readonly DatabaseRegistry _registry;
     private readonly ITraceLogger _traceLogger;
     private readonly Channel<UpgradeBatch> _upgradeQueue = Channel.CreateUnbounded<UpgradeBatch>(
@@ -76,6 +79,30 @@ internal sealed class DatabaseUpgradeService : IAsyncDisposable
         }
 
         _disposeCts.Dispose();
+    }
+
+    /// <summary>Snapshot of enqueued batches not yet picked up by the consumer.</summary>
+    public IReadOnlyList<QueuedBatchInfo> SnapshotQueuedBatches()
+    {
+        var snapshot = _queuedBatches.Values;
+        var list = new List<QueuedBatchInfo>(snapshot.Count);
+
+        foreach (var batch in snapshot)
+        {
+            var fileNames = batch.Entries
+                .Select(entry => entry.FileName)
+                .ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+            Action cancel = () =>
+            {
+                try { batch.BatchCts.Cancel(); }
+                catch (ObjectDisposedException) { /* Already disposed; cancellation is moot. */ }
+            };
+
+            list.Add(new QueuedBatchInfo(batch.Id, batch.Scope, fileNames, cancel));
+        }
+
+        return list;
     }
 
     public async Task<UpgradeBatchResult> UpgradeBatchAsync(
@@ -160,12 +187,14 @@ internal sealed class DatabaseUpgradeService : IAsyncDisposable
             rejected);
 
         Interlocked.Increment(ref _queuedBatchCount);
+        _queuedBatches[batch.Id] = batch;
 
         if (_upgradeQueue.Writer.TryWrite(batch))
         {
             return await tcs.Task.ConfigureAwait(false);
         }
 
+        _queuedBatches.TryRemove(batch.Id, out _);
         Interlocked.Decrement(ref _queuedBatchCount);
         batchCts.Dispose();
 
@@ -216,6 +245,7 @@ internal sealed class DatabaseUpgradeService : IAsyncDisposable
     {
         while (_upgradeQueue.Reader.TryRead(out var batch))
         {
+            _queuedBatches.TryRemove(batch.Id, out _);
             Interlocked.Decrement(ref _queuedBatchCount);
 
             try { batch.BatchCts.Cancel(); }
@@ -235,6 +265,9 @@ internal sealed class DatabaseUpgradeService : IAsyncDisposable
 
     private async Task ProcessBatchAsync(UpgradeBatch batch)
     {
+        // _queuedBatches.TryRemove deferred until after SafeRaise UpgradeBatchStarted: gives an
+        // explicit superset overlap (file findable in queued snapshot OR active progress at all
+        // times) instead of a transition gap the remove flow's lookup could miss.
         Interlocked.Decrement(ref _queuedBatchCount);
 
         var succeeded = new List<string>(batch.Entries.Count);
@@ -248,8 +281,13 @@ internal sealed class DatabaseUpgradeService : IAsyncDisposable
             _registry.SafeRaise(
                 UpgradeBatchStarted,
                 this,
-                new UpgradeBatchStartedEventArgs(batch.Id, batch.Scope, batch.Entries.Count, batch.BatchCts),
+                new UpgradeBatchStartedEventArgs(batch.Id, batch.Scope, batch.Entries.Count, batch.BatchCts)
+                {
+                    FileNames = batch.Entries.Select(entry => entry.FileName).ToArray()
+                },
                 nameof(UpgradeBatchStarted));
+
+            _queuedBatches.TryRemove(batch.Id, out _);
 
             for (var i = 0; i < batch.Entries.Count; i++)
             {

--- a/src/EventLogExpert.Runtime/Database/IDatabaseService.cs
+++ b/src/EventLogExpert.Runtime/Database/IDatabaseService.cs
@@ -49,6 +49,8 @@ public interface IDatabaseService : IAsyncDisposable
 
     Task RetryClassificationAsync(string fileName, CancellationToken cancellationToken = default);
 
+    IReadOnlyList<QueuedBatchInfo> SnapshotQueuedBatches();
+
     void Toggle(string fileName);
 
     Task<UpgradeBatchResult> UpgradeBatchAsync(

--- a/src/EventLogExpert.Runtime/Database/Upgrade/QueuedBatchInfo.cs
+++ b/src/EventLogExpert.Runtime/Database/Upgrade/QueuedBatchInfo.cs
@@ -1,0 +1,10 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Database.Upgrade;
+
+public sealed record QueuedBatchInfo(
+    UpgradeBatchId BatchId,
+    UpgradeProgressScope Scope,
+    IReadOnlySet<string> FileNames,
+    Action Cancel);

--- a/src/EventLogExpert.Runtime/Database/Upgrade/UpgradeBatchStartedEventArgs.cs
+++ b/src/EventLogExpert.Runtime/Database/Upgrade/UpgradeBatchStartedEventArgs.cs
@@ -15,6 +15,8 @@ public sealed class UpgradeBatchStartedEventArgs(
 
     public int BatchSize { get; } = batchSize;
 
+    public IReadOnlyList<string> FileNames { get; init; } = [];
+
     public UpgradeProgressScope Scope { get; } = scope;
 
     public void Cancel()

--- a/src/EventLogExpert.UI/Banner/BannerCycleStateService.cs
+++ b/src/EventLogExpert.UI/Banner/BannerCycleStateService.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Runtime.Banner;
+using EventLogExpert.Runtime.Database;
 using EventLogExpert.Runtime.Modal;
 using EventLogExpert.UI.DatabaseTools;
 
@@ -22,7 +23,19 @@ public sealed class BannerCycleStateService : IBannerCycleStateService, IDisposa
     private IReadOnlyList<BannerCycleItem> _items = [];
     private bool _modalContentDisplayed;
     private BannerCycleItem? _pendingOverrideItem;
+    // _priorityStolenSelection holds the most recent item that won selection via priorityOverride
+    // (i.e., a newly-arrived higher-priority item). Cleared (a) when its source identity is no longer
+    // in the current source fingerprint, or (b) when the user explicitly navigates via MoveNext/MovePrev
+    // (user-acknowledgment). While non-null, the _userPreferredItem restore path is gated off so a
+    // stale low-priority preference cannot bounce back over the priority-stolen selection on the next
+    // unrelated rebuild.
+    private BannerCycleItem? _priorityStolenSelection;
+    private HashSet<(BannerView View, BannerId? EntryId)> _priorSourceFingerprint = [];
     private BannerCycleItem? _selectedItem;
+    // _userPreferredItem captures the last item the user explicitly selected via MoveNext/MovePrev.
+    // It survives temporary source-filter events (e.g., the DatabaseToolsModal suppressing the
+    // Attention banner) so the user's preferred banner is restored when the filter lifts.
+    private BannerCycleItem? _userPreferredItem;
 
     public BannerCycleStateService(
         IAttentionBannerService attention,
@@ -96,6 +109,8 @@ public sealed class BannerCycleStateService : IBannerCycleStateService, IDisposa
             _displayedIndex++;
             _selectedItem = items[_displayedIndex];
             _currentView = _selectedItem.View;
+            _userPreferredItem = _selectedItem;
+            _priorityStolenSelection = null;
         }
 
         StateChanged?.Invoke();
@@ -111,6 +126,8 @@ public sealed class BannerCycleStateService : IBannerCycleStateService, IDisposa
             _displayedIndex--;
             _selectedItem = items[_displayedIndex];
             _currentView = _selectedItem.View;
+            _userPreferredItem = _selectedItem;
+            _priorityStolenSelection = null;
         }
 
         StateChanged?.Invoke();
@@ -139,12 +156,69 @@ public sealed class BannerCycleStateService : IBannerCycleStateService, IDisposa
         StateChanged?.Invoke();
     }
 
+    private static BannerCycleItem? ComputePriorityOverride(
+        IReadOnlyList<BannerCycleItem> items,
+        HashSet<(BannerView View, BannerId? EntryId)> priorFingerprint,
+        BannerCycleItem? currentSelection)
+    {
+        int currentRank = currentSelection is null ? 0 : PriorityRank(currentSelection.View);
+        BannerCycleItem? highest = null;
+        int highestRank = currentRank;
+
+        foreach (var item in items)
+        {
+            if (priorFingerprint.Contains((item.View, item.EntryId))) { continue; }
+
+            int rank = PriorityRank(item.View);
+            if (rank > highestRank)
+            {
+                highest = item;
+                highestRank = rank;
+            }
+        }
+
+        return highest;
+    }
+
+    private static HashSet<(BannerView View, BannerId? EntryId)> ComputeSourceFingerprintFromSnapshot(
+        Exception? critical,
+        IReadOnlyList<ErrorBannerEntry> errors,
+        IReadOnlyList<DatabaseEntry> attentionEntries,
+        BannerProgressEntry? backgroundProgress,
+        IReadOnlyList<BannerInfoEntry> infos)
+    {
+        var result = new HashSet<(BannerView View, BannerId? EntryId)>();
+
+        if (critical is not null) { result.Add((BannerView.Critical, null)); }
+
+        foreach (var err in errors) { result.Add((BannerView.Error, err.Id)); }
+
+        if (attentionEntries.Count > 0) { result.Add((BannerView.Attention, null)); }
+
+        if (backgroundProgress is not null) { result.Add((BannerView.UpgradeProgress, null)); }
+
+        foreach (var info in infos) { result.Add((BannerView.Info, info.Id)); }
+
+        return result;
+    }
+
     private static bool ItemMatches(BannerCycleItem selected, BannerCycleItem candidate)
     {
         if (selected.View != candidate.View) { return false; }
 
         return selected.EntryId == candidate.EntryId;
     }
+
+    // BannerView enum is ordered for display, not priority — use this rank for comparisons.
+    private static int PriorityRank(BannerView view) => view switch
+    {
+        BannerView.Critical => 5,
+        BannerView.Error => 4,
+        BannerView.Attention => 3,
+        BannerView.UpgradeProgress => 2,
+        BannerView.Info => 1,
+        _ => 0
+    };
 
     private void OnFacetChanged()
     {
@@ -174,14 +248,52 @@ public sealed class BannerCycleStateService : IBannerCycleStateService, IDisposa
         bool attentionSuppressed =
             _modalCoordinator.ActiveSession?.ComponentType == typeof(DatabaseToolsModal);
 
+        // Capture each facet snapshot once — the same data drives BuildCycle AND the fingerprint.
+        var critical = _critical.CurrentCritical;
+        var errors = _errors.ErrorBanners;
+        var attentionEntries = _attention.AttentionEntries;
+        var attentionDismissed = _attention.AttentionDismissed;
+        var backgroundProgress = _progress.BackgroundProgress;
+        var infos = _infos.InfoBanners;
+
         IReadOnlyList<BannerCycleItem> items = BannerViewSelector.BuildCycle(
-            _critical.CurrentCritical,
-            _errors.ErrorBanners,
-            _attention.AttentionEntries,
-            _attention.AttentionDismissed,
+            critical,
+            errors,
+            attentionEntries,
+            attentionDismissed,
             attentionSuppressed,
-            _progress.BackgroundProgress,
-            _infos.InfoBanners);
+            backgroundProgress,
+            infos);
+
+        // Fingerprint is built from the UNFILTERED source — otherwise modal close would re-introduce
+        // Attention and wrongly trigger priorityOverride on every reentry.
+        var currentSourceFingerprint = ComputeSourceFingerprintFromSnapshot(
+            critical,
+            errors,
+            attentionEntries,
+            backgroundProgress,
+            infos);
+
+        BannerCycleItem? priorityOverride = ComputePriorityOverride(
+            items,
+            _priorSourceFingerprint,
+            _selectedItem);
+
+        // Advance fingerprint before any early-return so the next rebuild compares against current state.
+        _priorSourceFingerprint = currentSourceFingerprint;
+
+        if (_userPreferredItem is not null
+            && !currentSourceFingerprint.Contains((_userPreferredItem.View, _userPreferredItem.EntryId)))
+        {
+            _userPreferredItem = null;
+        }
+
+        if (_priorityStolenSelection is not null
+            && !currentSourceFingerprint.Contains(
+                (_priorityStolenSelection.View, _priorityStolenSelection.EntryId)))
+        {
+            _priorityStolenSelection = null;
+        }
 
         _items = items;
 
@@ -194,37 +306,45 @@ public sealed class BannerCycleStateService : IBannerCycleStateService, IDisposa
             return;
         }
 
-        if (_pendingOverrideItem is not null)
+        // Priority order: explicit override > priority watermark > user-preferred (gated) > current > clamp.
+        if (TryApplySelection(_pendingOverrideItem, items)) { _pendingOverrideItem = null; return; }
+
+        if (TryApplySelection(priorityOverride, items))
         {
-            for (int i = 0; i < items.Count; i++)
-            {
-                if (!ItemMatches(_pendingOverrideItem, items[i])) { continue; }
-
-                _displayedIndex = i;
-                _selectedItem = items[i];
-                _currentView = _selectedItem.View;
-                _pendingOverrideItem = null;
-                return;
-            }
-
-            _pendingOverrideItem = null;
+            _priorityStolenSelection = priorityOverride;
+            return;
         }
 
-        if (_selectedItem is not null)
+        // Gate user-preferred restore against a still-active priority-stolen item only. This does NOT
+        // block restore when a higher-priority item that COEXISTED with the user's preference is
+        // present — only blocks against a newly-arrived steal that is still in the cycle.
+        if (_priorityStolenSelection is null
+            && TryApplySelection(_userPreferredItem, items))
         {
-            for (int i = 0; i < items.Count; i++)
-            {
-                if (!ItemMatches(_selectedItem, items[i])) { continue; }
-
-                _displayedIndex = i;
-                _selectedItem = items[i];
-                _currentView = _selectedItem.View;
-                return;
-            }
+            return;
         }
+
+        if (TryApplySelection(_selectedItem, items)) { return; }
 
         _displayedIndex = Math.Clamp(_displayedIndex, 0, items.Count - 1);
         _selectedItem = items[_displayedIndex];
         _currentView = _selectedItem.View;
+    }
+
+    private bool TryApplySelection(BannerCycleItem? target, IReadOnlyList<BannerCycleItem> items)
+    {
+        if (target is null) { return false; }
+
+        for (int i = 0; i < items.Count; i++)
+        {
+            if (!ItemMatches(target, items[i])) { continue; }
+
+            _displayedIndex = i;
+            _selectedItem = items[i];
+            _currentView = _selectedItem.View;
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.cs
+++ b/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.cs
@@ -250,25 +250,19 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
     {
         var batchesToCancel = new Dictionary<UpgradeBatchId, Action>();
         var batchToFiles = new Dictionary<UpgradeBatchId, List<string>>();
-        var entries = DatabaseService.Entries.ToList();
 
         foreach (var fileName in fileNames)
         {
-            var entry = entries.FirstOrDefault(
-                e => string.Equals(e.FileName, fileName, StringComparison.OrdinalIgnoreCase));
+            var cancellable = GetCancellableBatchForFile(fileName);
 
-            if (entry is null) { continue; }
+            if (cancellable is null) { continue; }
 
-            var progress = GetUpgradeProgressForEntry(entry);
+            batchesToCancel.TryAdd(cancellable.Value.BatchId, cancellable.Value.Cancel);
 
-            if (progress is null) { continue; }
-
-            batchesToCancel.TryAdd(progress.BatchId, progress.Cancel);
-
-            if (!batchToFiles.TryGetValue(progress.BatchId, out var files))
+            if (!batchToFiles.TryGetValue(cancellable.Value.BatchId, out var files))
             {
                 files = [];
-                batchToFiles[progress.BatchId] = files;
+                batchToFiles[cancellable.Value.BatchId] = files;
             }
 
             files.Add(fileName);
@@ -296,6 +290,9 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
             }
         }
 
+        // Coordinator-only — adding IsFileInAnyKnownBatch here would 30s-hang on background batches
+        // (no UpgradeStateChanged event ever fires to re-trigger). pendingBatches + stillAlive below
+        // already gate Remove via UpgradeBatchCompleted.
         void StateChangedHandler()
         {
             if (!fileNames.Any(f => Coordinator.IsUpgradeInFlight(f)))
@@ -311,12 +308,15 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
         {
             foreach (var (batchId, files) in batchToFiles)
             {
+                // stillAlive includes IsFileInAnyKnownBatch so pendingBatches stays unset for
+                // pre-progress / queued files until the real UpgradeBatchCompleted fires.
                 bool stillAlive = files.Any(file =>
                 {
                     var entry = DatabaseService.Entries.FirstOrDefault(
                         e => string.Equals(e.FileName, file, StringComparison.OrdinalIgnoreCase));
                     return Coordinator.IsUpgradeInFlight(file) ||
-                           (entry is not null && GetUpgradeProgressForEntry(entry) is not null);
+                           (entry is not null && GetUpgradeProgressForEntry(entry) is not null) ||
+                           IsFileInAnyKnownBatch(file);
                 });
                 if (!stillAlive) { pendingBatches[batchId].TrySetResult(); }
             }
@@ -439,6 +439,33 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
         _pendingToggles.Clear();
     }
 
+    // Lookup by batch membership (active + queued) for the cancel-then-remove flow. Distinct from
+    // GetUpgradeProgressForEntry, which matches by CurrentEntryName for per-row display only.
+    private CancellableBatch? GetCancellableBatchForFile(string fileName)
+    {
+        var manage = ProgressBannerService.ManageDatabasesProgress;
+        if (manage is not null && manage.BatchFileNames.Contains(fileName))
+        {
+            return new CancellableBatch(manage.BatchId, manage.Cancel);
+        }
+
+        var background = ProgressBannerService.BackgroundProgress;
+        if (background is not null && background.BatchFileNames.Contains(fileName))
+        {
+            return new CancellableBatch(background.BatchId, background.Cancel);
+        }
+
+        foreach (var queued in DatabaseService.SnapshotQueuedBatches())
+        {
+            if (queued.FileNames.Contains(fileName))
+            {
+                return new CancellableBatch(queued.BatchId, queued.Cancel);
+            }
+        }
+
+        return null;
+    }
+
     private bool GetEffectiveEnabled(DatabaseEntry entry) =>
         _pendingToggles.TryGetValue(entry.FileName, out var pending) ? pending : entry.IsEnabled;
 
@@ -491,18 +518,20 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
             var entry = entries.FirstOrDefault(
                 e => string.Equals(e.FileName, fileName, StringComparison.OrdinalIgnoreCase));
 
-            if (entry is null) { continue; }
-
             bool coordinatorSays = Coordinator.IsUpgradeInFlight(fileName);
-            bool bannerSays = GetUpgradeProgressForEntry(entry) is not null;
+            bool bannerSays = entry is not null && GetUpgradeProgressForEntry(entry) is not null;
+            bool batchSays = IsFileInAnyKnownBatch(fileName);
 
-            if (coordinatorSays || bannerSays) { upgrading.Add(fileName); }
+            if (coordinatorSays || bannerSays || batchSays) { upgrading.Add(fileName); }
         }
 
         upgradingFiles = upgrading;
 
         return upgrading.Count > 0;
     }
+
+    private bool IsFileInAnyKnownBatch(string fileName) =>
+        GetCancellableBatchForFile(fileName) is not null;
 
     private async Task ObserveClassificationCompletionAsync(CancellationToken cancellationToken)
     {
@@ -784,4 +813,6 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
 
         await InvokeAsyncSafe();
     }
+
+    private readonly record struct CancellableBatch(UpgradeBatchId BatchId, Action Cancel);
 }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Banner/BannerServiceTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Banner/BannerServiceTests.cs
@@ -429,6 +429,69 @@ public sealed class BannerServiceTests
     }
 
     [Fact]
+    public void OnUpgradeBatchProgress_PreservesBatchFileNamesOnRecordWith()
+    {
+        var databaseService = Substitute.For<IDatabaseService>();
+        var sut = new BannerService(databaseService, Substitute.For<ITraceLogger>());
+        var batchId = UpgradeBatchId.Create();
+        using var cts = new CancellationTokenSource();
+        var startedArgs = new UpgradeBatchStartedEventArgs(batchId, UpgradeProgressScope.Background, 2, cts)
+        {
+            FileNames = ["a.db", "b.db"]
+        };
+        databaseService.UpgradeBatchStarted += Raise.EventWith(databaseService, startedArgs);
+
+        var progressArgs = new UpgradeBatchProgressEventArgs(batchId, 1, "a.db", UpgradePhase.MigratingSchema);
+        databaseService.UpgradeBatchProgress += Raise.EventWith(databaseService, progressArgs);
+
+        var progress = sut.BackgroundProgress;
+        Assert.NotNull(progress);
+        Assert.Equal("a.db", progress.CurrentEntryName);
+        Assert.Equal(2, progress.BatchFileNames.Count);
+        Assert.Contains("a.db", progress.BatchFileNames);
+        Assert.Contains("b.db", progress.BatchFileNames);
+    }
+
+    [Fact]
+    public void OnUpgradeBatchStarted_FileNamesEmpty_DefaultsToEmptySet()
+    {
+        var databaseService = Substitute.For<IDatabaseService>();
+        var sut = new BannerService(databaseService, Substitute.For<ITraceLogger>());
+        var batchId = UpgradeBatchId.Create();
+        using var cts = new CancellationTokenSource();
+        var args = new UpgradeBatchStartedEventArgs(batchId, UpgradeProgressScope.Background, 1, cts);
+
+        databaseService.UpgradeBatchStarted += Raise.EventWith(databaseService, args);
+
+        var progress = sut.BackgroundProgress;
+        Assert.NotNull(progress);
+        Assert.NotNull(progress.BatchFileNames);
+        Assert.Empty(progress.BatchFileNames);
+    }
+
+    [Fact]
+    public void OnUpgradeBatchStarted_PopulatesBatchFileNamesCaseInsensitive()
+    {
+        var databaseService = Substitute.For<IDatabaseService>();
+        var sut = new BannerService(databaseService, Substitute.For<ITraceLogger>());
+        var batchId = UpgradeBatchId.Create();
+        using var cts = new CancellationTokenSource();
+        var args = new UpgradeBatchStartedEventArgs(batchId, UpgradeProgressScope.Background, 2, cts)
+        {
+            FileNames = ["DB-One.db", "Db-Two.db"]
+        };
+
+        databaseService.UpgradeBatchStarted += Raise.EventWith(databaseService, args);
+
+        var progress = sut.BackgroundProgress;
+        Assert.NotNull(progress);
+        Assert.Equal(2, progress.BatchFileNames.Count);
+        Assert.Contains("db-one.db", progress.BatchFileNames);
+        Assert.Contains("DB-ONE.DB", progress.BatchFileNames);
+        Assert.Contains("db-two.db", progress.BatchFileNames);
+    }
+
+    [Fact]
     public void RaiseStateChanged_WhenSubscriberThrows_StillFiresLaterSubscribersAndLogs()
     {
         // Arrange — multicast safety: a throwing subscriber must not block siblings, and the throw

--- a/tests/Unit/EventLogExpert.UI.Tests/Banner/BannerCycleStateServiceTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Banner/BannerCycleStateServiceTests.cs
@@ -3,6 +3,7 @@
 
 using EventLogExpert.Runtime.Banner;
 using EventLogExpert.Runtime.Database;
+using EventLogExpert.Runtime.Database.Upgrade;
 using EventLogExpert.Runtime.Modal;
 using EventLogExpert.UI.Banner;
 using EventLogExpert.UI.DatabaseTools;
@@ -74,11 +75,81 @@ public sealed class BannerCycleStateServiceTests
     }
 
     [Fact]
+    public void Modal_Close_RestoresAttention_EvenWhenHigherPriorityErrorCoexists()
+    {
+        _errors.ErrorBanners.Returns([MakeError()]);
+        _attention.AttentionEntries.Returns([MakeAttention("db1.db")]);
+        var service = CreateService();
+        Assert.Equal(BannerView.Error, service.SelectedItem?.View);
+
+        service.MoveNext();
+        Assert.Equal(BannerView.Attention, service.SelectedItem?.View);
+
+        _modalCoordinator.ActiveSession.Returns(
+            new ModalSession(new ModalId(1), typeof(DatabaseToolsModal), null));
+        _modalCoordinator.StateChanged += Raise.Event<Action>();
+        Assert.Equal(BannerView.Error, service.SelectedItem?.View);
+
+        _modalCoordinator.ActiveSession.Returns((ModalSession?)null);
+        _modalCoordinator.StateChanged += Raise.Event<Action>();
+        Assert.Equal(BannerView.Attention, service.SelectedItem?.View);
+    }
+
+    [Fact]
+    public void Modal_Open_RemovesAttention_AndModal_Close_RestoresAttentionSelection()
+    {
+        _errors.ErrorBanners.Returns([]);
+        _attention.AttentionEntries.Returns([MakeAttention("db1.db")]);
+
+        var service = CreateService();
+        // Construction yields a single-item cycle; MoveNext is a no-op there. Add an Error to give
+        // a 2-item cycle so we can navigate and set _userPreferredItem.
+        _errors.ErrorBanners.Returns([MakeError()]);
+        _errors.StateChanged += Raise.Event<Action>();
+        Assert.Equal(2, service.Items.Count);
+
+        service.MoveNext();
+        Assert.Equal(BannerView.Attention, service.SelectedItem?.View);
+
+        _modalCoordinator.ActiveSession.Returns(
+            new ModalSession(new ModalId(1), typeof(DatabaseToolsModal), null));
+        _modalCoordinator.StateChanged += Raise.Event<Action>();
+        Assert.Equal(BannerView.Error, service.SelectedItem?.View);
+
+        _modalCoordinator.ActiveSession.Returns((ModalSession?)null);
+        _modalCoordinator.StateChanged += Raise.Event<Action>();
+        Assert.Equal(BannerView.Attention, service.SelectedItem?.View);
+    }
+
+    [Fact]
     public void ModalContentDisplayed_DefaultsFalse_OnNewInstance()
     {
         var service = CreateService();
 
         Assert.False(service.ModalContentDisplayed);
+    }
+
+    [Fact]
+    public void ModalSuppression_PreservesUserPreferredAttention_DoesNotTriggerPriorityOverrideOnReentry()
+    {
+        _attention.AttentionEntries.Returns([MakeAttention("db1.db")]);
+        _errors.ErrorBanners.Returns([MakeError()]);
+        var service = CreateService();
+        service.MoveNext();
+        Assert.Equal(BannerView.Attention, service.SelectedItem?.View);
+
+        _modalCoordinator.ActiveSession.Returns(
+            new ModalSession(new ModalId(1), typeof(DatabaseToolsModal), null));
+        _modalCoordinator.StateChanged += Raise.Event<Action>();
+
+        _modalCoordinator.ActiveSession.Returns((ModalSession?)null);
+        _modalCoordinator.StateChanged += Raise.Event<Action>();
+        Assert.Equal(BannerView.Attention, service.SelectedItem?.View);
+
+        // Trigger an unrelated rebuild — Attention must STAY selected (no stale priority steal).
+        _infos.InfoBanners.Returns([MakeInfo()]);
+        _infos.StateChanged += Raise.Event<Action>();
+        Assert.Equal(BannerView.Attention, service.SelectedItem?.View);
     }
 
     [Fact]
@@ -145,6 +216,61 @@ public sealed class BannerCycleStateServiceTests
     }
 
     [Fact]
+    public void MultipleNewItems_HighestPriorityWins()
+    {
+        var info = MakeInfo();
+        _infos.InfoBanners.Returns([info]);
+        var service = CreateService();
+
+        _critical.CurrentCritical.Returns(new InvalidOperationException("crit"));
+        _errors.ErrorBanners.Returns([MakeError()]);
+        _critical.StateChanged += Raise.Event<Action>();
+
+        // Critical present → BannerViewSelector returns ONLY Critical (exclusive).
+        Assert.Equal(BannerView.Critical, service.SelectedItem?.View);
+    }
+
+    [Fact]
+    public void NewlyArrivedBackgroundProgress_DoesNotStealFromAttention()
+    {
+        _attention.AttentionEntries.Returns([MakeAttention("db1.db")]);
+        var service = CreateService();
+        Assert.Equal(BannerView.Attention, service.SelectedItem?.View);
+
+        _progress.BackgroundProgress.Returns(MakeProgress());
+        _progress.StateChanged += Raise.Event<Action>();
+
+        Assert.Equal(BannerView.Attention, service.SelectedItem?.View);
+    }
+
+    [Fact]
+    public void NewlyArrivedCriticalError_StealsSelectionFromInfo()
+    {
+        var info = MakeInfo();
+        _infos.InfoBanners.Returns([info]);
+        var service = CreateService();
+        Assert.Equal(BannerView.Info, service.SelectedItem?.View);
+
+        var critEx = new InvalidOperationException("boom");
+        _critical.CurrentCritical.Returns(critEx);
+        _critical.StateChanged += Raise.Event<Action>();
+
+        Assert.Equal(BannerView.Critical, service.SelectedItem?.View);
+    }
+
+    [Fact]
+    public void NewlyArrivedInfo_DoesNotStealFromAttention()
+    {
+        _attention.AttentionEntries.Returns([MakeAttention("db1.db")]);
+        var service = CreateService();
+
+        _infos.InfoBanners.Returns([MakeInfo()]);
+        _infos.StateChanged += Raise.Event<Action>();
+
+        Assert.Equal(BannerView.Attention, service.SelectedItem?.View);
+    }
+
+    [Fact]
     public void OnFacetChanged_AfterDatabaseToolsModalActive_AttentionSuppressionApplied()
     {
         _attention.AttentionEntries.Returns([MakeAttention("a.db")]);
@@ -172,6 +298,43 @@ public sealed class BannerCycleStateServiceTests
         Assert.Single(service.Items);
         Assert.Equal(BannerView.Error, service.CurrentView);
         Assert.Equal(1, stateChangedFires);
+    }
+
+    [Fact]
+    public void PriorityOverride_DoesNotFireOnProgressTickOfExistingBatch()
+    {
+        _attention.AttentionEntries.Returns([MakeAttention("db1.db")]);
+        _progress.BackgroundProgress.Returns(MakeProgress());
+        var service = CreateService();
+        Assert.Equal(BannerView.Attention, service.SelectedItem?.View);
+
+        // Progress tick on the same background batch — fingerprint key (UpgradeProgress, null)
+        // unchanged, so NOT newly-arrived → selection stays.
+        _progress.BackgroundProgress.Returns(MakeProgress());
+        _progress.StateChanged += Raise.Event<Action>();
+
+        Assert.Equal(BannerView.Attention, service.SelectedItem?.View);
+    }
+
+    [Fact]
+    public void PriorityOverride_HoldsAgainstStaleUserPreferredItem()
+    {
+        var info = MakeInfo();
+        _infos.InfoBanners.Returns([info]);
+        var service = CreateService();
+        var info2 = MakeInfo();
+        _infos.InfoBanners.Returns([info, info2]);
+        _infos.StateChanged += Raise.Event<Action>();
+        service.MoveNext();
+        Assert.Equal(info2.Id, service.SelectedItem?.EntryId);
+
+        _critical.CurrentCritical.Returns(new InvalidOperationException("crit"));
+        _critical.StateChanged += Raise.Event<Action>();
+        Assert.Equal(BannerView.Critical, service.SelectedItem?.View);
+
+        // Unrelated rebuild — must NOT bounce to info2.
+        _critical.StateChanged += Raise.Event<Action>();
+        Assert.Equal(BannerView.Critical, service.SelectedItem?.View);
     }
 
     [Fact]
@@ -312,11 +475,92 @@ public sealed class BannerCycleStateServiceTests
         Assert.Equal(1, stateChangedFires);
     }
 
+    [Fact]
+    public void UserExplicitMoveAfterPriorityOverride_ClearsPriorityStolenMarker_AllowsRestoreAfterSuppression()
+    {
+        // Uses Error (non-exclusive — stays in the cycle) as the stealer so the user-ack clear is
+        // actually exercised; Critical is exclusive and self-clears from the fingerprint, making
+        // the user-ack code path a no-op for that view.
+        _attention.AttentionEntries.Returns([MakeAttention("db1.db")]);
+        _infos.InfoBanners.Returns([MakeInfo()]);
+        var service = CreateService();
+        Assert.Equal(BannerView.Attention, service.SelectedItem?.View);
+
+        var errorEntry = MakeError();
+        _errors.ErrorBanners.Returns([errorEntry]);
+        _errors.StateChanged += Raise.Event<Action>();
+        Assert.Equal(BannerView.Error, service.SelectedItem?.View);
+
+        service.MoveNext();
+        Assert.Equal(BannerView.Attention, service.SelectedItem?.View);
+
+        _modalCoordinator.ActiveSession.Returns(
+            new ModalSession(new ModalId(1), typeof(DatabaseToolsModal), null));
+        _modalCoordinator.StateChanged += Raise.Event<Action>();
+        Assert.NotEqual(BannerView.Attention, service.SelectedItem?.View);
+
+        _modalCoordinator.ActiveSession.Returns((ModalSession?)null);
+        _modalCoordinator.StateChanged += Raise.Event<Action>();
+        Assert.Equal(BannerView.Attention, service.SelectedItem?.View);
+    }
+
+    [Fact]
+    public void UserPreferredItem_NotUpdatedByRebuild_OnlyByExplicitMove()
+    {
+        var info1 = MakeInfo();
+        var info2 = MakeInfo();
+        _infos.InfoBanners.Returns([info1, info2]);
+        var service = CreateService();
+        Assert.Equal(info1.Id, service.SelectedItem?.EntryId);
+
+        _infos.StateChanged += Raise.Event<Action>();
+
+        // Remove info1: if the passive tick had implicitly recorded a preference for info1, the
+        // subsequent rebuild would still land on info2 via clamp — confirming no preference was set.
+        _infos.InfoBanners.Returns([info2]);
+        _infos.StateChanged += Raise.Event<Action>();
+        Assert.Equal(info2.Id, service.SelectedItem?.EntryId);
+    }
+
+    [Fact]
+    public void UserPreferredItem_RemovedFromSource_ClearedFromPreferred()
+    {
+        var info1 = MakeInfo();
+        var info2 = MakeInfo();
+        _infos.InfoBanners.Returns([info1, info2]);
+        var service = CreateService();
+        service.MoveNext();
+        Assert.Equal(info2.Id, service.SelectedItem?.EntryId);
+
+        _infos.InfoBanners.Returns([info1]);
+        _infos.StateChanged += Raise.Event<Action>();
+        Assert.Equal(info1.Id, service.SelectedItem?.EntryId);
+
+        // Re-add info2 — should NOT snap back via stale preference.
+        _infos.InfoBanners.Returns([info1, info2]);
+        _infos.StateChanged += Raise.Event<Action>();
+        Assert.Equal(info1.Id, service.SelectedItem?.EntryId);
+    }
+
     private static DatabaseEntry MakeAttention(string fileName) =>
         new(fileName, $@"C:\dbs\{fileName}", IsEnabled: false, DatabaseStatus.UpgradeRequired);
 
     private static ErrorBannerEntry MakeError() =>
         new(BannerId.Create(), "Title", "msg", null, null, DateTime.UtcNow);
+
+    private static BannerInfoEntry MakeInfo() =>
+        new(BannerId.Create(), "Title", "msg", BannerSeverity.Info, DateTime.UtcNow);
+
+    private static BannerProgressEntry MakeProgress() =>
+        new(
+            new UpgradeBatchId(Guid.NewGuid()),
+            UpgradeProgressScope.Background,
+            0,
+            1,
+            string.Empty,
+            UpgradePhase.BackingUp,
+            0,
+            () => { });
 
     private BannerCycleStateService CreateService() =>
         new(_attention, _errors, _infos, _progress, _critical, _modalCoordinator);

--- a/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/Tabs/FakeDatabaseService.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/Tabs/FakeDatabaseService.cs
@@ -27,6 +27,8 @@ internal sealed class FakeDatabaseService : IDatabaseService
 
     public int QueuedBatchCount => 0;
 
+    public IReadOnlyList<QueuedBatchInfo> QueuedBatchesForTest { get; set; } = [];
+
     public int RestoreFromBackupCalls { get; private set; }
 
     public bool RestoreFromBackupReturnValue { get; set; } = true;
@@ -65,6 +67,12 @@ internal sealed class FakeDatabaseService : IDatabaseService
     public void RaiseUpgradeBatchCompleted(UpgradeBatchCompletedEventArgs args) =>
         UpgradeBatchCompleted?.Invoke(this, args);
 
+    public void RaiseUpgradeBatchProgress(UpgradeBatchProgressEventArgs args) =>
+        UpgradeBatchProgress?.Invoke(this, args);
+
+    public void RaiseUpgradeBatchStarted(UpgradeBatchStartedEventArgs args) =>
+        UpgradeBatchStarted?.Invoke(this, args);
+
     public void Refresh() { }
 
     public Task RemoveAsync(
@@ -84,6 +92,8 @@ internal sealed class FakeDatabaseService : IDatabaseService
         RetryClassificationCalls++;
         return Task.CompletedTask;
     }
+
+    public IReadOnlyList<QueuedBatchInfo> SnapshotQueuedBatches() => QueuedBatchesForTest;
 
     public void Toggle(string fileName) { }
 

--- a/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/Tabs/ManageDatabasesTabTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/Tabs/ManageDatabasesTabTests.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
+using System.Collections.Frozen;
 using System.Reflection;
 using TestContext = Xunit.TestContext;
 
@@ -65,6 +66,27 @@ public sealed class ManageDatabasesTabTests : BunitContext
 
         Assert.True(saved);
         _announcementService.DidNotReceive().Announce(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task Background_PreProgress_IsFileInActiveBatch_DetectsFileInBatch()
+    {
+        var entry = Entry("b.db", isEnabled: false, status: DatabaseStatus.Ready);
+        _databaseService.Entries = [entry];
+        _progressBannerService.BackgroundProgress.Returns(MakeProgress(
+            currentEntryName: string.Empty,
+            currentPhase: UpgradePhase.BackingUp,
+            scope: UpgradeProgressScope.Background,
+            batchFileNames: new[] { "b.db" }.ToFrozenSet(StringComparer.OrdinalIgnoreCase)));
+
+        var alertSurface = new FakeInlineAlertSurface { Result = new InlineAlertResult(false, null) };
+        var component = RenderWithAlertSurface(alertSurface);
+
+        await component.InvokeAsync(() => component.Find(".db-entry-remove-btn").Click());
+
+        var captured = Assert.Single(alertSurface.Requests);
+        Assert.Contains("Cancel", captured.AcceptLabel ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("upgrade", captured.AcceptLabel ?? string.Empty, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -200,6 +222,134 @@ public sealed class ManageDatabasesTabTests : BunitContext
     }
 
     [Fact]
+    public async Task CancelThenRemove_DuringPreProgressWindow_CancelsActualBatchAndProceeds()
+    {
+        var entry = Entry("b.db", isEnabled: false, status: DatabaseStatus.Ready);
+        _databaseService.Entries = [entry];
+        var batchId = UpgradeBatchId.Create();
+        var cancelCalled = false;
+        _progressBannerService.BackgroundProgress.Returns(MakeProgress(
+            currentEntryName: string.Empty,
+            currentPhase: UpgradePhase.BackingUp,
+            scope: UpgradeProgressScope.Background,
+            batchId: batchId,
+            cancel: () => cancelCalled = true,
+            batchFileNames: new[] { "b.db" }.ToFrozenSet(StringComparer.OrdinalIgnoreCase)));
+
+        var component = Render<ManageDatabasesTab>();
+
+        var cancelTask = InvokeCancelUpgradesAsync(component, ["b.db"]);
+
+        await Task.Delay(50, TestContext.Current.CancellationToken);
+        Assert.True(cancelCalled);
+        Assert.False(cancelTask.IsCompleted);
+
+        _databaseService.RaiseUpgradeBatchCompleted(
+            new UpgradeBatchCompletedEventArgs(
+                batchId,
+                new UpgradeBatchResult([], ["b.db"], []),
+                wasCancelled: true));
+
+        await cancelTask.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CancelThenRemove_FileNotYetReachedInActiveBatch_CancelsBatchAndProceeds()
+    {
+        var entry = Entry("c.db", isEnabled: false, status: DatabaseStatus.Ready);
+        _databaseService.Entries = [entry];
+        var batchId = UpgradeBatchId.Create();
+        var cancelCalled = false;
+        _progressBannerService.BackgroundProgress.Returns(MakeProgress(
+            currentEntryName: "a.db",
+            currentPhase: UpgradePhase.MigratingSchema,
+            scope: UpgradeProgressScope.Background,
+            batchId: batchId,
+            cancel: () => cancelCalled = true,
+            batchFileNames: new[] { "a.db", "b.db", "c.db" }.ToFrozenSet(StringComparer.OrdinalIgnoreCase)));
+
+        var component = Render<ManageDatabasesTab>();
+
+        var cancelTask = InvokeCancelUpgradesAsync(component, ["c.db"]);
+
+        await Task.Delay(50, TestContext.Current.CancellationToken);
+        Assert.True(cancelCalled);
+        Assert.False(cancelTask.IsCompleted);
+
+        _databaseService.RaiseUpgradeBatchCompleted(
+            new UpgradeBatchCompletedEventArgs(
+                batchId,
+                new UpgradeBatchResult([], ["c.db"], []),
+                wasCancelled: true));
+
+        await cancelTask.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CancelThenRemove_PreProgressWindow_AwaitsUpgradeBatchCompletedBeforeRemoveAndProceedsPromptly()
+    {
+        var entry = Entry("b.db", isEnabled: false, status: DatabaseStatus.Ready);
+        _databaseService.Entries = [entry];
+        var batchId = UpgradeBatchId.Create();
+        _progressBannerService.BackgroundProgress.Returns(MakeProgress(
+            currentEntryName: string.Empty,
+            currentPhase: UpgradePhase.BackingUp,
+            scope: UpgradeProgressScope.Background,
+            batchId: batchId,
+            batchFileNames: new[] { "b.db" }.ToFrozenSet(StringComparer.OrdinalIgnoreCase)));
+
+        var component = Render<ManageDatabasesTab>();
+
+        var cancelTask = InvokeCancelUpgradesAsync(component, ["b.db"]);
+
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        Assert.False(cancelTask.IsCompleted);
+
+        var beforeRaise = DateTime.UtcNow;
+        _databaseService.RaiseUpgradeBatchCompleted(
+            new UpgradeBatchCompletedEventArgs(
+                batchId,
+                new UpgradeBatchResult([], ["b.db"], []),
+                wasCancelled: true));
+
+        await cancelTask.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+        var elapsed = DateTime.UtcNow - beforeRaise;
+        // Must complete well under s_cancelTimeout (30s) — otherwise a hang regression would pass.
+        Assert.True(elapsed < TimeSpan.FromSeconds(2), $"Cancel flow took {elapsed} after batch completion (should be <2s).");
+    }
+
+    [Fact]
+    public async Task CancelThenRemove_QueuedBatchFile_AwaitsConsumerPickupAndCompletionBeforeRemove()
+    {
+        var entry = Entry("c.db", isEnabled: false, status: DatabaseStatus.Ready);
+        _databaseService.Entries = [entry];
+        var batchId = UpgradeBatchId.Create();
+        var cancelCalled = false;
+        _databaseService.QueuedBatchesForTest = [new QueuedBatchInfo(
+            batchId,
+            UpgradeProgressScope.Background,
+            new[] { "c.db" }.ToFrozenSet(StringComparer.OrdinalIgnoreCase),
+            () => cancelCalled = true)];
+
+        var component = Render<ManageDatabasesTab>();
+
+        var cancelTask = InvokeCancelUpgradesAsync(component, ["c.db"]);
+
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+        Assert.True(cancelCalled);
+        Assert.False(cancelTask.IsCompleted);
+
+        _databaseService.RaiseUpgradeBatchCompleted(
+            new UpgradeBatchCompletedEventArgs(
+                batchId,
+                new UpgradeBatchResult([], ["c.db"], []),
+                wasCancelled: true));
+
+        await cancelTask.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
     public async Task ClearSelection_EmptiesSet_HidesBulkStrip()
     {
         _databaseService.Entries = [
@@ -296,6 +446,23 @@ public sealed class ManageDatabasesTabTests : BunitContext
 
         Assert.Equal(0, _databaseService.EntriesChangedHandlerCount);
         Assert.Equal(0, _databaseService.UpgradeBatchCompletedHandlerCount);
+    }
+
+    [Fact]
+    public async Task GetUpgradeProgressForEntry_Display_OnlyMatchesCurrentEntryName_NotBatchFileNames()
+    {
+        var entry = Entry("b.db", isEnabled: false, status: DatabaseStatus.UpgradeRequired);
+        _databaseService.Entries = [entry];
+        _progressBannerService.BackgroundProgress.Returns(MakeProgress(
+            currentEntryName: string.Empty,
+            currentPhase: UpgradePhase.BackingUp,
+            scope: UpgradeProgressScope.Background,
+            batchFileNames: new[] { "b.db" }.ToFrozenSet(StringComparer.OrdinalIgnoreCase)));
+
+        var component = Render<ManageDatabasesTab>();
+
+        Assert.Empty(component.FindAll(".db-entry-upgrading-text"));
+        await Task.CompletedTask;
     }
 
     [Fact]
@@ -454,6 +621,27 @@ public sealed class ManageDatabasesTabTests : BunitContext
         await Task.Delay(50, TestContext.Current.CancellationToken);
 
         Assert.True(component.Instance.HasDatabaseStateChanged);
+    }
+
+    [Fact]
+    public async Task Remove_FileInQueuedBatch_IsAnyFileUpgradingReturnsTrue()
+    {
+        var entry = Entry("c.db", isEnabled: false, status: DatabaseStatus.Ready);
+        _databaseService.Entries = [entry];
+        _databaseService.QueuedBatchesForTest = [new QueuedBatchInfo(
+            UpgradeBatchId.Create(),
+            UpgradeProgressScope.Background,
+            new[] { "c.db" }.ToFrozenSet(StringComparer.OrdinalIgnoreCase),
+            () => { })];
+
+        var alertSurface = new FakeInlineAlertSurface { Result = new InlineAlertResult(false, null) };
+        var component = RenderWithAlertSurface(alertSurface);
+
+        await component.InvokeAsync(() => component.Find(".db-entry-remove-btn").Click());
+
+        var captured = Assert.Single(alertSurface.Requests);
+        Assert.Contains("Cancel", captured.AcceptLabel ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("upgrade", captured.AcceptLabel ?? string.Empty, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -728,22 +916,41 @@ public sealed class ManageDatabasesTabTests : BunitContext
     private static DatabaseEntry Entry(string fileName, bool isEnabled, DatabaseStatus status, bool backupExists = false) =>
         new(fileName, $@"C:\dbs\{fileName}", isEnabled, status, backupExists);
 
+    private static Task InvokeCancelUpgradesAsync(
+        IRenderedComponent<ManageDatabasesTab> component,
+        IReadOnlyList<string> fileNames)
+    {
+        // Reflection bypasses the bunit click + alert-surface chain so the test can deterministically
+        // interleave the batch-completion signal with the await on pendingBatches.
+        var method = typeof(ManageDatabasesTab).GetMethod(
+            "CancelUpgradesAndAwaitCompletionAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        return (Task)method!.Invoke(component.Instance, [fileNames])!;
+    }
+
     private static BannerProgressEntry MakeProgress(
         string currentEntryName = "a.db",
         UpgradePhase currentPhase = UpgradePhase.MigratingSchema,
         int currentBatchPosition = 1,
         int currentBatchSize = 1,
         int queuedBatchesAfter = 0,
-        UpgradeProgressScope scope = UpgradeProgressScope.ManageDatabasesTriggered) =>
+        UpgradeProgressScope scope = UpgradeProgressScope.ManageDatabasesTriggered,
+        UpgradeBatchId? batchId = null,
+        Action? cancel = null,
+        IReadOnlySet<string>? batchFileNames = null) =>
         new(
-            UpgradeBatchId.Create(),
+            batchId ?? UpgradeBatchId.Create(),
             scope,
             currentBatchPosition,
             currentBatchSize,
             currentEntryName,
             currentPhase,
             queuedBatchesAfter,
-            () => { });
+            cancel ?? (() => { }))
+        {
+            BatchFileNames = batchFileNames ?? FrozenSet<string>.Empty
+        };
 
     private IRenderedComponent<ManageDatabasesTab> RenderWithAlertSurface(IInlineAlertSurface alertSurface) =>
         Render<ManageDatabasesTab>(parameters => parameters


### PR DESCRIPTION
Follow-up branch addressing 3 deferred panel-tracked findings from PR #553. R7-panel converged (4 READY) on spec; 3-slot post-impl panel reviewed implementation, addressed all findings (test-coverage gap for user-acknowledgment clear corrected; spec-revision artifacts stripped from comments). Regression-verified: the user-ack test fails with the production fix temporarily removed, confirming it's a real regression guard.

## What's in this PR

**Item 1 — Selection drift restore (modal open/close):**
The DatabaseToolsModal suppresses the Attention banner from the cycle. Before this fix, the selection-restore logic would lose the user's preference. New `_userPreferredItem` field (set ONLY by `MoveNext` / `MovePrev` — true user navigation) lets `RebuildAndReselectLocked` restore the user's choice when the suppression lifts.

**Item 2a — Priority watermark on newly-arrived items:**
When a higher-priority item (Critical, Error) arrives, selection snaps to it via a source-fingerprint diff (newly-arrived only — progress ticks on existing batches don't re-trigger). `_priorityStolenSelection` tracks the steal so subsequent unrelated rebuilds don't bounce back to a stale lower-priority preference; cleared either when the stolen item leaves the source or when the user explicitly navigates (user-acknowledgment).

**Item 2b — Per-row Remove guard during pre-progress and queued window:**
Background upgrades start with an empty `CurrentEntryName` (the WAL-checkpoint phase fires before any per-file progress event), so the per-row Remove guard previously missed files in an active batch's pre-progress window. Additionally, separately-queued (not-yet-started) batches had no `BannerProgressEntry` at all, so files queued behind an active batch could also miss the guard — both paths led to `ReserveFileOperation` crashes when the user removed a queued/pre-progress file.

Plumbing:
- Added `BatchFileNames` (case-insensitive `IReadOnlySet<string>`) to `BannerProgressEntry` plumbed via new `FileNames` init-property on `UpgradeBatchStartedEventArgs` (source-compatible — the existing CTS-based primary constructor is preserved).
- Exposed queued batches via new `IDatabaseService.SnapshotQueuedBatches()` + `QueuedBatchInfo` DTO + `DatabaseUpgradeService._queuedBatches` `ConcurrentDictionary`. Adds to dict BEFORE `TryWrite` (with rollback on failure); removes AFTER `SafeRaise UpgradeBatchStarted` in `ProcessBatchAsync` so external lookups never miss the file during the active-batch handoff (explicit superset overlap instead of a transition gap).
- `ManageDatabasesTab` gains `GetCancellableBatchForFile` (active + queued) + `IsFileInAnyKnownBatch`; `CancelUpgradesAndAwaitCompletionAsync` uses the unified lookup; the `stillAlive` probe checks batch membership so `pendingBatches` gates Remove on the real `UpgradeBatchCompleted` event for both pre-progress and queued files.

## Tests added (22 total)

- BannerCycleStateService: 12 tests (selection-drift restore, priority watermark, bounce-back guard, user-ack clear, modal-suppression interaction)
- BannerService: 3 tests (BatchFileNames plumbing + case-insensitive + record-with preservation)
- ManageDatabasesTab: 7 tests (display-lookup narrowness, pre-progress detection, queued-batch detection, cancel-then-remove flow including the ordering + promptness contract)

## Out of scope

- Issue #3 (MAUI WebView staleness) — verified manually by user; likely fixed as side-effect of Commit D's singleton `BannerCycleStateService` + `StateChanged` event pattern. Reopen as separate follow-up if it resurfaces.
- 2 spec-listed integration tests (`SnapshotQueuedBatches_IncludesAllBatchesAfterTryWrite_RemovesAfterConsumerPickup`, `ProcessBatchAsync_FileVisibleInBothSnapshots_DuringSafeRaiseUpgradeBatchStarted_NoLookupGap`) deferred — `DatabaseRegistry` is `internal sealed` with no interface, making `DatabaseUpgradeService` uninstantiable at unit level. The observable consequence (cancel flow awaits batch completion correctly) is covered by the unit-level tests; the consumer-loop ordering invariant has a `NOTE on ordering:` comment at the call site.

## Verification

- 2,467 unit tests pass; no regressions.
- User-ack-clear regression test verified by temporarily removing the production fix — test failed as expected, confirming the guard.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>