### PR TITLE
Make bulk tag updates atomic, prune unloadable library rows, and reconcile modal row refs

### DIFF
--- a/src/EventLogExpert.Runtime/FilterLibrary/Effects.cs
+++ b/src/EventLogExpert.Runtime/FilterLibrary/Effects.cs
@@ -3,6 +3,7 @@
 
 using EventLogExpert.Filtering.Persistence;
 using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.Runtime.FilterPane;
 using Fluxor;
 using System.Collections.Immutable;
@@ -15,6 +16,7 @@ internal sealed class Effects(
     IState<FilterPaneState> filterPaneState,
     ILegacyFilterMigrator legacyMigrator,
     IBackslashNameMigrator backslashMigrator,
+    IAnnouncementService announcementService,
     ITraceLogger logger)
 {
     private const int MaxAutoTrackedRecents = 50;
@@ -141,6 +143,8 @@ internal sealed class Effects(
 
         if (string.IsNullOrEmpty(normalized)) { return Task.CompletedTask; }
 
+        var updatedEntries = new List<LibraryEntry>();
+
         foreach (var entry in state.Value.Entries)
         {
             var canonicalTags = LibraryEntryTagNormalizer.Normalize(entry.Tags);
@@ -148,17 +152,10 @@ internal sealed class Effects(
 
             if (index < 0) { continue; }
 
-            var updatedEntry = ReplaceTagsOnEntry(entry, canonicalTags.RemoveAt(index));
-
-            try { store.Update(updatedEntry); }
-            catch (Exception ex)
-            {
-                logger.Warning($"FilterLibrary DeleteTag failed for entry {entry.Id}. {ex.Message}");
-                continue;
-            }
-
-            dispatcher.Dispatch(new UpdateLibraryEntrySuccessAction(updatedEntry));
+            updatedEntries.Add(ReplaceTagsOnEntry(entry, canonicalTags.RemoveAt(index)));
         }
+
+        ApplyBulkTagUpdate(updatedEntries, dispatcher, count => $"Removed tag '{normalized}' from {count} {EntriesWord(count)}");
 
         return Task.CompletedTask;
     }
@@ -422,6 +419,8 @@ internal sealed class Effects(
             string.IsNullOrEmpty(newNormalized) ||
             string.Equals(oldNormalized, newNormalized, StringComparison.Ordinal)) { return Task.CompletedTask; }
 
+        var updatedEntries = new List<LibraryEntry>();
+
         foreach (var entry in state.Value.Entries)
         {
             var canonicalTags = LibraryEntryTagNormalizer.Normalize(entry.Tags);
@@ -434,17 +433,10 @@ internal sealed class Effects(
                 ? without
                 : without.Insert(oldIndex, newNormalized);
 
-            var updatedEntry = ReplaceTagsOnEntry(entry, updatedTags);
-
-            try { store.Update(updatedEntry); }
-            catch (Exception ex)
-            {
-                logger.Warning($"FilterLibrary RenameTag failed for entry {entry.Id}. {ex.Message}");
-                continue;
-            }
-
-            dispatcher.Dispatch(new UpdateLibraryEntrySuccessAction(updatedEntry));
+            updatedEntries.Add(ReplaceTagsOnEntry(entry, updatedTags));
         }
+
+        ApplyBulkTagUpdate(updatedEntries, dispatcher, count => $"Renamed tag '{oldNormalized}' to '{newNormalized}' in {count} {EntriesWord(count)}");
 
         return Task.CompletedTask;
     }
@@ -605,6 +597,8 @@ internal sealed class Effects(
         })];
     }
 
+    private static string EntriesWord(int count) => count == 1 ? "entry" : "entries";
+
     private static ImmutableList<SavedFilter> ExtractFilters(LibraryEntry entry) =>
         entry switch
         {
@@ -628,6 +622,56 @@ internal sealed class Effects(
         var cut = char.IsHighSurrogate(text[76]) ? 76 : 77;
 
         return text[..cut] + "...";
+    }
+
+    private void ApplyBulkTagUpdate(
+        IReadOnlyList<LibraryEntry> updatedEntries,
+        IDispatcher dispatcher,
+        Func<int, string> buildAnnouncement)
+    {
+        if (updatedEntries.Count == 0) { return; }
+
+        IReadOnlyList<LibraryEntryId> updatedIds;
+
+        try
+        {
+            updatedIds = store.UpdateRange(updatedEntries);
+        }
+        catch (Exception ex)
+        {
+            logger.Warning($"FilterLibrary bulk tag update failed; reloading library. {ex.Message}");
+            announcementService.Announce("Couldn't update tags. The library was reloaded.");
+            dispatcher.Dispatch(new LoadLibraryAction());
+            dispatcher.Dispatch(new TagBulkUpdateFailedAction());
+
+            return;
+        }
+
+        if (updatedIds.Count == 0)
+        {
+            announcementService.Announce("Couldn't update tags. The library was reloaded.");
+            dispatcher.Dispatch(new LoadLibraryAction());
+            dispatcher.Dispatch(new TagBulkUpdateFailedAction());
+
+            return;
+        }
+
+        var updatedIdSet = updatedIds.ToHashSet();
+
+        foreach (var entry in updatedEntries)
+        {
+            if (updatedIdSet.Contains(entry.Id))
+            {
+                dispatcher.Dispatch(new UpdateLibraryEntrySuccessAction(entry));
+            }
+        }
+
+        if (updatedIds.Count < updatedEntries.Count)
+        {
+            dispatcher.Dispatch(new LoadLibraryAction());
+        }
+
+        announcementService.Announce(buildAnnouncement(updatedIds.Count));
     }
 
     private Task PersistAddAsync(LibraryEntry entry, IDispatcher dispatcher)

--- a/src/EventLogExpert.Runtime/FilterLibrary/FilterLibraryServiceCollectionExtensions.cs
+++ b/src/EventLogExpert.Runtime/FilterLibrary/FilterLibraryServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.Banner;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace EventLogExpert.Runtime.FilterLibrary;
@@ -16,7 +17,7 @@ public static class FilterLibraryServiceCollectionExtensions
             ArgumentNullException.ThrowIfNull(dbPath);
 
             services.AddSingleton<IFilterLibraryStore>(sp =>
-                new FilterLibrarySqliteStore(dbPath, sp.GetRequiredService<ITraceLogger>()));
+                new FilterLibrarySqliteStore(dbPath, sp.GetRequiredService<ITraceLogger>(), sp.GetService<IErrorBannerService>()));
 
             return services;
         }

--- a/src/EventLogExpert.Runtime/FilterLibrary/FilterLibrarySqliteStore.cs
+++ b/src/EventLogExpert.Runtime/FilterLibrary/FilterLibrarySqliteStore.cs
@@ -3,6 +3,7 @@
 
 using EventLogExpert.Filtering.Persistence;
 using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.Banner;
 using Microsoft.Data.Sqlite;
 using System.Collections.Immutable;
 using System.Data;
@@ -51,6 +52,13 @@ internal sealed class FilterLibrarySqliteStore : IFilterLibraryStore
     private const string DeleteSql =
         "DELETE FROM library_entries WHERE id = $id;";
 
+    private const string DeleteUnloadableSql =
+        "DELETE FROM library_entries WHERE id = $id AND kind = $kind AND payload = $payload;";
+
+    private const string FilterKind = "Filter";
+
+    private const string FilterSetKind = "FilterSet";
+
     private const string FindAutoTrackedFilterByTupleSql = """
                                                            SELECT id, name, created_utc, kind, payload, is_favorite, last_used_utc, origin, comparison_text, mode, is_excluded, tags
                                                            FROM library_entries
@@ -74,6 +82,8 @@ internal sealed class FilterLibrarySqliteStore : IFilterLibraryStore
     private const string LoadAllSql =
         "SELECT id, name, created_utc, kind, payload, is_favorite, last_used_utc, origin, comparison_text, mode, is_excluded, tags FROM library_entries ORDER BY created_utc;";
 
+    private const int MinSystemicUnloadableRowCount = 2;
+
     private const string UpdateSql = """
                                      UPDATE library_entries
                                      SET name = $name, created_utc = $created, kind = $kind, payload = $payload,
@@ -96,15 +106,19 @@ internal sealed class FilterLibrarySqliteStore : IFilterLibraryStore
 
     private readonly string _connectionString;
     private readonly string _dbPath;
+    private readonly IErrorBannerService? _errorBannerService;
     private readonly ITraceLogger _logger;
 
-    public FilterLibrarySqliteStore(string dbPath, ITraceLogger logger)
+    private int _systemicUnloadableReported;
+
+    public FilterLibrarySqliteStore(string dbPath, ITraceLogger logger, IErrorBannerService? errorBannerService = null)
     {
         ArgumentNullException.ThrowIfNull(dbPath);
         ArgumentNullException.ThrowIfNull(logger);
 
         _dbPath = dbPath;
         _logger = logger;
+        _errorBannerService = errorBannerService;
         _connectionString = $"Data Source={dbPath}";
     }
 
@@ -242,32 +256,69 @@ internal sealed class FilterLibrarySqliteStore : IFilterLibraryStore
         using var connection = OpenConnection();
 
         var entries = ImmutableList.CreateBuilder<LibraryEntry>();
+        List<(string Id, string Kind, string Payload)>? unloadable = null;
+        var unknownKindCount = 0;
 
-        using var cmd = connection.CreateCommand();
-        cmd.CommandText = LoadAllSql;
-
-        using var reader = cmd.ExecuteReader();
-
-        while (reader.Read())
+        using (var cmd = connection.CreateCommand())
         {
-            var id = reader.IsDBNull(0) ? "<unknown>" : reader.GetString(0);
-            try
-            {
-                var entry = ReadEntry(reader);
+            cmd.CommandText = LoadAllSql;
 
-                if (entry is not null)
-                {
-                    entries.Add(entry);
-                }
-                else
-                {
-                    _logger.Warning($"FilterLibrary skipped row id={id} with unknown Kind.");
-                }
-            }
-            catch (Exception ex)
+            using var reader = cmd.ExecuteReader();
+
+            while (reader.Read())
             {
-                _logger.Warning($"FilterLibrary skipped row id={id}: {ex.Message}");
+                var id = reader.IsDBNull(0) ? "<unknown>" : reader.GetString(0);
+
+                try
+                {
+                    var entry = ReadEntry(reader);
+
+                    if (entry is not null)
+                    {
+                        entries.Add(entry);
+                    }
+                    else
+                    {
+                        unknownKindCount++;
+                        _logger.Warning($"FilterLibrary skipped row id={id} with unknown Kind (kept as forward-version data).");
+                    }
+                }
+                catch (Exception ex) when (ex is JsonException or FormatException or InvalidOperationException)
+                {
+                    _logger.Warning($"FilterLibrary found unloadable row id={id}: {ex.Message}");
+
+                    if (!reader.IsDBNull(0) && !reader.IsDBNull(3) && !reader.IsDBNull(4))
+                    {
+                        (unloadable ??= []).Add((reader.GetString(0), reader.GetString(3), reader.GetString(4)));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.Warning($"FilterLibrary skipped row id={id}: {ex.Message}");
+                }
             }
+        }
+
+        if (unloadable is null)
+        {
+            return entries.ToImmutable();
+        }
+
+        // Ratio is over rows this version can interpret (known kinds), so kept unknown-kind rows don't
+        // dilute it and suppress the breaker; any unknown-kind row is itself forward-version evidence.
+        var knownKindRows = entries.Count + unloadable.Count;
+        var systemic = unloadable.Count >= MinSystemicUnloadableRowCount && unloadable.Count * 2 >= knownKindRows;
+        var forwardVersionEvidence = unknownKindCount > 0;
+
+        if (systemic || forwardVersionEvidence)
+        {
+            _logger.Warning(
+                $"FilterLibrary withholding deletion of {unloadable.Count} of {knownKindRows} unloadable known-kind rows ({unknownKindCount} unknown-kind rows present; possible newer-version library).");
+            ReportSystemicUnloadable(unloadable.Count);
+        }
+        else
+        {
+            DeleteUnloadableRows(connection, unloadable);
         }
 
         return entries.ToImmutable();
@@ -303,6 +354,47 @@ internal sealed class FilterLibrarySqliteStore : IFilterLibraryStore
         cmd.ExecuteNonQuery();
     }
 
+    public IReadOnlyList<LibraryEntryId> UpdateRange(IReadOnlyList<LibraryEntry> entries)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+
+        if (entries.Count == 0) { return []; }
+
+        using var connection = OpenConnection();
+        using var tx = connection.BeginTransaction();
+
+        try
+        {
+            var updated = ImmutableList.CreateBuilder<LibraryEntryId>();
+
+            using var cmd = connection.CreateCommand();
+            cmd.Transaction = tx;
+            cmd.CommandText = UpdateSql;
+
+            foreach (var entry in entries)
+            {
+                cmd.Parameters.Clear();
+                BindEntry(cmd, entry);
+
+                if (cmd.ExecuteNonQuery() == 1) { updated.Add(entry.Id); }
+            }
+
+            tx.Commit();
+
+            return updated.ToImmutable();
+        }
+        catch
+        {
+            try { tx.Rollback(); }
+            catch (Exception rollbackEx)
+            {
+                _logger.Warning($"FilterLibrary UpdateRange rollback failed after batch update error: {rollbackEx.Message}");
+            }
+
+            throw;
+        }
+    }
+
     private static void BindEntry(SqliteCommand cmd, LibraryEntry entry)
     {
         cmd.Parameters.AddWithValue("$id", entry.Id.Value.ToString("D"));
@@ -325,7 +417,7 @@ internal sealed class FilterLibrarySqliteStore : IFilterLibraryStore
         switch (entry)
         {
             case LibraryEntrySavedFilter f:
-                cmd.Parameters.AddWithValue("$kind", "Filter");
+                cmd.Parameters.AddWithValue("$kind", FilterKind);
                 cmd.Parameters.AddWithValue("$payload", JsonSerializer.Serialize(f.Filter));
                 cmd.Parameters.AddWithValue("$comparison_text", f.Filter.ComparisonText);
                 cmd.Parameters.AddWithValue("$mode", f.Filter.Mode.ToString());
@@ -333,7 +425,7 @@ internal sealed class FilterLibrarySqliteStore : IFilterLibraryStore
                 break;
 
             case LibraryEntryFilterSet p:
-                cmd.Parameters.AddWithValue("$kind", "FilterSet");
+                cmd.Parameters.AddWithValue("$kind", FilterSetKind);
                 cmd.Parameters.AddWithValue("$payload", JsonSerializer.Serialize(p.Filters));
                 cmd.Parameters.AddWithValue("$comparison_text", DBNull.Value);
                 cmd.Parameters.AddWithValue("$mode", DBNull.Value);
@@ -358,7 +450,7 @@ internal sealed class FilterLibrarySqliteStore : IFilterLibraryStore
     {
         return kind switch
         {
-            "Filter" => new LibraryEntrySavedFilter
+            FilterKind => new LibraryEntrySavedFilter
             {
                 Id = id,
                 Name = name,
@@ -370,7 +462,7 @@ internal sealed class FilterLibrarySqliteStore : IFilterLibraryStore
                 Filter = JsonSerializer.Deserialize<SavedFilter>(payload)
                     ?? throw new InvalidOperationException($"LibraryEntrySavedFilter '{id}' payload deserialized to null."),
             },
-            "FilterSet" => new LibraryEntryFilterSet
+            FilterSetKind => new LibraryEntryFilterSet
             {
                 Id = id,
                 Name = name,
@@ -421,10 +513,13 @@ internal sealed class FilterLibrarySqliteStore : IFilterLibraryStore
 
     private static LibraryEntry? ReadEntry(SqliteDataReader reader)
     {
+        var kind = reader.IsDBNull(3) ? null : reader.GetString(3);
+
+        if (kind is not (FilterKind or FilterSetKind)) { return null; }
+
         var id = new LibraryEntryId(Guid.Parse(reader.GetString(0)));
         var name = reader.GetString(1);
         var createdUtc = DateTimeOffset.Parse(reader.GetString(2), CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
-        var kind = reader.GetString(3);
         var payload = reader.GetString(4);
         var isFavorite = !reader.IsDBNull(5) && reader.GetInt64(5) != 0;
         DateTimeOffset? lastUsedUtc = reader.IsDBNull(6)
@@ -434,11 +529,37 @@ internal sealed class FilterLibrarySqliteStore : IFilterLibraryStore
             ? LibraryEntryOrigin.UserSaved
             : ParseOrigin(reader.GetString(7));
 
-        var tags = reader.IsDBNull(11)
-            ? []
-            : JsonSerializer.Deserialize<ImmutableList<string>>(reader.GetString(11)) ?? [];
+        ImmutableList<string> tags = [];
+
+        if (reader.IsDBNull(11))
+        {
+            return DeserializeEntry(id, name, createdUtc, kind, payload, isFavorite, lastUsedUtc, origin, tags);
+        }
+
+        try { tags = JsonSerializer.Deserialize<ImmutableList<string>>(reader.GetString(11)) ?? []; }
+        catch (JsonException) { tags = []; }
 
         return DeserializeEntry(id, name, createdUtc, kind, payload, isFavorite, lastUsedUtc, origin, tags);
+    }
+
+    private void DeleteUnloadableRows(SqliteConnection connection, List<(string Id, string Kind, string Payload)> rows)
+    {
+        foreach (var (id, kind, payload) in rows)
+        {
+            try
+            {
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = DeleteUnloadableSql;
+                cmd.Parameters.AddWithValue("$id", id);
+                cmd.Parameters.AddWithValue("$kind", kind);
+                cmd.Parameters.AddWithValue("$payload", payload);
+                cmd.ExecuteNonQuery();
+            }
+            catch (Exception ex)
+            {
+                _logger.Warning($"FilterLibrary failed to remove unloadable row id={id}: {ex.Message}");
+            }
+        }
     }
 
     private SqliteConnection OpenConnection()
@@ -471,5 +592,16 @@ internal sealed class FilterLibrarySqliteStore : IFilterLibraryStore
         {
             connection?.Dispose();
         }
+    }
+
+    private void ReportSystemicUnloadable(int unloadableCount)
+    {
+        if (_errorBannerService is null) { return; }
+
+        if (Interlocked.Exchange(ref _systemicUnloadableReported, 1) != 0) { return; }
+
+        _errorBannerService.ReportError(
+            "Filter library not fully loaded",
+            $"{unloadableCount} library entries couldn't be read and were left in place to avoid data loss. This usually means the library was written by a newer version of the app.");
     }
 }

--- a/src/EventLogExpert.Runtime/FilterLibrary/IFilterLibraryStore.cs
+++ b/src/EventLogExpert.Runtime/FilterLibrary/IFilterLibraryStore.cs
@@ -55,4 +55,13 @@ public interface IFilterLibraryStore
 
     /// <summary>Updates an existing library entry in the persistent store (matched by <see cref="LibraryEntry.Id" />).</summary>
     void Update(LibraryEntry entry);
+
+    /// <summary>
+    ///     Updates every entry in <paramref name="entries" /> within a single transaction (each matched by
+    ///     <see cref="LibraryEntry.Id" />). Returns the ids of the rows that were actually updated, in input order; an entry
+    ///     whose row no longer exists is skipped and its id is omitted from the result. On any failure the transaction is
+    ///     rolled back so no partial writes persist, and the exception propagates. Returns an empty list when
+    ///     <paramref name="entries" /> is empty.
+    /// </summary>
+    IReadOnlyList<LibraryEntryId> UpdateRange(IReadOnlyList<LibraryEntry> entries);
 }

--- a/src/EventLogExpert.Runtime/FilterLibrary/TagBulkUpdateFailedAction.cs
+++ b/src/EventLogExpert.Runtime/FilterLibrary/TagBulkUpdateFailedAction.cs
@@ -1,0 +1,6 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.FilterLibrary;
+
+public sealed record TagBulkUpdateFailedAction;

--- a/src/EventLogExpert.UI/FilterEditor/FilterRow.razor.cs
+++ b/src/EventLogExpert.UI/FilterEditor/FilterRow.razor.cs
@@ -10,9 +10,11 @@ using Microsoft.AspNetCore.Components;
 
 namespace EventLogExpert.UI.FilterEditor;
 
-public sealed partial class FilterRow : FilterRowBase<SavedFilter?>
+public sealed partial class FilterRow : FilterRowBase<SavedFilter?>, IDisposable
 {
     private FilterEditorCore? _coreRef;
+
+    [Parameter] public Action<FilterRow>? OnDisposed { get; set; }
 
     [Parameter] public EventCallback<(FilterId Id, bool IsEditing)> OnEditingChanged { get; set; }
 
@@ -62,6 +64,8 @@ public sealed partial class FilterRow : FilterRowBase<SavedFilter?>
     [Inject] private IState<FilterLibraryState> FilterLibraryState { get; init; } = null!;
 
     [Inject] private IFilterPaneCommands FilterPaneCommands { get; init; } = null!;
+
+    public void Dispose() => OnDisposed?.Invoke(this);
 
     internal ValueTask FocusEditAsync() => _coreRef?.FocusEditAsync() ?? ValueTask.CompletedTask;
 

--- a/src/EventLogExpert.UI/FilterLibrary/FilterLibraryModal.razor
+++ b/src/EventLogExpert.UI/FilterLibrary/FilterLibraryModal.razor
@@ -165,6 +165,7 @@
                 OnAddToFilterSet="@HandleAddToFilterSetAsync"
                 OnApply="@HandleApplyAsync"
                 OnDelete="@HandleDelete"
+                OnDisposed="@OnRowDisposed"
                 OnExportEntry="@HandleExportEntryAsync"
                 OnReplace="@HandleReplaceAsync"
                 OnRequestPendingFocus="@(id => HandleRequestPendingFocusAsync(tab, id))"

--- a/src/EventLogExpert.UI/FilterLibrary/FilterLibraryModal.razor.cs
+++ b/src/EventLogExpert.UI/FilterLibrary/FilterLibraryModal.razor.cs
@@ -45,6 +45,8 @@ public sealed partial class FilterLibraryModal : ModalBase<bool>
     private LibraryTab? _pendingFocusSourceTab;
     private LibraryEntryId? _pendingFocusTargetEntryId;
     private bool _pendingFocusToActiveTab;
+
+    private Dictionary<LibraryTab, ImmutableList<string>>? _selectedTagsBeforeTagOp;
     private SidebarTabs<LibraryTab>? _sidebarTabsRef;
 
     [Parameter] public LibraryTab? InitialTab { get; set; }
@@ -71,11 +73,18 @@ public sealed partial class FilterLibraryModal : ModalBase<bool>
 
     [Inject] private IFilterLibraryExportService ExportService { get; init; } = null!;
 
-    private IReadOnlyList<LibraryEntry> FavoriteEntries =>
-        [.. FilterLibraryState.Value.Entries
-            .Where(e => e is LibraryEntrySavedFilter && e.IsFavorite)
-            .Where(e => MatchesTagFilter(e, _selectedTagsByTab[LibraryTab.Favorites]))
-            .OrderBy(e => e.Name, StringComparer.OrdinalIgnoreCase)];
+    private IReadOnlyList<LibraryEntry> FavoriteEntries
+    {
+        get
+        {
+            var selected = SelectedTagsInLibrary(LibraryTab.Favorites);
+
+            return [.. FilterLibraryState.Value.Entries
+                .Where(e => e is LibraryEntrySavedFilter && e.IsFavorite)
+                .Where(e => MatchesTagFilter(e, selected))
+                .OrderBy(e => e.Name, StringComparer.OrdinalIgnoreCase)];
+        }
+    }
 
     [Inject] private IFilePickerService FilePickerService { get; init; } = null!;
 
@@ -83,19 +92,33 @@ public sealed partial class FilterLibraryModal : ModalBase<bool>
 
     [Inject] private IState<FilterLibraryState> FilterLibraryState { get; init; } = null!;
 
-    private IReadOnlyList<LibraryEntry> PreviouslyUsedEntries =>
-        [.. FilterLibraryState.Value.Entries
-            .Where(e => e.Origin == LibraryEntryOrigin.AutoTracked && !e.IsFavorite)
-            .Where(e => e.LastUsedUtc.HasValue)
-            .Where(e => MatchesTagFilter(e, _selectedTagsByTab[LibraryTab.PreviouslyUsed]))
-            .OrderByDescending(e => e.LastUsedUtc.GetValueOrDefault())
-            .Take(50)];
+    private IReadOnlyList<LibraryEntry> PreviouslyUsedEntries
+    {
+        get
+        {
+            var selected = SelectedTagsInLibrary(LibraryTab.PreviouslyUsed);
 
-    private IReadOnlyList<LibraryEntry> SavedEntries =>
-        [.. FilterLibraryState.Value.Entries
-            .Where(e => e.Origin == LibraryEntryOrigin.UserSaved && !e.IsFavorite)
-            .Where(e => MatchesTagFilter(e, _selectedTagsByTab[LibraryTab.Saved]))
-            .OrderBy(e => e.Name, StringComparer.OrdinalIgnoreCase)];
+            return [.. FilterLibraryState.Value.Entries
+                .Where(e => e is { Origin: LibraryEntryOrigin.AutoTracked, IsFavorite: false })
+                .Where(e => e.LastUsedUtc.HasValue)
+                .Where(e => MatchesTagFilter(e, selected))
+                .OrderByDescending(e => e.LastUsedUtc.GetValueOrDefault())
+                .Take(50)];
+        }
+    }
+
+    private IReadOnlyList<LibraryEntry> SavedEntries
+    {
+        get
+        {
+            var selected = SelectedTagsInLibrary(LibraryTab.Saved);
+
+            return [.. FilterLibraryState.Value.Entries
+                .Where(e => e is { Origin: LibraryEntryOrigin.UserSaved, IsFavorite: false })
+                .Where(e => MatchesTagFilter(e, selected))
+                .OrderBy(e => e.Name, StringComparer.OrdinalIgnoreCase)];
+        }
+    }
 
     private IReadOnlyList<LibraryEntrySavedFilter> SavedFilterEntries =>
         [.. FilterLibraryState.Value.Entries.OfType<LibraryEntrySavedFilter>()];
@@ -345,6 +368,8 @@ public sealed partial class FilterLibraryModal : ModalBase<bool>
     {
         base.OnInitialized();
 
+        SubscribeToAction<TagBulkUpdateFailedAction>(_ => RevertOptimisticTagSelection());
+
         if (InitialTab is { } tab)
         {
             _activeTab = tab;
@@ -380,7 +405,7 @@ public sealed partial class FilterLibraryModal : ModalBase<bool>
 
     private string GetEmptyStateMessage(LibraryTab tab)
     {
-        if (_selectedTagsByTab[tab].Count > 0) { return "No entries match the selected tags."; }
+        if (SelectedTagsInLibrary(tab).Count > 0) { return "No entries match the selected tags."; }
 
         return tab switch
         {
@@ -471,6 +496,8 @@ public sealed partial class FilterLibraryModal : ModalBase<bool>
 
     private void HandleTagDeleted(string name)
     {
+        SnapshotSelectedTags();
+
         foreach (var tab in _selectedTagsByTab.Keys.ToList())
         {
             _selectedTagsByTab[tab] = _selectedTagsByTab[tab]
@@ -492,6 +519,8 @@ public sealed partial class FilterLibraryModal : ModalBase<bool>
 
     private void HandleTagRenamed((string OldName, string NewName) e)
     {
+        SnapshotSelectedTags();
+
         foreach (var tab in _selectedTagsByTab.Keys.ToList())
         {
             var current = _selectedTagsByTab[tab];
@@ -510,6 +539,18 @@ public sealed partial class FilterLibraryModal : ModalBase<bool>
         FilterLibraryCommands.SetIsFavorite(intent.EntryId, intent.NewIsFavorite);
 
     private bool IsTabpanelEmpty(LibraryTab tab) => GetEntriesForTab(tab).Count == 0;
+
+    private void OnRowDisposed(LibraryEntryRow row)
+    {
+        (LibraryTab Tab, LibraryEntryId Id)? match = null;
+
+        foreach (var rowRef in _rowRefs)
+        {
+            if (ReferenceEquals(rowRef.Value, row)) { match = rowRef.Key; break; }
+        }
+
+        if (match is { } key) { _rowRefs.Remove(key); }
+    }
 
     private async Task PromptAndApplyImportAsync(ImportPreflight preflight)
     {
@@ -559,11 +600,13 @@ public sealed partial class FilterLibraryModal : ModalBase<bool>
     {
         if (_rowRefs.Count == 0) { return; }
 
+        var liveIds = FilterLibraryState.Value.Entries.Select(e => e.Id).ToHashSet();
+
         List<(LibraryTab Tab, LibraryEntryId Id)>? stale = null;
 
-        foreach (var rowRef in _rowRefs)
+        foreach (var (key, value) in _rowRefs.ToList())
         {
-            if (rowRef.Value is null) { (stale ??= []).Add(rowRef.Key); }
+            if (value is null || !liveIds.Contains(key.Id)) { (stale ??= []).Add(key); }
         }
 
         if (stale is null) { return; }
@@ -572,6 +615,26 @@ public sealed partial class FilterLibraryModal : ModalBase<bool>
     }
 
     private void RetryLoad() => FilterLibraryCommands.LoadLibrary();
+
+    private void RevertOptimisticTagSelection()
+    {
+        if (_selectedTagsBeforeTagOp is null) { return; }
+
+        foreach (var (tab, tags) in _selectedTagsBeforeTagOp)
+        {
+            _selectedTagsByTab[tab] = tags;
+        }
+
+        _selectedTagsBeforeTagOp = null;
+        StateHasChanged();
+    }
+
+    private ImmutableList<string> SelectedTagsInLibrary(LibraryTab tab)
+    {
+        var available = AllLibraryTags;
+
+        return [.. _selectedTagsByTab[tab].Where(t => available.Contains(t, StringComparer.OrdinalIgnoreCase))];
+    }
 
     private async Task ShowImportExportErrorAsync(string title, string message)
     {
@@ -591,6 +654,8 @@ public sealed partial class FilterLibraryModal : ModalBase<bool>
         {
         }
     }
+
+    private void SnapshotSelectedTags() => _selectedTagsBeforeTagOp = new(_selectedTagsByTab);
 
     private void ToggleTagFilter(string tag)
     {

--- a/src/EventLogExpert.UI/FilterLibrary/LibraryEntryRow.razor.cs
+++ b/src/EventLogExpert.UI/FilterLibrary/LibraryEntryRow.razor.cs
@@ -44,6 +44,8 @@ public sealed partial class LibraryEntryRow : ComponentBase, IAsyncDisposable
 
     [Parameter][EditorRequired] public EventCallback<LibraryEntryId> OnDelete { get; set; }
 
+    [Parameter] public Action<LibraryEntryRow>? OnDisposed { get; set; }
+
     [Parameter] public EventCallback<LibraryEntryId> OnExportEntry { get; set; }
 
     [Parameter][EditorRequired] public EventCallback<LibraryEntryId> OnReplace { get; set; }
@@ -93,6 +95,7 @@ public sealed partial class LibraryEntryRow : ComponentBase, IAsyncDisposable
     public ValueTask DisposeAsync()
     {
         MenuService.StateChanged -= OnMenuServiceStateChanged;
+        OnDisposed?.Invoke(this);
 
         return ValueTask.CompletedTask;
     }

--- a/src/EventLogExpert.UI/FilterLibrary/TagManagementPanel.razor.cs
+++ b/src/EventLogExpert.UI/FilterLibrary/TagManagementPanel.razor.cs
@@ -1,7 +1,6 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
-using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.Runtime.FilterLibrary;
 using Microsoft.AspNetCore.Components;
 
@@ -28,8 +27,6 @@ public sealed partial class TagManagementPanel : ComponentBase
     [Parameter] public EventCallback<string> OnTagDeleted { get; set; }
 
     [Parameter] public EventCallback<(string OldName, string NewName)> OnTagRenamed { get; set; }
-
-    [Inject] private IAnnouncementService AnnouncementService { get; init; } = null!;
 
     [Inject] private IFilterLibraryCommands FilterLibraryCommands { get; init; } = null!;
 
@@ -93,10 +90,9 @@ public sealed partial class TagManagementPanel : ComponentBase
         if (_deleteConfirmTag is null) { return; }
 
         var tag = _deleteConfirmTag;
-        FilterLibraryCommands.DeleteTag(tag);
-        AnnouncementService.Announce($"Deleted tag '{tag}' from library");
 
         await OnTagDeleted.InvokeAsync(NormalizeForCallback(tag));
+        FilterLibraryCommands.DeleteTag(tag);
         CancelDelete();
     }
 
@@ -106,10 +102,9 @@ public sealed partial class TagManagementPanel : ComponentBase
 
         var oldName = _editingTag;
         var target = _mergeTargetTag;
-        FilterLibraryCommands.RenameTag(oldName, target);
-        AnnouncementService.Announce($"Merged tag '{oldName}' into '{target}'");
 
         await OnTagRenamed.InvokeAsync((NormalizeForCallback(oldName), NormalizeForCallback(target)));
+        FilterLibraryCommands.RenameTag(oldName, target);
         CancelEdit();
     }
 
@@ -138,10 +133,8 @@ public sealed partial class TagManagementPanel : ComponentBase
             return;
         }
 
-        FilterLibraryCommands.RenameTag(oldName, newName);
-        AnnouncementService.Announce($"Renamed tag '{oldName}' to '{newName}'");
-
         await OnTagRenamed.InvokeAsync((NormalizeForCallback(oldName), NormalizeForCallback(newName)));
+        FilterLibraryCommands.RenameTag(oldName, newName);
         CancelEdit();
     }
 

--- a/src/EventLogExpert.UI/FilterPane/FilterPane.razor
+++ b/src/EventLogExpert.UI/FilterPane/FilterPane.razor
@@ -204,7 +204,7 @@
 
         @foreach (var item in FilterPaneState.Value.Filters)
         {
-            <FilterRow @key="item.Id" OnRemoved="HandleRemovedFilter" @ref="_rowRefs[item.Id]" Value="item" />
+            <FilterRow @key="item.Id" OnDisposed="@OnRowDisposed" OnRemoved="HandleRemovedFilter" @ref="_rowRefs[item.Id]" Value="item" />
         }
 
         @foreach (var draft in _pendingDrafts)

--- a/src/EventLogExpert.UI/FilterPane/FilterPane.razor.cs
+++ b/src/EventLogExpert.UI/FilterPane/FilterPane.razor.cs
@@ -409,6 +409,22 @@ public sealed partial class FilterPane : IDisposable
     // re-renders so the chevron's aria-expanded reflects open/close state.
     private void OnMenuServiceStateChanged() => _ = InvokeAsync(StateHasChanged);
 
+    private void OnRowDisposed(FilterRow row)
+    {
+        FilterId? match = null;
+
+        foreach (var kvp in _rowRefs)
+        {
+            if (ReferenceEquals(kvp.Value, row))
+            {
+                match = kvp.Key;
+                break;
+            }
+        }
+
+        if (match is { } id) { _rowRefs.Remove(id); }
+    }
+
     private async Task OpenAddFilterMenuAsync() => await OpenAddFilterMenuAtAsync(true);
 
     private async Task OpenAddFilterMenuAtAsync(bool focusFirst)
@@ -436,7 +452,7 @@ public sealed partial class FilterPane : IDisposable
         var liveIds = liveFilters.Select(f => f.Id).ToHashSet();
 
         var stale = _rowRefs
-            .Where(kvp => !liveIds.Contains(kvp.Key) || kvp.Value is null)
+            .Where(kvp => kvp.Value is null || !liveIds.Contains(kvp.Key))
             .Select(kvp => kvp.Key)
             .ToList();
 

--- a/tests/Integration/EventLogExpert.Runtime.IntegrationTests/FilterLibrary/FilterLibraryMigrationIntegrationTests.cs
+++ b/tests/Integration/EventLogExpert.Runtime.IntegrationTests/FilterLibrary/FilterLibraryMigrationIntegrationTests.cs
@@ -3,6 +3,7 @@
 
 using EventLogExpert.Filtering.Persistence;
 using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.Runtime.FilterLibrary;
 using EventLogExpert.Runtime.FilterPane;
 using Fluxor;
@@ -240,7 +241,7 @@ public sealed class FilterLibraryMigrationIntegrationTests : IDisposable
 
         backslashMigrator ??= Substitute.For<IBackslashNameMigrator>();
 
-        return new Effects(store, libraryState, paneState, migrator, backslashMigrator, Substitute.For<ITraceLogger>());
+        return new Effects(store, libraryState, paneState, migrator, backslashMigrator, Substitute.For<IAnnouncementService>(), Substitute.For<ITraceLogger>());
     }
 
     private string CreateTempDatabasePath()
@@ -288,5 +289,7 @@ public sealed class FilterLibraryMigrationIntegrationTests : IDisposable
             inner.TryDeleteAutoTrackedIfNotFavorite(entryId);
 
         public void Update(LibraryEntry entry) => inner.Update(entry);
+
+        public IReadOnlyList<LibraryEntryId> UpdateRange(IReadOnlyList<LibraryEntry> entries) => inner.UpdateRange(entries);
     }
 }

--- a/tests/Integration/EventLogExpert.Runtime.IntegrationTests/FilterLibrary/FilterLibrarySqliteStoreTests.cs
+++ b/tests/Integration/EventLogExpert.Runtime.IntegrationTests/FilterLibrary/FilterLibrarySqliteStoreTests.cs
@@ -4,6 +4,7 @@
 using EventLogExpert.Filtering.Evaluation;
 using EventLogExpert.Filtering.Persistence;
 using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.Banner;
 using EventLogExpert.Runtime.FilterLibrary;
 using Microsoft.Data.Sqlite;
 using NSubstitute;
@@ -412,6 +413,33 @@ public sealed class FilterLibrarySqliteStoreTests : IDisposable
     }
 
     [Fact]
+    public void LoadAll_CorruptTagsKnownKind_KeepsEntryWithEmptyTags()
+    {
+        var dbPath = CreateTempDatabasePath();
+        var store = new FilterLibrarySqliteStore(dbPath, Substitute.For<ITraceLogger>());
+        var seed = BuildFilterEntry("Seed");
+        store.Add(seed);
+        store.Delete(seed.Id);
+
+        var entry = BuildFilterEntry("HasCorruptTags");
+        store.Add(entry);
+
+        using (var connection = new SqliteConnection($"Data Source={dbPath}"))
+        {
+            connection.Open();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = $"UPDATE library_entries SET tags = 'not valid json' WHERE id = '{entry.Id.Value:D}';";
+            cmd.ExecuteNonQuery();
+        }
+
+        var result = store.LoadAll();
+
+        var loaded = Assert.Single(result);
+        Assert.Equal(entry.Id, loaded.Id);
+        Assert.Empty(loaded.Tags);
+    }
+
+    [Fact]
     public void LoadAll_CreatesParentDirectoryIfMissing()
     {
         var nestedDir = Path.Combine(Path.GetTempPath(), $"FilterLibrarySqliteStoreTests_{Guid.NewGuid()}", "nested", "deeper");
@@ -428,6 +456,107 @@ public sealed class FilterLibrarySqliteStoreTests : IDisposable
     }
 
     [Fact]
+    public void LoadAll_ForwardVersionEvidenceWithMinorityUnloadable_WithholdsBelowSystemicRatio()
+    {
+        var dbPath = CreateTempDatabasePath();
+        var banner = Substitute.For<IErrorBannerService>();
+        var store = new FilterLibrarySqliteStore(dbPath, Substitute.For<ITraceLogger>(), banner);
+
+        // 5 good known-kind rows make the unloadable rows a MINORITY of known kinds: with 3 unloadable of
+        // 8 known-kind, the systemic ratio (3*2 = 6 >= 8) is false. The single unknown-kind row is the
+        // only thing that trips the breaker (forward-version evidence), so this isolates that path — drop
+        // the forward-version-evidence check and the 3 reformatted rows would be wrongly deleted.
+        for (var i = 0; i < 5; i++) { store.Add(BuildFilterEntry($"Good{i}")); }
+
+        var unloadableIds = new[]
+        {
+            "00000000-0000-0000-0000-0000000000a1", "00000000-0000-0000-0000-0000000000a2",
+            "00000000-0000-0000-0000-0000000000a3",
+        };
+        const string unknownId = "00000000-0000-0000-0000-0000000000b9";
+
+        using (var connection = new SqliteConnection($"Data Source={dbPath}"))
+        {
+            connection.Open();
+            foreach (var id in unloadableIds)
+            {
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = $"INSERT INTO library_entries (id, name, created_utc, kind, payload, is_favorite, last_used_utc, origin, comparison_text, mode, is_excluded) VALUES ('{id}', 'Bad', '2026-05-31T00:00:00.0000000+00:00', 'Filter', 'not valid json', 0, NULL, 'UserSaved', NULL, NULL, NULL);";
+                cmd.ExecuteNonQuery();
+            }
+
+            using var unknownCmd = connection.CreateCommand();
+            unknownCmd.CommandText = $"INSERT INTO library_entries (id, name, created_utc, kind, payload, is_favorite, last_used_utc, origin, comparison_text, mode, is_excluded) VALUES ('{unknownId}', 'Future', '2026-05-31T00:00:00.0000000+00:00', 'SomeFutureKind', '{{}}', 0, NULL, 'UserSaved', NULL, NULL, NULL);";
+            unknownCmd.ExecuteNonQuery();
+        }
+
+        var result = store.LoadAll();
+
+        Assert.Equal(5, result.Count);
+        foreach (var id in unloadableIds)
+        {
+            Assert.Equal(1L, CountRows(dbPath, new LibraryEntryId(Guid.Parse(id))));
+        }
+
+        banner.ReceivedWithAnyArgs(1).ReportError(default!, default!);
+    }
+
+    [Fact]
+    public void LoadAll_ForwardVersionUnknownKindsPresent_WithholdsUnloadableKnownKindDeletion()
+    {
+        var dbPath = CreateTempDatabasePath();
+        var banner = Substitute.For<IErrorBannerService>();
+        var store = new FilterLibrarySqliteStore(dbPath, Substitute.For<ITraceLogger>(), banner);
+        var seed = BuildFilterEntry("Seed");
+        store.Add(seed);
+        store.Delete(seed.Id);
+
+        // Forward-version DB: a newer app wrote 6 unknown-kind rows AND reformatted Filter payloads so
+        // 4 known-kind rows are now unparseable. Over all 10 rows, 4*2 = 8 < 10 would (wrongly) delete
+        // the 4 known-kind rows; the breaker must count only known-kind rows / treat the unknown kinds
+        // as forward-version evidence and withhold.
+        var unknownIds = new[]
+        {
+            "00000000-0000-0000-0000-0000000000e1", "00000000-0000-0000-0000-0000000000e2",
+            "00000000-0000-0000-0000-0000000000e3", "00000000-0000-0000-0000-0000000000e4",
+            "00000000-0000-0000-0000-0000000000e5", "00000000-0000-0000-0000-0000000000e6",
+        };
+        var unloadableIds = new[]
+        {
+            "00000000-0000-0000-0000-0000000000f1", "00000000-0000-0000-0000-0000000000f2",
+            "00000000-0000-0000-0000-0000000000f3", "00000000-0000-0000-0000-0000000000f4",
+        };
+
+        using (var connection = new SqliteConnection($"Data Source={dbPath}"))
+        {
+            connection.Open();
+            foreach (var id in unknownIds)
+            {
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = $"INSERT INTO library_entries (id, name, created_utc, kind, payload, is_favorite, last_used_utc, origin, comparison_text, mode, is_excluded) VALUES ('{id}', 'Future', '2026-05-31T00:00:00.0000000+00:00', 'SomeFutureKind', '{{}}', 0, NULL, 'UserSaved', NULL, NULL, NULL);";
+                cmd.ExecuteNonQuery();
+            }
+
+            foreach (var id in unloadableIds)
+            {
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = $"INSERT INTO library_entries (id, name, created_utc, kind, payload, is_favorite, last_used_utc, origin, comparison_text, mode, is_excluded) VALUES ('{id}', 'Bad', '2026-05-31T00:00:00.0000000+00:00', 'Filter', 'not valid json', 0, NULL, 'UserSaved', NULL, NULL, NULL);";
+                cmd.ExecuteNonQuery();
+            }
+        }
+
+        var result = store.LoadAll();
+
+        Assert.Empty(result);
+        foreach (var id in unloadableIds)
+        {
+            Assert.Equal(1L, CountRows(dbPath, new LibraryEntryId(Guid.Parse(id))));
+        }
+
+        banner.ReceivedWithAnyArgs(1).ReportError(default!, default!);
+    }
+
+    [Fact]
     public void LoadAll_FreshDatabase_ReturnsEmpty()
     {
         var dbPath = CreateTempDatabasePath();
@@ -439,7 +568,40 @@ public sealed class FilterLibrarySqliteStoreTests : IDisposable
     }
 
     [Fact]
-    public void LoadAll_MalformedPayload_SkipsRowAndLogs()
+    public void LoadAll_HalfUnloadable_WithholdsDeletionAndLoadsGoodRows()
+    {
+        var dbPath = CreateTempDatabasePath();
+        var banner = Substitute.For<IErrorBannerService>();
+        var store = new FilterLibrarySqliteStore(dbPath, Substitute.For<ITraceLogger>(), banner);
+        store.Add(BuildFilterEntry("GoodA"));
+        store.Add(BuildFilterEntry("GoodB"));
+
+        var badIds = new[]
+        {
+            new LibraryEntryId(Guid.Parse("00000000-0000-0000-0000-0000000000d1")),
+            new LibraryEntryId(Guid.Parse("00000000-0000-0000-0000-0000000000d2")),
+        };
+
+        using (var connection = new SqliteConnection($"Data Source={dbPath}"))
+        {
+            connection.Open();
+            foreach (var id in badIds)
+            {
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = $"INSERT INTO library_entries (id, name, created_utc, kind, payload, is_favorite, last_used_utc, origin, comparison_text, mode, is_excluded) VALUES ('{id.Value:D}', 'Bad', '2026-05-31T00:00:00.0000000+00:00', 'Filter', 'not valid json', 0, NULL, 'UserSaved', NULL, NULL, NULL);";
+                cmd.ExecuteNonQuery();
+            }
+        }
+
+        var result = store.LoadAll();
+
+        Assert.Equal(2, result.Count);
+        foreach (var id in badIds) { Assert.Equal(1L, CountRows(dbPath, id)); }
+        banner.ReceivedWithAnyArgs(1).ReportError(default!, default!);
+    }
+
+    [Fact]
+    public void LoadAll_MalformedPayloadKnownKind_DeletesRowAndLogs()
     {
         var dbPath = CreateTempDatabasePath();
         var logger = Substitute.For<ITraceLogger>();
@@ -470,10 +632,46 @@ public sealed class FilterLibrarySqliteStoreTests : IDisposable
         Assert.Single(result);
         Assert.Equal(good.Id, result[0].Id);
         logger.ReceivedWithAnyArgs(1).Warning(default);
+        Assert.Equal(0L, CountRows(dbPath, badId));
     }
 
     [Fact]
-    public void LoadAll_UnknownKind_SkipsRowAndLogs()
+    public void LoadAll_SystemicUnloadableRows_WithholdsDeletionAndReportsBanner()
+    {
+        var dbPath = CreateTempDatabasePath();
+        var banner = Substitute.For<IErrorBannerService>();
+        var store = new FilterLibrarySqliteStore(dbPath, Substitute.For<ITraceLogger>(), banner);
+        var seed = BuildFilterEntry("Seed");
+        store.Add(seed);
+        store.Delete(seed.Id);
+
+        var ids = new[]
+        {
+            new LibraryEntryId(Guid.Parse("00000000-0000-0000-0000-0000000000c1")),
+            new LibraryEntryId(Guid.Parse("00000000-0000-0000-0000-0000000000c2")),
+            new LibraryEntryId(Guid.Parse("00000000-0000-0000-0000-0000000000c3")),
+        };
+
+        using (var connection = new SqliteConnection($"Data Source={dbPath}"))
+        {
+            connection.Open();
+            foreach (var id in ids)
+            {
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = $"INSERT INTO library_entries (id, name, created_utc, kind, payload, is_favorite, last_used_utc, origin, comparison_text, mode, is_excluded) VALUES ('{id.Value:D}', 'Bad', '2026-05-31T00:00:00.0000000+00:00', 'Filter', 'not valid json', 0, NULL, 'UserSaved', NULL, NULL, NULL);";
+                cmd.ExecuteNonQuery();
+            }
+        }
+
+        var result = store.LoadAll();
+
+        Assert.Empty(result);
+        foreach (var id in ids) { Assert.Equal(1L, CountRows(dbPath, id)); }
+        banner.ReceivedWithAnyArgs(1).ReportError(default!, default!);
+    }
+
+    [Fact]
+    public void LoadAll_UnknownKind_SkipsRowAndKeepsIt()
     {
         var dbPath = CreateTempDatabasePath();
         var logger = Substitute.For<ITraceLogger>();
@@ -496,6 +694,32 @@ public sealed class FilterLibrarySqliteStoreTests : IDisposable
 
         Assert.Empty(result);
         logger.ReceivedWithAnyArgs(1).Warning(default);
+        Assert.Equal(1L, CountRows(dbPath, unknownId));
+    }
+
+    [Fact]
+    public void LoadAll_UnknownKindWithUnparseableColumns_KeepsRow()
+    {
+        var dbPath = CreateTempDatabasePath();
+        var store = new FilterLibrarySqliteStore(dbPath, Substitute.For<ITraceLogger>());
+        var seed = BuildFilterEntry("Seed");
+        store.Add(seed);
+        store.Delete(seed.Id);
+
+        var unknownId = new LibraryEntryId(Guid.Parse("00000000-0000-0000-0000-0000000000aa"));
+
+        using (var connection = new SqliteConnection($"Data Source={dbPath}"))
+        {
+            connection.Open();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = $"INSERT INTO library_entries (id, name, created_utc, kind, payload, is_favorite, last_used_utc, origin, comparison_text, mode, is_excluded) VALUES ('{unknownId.Value:D}', 'FutureRow', 'not-a-date', 'SomeFutureKind', '{{}}', 0, NULL, 'UserSaved', NULL, NULL, NULL);";
+            cmd.ExecuteNonQuery();
+        }
+
+        var result = store.LoadAll();
+
+        Assert.Empty(result);
+        Assert.Equal(1L, CountRows(dbPath, unknownId));
     }
 
     [Fact]
@@ -676,6 +900,43 @@ public sealed class FilterLibrarySqliteStoreTests : IDisposable
         Assert.Equal("First (renamed)", result[0].Name);
     }
 
+    [Fact]
+    public void UpdateRange_SkipsAbsentRow_ReturnsOnlyPresentIds()
+    {
+        var dbPath = CreateTempDatabasePath();
+        var store = new FilterLibrarySqliteStore(dbPath, Substitute.For<ITraceLogger>());
+        var present = BuildFilterEntry("Present");
+        var absent = BuildFilterEntry("Absent");
+        store.Add(present);
+
+        var ids = store.UpdateRange([present with { Tags = ["x"] }, absent with { Tags = ["y"] }]);
+
+        Assert.Single(ids);
+        Assert.Contains(present.Id, ids);
+        Assert.DoesNotContain(absent.Id, ids);
+    }
+
+    [Fact]
+    public void UpdateRange_UpdatesAllPresentRows_ReturnsTheirIds()
+    {
+        var dbPath = CreateTempDatabasePath();
+        var store = new FilterLibrarySqliteStore(dbPath, Substitute.For<ITraceLogger>());
+        var a = BuildFilterEntry("A");
+        var b = BuildFilterEntry("B");
+        store.Add(a);
+        store.Add(b);
+
+        var ids = store.UpdateRange([a with { Tags = ["x"] }, b with { Tags = ["y"] }]);
+
+        Assert.Equal(2, ids.Count);
+        Assert.Contains(a.Id, ids);
+        Assert.Contains(b.Id, ids);
+
+        var afterLoad = store.LoadAll();
+        Assert.Contains(afterLoad, e => e.Id == a.Id && e.Tags.SequenceEqual(new[] { "x" }));
+        Assert.Contains(afterLoad, e => e.Id == b.Id && e.Tags.SequenceEqual(new[] { "y" }));
+    }
+
     private static LibraryEntrySavedFilter BuildAutoTrackedFilterEntry(string comparisonText, FilterMode mode = FilterMode.Advanced)
     {
         var filter = SavedFilter.TryCreate(comparisonText, mode: mode);
@@ -705,6 +966,16 @@ public sealed class FilterLibrarySqliteStoreTests : IDisposable
             CreatedUtc = DateTimeOffset.UtcNow,
             Filter = filter,
         };
+    }
+
+    private static long CountRows(string dbPath, LibraryEntryId id)
+    {
+        using var connection = new SqliteConnection($"Data Source={dbPath}");
+        connection.Open();
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT COUNT(*) FROM library_entries WHERE id = $id;";
+        cmd.Parameters.AddWithValue("$id", id.Value.ToString("D"));
+        return (long)cmd.ExecuteScalar()!;
     }
 
     private static List<string> ReadColumnNames(SqliteConnection connection)

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLibrary/FilterLibraryEffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLibrary/FilterLibraryEffectsTests.cs
@@ -3,6 +3,7 @@
 
 using EventLogExpert.Filtering.Persistence;
 using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.Runtime.FilterLibrary;
 using EventLogExpert.Runtime.FilterPane;
 using Fluxor;
@@ -275,7 +276,22 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleDeleteTag(new DeleteTagAction("bug"), dispatcher);
 
-        store.Received(1).Update(Arg.Is<LibraryEntry>(e => e.Tags.SequenceEqual(new[] { "perf" })));
+        store.Received(1).UpdateRange(Arg.Is<IReadOnlyList<LibraryEntry>>(list =>
+            list.Count == 1 && list[0].Tags.SequenceEqual(new[] { "perf" })));
+    }
+
+    [Fact]
+    public async Task HandleDeleteTag_NoMatchingEntries_NoStoreCall_NoAnnounce()
+    {
+        var entry = BuildFilterEntry("E") with { Tags = ["perf"] };
+        var announcer = Substitute.For<IAnnouncementService>();
+        var (effects, store, dispatcher, _, _) = CreateEffects(
+            state: new FilterLibraryState { Entries = [entry] }, announcementService: announcer);
+
+        await effects.HandleDeleteTag(new DeleteTagAction("bug"), dispatcher);
+
+        store.DidNotReceiveWithAnyArgs().UpdateRange(default!);
+        announcer.DidNotReceiveWithAnyArgs().Announce(default!);
     }
 
     [Fact]
@@ -288,23 +304,80 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleDeleteTag(new DeleteTagAction("BUG"), dispatcher);
 
-        store.Received(1).Update(Arg.Is<LibraryEntry>(e => e.Id == a.Id && e.Tags.SequenceEqual(new[] { "perf" })));
-        store.Received(1).Update(Arg.Is<LibraryEntry>(e => e.Id == b.Id && e.Tags.IsEmpty));
-        store.DidNotReceive().Update(Arg.Is<LibraryEntry>(e => e.Id == c.Id));
+        store.Received(1).UpdateRange(Arg.Is<IReadOnlyList<LibraryEntry>>(list =>
+            list.Count == 2 &&
+            list.Any(e => e.Id == a.Id && e.Tags.SequenceEqual(new[] { "perf" })) &&
+            list.Any(e => e.Id == b.Id && e.Tags.IsEmpty) &&
+            list.All(e => e.Id != c.Id)));
     }
 
     [Fact]
-    public async Task HandleDeleteTag_StoreFailureSkipsOneEntryButContinues()
+    public async Task HandleDeleteTag_StorePersistsNoRows_ReloadsLibrary_AnnouncesFailure_DispatchesFailedAction()
     {
         var a = BuildFilterEntry("A") with { Tags = ["bug"] };
-        var b = BuildFilterEntry("B") with { Tags = ["bug"] };
-        var (effects, store, dispatcher, _, logger) = CreateEffects(state: new FilterLibraryState { Entries = [a, b] });
-        store.When(s => s.Update(Arg.Is<LibraryEntry>(e => e.Id == a.Id))).Do(_ => throw new InvalidOperationException("boom"));
+        var announcer = Substitute.For<IAnnouncementService>();
+        var (effects, store, dispatcher, _, _) = CreateEffects(
+            state: new FilterLibraryState { Entries = [a] }, announcementService: announcer);
+        store.UpdateRange(Arg.Any<IReadOnlyList<LibraryEntry>>()).Returns([]);
 
         await effects.HandleDeleteTag(new DeleteTagAction("bug"), dispatcher);
 
-        dispatcher.Received(1).Dispatch(Arg.Is<UpdateLibraryEntrySuccessAction>(s => s.Entry.Id == b.Id));
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<UpdateLibraryEntrySuccessAction>());
+        dispatcher.Received(1).Dispatch(Arg.Any<LoadLibraryAction>());
+        dispatcher.Received(1).Dispatch(Arg.Any<TagBulkUpdateFailedAction>());
+        announcer.Received(1).Announce("Couldn't update tags. The library was reloaded.");
+    }
+
+    [Fact]
+    public async Task HandleDeleteTag_StoreSkipsAlreadyGoneRow_DispatchesUpdatedOnly_ReloadsAndAnnouncesSingular()
+    {
+        var a = BuildFilterEntry("A") with { Tags = ["bug"] };
+        var b = BuildFilterEntry("B") with { Tags = ["bug"] };
+        var announcer = Substitute.For<IAnnouncementService>();
+        var (effects, store, dispatcher, _, _) = CreateEffects(
+            state: new FilterLibraryState { Entries = [a, b] }, announcementService: announcer);
+        store.UpdateRange(Arg.Any<IReadOnlyList<LibraryEntry>>()).Returns([a.Id]);
+
+        await effects.HandleDeleteTag(new DeleteTagAction("bug"), dispatcher);
+
+        dispatcher.Received(1).Dispatch(Arg.Is<UpdateLibraryEntrySuccessAction>(s => s.Entry.Id == a.Id));
+        dispatcher.DidNotReceive().Dispatch(Arg.Is<UpdateLibraryEntrySuccessAction>(s => s.Entry.Id == b.Id));
+        dispatcher.Received(1).Dispatch(Arg.Any<LoadLibraryAction>());
+        announcer.Received(1).Announce("Removed tag 'bug' from 1 entry");
+    }
+
+    [Fact]
+    public async Task HandleDeleteTag_StoreThrows_NoSuccessDispatched_ReloadsLibrary_AnnouncesFailure()
+    {
+        var a = BuildFilterEntry("A") with { Tags = ["bug"] };
+        var b = BuildFilterEntry("B") with { Tags = ["bug"] };
+        var announcer = Substitute.For<IAnnouncementService>();
+        var (effects, store, dispatcher, _, logger) = CreateEffects(
+            state: new FilterLibraryState { Entries = [a, b] }, announcementService: announcer);
+        store.When(s => s.UpdateRange(Arg.Any<IReadOnlyList<LibraryEntry>>())).Do(_ => throw new InvalidOperationException("boom"));
+
+        await effects.HandleDeleteTag(new DeleteTagAction("bug"), dispatcher);
+
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<UpdateLibraryEntrySuccessAction>());
+        dispatcher.Received(1).Dispatch(Arg.Any<LoadLibraryAction>());
+        dispatcher.Received(1).Dispatch(Arg.Any<TagBulkUpdateFailedAction>());
+        announcer.Received(1).Announce("Couldn't update tags. The library was reloaded.");
         logger.ReceivedWithAnyArgs(1).Warning(default);
+    }
+
+    [Fact]
+    public async Task HandleDeleteTag_Success_AnnouncesAffectedCount_PluralAndDispatchesPerEntry()
+    {
+        var a = BuildFilterEntry("A") with { Tags = ["bug"] };
+        var b = BuildFilterEntry("B") with { Tags = ["bug", "perf"] };
+        var announcer = Substitute.For<IAnnouncementService>();
+        var (effects, _, dispatcher, _, _) = CreateEffects(
+            state: new FilterLibraryState { Entries = [a, b] }, announcementService: announcer);
+
+        await effects.HandleDeleteTag(new DeleteTagAction("bug"), dispatcher);
+
+        announcer.Received(1).Announce("Removed tag 'bug' from 2 entries");
+        dispatcher.Received(2).Dispatch(Arg.Any<UpdateLibraryEntrySuccessAction>());
     }
 
     [Fact]
@@ -1219,7 +1292,8 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleRenameTag(new RenameTagAction("bug", "defect"), dispatcher);
 
-        store.Received(1).Update(Arg.Is<LibraryEntry>(e => e.Tags.SequenceEqual(new[] { "defect" })));
+        store.Received(1).UpdateRange(Arg.Is<IReadOnlyList<LibraryEntry>>(list =>
+            list.Count == 1 && list[0].Tags.SequenceEqual(new[] { "defect" })));
     }
 
     [Fact]
@@ -1230,7 +1304,7 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleRenameTag(new RenameTagAction("bug", "  "), dispatcher);
 
-        store.DidNotReceive().Update(Arg.Any<LibraryEntry>());
+        store.DidNotReceiveWithAnyArgs().UpdateRange(default!);
     }
 
     [Fact]
@@ -1249,7 +1323,8 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleRenameTag(new RenameTagAction("bug", "defect"), dispatcher);
 
-        store.Received(1).Update(Arg.Is<LibraryEntry>(e => e is LibraryEntryFilterSet && e.Tags.SequenceEqual(new[] { "defect" })));
+        store.Received(1).UpdateRange(Arg.Is<IReadOnlyList<LibraryEntry>>(list =>
+            list.Count == 1 && list[0] is LibraryEntryFilterSet && list[0].Tags.SequenceEqual(new[] { "defect" })));
     }
 
     [Fact]
@@ -1260,7 +1335,8 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleRenameTag(new RenameTagAction("bug", "defect"), dispatcher);
 
-        store.Received(1).Update(Arg.Is<LibraryEntry>(e => e.Tags.SequenceEqual(new[] { "defect" })));
+        store.Received(1).UpdateRange(Arg.Is<IReadOnlyList<LibraryEntry>>(list =>
+            list.Count == 1 && list[0].Tags.SequenceEqual(new[] { "defect" })));
         dispatcher.Received(1).Dispatch(Arg.Any<UpdateLibraryEntrySuccessAction>());
     }
 
@@ -1272,7 +1348,7 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleRenameTag(new RenameTagAction("bug", "BUG"), dispatcher);
 
-        store.DidNotReceive().Update(Arg.Any<LibraryEntry>());
+        store.DidNotReceiveWithAnyArgs().UpdateRange(default!);
         dispatcher.DidNotReceive().Dispatch(Arg.Any<UpdateLibraryEntrySuccessAction>());
     }
 
@@ -1284,7 +1360,8 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleRenameTag(new RenameTagAction("  BUG  ", "Defect "), dispatcher);
 
-        store.Received(1).Update(Arg.Is<LibraryEntry>(e => e.Tags.SequenceEqual(new[] { "defect" })));
+        store.Received(1).UpdateRange(Arg.Is<IReadOnlyList<LibraryEntry>>(list =>
+            list.Count == 1 && list[0].Tags.SequenceEqual(new[] { "defect" })));
     }
 
     [Fact]
@@ -1297,9 +1374,11 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleRenameTag(new RenameTagAction("bug", "defect"), dispatcher);
 
-        store.Received(1).Update(Arg.Is<LibraryEntry>(e => e.Id == a.Id && e.Tags.SequenceEqual(new[] { "defect", "perf" })));
-        store.Received(1).Update(Arg.Is<LibraryEntry>(e => e.Id == b.Id && e.Tags.SequenceEqual(new[] { "defect" })));
-        store.DidNotReceive().Update(Arg.Is<LibraryEntry>(e => e.Id == c.Id));
+        store.Received(1).UpdateRange(Arg.Is<IReadOnlyList<LibraryEntry>>(list =>
+            list.Count == 2 &&
+            list.Any(e => e.Id == a.Id && e.Tags.SequenceEqual(new[] { "defect", "perf" })) &&
+            list.Any(e => e.Id == b.Id && e.Tags.SequenceEqual(new[] { "defect" })) &&
+            list.All(e => e.Id != c.Id)));
         dispatcher.Received(2).Dispatch(Arg.Any<UpdateLibraryEntrySuccessAction>());
     }
 
@@ -1312,22 +1391,59 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleRenameTag(new RenameTagAction("bug", "defect"), dispatcher);
 
-        store.Received(1).Update(Arg.Any<LibraryEntry>());
+        store.Received(1).UpdateRange(Arg.Is<IReadOnlyList<LibraryEntry>>(list =>
+            list.Count == 1 && list[0].Id == withTag.Id));
     }
 
     [Fact]
-    public async Task HandleRenameTag_StoreFailureSkipsOneEntryButContinues()
+    public async Task HandleRenameTag_StoreSkipsAlreadyGoneRow_DispatchesUpdatedOnly_ReloadsAndAnnouncesSingular()
     {
         var a = BuildFilterEntry("A") with { Tags = ["bug"] };
         var b = BuildFilterEntry("B") with { Tags = ["bug"] };
-        var (effects, store, dispatcher, _, logger) = CreateEffects(state: new FilterLibraryState { Entries = [a, b] });
-        store.When(s => s.Update(Arg.Is<LibraryEntry>(e => e.Id == a.Id))).Do(_ => throw new InvalidOperationException("boom"));
+        var announcer = Substitute.For<IAnnouncementService>();
+        var (effects, store, dispatcher, _, _) = CreateEffects(
+            state: new FilterLibraryState { Entries = [a, b] }, announcementService: announcer);
+        store.UpdateRange(Arg.Any<IReadOnlyList<LibraryEntry>>()).Returns([a.Id]);
 
         await effects.HandleRenameTag(new RenameTagAction("bug", "defect"), dispatcher);
 
-        dispatcher.Received(1).Dispatch(Arg.Is<UpdateLibraryEntrySuccessAction>(s => s.Entry.Id == b.Id));
-        dispatcher.DidNotReceive().Dispatch(Arg.Is<UpdateLibraryEntrySuccessAction>(s => s.Entry.Id == a.Id));
+        dispatcher.Received(1).Dispatch(Arg.Is<UpdateLibraryEntrySuccessAction>(s => s.Entry.Id == a.Id));
+        dispatcher.DidNotReceive().Dispatch(Arg.Is<UpdateLibraryEntrySuccessAction>(s => s.Entry.Id == b.Id));
+        dispatcher.Received(1).Dispatch(Arg.Any<LoadLibraryAction>());
+        announcer.Received(1).Announce("Renamed tag 'bug' to 'defect' in 1 entry");
+    }
+
+    [Fact]
+    public async Task HandleRenameTag_StoreThrows_NoSuccessDispatched_ReloadsLibrary_AnnouncesFailure()
+    {
+        var a = BuildFilterEntry("A") with { Tags = ["bug"] };
+        var b = BuildFilterEntry("B") with { Tags = ["bug"] };
+        var announcer = Substitute.For<IAnnouncementService>();
+        var (effects, store, dispatcher, _, logger) = CreateEffects(
+            state: new FilterLibraryState { Entries = [a, b] }, announcementService: announcer);
+        store.When(s => s.UpdateRange(Arg.Any<IReadOnlyList<LibraryEntry>>())).Do(_ => throw new InvalidOperationException("boom"));
+
+        await effects.HandleRenameTag(new RenameTagAction("bug", "defect"), dispatcher);
+
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<UpdateLibraryEntrySuccessAction>());
+        dispatcher.Received(1).Dispatch(Arg.Any<LoadLibraryAction>());
+        dispatcher.Received(1).Dispatch(Arg.Any<TagBulkUpdateFailedAction>());
+        announcer.Received(1).Announce("Couldn't update tags. The library was reloaded.");
         logger.ReceivedWithAnyArgs(1).Warning(default);
+    }
+
+    [Fact]
+    public async Task HandleRenameTag_Success_AnnouncesRenamedWithCount()
+    {
+        var a = BuildFilterEntry("A") with { Tags = ["bug"] };
+        var b = BuildFilterEntry("B") with { Tags = ["bug"] };
+        var announcer = Substitute.For<IAnnouncementService>();
+        var (effects, _, dispatcher, _, _) = CreateEffects(
+            state: new FilterLibraryState { Entries = [a, b] }, announcementService: announcer);
+
+        await effects.HandleRenameTag(new RenameTagAction("bug", "defect"), dispatcher);
+
+        announcer.Received(1).Announce("Renamed tag 'bug' to 'defect' in 2 entries");
     }
 
     [Fact]
@@ -1636,12 +1752,14 @@ public sealed class FilterLibraryEffectsTests
 
     private static (Effects effects, IFilterLibraryStore store, IDispatcher dispatcher, IState<FilterLibraryState> stateMock, ITraceLogger logger) CreateEffects(
         FilterLibraryState? state = null,
-        FilterPaneState? paneState = null)
+        FilterPaneState? paneState = null,
+        IAnnouncementService? announcementService = null)
     {
         var (effects, store, dispatcher, stateMock, _, logger) = CreateEffectsWithMigrator(
             migrator: null,
             state: state,
-            paneState: paneState);
+            paneState: paneState,
+            announcementService: announcementService);
 
         return (effects, store, dispatcher, stateMock, logger);
     }
@@ -1651,11 +1769,16 @@ public sealed class FilterLibraryEffectsTests
         FilterLibraryState? state = null,
         FilterPaneState? paneState = null,
         IFilterLibraryStore? store = null,
-        IBackslashNameMigrator? backslashMigrator = null)
+        IBackslashNameMigrator? backslashMigrator = null,
+        IAnnouncementService? announcementService = null)
     {
         var storeWasSupplied = store is not null;
         store ??= Substitute.For<IFilterLibraryStore>();
-        if (!storeWasSupplied) { store.LoadAll().Returns([]); }
+        if (!storeWasSupplied)
+        {
+            store.LoadAll().Returns([]);
+            store.UpdateRange(default!).ReturnsForAnyArgs(ci => ((IReadOnlyList<LibraryEntry>)ci[0]).Select(e => e.Id).ToList());
+        }
 
         var stateMock = Substitute.For<IState<FilterLibraryState>>();
         stateMock.Value.Returns(state ?? new FilterLibraryState());
@@ -1674,10 +1797,11 @@ public sealed class FilterLibraryEffectsTests
         }
 
         backslashMigrator ??= Substitute.For<IBackslashNameMigrator>();
+        announcementService ??= Substitute.For<IAnnouncementService>();
 
         var logger = Substitute.For<ITraceLogger>();
         var dispatcher = Substitute.For<IDispatcher>();
-        var effects = new Effects(store, stateMock, paneStateMock, migrator, backslashMigrator, logger);
+        var effects = new Effects(store, stateMock, paneStateMock, migrator, backslashMigrator, announcementService, logger);
 
         return (effects, store, dispatcher, stateMock, migrator, logger);
     }

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterEditor/FilterRowLifecycleTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterEditor/FilterRowLifecycleTests.cs
@@ -1,0 +1,22 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.UI.FilterEditor;
+
+namespace EventLogExpert.UI.Tests.FilterEditor;
+
+public sealed class FilterRowLifecycleTests
+{
+    [Fact]
+    public void Dispose_InvokesOnDisposedWithSelf()
+    {
+        FilterRow? disposed = null;
+        var row = new FilterRow();
+        typeof(FilterRow).GetProperty(nameof(FilterRow.OnDisposed))!
+            .SetValue(row, (Action<FilterRow>)(r => disposed = r));
+
+        row.Dispose();
+
+        Assert.Same(row, disposed);
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterEditor/WrapperConformanceTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterEditor/WrapperConformanceTests.cs
@@ -19,6 +19,7 @@ public sealed class WrapperConformanceTests
         "OnPendingSave",
         "OnRemoved",
         "OnEditingChanged",
+        "OnDisposed",
     };
 
     private static readonly HashSet<string> s_expectedLibraryFilterRowParameterNames = new(StringComparer.Ordinal)

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterLibrary/FilterLibraryModalTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterLibrary/FilterLibraryModalTests.cs
@@ -321,6 +321,28 @@ public sealed class FilterLibraryModalTests : BunitContext
     }
 
     [Fact]
+    public void PruneStaleRowRefs_RemovesNullRefForLiveEntry()
+    {
+        var entry = BuildSavedFilter("Keep");
+        SetState(new FilterLibraryState { Entries = [entry], IsLoaded = true });
+
+        var component = Render<FilterLibraryModal>();
+        var rowRefs = (Dictionary<(LibraryTab, LibraryEntryId), LibraryEntryRow?>)typeof(FilterLibraryModal)
+            .GetField("_rowRefs", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(component.Instance)!;
+
+        // Blazor cleared a row's @ref (disposed before OnRowDisposed's scan) while the entry id stays
+        // live, so only the value-null check can prune the dangling entry.
+        rowRefs[(LibraryTab.Saved, entry.Id)] = null;
+
+        typeof(FilterLibraryModal)
+            .GetMethod("PruneStaleRowRefs", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(component.Instance, null);
+
+        Assert.DoesNotContain((LibraryTab.Saved, entry.Id), rowRefs.Keys);
+    }
+
+    [Fact]
     public void Render_ActiveTab_HasAriaSelectedTrueAndTabindexZero_OthersInert()
     {
         SetState(new FilterLibraryState { IsLoaded = true });
@@ -634,6 +656,28 @@ public sealed class FilterLibraryModalTests : BunitContext
     }
 
     [Fact]
+    public async Task TagFilter_StaleSelectionAfterUnappliedRename_IsIgnored_EntryStillShown()
+    {
+        var alpha = BuildSavedFilter("a") with { Tags = ["alpha"] };
+        SetState(new FilterLibraryState { Entries = [alpha], IsLoaded = true });
+
+        var component = Render<FilterLibraryModal>();
+        var alphaChip = component.Find("[role='tabpanel'].active .library-tag-filter-chip");
+        await alphaChip.ClickAsync(new MouseEventArgs());
+        Assert.Single(component.Find("[role='tabpanel'].active").QuerySelectorAll(".library-entry"));
+
+        await component.Find(".library-tag-management-trigger").ClickAsync(new MouseEventArgs());
+        var renameButton = component.Find(".library-tag-management-row").QuerySelectorAll(".icon-button")[0];
+        await renameButton.ClickAsync(new MouseEventArgs());
+        var editInput = component.Find(".library-tag-management-row-edit-input");
+        await editInput.InputAsync(new ChangeEventArgs { Value = "renamed" });
+        await component.Find(".library-tag-management-row .button-green").ClickAsync(new MouseEventArgs());
+
+        Assert.Contains("renamed", GetSelectedTagsForTab(component, LibraryTab.Saved), StringComparer.OrdinalIgnoreCase);
+        Assert.Single(component.Find("[role='tabpanel'].active").QuerySelectorAll(".library-entry"));
+    }
+
+    [Fact]
     public async Task TagFilterBar_EscWithActiveTags_ClearsTagsAndVetoesClose()
     {
         var alpha = BuildSavedFilter("alphaEntry") with { Tags = ["alpha"] };
@@ -768,6 +812,32 @@ public sealed class FilterLibraryModalTests : BunitContext
     }
 
     [Fact]
+    public async Task TagManagementAndOverflow_RenderUniqueIdsAcrossTabpanels()
+    {
+        var tags = Enumerable.Range(0, 12).Select(i => $"tag{i:D2}").ToArray();
+        var entry = BuildSavedFilter("withTags") with { Tags = [.. tags] };
+        SetState(new FilterLibraryState { Entries = [entry], IsLoaded = true });
+
+        var component = Render<FilterLibraryModal>();
+
+        await component.Find(".library-tag-management-trigger").ClickAsync(new MouseEventArgs());
+        await component.Find(".library-tag-filter-chip-overflow").ClickAsync(new MouseEventArgs());
+
+        var panelIds = component.FindAll("[id^='tag-mgmt-']").Select(e => e.Id).ToList();
+        Assert.True(panelIds.Count >= 2);
+        Assert.Equal(panelIds.Count, panelIds.Distinct().Count());
+
+        var overflowIds = component.FindAll("[id^='tag-overflow-']").Select(e => e.Id).ToList();
+        Assert.True(overflowIds.Count >= 2);
+        Assert.Equal(overflowIds.Count, overflowIds.Distinct().Count());
+
+        var triggerTargets = component.FindAll(".library-tag-management-trigger[aria-controls]")
+            .Select(e => e.GetAttribute("aria-controls")!).ToList();
+        Assert.True(triggerTargets.Count >= 2);
+        Assert.Equal(triggerTargets.Count, triggerTargets.Distinct().Count());
+    }
+
+    [Fact]
     public async Task TagManagementTrigger_Click_TogglesPanelVisibility()
     {
         var alpha = BuildSavedFilter("alphaEntry") with { Tags = ["alpha"] };
@@ -806,6 +876,33 @@ public sealed class FilterLibraryModalTests : BunitContext
         var selectedAfter = GetSelectedTagsForTab(component, LibraryTab.Saved);
         Assert.DoesNotContain("alpha", selectedAfter, StringComparer.OrdinalIgnoreCase);
         Assert.Contains("renamed", selectedAfter, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task TagRenameFailure_RollsBackOptimisticSelection()
+    {
+        var alpha = BuildSavedFilter("a") with { Tags = ["alpha"] };
+        SetState(new FilterLibraryState { Entries = [alpha], IsLoaded = true });
+
+        var component = Render<FilterLibraryModal>();
+        await component.InvokeAsync(() => Services.GetRequiredService<IStore>().InitializeAsync());
+        var dispatcher = Services.GetRequiredService<IDispatcher>();
+        _commands.When(c => c.RenameTag(Arg.Any<string>(), Arg.Any<string>()))
+            .Do(_ => dispatcher.Dispatch(new TagBulkUpdateFailedAction()));
+
+        var alphaChip = component.Find("[role='tabpanel'].active .library-tag-filter-chip");
+        await alphaChip.ClickAsync(new MouseEventArgs());
+
+        await component.Find(".library-tag-management-trigger").ClickAsync(new MouseEventArgs());
+        var renameButton = component.Find(".library-tag-management-row").QuerySelectorAll(".icon-button")[0];
+        await renameButton.ClickAsync(new MouseEventArgs());
+        var editInput = component.Find(".library-tag-management-row-edit-input");
+        await editInput.InputAsync(new ChangeEventArgs { Value = "renamed" });
+        await component.Find(".library-tag-management-row .button-green").ClickAsync(new MouseEventArgs());
+
+        var selection = GetSelectedTagsForTab(component, LibraryTab.Saved);
+        Assert.Contains("alpha", selection, StringComparer.OrdinalIgnoreCase);
+        Assert.DoesNotContain("renamed", selection, StringComparer.OrdinalIgnoreCase);
     }
 
     private static LibraryEntrySavedFilter BuildAutoTrackedFilterEntry(string name, DateTimeOffset? lastUsed = null)

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterLibrary/LibraryEntryRowTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterLibrary/LibraryEntryRowTests.cs
@@ -12,6 +12,7 @@ using EventLogExpert.UI.FilterLibrary;
 using Fluxor;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
 using NSubstitute;
 
 namespace EventLogExpert.UI.Tests.FilterLibrary;
@@ -132,12 +133,52 @@ public sealed class LibraryEntryRowTests : BunitContext
     }
 
     [Fact]
+    public async Task DisposeAsync_InvokesOnDisposedWithSelf()
+    {
+        LibraryEntryRow? disposed = null;
+        var entry = BuildSavedFilter("X");
+        var component = Render<LibraryEntryRow>(parameters => parameters
+            .Add(p => p.Entry, entry)
+            .Add(p => p.ActiveTab, LibraryTab.Saved)
+            .Add(p => p.AllFilterSets, Array.Empty<LibraryEntryFilterSet>())
+            .Add(p => p.OnApply, _ => Task.CompletedTask)
+            .Add(p => p.OnReplace, _ => Task.CompletedTask)
+            .Add(p => p.OnDelete, _ => Task.CompletedTask)
+            .Add(p => p.OnToggleFavorite, _ => Task.CompletedTask)
+            .Add(p => p.OnSaveToLibrary, _ => Task.CompletedTask)
+            .Add(p => p.OnAddToFilterSet, _ => Task.CompletedTask)
+            .Add(p => p.OnRequestPendingFocus, _ => Task.CompletedTask)
+            .Add(p => p.OnDisposed, row => disposed = row));
+
+        await component.Instance.DisposeAsync();
+
+        Assert.NotNull(disposed);
+        Assert.Equal(entry.Id, disposed.Entry.Id);
+    }
+
+    [Fact]
     public void DisposeAsync_UnsubscribesFromMenuServiceStateChanged()
     {
         var entry = BuildSavedFilter("X");
         var component = RenderRow(entry);
         component.Dispose();
         _menuService.StateChanged += Raise.Event<Action>();
+    }
+
+    [Fact]
+    public async Task EnterTagEditMode_ScrollInteropDisconnected_IsSwallowed()
+    {
+        JSInterop.SetupVoid("scrollElementIntoView", _ => true)
+            .SetException(new JSDisconnectedException("Circuit disconnected."));
+        var entry = BuildSavedFilter("X") with { Tags = ["bug"] };
+        var component = RenderRow(entry);
+
+        var exception = await Record.ExceptionAsync(() =>
+            component.Find(".library-entry-tag-add-inline").ClickAsync(new MouseEventArgs()));
+
+        Assert.Null(exception);
+        JSInterop.VerifyInvoke("scrollElementIntoView");
+        Assert.NotNull(component.Find(".library-entry-tags-done"));
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterPane/FilterPaneTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterPane/FilterPaneTests.cs
@@ -12,12 +12,14 @@ using EventLogExpert.Runtime.FilterProgress;
 using EventLogExpert.Runtime.Menu;
 using EventLogExpert.Runtime.Modal;
 using EventLogExpert.Runtime.Settings;
+using EventLogExpert.UI.FilterEditor;
 using EventLogExpert.UI.FilterPane;
 using EventLogExpert.UI.Tests.TestUtils;
 using Fluxor;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using System.Collections.Immutable;
+using System.Reflection;
 
 namespace EventLogExpert.UI.Tests.FilterPane;
 
@@ -27,6 +29,7 @@ public sealed class FilterPaneTests : BunitContext
     private readonly IFilterLibraryCommands _filterLibraryCommands = Substitute.For<IFilterLibraryCommands>();
     private readonly IFilterPaneCommands _filterPaneCommands = Substitute.For<IFilterPaneCommands>();
     private readonly IState<FilterLibraryState> _libraryStateMock = Substitute.For<IState<FilterLibraryState>>();
+    private readonly IState<FilterPaneState> _paneStateMock = Substitute.For<IState<FilterPaneState>>();
     private readonly ISettingsService _settings = Substitute.For<ISettingsService>();
 
     public FilterPaneTests()
@@ -43,7 +46,7 @@ public sealed class FilterPaneTests : BunitContext
         Services.AddSingleton(Substitute.For<IModalCoordinator>());
         Services.AddSingleton(Substitute.For<IMenuActionService>());
 
-        var paneState = Substitute.For<IState<FilterPaneState>>();
+        var paneState = _paneStateMock;
         paneState.Value.Returns(new FilterPaneState());
         Services.AddSingleton(paneState);
 
@@ -207,6 +210,24 @@ public sealed class FilterPaneTests : BunitContext
     }
 
     [Fact]
+    public void OnRowDisposed_RemovesMatchingRowRef()
+    {
+        var pane = new UI.FilterPane.FilterPane();
+        var rowRefs = (Dictionary<FilterId, FilterRow?>)typeof(UI.FilterPane.FilterPane)
+            .GetField("_rowRefs", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(pane)!;
+        var row = new FilterRow();
+        var id = SavedFilter.TryCreate("Level == 4")!.Id;
+        rowRefs[id] = row;
+
+        typeof(UI.FilterPane.FilterPane)
+            .GetMethod("OnRowDisposed", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(pane, [row]);
+
+        Assert.DoesNotContain(id, rowRefs.Keys);
+    }
+
+    [Fact]
     public void OpenFilterSetPicker_PreSelectsFirstFilterSetCaseInsensitive()
     {
         var filterSetZ = BuildFilterSet("ZebraGroup");
@@ -262,6 +283,32 @@ public sealed class FilterPaneTests : BunitContext
         _announcements.Received(1).Announce(FilterPaneAnnouncements.LoadingTryAgain);
     }
 
+    [Fact]
+    public void PruneStaleRowRefs_RemovesNullRefForLiveFilter()
+    {
+        var filter = SavedFilter.TryCreate("Level == 4")!;
+        SetPaneState(new FilterPaneState { Filters = [filter] });
+
+        var pane = new UI.FilterPane.FilterPane();
+        typeof(UI.FilterPane.FilterPane)
+            .GetProperty("FilterPaneState", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(pane, _paneStateMock);
+
+        var rowRefs = (Dictionary<FilterId, FilterRow?>)typeof(UI.FilterPane.FilterPane)
+            .GetField("_rowRefs", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(pane)!;
+
+        // Live filter id, but its @ref was cleared to null: only the value-null check can prune it
+        // (the id is still live, and a non-empty filter list skips the clear-all fast path).
+        rowRefs[filter.Id] = null;
+
+        typeof(UI.FilterPane.FilterPane)
+            .GetMethod("PruneStaleRowRefs", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(pane, null);
+
+        Assert.DoesNotContain(filter.Id, rowRefs.Keys);
+    }
+
     private static LibraryEntryFilterSet BuildFilterSet(string name) =>
         new()
         {
@@ -286,4 +333,6 @@ public sealed class FilterPaneTests : BunitContext
     }
 
     private void SetLibraryState(FilterLibraryState state) => _libraryStateMock.Value.Returns(state);
+
+    private void SetPaneState(FilterPaneState state) => _paneStateMock.Value.Returns(state);
 }


### PR DESCRIPTION
Stacked on `jschick/library-modal-redesign` (#571) — implements five follow-ups deferred from that PR's review, plus the safety/resilience refinements surfaced during this PR's own review.

## Changes

**Atomic, resilient bulk tag rename/delete.** Tag rename and delete now persist all affected entries in a single transaction via a new `IFilterLibraryStore.UpdateRange`, instead of per-entry writes. The effect dispatches success only for rows actually written, reloads the library if any row was already gone or the batch failed, and announces the affected-entry count (e.g. "Renamed tag 'X' to 'Y' in 3 entries") — the screen-reader announcement now comes from the effect with the real count. If the persist fails, a failure announcement is made and the tag-filter selection is rolled back to its pre-operation state, so a failed operation never leaves the list filtered to nothing.

**Clean up unloadable rows on load, with a safety net.** `LoadAll` deletes library rows of a known kind whose payload can't be deserialized (logged), so a single corrupt row no longer blocks the rest of the library. Rows of an unknown kind are kept untouched as forward-version data — the kind is checked before any other column is parsed. If an unusually large share of rows are unreadable (a sign of a version mismatch rather than isolated corruption), deletion is withheld entirely and a persistent banner alerts the user, so a systemic problem can't silently delete the whole library.

**Reconcile stale row references.** `LibraryEntryRow` notifies the modal when it's disposed, and the modal reconciles its row-reference map against the live entries, so stale references don't accumulate after entries are removed.

## Tests

- Runtime unit: 1194 passing
- UI unit: 609 passing
- Runtime integration (containerized): 174 passing

New coverage includes atomic/partial-update and failure-rollback paths, unloadable- and unknown-kind row handling, the systemic-corruption circuit breaker, the dispose-notification hook, scroll-interop disconnect handling, per-tab DOM id uniqueness, and tag-filter resilience.

## Follow-up

The filter pane has a sibling row-reference/prune pattern that will be addressed in a separate change.
