### PR TITLE
Fix native-shell-extension nuget.exe discovery when multiple nuget.exe are on PATH

### DIFF
--- a/src/EventLogExpert/EventLogExpert.csproj
+++ b/src/EventLogExpert/EventLogExpert.csproj
@@ -144,10 +144,14 @@
         <Output TaskParameter="ConsoleOutput" PropertyName="_WhereNugetOutput" />
       </Exec>
       <PropertyGroup>
-        <!-- where prints one match per line (newline-separated, NOT semicolon-separated).
-             Use Regex.Match to extract the first line; the trailing CR is implicitly excluded
-             by the [^\r\n]+ class. -->
-        <_NugetExePath Condition="'$(_WhereNugetExitCode)' == '0'">$([System.Text.RegularExpressions.Regex]::Match($(_WhereNugetOutput), '^[^\r\n]+').Value)</_NugetExePath>
+        <!-- where prints one match per line. Exec captures ConsoleOutput as ITaskItem[]
+             (one item per line); when MSBuild assigns that ITaskItem[] to a property via
+             <Output PropertyName=...>, it joins items with ';'. So $(_WhereNugetOutput)
+             is ';'-separated when 'where' returns multiple paths (build agents commonly
+             have nuget.exe at both C:\__t\NuGet\<ver>\x64\nuget.exe from NuGetToolInstaller
+             AND a pre-existing C:\nuget\nuget.exe). The character class excludes ';' (Windows
+             path separator-disallowed) and \r\n so Match returns just the first path. -->
+        <_NugetExePath Condition="'$(_WhereNugetExitCode)' == '0'">$([System.Text.RegularExpressions.Regex]::Match($(_WhereNugetOutput), '^[^;\r\n]+').Value)</_NugetExePath>
       </PropertyGroup>
       <Error Condition="'$(_NugetExePath)' == '' OR !Exists('$(_NugetExePath)')"
              Text="nuget.exe not found on PATH. The native shell extension's packages.config restore requires nuget.exe. Install via `winget install Microsoft.NuGet` (dev), the NuGetToolInstaller@1 pipeline task (ADO), or any equivalent. See docs/Explorer-Context-Menu.md for prereqs." />


### PR DESCRIPTION
## Summary

Pipeline build (`EventLogExpert-Release` run 118675) failed at the `BuildExplorerExtensionNative` target's nuget-discovery `Error` check after the recent `NuGetToolInstaller@1` addition (PR 2163) put a second `nuget.exe` on PATH on the build agent.

## Root cause

The target runs `where nuget.exe` via `Exec` with `ConsoleToMSBuild="true"`. `ConsoleOutput` is `ITaskItem[]` (one item per line). When assigned to a property via `<Output ... PropertyName="...">`, MSBuild joins the items with `;` (standard item-to-property conversion). So when `where` returned two paths (`C:\__t\NuGet\7.6.0\x64\nuget.exe` from `NuGetToolInstaller@1` AND a pre-existing `C:\nuget\nuget.exe`), `$(_WhereNugetOutput)` was `C:\__t\NuGet\7.6.0\x64\nuget.exe;C:\nuget\nuget.exe`. The existing regex `^[^\r\n]+` matched the entire `;`-joined string and `Exists('path1;path2')` returned false, firing the `nuget.exe not found on PATH` error.

The original comment was misleading — it claimed `where` output stays newline-separated in the property, which is true of the raw `where` stdout but is NOT true of MSBuild's representation after the `<Output>` item-to-property conversion.

## Fix

Add `;` to the regex character class (`^[^;\r\n]+`) so `Match` returns just the first path. `;` is invalid in Windows paths so this never truncates a legitimate single result. Comment rewritten to record both facts (where is line-based AND MSBuild joins items with `;` in property) so future maintainers don't revert.

## Verification

Local repro with a minimal MSBuild project:

```
OLD-extracts=[C:\__t\NuGet\7.6.0\x64\nuget.exe;C:\nuget\nuget.exe]   <- broken (Exists fails)
NEW-extracts=[C:\__t\NuGet\7.6.0\x64\nuget.exe]                        <- correct
```

Single-`nuget.exe` agents (typical dev box) are unaffected — single-item list joins to a string with no `;`, regex matches the entire path identically under both old and new patterns.

## Related

- Pipeline run: `EventLogExpert-Release` build 118675 (failed)
- Trigger commit: companion to PR 2163 (`Add NuGetToolInstaller@1 for native shell-extension nuget restore`)
- Reference: SUCCEED.tools work item 62523072 (different bug, similar SDL/CodeQL pipeline plumbing).
