### PR TITLE
Add FilterLibraryModal 3-tab redesign with LibraryEntryRow overflow menu and ARIA focus cascade

### DIFF
--- a/src/EventLogExpert.UI/FilterLibrary/AddToPresetIntent.cs
+++ b/src/EventLogExpert.UI/FilterLibrary/AddToPresetIntent.cs
@@ -1,0 +1,16 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Runtime.FilterLibrary;
+
+namespace EventLogExpert.UI.FilterLibrary;
+
+public sealed record AddToPresetIntent(
+    SavedFilter Filter,
+    LibraryEntryId? PresetId,
+    string? NewPresetName,
+    LibraryEntryId SourceEntryId)
+{
+    public SavedFilter Filter { get; init; } = Filter ?? throw new ArgumentNullException(nameof(Filter));
+}

--- a/src/EventLogExpert.UI/FilterLibrary/FavoriteToggleIntent.cs
+++ b/src/EventLogExpert.UI/FilterLibrary/FavoriteToggleIntent.cs
@@ -1,0 +1,8 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.FilterLibrary;
+
+namespace EventLogExpert.UI.FilterLibrary;
+
+public sealed record FavoriteToggleIntent(LibraryEntryId EntryId, bool NewIsFavorite);

--- a/src/EventLogExpert.UI/FilterLibrary/FilterLibraryModal.razor
+++ b/src/EventLogExpert.UI/FilterLibrary/FilterLibraryModal.razor
@@ -1,38 +1,79 @@
 @inherits ModalBase<bool>
 
-<ModalChrome AcceptLabel="Close"
-    CancelLabel="Close"
+<ModalChrome AriaLabel="Filter Library"
     CloseButtonAriaLabel="Close"
     Footer="FooterPreset.CloseOnly"
-    MaxWidth="40rem"
-    MinWidth="28rem"
+    MaxWidth="60rem"
+    MinWidth="40rem"
     OnClose="OnCancelAsync"
     OnDialogClosedByUser="HandleDialogClosedByUserAsync"
     @ref="ChromeRef"
     Title="Filter Library">
     @if (FilterLibraryState.Value.LoadError)
     {
-        <p class="filter-library-error">Could not load saved filters or presets. See trace log for details.</p>
+        <div class="filter-library-error" role="alert">
+            <p>Could not load saved filters or presets. See trace log for details.</p>
+            <button class="button" @onclick="RetryLoad" type="button">Retry</button>
+        </div>
     }
     else if (!FilterLibraryState.Value.IsLoaded)
     {
-        <p class="filter-library-loading" aria-busy="true">Loading filter library&hellip;</p>
-    }
-    else if (FilterLibraryState.Value.Entries.IsEmpty)
-    {
-        <p class="filter-library-empty">No saved filters or presets yet.</p>
+        <p aria-busy="true" class="filter-library-loading">Loading filter library&hellip;</p>
     }
     else
     {
-        <ul class="filter-library-list">
-            @foreach (var entry in FilterLibraryState.Value.Entries)
+        <div aria-label="Filter library views" class="library-tabs" @ref="_tablistRef" role="tablist">
+            @foreach (var (tab, label) in s_tabs)
             {
-                <li>
-                    <LibraryEntryRow Entry="@entry"
-                        OnApply="HandleApplyAsync"
-                        OnDelete="HandleDeleteAsync" />
-                </li>
+                <button aria-controls="@($"library-tabpanel-{tab}")"
+                    aria-selected="@(tab == _activeTab ? "true" : "false")"
+                    class="@(tab == _activeTab ? "tab active library-tab-button" : "tab library-tab-button")"
+                    id="@($"library-tab-{tab}")"
+                    @onclick="() => SetActiveTab(tab)"
+                    @onkeydown="e => OnTabKeyDown(e, tab)"
+                    @ref="_tabButtonRefs[tab]"
+                    role="tab"
+                    tabindex="@(tab == _activeTab ? "0" : "-1")"
+                    type="button">
+                    @label (@GetCount(tab))
+                </button>
             }
-        </ul>
+        </div>
+
+        @foreach (var (tab, _) in s_tabs)
+        {
+            <div aria-labelledby="@($"library-tab-{tab}")"
+                class="@(tab == _activeTab ? "library-tab-panel active" : "library-tab-panel")"
+                id="@($"library-tabpanel-{tab}")"
+                role="tabpanel"
+                style="@(tab == _activeTab ? "" : "display: none")"
+                tabindex="@(tab == _activeTab && NeedsTabpanelFocus ? "0" : null)">
+                @if (tab == _activeTab)
+                {
+                    @if (CurrentTabEntries.Count == 0)
+                    {
+                        <p class="library-empty-state">@EmptyStateMessage</p>
+                    }
+                    else
+                    {
+                        @foreach (var entry in CurrentTabEntries)
+                        {
+                            <LibraryEntryRow ActiveTab="_activeTab"
+                                AllPresets="AllPresets"
+                                Entry="entry"
+                                @key="entry.Id"
+                                OnAddToPreset="HandleAddToPresetAsync"
+                                OnApply="HandleApplyAsync"
+                                OnDelete="HandleDelete"
+                                OnReplace="HandleReplaceAsync"
+                                OnRequestPendingFocus="HandleRequestPendingFocusAsync"
+                                OnSaveToLibrary="HandleSaveToLibrary"
+                                OnToggleFavorite="HandleToggleFavorite"
+                                @ref="_rowRefs[entry.Id]" />
+                        }
+                    }
+                }
+            </div>
+        }
     }
 </ModalChrome>

--- a/src/EventLogExpert.UI/FilterLibrary/FilterLibraryModal.razor.cs
+++ b/src/EventLogExpert.UI/FilterLibrary/FilterLibraryModal.razor.cs
@@ -1,42 +1,349 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.Runtime.FilterLibrary;
+using EventLogExpert.UI.Focus;
 using EventLogExpert.UI.Modal;
 using Fluxor;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.JSInterop;
 
 namespace EventLogExpert.UI.FilterLibrary;
 
 public sealed partial class FilterLibraryModal : ModalBase<bool>
 {
+    private static readonly (LibraryTab Tab, string Label)[] s_tabs =
+    [
+        (LibraryTab.Saved, "Saved"),
+        (LibraryTab.Favorites, "Favorites"),
+        (LibraryTab.PreviouslyUsed, "Previously Used"),
+    ];
+    private readonly Dictionary<LibraryEntryId, LibraryEntryRow?> _rowRefs = new();
+
+    private readonly Dictionary<LibraryTab, ElementReference> _tabButtonRefs = new();
+
+    private LibraryTab _activeTab = LibraryTab.Saved;
+    private LibraryTab? _pendingFocusTab;
+    private LibraryEntryId? _pendingFocusTargetEntryId;
+    private bool _pendingFocusToActiveTab;
+    private IJSObjectReference? _tabKeyModule;
+    private bool _tabKeyShimAttached;
+    private ElementReference _tablistRef;
+
+    private IReadOnlyList<LibraryEntryPreset> AllPresets =>
+        [.. FilterLibraryState.Value.Entries
+            .OfType<LibraryEntryPreset>()
+            .OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase)];
+
+    [Inject] private IAnnouncementService AnnouncementService { get; init; } = null!;
+
+    private IReadOnlyList<LibraryEntry> CurrentTabEntries => _activeTab switch
+    {
+        LibraryTab.Favorites => FavoriteEntries,
+        LibraryTab.PreviouslyUsed => PreviouslyUsedEntries,
+        _ => SavedEntries,
+    };
+
+    private string EmptyStateMessage => _activeTab switch
+    {
+        LibraryTab.Favorites => "No favorited filters or presets yet. Star an entry to add it here.",
+        LibraryTab.PreviouslyUsed => "No filters have been applied recently.",
+        _ => "No saved filters or presets yet. Use \"Save as Preset\" from the filter pane.",
+    };
+
+    private IReadOnlyList<LibraryEntry> FavoriteEntries =>
+        [.. FilterLibraryState.Value.Entries
+            .Where(e => e.IsFavorite)
+            .OrderBy(e => e.Name, StringComparer.OrdinalIgnoreCase)];
+
     [Inject] private IFilterLibraryCommands FilterLibraryCommands { get; init; } = null!;
 
     [Inject] private IState<FilterLibraryState> FilterLibraryState { get; init; } = null!;
+
+    [Inject] private IJSRuntime JSRuntime { get; init; } = null!;
+
+    private bool NeedsTabpanelFocus => CurrentTabEntries.Count == 0;
+
+    private IReadOnlyList<LibraryEntry> PreviouslyUsedEntries =>
+        [.. FilterLibraryState.Value.Entries
+            .Where(e => e.LastUsedUtc is not null)
+            .OrderByDescending(e => e.LastUsedUtc!.Value)
+            .Take(50)];
+
+    private IReadOnlyList<LibraryEntry> SavedEntries =>
+        [.. FilterLibraryState.Value.Entries
+            .Where(e => e.Origin == LibraryEntryOrigin.UserSaved)
+            .OrderBy(e => e.Name, StringComparer.OrdinalIgnoreCase)];
+
+    internal static (LibraryEntryId? TargetId, bool FallbackToActiveTab) DecidePendingFocusAfterRemoval(
+        IReadOnlyList<LibraryEntry> snapshot,
+        LibraryEntryId removedEntryId)
+    {
+        var idx = -1;
+
+        for (int i = 0; i < snapshot.Count; i++)
+        {
+            if (snapshot[i].Id.Equals(removedEntryId)) { idx = i; break; }
+        }
+
+        if (idx < 0) { return (null, true); }
+
+        if (idx + 1 < snapshot.Count) { return (snapshot[idx + 1].Id, false); }
+
+        if (idx > 0) { return (snapshot[idx - 1].Id, false); }
+
+        return (null, true);
+    }
+
+    internal void RecordPendingFocusAfterRemoval(LibraryEntryId removedEntryId)
+    {
+        var (targetId, fallback) = DecidePendingFocusAfterRemoval(CurrentTabEntries, removedEntryId);
+
+        _pendingFocusTargetEntryId = targetId;
+        _pendingFocusToActiveTab = fallback;
+    }
+
+    protected override async ValueTask DisposeAsyncCore(bool disposing)
+    {
+        if (disposing && _tabKeyModule is not null)
+        {
+            try
+            {
+                await _tabKeyModule.InvokeVoidAsync("detach", _tablistRef);
+                await _tabKeyModule.DisposeAsync();
+            }
+            catch (JSDisconnectedException) { }
+            catch (JSException) { }
+            catch (ObjectDisposedException) { }
+        }
+
+        await base.DisposeAsyncCore(disposing);
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            try
+            {
+                _tabKeyModule = await JSRuntime.InvokeAsync<IJSObjectReference>(
+                    "import",
+                    "./_content/EventLogExpert.UI/FilterLibrary/FilterLibraryModal.js");
+            }
+            catch (JSDisconnectedException) { }
+            catch (JSException) { }
+        }
+
+        bool tablistRendered = FilterLibraryState.Value.IsLoaded && !FilterLibraryState.Value.LoadError;
+
+        if (!tablistRendered)
+        {
+            if (_tabKeyShimAttached && _tabKeyModule is not null)
+            {
+                try
+                {
+                    await _tabKeyModule.InvokeVoidAsync("detach", _tablistRef);
+                }
+                catch (JSDisconnectedException) { }
+                catch (JSException) { }
+            }
+
+            _tabKeyShimAttached = false;
+        }
+        else if (_tabKeyModule is not null && !_tabKeyShimAttached)
+        {
+            try
+            {
+                await _tabKeyModule.InvokeVoidAsync("attach", _tablistRef);
+                _tabKeyShimAttached = true;
+            }
+            catch (JSDisconnectedException) { }
+            catch (JSException) { }
+        }
+
+        PruneStaleRowRefs();
+
+        bool focused = false;
+
+        if (_pendingFocusTargetEntryId is { } entryId)
+        {
+            _pendingFocusTargetEntryId = null;
+
+            if (_rowRefs.TryGetValue(entryId, out var rowRef) && rowRef is not null)
+            {
+                focused = await rowRef.FocusMoreActionsButtonAsync();
+
+                if (focused)
+                {
+                    _pendingFocusTab = null;
+                    _pendingFocusToActiveTab = false;
+                }
+                else
+                {
+                    _pendingFocusToActiveTab = true;
+                    _pendingFocusTab = null;
+                }
+            }
+            else
+            {
+                _pendingFocusToActiveTab = true;
+                _pendingFocusTab = null;
+            }
+        }
+
+        if (!focused)
+        {
+            if (_pendingFocusTab is { } tab)
+            {
+                _pendingFocusTab = null;
+
+                if (_tabButtonRefs.TryGetValue(tab, out var tabRef))
+                {
+                    focused = await ElementFocus.TrySafelyAsync(tabRef);
+                }
+
+                _pendingFocusToActiveTab = !focused;
+            }
+
+            if (!focused && _pendingFocusToActiveTab)
+            {
+                _pendingFocusToActiveTab = false;
+
+                if (_tabButtonRefs.TryGetValue(_activeTab, out var activeTabRef))
+                {
+                    await ElementFocus.SafelyAsync(activeTabRef);
+                }
+            }
+        }
+
+        await base.OnAfterRenderAsync(firstRender);
+    }
 
     protected override void OnInitialized()
     {
         base.OnInitialized();
 
-        // Retry-on-reopen: re-dispatch when either the library hasn't loaded yet OR the prior
-        // load failed (gives transient failures a chance to clear).
         if (!FilterLibraryState.Value.IsLoaded || FilterLibraryState.Value.LoadError)
         {
             FilterLibraryCommands.LoadLibrary();
         }
     }
 
-    private Task HandleApplyAsync(LibraryEntryId entryId)
+    private static LibraryTab NextTab(LibraryTab current)
     {
-        FilterLibraryCommands.ApplyEntry(entryId);
+        var index = Array.FindIndex(s_tabs, t => t.Tab == current);
 
-        return CompleteAsync(true);
+        return index < s_tabs.Length - 1 ? s_tabs[index + 1].Tab : s_tabs[0].Tab;
     }
 
-    private Task HandleDeleteAsync(LibraryEntryId entryId)
+    private static LibraryTab PrevTab(LibraryTab current)
     {
-        FilterLibraryCommands.DeleteEntry(entryId);
+        var index = Array.FindIndex(s_tabs, t => t.Tab == current);
+
+        return index > 0 ? s_tabs[index - 1].Tab : s_tabs[^1].Tab;
+    }
+
+    private int GetCount(LibraryTab tab) => tab switch
+    {
+        LibraryTab.Favorites => FavoriteEntries.Count,
+        LibraryTab.PreviouslyUsed => PreviouslyUsedEntries.Count,
+        _ => SavedEntries.Count,
+    };
+
+    private Task HandleAddToPresetAsync(AddToPresetIntent intent)
+    {
+        if (intent.PresetId is { } presetId)
+        {
+            FilterLibraryCommands.AddFilterToExistingPreset(presetId, intent.Filter, intent.SourceEntryId);
+        }
+        else if (!string.IsNullOrWhiteSpace(intent.NewPresetName))
+        {
+            FilterLibraryCommands.AddFilterToNewPreset(intent.NewPresetName!, intent.Filter, intent.SourceEntryId);
+        }
 
         return Task.CompletedTask;
+    }
+
+    private async Task HandleApplyAsync(LibraryEntryId id)
+    {
+        FilterLibraryCommands.ApplyEntry(id);
+        var entry = FilterLibraryState.Value.Entries.FirstOrDefault(e => e.Id.Equals(id));
+        if (entry is not null) { AnnouncementService.Announce($"Applied {entry.Name}"); }
+        await CompleteAsync(true);
+    }
+
+    private void HandleDelete(LibraryEntryId id) => FilterLibraryCommands.DeleteEntry(id);
+
+    private async Task HandleReplaceAsync(LibraryEntryId id)
+    {
+        FilterLibraryCommands.ReplaceWithEntry(id);
+        var entry = FilterLibraryState.Value.Entries.FirstOrDefault(e => e.Id.Equals(id));
+        if (entry is not null) { AnnouncementService.Announce($"Replaced filters with {entry.Name}"); }
+        await CompleteAsync(true);
+    }
+
+    private Task HandleRequestPendingFocusAsync(LibraryEntryId entryId)
+    {
+        RecordPendingFocusAfterRemoval(entryId);
+
+        return Task.CompletedTask;
+    }
+
+    private void HandleSaveToLibrary(LibraryEntryId id) => FilterLibraryCommands.SaveEntry(id);
+
+    private void HandleToggleFavorite(FavoriteToggleIntent intent) =>
+        FilterLibraryCommands.SetIsFavorite(intent.EntryId, intent.NewIsFavorite);
+
+    private async Task OnTabKeyDown(KeyboardEventArgs e, LibraryTab tab)
+    {
+        LibraryTab target = tab;
+        bool handled = true;
+
+        switch (e.Key)
+        {
+            case "ArrowRight":
+                target = NextTab(tab);
+                break;
+            case "ArrowLeft":
+                target = PrevTab(tab);
+                break;
+            case "Home":
+                target = s_tabs[0].Tab;
+                break;
+            case "End":
+                target = s_tabs[^1].Tab;
+                break;
+            default:
+                handled = false;
+                break;
+        }
+
+        if (!handled || target == tab) { return; }
+
+        _activeTab = target;
+        _pendingFocusTab = target;
+
+        await Task.CompletedTask;
+    }
+
+    private void PruneStaleRowRefs()
+    {
+        if (_rowRefs.Count == 0) { return; }
+
+        var currentIds = new HashSet<LibraryEntryId>(CurrentTabEntries.Select(e => e.Id));
+        var stale = _rowRefs.Keys.Where(id => !currentIds.Contains(id)).ToList();
+
+        foreach (var id in stale) { _rowRefs.Remove(id); }
+    }
+
+    private void RetryLoad() => FilterLibraryCommands.LoadLibrary();
+
+    private void SetActiveTab(LibraryTab tab)
+    {
+        if (_activeTab == tab) { return; }
+
+        _activeTab = tab;
     }
 }

--- a/src/EventLogExpert.UI/FilterLibrary/FilterLibraryModal.razor.css
+++ b/src/EventLogExpert.UI/FilterLibrary/FilterLibraryModal.razor.css
@@ -1,21 +1,61 @@
-.filter-library-list {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-}
-
-.filter-library-list li {
-    margin-bottom: 0.25rem;
-}
-
-.filter-library-empty,
-.filter-library-error,
-.filter-library-loading {
-    color: var(--clr-text-secondary, currentColor);
-    text-align: center;
-    padding: 1rem 0;
-}
-
 .filter-library-error {
+    align-items: center;
     color: var(--clr-red, red);
+    display: flex;
+    flex-direction: column;
+    gap: .75rem;
+    padding: 1rem;
+    text-align: center;
+}
+
+.filter-library-loading,
+.library-empty-state {
+    color: var(--clr-text-secondary, currentColor);
+    padding: 1rem 0;
+    text-align: center;
+}
+
+.library-tabs {
+    border-bottom: 1px solid var(--clr-border, currentColor);
+    display: flex;
+    flex-wrap: wrap;
+    gap: .25rem;
+    margin-bottom: .5rem;
+}
+
+.library-tab-button {
+    background: transparent;
+    border: none;
+    border-bottom: 2px solid transparent;
+    cursor: pointer;
+    font: inherit;
+    padding: .5rem 1rem;
+}
+
+.library-tab-button:hover {
+    background: var(--clr-bg-hover, transparent);
+}
+
+.library-tab-button:focus-visible {
+    outline: 2px solid var(--clr-focus, currentColor);
+    outline-offset: 2px;
+}
+
+.library-tab-button.active {
+    border-bottom-color: var(--clr-accent, currentColor);
+    font-weight: 600;
+}
+
+.library-tab-panel {
+    display: flex;
+    flex-direction: column;
+    gap: .25rem;
+    max-height: 30rem;
+    overflow-y: auto;
+    padding: .5rem 0;
+}
+
+.library-tab-panel:focus-visible {
+    outline: 2px solid var(--clr-focus, currentColor);
+    outline-offset: -2px;
 }

--- a/src/EventLogExpert.UI/FilterLibrary/LibraryEntryRow.razor
+++ b/src/EventLogExpert.UI/FilterLibrary/LibraryEntryRow.razor
@@ -1,15 +1,44 @@
-<div class="library-entry-row">
-    <span class="library-entry-kind-badge">@KindLabel</span>
-    <span class="library-entry-name">@Entry.Name</span>
+<div class="library-entry-row" data-entry-id="@Entry.Id">
+    <i aria-label="@KindAriaLabel" class="@KindIconClass" role="img"></i>
 
-    <button class="button button-green"
-        @onclick="HandleApplyClicked"
+    <div class="library-entry-name">
+        <span class="library-entry-name-text" title="@Entry.Name">@Entry.Name</span>
+        @if (Entry is LibraryEntryPreset preset)
+        {
+            <span class="library-entry-detail">(@preset.Filters.Count filter@(preset.Filters.Count == 1 ? "" : "s"))</span>
+        }
+        @if (ActiveTab == LibraryTab.PreviouslyUsed && Entry.LastUsedUtc is { } lastUsed)
+        {
+            <span class="library-entry-detail">Last used: @FormatRelativeTime(lastUsed)</span>
+        }
+    </div>
+
+    <span class="library-entry-status-badge" data-status="@StatusBadgeKind">@StatusBadgeText</span>
+
+    <button aria-label="@($"Apply {Entry.Name} additively to current filters")"
+        class="button button-green"
+        @onclick="OnApplyAsync"
         type="button">
-        Apply
+        <i aria-hidden="true" class="bi bi-plus-circle"></i> Apply
     </button>
-    <button class="button button-red"
-        @onclick="HandleDeleteClicked"
+
+    <button aria-label="@FavoriteAriaLabel"
+        aria-pressed="@(Entry.IsFavorite ? "true" : "false")"
+        class="button button-yellow icon-button"
+        @onclick="OnToggleFavoriteAsync"
+        title="@FavoriteTitle"
         type="button">
-        Delete
+        <i aria-hidden="true" class="@FavoriteIconClass"></i>
+    </button>
+
+    <button aria-expanded="@(IsMoreMenuOpen ? "true" : "false")"
+        aria-haspopup="menu"
+        aria-label="@($"More actions for {Entry.Name}")"
+        class="button icon-button"
+        @onclick="ToggleMoreMenuAsync"
+        @ref="_moreMenuButtonRef"
+        title="More actions"
+        type="button">
+        <i aria-hidden="true" class="bi bi-three-dots-vertical"></i>
     </button>
 </div>

--- a/src/EventLogExpert.UI/FilterLibrary/LibraryEntryRow.razor.cs
+++ b/src/EventLogExpert.UI/FilterLibrary/LibraryEntryRow.razor.cs
@@ -1,33 +1,268 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Runtime.Alerts;
+using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.Runtime.FilterLibrary;
+using EventLogExpert.Runtime.FilterPane;
+using EventLogExpert.Runtime.Menu;
+using EventLogExpert.UI.Focus;
+using Fluxor;
 using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
 
 namespace EventLogExpert.UI.FilterLibrary;
 
-public sealed partial class LibraryEntryRow : ComponentBase
+public sealed partial class LibraryEntryRow : ComponentBase, IAsyncDisposable
 {
-    [Parameter][EditorRequired]
-    public required LibraryEntry Entry { get; set; }
+    private ElementReference _moreMenuButtonRef;
+    private long _moreMenuId;
 
-    [Parameter]
-    public EventCallback<LibraryEntryId> OnApply { get; set; }
+    [Parameter][EditorRequired] public LibraryTab ActiveTab { get; set; }
 
-    [Parameter]
-    public EventCallback<LibraryEntryId> OnDelete { get; set; }
+    [Parameter][EditorRequired] public required IReadOnlyList<LibraryEntryPreset> AllPresets { get; set; }
 
-    [Parameter]
-    public EventCallback<LibraryEntry> OnEdit { get; set; }
+    [Parameter][EditorRequired] public required LibraryEntry Entry { get; set; }
 
-    private string KindLabel => Entry switch
+    [Parameter][EditorRequired] public EventCallback<AddToPresetIntent> OnAddToPreset { get; set; }
+
+    [Parameter][EditorRequired] public EventCallback<LibraryEntryId> OnApply { get; set; }
+
+    [Parameter][EditorRequired] public EventCallback<LibraryEntryId> OnDelete { get; set; }
+
+    [Parameter][EditorRequired] public EventCallback<LibraryEntryId> OnReplace { get; set; }
+
+    [Parameter][EditorRequired] public EventCallback<LibraryEntryId> OnRequestPendingFocus { get; set; }
+
+    [Parameter][EditorRequired] public EventCallback<LibraryEntryId> OnSaveToLibrary { get; set; }
+
+    [Parameter][EditorRequired] public EventCallback<FavoriteToggleIntent> OnToggleFavorite { get; set; }
+
+    [Inject] private IAlertDialogService AlertDialogService { get; init; } = null!;
+
+    [Inject] private IAnnouncementService AnnouncementService { get; init; } = null!;
+
+    private string FavoriteAriaLabel => Entry.IsFavorite
+        ? $"Remove {Entry.Name} from favorites"
+        : $"Add {Entry.Name} to favorites";
+
+    private string FavoriteIconClass => Entry.IsFavorite ? "bi bi-star-fill" : "bi bi-star";
+
+    private string FavoriteTitle => Entry.IsFavorite ? "Remove from favorites" : "Add to favorites";
+
+    [Inject] private IState<FilterPaneState> FilterPaneState { get; init; } = null!;
+
+    private bool IsMoreMenuOpen =>
+        _moreMenuId != 0 && MenuService.ActiveMenuId == _moreMenuId && MenuService.ActiveItems is not null;
+
+    [Inject] private IJSRuntime JSRuntime { get; init; } = null!;
+
+    private string KindAriaLabel => Entry is LibraryEntryPreset ? "Preset" : "Filter";
+
+    private string KindIconClass => Entry is LibraryEntryPreset
+        ? "bi bi-collection library-entry-kind-icon"
+        : "bi bi-funnel library-entry-kind-icon";
+
+    [Inject] private IMenuService MenuService { get; init; } = null!;
+
+    private bool ShowSaveToLibraryItem =>
+        Entry is { Origin: LibraryEntryOrigin.AutoTracked, IsFavorite: false };
+
+    private string StatusBadgeKind
     {
-        LibraryEntrySavedFilter => "Filter",
-        LibraryEntryPreset => "Preset",
-        _ => "Unknown",
-    };
+        get
+        {
+            if (Entry.IsFavorite) { return "favorite"; }
 
-    private Task HandleApplyClicked() => OnApply.InvokeAsync(Entry.Id);
+            return Entry is { Origin: LibraryEntryOrigin.AutoTracked, LastUsedUtc: not null } ? "previously-used" : "saved";
+        }
+    }
 
-    private Task HandleDeleteClicked() => OnDelete.InvokeAsync(Entry.Id);
+    private string StatusBadgeText
+    {
+        get
+        {
+            if (Entry.IsFavorite) { return "Favorite"; }
+
+            return Entry is { Origin: LibraryEntryOrigin.AutoTracked, LastUsedUtc: not null } ? "Previously used" : "Saved";
+        }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        MenuService.StateChanged -= OnMenuServiceStateChanged;
+
+        return ValueTask.CompletedTask;
+    }
+
+    internal ValueTask<bool> FocusMoreActionsButtonAsync() => ElementFocus.TrySafelyAsync(_moreMenuButtonRef);
+
+    protected override void OnInitialized()
+    {
+        MenuService.StateChanged += OnMenuServiceStateChanged;
+
+        base.OnInitialized();
+    }
+
+    private static string FormatRelativeTime(DateTimeOffset lastUsed)
+    {
+        var diff = DateTimeOffset.UtcNow - lastUsed;
+
+        if (diff.TotalSeconds < 60) { return "just now"; }
+
+        if (diff.TotalMinutes < 60) { return $"{(int)diff.TotalMinutes}m ago"; }
+        
+        if (diff.TotalHours < 24) { return $"{(int)diff.TotalHours}h ago"; }
+        
+        return diff.TotalDays < 7 ?
+            $"{(int)diff.TotalDays}d ago" :
+            lastUsed.ToLocalTime().ToString("yyyy-MM-dd");
+    }
+
+    private MenuItem BuildAddToPresetItem(LibraryEntrySavedFilter filterEntry)
+    {
+        var children = new List<MenuItem>
+        {
+            MenuItem.Item("+ New preset...", () => OnNewPresetSelectedAsync(filterEntry)),
+        };
+
+        if (AllPresets.Count <= 0)
+        {
+            return MenuItem.SubMenu("Add to preset...", children);
+        }
+
+        children.Add(MenuItem.Separator());
+
+        foreach (var preset in AllPresets)
+        {
+            var pid = preset.Id;
+            var pname = preset.Name;
+            children.Add(MenuItem.Item(pname, () => OnExistingPresetSelectedAsync(filterEntry, pid, pname)));
+        }
+
+        return MenuItem.SubMenu("Add to preset...", children);
+    }
+
+    private IReadOnlyList<MenuItem> BuildMoreMenu()
+    {
+        var items = new List<MenuItem>
+        {
+            MenuItem.Item("Replace current filters", OnReplaceAsync),
+        };
+
+        if (ShowSaveToLibraryItem)
+        {
+            items.Add(MenuItem.Item("Save to Library", OnSaveToLibraryAsync));
+        }
+
+        if (Entry is LibraryEntrySavedFilter filterEntry)
+        {
+            items.Add(BuildAddToPresetItem(filterEntry));
+        }
+
+        items.Add(MenuItem.Separator());
+        items.Add(MenuItem.Item("Delete", OnDeleteAsync, isDanger: true));
+
+        return items;
+    }
+
+    private Task OnApplyAsync() => OnApply.InvokeAsync(Entry.Id);
+
+    private async Task OnDeleteAsync()
+    {
+        var needsConfirm = Entry is LibraryEntryPreset || Entry.Origin == LibraryEntryOrigin.UserSaved;
+
+        if (needsConfirm)
+        {
+            var entryKind = Entry is LibraryEntryPreset p
+                ? $"preset '{Entry.Name}' with {p.Filters.Count} filter{(p.Filters.Count == 1 ? "" : "s")}"
+                : $"filter '{Entry.Name}'";
+
+            var confirmed = await AlertDialogService.ShowAlert(
+                "Delete from library?",
+                $"This will permanently delete the {entryKind}. This cannot be undone.",
+                "Delete",
+                "Cancel");
+
+            if (!confirmed) { return; }
+        }
+
+        await OnRequestPendingFocus.InvokeAsync(Entry.Id);
+        await OnDelete.InvokeAsync(Entry.Id);
+        AnnouncementService.Announce($"Deleted {Entry.Name} from library");
+    }
+
+    private async Task OnExistingPresetSelectedAsync(LibraryEntrySavedFilter filterEntry, LibraryEntryId presetId, string presetName)
+    {
+        await OnAddToPreset.InvokeAsync(new AddToPresetIntent(filterEntry.Filter, presetId, null, filterEntry.Id));
+        AnnouncementService.Announce($"Added filter to preset '{presetName}'");
+    }
+
+    private void OnMenuServiceStateChanged() => _ = InvokeAsync(StateHasChanged);
+
+    private async Task OnNewPresetSelectedAsync(LibraryEntrySavedFilter filterEntry)
+    {
+        var name = await AlertDialogService.DisplayPrompt(
+            "Preset name",
+            "What would you like to name this preset? (use \\ for folder paths)",
+            "New Preset");
+
+        if (string.IsNullOrWhiteSpace(name)) { return; }
+
+        await OnAddToPreset.InvokeAsync(new AddToPresetIntent(filterEntry.Filter, null, name, filterEntry.Id));
+        AnnouncementService.Announce($"Added filter to new preset '{name}'");
+    }
+
+    private async Task OnReplaceAsync()
+    {
+        if (!FilterPaneState.Value.Filters.IsEmpty)
+        {
+            var confirmed = await AlertDialogService.ShowAlert(
+                "Replace current filters?",
+                $"This will replace your current filter list with the filters from '{Entry.Name}'. " +
+                "Your date filter and any in-progress filter drafts will be kept.",
+                "Replace",
+                "Cancel");
+
+            if (!confirmed) { return; }
+        }
+
+        await OnReplace.InvokeAsync(Entry.Id);
+    }
+
+    private async Task OnSaveToLibraryAsync()
+    {
+        await OnSaveToLibrary.InvokeAsync(Entry.Id);
+        AnnouncementService.Announce($"Saved {Entry.Name} to library");
+    }
+
+    private async Task OnToggleFavoriteAsync()
+    {
+        var newIsFavorite = !Entry.IsFavorite;
+        var willLeaveActiveTab =
+            (ActiveTab == LibraryTab.Favorites && Entry.IsFavorite) ||
+            (ActiveTab == LibraryTab.PreviouslyUsed && newIsFavorite);
+
+        if (willLeaveActiveTab) { await OnRequestPendingFocus.InvokeAsync(Entry.Id); }
+
+        await OnToggleFavorite.InvokeAsync(new FavoriteToggleIntent(Entry.Id, newIsFavorite));
+        AnnouncementService.Announce(newIsFavorite
+            ? $"Marked {Entry.Name} as favorite"
+            : $"Removed {Entry.Name} from favorites");
+    }
+
+    private async Task ToggleMoreMenuAsync()
+    {
+        if (IsMoreMenuOpen) { MenuService.Close(); return; }
+
+        try
+        {
+            var rect = await JSRuntime.InvokeAsync<MenuAnchorRect>("getMenuElementRect", _moreMenuButtonRef);
+            MenuService.OpenAt(rect.Left, rect.Bottom, BuildMoreMenu(), focusFirst: true);
+            _moreMenuId = MenuService.ActiveMenuId;
+            StateHasChanged();
+        }
+        catch (JSDisconnectedException) { }
+        catch (JSException) { }
+    }
 }

--- a/src/EventLogExpert.UI/FilterLibrary/LibraryEntryRow.razor.css
+++ b/src/EventLogExpert.UI/FilterLibrary/LibraryEntryRow.razor.css
@@ -1,24 +1,60 @@
 .library-entry-row {
-    display: flex;
     align-items: center;
-    gap: 0.5rem;
-    padding: 0.25rem 0.5rem;
+    border: 1px solid transparent;
+    display: flex;
+    gap: .5rem;
+    padding: .25rem .5rem;
 }
 
-.library-entry-kind-badge {
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
+.library-entry-row:hover {
+    background: var(--clr-bg-hover, transparent);
+}
+
+.library-entry-kind-icon {
     color: var(--clr-text-secondary, currentColor);
-    padding: 0.1rem 0.4rem;
-    border: 1px solid currentColor;
-    border-radius: 0.25rem;
     flex-shrink: 0;
 }
 
 .library-entry-name {
+    align-items: baseline;
+    display: flex;
     flex-grow: 1;
+    flex-wrap: wrap;
+    gap: .5rem;
+    min-width: 0;
+    overflow: hidden;
+}
+
+.library-entry-name-text {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+
+.library-entry-detail {
+    color: var(--clr-text-secondary, currentColor);
+    font-size: .85em;
+    white-space: nowrap;
+}
+
+.library-entry-status-badge {
+    border: 1px solid currentColor;
+    border-radius: .25rem;
+    flex-shrink: 0;
+    font-size: .75rem;
+    font-weight: 600;
+    padding: .1rem .4rem;
+    text-transform: uppercase;
+}
+
+.library-entry-status-badge[data-status="favorite"] {
+    color: var(--clr-yellow, currentColor);
+}
+
+.library-entry-status-badge[data-status="previously-used"] {
+    color: var(--clr-text-secondary, currentColor);
+}
+
+.library-entry-status-badge[data-status="saved"] {
+    color: var(--clr-accent, currentColor);
 }

--- a/src/EventLogExpert.UI/FilterLibrary/LibraryTab.cs
+++ b/src/EventLogExpert.UI/FilterLibrary/LibraryTab.cs
@@ -1,0 +1,11 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.UI.FilterLibrary;
+
+public enum LibraryTab
+{
+    Saved,
+    Favorites,
+    PreviouslyUsed,
+}

--- a/src/EventLogExpert.UI/Focus/ElementFocus.cs
+++ b/src/EventLogExpert.UI/Focus/ElementFocus.cs
@@ -19,4 +19,18 @@ internal static class ElementFocus
         catch (JSException) { }
         catch (TaskCanceledException) { }
     }
+
+    public static async ValueTask<bool> TrySafelyAsync(ElementReference target)
+    {
+        try
+        {
+            await target.FocusAsync();
+
+            return true;
+        }
+        catch (ObjectDisposedException) { return false; }
+        catch (JSDisconnectedException) { return false; }
+        catch (JSException) { return false; }
+        catch (TaskCanceledException) { return false; }
+    }
 }

--- a/src/EventLogExpert.UI/_Imports.razor
+++ b/src/EventLogExpert.UI/_Imports.razor
@@ -19,6 +19,7 @@
 @using EventLogExpert.Runtime.Common.Display
 @using EventLogExpert.Runtime.Database
 @using EventLogExpert.Runtime.FilterGroup
+@using EventLogExpert.Runtime.FilterLibrary
 @using EventLogExpert.Runtime.LogTable
 @using EventLogExpert.Runtime.Settings
 
@@ -29,6 +30,7 @@
 @using EventLogExpert.UI.FilterEditor.Comparison
 @using EventLogExpert.UI.FilterEditor.Editing
 @using EventLogExpert.UI.FilterEditor.Rows
+@using EventLogExpert.UI.FilterLibrary
 @using EventLogExpert.UI.Inputs
 @using EventLogExpert.UI.Menu
 @using EventLogExpert.UI.Modal

--- a/src/EventLogExpert.UI/wwwroot/FilterLibrary/FilterLibraryModal.js
+++ b/src/EventLogExpert.UI/wwwroot/FilterLibrary/FilterLibraryModal.js
@@ -1,0 +1,39 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+// JS shim for FilterLibraryModal. Suppresses the browser's default action ONLY for the
+// roving-focus keys the C# OnTabKeyDown handler consumes (ArrowLeft/ArrowRight/Home/End).
+// Up/Down are NOT prevented because the horizontal tablist doesn't consume them.
+
+const HANDLED_KEYS = new Set(["ArrowLeft", "ArrowRight", "Home", "End"]);
+
+const handlers = new WeakMap();
+
+export function attach(tablistElement) {
+    if (!tablistElement) { return; }
+
+    detach(tablistElement);
+
+    const onKeyDown = (event) => {
+        const target = event.target;
+
+        if (!target || target.getAttribute("role") !== "tab") { return; }
+        if (!HANDLED_KEYS.has(event.key)) { return; }
+
+        event.preventDefault();
+    };
+
+    tablistElement.addEventListener("keydown", onKeyDown);
+    handlers.set(tablistElement, onKeyDown);
+}
+
+export function detach(tablistElement) {
+    if (!tablistElement) { return; }
+
+    const onKeyDown = handlers.get(tablistElement);
+
+    if (onKeyDown) {
+        tablistElement.removeEventListener("keydown", onKeyDown);
+        handlers.delete(tablistElement);
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterLibrary/FilterLibraryModalTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterLibrary/FilterLibraryModalTests.cs
@@ -3,7 +3,10 @@
 
 using Bunit;
 using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Runtime.Alerts;
+using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.Runtime.FilterLibrary;
+using EventLogExpert.Runtime.FilterPane;
 using EventLogExpert.Runtime.Modal;
 using EventLogExpert.UI.FilterLibrary;
 using EventLogExpert.UI.Tests.TestUtils;
@@ -16,6 +19,7 @@ namespace EventLogExpert.UI.Tests.FilterLibrary;
 
 public sealed class FilterLibraryModalTests : BunitContext
 {
+    private readonly IAnnouncementService _announcements = Substitute.For<IAnnouncementService>();
     private readonly IFilterLibraryCommands _commands = Substitute.For<IFilterLibraryCommands>();
     private readonly IModalCoordinator _modalCoordinator = Substitute.For<IModalCoordinator>();
     private readonly ModalId _modalId = new(1L);
@@ -28,81 +32,332 @@ public sealed class FilterLibraryModalTests : BunitContext
 
         _modalService.ActiveModalId.Returns(_modalId);
 
+        Services.AddSingleton(_announcements);
         Services.AddSingleton(_commands);
         Services.AddSingleton(_modalCoordinator);
         Services.AddSingleton(_modalService);
+
+        var paneState = Substitute.For<IState<FilterPaneState>>();
+        paneState.Value.Returns(new FilterPaneState());
+        Services.AddSingleton(paneState);
+
+        Services.AddSingleton(Substitute.For<IAlertDialogService>());
+
         Services.AddFluxor(options => options.ScanAssemblies(typeof(FilterLibraryModal).Assembly));
 
         JSInterop.Mode = JSRuntimeMode.Loose;
     }
 
     [Fact]
-    public async Task Apply_DispatchesApplyEntryAndCompletesModalWithTrue()
+    public async Task ApplyClick_DispatchesApplyAndCompletesModalWithTrue()
     {
-        // Arrange
-        var entry = BuildFilterEntry("First");
+        var entry = BuildSavedFilter("S");
         SetState(new FilterLibraryState { Entries = [entry], IsLoaded = true });
 
         var component = Render<FilterLibraryModal>();
-
-        // Act
         await component.Find(".library-entry-row button.button-green").ClickAsync(new MouseEventArgs());
 
-        // Assert
         _commands.Received(1).ApplyEntry(entry.Id);
-        _modalService.Received(1).Complete(_modalId, Arg.Is<object?>(value => Equals(value, true)));
+        _modalService.Received(1).Complete(_modalId, Arg.Is<object?>(v => Equals(v, true)));
     }
 
     [Fact]
-    public void Render_WhenEntriesIsEmpty_RendersEmptyState()
+    public void DecidePendingFocusAfterRemoval_LastRow_TargetsPrevious()
     {
-        // Arrange — default FilterLibraryState has Entries empty, IsLoaded=false, LoadError=false.
+        var a = BuildSavedFilter("A");
+        var b = BuildSavedFilter("B");
+        var c = BuildSavedFilter("C");
+        var snapshot = new LibraryEntry[] { a, b, c };
+
+        var (targetId, fallback) = FilterLibraryModal.DecidePendingFocusAfterRemoval(snapshot, c.Id);
+
+        Assert.Equal(b.Id, targetId);
+        Assert.False(fallback);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void DecidePendingFocusAfterRemoval_MiddleOrFirstRow_TargetsNext(int removedIndex)
+    {
+        var a = BuildSavedFilter("A");
+        var b = BuildSavedFilter("B");
+        var c = BuildSavedFilter("C");
+        var snapshot = new LibraryEntry[] { a, b, c };
+        var removedId = snapshot[removedIndex].Id;
+        var expectedNextId = snapshot[removedIndex + 1].Id;
+
+        var (targetId, fallback) = FilterLibraryModal.DecidePendingFocusAfterRemoval(snapshot, removedId);
+
+        Assert.Equal(expectedNextId, targetId);
+        Assert.False(fallback);
+    }
+
+    [Fact]
+    public void DecidePendingFocusAfterRemoval_NotFound_FallsBackToActiveTab()
+    {
+        var a = BuildSavedFilter("A");
+        var b = BuildSavedFilter("B");
+        var missing = BuildSavedFilter("Missing");
+        var snapshot = new LibraryEntry[] { a, b };
+
+        var (targetId, fallback) = FilterLibraryModal.DecidePendingFocusAfterRemoval(snapshot, missing.Id);
+
+        Assert.Null(targetId);
+        Assert.True(fallback);
+    }
+
+    [Fact]
+    public void DecidePendingFocusAfterRemoval_SoleRow_FallsBackToActiveTab()
+    {
+        var a = BuildSavedFilter("A");
+        var snapshot = new LibraryEntry[] { a };
+
+        var (targetId, fallback) = FilterLibraryModal.DecidePendingFocusAfterRemoval(snapshot, a.Id);
+
+        Assert.Null(targetId);
+        Assert.True(fallback);
+    }
+
+    [Fact]
+    public async Task FavoritesTab_ProjectsOnlyFavorites_SortedByName()
+    {
+        var s1 = BuildSavedFilter("Saved");
+        var f1 = BuildFilterEntry("Beta") with { IsFavorite = true };
+        var f2 = BuildFilterEntry("Alpha") with { IsFavorite = true };
+        SetState(new FilterLibraryState { Entries = [s1, f1, f2], IsLoaded = true });
+
+        var component = Render<FilterLibraryModal>();
+        await component.FindAll("[role='tab']")[1].ClickAsync(new MouseEventArgs());
+
+        var names = component.FindAll(".library-entry-name-text").Select(n => n.TextContent.Trim()).ToList();
+        Assert.Equal(["Alpha", "Beta"], names);
+    }
+
+    [Fact]
+    public void OnInitialized_DispatchesLoadLibrary_WhenLoadError()
+    {
+        SetState(new FilterLibraryState { IsLoaded = true, LoadError = true });
+
+        Render<FilterLibraryModal>();
+
+        _commands.Received().LoadLibrary();
+    }
+
+    [Fact]
+    public void OnInitialized_DispatchesLoadLibrary_WhenNotLoaded()
+    {
+        SetState(new FilterLibraryState { IsLoaded = false });
+
+        Render<FilterLibraryModal>();
+
+        _commands.Received().LoadLibrary();
+    }
+
+    [Fact]
+    public void OnInitialized_DoesNotDispatchLoadLibrary_WhenLoadedAndNoError()
+    {
+        SetState(new FilterLibraryState { IsLoaded = true, LoadError = false });
+
+        Render<FilterLibraryModal>();
+
+        _commands.DidNotReceive().LoadLibrary();
+    }
+
+    [Fact]
+    public async Task PreviouslyUsedTab_ProjectsOnlyWithLastUsedUtc_OrderedDescTop50()
+    {
+        var older = BuildAutoTrackedFilterEntry("Old", DateTimeOffset.UtcNow.AddDays(-2));
+        var newer = BuildAutoTrackedFilterEntry("New", DateTimeOffset.UtcNow.AddHours(-1));
+        var saved = BuildSavedFilter("Saved"); // No LastUsedUtc → not in Previously Used
+        SetState(new FilterLibraryState { Entries = [older, newer, saved], IsLoaded = true });
+
+        var component = Render<FilterLibraryModal>();
+        await component.FindAll("[role='tab']")[2].ClickAsync(new MouseEventArgs());
+
+        var names = component.FindAll(".library-entry-name-text").Select(n => n.TextContent.Trim()).ToList();
+        Assert.Equal(["New", "Old"], names);
+    }
+
+    [Fact]
+    public void Render_ActiveTab_HasAriaSelectedTrueAndTabindexZero_OthersInert()
+    {
         SetState(new FilterLibraryState { IsLoaded = true });
 
-        // Act
         var component = Render<FilterLibraryModal>();
 
-        // Assert
-        Assert.NotNull(component.Find(".filter-library-empty"));
+        var tabs = component.FindAll("[role='tab']");
+        Assert.Equal("true", tabs[0].GetAttribute("aria-selected"));
+        Assert.Equal("0", tabs[0].GetAttribute("tabindex"));
+        Assert.Equal("false", tabs[1].GetAttribute("aria-selected"));
+        Assert.Equal("-1", tabs[1].GetAttribute("tabindex"));
+    }
+
+    [Theory]
+    [InlineData(0, "No saved filters or presets")]
+    [InlineData(1, "No favorited")]
+    [InlineData(2, "No filters have been applied recently")]
+    public async Task Render_EmptyTab_ShowsTabSpecificMessage(int tabIndex, string expectedFragment)
+    {
+        SetState(new FilterLibraryState { IsLoaded = true });
+
+        var component = Render<FilterLibraryModal>();
+        if (tabIndex != 0)
+        {
+            await component.FindAll("[role='tab']")[tabIndex].ClickAsync(new MouseEventArgs());
+        }
+
+        Assert.Contains(expectedFragment, component.Find(".library-empty-state").TextContent);
     }
 
     [Fact]
-    public void Render_WhenLoadError_RendersErrorState()
+    public void Render_HiddenTabpanel_DoesNotRenderRowChildren()
     {
-        // Arrange
+        var saved = BuildSavedFilter("S");
+        SetState(new FilterLibraryState { Entries = [saved], IsLoaded = true });
+
+        var component = Render<FilterLibraryModal>();
+
+        // Only the active (Saved) tab should render its row; the other two tabpanels are empty.
+        Assert.Single(component.FindAll(".library-entry-row"));
+    }
+
+    [Fact]
+    public void Render_RendersThreeTabs_WithLabelsAndCounts()
+    {
+        var saved = BuildSavedFilter("Saved");
+        var fav = BuildFilterEntry("Favorited") with { IsFavorite = true };
+        var recent = BuildAutoTrackedFilterEntry("Recent");
+        SetState(new FilterLibraryState { Entries = [saved, fav, recent], IsLoaded = true });
+
+        var component = Render<FilterLibraryModal>();
+
+        var tabs = component.FindAll("[role='tab']");
+        Assert.Equal(3, tabs.Count);
+        // saved + fav both have Origin=UserSaved (BuildFilterEntry default) → 2 in Saved
+        Assert.Contains("Saved (2)", tabs[0].TextContent);
+        Assert.Contains("Favorites (1)", tabs[1].TextContent);
+        Assert.Contains("Previously Used (1)", tabs[2].TextContent);
+    }
+
+    [Fact]
+    public void Render_SavedTab_ProjectsOnlyUserSavedEntries_SortedByName()
+    {
+        var s1 = BuildSavedFilter("Beta");
+        var s2 = BuildSavedFilter("Alpha");
+        var recent = BuildAutoTrackedFilterEntry("Recent");
+        SetState(new FilterLibraryState { Entries = [s1, s2, recent], IsLoaded = true });
+
+        var component = Render<FilterLibraryModal>();
+
+        var names = component.FindAll(".library-entry-name-text").Select(n => n.TextContent.Trim()).ToList();
+        Assert.Equal(["Alpha", "Beta"], names);
+    }
+
+    [Fact]
+    public void Render_TabpanelTabindex_AbsentWhenRowsPresent()
+    {
+        SetState(new FilterLibraryState { Entries = [BuildSavedFilter("S")], IsLoaded = true });
+        var component = Render<FilterLibraryModal>();
+        Assert.Null(component.FindAll("[role='tabpanel']")[0].GetAttribute("tabindex"));
+    }
+
+    [Fact]
+    public void Render_TabpanelTabindex_ZeroWhenEmpty()
+    {
+        SetState(new FilterLibraryState { IsLoaded = true }); // empty
+        var component = Render<FilterLibraryModal>();
+        Assert.Equal("0", component.FindAll("[role='tabpanel']")[0].GetAttribute("tabindex"));
+    }
+
+    [Fact]
+    public void Render_ThreeTabpanelsInDom_InactiveOnesDisplayNone()
+    {
+        SetState(new FilterLibraryState { IsLoaded = true });
+
+        var component = Render<FilterLibraryModal>();
+
+        var panels = component.FindAll("[role='tabpanel']");
+        Assert.Equal(3, panels.Count);
+        // Saved is active by default — its style should not contain display:none
+        Assert.DoesNotContain("display: none", panels[0].GetAttribute("style") ?? string.Empty);
+        Assert.Contains("display: none", panels[1].GetAttribute("style") ?? string.Empty);
+        Assert.Contains("display: none", panels[2].GetAttribute("style") ?? string.Empty);
+    }
+
+    [Fact]
+    public void Render_WhenLoadError_RendersErrorStateWithRetry()
+    {
         SetState(new FilterLibraryState { LoadError = true, IsLoaded = true });
 
-        // Act
         var component = Render<FilterLibraryModal>();
 
-        // Assert
         Assert.NotNull(component.Find(".filter-library-error"));
+        Assert.NotNull(component.Find(".filter-library-error button"));
     }
 
     [Fact]
-    public void Render_WhenNotLoaded_RendersLoadingStateNotEmptyState()
+    public void Render_WhenNotLoaded_RendersLoadingState()
     {
-        SetState(new FilterLibraryState { IsLoaded = false, IsLoading = true });
+        SetState(new FilterLibraryState { IsLoaded = false });
 
         var component = Render<FilterLibraryModal>();
 
         Assert.NotNull(component.Find(".filter-library-loading"));
-        Assert.Empty(component.FindAll(".filter-library-empty"));
+        Assert.Equal("true", component.Find(".filter-library-loading").GetAttribute("aria-busy"));
     }
 
     [Fact]
-    public void Render_WithEntries_RendersOneRowPerEntry()
+    public async Task RetryButton_DispatchesLoadLibrary()
     {
-        // Arrange
-        var e1 = BuildFilterEntry("First");
-        var e2 = BuildFilterEntry("Second");
-        SetState(new FilterLibraryState { Entries = [e1, e2], IsLoaded = true });
+        SetState(new FilterLibraryState { LoadError = true, IsLoaded = true });
 
-        // Act
         var component = Render<FilterLibraryModal>();
+        await component.Find(".filter-library-error button").ClickAsync(new MouseEventArgs());
 
-        // Assert
-        Assert.Equal(2, component.FindAll(".library-entry-row").Count);
+        _commands.Received().LoadLibrary();
+    }
+
+    [Fact]
+    public async Task TabClick_SwitchesActiveTab()
+    {
+        SetState(new FilterLibraryState { IsLoaded = true });
+
+        var component = Render<FilterLibraryModal>();
+        await component.FindAll("[role='tab']")[1].ClickAsync(new MouseEventArgs());
+
+        Assert.Equal("true", component.FindAll("[role='tab']")[1].GetAttribute("aria-selected"));
+    }
+
+    [Theory]
+    [InlineData("ArrowRight", 1)]
+    [InlineData("ArrowLeft", 2)] // wraps to End
+    [InlineData("Home", 0)]
+    [InlineData("End", 2)]
+    public async Task TabKeydown_RotatesActiveTab(string key, int expectedTabIndex)
+    {
+        SetState(new FilterLibraryState { IsLoaded = true });
+
+        var component = Render<FilterLibraryModal>();
+        await component.FindAll("[role='tab']")[0].KeyDownAsync(new KeyboardEventArgs { Key = key });
+
+        var tabs = component.FindAll("[role='tab']");
+        Assert.Equal("true", tabs[expectedTabIndex].GetAttribute("aria-selected"));
+    }
+
+    private static LibraryEntrySavedFilter BuildAutoTrackedFilterEntry(string name, DateTimeOffset? lastUsed = null)
+    {
+        var filter = SavedFilter.TryCreate("Level == 4");
+        Assert.NotNull(filter);
+
+        return new LibraryEntrySavedFilter
+        {
+            Name = name,
+            CreatedUtc = DateTimeOffset.UtcNow,
+            Filter = filter,
+            Origin = LibraryEntryOrigin.AutoTracked,
+            LastUsedUtc = lastUsed ?? DateTimeOffset.UtcNow,
+        };
     }
 
     private static LibraryEntrySavedFilter BuildFilterEntry(string name)
@@ -117,6 +372,9 @@ public sealed class FilterLibraryModalTests : BunitContext
             Filter = filter,
         };
     }
+
+    private static LibraryEntrySavedFilter BuildSavedFilter(string name) =>
+        BuildFilterEntry(name) with { Origin = LibraryEntryOrigin.UserSaved };
 
     private void SetState(FilterLibraryState state)
     {

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterLibrary/LibraryEntryRowTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterLibrary/LibraryEntryRowTests.cs
@@ -3,88 +3,434 @@
 
 using Bunit;
 using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Runtime.Alerts;
+using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.Runtime.FilterLibrary;
+using EventLogExpert.Runtime.FilterPane;
+using EventLogExpert.Runtime.Menu;
 using EventLogExpert.UI.FilterLibrary;
+using Fluxor;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
 
 namespace EventLogExpert.UI.Tests.FilterLibrary;
 
 public sealed class LibraryEntryRowTests : BunitContext
 {
-    [Fact]
-    public async Task Apply_InvokesOnApplyWithEntryId()
-    {
-        // Arrange
-        LibraryEntryId? captured = null;
-        var entry = BuildFilterEntry("Test");
-        var component = Render<LibraryEntryRow>(parameters => parameters
-            .Add(p => p.Entry, entry)
-            .Add(p => p.OnApply, id => { captured = id; return Task.CompletedTask; }));
+    private readonly IAlertDialogService _alerts = Substitute.For<IAlertDialogService>();
+    private readonly IAnnouncementService _announcements = Substitute.For<IAnnouncementService>();
+    private readonly IMenuService _menuService = Substitute.For<IMenuService>();
+    private FilterPaneState _paneState = new();
 
-        // Act
+    public LibraryEntryRowTests()
+    {
+        Services.AddSingleton(_alerts);
+        Services.AddSingleton(_announcements);
+        Services.AddSingleton(_menuService);
+
+        var paneStateMock = Substitute.For<IState<FilterPaneState>>();
+        paneStateMock.Value.Returns(_ => _paneState);
+        Services.AddSingleton(paneStateMock);
+
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        JSInterop.Setup<MenuAnchorRect>("getMenuElementRect", _ => true)
+            .SetResult(new MenuAnchorRect(0, 0, 0, 0, 0, 0));
+    }
+
+    [Fact]
+    public async Task AddToPresetSubmenu_WithNoPresets_OnlyHasNewPresetItem()
+    {
+        var entry = BuildSavedFilter("X");
+        var component = RenderRow(entry, allPresets: []);
+
+        var items = await CapturedMoreMenuItemsAsync(component);
+        var sub = items.First(i => i.Label == "Add to preset...").Children;
+
+        Assert.NotNull(sub);
+        Assert.Single(sub);
+        Assert.Equal("+ New preset...", sub[0].Label);
+    }
+
+    [Fact]
+    public async Task AddToPresetSubmenu_WithPresets_HasNewSeparatorAndPresets()
+    {
+        var entry = BuildSavedFilter("X");
+        var preset = BuildPreset("P1");
+        var component = RenderRow(entry, allPresets: [preset]);
+
+        var items = await CapturedMoreMenuItemsAsync(component);
+        var sub = items.First(i => i.Label == "Add to preset...").Children!;
+
+        Assert.Equal(3, sub.Count); // "+ New preset...", separator, "P1"
+        Assert.Equal("+ New preset...", sub[0].Label);
+        Assert.True(sub[1].IsSeparator);
+        Assert.Equal("P1", sub[2].Label);
+    }
+
+    [Fact]
+    public async Task ApplyClick_InvokesOnApplyWithEntryId()
+    {
+        var entry = BuildSavedFilter("X");
+        LibraryEntryId? captured = null;
+        var component = RenderRow(entry, onApply: id => { captured = id; return Task.CompletedTask; });
+
         await component.Find("button.button-green").ClickAsync(new MouseEventArgs());
 
-        // Assert
         Assert.Equal(entry.Id, captured);
     }
 
     [Fact]
-    public async Task Delete_InvokesOnDeleteWithEntryId()
+    public async Task DeleteOnAutoTrackedFilter_NoConfirm_InvokesPendingFocusThenDelete()
     {
-        // Arrange
+        var entry = BuildAutoTrackedFilterEntry("X");
+        var calls = new List<string>();
+        var component = RenderRow(
+            entry,
+            onDelete: id => { calls.Add("delete"); return Task.CompletedTask; },
+            onRequestPendingFocus: id => { calls.Add("focus"); return Task.CompletedTask; });
+
+        var items = await CapturedMoreMenuItemsAsync(component);
+        await items.First(i => i.Label == "Delete").OnClickAsync!.Invoke();
+
+        Assert.Equal(["focus", "delete"], calls);
+    }
+
+    [Fact]
+    public async Task DeleteOnPreset_ShowsConfirm()
+    {
+        var preset = BuildPreset("P", filterCount: 2);
+        var component = RenderRow(preset);
+        _alerts.ShowAlert(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+
+        var items = await CapturedMoreMenuItemsAsync(component);
+        await items.First(i => i.Label == "Delete").OnClickAsync!.Invoke();
+
+        await _alerts.Received(1).ShowAlert("Delete from library?", Arg.Is<string>(m => m.Contains("preset 'P' with 2 filters")), "Delete", "Cancel");
+    }
+
+    [Fact]
+    public async Task DeleteOnUserSavedFilter_ShowsConfirm_InvokesOnlyOnAccept()
+    {
+        var entry = BuildSavedFilter("X");
+        bool deleted = false;
+        var component = RenderRow(entry, onDelete: id => { deleted = true; return Task.CompletedTask; });
+        _alerts.ShowAlert("Delete from library?", Arg.Any<string>(), "Delete", "Cancel").Returns(false);
+
+        var items = await CapturedMoreMenuItemsAsync(component);
+        await items.First(i => i.Label == "Delete").OnClickAsync!.Invoke();
+
+        Assert.False(deleted);
+    }
+
+    [Fact]
+    public void DisposeAsync_UnsubscribesFromMenuServiceStateChanged()
+    {
+        var entry = BuildSavedFilter("X");
+        var component = RenderRow(entry);
+        component.Dispose();
+        _menuService.StateChanged += Raise.Event<Action>();
+    }
+
+    [Fact]
+    public async Task ExistingPresetSelected_InvokesAddToPresetWithPresetId()
+    {
+        var entry = BuildSavedFilter("X");
+        var preset = BuildPreset("P1");
+        AddToPresetIntent? captured = null;
+        var component = RenderRow(
+            entry,
+            allPresets: [preset],
+            onAddToPreset: i => { captured = i; return Task.CompletedTask; });
+
+        var items = await CapturedMoreMenuItemsAsync(component);
+        var p1Item = items.First(i => i.Label == "Add to preset...").Children!.First(c => c.Label == "P1");
+        await p1Item.OnClickAsync!.Invoke();
+
+        Assert.NotNull(captured);
+        Assert.Equal(preset.Id, captured.PresetId);
+        Assert.Null(captured.NewPresetName);
+    }
+
+    [Fact]
+    public void FavoriteButton_AriaPressedReflectsState()
+    {
+        var entry = BuildSavedFilter("X") with { IsFavorite = true };
+        var component = RenderRow(entry);
+
+        Assert.Equal("true", component.Find("button.button-yellow").GetAttribute("aria-pressed"));
+    }
+
+    [Fact]
+    public async Task FavoriteClick_InvokesOnToggleFavoriteWithNewState()
+    {
+        var entry = BuildSavedFilter("X");
+        FavoriteToggleIntent? captured = null;
+        var component = RenderRow(entry, onToggleFavorite: i => { captured = i; return Task.CompletedTask; });
+
+        await component.Find("button.button-yellow").ClickAsync(new MouseEventArgs());
+
+        Assert.NotNull(captured);
+        Assert.Equal(entry.Id, captured.EntryId);
+        Assert.True(captured.NewIsFavorite);
+        _announcements.Received(1).Announce(Arg.Is<string>(s => s.Contains("Marked X as favorite")));
+    }
+
+    [Fact]
+    public async Task FavoriteOnPreviouslyUsedTab_InvokesPendingFocusBeforeToggle()
+    {
+        var entry = BuildAutoTrackedFilterEntry("X");
+        var calls = new List<string>();
+        var component = RenderRow(
+            entry,
+            activeTab: LibraryTab.PreviouslyUsed,
+            onRequestPendingFocus: id => { calls.Add("focus"); return Task.CompletedTask; },
+            onToggleFavorite: i => { calls.Add("toggle"); return Task.CompletedTask; });
+
+        await component.Find("button.button-yellow").ClickAsync(new MouseEventArgs());
+
+        Assert.Equal(["focus", "toggle"], calls);
+    }
+
+    [Fact]
+    public async Task FavoriteOnSavedTab_DoesNotInvokePendingFocus()
+    {
+        var entry = BuildSavedFilter("X");
+        var focusCalled = false;
+        var component = RenderRow(
+            entry,
+            activeTab: LibraryTab.Saved,
+            onRequestPendingFocus: id => { focusCalled = true; return Task.CompletedTask; });
+
+        await component.Find("button.button-yellow").ClickAsync(new MouseEventArgs());
+
+        Assert.False(focusCalled);
+    }
+
+    [Fact]
+    public void MoreButton_HasAriaLabel_AriaHaspopup_AriaExpandedFalseInitial()
+    {
+        var entry = BuildSavedFilter("X");
+        var component = RenderRow(entry);
+
+        var more = component.FindAll("button.icon-button").Last();
+        Assert.Contains("More actions for X", more.GetAttribute("aria-label"));
+        Assert.Equal("menu", more.GetAttribute("aria-haspopup"));
+        Assert.Equal("false", more.GetAttribute("aria-expanded"));
+    }
+
+    [Fact]
+    public async Task MoreButtonClick_OpensMenuViaIMenuServiceWithAnchorCoords()
+    {
+        var entry = BuildSavedFilter("X");
+        var component = RenderRow(entry);
+
+        await component.FindAll("button.icon-button").Last().ClickAsync(new MouseEventArgs());
+
+        _menuService.Received(1).OpenAt(
+            Arg.Any<double>(),
+            Arg.Any<double>(),
+            Arg.Any<IReadOnlyList<MenuItem>>());
+    }
+
+    [Fact]
+    public async Task MoreMenu_OnAutoTrackedFilter_IncludesSaveToLibraryItem()
+    {
+        var entry = BuildAutoTrackedFilterEntry("X");
+        var component = RenderRow(entry);
+
+        var items = await CapturedMoreMenuItemsAsync(component);
+
+        Assert.Contains(items, i => i.Label == "Save to Library");
+    }
+
+    [Fact]
+    public async Task MoreMenu_OnFavoritedAutoTracked_OmitsSaveToLibraryItem()
+    {
+        var entry = BuildAutoTrackedFilterEntry("X") with { IsFavorite = true };
+        var component = RenderRow(entry);
+
+        var items = await CapturedMoreMenuItemsAsync(component);
+
+        Assert.DoesNotContain(items, i => i.Label == "Save to Library");
+    }
+
+    [Fact]
+    public async Task MoreMenu_OnFilterEntry_IncludesAddToPresetSubmenu()
+    {
+        var entry = BuildSavedFilter("X");
+        var component = RenderRow(entry);
+
+        var items = await CapturedMoreMenuItemsAsync(component);
+        var addToPreset = items.FirstOrDefault(i => i.Label == "Add to preset...");
+
+        Assert.NotNull(addToPreset);
+        Assert.NotNull(addToPreset.Children);
+    }
+
+    [Fact]
+    public async Task MoreMenu_OnPresetEntry_OmitsAddToPresetItem()
+    {
+        var preset = BuildPreset("P");
+        var component = RenderRow(preset);
+
+        var items = await CapturedMoreMenuItemsAsync(component);
+
+        Assert.DoesNotContain(items, i => i.Label == "Add to preset...");
+    }
+
+    [Fact]
+    public async Task MoreMenu_OnUserSavedFilter_OmitsSaveToLibraryItem()
+    {
+        var entry = BuildSavedFilter("X");
+        var component = RenderRow(entry);
+
+        var items = await CapturedMoreMenuItemsAsync(component);
+
+        Assert.DoesNotContain(items, i => i.Label == "Save to Library");
+    }
+
+    [Fact]
+    public async Task NewPresetSelected_PromptCancelled_DoesNotInvokeCallback()
+    {
+        var entry = BuildSavedFilter("X");
+        bool invoked = false;
+        var component = RenderRow(entry, onAddToPreset: _ => { invoked = true; return Task.CompletedTask; });
+        _alerts.DisplayPrompt(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>()).Returns("");
+
+        var items = await CapturedMoreMenuItemsAsync(component);
+        await items.First(i => i.Label == "Add to preset...").Children!.First().OnClickAsync!.Invoke();
+
+        Assert.False(invoked);
+    }
+
+    [Fact]
+    public async Task NewPresetSelected_PromptReturnsName_InvokesAddToPresetWithNewName()
+    {
+        var entry = BuildSavedFilter("X");
+        AddToPresetIntent? captured = null;
+        var component = RenderRow(entry, onAddToPreset: i => { captured = i; return Task.CompletedTask; });
+        _alerts.DisplayPrompt(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>()).Returns("My Preset");
+
+        var items = await CapturedMoreMenuItemsAsync(component);
+        await items.First(i => i.Label == "Add to preset...").Children!.First().OnClickAsync!.Invoke();
+
+        Assert.NotNull(captured);
+        Assert.Null(captured.PresetId);
+        Assert.Equal("My Preset", captured.NewPresetName);
+    }
+
+    [Fact]
+    public void Render_FilterEntry_ShowsKindIconAndStatusBadge()
+    {
+        var entry = BuildSavedFilter("F");
+        var component = RenderRow(entry);
+
+        Assert.Contains("bi-funnel", component.Find("i.library-entry-kind-icon").GetAttribute("class"));
+        Assert.Equal("Saved", component.Find(".library-entry-status-badge").TextContent.Trim());
+    }
+
+    [Fact]
+    public void Render_PresetEntry_ShowsPresetIconAndFiltersCount()
+    {
+        var preset = BuildPreset("P", filterCount: 3);
+        var component = RenderRow(preset);
+
+        Assert.Contains("bi-collection", component.Find("i.library-entry-kind-icon").GetAttribute("class"));
+        Assert.Contains("(3 filters)", component.Find(".library-entry-name").TextContent);
+    }
+
+    [Fact]
+    public async Task ReplaceOnEmptyPane_NoConfirm_InvokesOnReplace()
+    {
+        var entry = BuildSavedFilter("X");
         LibraryEntryId? captured = null;
-        var entry = BuildFilterEntry("Test");
-        var component = Render<LibraryEntryRow>(parameters => parameters
-            .Add(p => p.Entry, entry)
-            .Add(p => p.OnDelete, id => { captured = id; return Task.CompletedTask; }));
+        var component = RenderRow(entry, onReplace: id => { captured = id; return Task.CompletedTask; });
 
-        // Act
-        await component.Find("button.button-red").ClickAsync(new MouseEventArgs());
+        var items = await CapturedMoreMenuItemsAsync(component);
+        var replace = items.First(i => i.Label == "Replace current filters");
+        await replace.OnClickAsync!.Invoke();
 
-        // Assert
         Assert.Equal(entry.Id, captured);
+        await _alerts.DidNotReceiveWithAnyArgs().ShowAlert(default!, default!, default!, default(string)!);
     }
 
     [Fact]
-    public void Render_DoesNotRenderEditButton_ForPR2()
+    public async Task ReplaceOnNonEmptyPane_ShowsConfirm_InvokesOnlyOnAccept()
     {
-        // PR-2 deliberately ships without an Edit button (regression guard against accidentally adding one back).
-        var component = Render<LibraryEntryRow>(parameters => parameters
-            .Add(p => p.Entry, BuildFilterEntry("Test")));
+        var filter = SavedFilter.TryCreate("Level == 9")!;
+        SetPaneFilters([filter]);
 
-        Assert.DoesNotContain(component.FindAll("button"), b => b.TextContent.Trim() == "Edit");
+        var entry = BuildSavedFilter("X");
+        bool replaced = false;
+        var component = RenderRow(entry, onReplace: id => { replaced = true; return Task.CompletedTask; });
+
+        _alerts.ShowAlert("Replace current filters?", Arg.Any<string>(), "Replace", "Cancel").Returns(false);
+
+        var items = await CapturedMoreMenuItemsAsync(component);
+        await items.First(i => i.Label == "Replace current filters").OnClickAsync!.Invoke();
+
+        Assert.False(replaced);
     }
 
     [Fact]
-    public void Render_PresetEntry_DisplaysPresetBadge()
+    public async Task SaveToLibrary_InvokesCallbackAndAnnounces()
     {
-        // Arrange
-        var f1 = SavedFilter.TryCreate("Level == 2");
-        Assert.NotNull(f1);
-        var preset = new LibraryEntryPreset
+        var entry = BuildAutoTrackedFilterEntry("X");
+        bool invoked = false;
+        var component = RenderRow(entry, onSaveToLibrary: id => { invoked = true; return Task.CompletedTask; });
+
+        var items = await CapturedMoreMenuItemsAsync(component);
+        await items.First(i => i.Label == "Save to Library").OnClickAsync!.Invoke();
+
+        Assert.True(invoked);
+        _announcements.Received(1).Announce(Arg.Is<string>(s => s.Contains("Saved X to library")));
+    }
+
+    [Theory]
+    [InlineData(LibraryEntryOrigin.UserSaved, false, null, "Saved", "saved")]
+    [InlineData(LibraryEntryOrigin.AutoTracked, false, "2025-01-01", "Previously used", "previously-used")]
+    [InlineData(LibraryEntryOrigin.UserSaved, true, null, "Favorite", "favorite")]
+    public void StatusBadge_ReflectsEntryState(LibraryEntryOrigin origin, bool isFav, string? lastUsedString, string expectedText, string expectedKind)
+    {
+        DateTimeOffset? lastUsed = lastUsedString is null ? null : DateTimeOffset.Parse(lastUsedString);
+        var entry = BuildFilterEntry("X") with { Origin = origin, IsFavorite = isFav, LastUsedUtc = lastUsed };
+        var component = RenderRow(entry);
+
+        var badge = component.Find(".library-entry-status-badge");
+        Assert.Equal(expectedText, badge.TextContent.Trim());
+        Assert.Equal(expectedKind, badge.GetAttribute("data-status"));
+    }
+
+    [Fact]
+    public async Task UnfavoriteOnFavoritesTab_InvokesPendingFocusBeforeToggle()
+    {
+        var entry = BuildSavedFilter("X") with { IsFavorite = true };
+        var calls = new List<string>();
+        var component = RenderRow(
+            entry,
+            activeTab: LibraryTab.Favorites,
+            onRequestPendingFocus: id => { calls.Add("focus"); return Task.CompletedTask; },
+            onToggleFavorite: i => { calls.Add("toggle"); return Task.CompletedTask; });
+
+        await component.Find("button.button-yellow").ClickAsync(new MouseEventArgs());
+
+        Assert.Equal(["focus", "toggle"], calls);
+    }
+
+    private static LibraryEntrySavedFilter BuildAutoTrackedFilterEntry(string name)
+    {
+        var filter = SavedFilter.TryCreate("Level == 4");
+        Assert.NotNull(filter);
+
+        return new LibraryEntrySavedFilter
         {
-            Name = "Test",
+            Name = name,
             CreatedUtc = DateTimeOffset.UtcNow,
-            Filters = [f1],
+            Filter = filter,
+            Origin = LibraryEntryOrigin.AutoTracked,
+            LastUsedUtc = DateTimeOffset.UtcNow,
         };
-
-        // Act
-        var component = Render<LibraryEntryRow>(parameters => parameters
-            .Add(p => p.Entry, preset));
-
-        // Assert
-        Assert.Equal("Preset", component.Find(".library-entry-kind-badge").TextContent.Trim());
-    }
-
-    [Fact]
-    public void Render_SavedFilterEntry_DisplaysFilterBadge()
-    {
-        // Arrange + Act
-        var component = Render<LibraryEntryRow>(parameters => parameters
-            .Add(p => p.Entry, BuildFilterEntry("Test")));
-
-        // Assert
-        Assert.Equal("Filter", component.Find(".library-entry-kind-badge").TextContent.Trim());
     }
 
     private static LibraryEntrySavedFilter BuildFilterEntry(string name)
@@ -98,5 +444,59 @@ public sealed class LibraryEntryRowTests : BunitContext
             CreatedUtc = DateTimeOffset.UtcNow,
             Filter = filter,
         };
+    }
+
+    private static LibraryEntryPreset BuildPreset(string name, int filterCount = 1)
+    {
+        var filters = new List<SavedFilter>();
+        for (var i = 0; i < filterCount; i++) { filters.Add(SavedFilter.TryCreate($"Level == {i}")!); }
+
+        return new LibraryEntryPreset
+        {
+            Name = name,
+            CreatedUtc = DateTimeOffset.UtcNow,
+            Filters = [.. filters],
+        };
+    }
+
+    private static LibraryEntrySavedFilter BuildSavedFilter(string name) =>
+        BuildFilterEntry(name) with { Origin = LibraryEntryOrigin.UserSaved };
+
+    private async Task<IReadOnlyList<MenuItem>> CapturedMoreMenuItemsAsync(IRenderedComponent<LibraryEntryRow> component)
+    {
+        IReadOnlyList<MenuItem>? captured = null;
+        _menuService.WhenForAnyArgs(s => s.OpenAt(0, 0, null!, false, false))
+            .Do(call => captured = (IReadOnlyList<MenuItem>)call[2]!);
+        await component.FindAll("button.icon-button").Last().ClickAsync(new MouseEventArgs());
+        Assert.NotNull(captured);
+        return captured;
+    }
+
+    private IRenderedComponent<LibraryEntryRow> RenderRow(
+        LibraryEntry entry,
+        LibraryTab activeTab = LibraryTab.Saved,
+        IReadOnlyList<LibraryEntryPreset>? allPresets = null,
+        Func<LibraryEntryId, Task>? onApply = null,
+        Func<LibraryEntryId, Task>? onReplace = null,
+        Func<LibraryEntryId, Task>? onDelete = null,
+        Func<FavoriteToggleIntent, Task>? onToggleFavorite = null,
+        Func<LibraryEntryId, Task>? onSaveToLibrary = null,
+        Func<AddToPresetIntent, Task>? onAddToPreset = null,
+        Func<LibraryEntryId, Task>? onRequestPendingFocus = null) =>
+        Render<LibraryEntryRow>(parameters => parameters
+            .Add(p => p.Entry, entry)
+            .Add(p => p.ActiveTab, activeTab)
+            .Add(p => p.AllPresets, allPresets ?? [])
+            .Add(p => p.OnApply, onApply ?? (_ => Task.CompletedTask))
+            .Add(p => p.OnReplace, onReplace ?? (_ => Task.CompletedTask))
+            .Add(p => p.OnDelete, onDelete ?? (_ => Task.CompletedTask))
+            .Add(p => p.OnToggleFavorite, onToggleFavorite ?? (_ => Task.CompletedTask))
+            .Add(p => p.OnSaveToLibrary, onSaveToLibrary ?? (_ => Task.CompletedTask))
+            .Add(p => p.OnAddToPreset, onAddToPreset ?? (_ => Task.CompletedTask))
+            .Add(p => p.OnRequestPendingFocus, onRequestPendingFocus ?? (_ => Task.CompletedTask)));
+
+    private void SetPaneFilters(IEnumerable<SavedFilter> filters)
+    {
+        _paneState = new FilterPaneState { Filters = [.. filters] };
     }
 }


### PR DESCRIPTION
Redesigns the FilterLibraryModal as a 3-tab (Saved / Favorites / Previously Used) layout with an LibraryEntryRow that has Apply/Favorite/More overflow menu, ARIA tablist roving focus, and a strict-priority focus restoration cascade after row removal.

## Scope
- New public types: `LibraryTab` (enum), `FavoriteToggleIntent` + `AddToPresetIntent` (records with non-null param validation on AddToPresetIntent.Filter)
- New `wwwroot/FilterLibrary/FilterLibraryModal.js` keydown shim (idempotent attach/detach; HANDLED_KEYS = ArrowLeft/ArrowRight/Home/End for role=tab only)
- `FilterLibraryModal.razor*` rewrite: 3 tabs always in DOM with `display:none` for inactive (preserves `aria-controls` integrity); active tabpanel `tabindex=0` only when empty; strict-priority focus cascade (target-row -> tab-button -> active-tab fallback within same render); `@key="entry.Id"` for ref stability; `OnDialogClosedByUser` wired for Esc/backdrop dismiss
- `LibraryEntryRow.razor*` rewrite: icon + name + status badge + Apply/Favorite/More buttons; 7 EventCallback params (OnApply/OnReplace/OnDelete/OnToggleFavorite/OnSaveToLibrary/OnAddToPreset/OnRequestPendingFocus); `IMenuService.StateChanged` per-row subscription; `IAsyncDisposable`; confirm dialogs for destructive actions; `BuildMoreMenu()` with `SubMenu` for Add-to-preset; JS bounding-rect for menu anchoring
- `ElementFocus.TrySafelyAsync` - new `ValueTask<bool>` helper parallel to existing `SafelyAsync` for cascade-on-failure semantics

## Spec invariants
- Previously Used = `LastUsedUtc != null`, ordered desc, top 50
- `IsFavorite=true => LastUsedUtc=null` (favorites leave Previously Used)
- Favoriting promotes `Origin=UserSaved`; once UserSaved stays UserSaved
- Result: a favorited UserSaved entry appears in BOTH Saved AND Favorites tabs

## Tests
- 60/60 FilterLibrary UI tests (+50 net new vs PR #562 baseline)
- Full slnx green: UI 456+ / Runtime 1160 / Filtering 869 / Eventing 230 / etc.
- 0 warnings, 0 errors

## Pre-PR review (Section 2D 5-model panel)
- Round 1: 3 NEEDS_ANOTHER + 2 READY; 2 convergent MAJOR findings (Esc/backdrop dismiss wire-up missing; JS keydown shim attach timing) + 1 MAJOR (focus-cascade tests gap) + 5 minor
- Round 2: **unanimous READY_TO_IMPLEMENT** (5/5) after 1 fix iteration
- All 8 findings addressed via amend; round 2 verified fixes are correct + complete + no regressions

## Follow-up commits
- F: Rewire FilterPane / FilterRow / MainPage / MauiMenuActionService / _Imports to use the new modal+row API; drop FilterCache/FilterGroup injections
- G: Delete legacy FilterCache + FilterGroup runtime + UI domains + preferences adapters + modal launchers; grep-gate verification
