### PR TITLE
Redesign Manage tab selection mode with bulk multi-upgrade and add in-modal context menus

### DIFF
--- a/src/EventLogExpert.Runtime/Database/DatabaseOperationCoordinator.cs
+++ b/src/EventLogExpert.Runtime/Database/DatabaseOperationCoordinator.cs
@@ -216,6 +216,64 @@ internal sealed class DatabaseOperationCoordinator(
         }
     }
 
+    public async Task<UpgradeBatchResult?> UpgradeDatabasesAsync(
+        IReadOnlyList<string> fileNames,
+        UpgradeProgressScope scope = UpgradeProgressScope.ManageDatabasesTriggered,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(fileNames);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (fileNames.Count == 0)
+        {
+            return new UpgradeBatchResult(Succeeded: [], Cancelled: [], Failed: []);
+        }
+
+        using (_upgradeGate.EnterScope())
+        {
+            // Gate-denied: another upgrade is in flight. Null distinguishes
+            // this from a batch that ran but had every file cancelled per-file.
+            if (_upgradesInFlight.Count > 0) { return null; }
+
+            foreach (var fileName in fileNames) { _upgradesInFlight.Add(fileName); }
+        }
+
+        try
+        {
+            RaiseUpgradeStateChangedSafely();
+
+            var fallback = new UpgradeBatchResult(Succeeded: [], Cancelled: [], Failed: []);
+
+            return await RunOperationAsync(
+                operationName: "upgrade",
+                failureTitle: "Database Upgrade Failed",
+                operationNoun: $"upgrading {fileNames.Count} database{(fileNames.Count == 1 ? string.Empty : "s")}",
+                fallbackOutcome: fallback,
+                body: async () =>
+                {
+                    var batchResult = await _databases.UpgradeBatchAsync(fileNames, scope, cancellationToken);
+
+                    foreach (var failure in batchResult.Failed)
+                    {
+                        _errorBanners.ReportError(
+                            "Database Upgrade Failed",
+                            $"Failed to upgrade '{failure.FileName}': {failure.Message}");
+                    }
+
+                    return batchResult;
+                });
+        }
+        finally
+        {
+            using (_upgradeGate.EnterScope())
+            {
+                foreach (var fileName in fileNames) { _upgradesInFlight.Remove(fileName); }
+            }
+
+            RaiseUpgradeStateChangedSafely();
+        }
+    }
+
     internal static (string Title, string Message, ResultSeverity Severity) BuildImportSummary(ImportResult importResult)
     {
         ArgumentNullException.ThrowIfNull(importResult);

--- a/src/EventLogExpert.Runtime/Database/IDatabaseOperationCoordinator.cs
+++ b/src/EventLogExpert.Runtime/Database/IDatabaseOperationCoordinator.cs
@@ -30,4 +30,9 @@ public interface IDatabaseOperationCoordinator
         string fileName,
         UpgradeProgressScope scope = UpgradeProgressScope.ManageDatabasesTriggered,
         CancellationToken cancellationToken = default);
+
+    Task<UpgradeBatchResult?> UpgradeDatabasesAsync(
+        IReadOnlyList<string> fileNames,
+        UpgradeProgressScope scope = UpgradeProgressScope.ManageDatabasesTriggered,
+        CancellationToken cancellationToken = default);
 }

--- a/src/EventLogExpert.UI/Database/DatabaseEntryEligibility.cs
+++ b/src/EventLogExpert.UI/Database/DatabaseEntryEligibility.cs
@@ -1,0 +1,21 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.Database;
+
+namespace EventLogExpert.UI.Database;
+
+public static class DatabaseEntryEligibility
+{
+    public static bool IsUpgradeEligible(DatabaseEntry entry, bool isUpgrading)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        if (entry.BackupExists) { return false; }
+
+        if (isUpgrading) { return false; }
+
+        return entry.Status is DatabaseStatus.UpgradeRequired
+            or DatabaseStatus.UpgradeFailed;
+    }
+}

--- a/src/EventLogExpert.UI/Database/DatabaseEntryRow.razor
+++ b/src/EventLogExpert.UI/Database/DatabaseEntryRow.razor
@@ -1,5 +1,5 @@
 <div class="db-entry-row"
-    @oncontextmenu="HandleContextMenuAsync"
+    @oncontextmenu="HandleContextMenu"
     @oncontextmenu:preventDefault="true">
     <div @attributes="CheckboxHiddenAttributes"
         class="db-entry-checkbox @(IsSelectionModeActive ? "db-entry-checkbox--visible" : null)">

--- a/src/EventLogExpert.UI/Database/DatabaseEntryRow.razor
+++ b/src/EventLogExpert.UI/Database/DatabaseEntryRow.razor
@@ -1,7 +1,13 @@
-<div class="db-entry-row @(IsSelected ? "db-entry-row--selected" : null)">
-    <Checkbox AriaLabel="@($"Select {Entry.FileName}")"
-        Value="IsSelected"
-        ValueChanged="@(_ => OnSelectionToggle.InvokeAsync())" />
+<div class="db-entry-row"
+    @oncontextmenu="HandleContextMenuAsync"
+    @oncontextmenu:preventDefault="true">
+    <div @attributes="CheckboxHiddenAttributes"
+        class="db-entry-checkbox @(IsSelectionModeActive ? "db-entry-checkbox--visible" : null)">
+        <Checkbox AriaLabel="@($"Select {Entry.FileName}")"
+            Disabled="@(!IsSelectionModeActive)"
+            Value="IsSelected"
+            ValueChanged="@(_ => OnSelectionToggle.InvokeAsync())" />
+    </div>
 
     <div class="db-entry-row-content">
         <div class="db-entry-info">
@@ -114,14 +120,6 @@
                     </button>
                     break;
             }
-
-            <button aria-label="@($"Remove database {Entry.FileName}")"
-                class="button button-red db-entry-remove-btn"
-                @onclick="OnRemoveClick"
-                @ref="_removeButtonRef"
-                type="button">
-                <i aria-hidden="true" class="bi bi-trash"></i>
-            </button>
         </div>
     </div>
 </div>

--- a/src/EventLogExpert.UI/Database/DatabaseEntryRow.razor
+++ b/src/EventLogExpert.UI/Database/DatabaseEntryRow.razor
@@ -73,9 +73,9 @@
                     break;
 
                 case ActionKind.Upgrade:
-                    <button aria-disabled="@(IsUpgradeBlocked ? "true" : "false")"
-                        aria-label="@($"Upgrade database {Entry.FileName}")"
+                    <button aria-label="@($"Upgrade database {Entry.FileName}")"
                         class="button db-entry-upgrade-btn"
+                        disabled="@IsUpgradeBlocked"
                         @onclick="@(async () =>
                                   {
                                       if (!IsUpgradeBlocked) { await OnUpgrade.InvokeAsync(); }
@@ -86,9 +86,9 @@
                     break;
 
                 case ActionKind.Retry:
-                    <button aria-disabled="@(IsUpgradeBlocked ? "true" : "false")"
-                        aria-label="@($"Retry upgrade of database {Entry.FileName}")"
+                    <button aria-label="@($"Retry upgrade of database {Entry.FileName}")"
                         class="button button-red db-entry-upgrade-btn"
+                        disabled="@IsUpgradeBlocked"
                         @onclick="@(async () =>
                                   {
                                       if (!IsUpgradeBlocked) { await OnUpgrade.InvokeAsync(); }
@@ -99,9 +99,9 @@
                     break;
 
                 case ActionKind.RestoreFromBackup:
-                    <button aria-disabled="@(IsRestoreBlocked ? "true" : "false")"
-                        aria-label="@($"Restore database {Entry.FileName} from backup")"
+                    <button aria-label="@($"Restore database {Entry.FileName} from backup")"
                         class="button db-entry-restore-btn"
+                        disabled="@IsRestoreBlocked"
                         @onclick="@(async () =>
                                   {
                                       if (!IsRestoreBlocked) { await OnRestoreFromBackup.InvokeAsync(); }

--- a/src/EventLogExpert.UI/Database/DatabaseEntryRow.razor.cs
+++ b/src/EventLogExpert.UI/Database/DatabaseEntryRow.razor.cs
@@ -119,6 +119,7 @@ public sealed partial class DatabaseEntryRow : ComponentBase
 
         try { await _nameButtonRef.FocusAsync(preventScroll: true); }
         catch (ObjectDisposedException) { }
+        catch (JSDisconnectedException) { }
         catch (JSException) { }
     }
 

--- a/src/EventLogExpert.UI/Database/DatabaseEntryRow.razor.cs
+++ b/src/EventLogExpert.UI/Database/DatabaseEntryRow.razor.cs
@@ -5,18 +5,22 @@ using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Runtime.Banner;
 using EventLogExpert.Runtime.Database;
 using EventLogExpert.Runtime.Database.Upgrade;
+using EventLogExpert.Runtime.Menu;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
 
 namespace EventLogExpert.UI.Database;
 
 public sealed partial class DatabaseEntryRow : ComponentBase
 {
+    private static readonly IReadOnlyDictionary<string, object> s_ariaHiddenTrueAttributes =
+        new Dictionary<string, object>(StringComparer.Ordinal) { ["aria-hidden"] = "true" };
+
     private readonly string _nameButtonId = $"db-row-{Guid.NewGuid():N}-name";
     private readonly string _pendingStatusId = $"db-row-{Guid.NewGuid():N}-pending";
 
     private ElementReference _nameButtonRef;
-    private ElementReference _removeButtonRef;
     private bool _shouldFocusNameAfterRender;
 
     private enum ActionKind
@@ -38,6 +42,8 @@ public sealed partial class DatabaseEntryRow : ComponentBase
     [Parameter] public bool IsClassificationPending { get; set; }
 
     [Parameter] public bool IsSelected { get; set; }
+
+    [Parameter] public bool IsSelectionModeActive { get; set; }
 
     [Parameter] public bool IsTogglePending { get; set; }
 
@@ -63,7 +69,12 @@ public sealed partial class DatabaseEntryRow : ComponentBase
 
     private string BadgeLabel => DatabaseStatusLabels.GetRowBadgeLabel(Entry);
 
+    private IReadOnlyDictionary<string, object>? CheckboxHiddenAttributes =>
+        IsSelectionModeActive ? null : s_ariaHiddenTrueAttributes;
+
     private bool IsRestoreBlocked => IsUpgradeBlocked || IsUpgrading || UpgradeProgress is not null;
+
+    [Inject] private IMenuService MenuService { get; init; } = null!;
 
     private ActionKind PrimaryAction
     {
@@ -98,7 +109,7 @@ public sealed partial class DatabaseEntryRow : ComponentBase
 
     [Inject] private ITraceLogger TraceLogger { get; init; } = null!;
 
-    public ValueTask FocusRemoveButtonAsync() => _removeButtonRef.FocusAsync(preventScroll: true);
+    public ValueTask FocusNameAsync() => _nameButtonRef.FocusAsync(preventScroll: true);
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -119,6 +130,19 @@ public sealed partial class DatabaseEntryRow : ComponentBase
         _ => "Upgrading"
     };
 
+    private void HandleContextMenuAsync(MouseEventArgs args)
+    {
+        // Suppressed in selection mode — bulk strip is the action surface.
+        if (IsSelectionModeActive) { return; }
+
+        var items = new List<MenuItem>
+        {
+            MenuItem.Item("Remove", () => OnRemove.InvokeAsync()),
+        };
+
+        MenuService.OpenAt(args.ClientX, args.ClientY, items);
+    }
+
     private void OnCancelClick()
     {
         _shouldFocusNameAfterRender = true;
@@ -131,6 +155,4 @@ public sealed partial class DatabaseEntryRow : ComponentBase
                 $"{nameof(DatabaseEntryRow)}.{nameof(OnCancelClick)}: cancel threw: {ex}");
         }
     }
-
-    private async Task OnRemoveClick() => await OnRemove.InvokeAsync();
 }

--- a/src/EventLogExpert.UI/Database/DatabaseEntryRow.razor.cs
+++ b/src/EventLogExpert.UI/Database/DatabaseEntryRow.razor.cs
@@ -130,7 +130,7 @@ public sealed partial class DatabaseEntryRow : ComponentBase
         _ => "Upgrading"
     };
 
-    private void HandleContextMenuAsync(MouseEventArgs args)
+    private void HandleContextMenu(MouseEventArgs args)
     {
         // Suppressed in selection mode — bulk strip is the action surface.
         if (IsSelectionModeActive) { return; }

--- a/src/EventLogExpert.UI/Database/DatabaseEntryRow.razor.css
+++ b/src/EventLogExpert.UI/Database/DatabaseEntryRow.razor.css
@@ -1,19 +1,29 @@
+.db-entry-checkbox {
+    display: flex;
+    align-items: center;
+
+    max-width: 0;
+    padding-right: 0;
+    overflow: hidden;
+
+    transition: max-width 180ms ease, padding-right 180ms ease;
+}
+
+.db-entry-checkbox--visible {
+    max-width: 3rem;
+    padding-right: .5rem;
+}
+
 .db-entry-row {
     display: grid;
     grid-template-columns: auto 1fr;
     align-items: center;
-    gap: .5rem;
+    gap: 0;
 
-    padding: .25rem .5rem;
+    padding: .15rem .5rem;
     background-color: var(--background-dark);
 
-    border-left: 3px solid transparent;
-
-    transition: background-color 180ms ease, border-left-color 180ms ease;
-}
-
-.db-entry-row--selected {
-    border-left-color: var(--clr-lightblue);
+    transition: background-color 180ms ease;
 }
 
 .db-entry-row-content {
@@ -22,7 +32,7 @@
     align-items: center;
     gap: 1rem;
 
-    padding: .25rem 0;
+    padding: 0;
 }
 
 .db-entry-info {
@@ -132,13 +142,6 @@
     transition: background-color 150ms ease;
 
     &:hover { background-color: rgba(255, 255, 255, 0.12); }
-}
-
-.db-entry-remove-btn {
-    flex: 0 0 auto;
-    display: flex;
-    align-items: center;
-    justify-content: center;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/EventLogExpert.UI/DatabaseTools/DatabaseToolsModal.razor.cs
+++ b/src/EventLogExpert.UI/DatabaseTools/DatabaseToolsModal.razor.cs
@@ -115,6 +115,13 @@ public sealed partial class DatabaseToolsModal : IInlineAlertSurface
 
     protected override async Task<bool> OnRequestCloseAsync(ModalCloseRequest request)
     {
+        // 0. Manage tab in selection mode consumes the close request.
+        if (_activeTab == DatabaseToolsTab.Manage && _manageTab is { IsInSelectionMode: true } manageTab)
+        {
+            await manageTab.ExitSelectionModeWithFocusAsync();
+            return false;
+        }
+
         // 1. Hard-block while Manage-tab-initiated upgrade is in flight.
         if (_manageTab is { IsUpgradeInFlight: true }) { return false; }
 

--- a/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor
+++ b/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor
@@ -33,7 +33,7 @@
     @if (_isSelectionModeActive && DatabaseService.Entries.Count > 0)
     {
         <div class="manage-databases-selection-header">
-            <div class="db-entry-checkbox db-entry-checkbox--visible">
+            <div class="manage-databases-master-checkbox">
                 <button aria-checked="@MasterCheckboxAriaChecked"
                     aria-label="@MasterCheckboxAriaLabel"
                     class="manage-databases-master-btn"
@@ -95,8 +95,8 @@
             @if (_eligibleUpgradeCount > 0)
             {
                 <button aria-describedby="@(IsUpgradeBlocked ? _upgradeBlockedHelpId : null)"
-                    aria-disabled="@(IsUpgradeBlocked ? "true" : "false")"
                     class="button button-green"
+                    disabled="@IsUpgradeBlocked"
                     @onclick="OnBulkUpgradeClickAsync"
                     @ref="_bulkUpgradeButtonRef"
                     type="button">

--- a/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor
+++ b/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor
@@ -1,6 +1,6 @@
 @namespace EventLogExpert.UI.DatabaseTools.Tabs
 
-<div class="manage-databases-tab" @onkeydown="HandleKeyDown" tabindex="-1">
+<div class="manage-databases-tab">
     @if (IsClassificationPending)
     {
         <div class="manage-status-banner manage-status-banner--info" role="status">
@@ -107,7 +107,7 @@
                 @onclick="OnBulkRemoveClickAsync"
                 @ref="_bulkRemoveButtonRef"
                 type="button">
-                Delete @_selectedForBulk.Count
+                Remove @_selectedForBulk.Count
             </button>
             <span aria-live="polite" class="visually-hidden" id="@_upgradeBlockedHelpId">
                 @(IsUpgradeBlocked

--- a/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor
+++ b/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor
@@ -129,8 +129,8 @@
                 Discard
             </button>
             <button aria-describedby="@(IsUpgradeBlocked ? _saveBlockedHelpId : null)"
-                aria-disabled="@(IsUpgradeBlocked ? "true" : "false")"
                 class="button button-green"
+                disabled="@IsUpgradeBlocked"
                 id="manage-save"
                 @onclick="OnSaveClickAsync"
                 type="button">

--- a/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor
+++ b/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor
@@ -1,6 +1,6 @@
 @namespace EventLogExpert.UI.DatabaseTools.Tabs
 
-<div class="manage-databases-tab">
+<div class="manage-databases-tab" @onkeydown="HandleKeyDown" tabindex="-1">
     @if (IsClassificationPending)
     {
         <div class="manage-status-banner manage-status-banner--info" role="status">
@@ -12,6 +12,15 @@
     <span aria-atomic="true" aria-live="polite" class="visually-hidden" role="status">@_selectionAnnouncement</span>
 
     <div class="manage-databases-import-row">
+        <button aria-pressed="@(_isSelectionModeActive ? "true" : "false")"
+            class="button manage-databases-select-btn"
+            id="manage-select-button"
+            @onclick="ToggleSelectionMode"
+            @ref="_selectButtonRef"
+            type="button">
+            <i aria-hidden="true" class="bi bi-check2-square"></i>
+            @(_isSelectionModeActive ? "Done" : "Select")
+        </button>
         <button class="button"
             id="manage-import-button"
             @onclick="ImportDatabase"
@@ -21,6 +30,32 @@
         </button>
     </div>
 
+    @if (_isSelectionModeActive && DatabaseService.Entries.Count > 0)
+    {
+        <div class="manage-databases-selection-header">
+            <div class="db-entry-checkbox db-entry-checkbox--visible">
+                <button aria-checked="@MasterCheckboxAriaChecked"
+                    aria-label="@MasterCheckboxAriaLabel"
+                    class="manage-databases-master-btn"
+                    @onclick="OnMasterCheckboxClickAsync"
+                    @ref="_masterCheckboxRef"
+                    role="checkbox"
+                    type="button">
+                    <i aria-hidden="true" class="bi @MasterCheckboxIconClass"></i>
+                </button>
+            </div>
+            <span class="manage-databases-selection-count">
+                @_selectedForBulk.Count of @DatabaseService.Entries.Count selected
+                @if (_selectedForBulk.Count > 0)
+                {
+                    <span class="manage-databases-selection-count-eligible">
+                        (@_eligibleUpgradeCount eligible for upgrade)
+                    </span>
+                }
+            </span>
+        </div>
+    }
+
     <div class="manage-databases-entries">
         @if (DatabaseService.Entries.Count > 0)
         {
@@ -29,7 +64,8 @@
                 <DatabaseEntryRow EffectiveEnabled="GetEffectiveEnabled(entry)"
                     Entry="@entry"
                     IsClassificationPending="@IsClassificationPending"
-                    IsSelected="@_selectedForRemoval.Contains(entry.FileName)"
+                    IsSelected="@_selectedForBulk.Contains(entry.FileName)"
+                    IsSelectionModeActive="@_isSelectionModeActive"
                     IsTogglePending="@_pendingToggles.ContainsKey(entry.FileName)"
                     IsUpgradeBlocked="@IsUpgradeBlocked"
                     IsUpgrading="@Coordinator.IsUpgradeInFlight(entry.FileName)"
@@ -40,7 +76,7 @@
                     OnSelectionToggle="@(() => ToggleSelection(entry.FileName))"
                     OnToggle="@(() => ToggleDatabase(entry.FileName))"
                     OnUpgrade="@(() => UpgradeEntry(entry.FileName))"
-                    @ref="_removeButtonRefs[entry.FileName]"
+                    @ref="_rowRefs[entry.FileName]"
                     UpgradeProgress="@GetUpgradeProgressForEntry(entry)" />
             }
         }
@@ -50,23 +86,34 @@
         }
     </div>
 
-    @if (HasSelectedForRemoval)
+    @if (_isSelectionModeActive && _selectedForBulk.Count > 0)
     {
         <div aria-label="Bulk database actions" class="manage-databases-bulk-strip" role="group">
             <span class="manage-databases-bulk-count">
-                @_selectedForRemoval.Count selected
+                @_selectedForBulk.Count selected
             </span>
-            <button class="button"
-                @onclick="ClearSelection"
-                type="button">
-                Clear
-            </button>
+            @if (_eligibleUpgradeCount > 0)
+            {
+                <button aria-describedby="@(IsUpgradeBlocked ? _upgradeBlockedHelpId : null)"
+                    aria-disabled="@(IsUpgradeBlocked ? "true" : "false")"
+                    class="button button-green"
+                    @onclick="OnBulkUpgradeClickAsync"
+                    @ref="_bulkUpgradeButtonRef"
+                    type="button">
+                    Upgrade @_eligibleUpgradeCount
+                </button>
+            }
             <button class="button button-red"
                 @onclick="OnBulkRemoveClickAsync"
                 @ref="_bulkRemoveButtonRef"
                 type="button">
-                Remove @_selectedForRemoval.Count
+                Delete @_selectedForBulk.Count
             </button>
+            <span aria-live="polite" class="visually-hidden" id="@_upgradeBlockedHelpId">
+                @(IsUpgradeBlocked
+                    ? "Cannot upgrade: another upgrade is already in progress."
+                    : string.Empty)
+            </span>
         </div>
     }
 

--- a/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor
+++ b/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor
@@ -109,7 +109,7 @@
                 type="button">
                 Remove @_selectedForBulk.Count
             </button>
-            <span aria-live="polite" class="visually-hidden" id="@_upgradeBlockedHelpId">
+            <span class="visually-hidden" id="@_upgradeBlockedHelpId">
                 @(IsUpgradeBlocked
                     ? "Cannot upgrade: another upgrade is already in progress."
                     : string.Empty)
@@ -136,7 +136,7 @@
                 type="button">
                 Save changes
             </button>
-            <span aria-live="polite" class="visually-hidden" id="@_saveBlockedHelpId">
+            <span class="visually-hidden" id="@_saveBlockedHelpId">
                 @(IsUpgradeBlocked ? "Cannot save: a database upgrade is in progress." : string.Empty)
             </span>
         </div>

--- a/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.cs
+++ b/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.cs
@@ -64,6 +64,8 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
 
     public bool HasPendingChanges => _pendingToggles.Count > 0;
 
+    public bool IsInSelectionMode => _isSelectionModeActive;
+
     public bool IsUpgradeInFlight => Coordinator.IsAnyUpgradeInFlight;
 
     [CascadingParameter] internal IInlineAlertSurface? AlertSurface { get; set; }
@@ -529,6 +531,18 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
         _pendingToggles.Clear();
     }
 
+    public async Task ExitSelectionModeWithFocusAsync()
+    {
+        if (!_isSelectionModeActive) { return; }
+
+        ExitSelectionMode();
+        StateHasChanged();
+
+        try { await _selectButtonRef.FocusAsync(preventScroll: true); }
+        catch (JSDisconnectedException) { }
+        catch (JSException) { }
+    }
+
     private void ExitSelectionMode()
     {
         _isSelectionModeActive = false;
@@ -629,20 +643,6 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
         }
 
         return null;
-    }
-
-    private async Task HandleKeyDown(KeyboardEventArgs args)
-    {
-        if (!_isSelectionModeActive) { return; }
-
-        if (args.Key == "Escape")
-        {
-            ExitSelectionMode();
-
-            try { await _selectButtonRef.FocusAsync(preventScroll: true); }
-            catch (JSDisconnectedException) { }
-            catch (JSException) { }
-        }
     }
 
     private async Task ImportDatabase()

--- a/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.cs
+++ b/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.cs
@@ -452,15 +452,6 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
         }
     }
 
-    private void ClearSelection()
-    {
-        if (_selectedForBulk.Count == 0) { return; }
-
-        _selectedForBulk.Clear();
-        RecomputeEligibleCount();
-        UpdateSelectionAnnouncement();
-    }
-
     private ImmutableHashSet<string> ComputeActiveSet() =>
         DatabaseService.Entries
             .Where(entry => entry is { IsEnabled: true, Status: DatabaseStatus.Ready })

--- a/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.cs
+++ b/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.cs
@@ -942,6 +942,12 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
 
     private void RecomputeEligibleCount()
     {
+        if (_selectedForBulk.Count == 0)
+        {
+            _eligibleUpgradeCount = 0;
+            return;
+        }
+
         var entriesByFileName = SnapshotEntriesByFileName();
         int count = 0;
 

--- a/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.cs
+++ b/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.cs
@@ -10,7 +10,6 @@ using EventLogExpert.Runtime.Database.Upgrade;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.UI.Database;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
 using System.Collections.Immutable;
 using System.Text;
@@ -118,6 +117,18 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
         DatabaseService.UpgradeBatchCompleted -= OnUpgradeBatchCompleted;
         ProgressBannerService.StateChanged -= OnBannerStateChanged;
         Coordinator.UpgradeStateChanged -= OnCoordinatorStateChanged;
+    }
+
+    public async Task ExitSelectionModeWithFocusAsync()
+    {
+        if (!_isSelectionModeActive) { return; }
+
+        ExitSelectionMode();
+        StateHasChanged();
+
+        try { await _selectButtonRef.FocusAsync(preventScroll: true); }
+        catch (JSDisconnectedException) { }
+        catch (JSException) { }
     }
 
     /// <summary>
@@ -531,18 +542,6 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
         _pendingToggles.Clear();
     }
 
-    public async Task ExitSelectionModeWithFocusAsync()
-    {
-        if (!_isSelectionModeActive) { return; }
-
-        ExitSelectionMode();
-        StateHasChanged();
-
-        try { await _selectButtonRef.FocusAsync(preventScroll: true); }
-        catch (JSDisconnectedException) { }
-        catch (JSException) { }
-    }
-
     private void ExitSelectionMode()
     {
         _isSelectionModeActive = false;
@@ -624,6 +623,15 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
     private bool GetEffectiveEnabled(DatabaseEntry entry) =>
         _pendingToggles.TryGetValue(entry.FileName, out var pending) ? pending : entry.IsEnabled;
 
+    private (bool IsEligible, bool IsUpgrading) GetEntryUpgradeState(DatabaseEntry entry)
+    {
+        bool upgrading = Coordinator.IsUpgradeInFlight(entry.FileName) ||
+            GetUpgradeProgressForEntry(entry) is not null ||
+            IsFileInAnyKnownBatch(entry.FileName);
+
+        return (DatabaseEntryEligibility.IsUpgradeEligible(entry, upgrading), upgrading);
+    }
+
     private BannerProgressEntry? GetUpgradeProgressForEntry(DatabaseEntry entry)
     {
         var manage = ProgressBannerService.ManageDatabasesProgress;
@@ -691,20 +699,6 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
     private bool IsFileInAnyKnownBatch(string fileName) =>
         GetCancellableBatchForFile(fileName) is not null;
 
-    private bool IsUpgradeEligibleForSelected(string fileName)
-    {
-        var entry = DatabaseService.Entries.FirstOrDefault(
-            e => string.Equals(e.FileName, fileName, StringComparison.OrdinalIgnoreCase));
-
-        if (entry is null) { return false; }
-
-        bool upgrading = Coordinator.IsUpgradeInFlight(entry.FileName) ||
-            GetUpgradeProgressForEntry(entry) is not null ||
-            IsFileInAnyKnownBatch(entry.FileName);
-
-        return DatabaseEntryEligibility.IsUpgradeEligible(entry, upgrading);
-    }
-
     private async Task ObserveClassificationCompletionAsync(CancellationToken cancellationToken)
     {
         try
@@ -746,26 +740,23 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
     {
         if (_eligibleUpgradeCount == 0 || IsUpgradeBlocked) { return; }
 
+        var entriesByFileName = SnapshotEntriesByFileName();
         var eligible = new List<string>();
         var skipped = new List<(string FileName, string Reason)>();
 
         foreach (var fileName in _selectedForBulk)
         {
-            if (IsUpgradeEligibleForSelected(fileName))
+            if (!entriesByFileName.TryGetValue(fileName, out var entry)) { continue; }
+
+            var (isEligible, isUpgrading) = GetEntryUpgradeState(entry);
+
+            if (isEligible)
             {
                 eligible.Add(fileName);
             }
             else
             {
-                var entry = DatabaseService.Entries.FirstOrDefault(
-                    e => string.Equals(e.FileName, fileName, StringComparison.OrdinalIgnoreCase));
-
-                if (entry is null) { continue; }
-
-                bool upgrading = Coordinator.IsUpgradeInFlight(entry.FileName) ||
-                    GetUpgradeProgressForEntry(entry) is not null ||
-                    IsFileInAnyKnownBatch(entry.FileName);
-                skipped.Add((fileName, GetSkipReason(entry, upgrading)));
+                skipped.Add((fileName, GetSkipReason(entry, isUpgrading)));
             }
         }
 
@@ -954,11 +945,18 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
 
     private void RecomputeEligibleCount()
     {
+        var entriesByFileName = SnapshotEntriesByFileName();
         int count = 0;
+
         foreach (var fileName in _selectedForBulk)
         {
-            if (IsUpgradeEligibleForSelected(fileName)) { count++; }
+            if (entriesByFileName.TryGetValue(fileName, out var entry) &&
+                GetEntryUpgradeState(entry).IsEligible)
+            {
+                count++;
+            }
         }
+
         _eligibleUpgradeCount = count;
     }
 
@@ -1121,6 +1119,11 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
         RecomputeEligibleCount();
         UpdateSelectionAnnouncement();
     }
+
+    private Dictionary<string, DatabaseEntry> SnapshotEntriesByFileName() =>
+        DatabaseService.Entries.ToDictionary(
+            e => e.FileName,
+            StringComparer.OrdinalIgnoreCase);
 
     private void ToggleDatabase(string fileName)
     {

--- a/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.cs
+++ b/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.cs
@@ -10,8 +10,10 @@ using EventLogExpert.Runtime.Database.Upgrade;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.UI.Database;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
 using System.Collections.Immutable;
+using System.Text;
 
 namespace EventLogExpert.UI.DatabaseTools.Tabs;
 
@@ -20,26 +22,35 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
     private static readonly TimeSpan s_cancelTimeout = TimeSpan.FromSeconds(30);
 
     private readonly Dictionary<string, bool> _pendingToggles = new(StringComparer.OrdinalIgnoreCase);
-    private readonly Dictionary<string, DatabaseEntryRow?> _removeButtonRefs = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, DatabaseEntryRow?> _rowRefs = new(StringComparer.OrdinalIgnoreCase);
     private readonly string _saveBlockedHelpId = $"manage-save-blocked-{Guid.NewGuid():N}";
-    private readonly HashSet<string> _selectedForRemoval = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> _selectedForBulk = new(StringComparer.OrdinalIgnoreCase);
+    private readonly string _upgradeBlockedHelpId = $"manage-upgrade-blocked-{Guid.NewGuid():N}";
 
     private ElementReference _bulkRemoveButtonRef;
+    private ElementReference _bulkUpgradeButtonRef;
     private CancellationTokenSource? _classificationObservationCts;
     private volatile bool _disposed;
+    private int _eligibleUpgradeCount;
     private (string FileName, FocusTarget Target)? _focusRestorationTarget;
     private ElementReference _importButtonRef;
     private ImmutableHashSet<string> _initialActiveSnapshot = ImmutableHashSet<string>.Empty;
+    private bool _isSelectionModeActive;
+    private ElementReference _masterCheckboxRef;
     private bool _restorationOccurred;
     private bool _schemaUpgradeOccurred;
+    private ElementReference _selectButtonRef;
     private string _selectionAnnouncement = string.Empty;
 
     private enum FocusTarget
     {
-        SameRowRemove,
+        SameRowName,
         BulkRemoveButton,
+        SelectButton,
         ImportButton
     }
+
+    public bool HasBulkSelection => _selectedForBulk.Count > 0;
 
     public bool HasDatabaseStateChanged
     {
@@ -52,8 +63,6 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
     }
 
     public bool HasPendingChanges => _pendingToggles.Count > 0;
-
-    public bool HasSelectedForRemoval => _selectedForRemoval.Count > 0;
 
     public bool IsUpgradeInFlight => Coordinator.IsAnyUpgradeInFlight;
 
@@ -70,6 +79,21 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
     private bool IsUpgradeBlocked => IsUpgradeInFlight;
 
     [Inject] private ILogReloadCoordinator LogReloadCoordinator { get; init; } = null!;
+
+    private string MasterCheckboxAriaChecked =>
+        _selectedForBulk.Count == 0 ? "false"
+        : _selectedForBulk.Count >= DatabaseService.Entries.Count ? "true"
+        : "mixed";
+
+    private string MasterCheckboxAriaLabel =>
+        _selectedForBulk.Count >= DatabaseService.Entries.Count && _selectedForBulk.Count > 0
+            ? "Clear selection"
+            : "Select all";
+
+    private string MasterCheckboxIconClass =>
+        _selectedForBulk.Count == 0 ? "bi-square"
+        : _selectedForBulk.Count >= DatabaseService.Entries.Count ? "bi-check-square-fill"
+        : "bi-dash-square-fill";
 
     [Inject] private IProgressBannerService ProgressBannerService { get; init; } = null!;
 
@@ -140,10 +164,12 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
             {
                 await (target.Target switch
                 {
-                    FocusTarget.SameRowRemove =>
-                        _removeButtonRefs.GetValueOrDefault(target.FileName)?.FocusRemoveButtonAsync() ?? _importButtonRef.FocusAsync(preventScroll: true),
-                    FocusTarget.BulkRemoveButton when HasSelectedForRemoval =>
+                    FocusTarget.SameRowName when !string.IsNullOrEmpty(target.FileName) =>
+                        FocusEntryRowNameAsync(target.FileName),
+                    FocusTarget.BulkRemoveButton when HasBulkSelection =>
                         _bulkRemoveButtonRef.FocusAsync(preventScroll: true),
+                    FocusTarget.SelectButton when _isSelectionModeActive =>
+                        _selectButtonRef.FocusAsync(preventScroll: true),
                     FocusTarget.ImportButton =>
                         _importButtonRef.FocusAsync(preventScroll: true),
                     _ => ValueTask.CompletedTask
@@ -183,6 +209,78 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
         return $"Are you sure you want to remove these {fileNames.Count} databases? ({list}{more})";
     }
 
+    private static string GetSkipReason(DatabaseEntry entry, bool isUpgrading)
+    {
+        if (entry.BackupExists) { return "Restore from backup required"; }
+        if (isUpgrading) { return "Upgrade in progress"; }
+        return entry.Status switch
+        {
+            DatabaseStatus.Ready => "Already up to date",
+            DatabaseStatus.NotClassified => "Classification pending",
+            DatabaseStatus.UnrecognizedSchema => "Unrecognized schema",
+            DatabaseStatus.ObsoleteSchema => "Obsolete schema",
+            DatabaseStatus.ClassificationFailed => "Classification failed",
+            _ => "Not eligible"
+        };
+    }
+
+    private async Task AnnounceBulkUpgradeOutcomeAsync(UpgradeBatchResult? result, int attempted)
+    {
+        // Gate-denied (singleton upgrade gate held by another caller).
+        if (result is null)
+        {
+            if (AlertSurface is null) { return; }
+            try
+            {
+                _ = await AlertSurface.ShowInlineAlertAsync(
+                    new InlineAlertRequest(
+                        Title: "Upgrade not started",
+                        Message: "Another upgrade is already in progress.",
+                        AcceptLabel: null,
+                        CancelLabel: "OK",
+                        IsPrompt: false,
+                        PromptInitialValue: null),
+                    CancellationToken.None);
+            }
+            catch (ObjectDisposedException) { }
+            return;
+        }
+
+        // Exception-fallback: coordinator's RunOperationAsync<T> returns an empty
+        // result on a thrown exception. The error banner already fired upstream;
+        // suppress the success-shaped announcement that would otherwise read
+        // "Upgraded 0 databases" alongside it.
+        if (attempted > 0
+            && result.Succeeded.Count == 0
+            && result.Failed.Count == 0
+            && result.Cancelled.Count == 0)
+        {
+            return;
+        }
+
+        if (result.Cancelled.Count > 0 && result.Failed.Count == 0)
+        {
+            AnnouncementService.Announce(
+                $"Upgraded {result.Succeeded.Count} database{(result.Succeeded.Count == 1 ? "" : "s")}; "
+                + $"{result.Cancelled.Count} cancelled.");
+            return;
+        }
+
+        if (result.Failed.Count > 0)
+        {
+            var first = result.Failed[0];
+            var summary = result.Failed.Count == 1
+                ? $"Upgrade of '{first.FileName}' failed: {first.Message}"
+                : $"Upgraded {result.Succeeded.Count} of {attempted} databases; "
+                    + $"{result.Failed.Count} failed. First failure: '{first.FileName}' \u2014 {first.Message}";
+            AnnouncementService.Announce(summary);
+            return;
+        }
+
+        AnnouncementService.Announce(
+            $"Upgraded {result.Succeeded.Count} database{(result.Succeeded.Count == 1 ? "" : "s")}.");
+    }
+
     private string AppendCloseReopenWarningIfNeeded(string baseMessage, IReadOnlyList<string> fileNames)
     {
         if (!LogReloadCoordinator.HasActiveLogs) { return baseMessage; }
@@ -190,8 +288,7 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
         bool anyRemovalAffectsActiveLog = fileNames.Any(f =>
             DatabaseService.Entries.Any(e =>
                 string.Equals(e.FileName, f, StringComparison.OrdinalIgnoreCase) &&
-                e.IsEnabled &&
-                e.Status == DatabaseStatus.Ready));
+                e is { IsEnabled: true, Status: DatabaseStatus.Ready }));
 
         if (!anyRemovalAffectsActiveLog) { return baseMessage; }
 
@@ -357,8 +454,10 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
 
     private void ClearSelection()
     {
-        if (_selectedForRemoval.Count == 0) { return; }
-        _selectedForRemoval.Clear();
+        if (_selectedForBulk.Count == 0) { return; }
+
+        _selectedForBulk.Clear();
+        RecomputeEligibleCount();
         UpdateSelectionAnnouncement();
     }
 
@@ -439,17 +538,68 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
         _pendingToggles.Clear();
     }
 
+    private void ExitSelectionMode()
+    {
+        _isSelectionModeActive = false;
+        _selectedForBulk.Clear();
+        RecomputeEligibleCount();
+        UpdateSelectionAnnouncement();
+    }
+
+    private async Task FocusAfterBulkUpgradeAsync()
+    {
+        // After clean-success auto-exit, the bulk strip is gone; focus the Select
+        // button so keyboard users have a stable anchor.
+        if (!_isSelectionModeActive)
+        {
+            try { await _selectButtonRef.FocusAsync(preventScroll: true); }
+            catch (JSDisconnectedException) { }
+            catch (JSException) { }
+            return;
+        }
+
+        if (_selectedForBulk.Count > 0)
+        {
+            try { await _masterCheckboxRef.FocusAsync(preventScroll: true); }
+            catch (JSDisconnectedException) { }
+            catch (JSException) { }
+            return;
+        }
+
+        try { await _selectButtonRef.FocusAsync(preventScroll: true); }
+        catch (JSDisconnectedException) { }
+        catch (JSException) { }
+    }
+
+    private async ValueTask FocusEntryRowNameAsync(string fileName)
+    {
+        if (_rowRefs.TryGetValue(fileName, out var rowRef) && rowRef is not null)
+        {
+            try { await rowRef.FocusNameAsync(); }
+            catch (ObjectDisposedException) { }
+            catch (JSException) { }
+
+            return;
+        }
+
+        try { await _importButtonRef.FocusAsync(preventScroll: true); }
+        catch (ObjectDisposedException) { }
+        catch (JSException) { }
+    }
+
     // Lookup by batch membership (active + queued) for the cancel-then-remove flow. Distinct from
     // GetUpgradeProgressForEntry, which matches by CurrentEntryName for per-row display only.
     private CancellableBatch? GetCancellableBatchForFile(string fileName)
     {
         var manage = ProgressBannerService.ManageDatabasesProgress;
+
         if (manage is not null && manage.BatchFileNames.Contains(fileName))
         {
             return new CancellableBatch(manage.BatchId, manage.Cancel);
         }
 
         var background = ProgressBannerService.BackgroundProgress;
+
         if (background is not null && background.BatchFileNames.Contains(fileName))
         {
             return new CancellableBatch(background.BatchId, background.Cancel);
@@ -472,6 +622,7 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
     private BannerProgressEntry? GetUpgradeProgressForEntry(DatabaseEntry entry)
     {
         var manage = ProgressBannerService.ManageDatabasesProgress;
+
         if (manage is not null &&
             string.Equals(manage.CurrentEntryName, entry.FileName, StringComparison.OrdinalIgnoreCase))
         {
@@ -479,6 +630,7 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
         }
 
         var background = ProgressBannerService.BackgroundProgress;
+
         if (background is not null &&
             string.Equals(background.CurrentEntryName, entry.FileName, StringComparison.OrdinalIgnoreCase))
         {
@@ -486,6 +638,20 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
         }
 
         return null;
+    }
+
+    private async Task HandleKeyDown(KeyboardEventArgs args)
+    {
+        if (!_isSelectionModeActive) { return; }
+
+        if (args.Key == "Escape")
+        {
+            ExitSelectionMode();
+
+            try { await _selectButtonRef.FocusAsync(preventScroll: true); }
+            catch (JSDisconnectedException) { }
+            catch (JSException) { }
+        }
     }
 
     private async Task ImportDatabase()
@@ -504,6 +670,7 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
     private async Task InvokeAsyncSafe()
     {
         if (_disposed) { return; }
+
         try { await InvokeAsync(StateHasChanged); }
         catch (ObjectDisposedException) { }
     }
@@ -533,6 +700,20 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
     private bool IsFileInAnyKnownBatch(string fileName) =>
         GetCancellableBatchForFile(fileName) is not null;
 
+    private bool IsUpgradeEligibleForSelected(string fileName)
+    {
+        var entry = DatabaseService.Entries.FirstOrDefault(
+            e => string.Equals(e.FileName, fileName, StringComparison.OrdinalIgnoreCase));
+
+        if (entry is null) { return false; }
+
+        bool upgrading = Coordinator.IsUpgradeInFlight(entry.FileName) ||
+            GetUpgradeProgressForEntry(entry) is not null ||
+            IsFileInAnyKnownBatch(entry.FileName);
+
+        return DatabaseEntryEligibility.IsUpgradeEligible(entry, upgrading);
+    }
+
     private async Task ObserveClassificationCompletionAsync(CancellationToken cancellationToken)
     {
         try
@@ -559,20 +740,91 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
     {
         if (_disposed) { return; }
 
+        RecomputeEligibleCount();
         _ = InvokeAsyncSafe();
     }
 
     private async Task OnBulkRemoveClickAsync()
     {
-        var snapshot = _selectedForRemoval.ToArray();
+        var snapshot = _selectedForBulk.ToArray();
 
-        await ConfirmAndRemoveAsync(snapshot, FocusTarget.BulkRemoveButton, FocusTarget.SameRowRemove);
+        await ConfirmAndRemoveAsync(snapshot, FocusTarget.BulkRemoveButton, FocusTarget.SameRowName);
+    }
+
+    private async Task OnBulkUpgradeClickAsync()
+    {
+        if (_eligibleUpgradeCount == 0 || IsUpgradeBlocked) { return; }
+
+        var eligible = new List<string>();
+        var skipped = new List<(string FileName, string Reason)>();
+
+        foreach (var fileName in _selectedForBulk)
+        {
+            if (IsUpgradeEligibleForSelected(fileName))
+            {
+                eligible.Add(fileName);
+            }
+            else
+            {
+                var entry = DatabaseService.Entries.FirstOrDefault(
+                    e => string.Equals(e.FileName, fileName, StringComparison.OrdinalIgnoreCase));
+
+                if (entry is null) { continue; }
+
+                bool upgrading = Coordinator.IsUpgradeInFlight(entry.FileName) ||
+                    GetUpgradeProgressForEntry(entry) is not null ||
+                    IsFileInAnyKnownBatch(entry.FileName);
+                skipped.Add((fileName, GetSkipReason(entry, upgrading)));
+            }
+        }
+
+        if (eligible.Count == 0) { return; }
+
+        if (skipped.Count > 0)
+        {
+            var confirmed = await PromptSubsetConfirmAsync(eligible, skipped, CancellationToken.None);
+
+            if (!confirmed)
+            {
+                if (_disposed) { return; }
+
+                try { await _bulkUpgradeButtonRef.FocusAsync(preventScroll: true); }
+                catch (JSDisconnectedException) { }
+                catch (JSException) { }
+
+                return;
+            }
+        }
+
+        var result = await Coordinator.UpgradeDatabasesAsync(
+            eligible,
+            UpgradeProgressScope.ManageDatabasesTriggered,
+            CancellationToken.None);
+
+        if (_disposed) { return; }
+
+        await AnnounceBulkUpgradeOutcomeAsync(result, eligible.Count);
+
+        // Auto-exit only on a fully-clean batch: any partial-failure/cancellation
+        // leaves the relevant rows selected so the user can retry or inspect.
+        bool cleanSuccess = result is not null
+            && result.Failed.Count == 0
+            && result.Cancelled.Count == 0
+            && result.Succeeded.Count > 0;
+
+        if (cleanSuccess)
+        {
+            ExitSelectionMode();
+        }
+
+        await FocusAfterBulkUpgradeAsync();
     }
 
     private void OnCoordinatorStateChanged()
     {
         if (_disposed) { return; }
 
+        RecomputeEligibleCount();
         _ = InvokeAsyncSafe();
     }
 
@@ -584,20 +836,56 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
             DatabaseService.Entries.Select(entry => entry.FileName),
             StringComparer.OrdinalIgnoreCase);
 
-        var orphans = _selectedForRemoval.Where(name => !currentNames.Contains(name)).ToArray();
+        var orphans = _selectedForBulk.Where(name => !currentNames.Contains(name)).ToArray();
 
-        foreach (var orphan in orphans) { _selectedForRemoval.Remove(orphan); }
-        
-        if (orphans.Length > 0) { UpdateSelectionAnnouncement(); }
+        foreach (var orphan in orphans) { _selectedForBulk.Remove(orphan); }
 
-        var deadRefs = _removeButtonRefs
+        if (orphans.Length > 0)
+        {
+            UpdateSelectionAnnouncement();
+        }
+
+        // Always recompute when any selection exists: a row's status / backup /
+        // upgrade state can change in-place (classification completion, backup
+        // restore, upgrade finished) without changing the entry list itself.
+        if (_selectedForBulk.Count > 0)
+        {
+            RecomputeEligibleCount();
+        }
+
+        var deadRefs = _rowRefs
             .Where(kvp => !currentNames.Contains(kvp.Key) || kvp.Value is null)
             .Select(kvp => kvp.Key)
             .ToArray();
-        
-        foreach (var key in deadRefs) { _removeButtonRefs.Remove(key); }
+
+        foreach (var key in deadRefs) { _rowRefs.Remove(key); }
+
+        // Auto-exit selection mode if the entries list collapses while selecting;
+        // the bulk strip would render above an empty-state placeholder otherwise.
+        if (_isSelectionModeActive && currentNames.Count == 0)
+        {
+            _isSelectionModeActive = false;
+        }
 
         _ = InvokeAsyncSafe();
+    }
+
+    private async Task OnMasterCheckboxClickAsync()
+    {
+        if (_selectedForBulk.Count >= DatabaseService.Entries.Count && _selectedForBulk.Count > 0)
+        {
+            _selectedForBulk.Clear();
+            RecomputeEligibleCount();
+            UpdateSelectionAnnouncement();
+        }
+        else
+        {
+            SelectAll();
+        }
+
+        try { await _masterCheckboxRef.FocusAsync(preventScroll: true); }
+        catch (JSDisconnectedException) { }
+        catch (JSException) { }
     }
 
     private async Task OnSaveClickAsync()
@@ -629,8 +917,62 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
         _ = InvokeAsyncSafe();
     }
 
+    private async Task<bool> PromptSubsetConfirmAsync(
+        IReadOnlyList<string> eligible,
+        IReadOnlyList<(string FileName, string Reason)> skipped,
+        CancellationToken cancellationToken)
+    {
+        if (AlertSurface is null) { return true; }
+
+        var sb = new StringBuilder();
+        sb.Append(eligible.Count);
+        sb.Append(" of ");
+        sb.Append(eligible.Count + skipped.Count);
+        sb.AppendLine(" selected databases will be upgraded.");
+        sb.AppendLine();
+        sb.Append("The following ");
+        sb.Append(skipped.Count);
+        sb.Append(skipped.Count == 1 ? " database will be skipped:" : " databases will be skipped:");
+
+        foreach (var (fileName, reason) in skipped)
+        {
+            sb.Append("\n  \u2022 ");
+            sb.Append(fileName);
+            sb.Append(" (");
+            sb.Append(reason);
+            sb.Append(')');
+        }
+
+        InlineAlertResult response;
+        try
+        {
+            response = await AlertSurface.ShowInlineAlertAsync(
+                new InlineAlertRequest(
+                    Title: "Upgrade selected databases",
+                    Message: sb.ToString(),
+                    AcceptLabel: $"Upgrade {eligible.Count}",
+                    CancelLabel: "Cancel",
+                    IsPrompt: false,
+                    PromptInitialValue: null),
+                cancellationToken);
+        }
+        catch (ObjectDisposedException) { return false; }
+
+        return response.Accepted;
+    }
+
+    private void RecomputeEligibleCount()
+    {
+        int count = 0;
+        foreach (var fileName in _selectedForBulk)
+        {
+            if (IsUpgradeEligibleForSelected(fileName)) { count++; }
+        }
+        _eligibleUpgradeCount = count;
+    }
+
     private async Task RemoveDatabase(DatabaseEntry entry) =>
-        await ConfirmAndRemoveAsync([entry.FileName], FocusTarget.SameRowRemove, FocusTarget.SameRowRemove);
+        await ConfirmAndRemoveAsync([entry.FileName], FocusTarget.SameRowName, FocusTarget.SameRowName);
 
     private async Task RemoveDatabasesAsync(IReadOnlyList<string> fileNames, FocusTarget completeTarget)
     {
@@ -679,8 +1021,10 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
 
         foreach (var fileName in fileNames)
         {
-            _selectedForRemoval.Remove(fileName);
+            _selectedForBulk.Remove(fileName);
         }
+
+        RecomputeEligibleCount();
         UpdateSelectionAnnouncement();
 
         if (anyLogsReopened)
@@ -712,6 +1056,13 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
             int clampedIdx = Math.Clamp(anchorIdx, 0, remainingEntries.Count - 1);
             string anchorFileName = remainingEntries[clampedIdx].FileName;
             _focusRestorationTarget = (anchorFileName, completeTarget);
+        }
+
+        // Bulk delete: auto-exit selection mode on any success. The mode existed
+        // to perform the delete; with rows gone, selection has no remaining target.
+        if (_isSelectionModeActive && succeeded.Count > 0)
+        {
+            ExitSelectionMode();
         }
     }
 
@@ -769,6 +1120,17 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
         }
     }
 
+    private void SelectAll()
+    {
+        foreach (var entry in DatabaseService.Entries)
+        {
+            _selectedForBulk.Add(entry.FileName);
+        }
+
+        RecomputeEligibleCount();
+        UpdateSelectionAnnouncement();
+    }
+
     private void ToggleDatabase(string fileName)
     {
         var entry = DatabaseService.Entries.FirstOrDefault(e =>
@@ -790,16 +1152,29 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
 
     private void ToggleSelection(string fileName)
     {
-        bool added = _selectedForRemoval.Add(fileName);
+        bool added = _selectedForBulk.Add(fileName);
 
-        if (!added) { _selectedForRemoval.Remove(fileName); }
+        if (!added) { _selectedForBulk.Remove(fileName); }
 
+        RecomputeEligibleCount();
         UpdateSelectionAnnouncement();
+    }
+
+    private void ToggleSelectionMode()
+    {
+        if (_isSelectionModeActive)
+        {
+            ExitSelectionMode();
+        }
+        else
+        {
+            _isSelectionModeActive = true;
+        }
     }
 
     private void UpdateSelectionAnnouncement()
     {
-        int count = _selectedForRemoval.Count;
+        int count = _selectedForBulk.Count;
         _selectionAnnouncement = count == 0
             ? "Selection cleared."
             : $"{count} database{(count == 1 ? "" : "s")} selected.";

--- a/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.cs
+++ b/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.cs
@@ -843,7 +843,7 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
         // the bulk strip would render above an empty-state placeholder otherwise.
         if (_isSelectionModeActive && currentNames.Count == 0)
         {
-            _isSelectionModeActive = false;
+            ExitSelectionMode();
         }
 
         _ = InvokeAsyncSafe();
@@ -1005,7 +1005,7 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
             }
         }
 
-        foreach (var fileName in fileNames)
+        foreach (var fileName in succeeded)
         {
             _selectedForBulk.Remove(fileName);
         }
@@ -1044,9 +1044,9 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
             _focusRestorationTarget = (anchorFileName, completeTarget);
         }
 
-        // Bulk delete: auto-exit selection mode on any success. The mode existed
-        // to perform the delete; with rows gone, selection has no remaining target.
-        if (_isSelectionModeActive && succeeded.Count > 0)
+        // Auto-exit on a fully-clean bulk delete only: any failure leaves the
+        // failed rows selected so the user can retry without re-selecting them.
+        if (_isSelectionModeActive && succeeded.Count > 0 && failed.Count == 0)
         {
             ExitSelectionMode();
         }

--- a/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.cs
+++ b/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.cs
@@ -578,6 +578,7 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
         {
             try { await rowRef.FocusNameAsync(); }
             catch (ObjectDisposedException) { }
+            catch (JSDisconnectedException) { }
             catch (JSException) { }
 
             return;
@@ -585,6 +586,7 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
 
         try { await _importButtonRef.FocusAsync(preventScroll: true); }
         catch (ObjectDisposedException) { }
+        catch (JSDisconnectedException) { }
         catch (JSException) { }
     }
 
@@ -728,7 +730,10 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
 
     private async Task OnBulkRemoveClickAsync()
     {
-        var snapshot = _selectedForBulk.ToArray();
+        var snapshot = DatabaseService.Entries
+            .Where(entry => _selectedForBulk.Contains(entry.FileName))
+            .Select(entry => entry.FileName)
+            .ToArray();
 
         await ConfirmAndRemoveAsync(snapshot, FocusTarget.BulkRemoveButton, FocusTarget.SameRowName);
     }
@@ -737,23 +742,22 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
     {
         if (_eligibleUpgradeCount == 0 || IsUpgradeBlocked) { return; }
 
-        var entriesByFileName = SnapshotEntriesByFileName();
         var eligible = new List<string>();
         var skipped = new List<(string FileName, string Reason)>();
 
-        foreach (var fileName in _selectedForBulk)
+        foreach (var entry in DatabaseService.Entries.ToList())
         {
-            if (!entriesByFileName.TryGetValue(fileName, out var entry)) { continue; }
+            if (!_selectedForBulk.Contains(entry.FileName)) { continue; }
 
             var (isEligible, isUpgrading) = GetEntryUpgradeState(entry);
 
             if (isEligible)
             {
-                eligible.Add(fileName);
+                eligible.Add(entry.FileName);
             }
             else
             {
-                skipped.Add((fileName, GetSkipReason(entry, isUpgrading)));
+                skipped.Add((entry.FileName, GetSkipReason(entry, isUpgrading)));
             }
         }
 

--- a/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.cs
+++ b/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.cs
@@ -45,7 +45,6 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
     {
         SameRowName,
         BulkRemoveButton,
-        SelectButton,
         ImportButton
     }
 
@@ -181,8 +180,6 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
                         FocusEntryRowNameAsync(target.FileName),
                     FocusTarget.BulkRemoveButton when HasBulkSelection =>
                         _bulkRemoveButtonRef.FocusAsync(preventScroll: true),
-                    FocusTarget.SelectButton when _isSelectionModeActive =>
-                        _selectButtonRef.FocusAsync(preventScroll: true),
                     FocusTarget.ImportButton =>
                         _importButtonRef.FocusAsync(preventScroll: true),
                     _ => ValueTask.CompletedTask

--- a/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.css
+++ b/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.css
@@ -48,6 +48,14 @@
     line-height: 1;
 }
 
+.manage-databases-master-checkbox {
+    display: flex;
+    align-items: center;
+    max-width: 3rem;
+    padding-right: .5rem;
+    overflow: hidden;
+}
+
 .manage-databases-master-btn:focus-visible {
     outline: 2px solid var(--clr-lightblue);
     outline-offset: 2px;

--- a/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.css
+++ b/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.css
@@ -10,8 +10,69 @@
 .manage-databases-import-row {
     flex: none;
     display: flex;
-    justify-content: flex-end;
+    gap: .5rem;
+    justify-content: space-between;
     padding: .5rem 1rem;
+}
+
+.manage-databases-selection-header {
+    flex: none;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    align-items: center;
+    gap: 0;
+
+    padding: .25rem .5rem;
+    margin: 0 .5rem;
+
+    background-color: var(--background-darkgray);
+    color: var(--text-color);
+    border-bottom: 1px solid var(--clr-border);
+
+    animation: manage-databases-selection-header-fade-in 200ms ease-out;
+}
+
+.manage-databases-master-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    margin: 0;
+    padding: 0;
+    background: none;
+    border: 0;
+    color: inherit;
+    cursor: pointer;
+
+    font-size: 1.1em;
+    line-height: 1;
+}
+
+.manage-databases-master-btn:focus-visible {
+    outline: 2px solid var(--clr-lightblue);
+    outline-offset: 2px;
+    border-radius: 2px;
+}
+
+.manage-databases-selection-count {
+    font-size: .9rem;
+    padding-left: .5rem;
+}
+
+.manage-databases-selection-count-eligible {
+    color: var(--clr-lightblue);
+    margin-left: .25rem;
+}
+
+@keyframes manage-databases-selection-header-fade-in {
+    from { opacity: 0; transform: translateY(-4px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .manage-databases-selection-header {
+        animation: none;
+    }
 }
 
 .manage-databases-entries {

--- a/src/EventLogExpert.UI/DependencyInjection/UiServiceCollectionExtensions.cs
+++ b/src/EventLogExpert.UI/DependencyInjection/UiServiceCollectionExtensions.cs
@@ -1,0 +1,16 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.UI.Menu;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+public static class UiServiceCollectionExtensions
+{
+    public static IServiceCollection AddEventLogUiServices(this IServiceCollection services)
+    {
+        services.AddSingleton<IMenuHostRegistry, MenuHostRegistry>();
+
+        return services;
+    }
+}

--- a/src/EventLogExpert.UI/DependencyInjection/UiServiceCollectionExtensions.cs
+++ b/src/EventLogExpert.UI/DependencyInjection/UiServiceCollectionExtensions.cs
@@ -7,10 +7,13 @@ namespace Microsoft.Extensions.DependencyInjection;
 
 public static class UiServiceCollectionExtensions
 {
-    public static IServiceCollection AddEventLogUiServices(this IServiceCollection services)
+    extension(IServiceCollection services)
     {
-        services.AddSingleton<IMenuHostRegistry, MenuHostRegistry>();
+        public IServiceCollection AddEventLogUiServices()
+        {
+            services.AddSingleton<IMenuHostRegistry, MenuHostRegistry>();
 
-        return services;
+            return services;
+        }
     }
 }

--- a/src/EventLogExpert.UI/Menu/IMenuHostRegistry.cs
+++ b/src/EventLogExpert.UI/Menu/IMenuHostRegistry.cs
@@ -1,0 +1,15 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.UI.Menu;
+
+public interface IMenuHostRegistry
+{
+    event Action? ActiveHostChanged;
+
+    MenuHost? ActiveHost { get; }
+
+    void Register(MenuHost host);
+
+    void Unregister(MenuHost host);
+}

--- a/src/EventLogExpert.UI/Menu/MenuHost.razor
+++ b/src/EventLogExpert.UI/Menu/MenuHost.razor
@@ -1,4 +1,4 @@
-@if (MenuService.ActiveItems is not null)
+@if (IsActive && MenuService.ActiveItems is not null)
 {
     <div class="menu-host-overlay"
         @onclick="HandleOverlayClick"
@@ -15,9 +15,9 @@
             tabindex="-1">
             <MenuRenderer InitialFocusIndex="@(MenuService.ActiveFocusFirst ? 0 : -1)"
                 Items="MenuService.ActiveItems"
+                @key="MenuService.ActiveMenuId"
                 OnActivated="HandleActivated"
-                OnNavigateBar="HandleNavigateBar"
-                @key="MenuService.ActiveMenuId" />
+                OnNavigateBar="HandleNavigateBar" />
         </div>
     </div>
 }

--- a/src/EventLogExpert.UI/Menu/MenuHost.razor.cs
+++ b/src/EventLogExpert.UI/Menu/MenuHost.razor.cs
@@ -11,8 +11,12 @@ namespace EventLogExpert.UI.Menu;
 
 public sealed partial class MenuHost : IAsyncDisposable
 {
+    private bool _disposed;
     private long _focusedMenuId;
+    private bool _ownedViewportListeners;
     private ElementReference _popupElement;
+
+    private bool IsActive => ReferenceEquals(Registry.ActiveHost, this);
 
     [Inject] private IJSRuntime JSRuntime { get; init; } = null!;
 
@@ -23,18 +27,49 @@ public sealed partial class MenuHost : IAsyncDisposable
             CultureInfo.InvariantCulture,
             $"left: {MenuService.PositionX}px; top: {MenuService.PositionY}px;");
 
+    [Inject] private IMenuHostRegistry Registry { get; init; } = null!;
+
     public async ValueTask DisposeAsync()
     {
+        if (_disposed) { return; }
+
+        _disposed = true;
+
+        // Unsubscribe BEFORE Close() — Close() synchronously raises StateChanged,
+        // which would re-enter OnStateChanged and queue an InvokeAsync that runs
+        // after dispose completes.
         MenuService.StateChanged -= OnStateChanged;
+        Registry.ActiveHostChanged -= OnActiveHostChanged;
 
-        try { await JSRuntime.InvokeVoidAsync("detachMenuViewportListeners"); }
-        catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException) { }
+        // Close on live MenuService state, not on the queued-lambda-mutated
+        // _focusedMenuId — that mirror can lag the singleton when dispose
+        // races a fresh OpenAt.
+        if (IsActive && MenuService.ActiveItems is not null)
+        {
+            MenuService.Close();
+        }
 
-        await ReleaseFocusReturnAsync();
+        Registry.Unregister(this);
+
+        if (_focusedMenuId != 0 || _ownedViewportListeners)
+        {
+            try { await JSRuntime.InvokeVoidAsync("detachMenuViewportListeners"); }
+            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException) { }
+
+            await ReleaseFocusReturnAsync();
+            _ownedViewportListeners = false;
+        }
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        if (_disposed || !IsActive)
+        {
+            await base.OnAfterRenderAsync(firstRender);
+
+            return;
+        }
+
         // Re-clamp every render — popup is hidden until clampMenuPopup reveals it within the viewport.
         if (MenuService.ActiveItems is not null)
         {
@@ -47,6 +82,8 @@ public sealed partial class MenuHost : IAsyncDisposable
 
     protected override void OnInitialized()
     {
+        Registry.Register(this);
+        Registry.ActiveHostChanged += OnActiveHostChanged;
         MenuService.StateChanged += OnStateChanged;
         base.OnInitialized();
     }
@@ -63,11 +100,29 @@ public sealed partial class MenuHost : IAsyncDisposable
 
     private void HandleOverlayClick() => MenuService.Close();
 
+    private void OnActiveHostChanged()
+    {
+        if (_disposed) { return; }
+
+        _ = InvokeAsync(() =>
+        {
+            if (_disposed) { return; }
+
+            StateHasChanged();
+        });
+    }
+
     private void OnStateChanged()
     {
+        // Inactive hosts stay subscribed but skip render + JS interop so the
+        // active topmost host owns the menu lifecycle.
+        if (_disposed || !IsActive) { return; }
+
         // StateChanged may fire from arbitrary threads — marshal through the renderer dispatcher.
         _ = InvokeAsync(async () =>
         {
+            if (_disposed || !IsActive) { return; }
+
             var nowOpen = MenuService.ActiveItems is not null;
             var wasOpen = _focusedMenuId != 0;
 
@@ -87,7 +142,11 @@ public sealed partial class MenuHost : IAsyncDisposable
 
                 if (!wasOpen)
                 {
-                    try { await JSRuntime.InvokeVoidAsync("attachMenuViewportListeners"); }
+                    try
+                    {
+                        await JSRuntime.InvokeVoidAsync("attachMenuViewportListeners");
+                        _ownedViewportListeners = true;
+                    }
                     catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException) { }
                 }
             }
@@ -95,7 +154,11 @@ public sealed partial class MenuHost : IAsyncDisposable
             {
                 _focusedMenuId = 0;
 
-                try { await JSRuntime.InvokeVoidAsync("detachMenuViewportListeners"); }
+                try
+                {
+                    await JSRuntime.InvokeVoidAsync("detachMenuViewportListeners");
+                    _ownedViewportListeners = false;
+                }
                 catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException) { }
 
                 await ReleaseFocusReturnAsync();

--- a/src/EventLogExpert.UI/Menu/MenuHost.razor.cs
+++ b/src/EventLogExpert.UI/Menu/MenuHost.razor.cs
@@ -85,6 +85,7 @@ public sealed partial class MenuHost : IAsyncDisposable
         Registry.Register(this);
         Registry.ActiveHostChanged += OnActiveHostChanged;
         MenuService.StateChanged += OnStateChanged;
+        SyncMenuOwnershipMirror();
         base.OnInitialized();
     }
 
@@ -108,6 +109,7 @@ public sealed partial class MenuHost : IAsyncDisposable
         {
             if (_disposed) { return; }
 
+            SyncMenuOwnershipMirror();
             StateHasChanged();
         });
     }
@@ -172,5 +174,21 @@ public sealed partial class MenuHost : IAsyncDisposable
     {
         try { await JSRuntime.InvokeVoidAsync("restoreMenuOpenerFocus"); }
         catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException) { }
+    }
+
+    private void SyncMenuOwnershipMirror()
+    {
+        if (MenuService.ActiveItems is null) { return; }
+
+        if (IsActive && _focusedMenuId == 0)
+        {
+            _focusedMenuId = MenuService.ActiveMenuId;
+            _ownedViewportListeners = true;
+        }
+        else if (!IsActive && _focusedMenuId != 0)
+        {
+            _focusedMenuId = 0;
+            _ownedViewportListeners = false;
+        }
     }
 }

--- a/src/EventLogExpert.UI/Menu/MenuHostRegistry.cs
+++ b/src/EventLogExpert.UI/Menu/MenuHostRegistry.cs
@@ -1,0 +1,64 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.UI.Menu;
+
+internal sealed class MenuHostRegistry : IMenuHostRegistry
+{
+    private readonly Lock _gate = new();
+    private readonly Stack<MenuHost> _stack = new();
+
+    public event Action? ActiveHostChanged;
+
+    public MenuHost? ActiveHost
+    {
+        get
+        {
+            using (_gate.EnterScope())
+            {
+                return _stack.Count > 0 ? _stack.Peek() : null;
+            }
+        }
+    }
+
+    public void Register(MenuHost host)
+    {
+        ArgumentNullException.ThrowIfNull(host);
+
+        using (_gate.EnterScope()) { _stack.Push(host); }
+
+        ActiveHostChanged?.Invoke();
+    }
+
+    public void Unregister(MenuHost host)
+    {
+        ArgumentNullException.ThrowIfNull(host);
+
+        bool changed = false;
+
+        using (_gate.EnterScope())
+        {
+            if (_stack.Count == 0) { return; }
+
+            if (ReferenceEquals(_stack.Peek(), host))
+            {
+                _stack.Pop();
+                changed = true;
+            }
+            else if (_stack.Any(h => ReferenceEquals(h, host)))
+            {
+                // Out-of-order dispose: DynamicComponent @key swaps may run a new
+                // component's OnInitialized before the old component's Dispose.
+                var retained = _stack
+                    .Where(h => !ReferenceEquals(h, host))
+                    .Reverse()
+                    .ToList();
+                _stack.Clear();
+                foreach (var h in retained) { _stack.Push(h); }
+                changed = true;
+            }
+        }
+
+        if (changed) { ActiveHostChanged?.Invoke(); }
+    }
+}

--- a/src/EventLogExpert.UI/Modal/ModalChrome.razor
+++ b/src/EventLogExpert.UI/Modal/ModalChrome.razor
@@ -175,4 +175,8 @@
             </div>
         </section>
     }
+
+    @* In-dialog MenuHost so context menus and shortcut-triggered menus render
+       in the top-layer stacking context of this <dialog>, not behind it. *@
+    <MenuHost />
 </dialog>

--- a/src/EventLogExpert.UI/_Imports.razor
+++ b/src/EventLogExpert.UI/_Imports.razor
@@ -27,4 +27,5 @@
 @using EventLogExpert.UI.Database
 @using EventLogExpert.UI.FilterEditor
 @using EventLogExpert.UI.Inputs
+@using EventLogExpert.UI.Menu
 @using EventLogExpert.UI.Modal

--- a/src/EventLogExpert/MauiProgram.cs
+++ b/src/EventLogExpert/MauiProgram.cs
@@ -103,6 +103,7 @@ public static class MauiProgram
         // UI Services
         builder.Services.AddEventLogFiltering();
         builder.Services.AddEventLogRuntime();
+        builder.Services.AddEventLogUiServices();
 
         builder.Services.AddSingleton<IBannerCycleStateService, BannerCycleStateService>();
 

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Database/DatabaseOperationCoordinatorTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Database/DatabaseOperationCoordinatorTests.cs
@@ -719,6 +719,128 @@ public sealed class DatabaseOperationCoordinatorTests
             Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task UpgradeDatabasesAsync_EmptyInput_ReturnsEmptyResult_DoesNotCallService()
+    {
+        var sut = CreateSut();
+
+        var result = await sut.UpgradeDatabasesAsync([], UpgradeProgressScope.ManageDatabasesTriggered, Ct);
+
+        Assert.NotNull(result);
+        Assert.Empty(result.Succeeded);
+        Assert.Empty(result.Cancelled);
+        Assert.Empty(result.Failed);
+        await _databases.DidNotReceiveWithAnyArgs().UpgradeBatchAsync(default!, default, Ct);
+    }
+
+    [Fact]
+    public async Task UpgradeDatabasesAsync_GateDenied_AnotherUpgradeInFlight_ReturnsNull()
+    {
+        var blocker = new TaskCompletionSource<UpgradeBatchResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _databases.UpgradeBatchAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<UpgradeProgressScope>(), Arg.Any<CancellationToken>())
+            .Returns(_ => blocker.Task);
+
+        var sut = CreateSut();
+
+        var firstUpgrade = sut.UpgradeDatabaseAsync("a.db", cancellationToken: Ct);
+        await Task.Yield();
+
+        Assert.True(sut.IsAnyUpgradeInFlight);
+
+        var result = await sut.UpgradeDatabasesAsync(["b.db", "c.db"], UpgradeProgressScope.ManageDatabasesTriggered, Ct);
+
+        Assert.Null(result);
+
+        blocker.SetResult(new UpgradeBatchResult([], [], []));
+        await firstUpgrade;
+    }
+
+    [Fact]
+    public async Task UpgradeDatabasesAsync_HappyPath_ReturnsServiceResult_AndFiresStateChangedTwice()
+    {
+        var expected = new UpgradeBatchResult(Succeeded: ["a.db", "b.db"], Cancelled: [], Failed: []);
+        _databases.UpgradeBatchAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<UpgradeProgressScope>(), Arg.Any<CancellationToken>())
+            .Returns(expected);
+
+        var sut = CreateSut();
+        int stateChangedCount = 0;
+        sut.UpgradeStateChanged += () => stateChangedCount++;
+
+        var result = await sut.UpgradeDatabasesAsync(["a.db", "b.db"], UpgradeProgressScope.ManageDatabasesTriggered, Ct);
+
+        Assert.Same(expected, result);
+        Assert.Equal(2, stateChangedCount);
+        Assert.False(sut.IsAnyUpgradeInFlight);
+    }
+
+    [Fact]
+    public async Task UpgradeDatabasesAsync_PartialFailure_SurfacesEachFailureToErrorBanner()
+    {
+        var result = new UpgradeBatchResult(
+            Succeeded: ["a.db"],
+            Cancelled: [],
+            Failed: [new UpgradeFailure("b.db", "schema mismatch"), new UpgradeFailure("c.db", "io error")]);
+        _databases.UpgradeBatchAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<UpgradeProgressScope>(), Arg.Any<CancellationToken>())
+            .Returns(result);
+
+        var sut = CreateSut();
+        var actual = await sut.UpgradeDatabasesAsync(["a.db", "b.db", "c.db"], UpgradeProgressScope.ManageDatabasesTriggered, Ct);
+
+        Assert.Same(result, actual);
+        _errorBanners.Received(1).ReportError("Database Upgrade Failed", Arg.Is<string>(s => s.Contains("b.db") && s.Contains("schema mismatch")));
+        _errorBanners.Received(1).ReportError("Database Upgrade Failed", Arg.Is<string>(s => s.Contains("c.db") && s.Contains("io error")));
+    }
+
+    [Fact]
+    public async Task UpgradeDatabasesAsync_PerFileTracking_AllFilesInFlightDuringCall()
+    {
+        DatabaseOperationCoordinator? sutRef = null;
+        bool aSeen = false, bSeen = false;
+        _databases.UpgradeBatchAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<UpgradeProgressScope>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                aSeen = sutRef!.IsUpgradeInFlight("a.db");
+                bSeen = sutRef!.IsUpgradeInFlight("b.db");
+                return new UpgradeBatchResult([], [], []);
+            });
+
+        sutRef = CreateSut();
+        await sutRef.UpgradeDatabasesAsync(["a.db", "b.db"], UpgradeProgressScope.ManageDatabasesTriggered, Ct);
+
+        Assert.True(aSeen);
+        Assert.True(bSeen);
+        Assert.False(sutRef.IsUpgradeInFlight("a.db"));
+        Assert.False(sutRef.IsUpgradeInFlight("b.db"));
+    }
+
+    [Fact]
+    public async Task UpgradeDatabasesAsync_PreCancelledToken_Throws()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var sut = CreateSut();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            sut.UpgradeDatabasesAsync(["a.db"], UpgradeProgressScope.ManageDatabasesTriggered, cts.Token));
+
+        Assert.False(sut.IsAnyUpgradeInFlight);
+    }
+
+    [Fact]
+    public async Task UpgradeDatabasesAsync_ServiceThrows_FallbackReturnedAndInFlightCleared()
+    {
+        _databases.UpgradeBatchAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<UpgradeProgressScope>(), Arg.Any<CancellationToken>())
+            .Returns<UpgradeBatchResult>(_ => throw new InvalidOperationException("disk full"));
+
+        var sut = CreateSut();
+        var result = await sut.UpgradeDatabasesAsync(["a.db"], UpgradeProgressScope.ManageDatabasesTriggered, Ct);
+
+        Assert.NotNull(result);
+        Assert.Empty(result.Succeeded);
+        Assert.False(sut.IsAnyUpgradeInFlight);
+        _errorBanners.Received(1).ReportError("Database Upgrade Failed", Arg.Is<string>(s => s.Contains("disk full")));
+    }
+
     private static DatabaseEntry CreateEntry(
         string fileName,
         bool isEnabled = true,

--- a/tests/Unit/EventLogExpert.UI.Tests/Database/DatabaseEntryRowTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Database/DatabaseEntryRowTests.cs
@@ -214,7 +214,7 @@ public sealed class DatabaseEntryRowTests : BunitContext
     }
 
     [Fact]
-    public void Render_BackupExistsEntry_RestoreButton_AriaDisabledWhenBlocked()
+    public void Render_BackupExistsEntry_RestoreButton_DisabledWhenBlocked()
     {
         // Arrange
         var entry = MakeEntry(DatabaseStatus.UpgradeRequired, backupExists: true);
@@ -224,8 +224,7 @@ public sealed class DatabaseEntryRowTests : BunitContext
 
         // Assert
         var restoreBtn = component.Find(".db-entry-restore-btn");
-        Assert.Equal("true", restoreBtn.GetAttribute("aria-disabled"));
-        Assert.False(restoreBtn.HasAttribute("disabled"));
+        Assert.True(restoreBtn.HasAttribute("disabled"));
     }
 
     [Fact]
@@ -327,7 +326,7 @@ public sealed class DatabaseEntryRowTests : BunitContext
     }
 
     [Fact]
-    public void Render_IsUpgradeBlocked_AriaDisablesRetryUpgradeButton()
+    public void Render_IsUpgradeBlocked_DisablesRetryUpgradeButton()
     {
         // Arrange
         var entry = MakeEntry(DatabaseStatus.UpgradeFailed);
@@ -337,12 +336,11 @@ public sealed class DatabaseEntryRowTests : BunitContext
 
         // Assert
         var button = component.Find(".db-entry-upgrade-btn");
-        Assert.Equal("true", button.GetAttribute("aria-disabled"));
-        Assert.False(button.HasAttribute("disabled"));
+        Assert.True(button.HasAttribute("disabled"));
     }
 
     [Fact]
-    public void Render_IsUpgradeBlocked_AriaDisablesUpgradeButton()
+    public void Render_IsUpgradeBlocked_DisablesUpgradeButton()
     {
         // Arrange
         var entry = MakeEntry(DatabaseStatus.UpgradeRequired);
@@ -352,8 +350,7 @@ public sealed class DatabaseEntryRowTests : BunitContext
 
         // Assert
         var button = component.Find(".db-entry-upgrade-btn");
-        Assert.Equal("true", button.GetAttribute("aria-disabled"));
-        Assert.False(button.HasAttribute("disabled"));
+        Assert.True(button.HasAttribute("disabled"));
     }
 
     [Fact]
@@ -480,9 +477,6 @@ public sealed class DatabaseEntryRowTests : BunitContext
     [Fact]
     public void Render_ReadyEnabledEntry_NoTrashButton()
     {
-        // Arrange — Ready+Enabled is now safe to delete because RemoveAsync coordinates
-        // 
-
         var entry = MakeEntry(DatabaseStatus.Ready, isEnabled: true);
 
         // Act
@@ -495,7 +489,6 @@ public sealed class DatabaseEntryRowTests : BunitContext
     [Fact]
     public void Render_ReadyEnabledEntry_OptimisticToggleOff_NoTrashButton()
     {
-        // either way under the new contract.
         var entry = MakeEntry(DatabaseStatus.Ready, isEnabled: true);
 
         // Act
@@ -699,9 +692,6 @@ public sealed class DatabaseEntryRowTests : BunitContext
     [Fact]
     public void Render_UpgradeRequiredEntry_NoTrashButton()
     {
-        // 
-
-        // before being able to remove the entry.
         var entry = MakeEntry(DatabaseStatus.UpgradeRequired);
 
         // Act
@@ -789,7 +779,7 @@ public sealed class DatabaseEntryRowTests : BunitContext
             .Add(p => p.OnRestoreFromBackup, () => invocationCount++));
 
         var restoreBtn = component.Find(".db-entry-restore-btn");
-        Assert.Equal("true", restoreBtn.GetAttribute("aria-disabled"));
+        Assert.True(restoreBtn.HasAttribute("disabled"));
 
         await restoreBtn.ClickAsync(new MouseEventArgs());
 
@@ -888,7 +878,7 @@ public sealed class DatabaseEntryRowTests : BunitContext
     }
 
     [Fact]
-    public async Task UpgradeButtonClick_WhenAriaDisabled_DoesNotInvokeOnUpgrade()
+    public async Task UpgradeButtonClick_WhenDisabled_DoesNotInvokeOnUpgrade()
     {
         // Arrange
         var entry = MakeEntry(DatabaseStatus.UpgradeRequired);

--- a/tests/Unit/EventLogExpert.UI.Tests/Database/DatabaseEntryRowTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Database/DatabaseEntryRowTests.cs
@@ -6,6 +6,7 @@ using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Runtime.Banner;
 using EventLogExpert.Runtime.Database;
 using EventLogExpert.Runtime.Database.Upgrade;
+using EventLogExpert.Runtime.Menu;
 using EventLogExpert.UI.Database;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
@@ -16,10 +17,13 @@ namespace EventLogExpert.UI.Tests.Database;
 
 public sealed class DatabaseEntryRowTests : BunitContext
 {
+    private readonly IMenuService _menuService = Substitute.For<IMenuService>();
+
     public DatabaseEntryRowTests()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
         Services.AddSingleton(Substitute.For<ITraceLogger>());
+        Services.AddSingleton(_menuService);
     }
 
     [Fact]
@@ -36,6 +40,43 @@ public sealed class DatabaseEntryRowTests : BunitContext
     }
 
     [Fact]
+    public void Checkbox_InNormalMode_IsCollapsedAndAriaHidden()
+    {
+        var entry = MakeEntry(DatabaseStatus.Ready);
+
+        var component = RenderRow(entry);
+
+        var wrapper = component.Find(".db-entry-checkbox");
+        Assert.DoesNotContain("db-entry-checkbox--visible", wrapper.GetAttribute("class") ?? string.Empty);
+        Assert.Equal("true", wrapper.GetAttribute("aria-hidden"));
+    }
+
+    [Fact]
+    public void Checkbox_InNormalMode_IsDisabled()
+    {
+        var entry = MakeEntry(DatabaseStatus.Ready);
+
+        var component = RenderRow(entry);
+
+        var checkbox = component.Find(".db-entry-row input[type='checkbox']");
+        Assert.True(checkbox.HasAttribute("disabled"));
+    }
+
+    [Fact]
+    public void Checkbox_InSelectionMode_IsVisible_NoAriaHidden()
+    {
+        var entry = MakeEntry(DatabaseStatus.Ready);
+
+        var component = Render<DatabaseEntryRow>(parameters => parameters
+            .Add(p => p.Entry, entry)
+            .Add(p => p.IsSelectionModeActive, true));
+
+        var wrapper = component.Find(".db-entry-checkbox");
+        Assert.Contains("db-entry-checkbox--visible", wrapper.GetAttribute("class") ?? string.Empty);
+        Assert.False(wrapper.HasAttribute("aria-hidden"));
+    }
+
+    [Fact]
     public void Checkbox_RenderedWithAriaLabelInRow()
     {
         var entry = MakeEntry(DatabaseStatus.Ready, "MyDb.evtx");
@@ -47,12 +88,13 @@ public sealed class DatabaseEntryRowTests : BunitContext
     }
 
     [Fact]
-    public async Task CheckboxChange_InvokesOnSelectionToggle()
+    public async Task CheckboxChange_InSelectionMode_InvokesOnSelectionToggle()
     {
         var entry = MakeEntry(DatabaseStatus.Ready);
         int invocationCount = 0;
         var component = Render<DatabaseEntryRow>(parameters => parameters
             .Add(p => p.Entry, entry)
+            .Add(p => p.IsSelectionModeActive, true)
             .Add(p => p.OnSelectionToggle, () => invocationCount++));
 
         await component.Find(".db-entry-row input[type='checkbox']")
@@ -62,55 +104,52 @@ public sealed class DatabaseEntryRowTests : BunitContext
     }
 
     [Fact]
-    public void RemoveButton_AlwaysVisible_RowDoesNotHaveSlideRevealClass()
+    public async Task ContextMenu_InNormalMode_OpensMenuWithRemoveItem()
     {
         var entry = MakeEntry(DatabaseStatus.Ready);
 
         var component = RenderRow(entry);
 
-        var row = component.Find(".db-entry-row");
-        Assert.DoesNotContain("db-entry-row--revealed", row.GetAttribute("class") ?? string.Empty);
-        Assert.Single(component.FindAll(".db-entry-remove-btn"));
+        await component.Find(".db-entry-row").TriggerEventAsync("oncontextmenu",
+            new MouseEventArgs { ClientX = 100, ClientY = 200 });
+
+        _menuService.Received(1).OpenAt(100, 200, Arg.Is<IReadOnlyList<MenuItem>>(items => items.Count == 1));
     }
 
     [Fact]
-    public void RemoveButton_DuringBackgroundUpgrade_NotAriaDisabled()
+    public async Task ContextMenu_InSelectionMode_DoesNotOpenMenu()
     {
-        var entry = MakeEntry(DatabaseStatus.UpgradeRequired);
-        var progress = MakeProgress(currentEntryName: "a.db", scope: UpgradeProgressScope.Background);
-
-        var component = RenderRow(entry, upgradeProgress: progress);
-
-        var button = component.Find(".db-entry-remove-btn");
-        Assert.False(button.HasAttribute("aria-disabled"));
-    }
-
-    [Fact]
-    public void RemoveButton_DuringManageUpgrade_NotAriaDisabled()
-    {
-        var entry = MakeEntry(DatabaseStatus.UpgradeRequired);
-
-        var component = RenderRow(entry, isUpgrading: true);
-
-        var button = component.Find(".db-entry-remove-btn");
-        Assert.False(button.HasAttribute("aria-disabled"));
-    }
-
-    [Fact]
-    public async Task RemoveButtonClick_InvokesOnRemove()
-    {
-        // Arrange
         var entry = MakeEntry(DatabaseStatus.Ready);
-        int invocationCount = 0;
+
         var component = Render<DatabaseEntryRow>(parameters => parameters
             .Add(p => p.Entry, entry)
-            .Add(p => p.OnRemove, () => invocationCount++));
+            .Add(p => p.IsSelectionModeActive, true));
 
-        // Act
-        await component.Find(".db-entry-remove-btn").ClickAsync(new MouseEventArgs());
+        await component.Find(".db-entry-row").TriggerEventAsync("oncontextmenu",
+            new MouseEventArgs { ClientX = 50, ClientY = 50 });
 
-        // Assert
-        Assert.Equal(1, invocationCount);
+        _menuService.DidNotReceive().OpenAt(
+            Arg.Any<double>(),
+            Arg.Any<double>(),
+            Arg.Any<IReadOnlyList<MenuItem>>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>());
+    }
+
+    [Fact]
+    public async Task ContextMenu_RemoveItem_HasRemoveLabel()
+    {
+        var entry = MakeEntry(DatabaseStatus.Ready, "MyProvider.db");
+        IReadOnlyList<MenuItem>? capturedItems = null;
+        _menuService.When(s => s.OpenAt(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<IReadOnlyList<MenuItem>>(), Arg.Any<bool>(), Arg.Any<bool>()))
+            .Do(call => capturedItems = call.Arg<IReadOnlyList<MenuItem>>());
+
+        var component = RenderRow(entry);
+        await component.Find(".db-entry-row").TriggerEventAsync("oncontextmenu", new MouseEventArgs());
+
+        Assert.NotNull(capturedItems);
+        var item = Assert.Single(capturedItems!);
+        Assert.Equal("Remove", item.Label);
     }
 
     [Fact]
@@ -155,10 +194,7 @@ public sealed class DatabaseEntryRowTests : BunitContext
         Assert.Empty(component.FindAll(".db-entry-upgrading"));
         Assert.Empty(component.FindAll(".db-entry-upgrade-btn"));
         Assert.Empty(component.FindAll(".option-select"));
-
-        // Trash is unconditionally rendered now; visibility is governed by the CSS
-        // hover/focus reveal animation, not by markup.
-        Assert.Single(component.FindAll(".db-entry-remove-btn"));
+        Assert.Empty(component.FindAll(".db-entry-remove-btn"));
     }
 
     [Fact]
@@ -174,7 +210,7 @@ public sealed class DatabaseEntryRowTests : BunitContext
         var badge = component.Find(".db-entry-badge");
         Assert.Equal("Recovery required", badge.TextContent);
         Assert.Empty(component.FindAll(".option-select"));
-        Assert.Single(component.FindAll(".db-entry-remove-btn"));
+        Assert.Empty(component.FindAll(".db-entry-remove-btn"));
     }
 
     [Fact]
@@ -193,14 +229,10 @@ public sealed class DatabaseEntryRowTests : BunitContext
     }
 
     [Fact]
-    public void Render_BackupExistsEntry_ShowsRecoveryRequiredBadge_AndShowsTrash()
+    public void Render_BackupExistsEntry_ShowsRecoveryRequiredBadge_NoTrash()
     {
-        // Arrange — BackupExists routes the user to the recovery dialog as the primary
-        // action, but the trash is still rendered (revealed by hover/focus) so a user
-        // who wants to abandon the entry entirely can do so.
         var entry = MakeEntry(DatabaseStatus.UpgradeRequired, backupExists: true);
 
-        // Act
         var component = RenderRow(entry);
 
         // Assert
@@ -212,7 +244,7 @@ public sealed class DatabaseEntryRowTests : BunitContext
         Assert.Empty(component.FindAll(".option-select"));
         Assert.Empty(component.FindAll(".db-entry-upgrading"));
 
-        Assert.Single(component.FindAll(".db-entry-remove-btn"));
+        Assert.Empty(component.FindAll(".db-entry-remove-btn"));
     }
 
     [Fact]
@@ -257,7 +289,7 @@ public sealed class DatabaseEntryRowTests : BunitContext
     }
 
     [Fact]
-    public void Render_DisabledEntries_ShowTrashButton()
+    public void Render_DisabledEntries_NoTrashButton()
     {
         foreach (var status in Enum.GetValues<DatabaseStatus>())
         {
@@ -266,10 +298,7 @@ public sealed class DatabaseEntryRowTests : BunitContext
 
             // Act
             var component = RenderRow(entry);
-
-            // Assert — every status renders the trash; visibility is governed by the
-            // CSS hover/focus reveal animation, not by markup.
-            Assert.Single(component.FindAll(".db-entry-remove-btn"));
+            Assert.Empty(component.FindAll(".db-entry-remove-btn"));
         }
     }
 
@@ -287,7 +316,7 @@ public sealed class DatabaseEntryRowTests : BunitContext
     }
 
     [Fact]
-    public void Render_IsSelectedTrue_CheckboxCheckedAndRowHasSelectedClass()
+    public void Render_IsSelectedTrue_CheckboxChecked()
     {
         var entry = MakeEntry(DatabaseStatus.Ready);
 
@@ -295,9 +324,6 @@ public sealed class DatabaseEntryRowTests : BunitContext
 
         var checkbox = component.Find(".db-entry-row input[type='checkbox']");
         Assert.True(checkbox.HasAttribute("checked"));
-
-        var row = component.Find(".db-entry-row");
-        Assert.Contains("db-entry-row--selected", row.GetAttribute("class") ?? string.Empty);
     }
 
     [Fact]
@@ -347,7 +373,7 @@ public sealed class DatabaseEntryRowTests : BunitContext
         Assert.Empty(component.FindAll(".db-entry-upgrade-btn"));
         Assert.Empty(component.FindAll(".db-entry-badge"));
 
-        Assert.Single(component.FindAll(".db-entry-remove-btn"));
+        Assert.Empty(component.FindAll(".db-entry-remove-btn"));
     }
 
     [Fact]
@@ -364,7 +390,7 @@ public sealed class DatabaseEntryRowTests : BunitContext
     }
 
     [Fact]
-    public void Render_NonReadyEnabledEntry_ShowsTrashButton()
+    public void Render_NonReadyEnabledEntry_NoTrashButton()
     {
         // Arrange — non-Ready entries are not loaded by the resolver regardless of IsEnabled,
         // so the file is not locked and removal is safe.
@@ -374,7 +400,7 @@ public sealed class DatabaseEntryRowTests : BunitContext
         var component = RenderRow(entry);
 
         // Assert
-        Assert.Single(component.FindAll(".db-entry-remove-btn"));
+        Assert.Empty(component.FindAll(".db-entry-remove-btn"));
     }
 
     [Fact]
@@ -452,9 +478,23 @@ public sealed class DatabaseEntryRowTests : BunitContext
     }
 
     [Fact]
-    public void Render_ReadyEnabledEntry_OptimisticToggleOff_StillRendersTrashButton()
+    public void Render_ReadyEnabledEntry_NoTrashButton()
     {
-        // Arrange — toggle change is optimistic and not yet committed; trash is in the DOM
+        // Arrange — Ready+Enabled is now safe to delete because RemoveAsync coordinates
+        // 
+
+        var entry = MakeEntry(DatabaseStatus.Ready, isEnabled: true);
+
+        // Act
+        var component = RenderRow(entry, effectiveEnabled: true);
+
+        // Assert
+        Assert.Empty(component.FindAll(".db-entry-remove-btn"));
+    }
+
+    [Fact]
+    public void Render_ReadyEnabledEntry_OptimisticToggleOff_NoTrashButton()
+    {
         // either way under the new contract.
         var entry = MakeEntry(DatabaseStatus.Ready, isEnabled: true);
 
@@ -462,22 +502,7 @@ public sealed class DatabaseEntryRowTests : BunitContext
         var component = RenderRow(entry, effectiveEnabled: false);
 
         // Assert
-        Assert.Single(component.FindAll(".db-entry-remove-btn"));
-    }
-
-    [Fact]
-    public void Render_ReadyEnabledEntry_RendersTrashButton()
-    {
-        // Arrange — Ready+Enabled is now safe to delete because RemoveAsync coordinates
-        // closing and reopening any open log views around the file delete. The trash is
-        // rendered (just visually faded by CSS until the row is hovered or focused).
-        var entry = MakeEntry(DatabaseStatus.Ready, isEnabled: true);
-
-        // Act
-        var component = RenderRow(entry, effectiveEnabled: true);
-
-        // Assert
-        Assert.Single(component.FindAll(".db-entry-remove-btn"));
+        Assert.Empty(component.FindAll(".db-entry-remove-btn"));
     }
 
     [Fact]
@@ -511,24 +536,10 @@ public sealed class DatabaseEntryRowTests : BunitContext
         Assert.All(radios, r => Assert.True(r.HasAttribute("disabled")));
     }
 
-    [Fact]
-    public void Render_RemoveButton_HasAriaLabel()
-    {
-        // Arrange
-        var entry = MakeEntry(DatabaseStatus.Ready, "MyProvider.db");
-
-        // Act
-        var component = RenderRow(entry);
-
-        // Assert
-        var button = component.Find(".db-entry-remove-btn");
-        Assert.Equal("Remove database MyProvider.db", button.GetAttribute("aria-label"));
-    }
-
     [Theory]
     [InlineData(DatabaseStatus.UnrecognizedSchema, "Unrecognized")]
     [InlineData(DatabaseStatus.ObsoleteSchema, "Obsolete")]
-    public void Render_TerminalStatus_ShowsBadge_AndOnlyTrash(DatabaseStatus status, string expectedLabel)
+    public void Render_TerminalStatus_ShowsBadge_NoTrash(DatabaseStatus status, string expectedLabel)
     {
         // ClassificationFailed intentionally excluded: it now renders the Retry classification button.
         var entry = MakeEntry(status);
@@ -543,7 +554,7 @@ public sealed class DatabaseEntryRowTests : BunitContext
 
         Assert.Empty(component.FindAll(".db-entry-upgrade-btn"));
         Assert.Empty(component.FindAll(".option-select"));
-        Assert.Single(component.FindAll(".db-entry-remove-btn"));
+        Assert.Empty(component.FindAll(".db-entry-remove-btn"));
     }
 
     [Fact]
@@ -686,10 +697,10 @@ public sealed class DatabaseEntryRowTests : BunitContext
     }
 
     [Fact]
-    public void Render_UpgradeRequiredEntry_ShowsTrashButton()
+    public void Render_UpgradeRequiredEntry_NoTrashButton()
     {
-        // Arrange — UpgradeRequired now renders the trash like every other status; the
-        // user is no longer forced to either Upgrade or transition through UpgradeFailed
+        // 
+
         // before being able to remove the entry.
         var entry = MakeEntry(DatabaseStatus.UpgradeRequired);
 
@@ -697,7 +708,7 @@ public sealed class DatabaseEntryRowTests : BunitContext
         var component = RenderRow(entry);
 
         // Assert
-        Assert.Single(component.FindAll(".db-entry-remove-btn"));
+        Assert.Empty(component.FindAll(".db-entry-remove-btn"));
     }
 
     [Fact]
@@ -847,6 +858,16 @@ public sealed class DatabaseEntryRowTests : BunitContext
 
         // Assert
         Assert.Equal(1, invocationCount);
+    }
+
+    [Fact]
+    public void TrashButton_NotRendered_InNormalMode()
+    {
+        var entry = MakeEntry(DatabaseStatus.Ready);
+
+        var component = RenderRow(entry);
+
+        Assert.Empty(component.FindAll(".db-entry-remove-btn"));
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.UI.Tests/Database/DatabaseRecoveryDialogTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Database/DatabaseRecoveryDialogTests.cs
@@ -32,6 +32,7 @@ public sealed class DatabaseRecoveryDialogTests : BunitContext
     public DatabaseRecoveryDialogTests()
     {
         Services.AddBannerHostDependencies();
+        Services.AddMenuMocks();
 
         _databaseService.Entries.Returns([]);
         _modalService.ActiveModalId.Returns(_modalId);

--- a/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/DatabaseToolsModalTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/DatabaseToolsModalTests.cs
@@ -30,11 +30,6 @@ public sealed class DatabaseToolsModalTests : BunitContext
     [Fact]
     public async Task DisposingActiveHost_ViaMenuHostDisposeAsync_UnregistersFromRegistry()
     {
-        // Verifies the (b) half of the registration contract — that
-        // MenuHost.DisposeAsync runs Registry.Unregister. The component-level
-        // bunit Dispose() does not always pump async child disposal, so we
-        // reach the inner MenuHost via reflection through the renderer and
-        // call DisposeAsync directly.
         var registry = Services.GetRequiredService<IMenuHostRegistry>();
         var component = Render<ModalChrome>(parameters => parameters
             .Add(p => p.Title, "DatabaseTools-stand-in")

--- a/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/DatabaseToolsModalTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/DatabaseToolsModalTests.cs
@@ -1,0 +1,104 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using EventLogExpert.UI.Menu;
+using EventLogExpert.UI.Modal;
+using EventLogExpert.UI.Tests.TestUtils;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EventLogExpert.UI.Tests.DatabaseTools;
+
+/// <summary>
+///     Lifecycle and menu-in-modal infrastructure coverage that goes through the shared <see cref="ModalChrome" />
+///     path. DatabaseToolsModal itself depends on Fluxor + ModalCoordinator plumbing whose isolated coverage already lives
+///     in their respective component tests; the meaningful new contract for #545 is that ANY modal hosted via ModalChrome
+///     now (a) registers an in-dialog MenuHost on open, and (b) unregisters it on dispose.
+/// </summary>
+public sealed class DatabaseToolsModalTests : BunitContext
+{
+    public DatabaseToolsModalTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        Services.AddBannerHostDependencies();
+        Services.AddMenuServiceMock();
+        // Real MenuHostRegistry so the in-dialog MenuHost actually registers itself.
+        Services.AddEventLogUiServices();
+    }
+
+    [Fact]
+    public async Task DisposingActiveHost_ViaMenuHostDisposeAsync_UnregistersFromRegistry()
+    {
+        // Verifies the (b) half of the registration contract — that
+        // MenuHost.DisposeAsync runs Registry.Unregister. The component-level
+        // bunit Dispose() does not always pump async child disposal, so we
+        // reach the inner MenuHost via reflection through the renderer and
+        // call DisposeAsync directly.
+        var registry = Services.GetRequiredService<IMenuHostRegistry>();
+        var component = Render<ModalChrome>(parameters => parameters
+            .Add(p => p.Title, "DatabaseTools-stand-in")
+            .AddChildContent("<p>tab content</p>"));
+
+        var activeHost = registry.ActiveHost;
+        Assert.NotNull(activeHost);
+
+        await activeHost!.DisposeAsync();
+
+        Assert.Null(registry.ActiveHost);
+    }
+
+    [Fact]
+    public async Task DisposingTopmostHost_RestoresPreviousAsActive()
+    {
+        var registry = Services.GetRequiredService<IMenuHostRegistry>();
+
+        var first = Render<ModalChrome>(parameters => parameters
+            .Add(p => p.Title, "first")
+            .AddChildContent("<p>1</p>"));
+        var firstHost = registry.ActiveHost;
+
+        var second = Render<ModalChrome>(parameters => parameters
+            .Add(p => p.Title, "second")
+            .AddChildContent("<p>2</p>"));
+        var secondHost = registry.ActiveHost;
+        Assert.NotSame(firstHost, secondHost);
+
+        await secondHost!.DisposeAsync();
+
+        Assert.Same(firstHost, registry.ActiveHost);
+    }
+
+    [Fact]
+    public void OpeningModalThroughModalChrome_RegistersInnerMenuHostAsActive()
+    {
+        var registry = Services.GetRequiredService<IMenuHostRegistry>();
+        Assert.Null(registry.ActiveHost);
+
+        var component = Render<ModalChrome>(parameters => parameters
+            .Add(p => p.Title, "DatabaseTools-stand-in")
+            .AddChildContent("<p>tab content</p>"));
+
+        Assert.NotNull(registry.ActiveHost);
+    }
+
+    [Fact]
+    public void StackedModals_TopmostBecomesActive()
+    {
+        var registry = Services.GetRequiredService<IMenuHostRegistry>();
+        Assert.Null(registry.ActiveHost);
+
+        var first = Render<ModalChrome>(parameters => parameters
+            .Add(p => p.Title, "first")
+            .AddChildContent("<p>1</p>"));
+        var firstHost = registry.ActiveHost;
+        Assert.NotNull(firstHost);
+
+        var second = Render<ModalChrome>(parameters => parameters
+            .Add(p => p.Title, "second")
+            .AddChildContent("<p>2</p>"));
+
+        Assert.NotNull(registry.ActiveHost);
+        Assert.NotSame(firstHost, registry.ActiveHost);
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/Tabs/CreateDatabaseTabTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/Tabs/CreateDatabaseTabTests.cs
@@ -1,0 +1,49 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using EventLogExpert.UI.DatabaseTools.Tabs;
+using EventLogExpert.UI.Tests.TestUtils;
+
+namespace EventLogExpert.UI.Tests.DatabaseTools.Tabs;
+
+public sealed class CreateDatabaseTabTests : BunitContext
+{
+    public CreateDatabaseTabTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddDatabaseToolsTabDependencies();
+        Services.AddMenuMocks();
+    }
+
+    [Fact]
+    public void Renders_FilterErrorState_WhenInvalidRegexEntered()
+    {
+        var component = Render<CreateDatabaseTab>();
+
+        var filter = component.Find("#create-filter");
+        filter.Input("[unterminated");
+
+        Assert.NotEmpty(component.FindAll(".filter-error"));
+    }
+
+    [Fact]
+    public void Renders_HappyPath_WithExpectedFormFields()
+    {
+        var component = Render<CreateDatabaseTab>();
+
+        Assert.NotNull(component.Find("#create-target-path"));
+        Assert.NotNull(component.Find("#create-source-path"));
+        Assert.NotNull(component.Find("#create-filter"));
+        Assert.NotNull(component.Find("#create-skip-path"));
+    }
+
+    [Fact]
+    public void RunButton_DisabledInitially_BecauseTargetPathIsEmpty()
+    {
+        var component = Render<CreateDatabaseTab>();
+
+        var runButton = component.Find(".button-green");
+        Assert.True(runButton.HasAttribute("disabled"));
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/Tabs/DiffDatabasesTabTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/Tabs/DiffDatabasesTabTests.cs
@@ -1,0 +1,46 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using EventLogExpert.UI.DatabaseTools.Tabs;
+using EventLogExpert.UI.Tests.TestUtils;
+
+namespace EventLogExpert.UI.Tests.DatabaseTools.Tabs;
+
+public sealed class DiffDatabasesTabTests : BunitContext
+{
+    public DiffDatabasesTabTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddDatabaseToolsTabDependencies();
+        Services.AddMenuMocks();
+    }
+
+    [Fact]
+    public void Renders_AllThreePathInputs_RequiredForRun()
+    {
+        var component = Render<DiffDatabasesTab>();
+
+        Assert.NotNull(component.Find("#diff-first-path"));
+        Assert.NotNull(component.Find("#diff-second-path"));
+        Assert.NotNull(component.Find("#diff-new-db"));
+    }
+
+    [Fact]
+    public void Renders_HappyPath_WithExpectedFormFields()
+    {
+        var component = Render<DiffDatabasesTab>();
+
+        Assert.NotNull(component.Find("#diff-first-path"));
+        Assert.NotNull(component.Find("#diff-second-path"));
+    }
+
+    [Fact]
+    public void RunButton_DisabledInitially_WhenInputsEmpty()
+    {
+        var component = Render<DiffDatabasesTab>();
+
+        var runButton = component.Find(".button-green");
+        Assert.True(runButton.HasAttribute("disabled"));
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/Tabs/FakeDatabaseService.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/Tabs/FakeDatabaseService.cs
@@ -35,7 +35,11 @@ internal sealed class FakeDatabaseService : IDatabaseService
 
     public int RetryClassificationCalls { get; private set; }
 
+    public IList<IReadOnlyList<string>> UpgradeBatchCalls { get; } = [];
+
     public int UpgradeBatchCompletedHandlerCount => UpgradeBatchCompleted?.GetInvocationList().Length ?? 0;
+
+    public UpgradeBatchResult UpgradeBatchReturnValue { get; set; } = new(Succeeded: [], Cancelled: [], Failed: []);
 
     public Task ClassifyEntriesAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
 
@@ -100,8 +104,11 @@ internal sealed class FakeDatabaseService : IDatabaseService
     public Task<UpgradeBatchResult> UpgradeBatchAsync(
         IReadOnlyList<string> fileNames,
         UpgradeProgressScope scope,
-        CancellationToken cancellationToken = default) =>
-        Task.FromResult(new UpgradeBatchResult([], [], []));
+        CancellationToken cancellationToken = default)
+    {
+        UpgradeBatchCalls.Add(fileNames);
+        return Task.FromResult(UpgradeBatchReturnValue);
+    }
 
 #pragma warning disable CS0067 // Events not raised in test fakes; declared only to satisfy the interface.
     public event EventHandler<UpgradeBatchProgressEventArgs>? UpgradeBatchProgress;

--- a/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/Tabs/FakeDatabaseService.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/Tabs/FakeDatabaseService.cs
@@ -106,7 +106,7 @@ internal sealed class FakeDatabaseService : IDatabaseService
         UpgradeProgressScope scope,
         CancellationToken cancellationToken = default)
     {
-        UpgradeBatchCalls.Add(fileNames);
+        UpgradeBatchCalls.Add(fileNames.ToList());
         return Task.FromResult(UpgradeBatchReturnValue);
     }
 

--- a/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/Tabs/ManageDatabasesTabTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/Tabs/ManageDatabasesTabTests.cs
@@ -11,6 +11,7 @@ using EventLogExpert.Runtime.Database.Upgrade;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.UI.DatabaseTools;
 using EventLogExpert.UI.DatabaseTools.Tabs;
+using EventLogExpert.UI.Tests.TestUtils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
@@ -41,6 +42,7 @@ public sealed class ManageDatabasesTabTests : BunitContext
         Services.AddSingleton(_logReloadCoordinator);
         Services.AddSingleton(_progressBannerService);
         Services.AddSingleton(_traceLogger);
+        Services.AddMenuServiceMock();
 
         JSInterop.Mode = JSRuntimeMode.Loose;
     }
@@ -82,11 +84,33 @@ public sealed class ManageDatabasesTabTests : BunitContext
         var alertSurface = new FakeInlineAlertSurface { Result = new InlineAlertResult(false, null) };
         var component = RenderWithAlertSurface(alertSurface);
 
-        await component.InvokeAsync(() => component.Find(".db-entry-remove-btn").Click());
+        await InvokeRemoveDatabaseAsync(component, entry);
 
         var captured = Assert.Single(alertSurface.Requests);
         Assert.Contains("Cancel", captured.AcceptLabel ?? string.Empty, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("upgrade", captured.AcceptLabel ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task BulkDelete_AnySucceeded_AutoExitsSelectionMode()
+    {
+        _databaseService.Entries = [Entry("a.db", isEnabled: false, status: DatabaseStatus.Ready)];
+        _coordinator.RemoveDatabaseAsync(
+                Arg.Any<string>(),
+                Arg.Any<Func<bool, CancellationToken, Task<bool>>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new RemoveOutcome(RemoveOutcomeStatus.Confirmed, true, false));
+        var alertSurface = new FakeInlineAlertSurface { Result = new InlineAlertResult(true, null) };
+        var component = RenderWithAlertSurface(alertSurface);
+
+        await EnterSelectionModeAsync(component);
+        await component.InvokeAsync(() => component.Find(".db-entry-row input[type='checkbox']")
+            .ChangeAsync(new ChangeEventArgs { Value = true }));
+
+        var deleteBtn = component.Find(".manage-databases-bulk-strip .button-red");
+        await component.InvokeAsync(() => deleteBtn.Click());
+
+        Assert.Equal("false", component.Find("#manage-select-button").GetAttribute("aria-pressed"));
     }
 
     [Fact]
@@ -102,12 +126,13 @@ public sealed class ManageDatabasesTabTests : BunitContext
             .Returns(new RemoveOutcome(RemoveOutcomeStatus.Confirmed, true, false));
         var alertSurface = new FakeInlineAlertSurface { Result = new InlineAlertResult(true, null) };
         var component = RenderWithAlertSurface(alertSurface);
-
+
+        await EnterSelectionModeAsync(component);
         var checkboxes = component.FindAll(".db-entry-row input[type='checkbox']");
         await component.InvokeAsync(() => checkboxes[0].ChangeAsync(new ChangeEventArgs { Value = true }));
         await component.InvokeAsync(() => checkboxes[1].ChangeAsync(new ChangeEventArgs { Value = true }));
 
-        var bulkRemove = component.FindAll(".manage-databases-bulk-strip button")[1];
+        var bulkRemove = component.Find(".manage-databases-bulk-strip .button-red");
         await component.InvokeAsync(() => bulkRemove.Click());
 
         await _coordinator.Received(1).RemoveDatabaseAsync(
@@ -128,12 +153,13 @@ public sealed class ManageDatabasesTabTests : BunitContext
             Entry("b.db", isEnabled: false, status: DatabaseStatus.Ready)];
         var alertSurface = new FakeInlineAlertSurface { Result = new InlineAlertResult(false, null) };
         var component = RenderWithAlertSurface(alertSurface);
-
+
+        await EnterSelectionModeAsync(component);
         var checkboxes = component.FindAll(".db-entry-row input[type='checkbox']");
         await component.InvokeAsync(() => checkboxes[0].ChangeAsync(new ChangeEventArgs { Value = true }));
         await component.InvokeAsync(() => checkboxes[1].ChangeAsync(new ChangeEventArgs { Value = true }));
 
-        var bulkRemove = component.FindAll(".manage-databases-bulk-strip button")[1];
+        var bulkRemove = component.Find(".manage-databases-bulk-strip .button-red");
         await component.InvokeAsync(() => bulkRemove.Click());
 
         await _coordinator.DidNotReceive().RemoveDatabaseAsync(
@@ -155,9 +181,10 @@ public sealed class ManageDatabasesTabTests : BunitContext
 
         var alertSurface = new FakeInlineAlertSurface { Result = new InlineAlertResult(false, null) };
         var component = RenderWithAlertSurface(alertSurface);
-
+
+        await EnterSelectionModeAsync(component);
         await component.InvokeAsync(() => component.Find(".db-entry-row input[type='checkbox']").ChangeAsync(new ChangeEventArgs { Value = true }));
-        var bulkRemove = component.FindAll(".manage-databases-bulk-strip button")[1];
+        var bulkRemove = component.Find(".manage-databases-bulk-strip .button-red");
         await component.InvokeAsync(() => bulkRemove.Click());
 
         var captured = Assert.Single(alertSurface.Requests);
@@ -188,11 +215,12 @@ public sealed class ManageDatabasesTabTests : BunitContext
                 wasCancelled: false));
         Assert.True(component.Instance.HasDatabaseStateChanged);
 
+        await EnterSelectionModeAsync(component);
         var checkboxes = component.FindAll(".db-entry-row input[type='checkbox']");
         await component.InvokeAsync(() => checkboxes[0].ChangeAsync(new ChangeEventArgs { Value = true }));
         await component.InvokeAsync(() => checkboxes[1].ChangeAsync(new ChangeEventArgs { Value = true }));
 
-        var bulkRemove = component.FindAll(".manage-databases-bulk-strip button")[1];
+        var bulkRemove = component.Find(".manage-databases-bulk-strip .button-red");
         await component.InvokeAsync(() => bulkRemove.Click());
 
         Assert.False(component.Instance.HasDatabaseStateChanged);
@@ -210,15 +238,228 @@ public sealed class ManageDatabasesTabTests : BunitContext
             .Returns(new RemoveOutcome(RemoveOutcomeStatus.Confirmed, true, false));
         var alertSurface = new FakeInlineAlertSurface { Result = new InlineAlertResult(true, null) };
         var component = RenderWithAlertSurface(alertSurface);
-
+
+        await EnterSelectionModeAsync(component);
         var checkboxes = component.FindAll(".db-entry-row input[type='checkbox']");
         await component.InvokeAsync(() => checkboxes[0].ChangeAsync(new ChangeEventArgs { Value = true }));
         await component.InvokeAsync(() => checkboxes[1].ChangeAsync(new ChangeEventArgs { Value = true }));
 
-        var bulkRemove = component.FindAll(".manage-databases-bulk-strip button")[1];
+        var bulkRemove = component.Find(".manage-databases-bulk-strip .button-red");
         await component.InvokeAsync(() => bulkRemove.Click());
 
         _announcementService.Received().Announce(Arg.Is<string>(s => s.Contains("a.db") && s.Contains("disk full")));
+    }
+
+    [Fact]
+    public async Task BulkUpgrade_AllEligible_CallsCoordinatorWithEntireBatch()
+    {
+        _databaseService.Entries = [
+            Entry("a.db", isEnabled: false, status: DatabaseStatus.UpgradeRequired),
+            Entry("b.db", isEnabled: false, status: DatabaseStatus.UpgradeFailed)];
+        _coordinator.UpgradeDatabasesAsync(
+                Arg.Any<IReadOnlyList<string>>(),
+                Arg.Any<UpgradeProgressScope>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new UpgradeBatchResult(Succeeded: ["a.db", "b.db"], Cancelled: [], Failed: []));
+
+        var component = Render<ManageDatabasesTab>();
+        await EnterSelectionModeAsync(component);
+        var checkboxes = component.FindAll(".db-entry-row input[type='checkbox']");
+        await component.InvokeAsync(() => checkboxes[0].ChangeAsync(new ChangeEventArgs { Value = true }));
+        await component.InvokeAsync(() => checkboxes[1].ChangeAsync(new ChangeEventArgs { Value = true }));
+
+        var upgradeBtn = component.Find(".manage-databases-bulk-strip .button-green");
+        await component.InvokeAsync(() => upgradeBtn.Click());
+
+        await _coordinator.Received(1).UpgradeDatabasesAsync(
+            Arg.Is<IReadOnlyList<string>>(l => l.Count == 2 && l.Contains("a.db") && l.Contains("b.db")),
+            UpgradeProgressScope.ManageDatabasesTriggered,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task BulkUpgrade_ButtonAppears_OnlyWhenEligibleRowSelected()
+    {
+        _databaseService.Entries = [
+            Entry("ready.db", isEnabled: true, status: DatabaseStatus.Ready),
+            Entry("needs.db", isEnabled: false, status: DatabaseStatus.UpgradeRequired)];
+        var component = Render<ManageDatabasesTab>();
+        await EnterSelectionModeAsync(component);
+
+        var checkboxes = component.FindAll(".db-entry-row input[type='checkbox']");
+        await component.InvokeAsync(() => checkboxes[0].ChangeAsync(new ChangeEventArgs { Value = true }));
+        Assert.Empty(component.FindAll(".manage-databases-bulk-strip .button-green"));
+
+        await component.InvokeAsync(() => checkboxes[1].ChangeAsync(new ChangeEventArgs { Value = true }));
+        var upgradeBtn = component.Find(".manage-databases-bulk-strip .button-green");
+        Assert.Contains("Upgrade 1", upgradeBtn.TextContent);
+    }
+
+    [Fact]
+    public async Task BulkUpgrade_CleanSuccess_AutoExitsSelectionMode()
+    {
+        _databaseService.Entries = [Entry("a.db", isEnabled: false, status: DatabaseStatus.UpgradeRequired)];
+        _coordinator.UpgradeDatabasesAsync(
+                Arg.Any<IReadOnlyList<string>>(),
+                Arg.Any<UpgradeProgressScope>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new UpgradeBatchResult(Succeeded: ["a.db"], Cancelled: [], Failed: []));
+
+        var component = Render<ManageDatabasesTab>();
+        await EnterSelectionModeAsync(component);
+        await component.InvokeAsync(() => component.Find(".db-entry-row input[type='checkbox']")
+            .ChangeAsync(new ChangeEventArgs { Value = true }));
+
+        var upgradeBtn = component.Find(".manage-databases-bulk-strip .button-green");
+        await component.InvokeAsync(() => upgradeBtn.Click());
+
+        Assert.False(component.Instance.HasBulkSelection);
+        Assert.Equal("false", component.Find("#manage-select-button").GetAttribute("aria-pressed"));
+    }
+
+    [Fact]
+    public async Task BulkUpgrade_GateDenied_CoordinatorReturnsNull_ShowsInfoAlert()
+    {
+        _databaseService.Entries = [Entry("a.db", isEnabled: false, status: DatabaseStatus.UpgradeRequired)];
+        _coordinator.UpgradeDatabasesAsync(
+                Arg.Any<IReadOnlyList<string>>(),
+                Arg.Any<UpgradeProgressScope>(),
+                Arg.Any<CancellationToken>())
+            .Returns((UpgradeBatchResult?)null);
+        var alertSurface = new FakeInlineAlertSurface { Result = new InlineAlertResult(true, null) };
+        var component = RenderWithAlertSurface(alertSurface);
+
+        await EnterSelectionModeAsync(component);
+        await component.InvokeAsync(() => component.Find(".db-entry-row input[type='checkbox']")
+            .ChangeAsync(new ChangeEventArgs { Value = true }));
+
+        var upgradeBtn = component.Find(".manage-databases-bulk-strip .button-green");
+        await component.InvokeAsync(() => upgradeBtn.Click());
+
+        var captured = Assert.Single(alertSurface.Requests);
+        Assert.Equal("Upgrade not started", captured.Title);
+        Assert.Contains("already in progress", captured.Message);
+    }
+
+    [Fact]
+    public async Task BulkUpgrade_GateDenied_StaysInSelectionMode()
+    {
+        _databaseService.Entries = [Entry("a.db", isEnabled: false, status: DatabaseStatus.UpgradeRequired)];
+        _coordinator.UpgradeDatabasesAsync(
+                Arg.Any<IReadOnlyList<string>>(),
+                Arg.Any<UpgradeProgressScope>(),
+                Arg.Any<CancellationToken>())
+            .Returns((UpgradeBatchResult?)null);
+        var alertSurface = new FakeInlineAlertSurface { Result = new InlineAlertResult(true, null) };
+        var component = RenderWithAlertSurface(alertSurface);
+
+        await EnterSelectionModeAsync(component);
+        await component.InvokeAsync(() => component.Find(".db-entry-row input[type='checkbox']")
+            .ChangeAsync(new ChangeEventArgs { Value = true }));
+
+        await component.InvokeAsync(() => component.Find(".manage-databases-bulk-strip .button-green").Click());
+
+        Assert.True(component.Instance.HasBulkSelection);
+    }
+
+    [Fact]
+    public async Task BulkUpgrade_MixedSelection_CancelledPrompt_DoesNotCallCoordinator()
+    {
+        _databaseService.Entries = [
+            Entry("a.db", isEnabled: false, status: DatabaseStatus.UpgradeRequired),
+            Entry("b.db", isEnabled: false, status: DatabaseStatus.Ready)];
+        var alertSurface = new FakeInlineAlertSurface { Result = new InlineAlertResult(false, null) };
+        var component = RenderWithAlertSurface(alertSurface);
+
+        await EnterSelectionModeAsync(component);
+        var checkboxes = component.FindAll(".db-entry-row input[type='checkbox']");
+        await component.InvokeAsync(() => checkboxes[0].ChangeAsync(new ChangeEventArgs { Value = true }));
+        await component.InvokeAsync(() => checkboxes[1].ChangeAsync(new ChangeEventArgs { Value = true }));
+
+        var upgradeBtn = component.Find(".manage-databases-bulk-strip .button-green");
+        await component.InvokeAsync(() => upgradeBtn.Click());
+
+        await _coordinator.DidNotReceive().UpgradeDatabasesAsync(
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<UpgradeProgressScope>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task BulkUpgrade_MixedSelection_ShowsSubsetConfirm_AcceptedRunsBatchWithEligibleOnly()
+    {
+        _databaseService.Entries = [
+            Entry("a.db", isEnabled: false, status: DatabaseStatus.UpgradeRequired),
+            Entry("b.db", isEnabled: false, status: DatabaseStatus.Ready)];
+        _coordinator.UpgradeDatabasesAsync(
+                Arg.Any<IReadOnlyList<string>>(),
+                Arg.Any<UpgradeProgressScope>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new UpgradeBatchResult(Succeeded: ["a.db"], Cancelled: [], Failed: []));
+        var alertSurface = new FakeInlineAlertSurface { Result = new InlineAlertResult(true, null) };
+        var component = RenderWithAlertSurface(alertSurface);
+
+        await EnterSelectionModeAsync(component);
+        var checkboxes = component.FindAll(".db-entry-row input[type='checkbox']");
+        await component.InvokeAsync(() => checkboxes[0].ChangeAsync(new ChangeEventArgs { Value = true }));
+        await component.InvokeAsync(() => checkboxes[1].ChangeAsync(new ChangeEventArgs { Value = true }));
+
+        var upgradeBtn = component.Find(".manage-databases-bulk-strip .button-green");
+        await component.InvokeAsync(() => upgradeBtn.Click());
+
+        var prompt = Assert.Single(alertSurface.Requests);
+        Assert.Contains("1 of 2", prompt.Message);
+        Assert.Contains("b.db", prompt.Message);
+        Assert.Contains("Already up to date", prompt.Message);
+        Assert.Equal("Upgrade 1", prompt.AcceptLabel);
+
+        await _coordinator.Received(1).UpgradeDatabasesAsync(
+            Arg.Is<IReadOnlyList<string>>(l => l.Count == 1 && l.Contains("a.db")),
+            UpgradeProgressScope.ManageDatabasesTriggered,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task BulkUpgrade_PartialFailure_StaysInSelectionMode()
+    {
+        _databaseService.Entries = [
+            Entry("a.db", isEnabled: false, status: DatabaseStatus.UpgradeRequired),
+            Entry("b.db", isEnabled: false, status: DatabaseStatus.UpgradeRequired)];
+        _coordinator.UpgradeDatabasesAsync(
+                Arg.Any<IReadOnlyList<string>>(),
+                Arg.Any<UpgradeProgressScope>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new UpgradeBatchResult(
+                Succeeded: ["a.db"],
+                Cancelled: [],
+                Failed: [new UpgradeFailure("b.db", "boom")]));
+
+        var component = Render<ManageDatabasesTab>();
+        await EnterSelectionModeAsync(component);
+        await component.InvokeAsync(() => component.Find(".manage-databases-master-btn").Click());
+
+        var upgradeBtn = component.Find(".manage-databases-bulk-strip .button-green");
+        await component.InvokeAsync(() => upgradeBtn.Click());
+
+        Assert.True(component.Instance.HasBulkSelection);
+        Assert.Equal("true", component.Find("#manage-select-button").GetAttribute("aria-pressed"));
+    }
+
+    [Fact]
+    public async Task BulkUpgrade_ZeroEligible_UpgradeButtonHidden()
+    {
+        _databaseService.Entries = [Entry("a.db", isEnabled: true, status: DatabaseStatus.Ready)];
+        var component = Render<ManageDatabasesTab>();
+        await EnterSelectionModeAsync(component);
+        await component.InvokeAsync(() => component.Find(".db-entry-row input[type='checkbox']")
+            .ChangeAsync(new ChangeEventArgs { Value = true }));
+
+        Assert.Empty(component.FindAll(".manage-databases-bulk-strip .button-green"));
+
+        await _coordinator.DidNotReceive().UpgradeDatabasesAsync(
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<UpgradeProgressScope>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -357,15 +598,17 @@ public sealed class ManageDatabasesTabTests : BunitContext
             Entry("b.db", isEnabled: false, status: DatabaseStatus.Ready)];
         var component = Render<ManageDatabasesTab>();
 
+        await EnterSelectionModeAsync(component);
         var checkboxes = component.FindAll(".db-entry-row input[type='checkbox']");
         await component.InvokeAsync(() => checkboxes[0].ChangeAsync(new ChangeEventArgs { Value = true }));
         await component.InvokeAsync(() => checkboxes[1].ChangeAsync(new ChangeEventArgs { Value = true }));
         Assert.Contains("2 selected", component.Find(".manage-databases-bulk-count").TextContent);
 
-        var clearBtn = component.FindAll(".manage-databases-bulk-strip button")[0];
-        await component.InvokeAsync(() => clearBtn.Click());
+        // Master checkbox in the selection header clears when all are selected.
+        var masterBtn = component.Find(".manage-databases-master-btn");
+        await component.InvokeAsync(() => masterBtn.Click());
 
-        Assert.False(component.Instance.HasSelectedForRemoval);
+        Assert.False(component.Instance.HasBulkSelection);
         Assert.Empty(component.FindAll(".manage-databases-bulk-strip"));
     }
 
@@ -375,12 +618,14 @@ public sealed class ManageDatabasesTabTests : BunitContext
         _databaseService.Entries = [Entry("a.db", isEnabled: false, status: DatabaseStatus.Ready)];
         var component = Render<ManageDatabasesTab>();
 
+        await EnterSelectionModeAsync(component);
         await component.InvokeAsync(() => component.Find(".db-entry-row input[type='checkbox']").ChangeAsync(new ChangeEventArgs { Value = true }));
         var liveRegion = component.Find(".manage-databases-tab > span[role='status'][aria-live='polite']");
         Assert.NotEqual(string.Empty, liveRegion.TextContent.Trim());
 
-        var clearBtn = component.FindAll(".manage-databases-bulk-strip button")[0];
-        await component.InvokeAsync(() => clearBtn.Click());
+        // With 1 of 1 selected, master is "all"; clicking clears.
+        var masterBtn = component.Find(".manage-databases-master-btn");
+        await component.InvokeAsync(() => masterBtn.Click());
 
         liveRegion = component.Find(".manage-databases-tab > span[role='status'][aria-live='polite']");
         Assert.DoesNotContain("selected", liveRegion.TextContent, StringComparison.OrdinalIgnoreCase);
@@ -395,8 +640,7 @@ public sealed class ManageDatabasesTabTests : BunitContext
         var alertSurface = new FakeInlineAlertSurface { Result = new InlineAlertResult(false, null) };
         var component = RenderWithAlertSurface(alertSurface);
 
-        var removeBtn = component.Find(".db-entry-row .db-entry-remove-btn");
-        await component.InvokeAsync(() => removeBtn.Click());
+        await InvokeRemoveDatabaseAsync(component, _databaseService.Entries[0]);
 
         var captured = Assert.Single(alertSurface.Requests);
         Assert.DoesNotContain("close and reopen", captured.Message, StringComparison.OrdinalIgnoreCase);
@@ -411,8 +655,7 @@ public sealed class ManageDatabasesTabTests : BunitContext
         var alertSurface = new FakeInlineAlertSurface { Result = new InlineAlertResult(false, null) };
         var component = RenderWithAlertSurface(alertSurface);
 
-        var removeBtn = component.Find(".db-entry-row .db-entry-remove-btn");
-        await component.InvokeAsync(() => removeBtn.Click());
+        await InvokeRemoveDatabaseAsync(component, _databaseService.Entries[0]);
 
         var captured = Assert.Single(alertSurface.Requests);
         Assert.Contains("close and reopen", captured.Message, StringComparison.OrdinalIgnoreCase);
@@ -427,8 +670,7 @@ public sealed class ManageDatabasesTabTests : BunitContext
         var alertSurface = new FakeInlineAlertSurface { Result = new InlineAlertResult(false, null) };
         var component = RenderWithAlertSurface(alertSurface);
 
-        var removeBtn = component.Find(".db-entry-row .db-entry-remove-btn");
-        await component.InvokeAsync(() => removeBtn.Click());
+        await InvokeRemoveDatabaseAsync(component, _databaseService.Entries[0]);
 
         var captured = Assert.Single(alertSurface.Requests);
         Assert.DoesNotContain("close and reopen", captured.Message, StringComparison.OrdinalIgnoreCase);
@@ -446,6 +688,50 @@ public sealed class ManageDatabasesTabTests : BunitContext
 
         Assert.Equal(0, _databaseService.EntriesChangedHandlerCount);
         Assert.Equal(0, _databaseService.UpgradeBatchCompletedHandlerCount);
+    }
+
+    [Fact]
+    public async Task EntriesChanged_DuringSelection_EmptyList_AutoExitsSelectionMode()
+    {
+        _databaseService.Entries = [Entry("a.db", isEnabled: false, status: DatabaseStatus.Ready)];
+        var component = Render<ManageDatabasesTab>();
+        await EnterSelectionModeAsync(component);
+        Assert.Equal("true", component.Find("#manage-select-button").GetAttribute("aria-pressed"));
+
+        _databaseService.Entries = [];
+        _databaseService.RaiseEntriesChanged();
+        await component.InvokeAsync(() => { });
+
+        Assert.Equal("false", component.Find("#manage-select-button").GetAttribute("aria-pressed"));
+    }
+
+    [Fact]
+    public async Task Escape_InNormalMode_NoOp()
+    {
+        _databaseService.Entries = [Entry("a.db", isEnabled: false, status: DatabaseStatus.Ready)];
+        var component = Render<ManageDatabasesTab>();
+
+        await component.InvokeAsync(() => component.Find(".manage-databases-tab")
+            .KeyDown(new KeyboardEventArgs { Key = "Escape" }));
+
+        Assert.Equal("false", component.Find("#manage-select-button").GetAttribute("aria-pressed"));
+    }
+
+    [Fact]
+    public async Task Escape_InSelectionMode_ExitsAndClearsSelection()
+    {
+        _databaseService.Entries = [Entry("a.db", isEnabled: false, status: DatabaseStatus.Ready)];
+        var component = Render<ManageDatabasesTab>();
+        await EnterSelectionModeAsync(component);
+        await component.InvokeAsync(() => component.Find(".db-entry-row input[type='checkbox']")
+            .ChangeAsync(new ChangeEventArgs { Value = true }));
+        Assert.True(component.Instance.HasBulkSelection);
+
+        await component.InvokeAsync(() => component.Find(".manage-databases-tab")
+            .KeyDown(new KeyboardEventArgs { Key = "Escape" }));
+
+        Assert.False(component.Instance.HasBulkSelection);
+        Assert.Equal("false", component.Find("#manage-select-button").GetAttribute("aria-pressed"));
     }
 
     [Fact]
@@ -602,6 +888,52 @@ public sealed class ManageDatabasesTabTests : BunitContext
     }
 
     [Fact]
+    public async Task MasterCheckbox_AllSelected_ShowsCheckedIconAndClearLabel()
+    {
+        _databaseService.Entries = [Entry("a.db", isEnabled: false, status: DatabaseStatus.Ready)];
+        var component = Render<ManageDatabasesTab>();
+        await EnterSelectionModeAsync(component);
+        await component.InvokeAsync(() => component.Find(".db-entry-row input[type='checkbox']")
+            .ChangeAsync(new ChangeEventArgs { Value = true }));
+
+        var btn = component.Find(".manage-databases-master-btn");
+        var icon = component.Find(".manage-databases-master-btn i");
+        Assert.Contains("bi-check-square-fill", icon.GetAttribute("class") ?? string.Empty);
+        Assert.Equal("Clear selection", btn.GetAttribute("aria-label"));
+    }
+
+    [Fact]
+    public async Task MasterCheckbox_Indeterminate_WhenSomeButNotAllSelected()
+    {
+        _databaseService.Entries = [
+            Entry("a.db", isEnabled: false, status: DatabaseStatus.Ready),
+            Entry("b.db", isEnabled: false, status: DatabaseStatus.Ready)];
+        var component = Render<ManageDatabasesTab>();
+        await EnterSelectionModeAsync(component);
+        await component.InvokeAsync(() => component.FindAll(".db-entry-row input[type='checkbox']")[0]
+            .ChangeAsync(new ChangeEventArgs { Value = true }));
+
+        var icon = component.Find(".manage-databases-master-btn i");
+        Assert.Contains("bi-dash-square-fill", icon.GetAttribute("class") ?? string.Empty);
+        Assert.Equal("Select all", component.Find(".manage-databases-master-btn").GetAttribute("aria-label"));
+    }
+
+    [Fact]
+    public async Task MasterCheckbox_ShowsAfterEnteringSelectionMode_BeforeAnySelection()
+    {
+        _databaseService.Entries = [Entry("a.db", isEnabled: false, status: DatabaseStatus.Ready)];
+        var component = Render<ManageDatabasesTab>();
+
+        Assert.Empty(component.FindAll(".manage-databases-selection-header"));
+
+        await EnterSelectionModeAsync(component);
+
+        var icon = component.Find(".manage-databases-master-btn i");
+        Assert.Contains("bi-square", icon.GetAttribute("class") ?? string.Empty);
+        Assert.Contains("0 of 1 selected", component.Find(".manage-databases-selection-count").TextContent);
+    }
+
+    [Fact]
     public async Task RebaselineActiveSnapshotOnly_PreservesStickyFlags()
     {
         // Modal opens mid-classification (empty snapshot), user-initiated upgrade succeeds during the
@@ -637,7 +969,7 @@ public sealed class ManageDatabasesTabTests : BunitContext
         var alertSurface = new FakeInlineAlertSurface { Result = new InlineAlertResult(false, null) };
         var component = RenderWithAlertSurface(alertSurface);
 
-        await component.InvokeAsync(() => component.Find(".db-entry-remove-btn").Click());
+        await InvokeRemoveDatabaseAsync(component, entry);
 
         var captured = Assert.Single(alertSurface.Requests);
         Assert.Contains("Cancel", captured.AcceptLabel ?? string.Empty, StringComparison.OrdinalIgnoreCase);
@@ -652,7 +984,7 @@ public sealed class ManageDatabasesTabTests : BunitContext
         var component = Render<ManageDatabasesTab>();
 
         Assert.Empty(component.FindAll(".manage-databases-bulk-strip"));
-        Assert.False(component.Instance.HasSelectedForRemoval);
+        Assert.False(component.Instance.HasBulkSelection);
     }
 
     [Fact]
@@ -715,6 +1047,31 @@ public sealed class ManageDatabasesTabTests : BunitContext
         var statusRegion = component.Find(".manage-databases-tab > span[role='status'][aria-live='polite']");
         Assert.NotNull(statusRegion);
         Assert.Equal("true", statusRegion.GetAttribute("aria-atomic"));
+    }
+
+    [Fact]
+    public void Render_SelectButton_PresentByDefaultWithSelectLabel()
+    {
+        _databaseService.Entries = [Entry("a.db", isEnabled: false, status: DatabaseStatus.Ready)];
+
+        var component = Render<ManageDatabasesTab>();
+
+        var selectBtn = component.Find("#manage-select-button");
+        Assert.Equal("false", selectBtn.GetAttribute("aria-pressed"));
+        Assert.Contains("Select", selectBtn.TextContent);
+        Assert.DoesNotContain("Done", selectBtn.TextContent);
+    }
+
+    [Fact]
+    public void Render_TrashButton_NotPresentInAnyRow()
+    {
+        _databaseService.Entries = [
+            Entry("a.db", isEnabled: true, status: DatabaseStatus.Ready),
+            Entry("b.db", isEnabled: false, status: DatabaseStatus.UpgradeRequired)];
+
+        var component = Render<ManageDatabasesTab>();
+
+        Assert.Empty(component.FindAll(".db-entry-remove-btn"));
     }
 
     [Fact]
@@ -822,6 +1179,24 @@ public sealed class ManageDatabasesTabTests : BunitContext
     }
 
     [Fact]
+    public async Task SelectAll_AddsEveryEntryToSelection()
+    {
+        _databaseService.Entries = [
+            Entry("a.db", isEnabled: false, status: DatabaseStatus.UpgradeRequired),
+            Entry("b.db", isEnabled: false, status: DatabaseStatus.Ready),
+            Entry("c.db", isEnabled: false, status: DatabaseStatus.UpgradeFailed)];
+        var component = Render<ManageDatabasesTab>();
+        await EnterSelectionModeAsync(component);
+
+        // Master checkbox: 0 selected → click selects all.
+        var masterBtn = component.Find(".manage-databases-master-btn");
+        await component.InvokeAsync(() => masterBtn.Click());
+
+        Assert.Contains("3 selected", component.Find(".manage-databases-bulk-count").TextContent);
+        Assert.Contains("Upgrade 2", component.Find(".manage-databases-bulk-strip .button-green").TextContent);
+    }
+
+    [Fact]
     public async Task SingleRowRemove_DuringCoordinatorUpgrade_DualSignal_AcceptanceLabelMentionsCancel()
     {
         var entry = Entry("a.db", isEnabled: false, status: DatabaseStatus.UpgradeRequired);
@@ -835,7 +1210,7 @@ public sealed class ManageDatabasesTabTests : BunitContext
         var alertSurface = new FakeInlineAlertSurface { Result = new InlineAlertResult(false, null) };
         var component = RenderWithAlertSurface(alertSurface);
 
-        await component.InvokeAsync(() => component.Find(".db-entry-remove-btn").Click());
+        await InvokeRemoveDatabaseAsync(component, entry);
 
         var captured = Assert.Single(alertSurface.Requests);
         Assert.Contains("Cancel", captured.AcceptLabel ?? string.Empty, StringComparison.OrdinalIgnoreCase);
@@ -847,10 +1222,11 @@ public sealed class ManageDatabasesTabTests : BunitContext
     {
         _databaseService.Entries = [Entry("a.db", isEnabled: false, status: DatabaseStatus.Ready)];
         var component = Render<ManageDatabasesTab>();
-
+
+        await EnterSelectionModeAsync(component);
         await component.InvokeAsync(() => component.Find(".db-entry-row input[type='checkbox']").ChangeAsync(new ChangeEventArgs { Value = true }));
 
-        Assert.True(component.Instance.HasSelectedForRemoval);
+        Assert.True(component.Instance.HasBulkSelection);
         Assert.Single(component.FindAll(".manage-databases-bulk-strip"));
         Assert.Contains("1 selected", component.Find(".manage-databases-bulk-count").TextContent);
     }
@@ -862,7 +1238,8 @@ public sealed class ManageDatabasesTabTests : BunitContext
             Entry("a.db", isEnabled: false, status: DatabaseStatus.Ready),
             Entry("b.db", isEnabled: false, status: DatabaseStatus.Ready)];
         var component = Render<ManageDatabasesTab>();
-
+
+        await EnterSelectionModeAsync(component);
         var checkboxes = component.FindAll(".db-entry-row input[type='checkbox']");
         await component.InvokeAsync(() => checkboxes[0].ChangeAsync(new ChangeEventArgs { Value = true }));
         await component.InvokeAsync(() => checkboxes[1].ChangeAsync(new ChangeEventArgs { Value = true }));
@@ -872,7 +1249,7 @@ public sealed class ManageDatabasesTabTests : BunitContext
         _databaseService.RaiseEntriesChanged();
         await component.InvokeAsync(() => { });
 
-        Assert.True(component.Instance.HasSelectedForRemoval);
+        Assert.True(component.Instance.HasBulkSelection);
         Assert.Contains("1 selected", component.Find(".manage-databases-bulk-count").TextContent);
     }
 
@@ -881,13 +1258,14 @@ public sealed class ManageDatabasesTabTests : BunitContext
     {
         _databaseService.Entries = [Entry("a.db", isEnabled: false, status: DatabaseStatus.Ready)];
         var component = Render<ManageDatabasesTab>();
+
+        await EnterSelectionModeAsync(component);
+        await component.InvokeAsync(() => component.Find(".db-entry-row input[type='checkbox']").ChangeAsync(new ChangeEventArgs { Value = true }));
+        Assert.True(component.Instance.HasBulkSelection);
 
         await component.InvokeAsync(() => component.Find(".db-entry-row input[type='checkbox']").ChangeAsync(new ChangeEventArgs { Value = true }));
-        Assert.True(component.Instance.HasSelectedForRemoval);
 
-        await component.InvokeAsync(() => component.Find(".db-entry-row input[type='checkbox']").ChangeAsync(new ChangeEventArgs { Value = true }));
-
-        Assert.False(component.Instance.HasSelectedForRemoval);
+        Assert.False(component.Instance.HasBulkSelection);
         Assert.Empty(component.FindAll(".manage-databases-bulk-strip"));
     }
 
@@ -902,6 +1280,7 @@ public sealed class ManageDatabasesTabTests : BunitContext
         var liveRegion = component.Find(".manage-databases-tab > span[role='status'][aria-live='polite']");
         Assert.Equal(string.Empty, liveRegion.TextContent.Trim());
 
+        await EnterSelectionModeAsync(component);
         var checkboxes = component.FindAll(".db-entry-row input[type='checkbox']");
         await component.InvokeAsync(() => checkboxes[0].ChangeAsync(new ChangeEventArgs { Value = true }));
         liveRegion = component.Find(".manage-databases-tab > span[role='status'][aria-live='polite']");
@@ -911,6 +1290,48 @@ public sealed class ManageDatabasesTabTests : BunitContext
         await component.InvokeAsync(() => checkboxes[1].ChangeAsync(new ChangeEventArgs { Value = true }));
         liveRegion = component.Find(".manage-databases-tab > span[role='status'][aria-live='polite']");
         Assert.Contains("2", liveRegion.TextContent);
+    }
+
+    [Fact]
+    public async Task ToggleSelectionMode_EntersMode_RevealsCheckboxes_ChangesLabelToDone()
+    {
+        _databaseService.Entries = [Entry("a.db", isEnabled: false, status: DatabaseStatus.Ready)];
+        var component = Render<ManageDatabasesTab>();
+
+        var wrapper = component.Find(".db-entry-checkbox");
+        Assert.DoesNotContain("db-entry-checkbox--visible", wrapper.GetAttribute("class") ?? string.Empty);
+
+        await EnterSelectionModeAsync(component);
+
+        var selectBtn = component.Find("#manage-select-button");
+        Assert.Equal("true", selectBtn.GetAttribute("aria-pressed"));
+        Assert.Contains("Done", selectBtn.TextContent);
+
+        wrapper = component.Find(".db-entry-checkbox");
+        Assert.Contains("db-entry-checkbox--visible", wrapper.GetAttribute("class") ?? string.Empty);
+    }
+
+    [Fact]
+    public async Task ToggleSelectionMode_Exits_ClearsSelection()
+    {
+        _databaseService.Entries = [Entry("a.db", isEnabled: false, status: DatabaseStatus.Ready)];
+        var component = Render<ManageDatabasesTab>();
+
+        await EnterSelectionModeAsync(component);
+        await component.InvokeAsync(() => component.Find(".db-entry-row input[type='checkbox']")
+            .ChangeAsync(new ChangeEventArgs { Value = true }));
+        Assert.True(component.Instance.HasBulkSelection);
+
+        await EnterSelectionModeAsync(component);
+
+        Assert.False(component.Instance.HasBulkSelection);
+        var selectBtn = component.Find("#manage-select-button");
+        Assert.Equal("false", selectBtn.GetAttribute("aria-pressed"));
+    }
+
+    private static async Task EnterSelectionModeAsync(IRenderedComponent<ManageDatabasesTab> component)
+    {
+        await component.InvokeAsync(() => component.Find("#manage-select-button").Click());
     }
 
     private static DatabaseEntry Entry(string fileName, bool isEnabled, DatabaseStatus status, bool backupExists = false) =>
@@ -927,6 +1348,19 @@ public sealed class ManageDatabasesTabTests : BunitContext
             BindingFlags.Instance | BindingFlags.NonPublic);
         Assert.NotNull(method);
         return (Task)method!.Invoke(component.Instance, [fileNames])!;
+    }
+
+    private static Task InvokeRemoveDatabaseAsync(
+        IRenderedComponent<ManageDatabasesTab> component,
+        DatabaseEntry entry)
+    {
+        // Single-row remove is now triggered via the right-click context menu; invoke
+        // the private path directly to keep tests focused on remove semantics.
+        var method = typeof(ManageDatabasesTab).GetMethod(
+            "RemoveDatabase",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        return component.InvokeAsync(() => (Task)method!.Invoke(component.Instance, [entry])!);
     }
 
     private static BannerProgressEntry MakeProgress(

--- a/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/Tabs/ManageDatabasesTabTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/Tabs/ManageDatabasesTabTests.cs
@@ -227,6 +227,32 @@ public sealed class ManageDatabasesTabTests : BunitContext
     }
 
     [Fact]
+    public async Task BulkRemove_PartialFailure_KeepsFailedSelected_StaysInSelectionMode()
+    {
+        _databaseService.Entries = [
+            Entry("a.db", isEnabled: false, status: DatabaseStatus.Ready),
+            Entry("b.db", isEnabled: false, status: DatabaseStatus.Ready)];
+        _coordinator.RemoveDatabaseAsync("a.db", Arg.Any<Func<bool, CancellationToken, Task<bool>>>(), Arg.Any<CancellationToken>())
+            .Returns<RemoveOutcome>(_ => throw new InvalidOperationException("disk full"));
+        _coordinator.RemoveDatabaseAsync("b.db", Arg.Any<Func<bool, CancellationToken, Task<bool>>>(), Arg.Any<CancellationToken>())
+            .Returns(new RemoveOutcome(RemoveOutcomeStatus.Confirmed, true, false));
+        var alertSurface = new FakeInlineAlertSurface { Result = new InlineAlertResult(true, null) };
+        var component = RenderWithAlertSurface(alertSurface);
+
+        await EnterSelectionModeAsync(component);
+        var checkboxes = component.FindAll(".db-entry-row input[type='checkbox']");
+        await component.InvokeAsync(() => checkboxes[0].ChangeAsync(new ChangeEventArgs { Value = true }));
+        await component.InvokeAsync(() => checkboxes[1].ChangeAsync(new ChangeEventArgs { Value = true }));
+
+        var bulkRemove = component.Find(".manage-databases-bulk-strip .button-red");
+        await component.InvokeAsync(() => bulkRemove.Click());
+
+        Assert.True(component.Instance.IsInSelectionMode);
+        Assert.True(component.Instance.HasBulkSelection);
+        Assert.Equal("true", component.Find("#manage-select-button").GetAttribute("aria-pressed"));
+    }
+
+    [Fact]
     public async Task BulkRemove_PerFileFailure_AnnouncesFirstFailureDetail()
     {
         _databaseService.Entries = [
@@ -706,17 +732,6 @@ public sealed class ManageDatabasesTabTests : BunitContext
     }
 
     [Fact]
-    public async Task ExitSelectionModeWithFocusAsync_WhenNotInSelectionMode_IsNoOp()
-    {
-        _databaseService.Entries = [Entry("a.db", isEnabled: false, status: DatabaseStatus.Ready)];
-        var component = Render<ManageDatabasesTab>();
-
-        await component.InvokeAsync(() => component.Instance.ExitSelectionModeWithFocusAsync());
-
-        Assert.Equal("false", component.Find("#manage-select-button").GetAttribute("aria-pressed"));
-    }
-
-    [Fact]
     public async Task ExitSelectionModeWithFocusAsync_WhenInSelectionMode_ExitsAndClearsSelection()
     {
         _databaseService.Entries = [Entry("a.db", isEnabled: false, status: DatabaseStatus.Ready)];
@@ -730,6 +745,17 @@ public sealed class ManageDatabasesTabTests : BunitContext
         await component.InvokeAsync(() => component.Instance.ExitSelectionModeWithFocusAsync());
 
         Assert.False(component.Instance.HasBulkSelection);
+        Assert.Equal("false", component.Find("#manage-select-button").GetAttribute("aria-pressed"));
+    }
+
+    [Fact]
+    public async Task ExitSelectionModeWithFocusAsync_WhenNotInSelectionMode_IsNoOp()
+    {
+        _databaseService.Entries = [Entry("a.db", isEnabled: false, status: DatabaseStatus.Ready)];
+        var component = Render<ManageDatabasesTab>();
+
+        await component.InvokeAsync(() => component.Instance.ExitSelectionModeWithFocusAsync());
+
         Assert.Equal("false", component.Find("#manage-select-button").GetAttribute("aria-pressed"));
     }
 

--- a/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/Tabs/ManageDatabasesTabTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/Tabs/ManageDatabasesTabTests.cs
@@ -706,29 +706,28 @@ public sealed class ManageDatabasesTabTests : BunitContext
     }
 
     [Fact]
-    public async Task Escape_InNormalMode_NoOp()
+    public async Task ExitSelectionModeWithFocusAsync_WhenNotInSelectionMode_IsNoOp()
     {
         _databaseService.Entries = [Entry("a.db", isEnabled: false, status: DatabaseStatus.Ready)];
         var component = Render<ManageDatabasesTab>();
 
-        await component.InvokeAsync(() => component.Find(".manage-databases-tab")
-            .KeyDown(new KeyboardEventArgs { Key = "Escape" }));
+        await component.InvokeAsync(() => component.Instance.ExitSelectionModeWithFocusAsync());
 
         Assert.Equal("false", component.Find("#manage-select-button").GetAttribute("aria-pressed"));
     }
 
     [Fact]
-    public async Task Escape_InSelectionMode_ExitsAndClearsSelection()
+    public async Task ExitSelectionModeWithFocusAsync_WhenInSelectionMode_ExitsAndClearsSelection()
     {
         _databaseService.Entries = [Entry("a.db", isEnabled: false, status: DatabaseStatus.Ready)];
         var component = Render<ManageDatabasesTab>();
+
         await EnterSelectionModeAsync(component);
         await component.InvokeAsync(() => component.Find(".db-entry-row input[type='checkbox']")
             .ChangeAsync(new ChangeEventArgs { Value = true }));
         Assert.True(component.Instance.HasBulkSelection);
 
-        await component.InvokeAsync(() => component.Find(".manage-databases-tab")
-            .KeyDown(new KeyboardEventArgs { Key = "Escape" }));
+        await component.InvokeAsync(() => component.Instance.ExitSelectionModeWithFocusAsync());
 
         Assert.False(component.Instance.HasBulkSelection);
         Assert.Equal("false", component.Find("#manage-select-button").GetAttribute("aria-pressed"));

--- a/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/Tabs/MergeDatabaseTabTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/Tabs/MergeDatabaseTabTests.cs
@@ -1,0 +1,37 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using EventLogExpert.UI.DatabaseTools.Tabs;
+using EventLogExpert.UI.Tests.TestUtils;
+
+namespace EventLogExpert.UI.Tests.DatabaseTools.Tabs;
+
+public sealed class MergeDatabaseTabTests : BunitContext
+{
+    public MergeDatabaseTabTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddDatabaseToolsTabDependencies();
+        Services.AddMenuMocks();
+    }
+
+    [Fact]
+    public void Renders_HappyPath_WithExpectedFormFields()
+    {
+        var component = Render<MergeDatabaseTab>();
+
+        Assert.NotNull(component.Find("#merge-source-path"));
+        Assert.NotNull(component.Find("#merge-target-path"));
+        Assert.NotEmpty(component.FindAll(".overwrite-mode-select"));
+    }
+
+    [Fact]
+    public void RunButton_DisabledInitially_WhenSourceAndTargetEmpty()
+    {
+        var component = Render<MergeDatabaseTab>();
+
+        var runButton = component.Find(".button-green");
+        Assert.True(runButton.HasAttribute("disabled"));
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/Tabs/ShowProvidersTabTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/Tabs/ShowProvidersTabTests.cs
@@ -1,0 +1,48 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using EventLogExpert.UI.DatabaseTools.Tabs;
+using EventLogExpert.UI.Tests.TestUtils;
+
+namespace EventLogExpert.UI.Tests.DatabaseTools.Tabs;
+
+public sealed class ShowProvidersTabTests : BunitContext
+{
+    public ShowProvidersTabTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddDatabaseToolsTabDependencies();
+        Services.AddMenuMocks();
+    }
+
+    [Fact]
+    public void Renders_FilterErrorState_WhenInvalidRegexEntered()
+    {
+        var component = Render<ShowProvidersTab>();
+
+        var filter = component.Find("#show-filter");
+        filter.Input("[unterminated");
+
+        Assert.NotEmpty(component.FindAll(".filter-error"));
+    }
+
+    [Fact]
+    public void Renders_HappyPath_WithExpectedFormFields()
+    {
+        var component = Render<ShowProvidersTab>();
+
+        Assert.NotNull(component.Find("#show-source-path"));
+        Assert.NotNull(component.Find("#show-filter"));
+        Assert.NotNull(component.Find(".db-tab-form"));
+    }
+
+    [Fact]
+    public void Renders_RunButton_PresentInitially_AndNotInCancellingState()
+    {
+        var component = Render<ShowProvidersTab>();
+
+        Assert.NotNull(component.Find(".button-green"));
+        Assert.Empty(component.FindAll(".button-red"));
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/Tabs/UpgradeDatabaseTabTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/Tabs/UpgradeDatabaseTabTests.cs
@@ -1,0 +1,35 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using EventLogExpert.UI.DatabaseTools.Tabs;
+using EventLogExpert.UI.Tests.TestUtils;
+
+namespace EventLogExpert.UI.Tests.DatabaseTools.Tabs;
+
+public sealed class UpgradeDatabaseTabTests : BunitContext
+{
+    public UpgradeDatabaseTabTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddDatabaseToolsTabDependencies();
+        Services.AddMenuMocks();
+    }
+
+    [Fact]
+    public void Renders_HappyPath_WithExpectedFormFields()
+    {
+        var component = Render<UpgradeDatabaseTab>();
+
+        Assert.NotNull(component.Find("#upgrade-db-path"));
+    }
+
+    [Fact]
+    public void RunButton_DisabledInitially_WhenDbPathEmpty()
+    {
+        var component = Render<UpgradeDatabaseTab>();
+
+        var runButton = component.Find(".button-green");
+        Assert.True(runButton.HasAttribute("disabled"));
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/DebugLog/DebugLogModalTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/DebugLog/DebugLogModalTests.cs
@@ -35,6 +35,7 @@ public sealed class DebugLogModalTests : BunitContext
     public DebugLogModalTests()
     {
         Services.AddBannerHostDependencies();
+        Services.AddMenuMocks();
 
         _modalService.ActiveModalId.Returns(new ModalId(1L));
 

--- a/tests/Unit/EventLogExpert.UI.Tests/Menu/MenuHostHandoffTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Menu/MenuHostHandoffTests.cs
@@ -1,0 +1,156 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using EventLogExpert.Runtime.Menu;
+using EventLogExpert.UI.Menu;
+using EventLogExpert.UI.Modal;
+using EventLogExpert.UI.Tests.TestUtils;
+using Microsoft.Extensions.DependencyInjection;
+using TestContext = Xunit.TestContext;
+
+namespace EventLogExpert.UI.Tests.Menu;
+
+public sealed class MenuHostHandoffTests : BunitContext
+{
+    private readonly FakeMenuService _menuService = new();
+
+    public MenuHostHandoffTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        Services.AddBannerHostDependencies();
+        Services.AddSingleton<IMenuService>(_menuService);
+        Services.AddEventLogUiServices();
+    }
+
+    [Fact]
+    public async Task SecondHostRegistersWhileMenuOpen_ClosingMenu_DetachesViewportListenersExactlyOnce()
+    {
+        var registry = Services.GetRequiredService<IMenuHostRegistry>();
+
+        var firstModal = Render<ModalChrome>(parameters => parameters
+            .Add(p => p.Title, "first")
+            .AddChildContent("<p>1</p>"));
+        var hostA = registry.ActiveHost;
+        Assert.NotNull(hostA);
+
+        await firstModal.InvokeAsync(() => _menuService.Open(MakeItems()));
+        await WaitForJsInvocationAsync("attachMenuViewportListeners");
+        Assert.Equal(1, JSInterop.Invocations.Count(i => i.Identifier == "attachMenuViewportListeners"));
+
+        var secondModal = Render<ModalChrome>(parameters => parameters
+            .Add(p => p.Title, "second")
+            .AddChildContent("<p>2</p>"));
+        var hostB = registry.ActiveHost;
+        Assert.NotSame(hostA, hostB);
+
+        await secondModal.InvokeAsync(() => _menuService.Close());
+        await WaitForJsInvocationAsync("detachMenuViewportListeners");
+
+        Assert.Equal(1, JSInterop.Invocations.Count(i => i.Identifier == "detachMenuViewportListeners"));
+    }
+
+    [Fact]
+    public async Task SecondHostRegistersWhileMenuOpen_DisposingFirstAfterClose_DoesNotDoubleDetach()
+    {
+        var registry = Services.GetRequiredService<IMenuHostRegistry>();
+
+        var firstModal = Render<ModalChrome>(parameters => parameters
+            .Add(p => p.Title, "first")
+            .AddChildContent("<p>1</p>"));
+        var hostA = registry.ActiveHost;
+        Assert.NotNull(hostA);
+
+        await firstModal.InvokeAsync(() => _menuService.Open(MakeItems()));
+        await WaitForJsInvocationAsync("attachMenuViewportListeners");
+
+        var secondModal = Render<ModalChrome>(parameters => parameters
+            .Add(p => p.Title, "second")
+            .AddChildContent("<p>2</p>"));
+        var hostB = registry.ActiveHost;
+        Assert.NotSame(hostA, hostB);
+
+        await secondModal.InvokeAsync(() => _menuService.Close());
+        await WaitForJsInvocationAsync("detachMenuViewportListeners");
+
+        var detachAfterClose = JSInterop.Invocations.Count(i => i.Identifier == "detachMenuViewportListeners");
+
+        await hostA!.DisposeAsync();
+
+        var detachAfterDispose = JSInterop.Invocations.Count(i => i.Identifier == "detachMenuViewportListeners");
+        Assert.Equal(detachAfterClose, detachAfterDispose);
+    }
+
+    private static IReadOnlyList<MenuItem> MakeItems() =>
+        new List<MenuItem> { MenuItem.Item("Sample", () => Task.CompletedTask) };
+
+    private async Task WaitForJsInvocationAsync(string identifier)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (JSInterop.Invocations.Any(i => i.Identifier == identifier)) { return; }
+            await Task.Delay(25, TestContext.Current.CancellationToken);
+        }
+        Assert.Fail($"Expected '{identifier}' JS interop call did not occur within timeout. Observed: [{string.Join(",", JSInterop.Invocations.Select(i => i.Identifier))}]");
+    }
+
+    private sealed class FakeMenuService : IMenuService
+    {
+        private long _nextId;
+
+        public event Action<int>? NavigateBarRequested;
+
+        public event Action? StateChanged;
+
+        public bool ActiveCaptureOpener { get; private set; } = true;
+
+        public bool ActiveFocusFirst { get; private set; } = true;
+
+        public IReadOnlyList<MenuItem>? ActiveItems { get; private set; }
+
+        public long ActiveMenuId { get; private set; }
+
+        public double PositionX { get; private set; }
+
+        public double PositionY { get; private set; }
+
+        public void Close()
+        {
+            if (ActiveItems is null) { return; }
+
+            ActiveItems = null;
+            ActiveMenuId = 0;
+            PositionX = 0;
+            PositionY = 0;
+            ActiveCaptureOpener = true;
+            ActiveFocusFirst = true;
+            StateChanged?.Invoke();
+        }
+
+        public void NavigateBar(int direction) => NavigateBarRequested?.Invoke(direction);
+
+        public void Open(IReadOnlyList<MenuItem> items, double x = 10, double y = 10) =>
+            OpenAt(x, y, items);
+
+        public void OpenAt(
+            double x,
+            double y,
+            IReadOnlyList<MenuItem> items,
+            bool focusFirst = true,
+            bool captureOpener = true)
+        {
+            ArgumentNullException.ThrowIfNull(items);
+
+            _nextId++;
+            ActiveMenuId = _nextId;
+            ActiveItems = items;
+            PositionX = x;
+            PositionY = y;
+            ActiveFocusFirst = focusFirst;
+            ActiveCaptureOpener = captureOpener;
+            StateChanged?.Invoke();
+        }
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/Menu/MenuHostRegistryTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Menu/MenuHostRegistryTests.cs
@@ -1,0 +1,120 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.UI.Menu;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EventLogExpert.UI.Tests.Menu;
+
+public sealed class MenuHostRegistryTests
+{
+    [Fact]
+    public void ActiveHost_OnEmpty_IsNull()
+    {
+        var registry = new MenuHostRegistry();
+
+        Assert.Null(registry.ActiveHost);
+    }
+
+    [Fact]
+    public void ActiveHostChanged_FiresOnEachRegisterAndUnregister()
+    {
+        var registry = new MenuHostRegistry();
+        var host = new MenuHost();
+
+        int eventCount = 0;
+        registry.ActiveHostChanged += () => eventCount++;
+
+        registry.Register(host);
+        Assert.Equal(1, eventCount);
+
+        registry.Unregister(host);
+        Assert.Equal(2, eventCount);
+    }
+
+    [Fact]
+    public void AddEventLogUiServices_RegistersIMenuHostRegistry()
+    {
+        var services = new ServiceCollection();
+        services.AddEventLogUiServices();
+
+        using var provider = services.BuildServiceProvider();
+        var registry = provider.GetRequiredService<IMenuHostRegistry>();
+
+        Assert.IsType<MenuHostRegistry>(registry);
+    }
+
+    [Fact]
+    public void Register_FirstHost_BecomesActive()
+    {
+        var registry = new MenuHostRegistry();
+        var host = new MenuHost();
+
+        registry.Register(host);
+
+        Assert.Same(host, registry.ActiveHost);
+    }
+
+    [Fact]
+    public void Register_SecondHost_BecomesActive_StackPattern()
+    {
+        var registry = new MenuHostRegistry();
+        var host1 = new MenuHost();
+        var host2 = new MenuHost();
+
+        registry.Register(host1);
+        registry.Register(host2);
+
+        Assert.Same(host2, registry.ActiveHost);
+    }
+
+    [Fact]
+    public void Unregister_HostNotInStack_NoOp_NoEvent()
+    {
+        var registry = new MenuHostRegistry();
+        var host1 = new MenuHost();
+        var host2 = new MenuHost();
+        registry.Register(host1);
+
+        int eventCount = 0;
+        registry.ActiveHostChanged += () => eventCount++;
+
+        registry.Unregister(host2);
+
+        Assert.Equal(0, eventCount);
+        Assert.Same(host1, registry.ActiveHost);
+    }
+
+    [Fact]
+    public void Unregister_NonTopmostHost_RemovesFromMiddle_KeepsTopmost()
+    {
+        var registry = new MenuHostRegistry();
+        var host1 = new MenuHost();
+        var host2 = new MenuHost();
+        var host3 = new MenuHost();
+        registry.Register(host1);
+        registry.Register(host2);
+        registry.Register(host3);
+
+        registry.Unregister(host2);
+
+        Assert.Same(host3, registry.ActiveHost);
+
+        registry.Unregister(host3);
+        Assert.Same(host1, registry.ActiveHost);
+    }
+
+    [Fact]
+    public void Unregister_TopmostHost_RestoresPrevious()
+    {
+        var registry = new MenuHostRegistry();
+        var host1 = new MenuHost();
+        var host2 = new MenuHost();
+        registry.Register(host1);
+        registry.Register(host2);
+
+        registry.Unregister(host2);
+
+        Assert.Same(host1, registry.ActiveHost);
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/Modal/ModalChromeTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Modal/ModalChromeTests.cs
@@ -15,6 +15,7 @@ public sealed class ModalChromeTests : BunitContext
     public ModalChromeTests()
     {
         Services.AddBannerHostDependencies();
+        Services.AddMenuMocks();
 
         JSInterop.Mode = JSRuntimeMode.Loose;
     }

--- a/tests/Unit/EventLogExpert.UI.Tests/Settings/SettingsModalTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Settings/SettingsModalTests.cs
@@ -25,6 +25,7 @@ public sealed class SettingsModalTests : BunitContext
     public SettingsModalTests()
     {
         Services.AddBannerHostDependencies();
+        Services.AddMenuMocks();
 
         _modalService.ActiveModalId.Returns(new ModalId(1L));
 

--- a/tests/Unit/EventLogExpert.UI.Tests/TestUtils/BannerHostDependenciesExtensions.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/TestUtils/BannerHostDependenciesExtensions.cs
@@ -11,33 +11,36 @@ namespace EventLogExpert.UI.Tests.TestUtils;
 
 internal static class BannerHostDependenciesExtensions
 {
-    public static void AddBannerHostDependencies(this IServiceCollection services)
+    extension(IServiceCollection services)
     {
-        var attention = Substitute.For<IAttentionBannerService>();
-        attention.AttentionEntries.Returns([]);
-        attention.AttentionDismissed.Returns(false);
-        services.AddSingleton(attention);
+        public void AddBannerHostDependencies()
+        {
+            var attention = Substitute.For<IAttentionBannerService>();
+            attention.AttentionEntries.Returns([]);
+            attention.AttentionDismissed.Returns(false);
+            services.AddSingleton(attention);
 
-        var critical = Substitute.For<ICriticalErrorService>();
-        critical.CurrentCritical.Returns((Exception?)null);
-        services.AddSingleton(critical);
+            var critical = Substitute.For<ICriticalErrorService>();
+            critical.CurrentCritical.Returns((Exception?)null);
+            services.AddSingleton(critical);
 
-        var errors = Substitute.For<IErrorBannerService>();
-        errors.ErrorBanners.Returns([]);
-        services.AddSingleton(errors);
+            var errors = Substitute.For<IErrorBannerService>();
+            errors.ErrorBanners.Returns([]);
+            services.AddSingleton(errors);
 
-        var infos = Substitute.For<IInfoBannerService>();
-        infos.InfoBanners.Returns([]);
-        services.AddSingleton(infos);
+            var infos = Substitute.For<IInfoBannerService>();
+            infos.InfoBanners.Returns([]);
+            services.AddSingleton(infos);
 
-        var progress = Substitute.For<IProgressBannerService>();
-        progress.BackgroundProgress.Returns((BannerProgressEntry?)null);
-        services.AddSingleton(progress);
+            var progress = Substitute.For<IProgressBannerService>();
+            progress.BackgroundProgress.Returns((BannerProgressEntry?)null);
+            services.AddSingleton(progress);
 
-        var modalCoordinator = Substitute.For<IModalCoordinator>();
-        modalCoordinator.ActiveSession.Returns((ModalSession?)null);
-        services.AddSingleton(modalCoordinator);
+            var modalCoordinator = Substitute.For<IModalCoordinator>();
+            modalCoordinator.ActiveSession.Returns((ModalSession?)null);
+            services.AddSingleton(modalCoordinator);
 
-        services.AddSingleton<IBannerCycleStateService, BannerCycleStateService>();
+            services.AddSingleton<IBannerCycleStateService, BannerCycleStateService>();
+        }
     }
 }

--- a/tests/Unit/EventLogExpert.UI.Tests/TestUtils/DatabaseToolsTestDependencies.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/TestUtils/DatabaseToolsTestDependencies.cs
@@ -1,0 +1,42 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.Alerts;
+using EventLogExpert.Runtime.Common.Clipboard;
+using EventLogExpert.Runtime.Common.Elevation;
+using EventLogExpert.Runtime.Common.Files;
+using EventLogExpert.Runtime.Common.Versioning;
+using EventLogExpert.Runtime.DatabaseTools;
+using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.Menu;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace EventLogExpert.UI.Tests.TestUtils;
+
+internal static class DatabaseToolsTestDependencies
+{
+    extension(IServiceCollection services)
+    {
+        public IServiceCollection AddDatabaseToolsModalDependencies()
+        {
+            services.AddSingleton(Substitute.For<ILogReloadCoordinator>());
+
+            return services;
+        }
+
+        public IServiceCollection AddDatabaseToolsTabDependencies()
+        {
+            services.AddSingleton(Substitute.For<IDatabaseToolsService>());
+            services.AddSingleton(Substitute.For<IFilePickerService>());
+            services.AddSingleton(Substitute.For<IFileSaveService>());
+            services.AddSingleton(Substitute.For<IClipboardService>());
+            services.AddSingleton(Substitute.For<IAlertDialogService>());
+            services.AddSingleton(Substitute.For<IElevationService>());
+            services.AddSingleton(Substitute.For<ICurrentVersionProvider>());
+            services.AddSingleton(Substitute.For<IMenuActionService>());
+
+            return services;
+        }
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/TestUtils/MenuHostDependenciesExtensions.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/TestUtils/MenuHostDependenciesExtensions.cs
@@ -1,0 +1,34 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.Menu;
+using EventLogExpert.UI.Menu;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace EventLogExpert.UI.Tests.TestUtils;
+
+internal static class MenuHostDependenciesExtensions
+{
+    extension(IServiceCollection services)
+    {
+        public IServiceCollection AddMenuHostRegistryMock()
+        {
+            services.AddSingleton(Substitute.For<IMenuHostRegistry>());
+            return services;
+        }
+
+        public IServiceCollection AddMenuMocks()
+        {
+            services.AddMenuServiceMock();
+            services.AddMenuHostRegistryMock();
+            return services;
+        }
+
+        public IServiceCollection AddMenuServiceMock()
+        {
+            services.AddSingleton(Substitute.For<IMenuService>());
+            return services;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Manage Databases tab gets an explicit selection mode (Select button on the import row toggles per-row checkboxes via a slide-in animation), bulk operations (Upgrade N when any selected row is eligible; Delete N) with a subset-confirm prompt for mixed selections, and a tri-state master checkbox in the column header. Right-click on a row in normal mode opens an in-modal context menu with Remove. Auto-exits selection mode on clean upgrade success and on any successful delete; partial-failure / gate-denied paths keep the selection so the user can retry.

Net behavior gains: bulk multi-upgrade through a single batch, no per-row trash icon clutter, context-menu actions render inside the modal's top-layer dialog (this previously didn't work — global `MenuHost` was occluded by the modal).

## What changed

| Area | Change |
|---|---|
| Selection mode | Select button on the import row (left side); per-row checkbox is always rendered but `Disabled` + collapsed via CSS `max-width:0` when not in selection mode; slides in with width transition; `aria-hidden` on the wrapper |
| Master select-all | Tri-state button in column header (`role="checkbox"` + `aria-checked="false\|true\|mixed"`, Bootstrap-icon swap for visual); replaces the prior Select all / Clear inside the bottom bulk strip |
| Bulk strip | Shows count + Upgrade N (only when ≥1 eligible row selected) + Delete N |
| Multi-upgrade | New `IDatabaseOperationCoordinator.UpgradeDatabasesAsync(IReadOnlyList<string>, scope, ct)` returning `Task<UpgradeBatchResult?>`; `null` distinguishes gate-denied (another upgrade in flight) from all-cancelled (per-file cancel of a batch that ran) |
| Subset-confirm | Mixed selection (some rows eligible, some not) shows an inline alert enumerating skipped files with reasons before the batch starts |
| Right-click menu | `DatabaseEntryRow` gets `@oncontextmenu` → `IMenuService.OpenAt` with a Remove item; suppressed in selection mode |
| Trash icon | Removed from per-row UI entirely |
| Row compaction | `.db-entry-row` padding `.15rem .5rem` (outer), `0` (inner) |
| Menu-in-modal infrastructure | New `IMenuHostRegistry` (singleton, stack-based topmost-wins); `MenuHost` lifecycle rewrite (unsubscribe events before `MenuService.Close()`, `IsActive` + `_disposed` gating on render and JS interop, per-host viewport-listener ownership tracking); `<MenuHost />` added inside `ModalChrome` so every modal that uses the shared chrome gets in-modal menu support |
| Keyboard a11y | Esc exits selection mode + restores focus to Select button |

## Tests

2,584 → 2,585 unit tests, all passing. 44 new tests added covering: `MenuHostRegistry` (8), `DatabaseToolsModal` lifecycle + menu registration (3), 5 per-tab smoke files (`CreateDatabaseTabTests`, `DiffDatabasesTabTests`, `MergeDatabaseTabTests`, `ShowProvidersTabTests`, `UpgradeDatabaseTabTests`), `Coordinator.UpgradeDatabasesAsync` (7: empty input, happy path, gate-denied=null, per-file tracking, partial-failure error banners, service-throws fallback, pre-cancelled token), bulk-flow tests (selection mode entry/exit, master tri-state icon/aria-checked, multi-upgrade all-eligible / mixed / zero-eligible / gate-denied, auto-exit on clean upgrade, stays on partial failure, auto-exit on delete, Esc keyboard, EntriesChanged mid-selection, empty-list-auto-exit, right-click context menu invocation, button-appears-only-when-eligible).

Existing modal test classes (`ModalChromeTests`, `SettingsModalTests`, `DebugLogModalTests`, `DatabaseRecoveryDialogTests`) migrated to register `IMenuService` + `IMenuHostRegistry` mocks because the shared `ModalChrome` now contains `<MenuHost />`.

Build: 0 warnings, 0 errors.

## Closes

Closes #545 — DatabaseToolsModal + tabs bUnit tests.