### PR TITLE
Add legacy FilterCache and FilterGroup preferences migration adapter with feature flag to skip after first successful run

### DIFF
--- a/src/EventLogExpert.Runtime/FilterLibrary/Effects.cs
+++ b/src/EventLogExpert.Runtime/FilterLibrary/Effects.cs
@@ -13,9 +13,12 @@ internal sealed class Effects(
     IFilterLibraryStore store,
     IState<FilterLibraryState> state,
     IState<FilterPaneState> filterPaneState,
+    ILegacyFilterMigrator legacyMigrator,
     ITraceLogger logger)
 {
     private const int MaxAutoTrackedRecents = 50;
+
+    private readonly SemaphoreSlim _migrationGate = new(initialCount: 1, maxCount: 1);
 
     [EffectMethod]
     public Task HandleAddFilterToExistingPreset(AddFilterToExistingPresetAction action, IDispatcher dispatcher)
@@ -131,17 +134,54 @@ internal sealed class Effects(
     }
 
     [EffectMethod(typeof(LoadLibraryAction))]
-    public Task HandleLoadLibrary(IDispatcher dispatcher)
+    public async Task HandleLoadLibrary(IDispatcher dispatcher)
     {
-        // LoadLibraryStartedAction is queued (not run inline) per Fluxor 6.9 re-entrancy semantics —
-        // it flips IsLoading=true between Started and Success reducer commits for UI subscribers, but
-        // it does NOT prevent concurrent loads from inside this effect. The modal's
-        // `!IsLoaded || LoadError` check is the effective re-open guard.
         dispatcher.Dispatch(new LoadLibraryStartedAction());
+
+        await _migrationGate.WaitAsync().ConfigureAwait(false);
 
         try
         {
             var entries = store.LoadAll().ToImmutableList();
+
+            if (entries.IsEmpty && legacyMigrator.ShouldRunMigration())
+            {
+                // AddRange-throws → Success(empty) + return without marking complete (retries next launch).
+                // Post-AddRange LoadAll-throws → in-memory fallback + MarkMigrationCompleted as on happy path.
+                var migrationResult = legacyMigrator.BuildEntriesFromLegacy();
+
+                if (migrationResult.Entries.Count > 0)
+                {
+                    try
+                    {
+                        store.AddRange(migrationResult.Entries);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.Warning($"FilterLibrary migration AddRange failed; legacy preserved. {ex.Message}");
+                        dispatcher.Dispatch(new LoadLibrarySuccessAction(ImmutableList<LibraryEntry>.Empty));
+
+                        return;
+                    }
+
+                    try
+                    {
+                        entries = store.LoadAll().ToImmutableList();
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.Warning($"FilterLibrary post-migration reload failed; using in-memory result. {ex.Message}");
+                        entries = migrationResult.Entries;
+                    }
+
+                    logger.Information($"Migrated {entries.Count} legacy entries to filter library.");
+                }
+
+                // Not wrapped: a SetString failure surfaces via the outer catch (LoadLibraryFailure). Next launch
+                // self-heals because the store is already non-empty (or the same retry decision repeats).
+                legacyMigrator.MarkMigrationCompleted(migrationResult.SuccessfulSections);
+            }
+
             dispatcher.Dispatch(new LoadLibrarySuccessAction(entries));
         }
         catch (Exception ex)
@@ -149,8 +189,10 @@ internal sealed class Effects(
             logger.Warning($"FilterLibrary load failed; rendering error state. {ex.Message}");
             dispatcher.Dispatch(new LoadLibraryFailureAction());
         }
-
-        return Task.CompletedTask;
+        finally
+        {
+            _migrationGate.Release();
+        }
     }
 
     [EffectMethod]

--- a/src/EventLogExpert.Runtime/FilterLibrary/FilterLibraryServiceCollectionExtensions.cs
+++ b/src/EventLogExpert.Runtime/FilterLibrary/FilterLibraryServiceCollectionExtensions.cs
@@ -8,19 +8,32 @@ namespace EventLogExpert.Runtime.FilterLibrary;
 
 public static class FilterLibraryServiceCollectionExtensions
 {
-    /// <summary>
-    ///     Registers the SQLite-backed <see cref="IFilterLibraryStore" /> implementation at <paramref name="dbPath" />.
-    ///     The concrete <c>FilterLibrarySqliteStore</c> type stays internal to the runtime assembly; consumers depend on
-    ///     <see cref="IFilterLibraryStore" /> only.
-    /// </summary>
-    public static IServiceCollection AddFilterLibrarySqliteStore(this IServiceCollection services, string dbPath)
+    extension(IServiceCollection services)
     {
-        ArgumentNullException.ThrowIfNull(services);
-        ArgumentNullException.ThrowIfNull(dbPath);
+        /// <summary>
+        ///     Registers the SQLite-backed <see cref="IFilterLibraryStore" /> implementation at <paramref name="dbPath" />.
+        ///     The concrete <c>FilterLibrarySqliteStore</c> type stays internal to the runtime assembly; consumers depend on
+        ///     <see cref="IFilterLibraryStore" /> only.
+        /// </summary>
+        public IServiceCollection AddFilterLibrarySqliteStore(string dbPath)
+        {
+            ArgumentNullException.ThrowIfNull(services);
+            ArgumentNullException.ThrowIfNull(dbPath);
 
-        services.AddSingleton<IFilterLibraryStore>(sp =>
-            new FilterLibrarySqliteStore(dbPath, sp.GetRequiredService<ITraceLogger>()));
+            services.AddSingleton<IFilterLibraryStore>(sp =>
+                new FilterLibrarySqliteStore(dbPath, sp.GetRequiredService<ITraceLogger>()));
 
-        return services;
+            return services;
+        }
+
+        /// <summary>Registers the legacy-filter migration singleton. Callers MUST also register <see cref="ILegacyPreferences" />.</summary>
+        public IServiceCollection AddLegacyFilterMigration()
+        {
+            ArgumentNullException.ThrowIfNull(services);
+
+            services.AddSingleton<ILegacyFilterMigrator, LegacyFilterMigrator>();
+
+            return services;
+        }
     }
 }

--- a/src/EventLogExpert.Runtime/FilterLibrary/ILegacyFilterMigrator.cs
+++ b/src/EventLogExpert.Runtime/FilterLibrary/ILegacyFilterMigrator.cs
@@ -1,0 +1,43 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Collections.Immutable;
+
+namespace EventLogExpert.Runtime.FilterLibrary;
+
+public interface ILegacyFilterMigrator
+{
+    /// <summary>
+    ///     Builds library entries from legacy preference keys. Each section (favorites, groups) is built independently;
+    ///     per-item exceptions discard the whole section and leave its flag UNSET. ABSENT keys are treated as
+    ///     parsed-successfully and DO set the section flag. Recents flag is always set.
+    /// </summary>
+    LegacyMigrationResult BuildEntriesFromLegacy();
+
+    /// <summary>
+    ///     Removes legacy preference keys corresponding to <paramref name="sectionsToDelete" />. NOT called by the
+    ///     migration adapter itself; reserved for a future cleanup pass after migration is confirmed stable.
+    /// </summary>
+    void DeleteLegacyData(LegacyMigrationSections sectionsToDelete);
+
+    /// <summary>Persists <paramref name="successfulSections" /> as the migration completion bitmask.</summary>
+    void MarkMigrationCompleted(LegacyMigrationSections successfulSections);
+
+    /// <summary>Returns <c>true</c> unless the persisted bitmask has both Favorites and Groups flags set.</summary>
+    bool ShouldRunMigration();
+}
+
+public sealed record LegacyMigrationResult(
+    ImmutableList<LibraryEntry> Entries,
+    LegacyMigrationSections SuccessfulSections);
+
+[Flags]
+public enum LegacyMigrationSections
+{
+    None = 0,
+    Favorites = 1,
+    Groups = 2,
+
+    /// <summary>Always set (recents are dropped, not migrated). Used by future cleanup paths to drive recents-key deletion.</summary>
+    Recents = 4,
+}

--- a/src/EventLogExpert.Runtime/FilterLibrary/ILegacyPreferences.cs
+++ b/src/EventLogExpert.Runtime/FilterLibrary/ILegacyPreferences.cs
@@ -1,0 +1,16 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.FilterLibrary;
+
+public interface ILegacyPreferences
+{
+    bool ContainsKey(string key);
+
+    string? GetString(string key);
+
+    /// <summary>Removes <paramref name="key" /> from the persistent store; no-op when the key is absent.</summary>
+    void Remove(string key);
+
+    void SetString(string key, string value);
+}

--- a/src/EventLogExpert.Runtime/FilterLibrary/LegacyFilterMigrator.cs
+++ b/src/EventLogExpert.Runtime/FilterLibrary/LegacyFilterMigrator.cs
@@ -1,0 +1,188 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Evaluation;
+using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Logging.Abstractions;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Text.Json;
+
+namespace EventLogExpert.Runtime.FilterLibrary;
+
+internal sealed class LegacyFilterMigrator(ILegacyPreferences preferences, ITraceLogger logger) : ILegacyFilterMigrator
+{
+    private const int DisplayNameMaxLength = 80;
+    private const string FavoriteFiltersKey = "favorite-filters";
+    private const string MigrationSectionsKey = "filter-library-migration-sections";
+    private const string RecentFiltersKey = "recent-filters";
+    private const LegacyMigrationSections RequiredForCompletion =
+        LegacyMigrationSections.Favorites | LegacyMigrationSections.Groups;
+    private const string SavedGroupsKey = "saved-filters";
+
+    public LegacyMigrationResult BuildEntriesFromLegacy()
+    {
+        var builder = ImmutableList.CreateBuilder<LibraryEntry>();
+        var now = DateTimeOffset.UtcNow;
+        var successful = LegacyMigrationSections.Recents;
+
+        if (TryReadFavorites(out var favorites))
+        {
+            var localFavoriteEntries = new List<LibraryEntry>();
+            bool favoritesSucceeded = true;
+
+            try
+            {
+                foreach (var favText in favorites.Where(static s => !string.IsNullOrWhiteSpace(s)))
+                {
+                    var filter = SavedFilter.LoadFromPersisted(
+                        favText,
+                        HighlightColor.None,
+                        isExcluded: false,
+                        persistedBasicFilter: null,
+                        mode: FilterMode.Advanced);
+
+                    localFavoriteEntries.Add(new LibraryEntrySavedFilter
+                    {
+                        Id = LibraryEntryId.Create(),
+                        Name = TruncateForDisplay(favText),
+                        CreatedUtc = now,
+                        Filter = filter with { IsEnabled = false },
+                        IsFavorite = true,
+                        LastUsedUtc = null,
+                        Origin = LibraryEntryOrigin.UserSaved,
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.Warning($"Failed to migrate favorite filters (partial section discarded): {ex.Message}");
+                favoritesSucceeded = false;
+            }
+
+            if (favoritesSucceeded)
+            {
+                builder.AddRange(localFavoriteEntries);
+                successful |= LegacyMigrationSections.Favorites;
+            }
+        }
+
+        if (TryReadGroups(out var groups))
+        {
+            var localGroupEntries = new List<LibraryEntry>();
+            bool groupsSucceeded = true;
+
+            try
+            {
+                foreach (var group in groups.Where(static g => g.Filters.Count > 0))
+                {
+                    localGroupEntries.Add(new LibraryEntryPreset
+                    {
+                        Id = LibraryEntryId.Create(),
+                        Name = string.IsNullOrWhiteSpace(group.Name) ? "(unnamed)" : group.Name,
+                        CreatedUtc = now,
+                        Filters = [.. group.Filters.Select(f => f with { Id = FilterId.Create(), IsEnabled = false })],
+                        IsFavorite = false,
+                        LastUsedUtc = null,
+                        Origin = LibraryEntryOrigin.UserSaved,
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.Warning($"Failed to migrate filter groups (partial section discarded): {ex.Message}");
+                groupsSucceeded = false;
+            }
+
+            if (groupsSucceeded)
+            {
+                builder.AddRange(localGroupEntries);
+                successful |= LegacyMigrationSections.Groups;
+            }
+        }
+
+        return new LegacyMigrationResult(builder.ToImmutable(), successful);
+    }
+
+    public void DeleteLegacyData(LegacyMigrationSections sectionsToDelete)
+    {
+        if (sectionsToDelete.HasFlag(LegacyMigrationSections.Favorites))
+        {
+            preferences.Remove(FavoriteFiltersKey);
+        }
+
+        if (sectionsToDelete.HasFlag(LegacyMigrationSections.Groups))
+        {
+            preferences.Remove(SavedGroupsKey);
+        }
+
+        if (sectionsToDelete.HasFlag(LegacyMigrationSections.Recents))
+        {
+            preferences.Remove(RecentFiltersKey);
+        }
+    }
+
+    public void MarkMigrationCompleted(LegacyMigrationSections successfulSections) =>
+        preferences.SetString(
+            MigrationSectionsKey,
+            ((int)successfulSections).ToString(CultureInfo.InvariantCulture));
+
+    public bool ShouldRunMigration()
+    {
+        var raw = preferences.GetString(MigrationSectionsKey);
+
+        if (raw is null ||
+            !int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var sectionsInt) ||
+            sectionsInt < 0)
+        {
+            return true;
+        }
+
+        return ((LegacyMigrationSections)sectionsInt & RequiredForCompletion) != RequiredForCompletion;
+    }
+
+    private static string TruncateForDisplay(string text) =>
+        text.Length <= DisplayNameMaxLength ? text : text[..(DisplayNameMaxLength - 3)] + "...";
+
+    private bool TryReadFavorites(out List<string> favorites)
+    {
+        favorites = [];
+
+        if (!preferences.ContainsKey(FavoriteFiltersKey)) { return true; }
+
+        try
+        {
+            var json = preferences.GetString(FavoriteFiltersKey) ?? "[]";
+            favorites = JsonSerializer.Deserialize<List<string>>(json) ?? [];
+
+            return true;
+        }
+        catch (JsonException ex)
+        {
+            logger.Warning($"Failed to parse legacy favorite-filters preference: {ex.Message}");
+
+            return false;
+        }
+    }
+
+    private bool TryReadGroups(out List<SavedFilterGroup> groups)
+    {
+        groups = [];
+
+        if (!preferences.ContainsKey(SavedGroupsKey)) { return true; }
+
+        try
+        {
+            var json = preferences.GetString(SavedGroupsKey) ?? "[]";
+            groups = JsonSerializer.Deserialize<List<SavedFilterGroup>>(json) ?? [];
+
+            return true;
+        }
+        catch (JsonException ex)
+        {
+            logger.Warning($"Failed to parse legacy saved-filters preference: {ex.Message}");
+
+            return false;
+        }
+    }
+}

--- a/src/EventLogExpert/Adapters/Settings/MauiLegacyPreferencesAdapter.cs
+++ b/src/EventLogExpert/Adapters/Settings/MauiLegacyPreferencesAdapter.cs
@@ -1,0 +1,20 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.FilterLibrary;
+
+namespace EventLogExpert.Adapters.Settings;
+
+internal sealed class MauiLegacyPreferencesAdapter : ILegacyPreferences
+{
+    public bool ContainsKey(string key) => Preferences.Default.ContainsKey(key);
+
+    public string? GetString(string key) => Preferences.Default.Get<string?>(key, null);
+
+    public void Remove(string key)
+    {
+        if (Preferences.Default.ContainsKey(key)) { Preferences.Default.Remove(key); }
+    }
+
+    public void SetString(string key, string value) => Preferences.Default.Set(key, value);
+}

--- a/src/EventLogExpert/MauiProgram.cs
+++ b/src/EventLogExpert/MauiProgram.cs
@@ -104,6 +104,8 @@ public static class MauiProgram
 
         builder.Services.AddFilterLibrarySqliteStore(
             Path.Combine(FileSystem.AppDataDirectory, "filter-library.db"));
+        builder.Services.AddSingleton<ILegacyPreferences, MauiLegacyPreferencesAdapter>();
+        builder.Services.AddLegacyFilterMigration();
 
         // UI Services
         builder.Services.AddEventLogFiltering();

--- a/tests/Integration/EventLogExpert.Runtime.IntegrationTests/FilterLibrary/FilterLibraryMigrationIntegrationTests.cs
+++ b/tests/Integration/EventLogExpert.Runtime.IntegrationTests/FilterLibrary/FilterLibraryMigrationIntegrationTests.cs
@@ -1,0 +1,282 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.FilterLibrary;
+using EventLogExpert.Runtime.FilterPane;
+using Fluxor;
+using Microsoft.Data.Sqlite;
+using NSubstitute;
+using System.Text.Json;
+using Effects = EventLogExpert.Runtime.FilterLibrary.Effects;
+
+namespace EventLogExpert.Runtime.IntegrationTests.FilterLibrary;
+
+public sealed class FilterLibraryMigrationIntegrationTests : IDisposable
+{
+    private const string FavoriteFiltersKey = "favorite-filters";
+    private const string MigrationSectionsKey = "filter-library-migration-sections";
+    private const string SavedGroupsKey = "saved-filters";
+
+    private readonly List<string> _tempDatabases = [];
+
+    public void Dispose()
+    {
+        SqliteConnection.ClearAllPools();
+
+        foreach (var path in _tempDatabases)
+        {
+            try
+            {
+                if (File.Exists(path)) { File.Delete(path); }
+                var dir = Path.GetDirectoryName(path);
+                while (dir is not null && Directory.Exists(dir) && !Directory.EnumerateFileSystemEntries(dir).Any())
+                {
+                    Directory.Delete(dir);
+                    dir = Path.GetDirectoryName(dir);
+                }
+            }
+            catch
+            {
+                // Best-effort cleanup; CI temp dir is wiped between runs.
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Migration_AddRangeThrows_LegacyDataPreserved_DispatchesLoadSuccessEmpty_DoesNotMarkCompleted()
+    {
+        var dbPath = CreateTempDatabasePath();
+        var realStore = new FilterLibrarySqliteStore(dbPath, Substitute.For<ITraceLogger>());
+        var throwingStore = new ThrowingAddRangeStoreWrapper(realStore);
+
+        var favoritesJson = JsonSerializer.Serialize(new List<string> { "Level == 4" });
+        var prefs = new InMemoryLegacyPreferences { [FavoriteFiltersKey] = favoritesJson };
+        var migrator = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+        var effects = BuildEffects(throwingStore, migrator);
+        var dispatcher = Substitute.For<IDispatcher>();
+
+        await effects.HandleLoadLibrary(dispatcher);
+
+        Assert.Empty(realStore.LoadAll());
+        Assert.True(prefs.ContainsKey(FavoriteFiltersKey));
+        Assert.False(prefs.ContainsKey(MigrationSectionsKey));
+        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a.Entries.IsEmpty));
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<LoadLibraryFailureAction>());
+    }
+
+    [Fact]
+    public async Task Migration_BothCorruptLegacyData_FirstLoadMigratesNothing_StoreStillEmpty_SecondLoadRetriesAllSections()
+    {
+        var dbPath = CreateTempDatabasePath();
+        var store = new FilterLibrarySqliteStore(dbPath, Substitute.For<ITraceLogger>());
+
+        var prefs = new InMemoryLegacyPreferences
+        {
+            [FavoriteFiltersKey] = "{not-json",
+            [SavedGroupsKey] = "[\"unterminated",
+        };
+        var migrator = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+        var spyMigrator = Substitute.For<ILegacyFilterMigrator>();
+        spyMigrator.ShouldRunMigration().Returns(_ => migrator.ShouldRunMigration());
+        spyMigrator.BuildEntriesFromLegacy().Returns(_ => migrator.BuildEntriesFromLegacy());
+        spyMigrator.When(m => m.MarkMigrationCompleted(Arg.Any<LegacyMigrationSections>()))
+            .Do(call => migrator.MarkMigrationCompleted((LegacyMigrationSections)call[0]!));
+        var effects = BuildEffects(store, spyMigrator);
+        var dispatcher = Substitute.For<IDispatcher>();
+
+        await effects.HandleLoadLibrary(dispatcher);
+        await effects.HandleLoadLibrary(dispatcher);
+
+        spyMigrator.Received(2).BuildEntriesFromLegacy();
+        Assert.Empty(store.LoadAll());
+        Assert.Equal("4", prefs.GetString(MigrationSectionsKey));
+    }
+
+    [Fact]
+    public async Task Migration_Concurrent_TwoSimultaneousLoadLibraryCalls_MigratorBuildCalledExactlyOnce()
+    {
+        var dbPath = CreateTempDatabasePath();
+        var store = new FilterLibrarySqliteStore(dbPath, Substitute.For<ITraceLogger>());
+
+        var favoritesJson = JsonSerializer.Serialize(new List<string> { "Level == 4" });
+        var prefs = new InMemoryLegacyPreferences { [FavoriteFiltersKey] = favoritesJson };
+        var innerMigrator = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+        var spyMigrator = Substitute.For<ILegacyFilterMigrator>();
+        spyMigrator.ShouldRunMigration().Returns(_ => innerMigrator.ShouldRunMigration());
+        spyMigrator.BuildEntriesFromLegacy().Returns(_ => innerMigrator.BuildEntriesFromLegacy());
+        spyMigrator.When(m => m.MarkMigrationCompleted(Arg.Any<LegacyMigrationSections>()))
+            .Do(call => innerMigrator.MarkMigrationCompleted((LegacyMigrationSections)call[0]!));
+        var effects = BuildEffects(store, spyMigrator);
+        var dispatcher = Substitute.For<IDispatcher>();
+
+        var ct = TestContext.Current.CancellationToken;
+        var t1 = Task.Run(() => effects.HandleLoadLibrary(dispatcher), ct);
+        var t2 = Task.Run(() => effects.HandleLoadLibrary(dispatcher), ct);
+        await Task.WhenAll(t1, t2);
+
+        spyMigrator.Received(1).BuildEntriesFromLegacy();
+        var loaded = store.LoadAll();
+        Assert.Single(loaded);
+        dispatcher.Received(2).Dispatch(Arg.Any<LoadLibrarySuccessAction>());
+    }
+
+    [Fact]
+    public async Task Migration_CorruptGroupsLegacyData_FirstLoadMigratesFavoritesOnly_SecondLoadSkipsBecauseStoreNonEmpty_GroupsStranded()
+    {
+        var dbPath = CreateTempDatabasePath();
+        var store = new FilterLibrarySqliteStore(dbPath, Substitute.For<ITraceLogger>());
+
+        var favoritesJson = JsonSerializer.Serialize(new List<string> { "Level == 4" });
+        var prefs = new InMemoryLegacyPreferences
+        {
+            [FavoriteFiltersKey] = favoritesJson,
+            [SavedGroupsKey] = "{not-json",
+        };
+        var migrator = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+        var spyMigrator = Substitute.For<ILegacyFilterMigrator>();
+        spyMigrator.ShouldRunMigration().Returns(_ => migrator.ShouldRunMigration());
+        spyMigrator.BuildEntriesFromLegacy().Returns(_ => migrator.BuildEntriesFromLegacy());
+        spyMigrator.When(m => m.MarkMigrationCompleted(Arg.Any<LegacyMigrationSections>()))
+            .Do(call => migrator.MarkMigrationCompleted((LegacyMigrationSections)call[0]!));
+        var effects = BuildEffects(store, spyMigrator);
+        var dispatcher = Substitute.For<IDispatcher>();
+
+        await effects.HandleLoadLibrary(dispatcher);
+        await effects.HandleLoadLibrary(dispatcher);
+
+        spyMigrator.Received(1).BuildEntriesFromLegacy();
+        Assert.Single(store.LoadAll());
+        Assert.Equal("5", prefs.GetString(MigrationSectionsKey));
+        Assert.True(prefs.ContainsKey(SavedGroupsKey));
+    }
+
+    [Fact]
+    public async Task Migration_EndToEnd_EmptyDb_LegacyFavoritesAndGroups_PopulatesStoreCorrectly()
+    {
+        var dbPath = CreateTempDatabasePath();
+        var store = new FilterLibrarySqliteStore(dbPath, Substitute.For<ITraceLogger>());
+
+        var favoritesJson = JsonSerializer.Serialize(new List<string> { "Level == 2", "Source == \"x\"" });
+        var groupsJson = JsonSerializer.Serialize(new List<SavedFilterGroup>
+        {
+            new()
+            {
+                Name = "PresetA",
+                Filters = [SavedFilter.TryCreate("Level == 4")!, SavedFilter.TryCreate("Level == 5")!],
+            },
+        });
+        var prefs = new InMemoryLegacyPreferences
+        {
+            [FavoriteFiltersKey] = favoritesJson,
+            [SavedGroupsKey] = groupsJson,
+        };
+        var migrator = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+        var effects = BuildEffects(store, migrator);
+        var dispatcher = Substitute.For<IDispatcher>();
+
+        await effects.HandleLoadLibrary(dispatcher);
+
+        var loaded = store.LoadAll();
+        Assert.Equal(3, loaded.Count);
+        var favorites = loaded.OfType<LibraryEntrySavedFilter>().ToList();
+        Assert.Equal(2, favorites.Count);
+        Assert.All(favorites, f => Assert.True(f.IsFavorite));
+        Assert.All(favorites, f => Assert.Equal(LibraryEntryOrigin.UserSaved, f.Origin));
+        var preset = Assert.Single(loaded.OfType<LibraryEntryPreset>());
+        Assert.Equal("PresetA", preset.Name);
+        Assert.Equal(2, preset.Filters.Count);
+        Assert.Equal(LibraryEntryOrigin.UserSaved, preset.Origin);
+
+        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a.Entries.Count == 3));
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<LoadLibraryFailureAction>());
+
+        Assert.True(prefs.ContainsKey(FavoriteFiltersKey));
+        Assert.True(prefs.ContainsKey(SavedGroupsKey));
+        Assert.Equal("7", prefs.GetString(MigrationSectionsKey));
+    }
+
+    [Fact]
+    public async Task Migration_FreshUser_NoLegacyKeys_MarksCompletedWithAllSections_SecondLoadSkipsMigrator()
+    {
+        var dbPath = CreateTempDatabasePath();
+        var store = new FilterLibrarySqliteStore(dbPath, Substitute.For<ITraceLogger>());
+
+        var prefs = new InMemoryLegacyPreferences();
+        var migrator = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+        var spyMigrator = Substitute.For<ILegacyFilterMigrator>();
+        spyMigrator.ShouldRunMigration().Returns(_ => migrator.ShouldRunMigration());
+        spyMigrator.BuildEntriesFromLegacy().Returns(_ => migrator.BuildEntriesFromLegacy());
+        spyMigrator.When(m => m.MarkMigrationCompleted(Arg.Any<LegacyMigrationSections>()))
+            .Do(call => migrator.MarkMigrationCompleted((LegacyMigrationSections)call[0]!));
+        var effects = BuildEffects(store, spyMigrator);
+        var dispatcher = Substitute.For<IDispatcher>();
+
+        await effects.HandleLoadLibrary(dispatcher);
+        await effects.HandleLoadLibrary(dispatcher);
+
+        spyMigrator.Received(1).BuildEntriesFromLegacy();
+        spyMigrator.Received(2).ShouldRunMigration();
+        spyMigrator.Received(1).MarkMigrationCompleted(
+            LegacyMigrationSections.Favorites | LegacyMigrationSections.Groups | LegacyMigrationSections.Recents);
+        Assert.Equal("7", prefs.GetString(MigrationSectionsKey));
+    }
+
+    private static Effects BuildEffects(IFilterLibraryStore store, ILegacyFilterMigrator migrator)
+    {
+        var libraryState = Substitute.For<IState<FilterLibraryState>>();
+        libraryState.Value.Returns(new FilterLibraryState());
+        var paneState = Substitute.For<IState<FilterPaneState>>();
+        paneState.Value.Returns(new FilterPaneState());
+
+        return new Effects(store, libraryState, paneState, migrator, Substitute.For<ITraceLogger>());
+    }
+
+    private string CreateTempDatabasePath()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"FilterLibraryMigrationIntegrationTests_{Guid.NewGuid()}.db");
+        _tempDatabases.Add(path);
+        return path;
+    }
+
+    private sealed class InMemoryLegacyPreferences : ILegacyPreferences
+    {
+        private readonly Dictionary<string, string> _values = [];
+
+        public string? this[string key]
+        {
+            set => _values[key] = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
+        public bool ContainsKey(string key) => _values.ContainsKey(key);
+
+        public string? GetString(string key) => _values.TryGetValue(key, out var value) ? value : null;
+
+        public void Remove(string key) => _values.Remove(key);
+
+        public void SetString(string key, string value) => _values[key] = value;
+    }
+
+    private sealed class ThrowingAddRangeStoreWrapper(IFilterLibraryStore inner) : IFilterLibraryStore
+    {
+        public void Add(LibraryEntry entry) => inner.Add(entry);
+
+        public (LibraryEntry Entry, bool WasInserted) AddOrReturnExistingFilter(LibraryEntrySavedFilter candidate) =>
+            inner.AddOrReturnExistingFilter(candidate);
+
+        public void AddRange(IEnumerable<LibraryEntry> entries) => throw new SqliteException("simulated AddRange failure", 1);
+
+        public void Delete(LibraryEntryId entryId) => inner.Delete(entryId);
+
+        public IReadOnlyList<LibraryEntry> LoadAll() => inner.LoadAll();
+
+        public bool TryBumpLastUsedIfNotFavorite(LibraryEntryId entryId, DateTimeOffset lastUsedUtc) =>
+            inner.TryBumpLastUsedIfNotFavorite(entryId, lastUsedUtc);
+
+        public bool TryDeleteAutoTrackedIfNotFavorite(LibraryEntryId entryId) =>
+            inner.TryDeleteAutoTrackedIfNotFavorite(entryId);
+
+        public void Update(LibraryEntry entry) => inner.Update(entry);
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLibrary/FilterLibraryEffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLibrary/FilterLibraryEffectsTests.cs
@@ -7,6 +7,7 @@ using EventLogExpert.Runtime.FilterLibrary;
 using EventLogExpert.Runtime.FilterPane;
 using Fluxor;
 using NSubstitute;
+using System.Collections.Immutable;
 using Effects = EventLogExpert.Runtime.FilterLibrary.Effects;
 
 namespace EventLogExpert.Runtime.Tests.FilterLibrary;
@@ -256,6 +257,109 @@ public sealed class FilterLibraryEffectsTests
     }
 
     [Fact]
+    public async Task HandleLoadLibrary_BuildEntriesFromLegacyThrows_OuterCatchFires_GateReleased_SecondLoadSucceeds()
+    {
+        var shouldThrow = true;
+        var migrator = Substitute.For<ILegacyFilterMigrator>();
+        migrator.ShouldRunMigration().Returns(true);
+        migrator.BuildEntriesFromLegacy().Returns(_ => shouldThrow
+            ? throw new InvalidOperationException("migrator broke")
+            : new LegacyMigrationResult(ImmutableList<LibraryEntry>.Empty, LegacyMigrationSections.Recents));
+        var (effects, store, dispatcher, _, _, logger) = CreateEffectsWithMigrator(migrator);
+        store.LoadAll().Returns([]);
+
+        await effects.HandleLoadLibrary(dispatcher);
+        shouldThrow = false;
+        await effects.HandleLoadLibrary(dispatcher);
+
+        dispatcher.Received(1).Dispatch(Arg.Any<LoadLibraryFailureAction>());
+        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a.Entries.IsEmpty));
+        logger.ReceivedWithAnyArgs(1).Warning(default);
+    }
+
+    [Fact]
+    public async Task HandleLoadLibrary_Concurrent_TwoSimultaneousDispatches_MigratorBuildCalledExactlyOnce()
+    {
+        var migratedEntry = BuildFilterEntry("migrated");
+        var migrator = Substitute.For<ILegacyFilterMigrator>();
+        migrator.ShouldRunMigration().Returns(true);
+        migrator.BuildEntriesFromLegacy()
+            .Returns(new LegacyMigrationResult(
+                ImmutableList.Create<LibraryEntry>(migratedEntry),
+                LegacyMigrationSections.Favorites | LegacyMigrationSections.Groups | LegacyMigrationSections.Recents));
+        var store = Substitute.For<IFilterLibraryStore>();
+        var loadAllCount = 0;
+        store.LoadAll().Returns(_ =>
+        {
+            loadAllCount++;
+            return loadAllCount == 1 ? [] : new[] { migratedEntry };
+        });
+        var (effects, _, dispatcher, _, _, _) = CreateEffectsWithMigrator(migrator, store: store);
+
+        var ct = TestContext.Current.CancellationToken;
+        var task1 = Task.Run(() => effects.HandleLoadLibrary(dispatcher), ct);
+        var task2 = Task.Run(() => effects.HandleLoadLibrary(dispatcher), ct);
+        await Task.WhenAll(task1, task2);
+
+        migrator.Received(1).BuildEntriesFromLegacy();
+        store.Received(1).AddRange(Arg.Any<IEnumerable<LibraryEntry>>());
+        dispatcher.Received(2).Dispatch(Arg.Any<LoadLibrarySuccessAction>());
+    }
+
+    [Fact]
+    public async Task HandleLoadLibrary_DispatchesStartedActionBeforeAcquiringGate()
+    {
+        using var migratorReleaser = new SemaphoreSlim(initialCount: 0, maxCount: 1);
+        var migratorReachedSignal = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var migrator = Substitute.For<ILegacyFilterMigrator>();
+        migrator.ShouldRunMigration().Returns(true);
+        var migratorCallCount = 0;
+        migrator.BuildEntriesFromLegacy().Returns(_ =>
+        {
+            if (Interlocked.Increment(ref migratorCallCount) == 1)
+            {
+                migratorReachedSignal.TrySetResult();
+                migratorReleaser.Wait();
+            }
+
+            return new LegacyMigrationResult(
+                ImmutableList.Create<LibraryEntry>(BuildFilterEntry("migrated")),
+                LegacyMigrationSections.Favorites | LegacyMigrationSections.Groups | LegacyMigrationSections.Recents);
+        });
+        var store = Substitute.For<IFilterLibraryStore>();
+        var loadAllCount = 0;
+        var migratedEntry = BuildFilterEntry("migrated");
+        store.LoadAll().Returns(_ => Interlocked.Increment(ref loadAllCount) == 1 ? [] : new[] { migratedEntry });
+        var (effects, _, dispatcher, _, _, _) = CreateEffectsWithMigrator(migrator, store: store);
+
+        var ct = TestContext.Current.CancellationToken;
+        var load1 = Task.Run(() => effects.HandleLoadLibrary(dispatcher), ct);
+        var load2 = default(Task);
+        try
+        {
+            await migratorReachedSignal.Task.WaitAsync(TimeSpan.FromSeconds(5), ct);
+            load2 = Task.Run(() => effects.HandleLoadLibrary(dispatcher), ct);
+            await PollUntilAsync(
+                () => dispatcher.ReceivedCalls().Count(c => c.GetArguments().FirstOrDefault() is LoadLibraryStartedAction) >= 2,
+                TimeSpan.FromSeconds(5),
+                ct);
+
+            dispatcher.Received(2).Dispatch(Arg.Any<LoadLibraryStartedAction>());
+            dispatcher.DidNotReceive().Dispatch(Arg.Any<LoadLibrarySuccessAction>());
+        }
+        finally
+        {
+            // Always release the migrator so the load tasks unblock even if an assertion or polling timeout
+            // throws — otherwise xUnit's per-test cleanup hangs waiting for the still-running load tasks.
+            migratorReleaser.Release();
+            if (load2 is not null) { await Task.WhenAll(load1, load2); }
+            else { await load1; }
+        }
+
+        dispatcher.Received(2).Dispatch(Arg.Any<LoadLibrarySuccessAction>());
+    }
+
+    [Fact]
     public async Task HandleLoadLibrary_DispatchesStartedAndSuccessWithStoreEntries()
     {
         var entry = BuildFilterEntry("First");
@@ -266,6 +370,144 @@ public sealed class FilterLibraryEffectsTests
 
         dispatcher.Received(1).Dispatch(Arg.Any<LoadLibraryStartedAction>());
         dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a.Entries.Count == 1 && a.Entries[0].Id == entry.Id));
+    }
+
+    [Fact]
+    public async Task HandleLoadLibrary_EmptyStore_AddRangeSucceeds_PostMigrationLoadAllThrows_FallsBackToInMemoryResult_StillMarksCompleted()
+    {
+        var migratedEntry = BuildFilterEntry("migrated");
+        var sections = LegacyMigrationSections.Favorites | LegacyMigrationSections.Groups | LegacyMigrationSections.Recents;
+        var migrator = Substitute.For<ILegacyFilterMigrator>();
+        migrator.ShouldRunMigration().Returns(true);
+        migrator.BuildEntriesFromLegacy()
+            .Returns(new LegacyMigrationResult(ImmutableList.Create<LibraryEntry>(migratedEntry), sections));
+        var store = Substitute.For<IFilterLibraryStore>();
+        var loadAllCallCount = 0;
+        store.LoadAll().Returns(_ =>
+        {
+            loadAllCallCount++;
+            if (loadAllCallCount == 1) { return []; }
+            throw new InvalidOperationException("reload blew up");
+        });
+        var (effects, _, dispatcher, _, _, logger) = CreateEffectsWithMigrator(migrator, store: store);
+
+        await effects.HandleLoadLibrary(dispatcher);
+
+        store.Received(1).AddRange(Arg.Any<IEnumerable<LibraryEntry>>());
+        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a.Entries.Count == 1 && a.Entries[0].Id == migratedEntry.Id));
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<LoadLibraryFailureAction>());
+        migrator.Received(1).MarkMigrationCompleted(sections);
+        logger.ReceivedWithAnyArgs(1).Warning(default);
+    }
+
+    [Fact]
+    public async Task HandleLoadLibrary_EmptyStore_AddRangeThrows_DispatchesSuccessEmpty_DoesNotMarkMigrationCompleted()
+    {
+        var migrator = Substitute.For<ILegacyFilterMigrator>();
+        migrator.ShouldRunMigration().Returns(true);
+        migrator.BuildEntriesFromLegacy()
+            .Returns(new LegacyMigrationResult(
+                ImmutableList.Create<LibraryEntry>(BuildFilterEntry("migrated")),
+                LegacyMigrationSections.Favorites | LegacyMigrationSections.Recents));
+        var store = Substitute.For<IFilterLibraryStore>();
+        store.LoadAll().Returns([]);
+        store.When(s => s.AddRange(Arg.Any<IEnumerable<LibraryEntry>>())).Do(_ => throw new InvalidOperationException("sqlite locked"));
+        var (effects, _, dispatcher, _, _, logger) = CreateEffectsWithMigrator(migrator, store: store);
+
+        await effects.HandleLoadLibrary(dispatcher);
+
+        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a.Entries.IsEmpty));
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<LoadLibraryFailureAction>());
+        migrator.DidNotReceive().MarkMigrationCompleted(Arg.Any<LegacyMigrationSections>());
+        logger.ReceivedWithAnyArgs(1).Warning(default);
+    }
+
+    [Fact]
+    public async Task HandleLoadLibrary_EmptyStore_MigratorReturnsEmptyEntries_DoesNotCallAddRange_MarksMigrationCompletedWithBuildResultSections()
+    {
+        var sections = LegacyMigrationSections.Favorites | LegacyMigrationSections.Groups | LegacyMigrationSections.Recents;
+        var migrator = Substitute.For<ILegacyFilterMigrator>();
+        migrator.ShouldRunMigration().Returns(true);
+        migrator.BuildEntriesFromLegacy().Returns(new LegacyMigrationResult(ImmutableList<LibraryEntry>.Empty, sections));
+        var (effects, store, dispatcher, _, _, _) = CreateEffectsWithMigrator(migrator);
+
+        await effects.HandleLoadLibrary(dispatcher);
+
+        store.DidNotReceive().AddRange(Arg.Any<IEnumerable<LibraryEntry>>());
+        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a.Entries.IsEmpty));
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<LoadLibraryFailureAction>());
+        migrator.Received(1).MarkMigrationCompleted(sections);
+    }
+
+    [Fact]
+    public async Task HandleLoadLibrary_EmptyStore_MigratorReturnsEntries_AddRangeSucceeds_DispatchesReloadedEntries_MarksMigrationCompleted()
+    {
+        var migratedEntry = BuildFilterEntry("migrated");
+        var sections = LegacyMigrationSections.Favorites | LegacyMigrationSections.Groups | LegacyMigrationSections.Recents;
+        var migrator = Substitute.For<ILegacyFilterMigrator>();
+        migrator.ShouldRunMigration().Returns(true);
+        migrator.BuildEntriesFromLegacy()
+            .Returns(new LegacyMigrationResult(ImmutableList.Create<LibraryEntry>(migratedEntry), sections));
+        var store = Substitute.For<IFilterLibraryStore>();
+        store.LoadAll().Returns([], [migratedEntry]);
+        var (effects, _, dispatcher, _, _, _) = CreateEffectsWithMigrator(migrator, store: store);
+
+        await effects.HandleLoadLibrary(dispatcher);
+
+        store.Received(1).AddRange(Arg.Is<IEnumerable<LibraryEntry>>(e => e.Count() == 1));
+        store.Received(2).LoadAll();
+        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a.Entries.Count == 1 && a.Entries[0].Id == migratedEntry.Id));
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<LoadLibraryFailureAction>());
+        migrator.Received(1).MarkMigrationCompleted(sections);
+    }
+
+    [Fact]
+    public async Task HandleLoadLibrary_EmptyStore_NoMigratableData_DispatchesSuccessWithEmptyEntries()
+    {
+        var (effects, store, dispatcher, _, migrator, _) = CreateEffectsWithMigrator();
+        store.LoadAll().Returns([]);
+
+        await effects.HandleLoadLibrary(dispatcher);
+
+        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a.Entries.IsEmpty));
+        store.DidNotReceive().AddRange(Arg.Any<IEnumerable<LibraryEntry>>());
+        migrator.Received(1).MarkMigrationCompleted(Arg.Any<LegacyMigrationSections>());
+    }
+
+    [Fact]
+    public async Task HandleLoadLibrary_MigratorShouldRunReturnsFalse_SkipsBuildEntriesFromLegacy_DispatchesSuccessEmpty()
+    {
+        var migrator = Substitute.For<ILegacyFilterMigrator>();
+        migrator.ShouldRunMigration().Returns(false);
+        var (effects, store, dispatcher, _, _, _) = CreateEffectsWithMigrator(migrator);
+        store.LoadAll().Returns([]);
+
+        await effects.HandleLoadLibrary(dispatcher);
+
+        migrator.Received(1).ShouldRunMigration();
+        migrator.DidNotReceive().BuildEntriesFromLegacy();
+        migrator.DidNotReceive().MarkMigrationCompleted(Arg.Any<LegacyMigrationSections>());
+        store.DidNotReceive().AddRange(Arg.Any<IEnumerable<LibraryEntry>>());
+        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a.Entries.IsEmpty));
+    }
+
+    [Fact]
+    public async Task HandleLoadLibrary_NonEmptyStore_DoesNotInvokeMigrator()
+    {
+        var migrator = Substitute.For<ILegacyFilterMigrator>();
+        migrator.ShouldRunMigration().Returns(true);
+        migrator.BuildEntriesFromLegacy()
+            .Returns(new LegacyMigrationResult(ImmutableList<LibraryEntry>.Empty, LegacyMigrationSections.Recents));
+        var (effects, store, dispatcher, _, _, _) = CreateEffectsWithMigrator(migrator);
+        store.LoadAll().Returns([BuildFilterEntry("existing")]);
+
+        await effects.HandleLoadLibrary(dispatcher);
+
+        migrator.DidNotReceive().ShouldRunMigration();
+        migrator.DidNotReceive().BuildEntriesFromLegacy();
+        migrator.DidNotReceive().MarkMigrationCompleted(Arg.Any<LegacyMigrationSections>());
+        store.DidNotReceive().AddRange(Arg.Any<IEnumerable<LibraryEntry>>());
+        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a.Entries.Count == 1));
     }
 
     [Fact]
@@ -984,8 +1226,23 @@ public sealed class FilterLibraryEffectsTests
         FilterLibraryState? state = null,
         FilterPaneState? paneState = null)
     {
-        var store = Substitute.For<IFilterLibraryStore>();
-        store.LoadAll().Returns([]);
+        var (effects, store, dispatcher, stateMock, _, logger) = CreateEffectsWithMigrator(
+            migrator: null,
+            state: state,
+            paneState: paneState);
+
+        return (effects, store, dispatcher, stateMock, logger);
+    }
+
+    private static (Effects effects, IFilterLibraryStore store, IDispatcher dispatcher, IState<FilterLibraryState> stateMock, ILegacyFilterMigrator migrator, ITraceLogger logger) CreateEffectsWithMigrator(
+        ILegacyFilterMigrator? migrator = null,
+        FilterLibraryState? state = null,
+        FilterPaneState? paneState = null,
+        IFilterLibraryStore? store = null)
+    {
+        var storeWasSupplied = store is not null;
+        store ??= Substitute.For<IFilterLibraryStore>();
+        if (!storeWasSupplied) { store.LoadAll().Returns([]); }
 
         var stateMock = Substitute.For<IState<FilterLibraryState>>();
         stateMock.Value.Returns(state ?? new FilterLibraryState());
@@ -993,11 +1250,32 @@ public sealed class FilterLibraryEffectsTests
         var paneStateMock = Substitute.For<IState<FilterPaneState>>();
         paneStateMock.Value.Returns(paneState ?? new FilterPaneState());
 
+        if (migrator is null)
+        {
+            migrator = Substitute.For<ILegacyFilterMigrator>();
+            migrator.ShouldRunMigration().Returns(true);
+            migrator.BuildEntriesFromLegacy()
+                .Returns(new LegacyMigrationResult(
+                    ImmutableList<LibraryEntry>.Empty,
+                    LegacyMigrationSections.Favorites | LegacyMigrationSections.Groups | LegacyMigrationSections.Recents));
+        }
+
         var logger = Substitute.For<ITraceLogger>();
         var dispatcher = Substitute.For<IDispatcher>();
-        var effects = new Effects(store, stateMock, paneStateMock, logger);
+        var effects = new Effects(store, stateMock, paneStateMock, migrator, logger);
 
-        return (effects, store, dispatcher, stateMock, logger);
+        return (effects, store, dispatcher, stateMock, migrator, logger);
+    }
+
+    private static async Task PollUntilAsync(Func<bool> predicate, TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (predicate()) { return; }
+            await Task.Delay(10, cancellationToken);
+        }
+        if (!predicate()) { throw new TimeoutException($"Predicate did not become true within {timeout}."); }
     }
 
     // Used for the unknown-concrete-type wildcard test (covers the throw arm in HandleApplyLibraryEntry).

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLibrary/LegacyFilterMigratorTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLibrary/LegacyFilterMigratorTests.cs
@@ -1,0 +1,440 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.FilterLibrary;
+using NSubstitute;
+using System.Text.Json;
+
+namespace EventLogExpert.Runtime.Tests.FilterLibrary;
+
+public sealed class LegacyFilterMigratorTests
+{
+    private const string FavoriteFiltersKey = "favorite-filters";
+    private const string RecentFiltersKey = "recent-filters";
+    private const string SavedGroupsKey = "saved-filters";
+
+    [Fact]
+    public void BuildEntriesFromLegacy_FavoritesAbsent_GroupsValid_BothRequiredSectionsSuccessful()
+    {
+        var groupsJson = JsonSerializer.Serialize(new List<SavedFilterGroup>
+        {
+            new() { Name = "G1", Filters = [SavedFilter.TryCreate("Level == 4")!] },
+        });
+        var prefs = StubPreferences(groupsJson: groupsJson);
+        var sut = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+
+        var result = sut.BuildEntriesFromLegacy();
+
+        Assert.IsType<LibraryEntryPreset>(Assert.Single(result.Entries));
+        Assert.True(result.SuccessfulSections.HasFlag(LegacyMigrationSections.Favorites));
+        Assert.True(result.SuccessfulSections.HasFlag(LegacyMigrationSections.Groups));
+    }
+
+    [Fact]
+    public void BuildEntriesFromLegacy_FavoritesContainsWhitespaceEntries_WhitespaceIsFilteredOut()
+    {
+        var favoritesJson = JsonSerializer.Serialize(new List<string> { "", "  ", "Level == 4", "\t" });
+        var prefs = StubPreferences(favoritesJson: favoritesJson);
+        var sut = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+
+        var result = sut.BuildEntriesFromLegacy();
+
+        Assert.Single(result.Entries);
+        var entry = Assert.IsType<LibraryEntrySavedFilter>(result.Entries[0]);
+        Assert.Equal("Level == 4", entry.Filter.ComparisonText);
+    }
+
+    [Fact]
+    public void BuildEntriesFromLegacy_FavoritesCorrupt_GroupsAbsent_GroupsAndRecentsOnly_FavoritesUnset()
+    {
+        var prefs = StubPreferences(favoritesJson: "{not-json");
+        var sut = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+
+        var result = sut.BuildEntriesFromLegacy();
+
+        Assert.Empty(result.Entries);
+        Assert.False(result.SuccessfulSections.HasFlag(LegacyMigrationSections.Favorites));
+        Assert.True(result.SuccessfulSections.HasFlag(LegacyMigrationSections.Groups));
+        Assert.True(result.SuccessfulSections.HasFlag(LegacyMigrationSections.Recents));
+    }
+
+    [Fact]
+    public void BuildEntriesFromLegacy_FavoritesCorrupt_GroupsValid_MigratesGroupsOnly_FavoritesFlagUnset()
+    {
+        var groupsJson = JsonSerializer.Serialize(new List<SavedFilterGroup>
+        {
+            new()
+            {
+                Name = "G1",
+                Filters = [SavedFilter.TryCreate("Level == 4")!],
+            },
+        });
+        var prefs = StubPreferences(favoritesJson: "{not-json", groupsJson: groupsJson);
+        var sut = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+
+        var result = sut.BuildEntriesFromLegacy();
+
+        Assert.Single(result.Entries);
+        Assert.IsType<LibraryEntryPreset>(result.Entries[0]);
+        Assert.Equal(
+            LegacyMigrationSections.Groups | LegacyMigrationSections.Recents,
+            result.SuccessfulSections);
+        Assert.False(result.SuccessfulSections.HasFlag(LegacyMigrationSections.Favorites));
+    }
+
+    [Fact]
+    public void BuildEntriesFromLegacy_FavoritesCorruptJson_GroupsCorruptJson_ReturnsEmpty_OnlyRecentsSuccessful()
+    {
+        var prefs = StubPreferences(favoritesJson: "{not-json", groupsJson: "[\"unterminated");
+        var sut = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+
+        var result = sut.BuildEntriesFromLegacy();
+
+        Assert.Empty(result.Entries);
+        Assert.Equal(LegacyMigrationSections.Recents, result.SuccessfulSections);
+    }
+
+    [Fact]
+    public void BuildEntriesFromLegacy_FavoritesEmpty_GroupsCorrupt_FavoritesSuccessful_NoEntries()
+    {
+        var prefs = StubPreferences(favoritesJson: "[]", groupsJson: "{not-json");
+        var sut = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+
+        var result = sut.BuildEntriesFromLegacy();
+
+        Assert.Empty(result.Entries);
+        Assert.Equal(
+            LegacyMigrationSections.Favorites | LegacyMigrationSections.Recents,
+            result.SuccessfulSections);
+    }
+
+    [Fact]
+    public void BuildEntriesFromLegacy_FavoritesEmptyArray_GroupsEmptyArray_AllSectionsSuccessful_NoEntries()
+    {
+        var prefs = StubPreferences(favoritesJson: "[]", groupsJson: "[]");
+        var sut = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+
+        var result = sut.BuildEntriesFromLegacy();
+
+        Assert.Empty(result.Entries);
+        Assert.Equal(
+            LegacyMigrationSections.Favorites | LegacyMigrationSections.Groups | LegacyMigrationSections.Recents,
+            result.SuccessfulSections);
+    }
+
+    [Fact]
+    public void BuildEntriesFromLegacy_FavoritesValid_AssertsCanonicalEntryShape()
+    {
+        var favoritesJson = JsonSerializer.Serialize(new List<string> { "Level == 4" });
+        var prefs = StubPreferences(favoritesJson: favoritesJson);
+        var before = DateTimeOffset.UtcNow;
+
+        var sut = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+        var result = sut.BuildEntriesFromLegacy();
+        var after = DateTimeOffset.UtcNow;
+
+        var entry = Assert.IsType<LibraryEntrySavedFilter>(Assert.Single(result.Entries));
+        Assert.True(entry.IsFavorite);
+        Assert.Equal(LibraryEntryOrigin.UserSaved, entry.Origin);
+        Assert.Null(entry.LastUsedUtc);
+        Assert.False(entry.Filter.IsEnabled);
+        Assert.InRange(entry.CreatedUtc, before, after);
+        Assert.NotEqual(default, entry.Id);
+    }
+
+    [Fact]
+    public void BuildEntriesFromLegacy_FavoritesValid_GroupsCorrupt_MigratesFavoritesOnly_GroupsFlagUnset()
+    {
+        var favoritesJson = JsonSerializer.Serialize(new List<string> { "Level == 2" });
+        var prefs = StubPreferences(favoritesJson: favoritesJson, groupsJson: "{not-json");
+        var sut = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+
+        var result = sut.BuildEntriesFromLegacy();
+
+        Assert.Single(result.Entries);
+        Assert.IsType<LibraryEntrySavedFilter>(result.Entries[0]);
+        Assert.Equal(
+            LegacyMigrationSections.Favorites | LegacyMigrationSections.Recents,
+            result.SuccessfulSections);
+        Assert.False(result.SuccessfulSections.HasFlag(LegacyMigrationSections.Groups));
+    }
+
+    [Fact]
+    public void BuildEntriesFromLegacy_FavoritesValidAndGroupsValid_ReturnsBothSetsAndAllSectionsSuccessful()
+    {
+        var favoritesJson = JsonSerializer.Serialize(new List<string> { "Level == 2", "Source == \"x\"" });
+        var groupsJson = JsonSerializer.Serialize(new List<SavedFilterGroup>
+        {
+            new()
+            {
+                Name = "G1",
+                Filters = [SavedFilter.TryCreate("Level == 4")!],
+            },
+        });
+        var prefs = StubPreferences(favoritesJson: favoritesJson, groupsJson: groupsJson);
+        var sut = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+
+        var result = sut.BuildEntriesFromLegacy();
+
+        Assert.Equal(3, result.Entries.Count);
+        Assert.Equal(2, result.Entries.OfType<LibraryEntrySavedFilter>().Count());
+        Assert.Single(result.Entries.OfType<LibraryEntryPreset>());
+        Assert.Equal(
+            LegacyMigrationSections.Favorites | LegacyMigrationSections.Groups | LegacyMigrationSections.Recents,
+            result.SuccessfulSections);
+    }
+
+    [Fact]
+    public void BuildEntriesFromLegacy_FavoritesWithUncompilableExpression_StillCreatesEntry()
+    {
+        var favoritesJson = JsonSerializer.Serialize(new List<string> { "??? not a valid filter ???" });
+        var prefs = StubPreferences(favoritesJson: favoritesJson);
+
+        var sut = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+        var result = sut.BuildEntriesFromLegacy();
+
+        var entry = Assert.IsType<LibraryEntrySavedFilter>(Assert.Single(result.Entries));
+        Assert.Equal("??? not a valid filter ???", entry.Filter.ComparisonText);
+        Assert.Null(entry.Filter.Compiled);
+        Assert.False(entry.Filter.IsEnabled);
+        Assert.True(result.SuccessfulSections.HasFlag(LegacyMigrationSections.Favorites));
+    }
+
+    [Fact]
+    public void BuildEntriesFromLegacy_FavoriteTextLongerThanDisplayLimit_NameIsTruncatedWithEllipsis()
+    {
+        var longText = new string('a', 200);
+        var favoritesJson = JsonSerializer.Serialize(new List<string> { longText });
+        var prefs = StubPreferences(favoritesJson: favoritesJson);
+
+        var sut = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+        var result = sut.BuildEntriesFromLegacy();
+
+        var entry = Assert.IsType<LibraryEntrySavedFilter>(Assert.Single(result.Entries));
+        Assert.Equal(80, entry.Name.Length);
+        Assert.EndsWith("...", entry.Name);
+        Assert.Equal(longText, entry.Filter.ComparisonText);
+    }
+
+    [Fact]
+    public void BuildEntriesFromLegacy_GroupsContainsEmptyFilterLists_EmptyGroupsAreFilteredOut()
+    {
+        var groupsJson = JsonSerializer.Serialize(new List<SavedFilterGroup>
+        {
+            new() { Name = "EmptyOne", Filters = [] },
+            new() { Name = "WithFilters", Filters = [SavedFilter.TryCreate("Level == 4")!] },
+            new() { Name = "EmptyTwo", Filters = [] },
+        });
+        var prefs = StubPreferences(groupsJson: groupsJson);
+        var sut = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+
+        var result = sut.BuildEntriesFromLegacy();
+
+        var preset = Assert.IsType<LibraryEntryPreset>(Assert.Single(result.Entries));
+        Assert.Equal("WithFilters", preset.Name);
+    }
+
+    [Fact]
+    public void BuildEntriesFromLegacy_GroupsValid_FilterIdsAreRegenerated()
+    {
+        var originalFilter = SavedFilter.TryCreate("Level == 4")!;
+        var originalFilterId = originalFilter.Id;
+        var groupsJson = JsonSerializer.Serialize(new List<SavedFilterGroup>
+        {
+            new() { Name = "G1", Filters = [originalFilter] },
+        });
+        var prefs = StubPreferences(groupsJson: groupsJson);
+
+        var sut = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+        var result = sut.BuildEntriesFromLegacy();
+
+        var preset = Assert.IsType<LibraryEntryPreset>(Assert.Single(result.Entries));
+        Assert.False(preset.IsFavorite);
+        Assert.Equal(LibraryEntryOrigin.UserSaved, preset.Origin);
+        Assert.Null(preset.LastUsedUtc);
+        var migratedFilter = Assert.Single(preset.Filters);
+        Assert.NotEqual(originalFilterId, migratedFilter.Id);
+        Assert.False(migratedFilter.IsEnabled);
+    }
+
+    [Fact]
+    public void BuildEntriesFromLegacy_NoLegacyKeys_ReturnsEmptyEntriesAndAllRequiredSectionsSuccessful()
+    {
+        var prefs = Substitute.For<ILegacyPreferences>();
+        var sut = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+
+        var result = sut.BuildEntriesFromLegacy();
+
+        Assert.Empty(result.Entries);
+        Assert.Equal(
+            LegacyMigrationSections.Favorites | LegacyMigrationSections.Groups | LegacyMigrationSections.Recents,
+            result.SuccessfulSections);
+    }
+
+    [Fact]
+    public void DeleteLegacyData_AllFlags_RemovesAllThreeKeys()
+    {
+        var prefs = Substitute.For<ILegacyPreferences>();
+        var sut = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+
+        sut.DeleteLegacyData(
+            LegacyMigrationSections.Favorites | LegacyMigrationSections.Groups | LegacyMigrationSections.Recents);
+
+        prefs.Received(1).Remove(FavoriteFiltersKey);
+        prefs.Received(1).Remove(SavedGroupsKey);
+        prefs.Received(1).Remove(RecentFiltersKey);
+    }
+
+    [Fact]
+    public void DeleteLegacyData_Favorites_RemovesOnlyFavoriteFiltersKey()
+    {
+        var prefs = Substitute.For<ILegacyPreferences>();
+        var sut = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+
+        sut.DeleteLegacyData(LegacyMigrationSections.Favorites);
+
+        prefs.Received(1).Remove(FavoriteFiltersKey);
+        prefs.DidNotReceive().Remove(SavedGroupsKey);
+        prefs.DidNotReceive().Remove(RecentFiltersKey);
+    }
+
+    [Fact]
+    public void DeleteLegacyData_Groups_RemovesOnlySavedGroupsKey()
+    {
+        var prefs = Substitute.For<ILegacyPreferences>();
+        var sut = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+
+        sut.DeleteLegacyData(LegacyMigrationSections.Groups);
+
+        prefs.Received(1).Remove(SavedGroupsKey);
+        prefs.DidNotReceive().Remove(FavoriteFiltersKey);
+        prefs.DidNotReceive().Remove(RecentFiltersKey);
+    }
+
+    [Fact]
+    public void DeleteLegacyData_None_RemovesNothing()
+    {
+        var prefs = Substitute.For<ILegacyPreferences>();
+        var sut = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+
+        sut.DeleteLegacyData(LegacyMigrationSections.None);
+
+        prefs.DidNotReceive().Remove(Arg.Any<string>());
+    }
+
+    [Fact]
+    public void DeleteLegacyData_Recents_RemovesOnlyRecentFiltersKey()
+    {
+        var prefs = Substitute.For<ILegacyPreferences>();
+        var sut = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+
+        sut.DeleteLegacyData(LegacyMigrationSections.Recents);
+
+        prefs.Received(1).Remove(RecentFiltersKey);
+        prefs.DidNotReceive().Remove(FavoriteFiltersKey);
+        prefs.DidNotReceive().Remove(SavedGroupsKey);
+    }
+
+    [Fact]
+    public void MarkMigrationCompleted_PartialBitmask_WritesPartialValue()
+    {
+        var prefs = Substitute.For<ILegacyPreferences>();
+        var sut = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+
+        sut.MarkMigrationCompleted(LegacyMigrationSections.Favorites | LegacyMigrationSections.Recents);
+
+        prefs.Received(1).SetString("filter-library-migration-sections", "5");
+    }
+
+    [Fact]
+    public void MarkMigrationCompleted_WritesBitmaskAsDecimalString()
+    {
+        var prefs = Substitute.For<ILegacyPreferences>();
+        var sut = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+
+        sut.MarkMigrationCompleted(
+            LegacyMigrationSections.Favorites | LegacyMigrationSections.Groups | LegacyMigrationSections.Recents);
+
+        prefs.Received(1).SetString("filter-library-migration-sections", "7");
+    }
+
+    [Fact]
+    public void ShouldRunMigration_FlagBitmaskContainsBothFavoritesAndGroups_ReturnsFalse()
+    {
+        var prefs = Substitute.For<ILegacyPreferences>();
+        prefs.GetString("filter-library-migration-sections").Returns("7");
+        var sut = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+
+        Assert.False(sut.ShouldRunMigration());
+    }
+
+    [Fact]
+    public void ShouldRunMigration_FlagBitmaskMissingFavorites_ReturnsTrue()
+    {
+        var prefs = Substitute.For<ILegacyPreferences>();
+        prefs.GetString("filter-library-migration-sections").Returns("6");
+        var sut = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+
+        Assert.True(sut.ShouldRunMigration());
+    }
+
+    [Fact]
+    public void ShouldRunMigration_FlagBitmaskMissingGroups_ReturnsTrue()
+    {
+        var prefs = Substitute.For<ILegacyPreferences>();
+        prefs.GetString("filter-library-migration-sections").Returns("5");
+        var sut = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+
+        Assert.True(sut.ShouldRunMigration());
+    }
+
+    [Fact]
+    public void ShouldRunMigration_FlagKeyAbsent_ReturnsTrue()
+    {
+        var prefs = Substitute.For<ILegacyPreferences>();
+        var sut = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+
+        Assert.True(sut.ShouldRunMigration());
+    }
+
+    [Fact]
+    public void ShouldRunMigration_FlagKeyContainsNegativeInteger_ReturnsTrue()
+    {
+        var prefs = Substitute.For<ILegacyPreferences>();
+        prefs.GetString("filter-library-migration-sections").Returns("-1");
+        var sut = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+
+        Assert.True(sut.ShouldRunMigration());
+    }
+
+    [Fact]
+    public void ShouldRunMigration_FlagKeyContainsNonInteger_ReturnsTrue()
+    {
+        var prefs = Substitute.For<ILegacyPreferences>();
+        prefs.GetString("filter-library-migration-sections").Returns("hello");
+        var sut = new LegacyFilterMigrator(prefs, Substitute.For<ITraceLogger>());
+
+        Assert.True(sut.ShouldRunMigration());
+    }
+
+    private static ILegacyPreferences StubPreferences(string? favoritesJson = null, string? groupsJson = null)
+    {
+        var prefs = Substitute.For<ILegacyPreferences>();
+
+        if (favoritesJson is not null)
+        {
+            prefs.GetString(FavoriteFiltersKey).Returns(favoritesJson);
+            prefs.ContainsKey(FavoriteFiltersKey).Returns(true);
+        }
+
+        if (groupsJson is not null)
+        {
+            prefs.GetString(SavedGroupsKey).Returns(groupsJson);
+            prefs.ContainsKey(SavedGroupsKey).Returns(true);
+        }
+
+        return prefs;
+    }
+}


### PR DESCRIPTION
## Stacked PR

**Base**: `jschick/library-modal-infra` (PR #560) — this PR stacks on top of #560 and contains Commit D of the PR-3 chain.

Once PR #560 merges to `main`, this PR's base will be retargeted to `main` and the diff will then be only this commit (~1318/-22 LOC across 10 files).

## Scope

PR-3 Commit D: legacy migration adapter. Reads the user's existing `favorite-filters` (FilterCache) and `saved-filters` (FilterGroup) preference keys on first FilterLibrary load and persists them as `LibraryEntry` instances in the new SQLite store. Feature-flagged so subsequent loads skip the migration branch entirely once both required sections have completed successfully.

## What's in this PR

### Production code (4 new + 3 modified)

- **NEW `ILegacyPreferences`** (Runtime tier) — thin read/write/contains/remove seam over the platform key-value store
- **NEW `ILegacyFilterMigrator`** (Runtime tier) — 4-method interface: `ShouldRunMigration()`, `MarkMigrationCompleted(LegacyMigrationSections)`, `BuildEntriesFromLegacy()`, `DeleteLegacyData(LegacyMigrationSections)`
- **NEW `LegacyFilterMigrator`** (Runtime internal sealed) — production implementation; per-section local-builder pattern with discard-on-throw semantics
- **NEW `MauiLegacyPreferencesAdapter`** (MAUI head internal sealed) — delegates to `Microsoft.Maui.Storage.Preferences.Default`
- **MOD `FilterLibraryServiceCollectionExtensions`** — added `AddLegacyFilterMigration()` extension
- **MOD `Effects.cs`** — `HandleLoadLibrary` extended with migration branch (gated on `legacyMigrator.ShouldRunMigration()` AND empty store); `_migrationGate` SemaphoreSlim added to serialize the load-and-maybe-migrate sequence; ctor extended with `ILegacyFilterMigrator` dep
- **MOD `MauiProgram.cs`** — 2 DI registrations

### Test code (2 new + 1 modified) — 31 net-new tests

- **NEW `LegacyFilterMigratorTests`** (28 tests) — BuildEntriesFromLegacy (13: no-keys/corrupt/mixed-corruption/whitespace-filter/entry-shapes/FilterId-regen/compile-failure/name-truncation), DeleteLegacyData (5: per-flag combinations), ShouldRunMigration (6: absent/non-integer/negative/missing-Favorites/missing-Groups/both-present), MarkMigrationCompleted (2: full-bitmask + partial)
- **MOD `FilterLibraryEffectsTests`** — added `CreateEffectsWithMigrator` helper (existing 52 `CreateEffects` callers unchanged) + 13 migration-branch tests (no-legacy / non-empty-store-skips / migrator-returns-entries / empty-result / AddRange-throws / post-reload-throws-fallback / concurrent-build-once / build-throws-gate-released / Started-before-gate ordering / etc.)
- **NEW `FilterLibraryMigrationIntegrationTests`** (6 integration tests) — end-to-end migration with real `FilterLibrarySqliteStore`; concurrent dispatches → exactly-once build; AddRange-throws → legacy preserved + no mark-completed; fresh-user-no-legacy → marks Favorites|Groups|Recents + second load skips; corrupt-groups → favorites-only migrate + groups stranded; both-corrupt → store-stays-empty + retries

## Feature flag mechanism

**Preference key**: `"filter-library-migration-sections"` stores `(int)LegacyMigrationSections` as decimal string. Absent/non-numeric/negative/missing-bits = needs migration. Both Favorites + Groups bits set = migration complete, skip branch.

**Mark timing**: `MarkMigrationCompleted` called on SUCCESS code paths only (after `AddRange` succeeded AND post-AddRange `LoadAll` either succeeded or fell back to in-memory). NOT called on `AddRange`-throws (so retry happens next launch). NOT called on initial `LoadAll`-throws (genuine library-load failure surfaces as `LoadLibraryFailureAction`).

**Strip path**: future "strip" commit deletes `ILegacyFilterMigrator` + `LegacyFilterMigrator` + `ILegacyPreferences` + `MauiLegacyPreferencesAdapter` + DI registration + Effects ctor dep + migration branch in `HandleLoadLibrary`. Legacy preference keys + flag key become inert on disk; can optionally be one-time-cleaned in the same commit.

## Behavior matrix

| User state | First load result | Second load behavior |
|---|---|---|
| Fresh install (no legacy keys) | Migrate 0 entries; mark `Favorites \| Groups \| Recents` | Skip (`ShouldRunMigration=false`) |
| Both keys valid | Migrate all entries; mark `Favorites \| Groups \| Recents` | Skip |
| Favorites valid, groups corrupt | Migrate favorites; mark `Favorites \| Recents` | Skip (`entries.IsEmpty=false`). **Groups stranded.** |
| Favorites corrupt, groups valid | Migrate groups; mark `Groups \| Recents` | Skip. **Favorites stranded.** |
| Both keys corrupt | Migrate 0; mark `Recents` only | Retry every launch until either parseable or strip commit |

## Accepted limitations

1. **Partial-corruption stranding**: if one legacy section parses successfully and persists entries while the other section's JSON is corrupt, the corrupt section stays in legacy preferences forever (the `entries.IsEmpty` guard prevents future migration once any data is persisted). Recovery: manual `Preferences.Default` hand-edit OR wait for the strip commit. Mitigated by: legacy keys preserved (never deleted in Commit D), so power users can recover.
2. **Downgrade-then-upgrade**: user installs v1 with old UI → upgrades to v2 (migration runs) → downgrades back to v1 → adds new favorites/groups via old UI → re-upgrades to v2 → new legacy data stranded (flag already set, store non-empty). Same recovery paths.
3. **`IsLoading` state flicker on concurrent loads**: two simultaneous `LoadLibrary` dispatches both dispatch `LoadLibraryStartedAction` before contending on the `_migrationGate`. UI uses `IsLoaded`/`LoadError` for the modal re-open guard (NOT `IsLoading`), so functionally invisible.
4. **Log-message-only exception capture**: `logger.Warning($"... {ex.Message}")` uses interpolation instead of structured exception logging. Matches existing project `ITraceLogger` shape (interface accepts only string).

## Race-fix architecture (preserved from PR #560 design)

- **Migration serialization**: `_migrationGate` SemaphoreSlim (private field on `Effects`, registered Scoped by Fluxor's standard Blazor extension; one instance per Blazor circuit in MAUI Blazor) serializes the load-and-maybe-migrate sequence. Second concurrent caller waits, then sees post-migration non-empty store and skips the migration branch entirely.
- **Atomic batch insert**: `IFilterLibraryStore.AddRange` (added in PR #560 LPA commit) executes the migration inserts in a single SQLite transaction. Rollback on any per-row failure preserves the legacy preferences for next-launch retry.

## Verification

- Build: 0 warnings, 0 errors on full `EventLogExpert.slnx`
- Tests: **1160 Runtime unit** (+11 vs v3 baseline 1149) + **164 Runtime integration** (+3 vs 161) — all green
- Other test projects (Provider 35, Provider.Database 43+35IT, Eventing 230+303IT, Filtering 869, DatabaseTools.IT 31, EventDbTool 8, UI 412) — unchanged baselines, all green

## Process discipline

- 4 rubber-duck iteration rounds (v4.0 → v4.3) caught 4 real bugs before implementation: Commit G cleanup info loss → bitmask persistence; "empty result" vs "successful parseable empty" conflation → absent-key fix; helper substitute default false → helper returns true; partial-success retry guarded by store-empty check → accepted as documented limitation
- 2 multi-model panel rounds: v3 unanimous READY across Opus 4.7 + GPT-5.5 + GPT-5.4 + GPT-5.3-Codex (artifact-hash `44aeb5b306b0`); v4.3 unanimous READY across same slate (artifact-hash `9aee44c76717`) with 5 minor findings folded in (`using System.Globalization`, reject-negative-bitmask, post-reload-throw-still-marks test, etc.)
- §0 git gate compliance: PRE-GIT SENTINEL emitted, ask_user × 3 (diff approval / commit message / push approval), PRE-COMMIT GATE PASSED with full `core_rules_acknowledged` block (45 HIGH-tier slugs)