### PR TITLE
Add Explorer context menu for evtx files and folders

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,10 @@
         <PackageVersion Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
         <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
         <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
+        <!-- Pinned to the version transitively resolved through Microsoft.Maui.Controls (per
+             dotnet list package, include-transitive) so the ExplorerExtension companion exe and
+             the MAUI head share a single Microsoft.WindowsAppSDK version. -->
+        <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.7.250909003" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
         <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />

--- a/EventLogExpert.slnx
+++ b/EventLogExpert.slnx
@@ -22,9 +22,19 @@
     <Project Path="src/EventLogExpert.Filtering/EventLogExpert.Filtering.csproj" />
     <Project Path="src/EventLogExpert.Provider.Database/EventLogExpert.Provider.Database.csproj" />
     <Project Path="src/EventLogExpert.DatabaseTools/EventLogExpert.DatabaseTools.csproj" />
+    <Project Path="src/EventLogExpert.WindowsPlatform/EventLogExpert.WindowsPlatform.csproj" />
+    <!--
+      Native C++/WinRT shell extension is NOT in the slnx because dotnet build cannot process
+      .vcxproj (the .NET SDK MSBuild lacks $(VCTargetsPath)). It's built indirectly by the
+      EventLogExpert csproj's BuildExplorerExtensionNative target via VS MSBuild during MSIX
+      packaging. Open it in Visual Studio manually if you need to edit the C++ project file.
+
+      Project at: src/EventLogExpert.ExplorerExtensionNative/EventLogExpert.ExplorerExtensionNative.vcxproj
+    -->
   </Folder>
   <Folder Name="/tests/Unit/">
     <Project Path="tests/Unit/EventLogExpert.UI.Tests/EventLogExpert.UI.Tests.csproj" />
+    <Project Path="tests/Unit/EventLogExpert.Windows.Tests/EventLogExpert.Windows.Tests.csproj" />
     <Project Path="tests/Unit/EventLogExpert.EventDbTool.Tests/EventLogExpert.EventDbTool.Tests.csproj" />
     <Project Path="tests/Unit/EventLogExpert.Eventing.Tests/EventLogExpert.Eventing.Tests.csproj" />
     <Project Path="tests/Unit/EventLogExpert.Runtime.Tests/EventLogExpert.Runtime.Tests.csproj" />

--- a/docs/Explorer-Context-Menu.md
+++ b/docs/Explorer-Context-Menu.md
@@ -1,0 +1,124 @@
+# Explorer context menu — install + smoke recipe
+
+EventLogExpert's MSIX package registers three Windows Explorer right-click context menu entries:
+
+| Right-click target | Verb | Surface | Implementation |
+|---|---|---|---|
+| `.evtx` file (single or multi-select) | **Open with EventLogExpert** | Top-level Win11 modern menu (via `desktop4:fileExplorerContextMenus` + `IExplorerCommand`) AND `Open With` submenu (via FTA `uap3:Verb`) | Native C++/WinRT shell extension DLL + MAUI activation pipeline |
+| Folder icon | **Open with EventLogExpert** | Top-level Win11 modern menu (via `desktop5:ItemType Type="Directory"`) | Same native DLL filters `Directory` items + spawns the main exe with the folder path |
+| Empty space inside an open folder | **Open with EventLogExpert** | Top-level Win11 modern menu (via `desktop5:ItemType Type="Directory\Background"`) | Same native DLL, same handler |
+
+Single-instance activation is handled by `Microsoft.Windows.AppLifecycle.AppInstance.FindOrRegisterForKey`, wired in a handwritten WinUI `Main` (`src/EventLogExpert/Platforms/Windows/Program.cs`) so secondary launches route activation args to the running primary instance via the `ActivationDispatcher` channel. Multi-select fans into a single combined view.
+
+## Architecture
+
+The shell extension is a **native C++/WinRT DLL** (`src/EventLogExpert.ExplorerExtensionNative/`), packaged at the MSIX root as `EventLogExpert.ExplorerExtension.dll` and loaded by `dllhost.exe` via the manifest's `<com:SurrogateServer>` registration. A native DLL is required: Explorer activates context-menu COM handlers via `CLSCTX_INPROC_HANDLER` (in-process surrogate), not `CLSCTX_LOCAL_SERVER` (standalone exe).
+
+The `IExplorerCommand` implementation:
+- `GetTitle` → `"Open with EventLogExpert"`
+- `GetIcon` → main exe path (Explorer picks the embedded default icon resource)
+- `GetState` → `ECS_ENABLED` only when the selection contains at least one `.evtx` file or directory; otherwise `ECS_HIDDEN`. Required because the manifest registers `Type="*"` (every file); without filtering the verb would appear on every right-click in Explorer. The fast path uses `IShellItem::GetAttributes(SFGAO_FOLDER)` and path extension only — no filesystem syscalls during menu construction. When `okToBeSlow` is FALSE on the background-menu surface, the verb is enabled without a folder probe (deferring the `.evtx`-presence check to `Invoke`).
+- `Invoke` → `CreateProcessW` of the sibling `eventlogexpert.exe` with each selected `.evtx` file / directory passed as a quoted argument. Folders are pre-filtered for at least one `.evtx` child to avoid a flash of empty app window.
+- `IObjectWithSite::SetSite` → stores the shell-supplied site so the `Directory\Background` surface (right-click inside an open folder's empty space) can resolve the current folder via `QueryService(SID_SFolderView, IFolderView)` → `IPersistFolder2::GetCurFolder` → `SHGetPathFromIDListEx` (32K wstring buffer + `GPFIDL_DEFAULT`, long-path-safe — the legacy `SHGetPathFromIDListW` caps at `MAX_PATH` regardless of process long-path awareness). Required because the shell passes `items == null` for that surface.
+
+The MAUI receiving side:
+- `Program.Main` runs before `Application.Start`, calls `AppInstance.FindOrRegisterForKey("eventlogexpert-main")`. Secondary instances redirect their activation args to the primary and exit.
+- `ActivationBootstrap` (thread-safe static buffer) seeds cold-launch args BEFORE MAUI DI is built, so they're not lost when `MainPage` is constructed.
+- `ActivationDispatcher` (channel + `Interlocked` idempotent start) drains the buffer + listens for redirected `AppInstance.Activated` events. UI work is marshaled via `MainThread.InvokeOnMainThreadAsync`.
+- `ActivationArgsExtractor` discriminates per `ExtendedActivationKind`: `File` → `IFileActivatedEventArgs.Files`, `Launch` → `ILaunchActivatedEventArgs.Arguments` parsed via `CommandLineToArgvW`, `CommandLineLaunch` → `ICommandLineActivatedEventArgs.Operation.Arguments`. Tokens are classified via `ActivationTokenClassifier` (in `EventLogExpert.WindowsPlatform`) — only `.evtx`-extension files and existing directories are accepted, so the launching exe path (`argv[0]` from the shell extension's `CreateProcess` spawn) is silently dropped instead of being treated as a log to open.
+
+## Build prerequisites
+
+The native shell extension requires the **MSVC C++ workload** + the **Windows 10/11 SDK 10.0.26100+** to build. Specifically:
+
+- Visual Studio 2026 (or 2022) with the **Desktop development with C++** workload
+- Windows SDK 10.0.26100.0 or newer (the C++/WinRT projection headers shipped with this SDK)
+- `nuget.exe` on PATH. Install via `winget install Microsoft.NuGet` (dev), the `NuGetToolInstaller@1` pipeline task (ADO), or any equivalent. The `BuildExplorerExtensionNative` MSBuild target fails fast with an actionable error if not found — there is no auto-download (removed to eliminate supply-chain risk from the moving `latest` URL).
+
+`dotnet build` of the .NET solution alone does NOT exercise the C++ build — the C++ project is intentionally not in `EventLogExpert.slnx` because the .NET SDK MSBuild doesn't include `$(VCTargetsPath)`. The native build is triggered only during MSIX packaging (`/p:WindowsPackageType=MSIX`) by the `BuildExplorerExtensionNative` MSBuild target in `src/EventLogExpert/EventLogExpert.csproj`, which locates VS MSBuild via `vswhere` and invokes the vcxproj.
+
+### One-time NuGet restore
+
+After cloning, restore the C++ project's packages once:
+
+```powershell
+cd src/EventLogExpert.ExplorerExtensionNative
+nuget restore packages.config -PackagesDirectory ..\packages
+```
+
+This populates `src/packages/Microsoft.Windows.CppWinRT.*` and `src/packages/Microsoft.Windows.ImplementationLibrary.*` (WIL). Both are gitignored.
+
+## Local dev install (signed MSIX)
+
+Loose-file deploy (`Add-AppxPackage -Register AppxManifest.xml`) leaves the package with `SignatureKind=None`, which silently drops the COM server + context menu extension registrations. **Use the signed-MSIX install path** for any local testing of the context menu surface.
+
+A one-shot installation script is at `eng/install-signed-dev-msix.ps1` — run from an ELEVATED PowerShell. To replicate manually:
+
+```powershell
+# 1. Generate a self-signed dev cert matching the manifest's Publisher
+$publisher = "CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
+$cert = New-SelfSignedCertificate -Type Custom -Subject $publisher `
+  -KeyUsage DigitalSignature -FriendlyName "EventLogExpert Dev Cert" `
+  -CertStoreLocation "Cert:\CurrentUser\My" `
+  -TextExtension @("2.5.29.37={text}1.3.6.1.5.5.7.3.3","2.5.29.19={text}")
+
+# 2. Export + trust in LocalMachine\Root (requires elevation; needed for Add-AppxPackage of dev MSIX)
+$pwd = ConvertTo-SecureString "elx-dev-cert" -Force -AsPlainText
+$pfx = "$env:TEMP\eventlogexpert-dev.pfx"
+Export-PfxCertificate -Cert "Cert:\CurrentUser\My\$($cert.Thumbprint)" -FilePath $pfx -Password $pwd | Out-Null
+$rootStore = New-Object System.Security.Cryptography.X509Certificates.X509Store("Root", "LocalMachine")
+$rootStore.Open("ReadWrite"); $rootStore.Add($cert); $rootStore.Close()
+
+# 3. Build + sign MSIX
+dotnet publish src/EventLogExpert -c Debug `
+  /p:GenerateAppxPackageOnBuild=true /p:AppxPackageSigningEnabled=false /p:WindowsPackageType=MSIX
+& "C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe" `
+  sign /fd SHA256 /a /f $pfx /p "elx-dev-cert" `
+  "src/EventLogExpert/bin/Debug/net10.0-windows10.0.19041.0/win-x64/AppPackages/EventLogExpert_0.9.0.0_Debug_Test/EventLogExpert_0.9.0.0_x64_Debug.msix"
+
+# 4. Install
+Add-AppxPackage -Path "src/EventLogExpert/bin/Debug/.../EventLogExpert_0.9.0.0_x64_Debug.msix"
+```
+
+## Smoke recipe
+
+Run after any change touching the manifest, the activation pipeline, the native shell extension DLL, or `MauiMenuActionService.OpenFolderAsync`. Automated tests cover manifest structural invariants (`ManifestSchemaTests`), folder enumeration (`EvtxFolderEnumeratorTests`), CLI parsing (`CommandLineToArgvWHelperTests`), and token classification (`ActivationTokenClassifierTests`) but cannot verify Explorer integration end-to-end.
+
+**Prerequisites:**
+- Windows 11 (the only target — Win10 dropped per scope decision since OOS in Oct 2025).
+- The signed MSIX installed per above; cert trusted in `LocalMachine\Root`.
+- A folder containing 2+ `.evtx` files plus a folder containing no `.evtx` files.
+
+**Scenarios:**
+
+1. **FTA single-file double-click (regression gate)** — Double-click a `.evtx` in Explorer. EventLogExpert launches and loads the file. **Required to pass** — the activation refactor changes how all FTA opens flow.
+2. **Single-file right-click** — Right-click one `.evtx` → "Open with EventLogExpert" at top level → app opens with the file.
+3. **Multi-file right-click** — Select 3–5 `.evtx` files → "Open with EventLogExpert" → **one** app instance opens with all files combined.
+4. **Secondary activation redirect** — With app already running, right-click another `.evtx` → existing window receives the file (no new window).
+5. **Folder icon right-click** — Folder with `.evtx` files → "Open with EventLogExpert" → all top-level `.evtx` open in one app instance.
+6. **Folder background right-click** — Open a folder containing `.evtx` files, right-click in the empty space inside it → "Open with EventLogExpert" → all top-level `.evtx` open in one app instance. This surface relies on `IObjectWithSite` recovering the folder from the shell view; if it fails, the verb is silently absent.
+7. **Empty folder right-click** — Folder with no `.evtx` → verb still appears (filtering happens lazily) → click → silent no-op (native DLL pre-filters via `Directory.EnumerateFiles(*.evtx).Any()` before spawning).
+
+## Diagnostics
+
+- **Folder verb missing after upgrade install** → restart Explorer: `Stop-Process -Id (Get-Process explorer).Id -Force; Start-Process explorer`. Required to refresh the COM extension catalog.
+- **Verb shows but click does nothing** → check **Event Viewer → Windows Logs → Application** for COM activation failures matching the verb's CLSID (`F1B2C3D4-E5F6-4789-AB12-CD34EF567890`). Verify the package is `SignatureKind=Developer` or `Store`, not `None` (loose-file register doesn't activate the COM extensions).
+- **Verb missing entirely** → verify the manifest registration is intact:
+  ```powershell
+  (Get-AppxPackageManifest -Package "EventLogExpert_0.9.0.0_x64__8wekyb3d8bbwe").Package.Applications.Application.Extensions.Extension | Select-Object Category
+  # Should list: windows.appExecutionAlias, windows.fileTypeAssociation, windows.fileExplorerContextMenus, windows.comServer
+  ```
+  And the COM class:
+  ```powershell
+  reg query "HKCR\PackagedCom\Package\EventLogExpert_0.9.0.0_x64__8wekyb3d8bbwe\Class\{F1B2C3D4-E5F6-4789-AB12-CD34EF567890}"
+  # Should show DllPath = EventLogExpert.ExplorerExtension.dll, Threading = 0
+  ```
+- **"Failed to open Log" dialog on launch** → the activation pipeline tried to open a non-`.evtx` token as a log. Should not happen (filtered in `ActivationTokenClassifier` + regression-tested), but if seen, check `%LOCALAPPDATA%\Packages\EventLogExpert_8wekyb3d8bbwe\LocalState\debug.log` for which path triggered `HandleOpenLog`.
+
+## CLSID immutability
+
+The verb's CLSID is `F1B2C3D4-E5F6-4789-AB12-CD34EF567890`. It is **immutable across releases** — changing it orphans Explorer's COM catalog from prior installations. The CLSID appears in three places that MUST stay in sync:
+
+1. `src/EventLogExpert.ExplorerExtensionNative/dllmain.cpp` — `CLSID_UUID` macro + `kCanonical` constant
+2. `src/EventLogExpert/Platforms/Windows/Package.appxmanifest` — `<com:Class Id=...>` + both `<desktop4:Verb Clsid=...>` / `<desktop5:Verb Clsid=...>`
+3. `tests/Unit/EventLogExpert.Windows.Tests/ManifestSchemaTests.cs` — `OpenEvtxCommandClsid` constant; the tests fail on mismatch.

--- a/docs/Opening-Logs.md
+++ b/docs/Opening-Logs.md
@@ -6,6 +6,13 @@ The `File` menu is the primary entry point for opening logs. There are three sou
 
 `.evtx` files can also be opened by drag-and-drop onto the window or by passing them as command-line arguments at launch. Both routes always combine — they add to the current log set rather than replacing it.
 
+### Explorer right-click context menu
+
+If EventLogExpert is installed as the packaged (MSIX) app, two right-click context menu entries are registered with Windows Explorer:
+
+- **`.evtx` files** → `Open with EventLogExpert` appears as a top-level right-click verb. Selecting one or more `.evtx` files and invoking the verb opens them all in a single EventLogExpert window (combined view). If the app is already running, the selected files are routed to the existing window instead of launching a new instance.
+- **Folders** → `Open with EventLogExpert` opens every `.evtx` file in the right-clicked folder (top-level only, no recursion — same semantic as `File` → `Open` → `Folder`). The verb appears both on a folder icon's right-click AND when right-clicking inside an open folder's empty space (the *Directory\\Background* item type, same pattern Windows Terminal uses for "Open in Terminal"). The folder verb is implemented via a packaged COM Explorer extension and may require an Explorer restart after first install for the entry to surface. If the folder contains no `.evtx` files, invoking the verb is a no-op.
+
 ### File
 
 `File` → `Open` → `File` (`Ctrl+O`) opens the system file picker filtered to `.evtx`. Pick one file or many — every selected `.evtx` is loaded concurrently as a separate log. The same applies for `File` → `Combine` → `File`, which adds the picked files to the existing log set.

--- a/eng/install-signed-dev-msix.ps1
+++ b/eng/install-signed-dev-msix.ps1
@@ -1,0 +1,51 @@
+# EventLogExpert dev install — run from an ELEVATED PowerShell.
+# Trusts the dev signing cert in LocalMachine\Root and installs the signed MSIX so packaged
+# COM + Explorer context menu extensions register with the shell. Loose-file
+# Add-AppxPackage -Register leaves SignatureKind=None which silently drops those extensions.
+
+[CmdletBinding()]
+param(
+    [string]$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path,
+    [string]$PfxPath = "$env:TEMP\eventlogexpert-dev.pfx",
+    [string]$Configuration = 'Debug',
+    [string]$PfxPassword = 'elx-dev-cert'
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Error "This script must run from an ELEVATED PowerShell (right-click PowerShell -> Run as administrator)."
+    exit 1
+}
+
+$msix = Join-Path $RepoRoot "src\EventLogExpert\bin\$Configuration\net10.0-windows10.0.19041.0\win-x64\AppPackages\EventLogExpert_0.9.0.0_${Configuration}_Test\EventLogExpert_0.9.0.0_x64_${Configuration}.msix"
+$pwd = ConvertTo-SecureString -String $PfxPassword -Force -AsPlainText
+
+if (-not (Test-Path $PfxPath)) {
+    Write-Error "Dev cert not found at $PfxPath. Generate one per docs/Explorer-Context-Menu.md (Local dev install section)."
+    exit 1
+}
+if (-not (Test-Path $msix)) {
+    Write-Error "Signed MSIX not found at $msix. Run 'dotnet publish src/EventLogExpert -c $Configuration /p:GenerateAppxPackageOnBuild=true /p:WindowsPackageType=MSIX' + signtool sign first."
+    exit 1
+}
+
+Write-Host "[1/3] Trusting dev cert in LocalMachine\Root..."
+$cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($PfxPath, $pwd, "Exportable")
+$rootStore = New-Object System.Security.Cryptography.X509Certificates.X509Store("Root", "LocalMachine")
+$rootStore.Open("ReadWrite")
+$rootStore.Add($cert)
+$rootStore.Close()
+Write-Host "   Trusted: $($cert.Thumbprint)"
+
+Write-Host "[2/3] Removing previous install (if any)..."
+Get-AppxPackage -Name "EventLogExpert" -ErrorAction SilentlyContinue | Remove-AppxPackage -ErrorAction SilentlyContinue
+Get-AppxPackage -Name "EventLogExpert" -AllUsers -ErrorAction SilentlyContinue | ForEach-Object { Remove-AppxPackage -AllUsers -Package $_.PackageFullName -ErrorAction SilentlyContinue }
+
+Write-Host "[3/3] Installing signed MSIX..."
+Add-AppxPackage -Path $msix -ForceApplicationShutdown
+$installed = Get-AppxPackage -Name "EventLogExpert"
+Write-Host "   Installed: $($installed.PackageFullName)  SignatureKind=$($installed.SignatureKind)  Status=$($installed.Status)"
+
+Write-Host "[done] Restart Explorer to refresh the COM context-menu catalog:"
+Write-Host "   Stop-Process -Name explorer -Force; Start-Process explorer"

--- a/src/EventLogExpert.ExplorerExtensionNative/EventLogExpert.ExplorerExtensionNative.vcxproj
+++ b/src/EventLogExpert.ExplorerExtensionNative/EventLogExpert.ExplorerExtensionNative.vcxproj
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+    Explorer context menu shell extension (native C++/WinRT DLL) loaded by dllhost.exe via the
+    <com:SurrogateServer> registration in Package.appxmanifest. Output is renamed via TargetName
+    so the manifest's <com:Class Path="EventLogExpert.ExplorerExtension.dll" ...> stays accurate.
+    Build prereqs are documented in docs/Explorer-Context-Menu.md.
+  -->
+  <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{B9D2A1F3-8C47-4E2D-9F5B-6A1E2C3D4E5F}</ProjectGuid>
+    <RootNamespace>EventLogExpertExplorerExtension</RootNamespace>
+    <TargetName>EventLogExpert.ExplorerExtension</TargetName>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <!-- $(DefaultPlatformToolset) is set by Microsoft.Cpp.Default.props to the toolset shipped
+         with the calling VS (v143 on VS 2022, v145 on VS 2026). This avoids hard-coding either
+         and lets the project build on any VS 2022+ environment, including hosted runners. -->
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <!-- Spectre mitigation requires the Spectre-mitigated runtime libs to be installed in the VS
+         workload. Disabled to keep the C++ build dependency footprint minimal — shell extensions
+         load briefly from dllhost.exe and aren't a typical Spectre-sensitive surface. -->
+  </PropertyGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+
+  <PropertyGroup Label="UserMacros" />
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <IncludePath>$(IntDir)Generated Files;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <IncludePath>$(IntDir)Generated Files;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;EVENTLOGEXPERTEXPLOREREXTENSION_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+      <ModuleDefinitionFile>Source.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;EVENTLOGEXPERTEXPLOREREXTENSION_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+      <ModuleDefinitionFile>Source.def</ModuleDefinitionFile>
+      <CETCompat>true</CETCompat>
+    </Link>
+  </ItemDefinitionGroup>
+
+  <ItemGroup>
+    <ClInclude Include="framework.h" />
+    <ClInclude Include="pch.h" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ClCompile Include="dllmain.cpp" />
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="Source.def" />
+    <None Include="packages.config" />
+  </ItemGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.260126.7\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.260126.7\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them. For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.260126.7\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.260126.7\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
+  </Target>
+</Project>

--- a/src/EventLogExpert.ExplorerExtensionNative/Source.def
+++ b/src/EventLogExpert.ExplorerExtensionNative/Source.def
@@ -1,0 +1,7 @@
+; COM entry points for the surrogate-hosted shell extension.
+
+LIBRARY
+
+EXPORTS
+  DllGetClassObject         PRIVATE
+  DllCanUnloadNow           PRIVATE

--- a/src/EventLogExpert.ExplorerExtensionNative/dllmain.cpp
+++ b/src/EventLogExpert.ExplorerExtensionNative/dllmain.cpp
@@ -1,0 +1,471 @@
+// IExplorerCommand shell extension. Packaged COM in-proc handler loaded by dllhost.exe via
+// <com:SurrogateServer> in Package.appxmanifest; Explorer activates context-menu handlers via
+// CLSCTX_INPROC_HANDLER, so a DLL is required (an EXE COM server is never queried).
+//
+// CLSID below MUST match the manifest <com:Class Id="...">, all desktop4/desktop5 verb Clsid
+// attributes, and the kCanonical literal in GetCanonicalName. Stable across releases.
+
+#include "pch.h"
+
+#define CLSID_UUID "F1B2C3D4-E5F6-4789-AB12-CD34EF567890"
+
+constexpr const wchar_t* menu_entry_title = L"Open with EventLogExpert";
+constexpr const wchar_t* exe_filename = L"eventlogexpert.exe";
+constexpr const wchar_t* evtx_extension = L".evtx";
+
+BOOL APIENTRY DllMain(_In_ HMODULE hModule, _In_ DWORD ul_reason_for_call, _In_opt_ LPVOID lpReserved) {
+    UNREFERENCED_PARAMETER(hModule);
+    UNREFERENCED_PARAMETER(lpReserved);
+    switch (ul_reason_for_call) {
+    case DLL_PROCESS_ATTACH:
+    case DLL_THREAD_ATTACH:
+    case DLL_THREAD_DETACH:
+    case DLL_PROCESS_DETACH:
+        break;
+    }
+    return TRUE;
+}
+
+namespace {
+
+    // CommandLineToArgvW-compatible quoting per
+    // https://learn.microsoft.com/cpp/cpp/main-function-command-line-args#parsing-c-command-line-arguments.
+    std::wstring QuoteForCommandLineArg(_In_ const std::wstring& arg) {
+        // Includes ASCII whitespace beyond plain space — CreateProcessW splits on tab/CR/LF too.
+        const std::wstring quotable_chars(L" \t\r\n\\\"");
+
+        if (arg.find_first_of(quotable_chars) == std::wstring::npos) {
+            return arg;
+        }
+
+        std::wstring out;
+        out.push_back('"');
+
+        for (size_t i = 0; i < arg.size(); ++i) {
+            if (arg[i] == '\\') {
+                const size_t start = i;
+                size_t end = start + 1;
+
+                for (; end < arg.size() && arg[end] == '\\'; ++end) {}
+
+                size_t backslash_count = end - start;
+
+                if (end == arg.size() || arg[end] == '"') {
+                    backslash_count *= 2;
+                }
+
+                for (size_t j = 0; j < backslash_count; ++j)
+                    out.push_back('\\');
+
+                i = end - 1;
+            }
+            else if (arg[i] == '"') {
+                out.push_back('\\');
+                out.push_back('"');
+            }
+            else {
+                out.push_back(arg[i]);
+            }
+        }
+        out.push_back('"');
+
+        return out;
+    }
+
+    bool HasEvtxExtension(_In_ const std::wstring& path) noexcept {
+        try {
+            auto ext = std::filesystem::path{path}.extension().wstring();
+
+            if (ext.size() != wcslen(evtx_extension)) return false;
+
+            return _wcsicmp(ext.c_str(), evtx_extension) == 0;
+        }
+        catch (...) {
+            return false;
+        }
+    }
+
+    bool IsDirectoryOnDisk(_In_ const std::wstring& path) noexcept {
+        try {
+            std::error_code ec;
+
+            return std::filesystem::is_directory(path, ec) && !ec;
+        }
+        catch (...) {
+            return false;
+        }
+    }
+
+    // Pre-filter for folder Invoke: skip empty folders (no .evtx children); pass through
+    // enumeration failures so the launched app's alert path runs instead of silently dropping.
+    bool ShouldOpenFolder(_In_ const std::wstring& folder) noexcept {
+        try {
+            if (!std::filesystem::is_directory(folder)) return false;
+
+            bool has_evtx = false;
+            bool enum_ok = true;
+            std::error_code ec;
+            auto begin = std::filesystem::directory_iterator(folder, std::filesystem::directory_options::skip_permission_denied, ec);
+
+            if (ec) {
+                enum_ok = false;
+            } else {
+                for (auto it = begin; it != std::filesystem::directory_iterator(); it.increment(ec)) {
+                    if (ec) { enum_ok = false; break; }
+
+                    if (!it->is_regular_file(ec)) continue;
+
+                    auto ext = it->path().extension().wstring();
+
+                    if (ext.size() == wcslen(evtx_extension) && _wcsicmp(ext.c_str(), evtx_extension) == 0) {
+                        has_evtx = true;
+
+                        break;
+                    }
+                }
+            }
+            // Open ONLY when (a) enumeration succeeded AND found at least one .evtx, OR (b)
+            // enumeration failed (let the receiving app surface its alert).
+            return !enum_ok || has_evtx;
+        }
+        catch (...) {
+            return true;
+        }
+    }
+
+    // wil::GetModuleInstanceHandle returns THIS DLL's module — sibling exe_filename in the same
+    // directory is the install location.
+    std::filesystem::path GetMainExePath() {
+        std::filesystem::path module_path{wil::GetModuleFileNameW<std::wstring>(wil::GetModuleInstanceHandle())};
+        module_path.remove_filename();
+        module_path /= exe_filename;
+
+        return module_path;
+    }
+
+    void StripTrailingSeparators(std::wstring& path) noexcept {
+        // Preserve drive root: "C:\" stays "C:\" instead of becoming the drive-relative "C:".
+        while (!path.empty() && (path.back() == L'\\' || path.back() == L'/')) {
+            if (path.size() == 3 && path[1] == L':') break;
+
+            path.pop_back();
+        }
+    }
+
+} // namespace
+
+struct ExplorerCommandHandler : public winrt::implements<ExplorerCommandHandler, IExplorerCommand, IObjectWithSite> {
+public:
+    // IObjectWithSite — required for Directory\Background context-menu surface where the shell
+    // passes items=null and the handler must recover the current folder via the site's IShellView.
+    IFACEMETHODIMP SetSite(_In_opt_ IUnknown* pUnkSite) noexcept override {
+        // copy_from handles both null (releases site) and same-pointer reassignment safely;
+        // a manual nullptr-then-AddRef pattern would destroy the COM object if pUnkSite holds
+        // the only live reference.
+        m_site.copy_from(pUnkSite);
+
+        return S_OK;
+    }
+
+    IFACEMETHODIMP GetSite(_In_ REFIID riid, _COM_Outptr_ void** ppvSite) noexcept override {
+        if (!ppvSite) return E_POINTER;
+
+        *ppvSite = nullptr;
+
+        if (!m_site) return E_FAIL;
+
+        return m_site->QueryInterface(riid, ppvSite);
+    }
+
+    IFACEMETHODIMP GetTitle(_In_opt_ IShellItemArray* items, _Outptr_ PWSTR* name) override {
+        UNREFERENCED_PARAMETER(items);
+
+        RETURN_HR_IF_NULL(E_POINTER, name);
+        *name = nullptr;
+
+        return SHStrDupW(menu_entry_title, name);
+    }
+
+    IFACEMETHODIMP GetIcon(_In_opt_ IShellItemArray* items, _Outptr_ PWSTR* icon) override {
+        UNREFERENCED_PARAMETER(items);
+
+        RETURN_HR_IF_NULL(E_POINTER, icon);
+        *icon = nullptr;
+
+        auto exe_path = GetMainExePath();
+
+        return SHStrDupW(exe_path.c_str(), icon);
+    }
+
+    IFACEMETHODIMP GetToolTip(_In_opt_ IShellItemArray* items, _Outptr_ PWSTR* infoTip) override {
+        UNREFERENCED_PARAMETER(items);
+
+        RETURN_HR_IF_NULL(E_POINTER, infoTip);
+        *infoTip = nullptr;
+
+        return E_NOTIMPL;
+    }
+
+    IFACEMETHODIMP GetCanonicalName(_Out_ GUID* guidCommandName) override {
+        RETURN_HR_IF_NULL(E_POINTER, guidCommandName);
+
+        // Literal GUID (not __uuidof) because DECLSPEC_UUID is on ClassFactory, not on this type.
+        constexpr GUID kCanonical = {0xF1B2C3D4, 0xE5F6, 0x4789, {0xAB, 0x12, 0xCD, 0x34, 0xEF, 0x56, 0x78, 0x90}};
+        *guidCommandName = kCanonical;
+
+        return S_OK;
+    }
+
+    IFACEMETHODIMP GetState(_In_opt_ IShellItemArray* items, _In_ BOOL okToBeSlow, _Out_ EXPCMDSTATE* cmdState) override {
+        RETURN_HR_IF_NULL(E_POINTER, cmdState);
+
+        // Default hidden: the manifest registers Type="*" so every file right-click invokes us.
+        *cmdState = ECS_HIDDEN;
+
+        if (!items) {
+            // Background-menu surface — recover folder from site.
+            auto folder = GetFolderFromSite();
+
+            if (folder.empty()) return S_OK;
+
+            // Cheap path: enable when fast-render is requested; Invoke does the actual evtx check.
+            if (!okToBeSlow) {
+                *cmdState = ECS_ENABLED;
+
+                return S_OK;
+            }
+
+            if (ShouldOpenFolder(folder)) {
+                *cmdState = ECS_ENABLED;
+            }
+
+            return S_OK;
+        }
+
+        DWORD count = 0;
+        if (FAILED(items->GetCount(&count)) || count == 0) return S_OK;
+
+        for (DWORD i = 0; i < count; ++i) {
+            winrt::com_ptr<IShellItem> item;
+
+            if (FAILED(items->GetItemAt(i, item.put())) || !item) continue;
+
+            // Cheap path: shell-cached folder attribute, no filesystem syscall in typical case.
+            SFGAOF attr = 0;
+            bool isFolder = SUCCEEDED(item->GetAttributes(SFGAO_FOLDER, &attr)) && (attr & SFGAO_FOLDER);
+
+            if (isFolder) {
+                if (!okToBeSlow) {
+                    *cmdState = ECS_ENABLED;
+
+                    return S_OK;
+                }
+                // okToBeSlow=true: probe the folder for at least one .evtx so empty folders don't
+                // light up the verb (consistent with the background-menu surface).
+                wil::unique_cotaskmem_string folderPath;
+
+                if (FAILED(item->GetDisplayName(SIGDN_FILESYSPATH, &folderPath)) || !folderPath) continue;
+
+                if (ShouldOpenFolder(folderPath.get())) {
+                    *cmdState = ECS_ENABLED;
+
+                    return S_OK;
+                }
+                continue;
+            }
+
+            wil::unique_cotaskmem_string path;
+
+            if (FAILED(item->GetDisplayName(SIGDN_FILESYSPATH, &path)) || !path) continue;
+
+            if (HasEvtxExtension(path.get())) {
+                *cmdState = ECS_ENABLED;
+
+                return S_OK;
+            }
+        }
+
+        return S_OK;
+    }
+
+    IFACEMETHODIMP GetFlags(_Out_ EXPCMDFLAGS* flags) override {
+        RETURN_HR_IF_NULL(E_POINTER, flags);
+
+        *flags = ECF_DEFAULT;
+
+        return S_OK;
+    }
+
+    IFACEMETHODIMP EnumSubCommands(_Outptr_ IEnumExplorerCommand** enumCommands) override {
+        RETURN_HR_IF_NULL(E_POINTER, enumCommands);
+
+        *enumCommands = nullptr;
+
+        return E_NOTIMPL;
+    }
+
+    IFACEMETHODIMP Invoke(_In_opt_ IShellItemArray* items, _In_opt_ IBindCtx* bindCtx) override {
+        UNREFERENCED_PARAMETER(bindCtx);
+
+        auto exe_path = GetMainExePath();
+        auto command = wil::str_printf<std::wstring>(L"\"%s\"", exe_path.c_str());
+        bool any_added = false;
+
+        if (!items) {
+            // Background-menu surface — operate on the current folder from the site.
+            auto folder = GetFolderFromSite();
+
+            if (folder.empty()) return S_OK;
+
+            if (!ShouldOpenFolder(folder)) return S_OK;
+
+            std::wstring p{folder};
+            StripTrailingSeparators(p);
+            command = wil::str_printf<std::wstring>(L"%s %s", command.c_str(), QuoteForCommandLineArg(p).c_str());
+            any_added = true;
+        } else {
+            DWORD count = 0;
+
+            RETURN_IF_FAILED(items->GetCount(&count));
+
+            if (count == 0) return S_OK;
+
+            for (DWORD i = 0; i < count; ++i) {
+                winrt::com_ptr<IShellItem> item;
+
+                if (FAILED(items->GetItemAt(i, item.put())) || !item) continue;
+
+                wil::unique_cotaskmem_string path;
+
+                if (FAILED(item->GetDisplayName(SIGDN_FILESYSPATH, &path)) || !path) continue;
+
+                std::wstring p{path.get()};
+                bool is_dir = IsDirectoryOnDisk(p);
+
+                if (!is_dir && !HasEvtxExtension(p)) continue;
+
+                if (is_dir && !ShouldOpenFolder(p)) continue;
+
+                StripTrailingSeparators(p);
+                command = wil::str_printf<std::wstring>(L"%s %s", command.c_str(), QuoteForCommandLineArg(p).c_str());
+                any_added = true;
+            }
+        }
+
+        if (!any_added) return S_OK;
+
+        wil::unique_process_information process_info;
+        STARTUPINFOW startup_info = {sizeof(startup_info)};
+
+        RETURN_IF_WIN32_BOOL_FALSE(CreateProcessW(
+            nullptr,
+            command.data(),
+            nullptr,
+            nullptr,
+            FALSE,
+            CREATE_NO_WINDOW,
+            nullptr,
+            nullptr,
+            &startup_info,
+            &process_info));
+
+        return S_OK;
+    }
+
+private:
+    winrt::com_ptr<IUnknown> m_site;
+
+    // Resolve current folder from the site (Directory\Background surface). Returns empty string
+    // on any failure — caller treats empty as "no folder, do nothing".
+    std::wstring GetFolderFromSite() noexcept {
+        try {
+            if (!m_site) return {};
+
+            winrt::com_ptr<IServiceProvider> sp;
+
+            if (FAILED(m_site->QueryInterface(IID_PPV_ARGS(sp.put())))) return {};
+
+            winrt::com_ptr<IFolderView> folderView;
+
+            if (FAILED(sp->QueryService(SID_SFolderView, IID_PPV_ARGS(folderView.put())))) return {};
+
+            winrt::com_ptr<IPersistFolder2> persistFolder;
+
+            if (FAILED(folderView->GetFolder(IID_PPV_ARGS(persistFolder.put())))) return {};
+
+            // Allocate buffer BEFORE GetCurFolder so a bad_alloc throw cannot leak the PIDL.
+            // 32768 wchars covers the documented Windows absolute max path length (32767 + null).
+            std::wstring buffer(32768, L'\0');
+
+            PIDLIST_ABSOLUTE pidl = nullptr;
+
+            if (FAILED(persistFolder->GetCurFolder(&pidl)) || !pidl) return {};
+
+            // SHGetPathFromIDListEx + GPFIDL_DEFAULT preserves SHGetPathFromIDListW semantics
+            // without the MAX_PATH stack-buffer ceiling.
+            BOOL ok = SHGetPathFromIDListEx(pidl, buffer.data(), static_cast<DWORD>(buffer.size()), GPFIDL_DEFAULT);
+            CoTaskMemFree(pidl);
+
+            if (!ok) return {};
+
+            buffer.resize(wcslen(buffer.c_str()));
+
+            return buffer;
+        }
+        catch (...) {
+            return {};
+        }
+    }
+};
+
+struct DECLSPEC_UUID(CLSID_UUID) ClassFactory : public winrt::implements<ClassFactory, IClassFactory> {
+public:
+    IFACEMETHODIMP CreateInstance(_In_opt_ IUnknown* pUnkOuter, _In_ REFIID riid, _COM_Outptr_ void** ppvObject) noexcept override {
+        if (ppvObject) *ppvObject = nullptr;
+
+        if (pUnkOuter) return CLASS_E_NOAGGREGATION;
+
+        try {
+            return winrt::make<ExplorerCommandHandler>()->QueryInterface(riid, ppvObject);
+        }
+        catch (...) {
+            return winrt::to_hresult();
+        }
+    }
+
+    IFACEMETHODIMP LockServer(_In_ BOOL fLock) noexcept override {
+        if (fLock)
+            ++winrt::get_module_lock();
+        else
+            --winrt::get_module_lock();
+        return S_OK;
+    }
+};
+
+_Check_return_
+STDAPI DllGetClassObject(_In_ REFCLSID rclsid, _In_ REFIID riid, _Outptr_ LPVOID* ppv) {
+    if (ppv == nullptr) return E_POINTER;
+
+    *ppv = nullptr;
+
+    if (rclsid != __uuidof(ClassFactory)) return CLASS_E_CLASSNOTAVAILABLE;
+
+    if (riid != IID_IClassFactory && riid != IID_IUnknown) return E_NOINTERFACE;
+
+    try {
+        return winrt::make<ClassFactory>()->QueryInterface(riid, ppv);
+    }
+    catch (...) {
+        return winrt::to_hresult();
+    }
+}
+
+__control_entrypoint(DllExport)
+STDAPI DllCanUnloadNow(void) {
+    if (winrt::get_module_lock())
+        return S_FALSE;
+
+    winrt::clear_factory_cache();
+
+    return S_OK;
+}

--- a/src/EventLogExpert.ExplorerExtensionNative/framework.h
+++ b/src/EventLogExpert.ExplorerExtensionNative/framework.h
@@ -1,0 +1,7 @@
+#ifndef FRAMEWORK_H
+#define FRAMEWORK_H
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#endif //FRAMEWORK_H

--- a/src/EventLogExpert.ExplorerExtensionNative/packages.config
+++ b/src/EventLogExpert.ExplorerExtensionNative/packages.config
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.250303.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.260126.7" targetFramework="native" />
+</packages>

--- a/src/EventLogExpert.ExplorerExtensionNative/pch.cpp
+++ b/src/EventLogExpert.ExplorerExtensionNative/pch.cpp
@@ -1,0 +1,1 @@
+#include "pch.h"

--- a/src/EventLogExpert.ExplorerExtensionNative/pch.h
+++ b/src/EventLogExpert.ExplorerExtensionNative/pch.h
@@ -1,0 +1,24 @@
+#ifndef PCH_H
+#define PCH_H
+
+#include "framework.h"
+
+#include <filesystem>
+#include <string>
+
+#include <shlobj_core.h>
+#include <shlwapi.h>
+#include <ocidl.h>
+#include <servprov.h>
+#pragma comment(lib, "shlwapi.lib")
+
+#include <winrt/Windows.Foundation.Collections.h>
+
+#pragma warning(push)
+// WIL workaround per https://github.com/microsoft/wil/issues/610.
+#pragma warning(disable: 28182)
+#include <wil/stl.h>
+#include <wil/win32_helpers.h>
+#pragma warning(pop)
+
+#endif //PCH_H

--- a/src/EventLogExpert.Runtime/Common/Activation/ActivationArgs.cs
+++ b/src/EventLogExpert.Runtime/Common/Activation/ActivationArgs.cs
@@ -1,0 +1,19 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Common.Activation;
+
+/// <summary>
+///     Normalized result of inspecting a Windows app activation. <see cref="FilePaths" /> contains paths the producer
+///     verified at construction time as pointing at existing <c>.evtx</c> files; <see cref="FolderPaths" /> contains paths
+///     the producer verified at construction time as pointing at existing directories. Producers SHOULD drop nonexistent
+///     or inaccessible paths before construction (best-effort filtering), but consumers MUST still handle paths that
+///     became missing, locked, or otherwise inaccessible AFTER construction — the verification is point-in-time, not a
+///     live guarantee, and a TOCTOU window exists between producer-check and dispatcher-use.
+/// </summary>
+public sealed record ActivationArgs(IReadOnlyList<string> FilePaths, IReadOnlyList<string> FolderPaths)
+{
+    public static ActivationArgs Empty { get; } = new([], []);
+
+    public bool IsEmpty => FilePaths.Count == 0 && FolderPaths.Count == 0;
+}

--- a/src/EventLogExpert.Runtime/Common/Activation/IActivationDispatcher.cs
+++ b/src/EventLogExpert.Runtime/Common/Activation/IActivationDispatcher.cs
@@ -1,0 +1,21 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+
+namespace EventLogExpert.Runtime.Common.Activation;
+
+/// <summary>
+///     Buffers Windows shell activation requests (cold-launch, redirected secondary-instance, folder right-click) so
+///     first-activation args delivered before the UI consumer attaches are not lost. <see cref="StartConsumingAsync" /> is
+///     idempotent (guarded by <see cref="Interlocked" />) — safe to call from both <c>MainPage</c>'s constructor and
+///     <c>BlazorWebViewInitialized</c> so a missing WebView2 runtime does not strand buffered args.
+/// </summary>
+public interface IActivationDispatcher
+{
+    void Enqueue(ActivationArgs args);
+
+    Task StartConsumingAsync(
+        Func<IEnumerable<(string Path, LogPathType Type)>, bool, Task> openBatch,
+        CancellationToken cancellationToken);
+}

--- a/src/EventLogExpert.WindowsPlatform/ActivationDispatcher.cs
+++ b/src/EventLogExpert.WindowsPlatform/ActivationDispatcher.cs
@@ -1,0 +1,146 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.Alerts;
+using EventLogExpert.Runtime.Common.Activation;
+using EventLogExpert.Runtime.Common.Threading;
+using System.Threading.Channels;
+
+namespace EventLogExpert.WindowsPlatform;
+
+/// <summary>
+///     Owns a single-reader <see cref="Channel{T}" /> that serializes activation requests so concurrent right-clicks
+///     never interleave open-batch calls. Folder expansion happens off the UI thread; the batch open is marshaled back to
+///     the UI thread via <see cref="IMainThreadService.InvokeOnMainThreadAsync(Func{Task})" />.
+/// </summary>
+public sealed class ActivationDispatcher : IActivationDispatcher
+{
+    private readonly Channel<ActivationArgs> _channel;
+    private readonly IAlertDialogService _dialogService;
+    private readonly ITraceLogger _logger;
+    private readonly IMainThreadService _mainThread;
+
+    private int _started;
+
+    public ActivationDispatcher(IAlertDialogService dialogService, ITraceLogger logger, IMainThreadService mainThread)
+        : this(dialogService, logger, mainThread, channel: null) { }
+
+    internal ActivationDispatcher(
+        IAlertDialogService dialogService,
+        ITraceLogger logger,
+        IMainThreadService mainThread,
+        Channel<ActivationArgs>? channel)
+    {
+        ArgumentNullException.ThrowIfNull(dialogService);
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(mainThread);
+
+        _dialogService = dialogService;
+        _logger = logger;
+        _mainThread = mainThread;
+        _channel = channel ?? Channel.CreateUnbounded<ActivationArgs>(
+            new UnboundedChannelOptions { SingleReader = true });
+    }
+
+    public void Enqueue(ActivationArgs args)
+    {
+        if (args.IsEmpty) { return; }
+
+        if (!_channel.Writer.TryWrite(args))
+        {
+            _logger.Warning($"Activation args dropped: channel write rejected (writer completed). Files={args.FilePaths.Count}, Folders={args.FolderPaths.Count}");
+        }
+    }
+
+    public async Task StartConsumingAsync(
+        Func<IEnumerable<(string Path, LogPathType Type)>, bool, Task> openBatch,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(openBatch);
+
+        // Guard against duplicate subscriptions — MainPage subscribes from two places.
+        if (Interlocked.Exchange(ref _started, 1) == 1) { return; }
+
+        try
+        {
+            await foreach (var args in _channel.Reader.ReadAllAsync(cancellationToken))
+            {
+                try
+                {
+                    await ProcessBatchAsync(args, openBatch, cancellationToken);
+                }
+                // Cancellation during a batch is a clean shutdown, not a dispatch error — re-throw
+                // so the outer await-foreach loop exits via its own OperationCanceledException catch.
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    _logger.Error($"Activation dispatch failed: {ex}");
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+    }
+
+    private static (List<(string Path, LogPathType Type)> Paths, List<(string Title, string Message)> Alerts) ExpandToOpenList(ActivationArgs args)
+    {
+        var paths = new List<(string, LogPathType)>(args.FilePaths.Count + (args.FolderPaths.Count * 4));
+        var alerts = new List<(string, string)>();
+
+        foreach (var file in args.FilePaths)
+        {
+            paths.Add((file, LogPathType.File));
+        }
+
+        foreach (var folder in args.FolderPaths)
+        {
+            var result = EvtxFolderEnumerator.EnumerateEvtxTopLevel(folder);
+
+            if (result is EvtxEnumerationResult.Success success)
+            {
+                paths.AddRange(success.Files.Select(f => (f, LogPathType.File)));
+            }
+
+            var alertCopy = EvtxFolderEnumerator.ToAlertCopy(result);
+
+            if (alertCopy is { } copy)
+            {
+                alerts.Add(copy);
+            }
+        }
+
+        return (paths, alerts);
+    }
+
+    private async Task ProcessBatchAsync(
+        ActivationArgs args,
+        Func<IEnumerable<(string Path, LogPathType Type)>, bool, Task> openBatch,
+        CancellationToken cancellationToken)
+    {
+        // Pass the token to Task.Run so cancellation BEFORE the work starts short-circuits without
+        // running ExpandToOpenList (which does filesystem I/O for folder paths).
+        var (paths, alerts) = await Task.Run(() => ExpandToOpenList(args), cancellationToken);
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        foreach (var (title, message) in alerts)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await _mainThread.InvokeOnMainThreadAsync(() =>
+                _dialogService.ShowAlert(title, message, "Ok"));
+        }
+
+        if (paths.Count == 0) { return; }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        const bool CombineLog = true;
+        await _mainThread.InvokeOnMainThreadAsync(() => openBatch(paths, CombineLog));
+    }
+}

--- a/src/EventLogExpert.WindowsPlatform/ActivationTokenClassifier.cs
+++ b/src/EventLogExpert.WindowsPlatform/ActivationTokenClassifier.cs
@@ -1,0 +1,57 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.WindowsPlatform;
+
+public static class ActivationTokenClassifier
+{
+    /// <summary>
+    ///     Splits <paramref name="tokens" /> into <c>.evtx</c> files and folders.
+    ///     <list type="bullet">
+    ///         <item>Tokens that pass neither <paramref name="fileExists" /> nor <paramref name="dirExists" /> are dropped.</item>
+    ///         <item>Existing files whose extension is not <c>.evtx</c> (case-insensitive) are dropped.</item>
+    ///         <item>Whitespace and <c>null</c> tokens are dropped.</item>
+    ///         <item>Per-token filesystem-probe exceptions are caught and the token is dropped.</item>
+    ///     </list>
+    /// </summary>
+    public static Classified Classify(
+        IEnumerable<string> tokens,
+        Func<string, bool> fileExists,
+        Func<string, bool> dirExists)
+    {
+        ArgumentNullException.ThrowIfNull(tokens);
+        ArgumentNullException.ThrowIfNull(fileExists);
+        ArgumentNullException.ThrowIfNull(dirExists);
+
+        var files = new List<string>();
+        var folders = new List<string>();
+
+        foreach (var token in tokens)
+        {
+            if (string.IsNullOrWhiteSpace(token)) { continue; }
+
+            try
+            {
+                if (fileExists(token))
+                {
+                    if (Path.GetExtension(token).Equals(".evtx", StringComparison.OrdinalIgnoreCase))
+                    {
+                        files.Add(token);
+                    }
+                }
+                else if (dirExists(token))
+                {
+                    folders.Add(token);
+                }
+            }
+            catch (Exception)
+            {
+                // Per-token isolation — drop bad tokens, keep classifying the rest.
+            }
+        }
+
+        return new Classified(files, folders);
+    }
+
+    public sealed record Classified(IReadOnlyList<string> EvtxFiles, IReadOnlyList<string> Folders);
+}

--- a/src/EventLogExpert.WindowsPlatform/CommandLineToArgvWHelper.cs
+++ b/src/EventLogExpert.WindowsPlatform/CommandLineToArgvWHelper.cs
@@ -1,0 +1,57 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Runtime.InteropServices;
+
+namespace EventLogExpert.WindowsPlatform;
+
+/// <summary>
+///     P/Invoke wrapper around Windows' <c>shell32!CommandLineToArgvW</c>; recovers argv-style tokens from
+///     <c>ILaunchActivatedEventArgs.Arguments</c> and <c>ICommandLineActivatedEventArgs.Operation.Arguments</c> (each
+///     delivered as a single unparsed string).
+/// </summary>
+public static partial class CommandLineToArgvWHelper
+{
+    public static IReadOnlyList<string> Parse(string commandLine)
+    {
+        if (string.IsNullOrEmpty(commandLine))
+        {
+            return [];
+        }
+
+        nint argv = CommandLineToArgvW(commandLine, out int count);
+
+        if (argv == 0)
+        {
+            return [];
+        }
+
+        try
+        {
+            if (count <= 0)
+            {
+                return [];
+            }
+
+            var result = new string[count];
+
+            for (int i = 0; i < count; i++)
+            {
+                nint pStr = Marshal.ReadIntPtr(argv, i * IntPtr.Size);
+                result[i] = Marshal.PtrToStringUni(pStr) ?? string.Empty;
+            }
+
+            return result;
+        }
+        finally
+        {
+            _ = LocalFree(argv);
+        }
+    }
+
+    [LibraryImport("shell32.dll", EntryPoint = "CommandLineToArgvW", StringMarshalling = StringMarshalling.Utf16, SetLastError = true)]
+    private static partial nint CommandLineToArgvW(string lpCmdLine, out int pNumArgs);
+
+    [LibraryImport("kernel32.dll")]
+    private static partial nint LocalFree(nint hMem);
+}

--- a/src/EventLogExpert.WindowsPlatform/EventLogExpert.WindowsPlatform.csproj
+++ b/src/EventLogExpert.WindowsPlatform/EventLogExpert.WindowsPlatform.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>EventLogExpert.WindowsPlatform</RootNamespace>
+    <!-- Non-MAUI library — sits outside the UseMaui block in Directory.Build.props so the
+         Otherwise branch sets TargetFramework=net10.0-windows10.0.19041.0. Provides Windows-shell
+         helpers (folder enumeration, CommandLineToArgvW interop, activation dispatcher) that the
+         MAUI head and platform tests consume without dragging the MAUI build pipeline in. -->
+    <UseMaui>false</UseMaui>
+    <UseWindowsForms>false</UseWindowsForms>
+    <UseWPF>false</UseWPF>
+    <!-- Required by [LibraryImport] source generator (SYSLIB1062). -->
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EventLogExpert.Eventing\EventLogExpert.Eventing.csproj" />
+    <ProjectReference Include="..\EventLogExpert.Logging\EventLogExpert.Logging.csproj" />
+    <ProjectReference Include="..\EventLogExpert.Runtime\EventLogExpert.Runtime.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="EventLogExpert.Windows.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/EventLogExpert.WindowsPlatform/EvtxEnumerationResult.cs
+++ b/src/EventLogExpert.WindowsPlatform/EvtxEnumerationResult.cs
@@ -1,0 +1,26 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.WindowsPlatform;
+
+/// <summary>
+///     Discriminated record hierarchy for <see cref="EvtxFolderEnumerator.EnumerateEvtxTopLevel" /> so callers can
+///     apply distinct UX per failure mode without losing diagnostic detail.
+/// </summary>
+public abstract record EvtxEnumerationResult
+{
+    private EvtxEnumerationResult() { }
+
+    public sealed record Success(IReadOnlyList<string> Files) : EvtxEnumerationResult;
+
+    public sealed record Empty : EvtxEnumerationResult
+    {
+        private Empty() { }
+
+        public static Empty Instance { get; } = new();
+    }
+
+    public sealed record AccessDenied(string Message) : EvtxEnumerationResult;
+
+    public sealed record IoError(string Message) : EvtxEnumerationResult;
+}

--- a/src/EventLogExpert.WindowsPlatform/EvtxFolderEnumerator.cs
+++ b/src/EventLogExpert.WindowsPlatform/EvtxFolderEnumerator.cs
@@ -1,0 +1,47 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.WindowsPlatform;
+
+public static class EvtxFolderEnumerator
+{
+    private const string EvtxSearchPattern = "*.evtx";
+    private const string OpenFolderFailedTitle = "Open Folder Failed";
+
+    public static EvtxEnumerationResult EnumerateEvtxTopLevel(string folderPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(folderPath);
+
+        try
+        {
+            var files = Directory.EnumerateFiles(folderPath, EvtxSearchPattern, SearchOption.TopDirectoryOnly)
+                .ToList();
+
+            if (files.Count == 0)
+            {
+                return EvtxEnumerationResult.Empty.Instance;
+            }
+
+            return new EvtxEnumerationResult.Success(files);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return new EvtxEnumerationResult.AccessDenied(ex.Message);
+        }
+        catch (IOException ex)
+        {
+            return new EvtxEnumerationResult.IoError(ex.Message);
+        }
+    }
+
+    /// <returns>
+    ///     Alert copy for failure variants; <c>null</c> for <see cref="EvtxEnumerationResult.Success" /> and
+    ///     <see cref="EvtxEnumerationResult.Empty" />.
+    /// </returns>
+    public static (string Title, string Message)? ToAlertCopy(EvtxEnumerationResult result) => result switch
+    {
+        EvtxEnumerationResult.AccessDenied a => (OpenFolderFailedTitle, a.Message),
+        EvtxEnumerationResult.IoError i => (OpenFolderFailedTitle, i.Message),
+        _ => null,
+    };
+}

--- a/src/EventLogExpert/Adapters/Menu/MauiMenuActionService.cs
+++ b/src/EventLogExpert/Adapters/Menu/MauiMenuActionService.cs
@@ -18,6 +18,7 @@ using EventLogExpert.UI.DatabaseTools;
 using EventLogExpert.UI.DebugLog;
 using EventLogExpert.UI.Modal;
 using EventLogExpert.UI.Settings;
+using EventLogExpert.WindowsPlatform;
 using Fluxor;
 using Application = Microsoft.Maui.Controls.Application;
 using IDispatcher = Fluxor.IDispatcher;
@@ -177,29 +178,29 @@ public sealed class MauiMenuActionService(
         }
         catch (InvalidOperationException ex)
         {
-            await _dialogService.ShowAlert("Open Folder Failed", ex.Message, "OK");
+            await _dialogService.ShowAlert("Open Folder Failed", ex.Message, "Ok");
 
             return;
         }
 
         if (folderPath is null) { return; }
 
-        List<(string, LogPathType)> files;
+        var result = EvtxFolderEnumerator.EnumerateEvtxTopLevel(folderPath);
 
-        try
+        var alertCopy = EvtxFolderEnumerator.ToAlertCopy(result);
+
+        if (alertCopy is { } copy)
         {
-            files = Directory.EnumerateFiles(folderPath, "*.evtx", SearchOption.TopDirectoryOnly)
-                .Select(file => (file, LogPathType.File))
-                .ToList();
-        }
-        catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
-        {
-            await _dialogService.ShowAlert("Open Folder Failed", ex.Message, "OK");
+            await _dialogService.ShowAlert(copy.Title, copy.Message, "Ok");
 
             return;
         }
 
-        if (files.Count == 0) { return; }
+        if (result is not EvtxEnumerationResult.Success success) { return; }
+
+        var files = success.Files
+            .Select(file => (file, LogPathType.File))
+            .ToList();
 
         await OpenLogsBatchAsync(files, combineLog);
     }

--- a/src/EventLogExpert/App.xaml.cs
+++ b/src/EventLogExpert/App.xaml.cs
@@ -4,6 +4,7 @@
 using EventLogExpert.Adapters.Menu;
 using EventLogExpert.Eventing.Common.EventLogs;
 using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.Common.Activation;
 using EventLogExpert.Runtime.Common.AppTitle;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.Runtime.FilterCache;
@@ -30,7 +31,8 @@ public sealed partial class App : Application
         ISettingsService settings,
         IAppTitleService appTitleService,
         ITraceLogger traceLogger,
-        MauiMenuActionService menuActionService)
+        MauiMenuActionService menuActionService,
+        IActivationDispatcher activationDispatcher)
     {
         InitializeComponent();
 
@@ -47,7 +49,8 @@ public sealed partial class App : Application
             settings,
             appTitleService,
             traceLogger,
-            menuActionService);
+            menuActionService,
+            activationDispatcher);
     }
 
     protected override Window CreateWindow(IActivationState? activationState)

--- a/src/EventLogExpert/EventLogExpert.csproj
+++ b/src/EventLogExpert/EventLogExpert.csproj
@@ -27,6 +27,15 @@
         <ApplicationVersion>1</ApplicationVersion>
     </PropertyGroup>
 
+    <!-- Suppress MAUI's source-generated Windows Main on the Windows TFM so our handwritten
+         Platforms\Windows\Program.cs takes over. Required to intercept activation BEFORE
+         Application.Start() runs (AppInstance single-instance contract). Also embed app.manifest
+         so the exe is long-path-aware (filesystem operations against >MAX_PATH paths). -->
+    <PropertyGroup Condition="$(TargetFramework.Contains('-windows'))">
+        <DefineConstants>$(DefineConstants);DISABLE_XAML_GENERATED_MAIN</DefineConstants>
+        <ApplicationManifest>app.manifest</ApplicationManifest>
+    </PropertyGroup>
+
     <ItemGroup>
         <!-- App Icon -->
         <MauiIcon Include="Resources\AppIcon\eventlogexperticon.png" />
@@ -57,12 +66,106 @@
         <PackageReference Include="Microsoft.Maui.Controls" />
         <PackageReference Include="Microsoft.Maui.Controls.Compatibility" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" />
+        <PackageReference Include="Microsoft.WindowsAppSDK" />
     </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\EventLogExpert.Provider.Database\EventLogExpert.Provider.Database.csproj" />
       <ProjectReference Include="..\EventLogExpert.Runtime\EventLogExpert.Runtime.csproj" />
       <ProjectReference Include="..\EventLogExpert.UI\EventLogExpert.UI.csproj" />
+      <ProjectReference Include="..\EventLogExpert.WindowsPlatform\EventLogExpert.WindowsPlatform.csproj" />
     </ItemGroup>
+
+    <!--
+      Derive the native vcxproj Platform from the current .NET RuntimeIdentifier. Only x64 is
+      supported today — the vcxproj only declares Debug|x64/Release|x64 configurations. Other
+      RIDs (win-arm64, win-x86) require matching ProjectConfiguration entries in the vcxproj
+      first; the BuildExplorerExtensionNative target fails fast with a clear message rather
+      than producing a confusing MSB4126 from VS MSBuild.
+    -->
+    <PropertyGroup>
+      <ExplorerExtensionNativePlatform Condition="'$(RuntimeIdentifier)' == '' OR $(RuntimeIdentifier.Contains('-x64'))">x64</ExplorerExtensionNativePlatform>
+    </PropertyGroup>
+
+    <!--
+      Static items: tell MAUI the native DLL belongs in the package. Only included on MSIX
+      packaging builds — non-MSIX dotnet builds don't trigger BuildExplorerExtensionNative and
+      would fail trying to copy a missing DLL from the C++ project's build output.
+    -->
+    <ItemGroup Condition="$(TargetFramework.Contains('-windows')) AND '$(WindowsPackageType)' == 'MSIX'">
+      <Content Include="..\EventLogExpert.ExplorerExtensionNative\$(ExplorerExtensionNativePlatform)\$(Configuration)\EventLogExpert.ExplorerExtension.dll"
+               Link="EventLogExpert.ExplorerExtension.dll"
+               CopyToOutputDirectory="PreserveNewest"
+               Visible="false" />
+    </ItemGroup>
+
+    <!--
+        Native C++/WinRT shell extension DLL (EventLogExpert.ExplorerExtension.dll) — packaged
+        alongside the main exe at MSIX root and loaded by dllhost.exe via the
+        <com:SurrogateServer> registration in Package.appxmanifest.
+
+        Builds via VS MSBuild (NOT the .NET SDK MSBuild — .NET SDK doesn't include the C++ build
+        system $(VCTargetsPath)). We locate VS MSBuild via vswhere, requiring the VC toolset
+        component so we don't pick a Build Tools instance that lacks the C++ workload.
+        The C++ project is INTENTIONALLY not in EventLogExpert.slnx so `dotnet build` doesn't
+        try to process it.
+
+        Only runs when actually packaging an MSIX (WindowsPackageType=MSIX).
+    -->
+    <Target Name="BuildExplorerExtensionNative"
+            Condition="$(TargetFramework.Contains('-windows')) AND '$(WindowsPackageType)' == 'MSIX'"
+            BeforeTargets="AssignTargetPaths;_ComputeAppxPackagePayload">
+      <PropertyGroup>
+        <ExplorerExtensionNativeDir>$(MSBuildThisFileDirectory)..\EventLogExpert.ExplorerExtensionNative\</ExplorerExtensionNativeDir>
+        <ExplorerExtensionNativeProject>$(ExplorerExtensionNativeDir)EventLogExpert.ExplorerExtensionNative.vcxproj</ExplorerExtensionNativeProject>
+        <ExplorerExtensionPackagesDir>$(MSBuildThisFileDirectory)..\packages</ExplorerExtensionPackagesDir>
+        <ExplorerExtensionNativeOutDir>$(ExplorerExtensionNativeDir)$(ExplorerExtensionNativePlatform)\$(Configuration)\</ExplorerExtensionNativeOutDir>
+        <ExplorerExtensionNativeDll>$(ExplorerExtensionNativeOutDir)EventLogExpert.ExplorerExtension.dll</ExplorerExtensionNativeDll>
+        <_VswherePath>$(MSBuildProgramFiles32)\Microsoft Visual Studio\Installer\vswhere.exe</_VswherePath>
+      </PropertyGroup>
+      <Error Condition="'$(ExplorerExtensionNativePlatform)' == ''"
+             Text="EventLogExpert.ExplorerExtensionNative.vcxproj only declares x64 ProjectConfiguration entries. RuntimeIdentifier=$(RuntimeIdentifier) does not map to a supported native platform. Build for win-x64 OR add matching arm64/Win32 ProjectConfiguration + ItemDefinitionGroup blocks to the vcxproj." />
+      <!-- Locate VS MSBuild requiring the VC toolset specifically — bare Microsoft.Component.MSBuild
+           can match a Build Tools install without the C++ workload, which can't process vcxproj. -->
+      <Exec Command="&quot;$(_VswherePath)&quot; -latest -products * -requires Microsoft.Component.MSBuild Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -find MSBuild\Current\Bin\amd64\MSBuild.exe"
+            ConsoleToMSBuild="true"
+            ContinueOnError="true">
+        <Output TaskParameter="ConsoleOutput" PropertyName="VsMSBuildPath" />
+      </Exec>
+      <!-- ConsoleOutput from Exec includes the trailing newline; Exists(...) on a path with a
+           trailing CR/LF fails even when MSBuild.exe is found. Trim before any subsequent use. -->
+      <PropertyGroup>
+        <VsMSBuildPath>$(VsMSBuildPath.Trim())</VsMSBuildPath>
+      </PropertyGroup>
+      <Error Condition="'$(VsMSBuildPath)' == '' OR !Exists('$(VsMSBuildPath)')"
+             Text="Could not locate Visual Studio MSBuild.exe with the C++ workload via vswhere ($(_VswherePath)). The native shell extension requires the Desktop Development with C++ workload (Microsoft.VisualStudio.Component.VC.Tools.x86.x64) AND the Windows 10/11 SDK. See docs/Explorer-Context-Menu.md for prereqs." />
+      <Exec Command="where nuget.exe" ConsoleToMSBuild="true" ContinueOnError="true" IgnoreExitCode="true">
+        <Output TaskParameter="ExitCode" PropertyName="_WhereNugetExitCode" />
+        <Output TaskParameter="ConsoleOutput" PropertyName="_WhereNugetOutput" />
+      </Exec>
+      <PropertyGroup>
+        <!-- where prints one match per line (newline-separated, NOT semicolon-separated).
+             Use Regex.Match to extract the first line; the trailing CR is implicitly excluded
+             by the [^\r\n]+ class. -->
+        <_NugetExePath Condition="'$(_WhereNugetExitCode)' == '0'">$([System.Text.RegularExpressions.Regex]::Match($(_WhereNugetOutput), '^[^\r\n]+').Value)</_NugetExePath>
+      </PropertyGroup>
+      <Error Condition="'$(_NugetExePath)' == '' OR !Exists('$(_NugetExePath)')"
+             Text="nuget.exe not found on PATH. The native shell extension's packages.config restore requires nuget.exe. Install via `winget install Microsoft.NuGet` (dev), the NuGetToolInstaller@1 pipeline task (ADO), or any equivalent. See docs/Explorer-Context-Menu.md for prereqs." />
+      <!-- nuget restore source selection:
+           - $(RestoreConfigFile) is set when the caller passes the dotnet configfile flag
+             (the locked-down ADO pipeline pattern; the file points at the internal mirror).
+             Use -ConfigFile to honor it, and omit -Source so nuget doesn't bypass the config.
+           - Otherwise (dev), use the public nuget.org feed directly. -->
+      <PropertyGroup>
+        <_NugetRestoreConfigArg Condition="'$(RestoreConfigFile)' != '' AND Exists('$(RestoreConfigFile)')">-ConfigFile &quot;$(RestoreConfigFile)&quot;</_NugetRestoreConfigArg>
+        <_NugetRestoreSourceArg Condition="'$(_NugetRestoreConfigArg)' == ''">-Source https://api.nuget.org/v3/index.json</_NugetRestoreSourceArg>
+      </PropertyGroup>
+      <Exec Command="&quot;$(_NugetExePath)&quot; restore &quot;$(ExplorerExtensionNativeDir)packages.config&quot; -PackagesDirectory &quot;$(ExplorerExtensionPackagesDir)&quot; $(_NugetRestoreConfigArg) $(_NugetRestoreSourceArg) -NonInteractive"
+            ContinueOnError="false" />
+      <Exec Command="&quot;$(VsMSBuildPath)&quot; &quot;$(ExplorerExtensionNativeProject)&quot; /p:Configuration=$(Configuration) /p:Platform=$(ExplorerExtensionNativePlatform) /nologo /v:minimal"
+            ContinueOnError="false" />
+      <Error Condition="!Exists('$(ExplorerExtensionNativeDll)')"
+             Text="EventLogExpert.ExplorerExtension.dll native build did not produce output at $(ExplorerExtensionNativeDll). Check the C++ workload + Windows SDK install. See docs/Explorer-Context-Menu.md for prereqs." />
+    </Target>
 
 </Project>

--- a/src/EventLogExpert/MainPage.xaml.cs
+++ b/src/EventLogExpert/MainPage.xaml.cs
@@ -5,6 +5,7 @@ using EventLogExpert.Adapters.Menu;
 using EventLogExpert.Eventing.Common.Channels;
 using EventLogExpert.Eventing.Common.EventLogs;
 using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.Common.Activation;
 using EventLogExpert.Runtime.Common.AppTitle;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.Runtime.FilterCache;
@@ -24,8 +25,10 @@ namespace EventLogExpert;
 
 public sealed partial class MainPage : ContentPage, IDisposable
 {
+    private readonly IActivationDispatcher _activationDispatcher;
     private readonly IStateSelection<EventLogState, ImmutableDictionary<string, EventLogData>> _activeLogs;
     private readonly IAppTitleService _appTitleService;
+    private readonly CancellationTokenSource _consumerCts = new();
     private readonly MauiMenuActionService _menuActionService;
     private readonly ISettingsService _settings;
     private readonly ITraceLogger _traceLogger;
@@ -41,7 +44,8 @@ public sealed partial class MainPage : ContentPage, IDisposable
         ISettingsService settings,
         IAppTitleService appTitleService,
         ITraceLogger traceLogger,
-        MauiMenuActionService menuActionService)
+        MauiMenuActionService menuActionService,
+        IActivationDispatcher activationDispatcher)
     {
         InitializeComponent();
 
@@ -50,6 +54,7 @@ public sealed partial class MainPage : ContentPage, IDisposable
         _settings = settings;
         _traceLogger = traceLogger;
         _menuActionService = menuActionService;
+        _activationDispatcher = activationDispatcher;
 
         _activeLogs.Select(state => state.ActiveLogs);
 
@@ -60,7 +65,13 @@ public sealed partial class MainPage : ContentPage, IDisposable
         filterCacheCommands.LoadFilters();
         filterGroupCommands.LoadGroups();
 
-        _ = ProcessCommandLine();
+        // Eager subscription so cold-launch args buffered by ActivationBootstrap drain even when
+        // WebView2 is missing and BlazorWebViewInitialized never fires; the StartConsumingAsync
+        // call in BlazorWebViewInitialized is idempotent (guarded by Interlocked) so a second
+        // call from there is safe.
+        _ = _activationDispatcher.StartConsumingAsync(
+            _menuActionService.OpenLogsBatchAsync,
+            _consumerCts.Token);
     }
 
     public void Dispose()
@@ -68,6 +79,11 @@ public sealed partial class MainPage : ContentPage, IDisposable
         _disposed = true;
         _activeLogs.SelectedValueChanged -= OnActiveLogsChanged;
         _settings.ThemeChanged -= OnThemeChanged;
+
+        try { _consumerCts.Cancel(); }
+        catch (ObjectDisposedException) { /* already disposed */ }
+
+        _consumerCts.Dispose();
     }
 
     private void ApplyWebViewTheme(Theme theme)
@@ -139,6 +155,10 @@ public sealed partial class MainPage : ContentPage, IDisposable
     {
         _coreWebView = e.WebView.CoreWebView2;
 
+        _ = _activationDispatcher.StartConsumingAsync(
+            _menuActionService.OpenLogsBatchAsync,
+            _consumerCts.Token);
+
         if (_coreWebView is null) { return; }
 
         ApplyWebViewTheme(_settings.Theme);
@@ -176,23 +196,4 @@ public sealed partial class MainPage : ContentPage, IDisposable
         // ThemeChanged may be raised from non-UI threads; marshal to the UI thread before touching
         // WebView2's profile.
         MainThread.BeginInvokeOnMainThread(() => ApplyWebViewTheme(_settings.Theme));
-
-    private async Task ProcessCommandLine()
-    {
-        try
-        {
-            var evtxArgs = Environment.GetCommandLineArgs()
-                .Where(arg => arg.EndsWith(".evtx", StringComparison.OrdinalIgnoreCase))
-                .Select(arg => (arg, LogPathType.File))
-                .ToList();
-
-            if (evtxArgs.Count == 0) { return; }
-
-            await _menuActionService.OpenLogsBatchAsync(evtxArgs, combineLog: true);
-        }
-        catch (Exception e)
-        {
-            _traceLogger.Error($"Failed to process command line arguments: {e}");
-        }
-    }
 }

--- a/src/EventLogExpert/MauiProgram.cs
+++ b/src/EventLogExpert/MauiProgram.cs
@@ -14,8 +14,10 @@ using EventLogExpert.Adapters.Threading;
 using EventLogExpert.Adapters.Window;
 using EventLogExpert.Eventing.Resolvers;
 using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Platforms.Windows.Activation;
 using EventLogExpert.Runtime.Alerts;
 using EventLogExpert.Runtime.Banner;
+using EventLogExpert.Runtime.Common.Activation;
 using EventLogExpert.Runtime.Common.AppTitle;
 using EventLogExpert.Runtime.Common.Clipboard;
 using EventLogExpert.Runtime.Common.Elevation;
@@ -35,6 +37,7 @@ using EventLogExpert.Runtime.Settings;
 using EventLogExpert.UI.Alerts;
 using EventLogExpert.UI.Banner;
 using EventLogExpert.UI.Database;
+using EventLogExpert.WindowsPlatform;
 using Fluxor;
 using Fluxor.DependencyInjection;
 
@@ -126,6 +129,18 @@ public static class MauiProgram
 
         builder.Services.AddSingleton<IMenuActionService>(static provider =>
             provider.GetRequiredService<MauiMenuActionService>());
+
+        builder.Services.AddSingleton<IActivationDispatcher>(static provider =>
+        {
+            var dispatcher = new ActivationDispatcher(
+                provider.GetRequiredService<IAlertDialogService>(),
+                provider.GetRequiredService<ITraceLogger>(),
+                provider.GetRequiredService<IMainThreadService>());
+
+            ActivationBootstrap.AttachDispatcher(dispatcher);
+
+            return dispatcher;
+        });
 
         builder.Services.AddSingleton<KeyboardShortcutService>();
         builder.Services.AddSingleton<DatabaseRecoveryHost>();

--- a/src/EventLogExpert/Platforms/Windows/Activation/ActivationArgsExtractor.cs
+++ b/src/EventLogExpert/Platforms/Windows/Activation/ActivationArgsExtractor.cs
@@ -1,0 +1,80 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.Common.Activation;
+using EventLogExpert.WindowsPlatform;
+using Microsoft.Windows.AppLifecycle;
+using Windows.ApplicationModel.Activation;
+using Windows.Storage;
+
+namespace EventLogExpert.Platforms.Windows.Activation;
+
+internal static class ActivationArgsExtractor
+{
+    internal static ActivationArgs Extract(AppActivationArguments? args)
+    {
+        if (args is null) { return ActivationArgs.Empty; }
+
+        return args.Kind switch
+        {
+            ExtendedActivationKind.File => FromFile(args.Data as IFileActivatedEventArgs),
+            ExtendedActivationKind.Launch => FromLaunch(args.Data as ILaunchActivatedEventArgs),
+            ExtendedActivationKind.CommandLineLaunch => FromCommandLine(args.Data as ICommandLineActivatedEventArgs),
+            _ => ActivationArgs.Empty,
+        };
+    }
+
+    private static ActivationArgs ClassifyTokens(IReadOnlyList<string> tokens)
+    {
+        if (tokens.Count == 0) { return ActivationArgs.Empty; }
+
+        var classified = ActivationTokenClassifier.Classify(tokens, File.Exists, Directory.Exists);
+
+        return new ActivationArgs(classified.EvtxFiles, classified.Folders);
+    }
+
+    private static ActivationArgs FromCommandLine(ICommandLineActivatedEventArgs? cli)
+    {
+        var raw = cli?.Operation?.Arguments;
+
+        return string.IsNullOrWhiteSpace(raw) ? ActivationArgs.Empty : ClassifyTokens(CommandLineToArgvWHelper.Parse(raw));
+    }
+
+    private static ActivationArgs FromFile(IFileActivatedEventArgs? fileArgs)
+    {
+        if (fileArgs?.Files is null || fileArgs.Files.Count == 0)
+        {
+            return ActivationArgs.Empty;
+        }
+
+        var files = new List<string>();
+        var folders = new List<string>();
+
+        foreach (var item in fileArgs.Files)
+        {
+            switch (item)
+            {
+                case StorageFile file when !string.IsNullOrEmpty(file.Path):
+                    files.Add(file.Path);
+
+                    break;
+                case StorageFolder folder when !string.IsNullOrEmpty(folder.Path):
+                    folders.Add(folder.Path);
+
+                    break;
+            }
+        }
+
+        return new ActivationArgs(files, folders);
+    }
+
+    private static ActivationArgs FromLaunch(ILaunchActivatedEventArgs? launch)
+    {
+        if (launch is null || string.IsNullOrWhiteSpace(launch.Arguments))
+        {
+            return ActivationArgs.Empty;
+        }
+
+        return ClassifyTokens(CommandLineToArgvWHelper.Parse(launch.Arguments));
+    }
+}

--- a/src/EventLogExpert/Platforms/Windows/Activation/ActivationBootstrap.cs
+++ b/src/EventLogExpert/Platforms/Windows/Activation/ActivationBootstrap.cs
@@ -1,0 +1,64 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.Common.Activation;
+using Microsoft.Windows.AppLifecycle;
+using System.Collections.Concurrent;
+
+namespace EventLogExpert.Platforms.Windows.Activation;
+
+/// <summary>
+///     Bridges <c>Program.Main</c> (sees cold-launch + <see cref="AppInstance.Activated" /> before DI is built) and
+///     the <see cref="IActivationDispatcher" /> singleton (constructed by MAUI DI). Buffered args live in a thread-safe
+///     queue because <see cref="AppInstance.Activated" /> fires on a background thread while
+///     <see cref="AttachDispatcher" /> runs on the DI construction thread.
+/// </summary>
+internal static class ActivationBootstrap
+{
+    private static readonly Lock s_attachLock = new();
+    private static readonly ConcurrentQueue<ActivationArgs> s_buffer = new();
+
+    private static IActivationDispatcher? s_dispatcher;
+
+    internal static void AttachDispatcher(IActivationDispatcher dispatcher)
+    {
+        ArgumentNullException.ThrowIfNull(dispatcher);
+
+        lock (s_attachLock)
+        {
+            s_dispatcher = dispatcher;
+
+            while (s_buffer.TryDequeue(out var args))
+            {
+                dispatcher.Enqueue(args);
+            }
+        }
+    }
+
+    internal static void EnqueueRedirected(AppActivationArguments? redirected)
+    {
+        EnqueueArgs(ActivationArgsExtractor.Extract(redirected));
+    }
+
+    internal static void SeedColdLaunch(AppActivationArguments? coldLaunch)
+    {
+        EnqueueArgs(ActivationArgsExtractor.Extract(coldLaunch));
+    }
+
+    private static void EnqueueArgs(ActivationArgs args)
+    {
+        if (args.IsEmpty) { return; }
+
+        lock (s_attachLock)
+        {
+            if (s_dispatcher is not null)
+            {
+                s_dispatcher.Enqueue(args);
+
+                return;
+            }
+
+            s_buffer.Enqueue(args);
+        }
+    }
+}

--- a/src/EventLogExpert/Platforms/Windows/Package.appxmanifest
+++ b/src/EventLogExpert/Platforms/Windows/Package.appxmanifest
@@ -2,10 +2,14 @@
 <Package
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2"
   xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
   xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
+  xmlns:desktop4="http://schemas.microsoft.com/appx/manifest/desktop/windows10/4"
+  xmlns:desktop5="http://schemas.microsoft.com/appx/manifest/desktop/windows10/5"
+  xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
-  IgnorableNamespaces="uap uap3 rescap">
+  IgnorableNamespaces="uap rescap">
 
   <Identity Name="EventLogExpert" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="0.9.0.0" />
 
@@ -16,7 +20,9 @@
   </Properties>
 
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
+    <!-- Desktop-only. Windows.Universal causes AppX deployment to process under Universal rules
+         first, silently dropping Desktop-specific extension categories like
+         windows.fileExplorerContextMenus (the verb→handler mapping never lands). -->
     <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
   </Dependencies>
 
@@ -49,8 +55,56 @@
               <uap:FileType>.evtx</uap:FileType>
             </uap:SupportedFileTypes>
             <uap:DisplayName>Windows Event Log</uap:DisplayName>
+            <uap2:SupportedVerbs>
+              <!-- FTA "Open with EventLogExpert" verb. Surfaces in the Open With submenu; the
+                   top-level right-click entry comes from the desktop4:fileExplorerContextMenus
+                   block below, not from this verb.
+                   MultiSelectModel="Player" fans a multi-select into one activation — combined
+                   with AppInstance single-instancing in Platforms\Windows\Program.cs, N selected
+                   .evtx files open in one window.
+                   MultiSelectModel is unprefixed because the namespaced uap3:MultiSelectModel
+                   form fails MSIX deployment schema validation (DEP0700 / 0xC00CE015). -->
+              <uap3:Verb Id="open" MultiSelectModel="Player">Open with EventLogExpert</uap3:Verb>
+            </uap2:SupportedVerbs>
           </uap:FileTypeAssociation>
         </uap:Extension>
+
+        <!-- File Explorer context menu — top-level right-click verb backed by an IExplorerCommand
+             COM handler. Three item types, all routed to the same CLSID:
+             - Type="*" (desktop4:Verb) — any-file right-click. The handler's GetState filters
+               to show the verb only on .evtx files.
+             - Type="Directory" (desktop5:Verb) — right-click on a folder icon.
+             - Type="Directory\Background" (desktop5:Verb) — right-click inside an open folder's
+               empty space. -->
+        <desktop4:Extension Category="windows.fileExplorerContextMenus">
+          <desktop4:FileExplorerContextMenus>
+            <desktop4:ItemType Type="*">
+              <desktop4:Verb Id="OpenEvtx" Clsid="F1B2C3D4-E5F6-4789-AB12-CD34EF567890" />
+            </desktop4:ItemType>
+            <desktop5:ItemType Type="Directory">
+              <desktop5:Verb Id="OpenEvtx" Clsid="F1B2C3D4-E5F6-4789-AB12-CD34EF567890" />
+            </desktop5:ItemType>
+            <desktop5:ItemType Type="Directory\Background">
+              <desktop5:Verb Id="OpenEvtx" Clsid="F1B2C3D4-E5F6-4789-AB12-CD34EF567890" />
+            </desktop5:ItemType>
+          </desktop4:FileExplorerContextMenus>
+        </desktop4:Extension>
+
+        <!-- COM server for the IExplorerCommand implementation. Uses SurrogateServer (loaded
+             into dllhost.exe) — NOT ExeServer — because Explorer activates context-menu COM
+             handlers via CLSCTX_INPROC_HANDLER (in-process surrogate), not CLSCTX_LOCAL_SERVER
+             (standalone exe). ThreadingModel="STA" matches dllhost's STA activation for shell
+             extensions. The DLL is the native C++/WinRT shell extension built from
+             src\EventLogExpert.ExplorerExtensionNative. -->
+        <com:Extension Category="windows.comServer">
+          <com:ComServer>
+            <com:SurrogateServer DisplayName="EventLogExpert Context Menu">
+              <com:Class Id="F1B2C3D4-E5F6-4789-AB12-CD34EF567890"
+                         Path="EventLogExpert.ExplorerExtension.dll"
+                         ThreadingModel="STA" />
+            </com:SurrogateServer>
+          </com:ComServer>
+        </com:Extension>
       </Extensions>
     </Application>
   </Applications>

--- a/src/EventLogExpert/Platforms/Windows/Program.cs
+++ b/src/EventLogExpert/Platforms/Windows/Program.cs
@@ -1,0 +1,60 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Platforms.Windows.Activation;
+using Microsoft.UI.Dispatching;
+using Microsoft.Windows.AppLifecycle;
+using System.Runtime.InteropServices;
+using WinRT;
+
+namespace EventLogExpert.WinUI;
+
+/// <summary>
+///     Handwritten WinUI entry point. Replaces MAUI's source-generated <c>Main</c> (suppressed via
+///     <c>DISABLE_XAML_GENERATED_MAIN</c> in the csproj's Windows TFM) so activation interception can run BEFORE
+///     <see cref="Application.Start(Microsoft.UI.Xaml.ApplicationInitializationCallback)" /> — the only place the
+///     <see cref="AppInstance.FindOrRegisterForKey(string)" /> single-instance contract permits.
+/// </summary>
+internal static class Program
+{
+    [STAThread]
+    private static int Main(string[] args)
+    {
+        // Activation args are re-fetched from AppInstance below; the entry-point parameter is unused.
+        _ = args;
+        XamlCheckProcessRequirements();
+        ComWrappersSupport.InitializeComWrappers();
+
+        var activationArgs = AppInstance.GetCurrent().GetActivatedEventArgs();
+        var keyInstance = AppInstance.FindOrRegisterForKey("eventlogexpert-main");
+
+        if (!keyInstance.IsCurrent)
+        {
+            keyInstance.RedirectActivationToAsync(activationArgs).AsTask().GetAwaiter().GetResult();
+
+            return 0;
+        }
+
+        // Subscribe BEFORE SeedColdLaunch so the gap between FindOrRegisterForKey returning and the
+        // Activated handler being attached is a single statement wide. AppInstance.Activated does
+        // not buffer; redirects landing in the gap would be silently dropped.
+        keyInstance.Activated += (_, eventArgs) => ActivationBootstrap.EnqueueRedirected(eventArgs);
+        ActivationBootstrap.SeedColdLaunch(activationArgs);
+
+        // Non-static lambda: avoids the static-anonymous-function-cannot-reference-discard
+        // restriction on the `_ = new App()` line below.
+        Microsoft.UI.Xaml.Application.Start(p =>
+        {
+            var context = new DispatcherQueueSynchronizationContext(DispatcherQueue.GetForCurrentThread());
+            SynchronizationContext.SetSynchronizationContext(context);
+            _ = new App();
+        });
+
+        return 0;
+    }
+
+    // Declared explicitly so the call above resolves regardless of XAML generator behavior under
+    // DISABLE_XAML_GENERATED_MAIN.
+    [DllImport("Microsoft.ui.xaml.dll")]
+    private static extern void XamlCheckProcessRequirements();
+}

--- a/src/EventLogExpert/app.manifest
+++ b/src/EventLogExpert/app.manifest
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Embedded native application manifest for the MAUI head exe. Enables long-path support so
+  filesystem operations against >MAX_PATH paths (.evtx files, folder enumeration) don't
+  silently fail when the legacy 260-char limit would otherwise reject them.
+  See: https://learn.microsoft.com/windows/win32/fileio/maximum-file-path-limitation
+-->
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/tests/Unit/EventLogExpert.Windows.Tests/ActivationDispatcherTests.cs
+++ b/tests/Unit/EventLogExpert.Windows.Tests/ActivationDispatcherTests.cs
@@ -1,0 +1,258 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Logging.Abstractions.Handlers;
+using EventLogExpert.Runtime.Alerts;
+using EventLogExpert.Runtime.Common.Activation;
+using EventLogExpert.Runtime.Common.Threading;
+using EventLogExpert.WindowsPlatform;
+using NSubstitute;
+using System.Threading.Channels;
+using Xunit;
+
+namespace EventLogExpert.Windows.Tests;
+
+public sealed class ActivationDispatcherTests
+{
+    [Fact]
+    public async Task Enqueue_OnEmptyArgs_DoesNotInvokeOpenBatch()
+    {
+        var (dispatcher, channel) = CreateDispatcher();
+        var invocations = 0;
+
+        var consumerTask = dispatcher.StartConsumingAsync(
+            (_, _) => { Interlocked.Increment(ref invocations); return Task.CompletedTask; },
+            TestContext.Current.CancellationToken);
+
+        dispatcher.Enqueue(ActivationArgs.Empty);
+
+        channel.Writer.Complete();
+        await consumerTask;
+
+        Assert.Equal(0, invocations);
+    }
+
+    [Fact]
+    public void Enqueue_OnCompletedChannel_LogsWarning_AndDoesNotThrow()
+    {
+        var logger = Substitute.For<ITraceLogger>();
+        var (dispatcher, channel) = CreateDispatcher(logger: logger);
+
+        channel.Writer.Complete();
+
+        // TryWrite returns false on a completed unbounded channel; Enqueue must observe the
+        // rejection and surface it via the logger — silent drop hides "Explorer activation did
+        // nothing" failures in the field.
+        var exception = Record.Exception(() =>
+            dispatcher.Enqueue(new ActivationArgs([@"E:\Data\one.evtx"], [])));
+
+        Assert.Null(exception);
+        logger.Received(1).Warning(Arg.Any<WarningLogHandler>());
+    }
+
+    [Fact]
+    public async Task ProcessBatch_FolderFailureSurfacedAsAlert_BeforeOpenBatch()
+    {
+        var dialogService = Substitute.For<IAlertDialogService>();
+        var mainThread = Substitute.For<IMainThreadService>();
+        mainThread.InvokeOnMainThreadAsync(Arg.Any<Func<Task>>())
+            .Returns(callInfo => callInfo.Arg<Func<Task>>().Invoke());
+
+        var (dispatcher, channel) = CreateDispatcher(dialogService: dialogService, mainThread: mainThread);
+        var alertOrderedBeforeOpen = false;
+        var alertSeen = false;
+        var openCalled = false;
+
+        dialogService
+            .When(d => d.ShowAlert(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>()))
+            .Do(_ =>
+            {
+                alertSeen = true;
+                if (!openCalled) { alertOrderedBeforeOpen = true; }
+            });
+
+        var consumerTask = dispatcher.StartConsumingAsync(
+            (_, _) => { openCalled = true; return Task.CompletedTask; },
+            TestContext.Current.CancellationToken);
+
+        // Nonexistent folder -> IoError -> ToAlertCopy produces "Open Folder Failed".
+        var bogusFolder = Path.Combine(Path.GetTempPath(), "evtx-dispatcher-test-" + Guid.NewGuid().ToString("N"));
+        dispatcher.Enqueue(new ActivationArgs([], [bogusFolder]));
+
+        channel.Writer.Complete();
+        await consumerTask;
+
+        Assert.True(alertSeen);
+        Assert.False(openCalled, "openBatch must not be called when no .evtx files were enumerated");
+        Assert.True(alertOrderedBeforeOpen);
+    }
+
+    [Fact]
+    public async Task ProcessBatch_OnCancellationBeforeOpenBatch_DoesNotInvokeOpenBatch()
+    {
+        var mainThread = Substitute.For<IMainThreadService>();
+        mainThread.InvokeOnMainThreadAsync(Arg.Any<Func<Task>>())
+            .Returns(callInfo => callInfo.Arg<Func<Task>>().Invoke());
+
+        var (dispatcher, channel) = CreateDispatcher(mainThread: mainThread);
+        var openBatchInvoked = false;
+        using var cts = new CancellationTokenSource();
+
+        var consumerTask = dispatcher.StartConsumingAsync(
+            (_, _) =>
+            {
+                openBatchInvoked = true;
+                return Task.CompletedTask;
+            },
+            cts.Token);
+
+        // Cancel BEFORE enqueueing — the channel reader will throw OperationCanceledException
+        // and the consumer exits without ever invoking openBatch.
+        await cts.CancelAsync();
+        dispatcher.Enqueue(new ActivationArgs([@"E:\Data\one.evtx"], []));
+
+        await consumerTask;
+
+        Assert.False(openBatchInvoked, "openBatch must not run after cancellation");
+    }
+
+    [Fact]
+    public async Task ProcessBatch_RoutesFilesAsLogPathTypeFile_OnMainThread()
+    {
+        var mainThread = Substitute.For<IMainThreadService>();
+        mainThread.InvokeOnMainThreadAsync(Arg.Any<Func<Task>>())
+            .Returns(callInfo => callInfo.Arg<Func<Task>>().Invoke());
+
+        var (dispatcher, channel) = CreateDispatcher(mainThread: mainThread);
+        IEnumerable<(string Path, LogPathType Type)>? capturedPaths = null;
+        bool? capturedCombine = null;
+
+        var consumerTask = dispatcher.StartConsumingAsync(
+            (paths, combine) =>
+            {
+                capturedPaths = paths;
+                capturedCombine = combine;
+
+                return Task.CompletedTask;
+            },
+            TestContext.Current.CancellationToken);
+
+        dispatcher.Enqueue(new ActivationArgs([@"E:\Data\one.evtx", @"E:\Data\two.evtx"], []));
+
+        channel.Writer.Complete();
+        await consumerTask;
+
+        Assert.NotNull(capturedPaths);
+        var pathsList = capturedPaths.ToList();
+        Assert.Equal(2, pathsList.Count);
+        Assert.All(pathsList, p => Assert.Equal(LogPathType.File, p.Type));
+        Assert.True(capturedCombine);
+        await mainThread.Received().InvokeOnMainThreadAsync(Arg.Any<Func<Task>>());
+    }
+
+    [Fact]
+    public async Task StartConsumingAsync_IsIdempotent_SecondCallReturnsImmediately()
+    {
+        var (dispatcher, channel) = CreateDispatcher();
+        var firstInvocations = 0;
+        var secondInvocations = 0;
+
+        var firstTask = dispatcher.StartConsumingAsync(
+            (_, _) => { Interlocked.Increment(ref firstInvocations); return Task.CompletedTask; },
+            TestContext.Current.CancellationToken);
+
+        await dispatcher.StartConsumingAsync(
+            (_, _) => { Interlocked.Increment(ref secondInvocations); return Task.CompletedTask; },
+            TestContext.Current.CancellationToken);
+
+        dispatcher.Enqueue(new ActivationArgs([@"E:\sample.evtx"], []));
+
+        Assert.Equal(0, secondInvocations);
+
+        channel.Writer.Complete();
+        await firstTask;
+        Assert.Equal(1, firstInvocations);
+    }
+
+    [Fact]
+    public async Task StartConsumingAsync_OnCancellation_ExitsGracefullyWithoutRethrow()
+    {
+        var (dispatcher, _) = CreateDispatcher();
+        using var cts = new CancellationTokenSource();
+
+        var consumerTask = dispatcher.StartConsumingAsync(
+            (_, _) => Task.CompletedTask,
+            cts.Token);
+
+        await cts.CancelAsync();
+
+        // No exception should escape — the dispatcher swallows OperationCanceledException on shutdown.
+        await consumerTask;
+    }
+
+    [Fact]
+    public async Task StartConsumingAsync_PerBatchExceptionIsIsolated_ConsumerKeepsGoing()
+    {
+        var logger = Substitute.For<ITraceLogger>();
+        var (dispatcher, channel) = CreateDispatcher(logger: logger);
+        var seenBatches = new List<int>();
+        var batchIndex = 0;
+
+        var consumerTask = dispatcher.StartConsumingAsync(
+            (_, _) =>
+            {
+                var current = Interlocked.Increment(ref batchIndex);
+                if (current == 1) { throw new InvalidOperationException("first batch fails"); }
+
+                seenBatches.Add(current);
+
+                return Task.CompletedTask;
+            },
+            TestContext.Current.CancellationToken);
+
+        dispatcher.Enqueue(new ActivationArgs([@"E:\a.evtx"], []));
+        dispatcher.Enqueue(new ActivationArgs([@"E:\b.evtx"], []));
+        dispatcher.Enqueue(new ActivationArgs([@"E:\c.evtx"], []));
+
+        channel.Writer.Complete();
+        await consumerTask;
+
+        Assert.Contains(2, seenBatches);
+        Assert.Contains(3, seenBatches);
+    }
+
+    [Fact]
+    public async Task StartConsumingAsync_RejectsNullOpenBatch()
+    {
+        var (dispatcher, _) = CreateDispatcher();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            dispatcher.StartConsumingAsync(null!, TestContext.Current.CancellationToken));
+    }
+
+    private static (ActivationDispatcher dispatcher, Channel<ActivationArgs> channel) CreateDispatcher(
+        IAlertDialogService? dialogService = null,
+        ITraceLogger? logger = null,
+        IMainThreadService? mainThread = null)
+    {
+        var channel = Channel.CreateUnbounded<ActivationArgs>(new UnboundedChannelOptions { SingleReader = true });
+        var resolvedMainThread = mainThread ?? Substitute.For<IMainThreadService>();
+
+        if (mainThread is null)
+        {
+            // Default: run on-thread to keep tests deterministic.
+            resolvedMainThread.InvokeOnMainThreadAsync(Arg.Any<Func<Task>>())
+                .Returns(callInfo => callInfo.Arg<Func<Task>>().Invoke());
+        }
+
+        var dispatcher = new ActivationDispatcher(
+            dialogService ?? Substitute.For<IAlertDialogService>(),
+            logger ?? Substitute.For<ITraceLogger>(),
+            resolvedMainThread,
+            channel);
+
+        return (dispatcher, channel);
+    }
+}

--- a/tests/Unit/EventLogExpert.Windows.Tests/ActivationTokenClassifierTests.cs
+++ b/tests/Unit/EventLogExpert.Windows.Tests/ActivationTokenClassifierTests.cs
@@ -1,0 +1,131 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Windows.Tests.TestUtils;
+using EventLogExpert.Windows.Tests.TestUtils.Constants;
+using EventLogExpert.WindowsPlatform;
+using Xunit;
+
+namespace EventLogExpert.Windows.Tests;
+
+public sealed class ActivationTokenClassifierTests
+{
+    [Fact]
+    public void Classify_AcceptsOnlyEvtxFiles_CaseInsensitive()
+    {
+        var tokens = new[]
+        {
+            Constants.LowercaseEvtxFile,
+            Constants.UppercaseEvtxFile,
+            Constants.TxtFile,
+            Constants.LogFile,
+            Constants.NotesFile,
+        };
+
+        var result = ActivationTokenClassifier.Classify(
+            tokens,
+            ActivationFixtures.CreateFileExistsForExtensions(Constants.EvtxExtension, ".txt", ".log"),
+            ActivationFixtures.NeverDirExists);
+
+        Assert.Equal(2, result.EvtxFiles.Count);
+        Assert.Contains(Constants.LowercaseEvtxFile, result.EvtxFiles);
+        Assert.Contains(Constants.UppercaseEvtxFile, result.EvtxFiles);
+    }
+
+    [Fact]
+    public void Classify_BucketsFolders_Separately()
+    {
+        var tokens = new[] { Constants.LogsFolder, Constants.SampleEvtxFile };
+
+        var result = ActivationTokenClassifier.Classify(
+            tokens,
+            ActivationFixtures.AcceptOnlyEvtxFiles(),
+            ActivationFixtures.CreateDirExistsForPath(Constants.LogsFolder));
+
+        Assert.Single(result.EvtxFiles);
+        Assert.Single(result.Folders);
+        Assert.Equal(Constants.LogsFolder, result.Folders[0]);
+        Assert.Equal(Constants.SampleEvtxFile, result.EvtxFiles[0]);
+    }
+
+    [Fact]
+    public void Classify_CatchesProbeExceptionsAndContinues()
+    {
+        var tokens = new[] { Constants.ProbeFailurePath, Constants.RealEvtxFile };
+
+        var result = ActivationTokenClassifier.Classify(
+            tokens,
+            ActivationFixtures.CreateFileExistsThatThrowsFor(
+                Constants.ProbeFailurePath,
+                new IOException("simulated probe failure"),
+                Constants.RealEvtxFile),
+            ActivationFixtures.NeverDirExists);
+
+        Assert.Single(result.EvtxFiles);
+        Assert.Equal(Constants.RealEvtxFile, result.EvtxFiles[0]);
+    }
+
+    [Fact]
+    public void Classify_DropsNonexistentTokensSilently()
+    {
+        var tokens = new[] { Constants.NonexistentEvtxFile, Constants.RealEvtxFile };
+
+        var result = ActivationTokenClassifier.Classify(
+            tokens,
+            ActivationFixtures.CreateFileExistsForPath(Constants.RealEvtxFile),
+            ActivationFixtures.NeverDirExists);
+
+        Assert.Single(result.EvtxFiles);
+        Assert.Equal(Constants.RealEvtxFile, result.EvtxFiles[0]);
+    }
+
+    [Fact]
+    public void Classify_DropsWhitespaceAndNullTokens()
+    {
+        var tokens = new[] { "", "   ", "\t", Constants.RealEvtxFile, null! };
+
+        var result = ActivationTokenClassifier.Classify(
+            tokens,
+            ActivationFixtures.CreateFileExistsForPath(Constants.RealEvtxFile),
+            ActivationFixtures.NeverDirExists);
+
+        Assert.Single(result.EvtxFiles);
+    }
+
+    [Fact]
+    public void Classify_EmptyInput_ReturnsEmptyClassification()
+    {
+        var result = ActivationTokenClassifier.Classify([], ActivationFixtures.AlwaysFileExists, _ => true);
+
+        Assert.Empty(result.EvtxFiles);
+        Assert.Empty(result.Folders);
+    }
+
+    [Fact]
+    public void Classify_RejectsNullArguments()
+    {
+        Assert.Throws<ArgumentNullException>(() => ActivationTokenClassifier.Classify(null!, ActivationFixtures.AlwaysFileExists, _ => true));
+        Assert.Throws<ArgumentNullException>(() => ActivationTokenClassifier.Classify([], null!, _ => true));
+        Assert.Throws<ArgumentNullException>(() => ActivationTokenClassifier.Classify([], ActivationFixtures.AlwaysFileExists, null!));
+    }
+
+    [Fact]
+    public void Classify_SkipsExeTokenWhenLaunchedFromShellExtension()
+    {
+        var tokens = new[]
+        {
+            Constants.PackagedExePath,
+            Constants.SystemEvtxFile,
+            Constants.AppEvtxFile,
+        };
+
+        var result = ActivationTokenClassifier.Classify(
+            tokens,
+            ActivationFixtures.AlwaysFileExists,
+            ActivationFixtures.NeverDirExists);
+
+        Assert.Equal(2, result.EvtxFiles.Count);
+        Assert.DoesNotContain(result.EvtxFiles, p => p.EndsWith(".exe", StringComparison.OrdinalIgnoreCase));
+        Assert.All(result.EvtxFiles, p => Assert.EndsWith(Constants.EvtxExtension, p, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/tests/Unit/EventLogExpert.Windows.Tests/CommandLineToArgvWHelperTests.cs
+++ b/tests/Unit/EventLogExpert.Windows.Tests/CommandLineToArgvWHelperTests.cs
@@ -1,0 +1,64 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Windows.Tests.TestUtils.Constants;
+using EventLogExpert.WindowsPlatform;
+using Xunit;
+
+namespace EventLogExpert.Windows.Tests;
+
+public sealed class CommandLineToArgvWHelperTests
+{
+    [Fact]
+    public void Parse_DriveRootStrippedOfTrailingBackslash_RoundTripsCorrectly()
+    {
+        var result = CommandLineToArgvWHelper.Parse(Constants.QuotedDriveRoot);
+
+        Assert.Single(result);
+        Assert.Equal(Constants.UnquotedDriveRoot, result[0]);
+    }
+
+    [Fact]
+    public void Parse_EmptyString_ReturnsEmptyArray()
+    {
+        Assert.Empty(CommandLineToArgvWHelper.Parse(""));
+    }
+
+    [Fact]
+    public void Parse_MultipleQuotedAndUnquoted_PreservesEachToken()
+    {
+        var result = CommandLineToArgvWHelper.Parse(Constants.MultipleArgsCommandLine);
+
+        Assert.Equal(3, result.Count);
+        Assert.Equal(Constants.FirstArg, result[0]);
+        Assert.Equal(Constants.MiddleArgWithSpaces, result[1]);
+        Assert.Equal(Constants.LastArg, result[2]);
+    }
+
+    [Fact]
+    public void Parse_QuotedPathWithSpaces_PreservesAsOneToken()
+    {
+        var result = CommandLineToArgvWHelper.Parse(Constants.QuotedPathWithSpaces);
+
+        Assert.Single(result);
+        Assert.Equal(Constants.PathWithSpacesUnquoted, result[0]);
+    }
+
+    [Fact]
+    public void Parse_SingleUnquotedToken_ReturnsOneElement()
+    {
+        var result = CommandLineToArgvWHelper.Parse(Constants.UnquotedCLogsSampleEvtx);
+
+        Assert.Single(result);
+        Assert.Equal(Constants.UnquotedCLogsSampleEvtx, result[0]);
+    }
+
+    [Fact]
+    public void Parse_UncPath_PreservesAsOneToken()
+    {
+        var result = CommandLineToArgvWHelper.Parse(Constants.QuotedUncPath);
+
+        Assert.Single(result);
+        Assert.Equal(Constants.UnquotedUncPath, result[0]);
+    }
+}

--- a/tests/Unit/EventLogExpert.Windows.Tests/EventLogExpert.Windows.Tests.csproj
+++ b/tests/Unit/EventLogExpert.Windows.Tests/EventLogExpert.Windows.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <!-- Match the Windows TFM the MAUI head uses so Microsoft.Windows.SDK types referenced by
+         the helpers under test resolve correctly. Inherits net10.0-windows10.0.19041.0 from
+         Directory.Build.props' Otherwise branch (UseMaui is false here). -->
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\EventLogExpert.Runtime\EventLogExpert.Runtime.csproj" />
+    <ProjectReference Include="..\..\..\src\EventLogExpert.WindowsPlatform\EventLogExpert.WindowsPlatform.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Unit/EventLogExpert.Windows.Tests/EvtxFolderEnumeratorTests.cs
+++ b/tests/Unit/EventLogExpert.Windows.Tests/EvtxFolderEnumeratorTests.cs
@@ -1,0 +1,118 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Windows.Tests.TestUtils;
+using EventLogExpert.Windows.Tests.TestUtils.Constants;
+using EventLogExpert.WindowsPlatform;
+using Xunit;
+
+namespace EventLogExpert.Windows.Tests;
+
+public sealed class EvtxFolderEnumeratorTests : IDisposable
+{
+    private readonly string _tempRoot;
+
+    public EvtxFolderEnumeratorTests()
+    {
+        _tempRoot = EvtxFolderFixtures.CreateTempTestFolder();
+    }
+
+    public void Dispose()
+    {
+        EvtxFolderFixtures.TryDeleteFolder(_tempRoot);
+    }
+
+    [Fact]
+    public void EnumerateTopLevel_DoesNotRecurseIntoSubfolders()
+    {
+        var sub = Path.Combine(_tempRoot, "sub");
+        Directory.CreateDirectory(sub);
+        EvtxFolderFixtures.WriteEmptyFile(sub, "nested.evtx");
+        EvtxFolderFixtures.WriteEmptyFile(_tempRoot, "top.evtx");
+
+        var result = EvtxFolderEnumerator.EnumerateEvtxTopLevel(_tempRoot);
+
+        var success = Assert.IsType<EvtxEnumerationResult.Success>(result);
+        Assert.Single(success.Files);
+        Assert.EndsWith("top.evtx", success.Files[0], StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void EnumerateTopLevel_OnEmptyFolder_ReturnsEmptyVariant()
+    {
+        var result = EvtxFolderEnumerator.EnumerateEvtxTopLevel(_tempRoot);
+
+        Assert.IsType<EvtxEnumerationResult.Empty>(result);
+    }
+
+    [Fact]
+    public void EnumerateTopLevel_OnFolderWithEvtxAndOtherFiles_ReturnsOnlyEvtx()
+    {
+        EvtxFolderFixtures.WriteEmptyFile(_tempRoot, "a.evtx");
+        EvtxFolderFixtures.WriteEmptyFile(_tempRoot, "b.evtx");
+        EvtxFolderFixtures.WriteEmptyFile(_tempRoot, "ignored.txt");
+        EvtxFolderFixtures.WriteEmptyFile(_tempRoot, "ignored.log");
+
+        var result = EvtxFolderEnumerator.EnumerateEvtxTopLevel(_tempRoot);
+
+        var success = Assert.IsType<EvtxEnumerationResult.Success>(result);
+        Assert.Equal(2, success.Files.Count);
+        Assert.All(success.Files, f => Assert.EndsWith(Constants.EvtxExtension, f, StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void EnumerateTopLevel_OnLongPathBeyondMax_StillReturnsEvtxFiles()
+    {
+        // Uses the \\?\ prefix to bypass the test process's MAX_PATH limit during setup; the
+        // prefix is the cross-process portable long-path mechanism on Windows. The packaged
+        // MAUI head exe is independently long-path-aware via its embedded app.manifest, so a
+        // non-prefixed >MAX_PATH path also works when the OS LongPathsEnabled policy is set.
+        // This test pins one specific claim: EvtxFolderEnumerator does not impose its own
+        // artificial path-length cap (it forwards to Directory.EnumerateFiles which honors
+        // the prefix-based long-path API regardless of process awareness).
+        var nested = Path.Combine(_tempRoot, new string('a', 80), new string('b', 80), new string('c', 80));
+        var longPathPrefixed = @"\\?\" + nested;
+        Directory.CreateDirectory(longPathPrefixed);
+        EvtxFolderFixtures.WriteEmptyFile(longPathPrefixed, "longpath.evtx");
+
+        var result = EvtxFolderEnumerator.EnumerateEvtxTopLevel(longPathPrefixed);
+
+        var success = Assert.IsType<EvtxEnumerationResult.Success>(result);
+        Assert.Single(success.Files);
+        Assert.EndsWith("longpath.evtx", success.Files[0], StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void EnumerateTopLevel_OnNonexistentFolder_ReturnsIoErrorVariant()
+    {
+        var nonexistent = Path.Combine(_tempRoot, "does-not-exist");
+
+        var result = EvtxFolderEnumerator.EnumerateEvtxTopLevel(nonexistent);
+
+        Assert.IsType<EvtxEnumerationResult.IoError>(result);
+    }
+
+    [Fact]
+    public void EnumerateTopLevel_RejectsNullOrWhitespace()
+    {
+        Assert.Throws<ArgumentException>(() => EvtxFolderEnumerator.EnumerateEvtxTopLevel(""));
+        Assert.Throws<ArgumentException>(() => EvtxFolderEnumerator.EnumerateEvtxTopLevel("   "));
+    }
+
+    [Fact]
+    public void ToAlertCopy_OnEmpty_ReturnsNull()
+    {
+        var result = EvtxFolderEnumerator.EnumerateEvtxTopLevel(_tempRoot);
+
+        Assert.Null(EvtxFolderEnumerator.ToAlertCopy(result));
+    }
+
+    [Fact]
+    public void ToAlertCopy_OnSuccess_ReturnsNull()
+    {
+        EvtxFolderFixtures.WriteEmptyFile(_tempRoot, "a.evtx");
+        var result = EvtxFolderEnumerator.EnumerateEvtxTopLevel(_tempRoot);
+
+        Assert.Null(EvtxFolderEnumerator.ToAlertCopy(result));
+    }
+}

--- a/tests/Unit/EventLogExpert.Windows.Tests/ManifestSchemaTests.cs
+++ b/tests/Unit/EventLogExpert.Windows.Tests/ManifestSchemaTests.cs
@@ -1,0 +1,201 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace EventLogExpert.Windows.Tests;
+
+/// <summary>
+///     Loads the MAUI head's <c>Package.appxmanifest</c> at test time and asserts the structural invariants the
+///     Explorer context menu depends on. Catches drift between the manifest CLSID and the native C++/WinRT shell
+///     extension's hard-coded CLSID, missing namespace declarations, and verb mis-configuration that <c>MakeAppx</c>
+///     doesn't surface until packaging time.
+/// </summary>
+public class ManifestSchemaTests
+{
+    /// <summary>
+    ///     CLSID of the shell extension. MUST match the literal in
+    ///     <c>src/EventLogExpert.ExplorerExtensionNative/dllmain.cpp</c> (the <c>CLSID_UUID</c> macro and <c>kCanonical</c>
+    ///     constant) AND the manifest entries below.
+    /// </summary>
+    private const string OpenEvtxCommandClsid = "F1B2C3D4-E5F6-4789-AB12-CD34EF567890";
+
+    [Fact]
+    public void Manifest_ComSurrogateServer_PointsAtNativeDll()
+    {
+        var content = File.ReadAllText(ResolveManifestPath());
+
+        // SurrogateServer (dllhost-hosted) — NOT ExeServer. Required because Explorer activates
+        // context-menu COM handlers via CLSCTX_INPROC_HANDLER, not CLSCTX_LOCAL_SERVER.
+        Assert.Contains("<com:SurrogateServer", content);
+        Assert.Contains("Path=\"EventLogExpert.ExplorerExtension.dll\"", content);
+        Assert.Contains("ThreadingModel=\"STA\"", content);
+        Assert.Contains($"Id=\"{OpenEvtxCommandClsid}\"", content);
+        Assert.DoesNotContain("<com:ExeServer", content);
+        Assert.DoesNotContain("comhost.dll", content);
+    }
+
+    [Fact]
+    public void Manifest_DeclaresRequiredNamespaces()
+    {
+        var content = File.ReadAllText(ResolveManifestPath());
+
+        Assert.Contains("xmlns:uap2", content);
+        Assert.Contains("xmlns:uap3", content);
+        Assert.Contains("xmlns:desktop4", content);
+        Assert.Contains("xmlns:desktop5", content);
+        Assert.Contains("xmlns:com", content);
+    }
+
+    [Fact]
+    public void Manifest_Exists()
+    {
+        var path = ResolveManifestPath();
+
+        Assert.True(File.Exists(path), $"Manifest not found at {path}");
+    }
+
+    [Fact]
+    public void Manifest_FileContextMenu_RegistersAnyFileAndDirectoryAndBackground()
+    {
+        var content = File.ReadAllText(ResolveManifestPath());
+
+        // Three context-menu surfaces, all routed to the same CLSID; the native handler's
+        // GetState filters to .evtx files and directories.
+        //   - desktop4:ItemType Type="*"                   — any-file right-click
+        //   - desktop5:ItemType Type="Directory"           — folder-icon right-click
+        //   - desktop5:ItemType Type="Directory\Background" — right-click inside an open folder
+        Assert.Contains("<desktop4:ItemType Type=\"*\">", content);
+        Assert.Contains($"<desktop4:Verb Id=\"OpenEvtx\" Clsid=\"{OpenEvtxCommandClsid}\"", content);
+        Assert.Contains("<desktop5:ItemType Type=\"Directory\">", content);
+        Assert.Contains("<desktop5:ItemType Type=\"Directory\\Background\">", content);
+        // Both desktop5:ItemType entries must declare a desktop5:Verb with the same CLSID.
+        var verbMatches = Regex.Matches(
+            content,
+            $"<desktop5:Verb Id=\"OpenEvtx\" Clsid=\"{OpenEvtxCommandClsid}\"");
+        Assert.Equal(2, verbMatches.Count);
+    }
+
+    [Fact]
+    public void Manifest_FtaVerb_IsDeclaredAsPlayerOpenVerb()
+    {
+        var content = File.ReadAllText(ResolveManifestPath());
+
+        Assert.Contains("<uap2:SupportedVerbs>", content);
+        Assert.Contains("Id=\"open\"", content);
+        // MultiSelectModel is unprefixed — the uap3:-prefixed form fails MSIX deployment
+        // schema validation (DEP0700 / 0xC00CE015 attribute-not-defined-in-DTD).
+        Assert.Contains("MultiSelectModel=\"Player\"", content);
+        Assert.DoesNotContain("uap3:MultiSelectModel=\"", content);
+        // uap7:Default does not survive AppX deployment validation in our config and isn't
+        // required for top-level surfacing — desktop4:fileExplorerContextMenus produces those.
+        Assert.DoesNotContain("uap7:", content);
+    }
+
+    [Fact]
+    public void Manifest_IgnorableNamespaces_OmitsCategoriesActuallyUsed()
+    {
+        var content = File.ReadAllText(ResolveManifestPath());
+
+        // Namespaces actually consumed by extensions must NOT be listed as ignorable — the
+        // deployment engine silently drops the extension on schema-unknown surfaces if they are.
+        // Parse the attribute value rather than assert an exact string so reordering, extra
+        // whitespace, or additional truly-ignorable prefixes (e.g., mp, build) don't break the test.
+        var match = Regex.Match(content, @"IgnorableNamespaces=""([^""]*)""");
+
+        Assert.True(match.Success, "IgnorableNamespaces attribute not declared on the Package element.");
+
+        var ignorablePrefixes = match.Groups[1].Value
+            .Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries);
+
+        // Used prefixes derived from the namespace declarations + extension consumption sites:
+        // uap2 (SupportedVerbs), uap3 (Extensions tree), desktop4 (any-file fileExplorerContextMenus),
+        // desktop5 (Directory + Directory\Background fileExplorerContextMenus), com (SurrogateServer).
+        string[] usedPrefixes = ["uap2", "uap3", "desktop4", "desktop5", "com"];
+
+        foreach (var used in usedPrefixes)
+        {
+            Assert.DoesNotContain(used, ignorablePrefixes);
+        }
+    }
+
+    [Fact]
+    public void Manifest_TargetDeviceFamily_DesktopOnly()
+    {
+        var content = File.ReadAllText(ResolveManifestPath());
+
+        // Windows.Universal causes AppX deployment to process under Universal rules first,
+        // silently dropping Desktop-specific extension categories like
+        // windows.fileExplorerContextMenus.
+        Assert.Contains("<TargetDeviceFamily Name=\"Windows.Desktop\"", content);
+        Assert.DoesNotContain("<TargetDeviceFamily Name=\"Windows.Universal\"", content);
+    }
+
+    [Fact]
+    public void NativeShellExtension_HasSameClsidAsManifest()
+    {
+        // The CLSID lives in three sites that must stay in sync: the manifest XML, the constant
+        // above, and the native C++ source. Drift would orphan Explorer's COM catalog from prior
+        // installs. This test reads dllmain.cpp and asserts both the CLSID_UUID string macro AND
+        // the kCanonical GUID struct fragments match — so changing one without the others fails.
+        var dllmainPath = ResolveRepoRelativePath("src", "EventLogExpert.ExplorerExtensionNative", "dllmain.cpp");
+
+        var native = File.ReadAllText(dllmainPath);
+
+        Assert.Contains($"#define CLSID_UUID \"{OpenEvtxCommandClsid}\"", native);
+        // F1B2C3D4-E5F6-4789-AB12-CD34EF567890 →
+        // {0xF1B2C3D4, 0xE5F6, 0x4789, {0xAB, 0x12, 0xCD, 0x34, 0xEF, 0x56, 0x78, 0x90}}
+        Assert.Contains("0xF1B2C3D4, 0xE5F6, 0x4789", native);
+        Assert.Contains("0xAB, 0x12, 0xCD, 0x34, 0xEF, 0x56, 0x78, 0x90", native);
+    }
+
+    [Fact]
+    public void NativeShellExtension_ImplementsIObjectWithSite_ForBackgroundMenuSurface()
+    {
+        // The Directory\Background ItemType registered in the manifest delivers a null
+        // IShellItemArray to GetState/Invoke. Without IObjectWithSite + SID_SFolderView the
+        // handler cannot recover the current folder and the verb is permanently hidden in that
+        // surface — the manifest registration alone is insufficient. This test asserts the
+        // method-signature lines (not bare keyword presence) so a comment-only reference to the
+        // tokens does not silently let the test pass while the implementation is removed.
+        var dllmainPath = ResolveRepoRelativePath("src", "EventLogExpert.ExplorerExtensionNative", "dllmain.cpp");
+
+        var native = File.ReadAllText(dllmainPath);
+
+        Assert.Contains("IObjectWithSite", native);
+        Assert.Contains("IFACEMETHODIMP SetSite", native);
+        Assert.Contains("IFACEMETHODIMP GetSite", native);
+        Assert.Contains("SID_SFolderView", native);
+        Assert.Contains("IPersistFolder2", native);
+        Assert.Contains("GetCurFolder", native);
+        // SHGetPathFromIDListEx is the long-path-capable variant — drift back to
+        // SHGetPathFromIDListW would silently re-introduce the MAX_PATH ceiling on this surface.
+        Assert.Contains("SHGetPathFromIDListEx", native);
+    }
+
+    private static string ResolveManifestPath() =>
+        ResolveRepoRelativePath("src", "EventLogExpert", "Platforms", "Windows", "Package.appxmanifest");
+
+    // Walks up from the test's runtime directory until finding the directory containing
+    // EventLogExpert.slnx, then joins the supplied relative segments. Resilient to test-output
+    // layout differences across runners (net10.0-windows10.0.19041.0/ vs net10.0/, Debug/Release,
+    // win-x64/ subfolder when publish-style output is in play) where a fixed `..\..\..\` count
+    // can drift. Pattern mirrors tests/Unit/EventLogExpert.Filtering.Tests/Persistence/PersistencePolicyTests.cs.
+    private static string ResolveRepoRelativePath(params string[] segments)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "EventLogExpert.slnx")))
+        {
+            directory = directory.Parent;
+        }
+
+        Assert.NotNull(directory);
+
+        var combined = Path.Combine([directory.FullName, .. segments]);
+        Assert.True(File.Exists(combined), $"Expected file at {combined} to exist.");
+
+        return combined;
+    }
+}

--- a/tests/Unit/EventLogExpert.Windows.Tests/TestUtils/ActivationFixtures.cs
+++ b/tests/Unit/EventLogExpert.Windows.Tests/TestUtils/ActivationFixtures.cs
@@ -1,0 +1,31 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using static EventLogExpert.Windows.Tests.TestUtils.Constants.Constants;
+
+namespace EventLogExpert.Windows.Tests.TestUtils;
+
+internal static class ActivationFixtures
+{
+    public static readonly Func<string, bool> AlwaysFileExists = static _ => true;
+    public static readonly Func<string, bool> NeverDirExists = static _ => false;
+    public static readonly Func<string, bool> NeverFileExists = static _ => false;
+
+    public static Func<string, bool> AcceptOnlyEvtxFiles() =>
+        CreateFileExistsForExtensions(EvtxExtension);
+
+    public static Func<string, bool> CreateDirExistsForPath(string expected) =>
+        path => string.Equals(path, expected, StringComparison.OrdinalIgnoreCase);
+
+    public static Func<string, bool> CreateFileExistsForExtensions(params string[] extensions) =>
+        path => extensions.Any(ext => path.EndsWith(ext, StringComparison.OrdinalIgnoreCase));
+
+    public static Func<string, bool> CreateFileExistsForPath(string expected) =>
+        path => string.Equals(path, expected, StringComparison.OrdinalIgnoreCase);
+
+    public static Func<string, bool>
+        CreateFileExistsThatThrowsFor(string throwForPath, Exception toThrow, string acceptForPath) =>
+        path => string.Equals(path, throwForPath, StringComparison.OrdinalIgnoreCase) ?
+            throw toThrow :
+            string.Equals(path, acceptForPath, StringComparison.OrdinalIgnoreCase);
+}

--- a/tests/Unit/EventLogExpert.Windows.Tests/TestUtils/Constants/Constants.Activation.cs
+++ b/tests/Unit/EventLogExpert.Windows.Tests/TestUtils/Constants/Constants.Activation.cs
@@ -1,0 +1,12 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Windows.Tests.TestUtils.Constants;
+
+public static partial class Constants
+{
+    public const string EventLogExpertExeName = "eventlogexpert.exe";
+    public const string EvtxExtension = ".evtx";
+    public const string EvtxExtensionUpper = ".EVTX";
+    public const string PackagedExePath = @"C:\Program Files\WindowsApps\EventLogExpert_…\eventlogexpert.exe";
+}

--- a/tests/Unit/EventLogExpert.Windows.Tests/TestUtils/Constants/Constants.CommandLine.cs
+++ b/tests/Unit/EventLogExpert.Windows.Tests/TestUtils/Constants/Constants.CommandLine.cs
@@ -1,0 +1,19 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Windows.Tests.TestUtils.Constants;
+
+public static partial class Constants
+{
+    public const string FirstArg = "a.evtx";
+    public const string LastArg = "c.evtx";
+    public const string MiddleArgWithSpaces = "B with space.evtx";
+    public const string MultipleArgsCommandLine = @"a.evtx ""B with space.evtx"" c.evtx";
+    public const string PathWithSpacesUnquoted = @"C:\Users\Jane Doe\Logs\sample.evtx";
+    public const string QuotedDriveRoot = @"""C:""";
+    public const string QuotedPathWithSpaces = @"""C:\Users\Jane Doe\Logs\sample.evtx""";
+    public const string QuotedUncPath = @"""\\server\share\sample.evtx""";
+    public const string UnquotedCLogsSampleEvtx = @"C:\Logs\sample.evtx";
+    public const string UnquotedDriveRoot = "C:";
+    public const string UnquotedUncPath = @"\\server\share\sample.evtx";
+}

--- a/tests/Unit/EventLogExpert.Windows.Tests/TestUtils/Constants/Constants.SamplePaths.cs
+++ b/tests/Unit/EventLogExpert.Windows.Tests/TestUtils/Constants/Constants.SamplePaths.cs
@@ -1,0 +1,20 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Windows.Tests.TestUtils.Constants;
+
+public static partial class Constants
+{
+    public const string AppEvtxFile = @"E:\Data\app.evtx";
+    public const string LogFile = @"E:\Data\d.log";
+    public const string LogsFolder = @"E:\Logs";
+    public const string LowercaseEvtxFile = @"E:\Data\a.evtx";
+    public const string NonexistentEvtxFile = @"E:\does-not-exist.evtx";
+    public const string NotesFile = @"E:\Data\notes";
+    public const string ProbeFailurePath = @"E:\probe-failure-path";
+    public const string RealEvtxFile = @"E:\Data\real.evtx";
+    public const string SampleEvtxFile = @"E:\Data\sample.evtx";
+    public const string SystemEvtxFile = @"E:\Data\sys.evtx";
+    public const string TxtFile = @"E:\Data\c.txt";
+    public const string UppercaseEvtxFile = @"E:\Data\B.EVTX";
+}

--- a/tests/Unit/EventLogExpert.Windows.Tests/TestUtils/EvtxFolderFixtures.cs
+++ b/tests/Unit/EventLogExpert.Windows.Tests/TestUtils/EvtxFolderFixtures.cs
@@ -1,0 +1,31 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Windows.Tests.TestUtils;
+
+internal static class EvtxFolderFixtures
+{
+    private const string TempFolderPrefix = "evtx-enumerator-tests-";
+
+    public static string CreateTempTestFolder()
+    {
+        var folder = Path.Combine(Path.GetTempPath(), TempFolderPrefix + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(folder);
+        return folder;
+    }
+
+    public static void TryDeleteFolder(string folder)
+    {
+        try
+        {
+            Directory.Delete(folder, recursive: true);
+        }
+        catch
+        {
+            // best-effort cleanup
+        }
+    }
+
+    public static void WriteEmptyFile(string folder, string fileName) =>
+        File.WriteAllText(Path.Combine(folder, fileName), string.Empty);
+}


### PR DESCRIPTION
## Summary

Adds Windows Explorer right-click context menu entries for `.evtx` files and folders:

- **`.evtx` file (single or multi-select)** → "Open with EventLogExpert" appears at the top level of the modern Win11 context menu AND in the "Open With" submenu (via FTA).
- **Folder icon** → "Open with EventLogExpert" opens all top-level `.evtx` files in the folder in one app instance.
- **Inside an open folder's empty space** (Directory\Background surface) → same verb, same behavior.

Multi-select fans into a single combined-view app instance via `AppInstance.FindOrRegisterForKey` single-instance redirection.

## Architecture

- **Native C++/WinRT shell extension DLL** (`src/EventLogExpert.ExplorerExtensionNative/`) implementing `IExplorerCommand` + `IObjectWithSite`, loaded by `dllhost.exe` via the manifest's `<com:SurrogateServer>` registration. Required because Explorer activates context-menu handlers via `CLSCTX_INPROC_HANDLER` (DLL only, not EXE).
- **Testable .NET helper library** (`src/EventLogExpert.WindowsPlatform/`) with `ActivationTokenClassifier`, `CommandLineToArgvWHelper`, `EvtxFolderEnumerator`, `EvtxEnumerationResult`, `ActivationDispatcher` (channel-based + `IMainThreadService` injection).
- **Activation pipeline** in the MAUI head: handwritten `Program.Main` replaces MAUI's source-generated Main so `AppInstance.FindOrRegisterForKey` can run BEFORE `Application.Start`; `ActivationBootstrap` buffers cold-launch args until the dispatcher attaches via DI.
- **MSBuild target** in `EventLogExpert.csproj` auto-builds the C++ DLL via vswhere-located VS MSBuild during MSIX packaging (fail-fast Error for non-x64 RIDs since vcxproj has only x64 configurations today).
- **app.manifest** with `longPathAware=true` so filesystem operations honor paths beyond MAX_PATH.

## Tests

38 new tests in `EventLogExpert.Windows.Tests` covering manifest schema invariants, CLSID drift detection across the 3 sites (manifest XML, native C++ source, test constant), `IObjectWithSite` method-signature drift detection, activation-token classification (incl. the launching-exe-skip regression test), folder enumeration (incl. long-path via `\\?\` prefix), CLI parsing, and the activation dispatcher (idempotency, cancellation, exception isolation, alert-before-openBatch).

## Smoke recipe

Run after any change touching the manifest, native DLL, activation pipeline, or `MauiMenuActionService.OpenFolderAsync`. Documented in `docs/Explorer-Context-Menu.md` (7 scenarios — FTA double-click regression gate, single-file right-click, multi-file right-click, secondary activation redirect, folder icon right-click, folder background right-click, empty folder right-click).

## Reviewer notes

- The 3-site CLSID `F1B2C3D4-E5F6-4789-AB12-CD34EF567890` is **immutable across releases** — changing it orphans Explorer's COM catalog from prior installs. The new `ManifestSchemaTests` `NativeShellExtension_HasSameClsidAsManifest` + `NativeShellExtension_ImplementsIObjectWithSite_ForBackgroundMenuSurface` tests pin drift detection.
- The `Directory\Background` surface requires `IObjectWithSite` because the shell passes `items == null` for empty-space right-click; the handler recovers the current folder via `QueryService(SID_SFolderView)` → `IPersistFolder2::GetCurFolder` → `SHGetPathFromIDListEx` (long-path-safe; `SHGetPathFromIDListW` caps at MAX_PATH).
- Local dev install requires a signed MSIX (loose-file `Add-AppxPackage -Register` leaves `SignatureKind=None` which silently drops packaged COM + context menu registrations). See `docs/Explorer-Context-Menu.md` + `eng/install-signed-dev-msix.ps1`.