### PR TITLE
Decompose EventResolverBase and bound description cache (closes #539)

### DIFF
--- a/src/EventLogExpert.DatabaseTools/Common/Operations/OperationBase.cs
+++ b/src/EventLogExpert.DatabaseTools/Common/Operations/OperationBase.cs
@@ -133,7 +133,7 @@ internal abstract class OperationBase
             _providerDetailFormat,
             details.ProviderName,
             details.Events.Count,
-            details.Parameters.Count(),
+            details.Parameters.Count,
             details.Keywords.Count,
             details.Opcodes.Count,
             details.Tasks.Count,

--- a/src/EventLogExpert.Eventing/Common/Events/SeverityFormatter.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/SeverityFormatter.cs
@@ -1,9 +1,7 @@
-﻿// // Copyright (c) Microsoft Corporation.
+// // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
-using EventLogExpert.Eventing.Common.Events;
-
-namespace EventLogExpert.Eventing.Resolvers;
+namespace EventLogExpert.Eventing.Common.Events;
 
 public static class SeverityFormatter
 {

--- a/src/EventLogExpert.Eventing/Common/Events/SeverityFormatter.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/SeverityFormatter.cs
@@ -3,14 +3,14 @@
 
 namespace EventLogExpert.Eventing.Common.Events;
 
-public static class SeverityFormatter
+internal static class SeverityFormatter
 {
     /// <summary>Maps an ETW level byte to its display string.</summary>
     /// <remarks>
     ///     ETW level 0 is technically "LogAlways", but the Windows Event Viewer MMC and wevtutil both render it as
     ///     "Information". We match that behavior intentionally.
     /// </remarks>
-    public static string Format(byte? level) => level switch
+    internal static string Format(byte? level) => level switch
     {
         0 => nameof(SeverityLevel.Information), // LogAlways — rendered as Information by Windows
         1 => nameof(SeverityLevel.Critical),

--- a/src/EventLogExpert.Eventing/PublisherMetadata/MtaProviderSource.cs
+++ b/src/EventLogExpert.Eventing/PublisherMetadata/MtaProviderSource.cs
@@ -150,7 +150,7 @@ public static class MtaProviderSource
         details.Messages.Count == 0 &&
         details.Opcodes.Count == 0 &&
         details.Tasks.Count == 0 &&
-        !details.Parameters.Any();
+        details.Parameters.Count == 0;
 
     private static IEnumerable<ProviderDetails> LoadProvidersCore(
         string evtxPath,

--- a/src/EventLogExpert.Eventing/Resolvers/DescriptionFormatter.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/DescriptionFormatter.cs
@@ -4,7 +4,7 @@
 using EventLogExpert.Eventing.Interop;
 using EventLogExpert.Eventing.Readers;
 using EventLogExpert.Logging.Abstractions;
-using EventLogExpert.Provider.Models;
+using EventLogExpert.Provider.Resolution;
 using System.Buffers;
 using System.Collections.Frozen;
 using System.Collections.Immutable;
@@ -57,8 +57,6 @@ internal sealed partial class DescriptionFormatter(
         "win:Win32Error"
     }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 
-    private static readonly Func<long, MessageModel?> s_nullLookup = static _ => null;
-
     private readonly IEventResolverCache? _cache = cache;
     private readonly ITraceLogger? _logger = logger;
     private readonly Regex _sectionsToReplace = WildcardWithNumberRegex();
@@ -90,7 +88,7 @@ internal sealed partial class DescriptionFormatter(
             _logger?.Debug($"{nameof(Resolve)}: Using modern event description - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, PropertyCount={properties.Count}");
 
             return FormatDescription(properties, modernEvent.Description,
-                GetParameterLookupForDescription(primaryDetails, descriptionFromSupplemental, ref supplemental, eventRecord));
+                PickParameterSourceForDescription(modernEvent.Description, primaryDetails, descriptionFromSupplemental, ref supplemental, eventRecord));
         }
 
         // Legacy provider message lookup
@@ -101,7 +99,7 @@ internal sealed partial class DescriptionFormatter(
             _logger?.Debug($"{nameof(Resolve)}: Using legacy message - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, PropertyCount={properties.Count}");
 
             return FormatDescription(properties, legacyMessages[0].Text,
-                GetParameterLookupForDescription(primaryDetails, descriptionFromSupplemental, ref supplemental, eventRecord));
+                PickParameterSourceForDescription(legacyMessages[0].Text, primaryDetails, descriptionFromSupplemental, ref supplemental, eventRecord));
         }
 
         if (legacyMessages.Count > 1)
@@ -113,7 +111,7 @@ internal sealed partial class DescriptionFormatter(
                 _logger?.Debug($"{nameof(Resolve)}: Disambiguated legacy message - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, Level={eventRecord.Level}");
 
                 return FormatDescription(properties, bestMatch.Text,
-                    GetParameterLookupForDescription(primaryDetails, descriptionFromSupplemental, ref supplemental, eventRecord));
+                    PickParameterSourceForDescription(bestMatch.Text, primaryDetails, descriptionFromSupplemental, ref supplemental, eventRecord));
             }
 
             _logger?.Debug($"{nameof(Resolve)}: Multiple legacy messages found, could not disambiguate - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, MessageCount={legacyMessages.Count}");
@@ -132,7 +130,7 @@ internal sealed partial class DescriptionFormatter(
                     // Description came from supplemental, so resolve %%n parameter substitutions
                     // against supplemental's parameter table first.
                     return FormatDescription(supplementalProperties, supplementalModernEvent.Description,
-                        GetParameterLookupForDescription(primaryDetails, true, ref supplemental, eventRecord));
+                        PickParameterSourceForDescription(supplementalModernEvent.Description, primaryDetails, true, ref supplemental, eventRecord));
                 }
 
                 var supplementalLegacy = supplemental.GetMessagesByShortId(eventRecord.Id);
@@ -143,7 +141,7 @@ internal sealed partial class DescriptionFormatter(
                     _logger?.Debug($"{nameof(Resolve)}: Disambiguated via supplemental legacy message - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}");
 
                     return FormatDescription(properties, supplementalBest.Text,
-                        GetParameterLookupForDescription(primaryDetails, true, ref supplemental, eventRecord));
+                        PickParameterSourceForDescription(supplementalBest.Text, primaryDetails, true, ref supplemental, eventRecord));
                 }
             }
         }
@@ -155,7 +153,7 @@ internal sealed partial class DescriptionFormatter(
         {
             _logger?.Debug($"{nameof(Resolve)}: Using single-property description fallback - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}");
 
-            return FormatDescription(properties, null, s_nullLookup);
+            return FormatDescription(properties, null, null);
         }
 
         if (descriptionDetails.IsEmpty && (supplemental is null || supplemental.IsEmpty))
@@ -307,7 +305,7 @@ internal sealed partial class DescriptionFormatter(
     private string FormatDescription(
         List<string> properties,
         string? descriptionTemplate,
-        Func<long, MessageModel?> parameterLookup)
+        ProviderDetails? parameterSource)
     {
         string returnDescription;
 
@@ -406,7 +404,7 @@ internal sealed partial class DescriptionFormatter(
                         // Some parameters exceed int size and need to be cast from long to int
                         // because they are actually negative numbers
                         ReadOnlySpan<char> parameterMessage =
-                            parameterLookup((int)parameterId)?.Text ?? string.Empty;
+                            parameterSource?.GetParameterByRawId((int)parameterId)?.Text ?? string.Empty;
 
                         // Fallback to system FormatMessage for Win32 error codes
                         // when provider parameters aren't available (e.g., MTA/DB resolvers)
@@ -582,27 +580,35 @@ internal sealed partial class DescriptionFormatter(
     }
 
     /// <summary>
-    ///     Picks the parameter lookup for %%n substitutions, biased toward whichever provider supplied the description
+    ///     Picks the parameter source for %%n substitutions, biased toward whichever provider supplied the description
     ///     text. When <paramref name="descriptionFromSupplemental" /> is true, prefer supplemental's parameters and fall back
     ///     to primary; otherwise prefer primary and fall back to supplemental (lazily loading it when not yet available).
+    ///     Short-circuits to <c>null</c> when the description has no %% tokens, avoiding the eager supplemental load on hot
+    ///     paths where the lookup would never fire.
     /// </summary>
-    private Func<long, MessageModel?> GetParameterLookupForDescription(
+    private ProviderDetails? PickParameterSourceForDescription(
+        string? descriptionTemplate,
         ProviderDetails? primary,
         bool descriptionFromSupplemental,
         ref ProviderDetails? supplemental,
         EventRecord eventRecord)
     {
-        if (descriptionFromSupplemental && supplemental is not null)
+        if (descriptionTemplate is null || descriptionTemplate.IndexOf("%%", StringComparison.Ordinal) < 0)
         {
-            if (supplemental.Parameters.Count > 0) { return supplemental.GetParameterByRawIdDelegate; }
-
-            return primary?.GetParameterByRawIdDelegate ?? supplemental.GetParameterByRawIdDelegate;
+            return null;
         }
 
-        if (primary is not null && primary.Parameters.Count > 0) { return primary.GetParameterByRawIdDelegate; }
+        if (descriptionFromSupplemental && supplemental is not null)
+        {
+            if (supplemental.Parameters.Count > 0) { return supplemental; }
+
+            return primary ?? supplemental;
+        }
+
+        if (primary is not null && primary.Parameters.Count > 0) { return primary; }
 
         supplemental ??= _supplementalProvider(eventRecord);
 
-        return supplemental?.GetParameterByRawIdDelegate ?? primary?.GetParameterByRawIdDelegate ?? s_nullLookup;
+        return supplemental ?? primary;
     }
 }

--- a/src/EventLogExpert.Eventing/Resolvers/DescriptionFormatter.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/DescriptionFormatter.cs
@@ -1,0 +1,611 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Interop;
+using EventLogExpert.Eventing.Readers;
+using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Provider.Models;
+using System.Buffers;
+using System.Collections.Immutable;
+using System.Security.Principal;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace EventLogExpert.Eventing.Resolvers;
+
+/// <summary>
+///     Resolves and formats the human-readable description for an event record from provider metadata, handling %N
+///     positional substitution, %%N parameter resolution, %%-escape cleanup, and the no-metadata fallback path.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Construction injects the unified <see cref="TemplateAnalyzer" /> (for outType extraction), the
+///         <see cref="ModernEventMatcher" /> (for legacy-message disambiguation when the description comes from a
+///         multi-message provider), the optional <see cref="IEventResolverCache" /> for description / value interning, the
+///         optional <see cref="ITraceLogger" /> for diagnostics, and a <see cref="Func{T, TResult}" /> delegate that
+///         exposes the owning <see cref="EventResolverBase" />'s protected virtual <c>TryGetSupplementalDetails</c> hook
+///         for the lazy-load fallback inside <c>GetParametersForDescription</c>.
+///     </para>
+///     <para>
+///         The delegate-injection pattern captures the virtual-method slot at base-ctor time via <c>ldvirtftn</c>. When
+///         derived ctors run (e.g., <see cref="EventResolver" /> override), the delegate dispatches to the override.
+///         Invocation only happens during <see cref="Resolve" /> after the derived ctor body has completed, so
+///         override-side fields are fully initialized.
+///     </para>
+///     <para>
+///         Note: the <c>supplementalProvider</c> may return non-null even when the <c>supplemental</c> parameter passed
+///         to <see cref="Resolve" /> is null at entry. This is the lazy backstop for the modernEvent-decisive path where
+///         <c>EventResolverBase.ResolveEvent</c> short-circuits supplemental loading. Implementers must NOT assume
+///         entry-supplemental-null means no supplemental exists.
+///     </para>
+/// </remarks>
+internal sealed partial class DescriptionFormatter
+{
+    private const string DefaultFailedDescription = "Failed to resolve description, see XML for more details.";
+    private const string DefaultNoMatchingDescription = "No matching message found with loaded providers, see XML for more details.";
+    private const string DefaultNoProviderDescription = "No matching provider available, see XML for more details.";
+
+    /// <summary>
+    ///     The mappings from the outType attribute in the EventModel XML template to determine if it should be displayed
+    ///     as Hex.
+    /// </summary>
+    private static readonly List<string> s_displayAsHexTypes =
+    [
+        "win:HexInt32",
+        "win:HexInt64",
+        "win:Pointer",
+        "win:Win32Error"
+    ];
+
+    private readonly IEventResolverCache? _cache;
+    private readonly ITraceLogger? _logger;
+    private readonly ModernEventMatcher _matcher;
+    private readonly Regex _sectionsToReplace = WildcardWithNumberRegex();
+    private readonly Func<EventRecord, ProviderDetails?> _supplementalProvider;
+    private readonly TemplateAnalyzer _templates;
+
+    public DescriptionFormatter(
+        TemplateAnalyzer templates,
+        ModernEventMatcher matcher,
+        IEventResolverCache? cache,
+        ITraceLogger? logger,
+        Func<EventRecord, ProviderDetails?> supplementalProvider)
+    {
+        _templates = templates;
+        _matcher = matcher;
+        _cache = cache;
+        _logger = logger;
+        _supplementalProvider = supplementalProvider;
+    }
+
+    /// <summary>Resolve event descriptions from an event record.</summary>
+    public string Resolve(
+        EventRecord eventRecord,
+        ProviderDetails? primaryDetails,
+        ProviderDetails? details,
+        EventModel? modernEvent,
+        ProviderDetails? supplemental,
+        EventModel? supplementalModernEvent)
+    {
+        if (details is null)
+        {
+            _logger?.Debug($"{nameof(Resolve)}: No provider details available - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, RecordId={eventRecord.RecordId}");
+
+            return DefaultNoProviderDescription;
+        }
+
+        var properties = GetFormattedProperties(modernEvent?.Template, eventRecord.Properties);
+
+        var descriptionFromSupplemental = supplemental is not null && ReferenceEquals(details, supplemental);
+
+        if (!string.IsNullOrEmpty(modernEvent?.Description))
+        {
+            _logger?.Debug($"{nameof(Resolve)}: Using modern event description - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, PropertyCount={properties.Count}");
+
+            return FormatDescription(properties, modernEvent!.Description,
+                GetParametersForDescription(primaryDetails, supplemental, descriptionFromSupplemental, ref supplemental, eventRecord));
+        }
+
+        // Legacy provider message lookup
+        var legacyMessages = details.GetMessagesByShortId(eventRecord.Id);
+
+        if (legacyMessages.Count == 1)
+        {
+            _logger?.Debug($"{nameof(Resolve)}: Using legacy message - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, PropertyCount={properties.Count}");
+
+            return FormatDescription(properties, legacyMessages[0].Text,
+                GetParametersForDescription(primaryDetails, supplemental, descriptionFromSupplemental, ref supplemental, eventRecord));
+        }
+
+        if (legacyMessages.Count > 1)
+        {
+            var bestMatch = _matcher.DisambiguateLegacyMessage(eventRecord, legacyMessages);
+
+            if (bestMatch is not null)
+            {
+                _logger?.Debug($"{nameof(Resolve)}: Disambiguated legacy message - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, Level={eventRecord.Level}");
+
+                return FormatDescription(properties, bestMatch.Text,
+                    GetParametersForDescription(primaryDetails, supplemental, descriptionFromSupplemental, ref supplemental, eventRecord));
+            }
+
+            _logger?.Debug($"{nameof(Resolve)}: Multiple legacy messages found, could not disambiguate - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, MessageCount={legacyMessages.Count}");
+
+            // Last-resort: ambiguous primary may be resolvable via supplemental. ResolveEvent
+            // pre-loads supplemental and its modern event for count > 1, so both are already
+            // set here when supplemental is available.
+            if (supplemental is not null && !ReferenceEquals(supplemental, details))
+            {
+                if (!string.IsNullOrEmpty(supplementalModernEvent?.Description))
+                {
+                    _logger?.Debug($"{nameof(Resolve)}: Disambiguated via supplemental modern event - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}");
+
+                    var supplementalProperties = GetFormattedProperties(supplementalModernEvent!.Template, eventRecord.Properties);
+
+                    // Description came from supplemental, so resolve %%n parameter substitutions
+                    // against supplemental's parameter table first.
+                    return FormatDescription(supplementalProperties, supplementalModernEvent.Description,
+                        GetParametersForDescription(primaryDetails, supplemental, true, ref supplemental, eventRecord));
+                }
+
+                var supplementalLegacy = supplemental.GetMessagesByShortId(eventRecord.Id);
+                var supplementalBest = _matcher.DisambiguateLegacyMessage(eventRecord, supplementalLegacy);
+
+                if (supplementalBest is not null)
+                {
+                    _logger?.Debug($"{nameof(Resolve)}: Disambiguated via supplemental legacy message - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}");
+
+                    return FormatDescription(properties, supplementalBest.Text,
+                        GetParametersForDescription(primaryDetails, supplemental, true, ref supplemental, eventRecord));
+                }
+            }
+        }
+
+        // Some events store the entire description in a single property when no template exists.
+        // Only the single-property case is meaningful here; multi-property events without a template
+        // cannot be rendered into a description and would just emit a misleading constant.
+        if (properties.Count == 1)
+        {
+            _logger?.Debug($"{nameof(Resolve)}: Using single-property description fallback - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}");
+
+            return FormatDescription(properties, null, details.Parameters);
+        }
+
+        if (details.IsEmpty && (supplemental is null || supplemental.IsEmpty))
+        {
+            _logger?.Debug($"{nameof(Resolve)}: No provider metadata available - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, Version={eventRecord.Version}, LogName={eventRecord.LogName}, RecordId={eventRecord.RecordId}, Keywords=0x{eventRecord.Keywords ?? 0:X16}");
+
+            return BuildNoMetadataFallbackDescription(eventRecord, properties);
+        }
+
+        _logger?.Debug($"{nameof(Resolve)}: No matching description found - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, Version={eventRecord.Version}, LogName={eventRecord.LogName}, RecordId={eventRecord.RecordId}");
+
+        return DefaultNoMatchingDescription;
+    }
+
+    private static string? BuildEventDataTail(List<string> properties)
+    {
+        if (properties.Count == 0) { return null; }
+
+        StringBuilder builder = new();
+        builder.Append("The following information was included with the event:\r\n");
+
+        foreach (var property in properties)
+        {
+            builder.Append("\r\n").Append(property);
+        }
+
+        return builder.ToString();
+    }
+
+    private static void CleanupFormatting(ReadOnlySpan<char> unformattedString, ref Span<char> buffer, out int bufferIndex)
+    {
+        bufferIndex = 0;
+
+        for (int i = 0; i < unformattedString.Length; i++)
+        {
+            switch (unformattedString[i])
+            {
+                case '%' when i + 1 < unformattedString.Length:
+                    switch (unformattedString[i + 1])
+                    {
+                        case 'n':
+                            if (i + 2 >= unformattedString.Length || unformattedString[i + 2] != '\r')
+                            {
+                                buffer[bufferIndex++] = '\r';
+                                buffer[bufferIndex++] = '\n';
+                            }
+
+                            i++;
+
+                            break;
+                        case 't':
+                            buffer[bufferIndex++] = '\t';
+                            i++;
+
+                            break;
+                        default:
+                            buffer[bufferIndex++] = unformattedString[i];
+
+                            break;
+                    }
+
+                    break;
+                case '\r' when i + 1 < unformattedString.Length && unformattedString[i + 1] != '\n':
+                    buffer[bufferIndex++] = '\r';
+                    buffer[bufferIndex++] = '\n';
+
+                    break;
+                case '\0':
+                case '\r' when i + 1 >= unformattedString.Length:
+                case '\r' when i + 3 >= unformattedString.Length && unformattedString[i + 1] == '\n':
+                case '\r' when i + 5 >= unformattedString.Length && unformattedString[i + 2] == '\r':
+                    i++;
+
+                    break;
+                case '\r' when i + 3 < unformattedString.Length && unformattedString[i + 2] == '%' && unformattedString[i + 3] == 'n':
+                    buffer[bufferIndex++] = '\r';
+                    buffer[bufferIndex++] = '\n';
+                    i += 3;
+
+                    break;
+                default:
+                    buffer[bufferIndex++] = unformattedString[i];
+
+                    break;
+            }
+        }
+    }
+
+    private static void ResizeBuffer(ref char[] buffer, ref Span<char> source, int sizeToAdd)
+    {
+        char[] newBuffer = ArrayPool<char>.Shared.Rent(source.Length + sizeToAdd);
+        source.CopyTo(newBuffer);
+        ArrayPool<char>.Shared.Return(buffer);
+        source = buffer = newBuffer;
+    }
+
+    [GeneratedRegex("%+[0-9]+")]
+    private static partial Regex WildcardWithNumberRegex();
+
+    private string BuildNoMetadataFallbackDescription(EventRecord eventRecord, List<string> properties)
+    {
+        const long classicKeywordBit = 0x0080000000000000L;
+        bool isClassic = ((eventRecord.Keywords ?? 0) & classicKeywordBit) != 0;
+
+        string? systemMessage = null;
+
+        if (isClassic && eventRecord.Id == 0)
+        {
+            // EventId 0 with the Classic keyword bit is what mmc renders as the Win32
+            // ERROR_SUCCESS text ("The operation completed successfully."). The Win32
+            // ERROR_SUCCESS code happens to be 0 too, but we are deliberately requesting
+            // the ERROR_SUCCESS message — not treating the EventId as a Win32 error code.
+            const uint Win32ErrorSuccess = 0;
+            systemMessage = NativeMethods.FormatSystemMessage(Win32ErrorSuccess);
+        }
+
+        string? propertyTail = BuildEventDataTail(properties);
+
+        // The propertyTail varies per event (timestamps, paths, IDs, etc.) — caching it
+        // would grow the description cache unboundedly. Only cache the low-cardinality
+        // canned strings (DefaultNoProviderDescription, systemMessage).
+        if (propertyTail is not null)
+        {
+            return string.IsNullOrWhiteSpace(systemMessage)
+                ? propertyTail
+                : $"{systemMessage}\r\n\r\n{propertyTail}";
+        }
+
+        string fallback = string.IsNullOrWhiteSpace(systemMessage)
+            ? DefaultNoProviderDescription
+            : systemMessage!;
+
+        return _cache?.GetOrAddDescription(fallback) ?? fallback;
+    }
+
+    private string FormatDescription(
+        List<string> properties,
+        string? descriptionTemplate,
+        IEnumerable<MessageModel> parameters)
+    {
+        string returnDescription;
+
+        if (string.IsNullOrWhiteSpace(descriptionTemplate))
+        {
+            // If there is only one property then this is what certain EventRecords look like
+            // when the entire description is a string literal, and there is no provider DLL needed.
+            // Found a few providers that have their properties wrapped with \r\n for some reason.
+            // Multi-property fall-through is a defensive backstop (e.g. a legacy message row with
+            // empty Text); DefaultFailedDescription is reserved for actual formatting exceptions.
+            returnDescription = properties.Count == 1 ?
+                properties[0].TrimEnd('\0', '\r', '\n') :
+                DefaultNoMatchingDescription;
+
+            return _cache?.GetOrAddDescription(returnDescription) ?? returnDescription;
+        }
+
+        // Guard against stack overflow from very large templates
+        const int maxStackAllocChars = 4096;
+        int cleanupBufferSize = descriptionTemplate.Length * 2;
+        char[]? cleanupRented = null;
+
+        Span<char> description = cleanupBufferSize <= maxStackAllocChars
+            ? stackalloc char[cleanupBufferSize]
+            : (cleanupRented = ArrayPool<char>.Shared.Rent(cleanupBufferSize));
+
+        CleanupFormatting(descriptionTemplate, ref description, out int length);
+
+        description = description[..length];
+
+        if (properties.Count <= 0 && description.IndexOf("%%".AsSpan()) < 0)
+        {
+            returnDescription = description.ToString();
+
+            if (cleanupRented is not null) { ArrayPool<char>.Shared.Return(cleanupRented); }
+
+            return _cache?.GetOrAddDescription(returnDescription) ?? returnDescription;
+        }
+
+        char[] buffer = ArrayPool<char>.Shared.Rent(description.Length * 2);
+
+        try
+        {
+            int currentLength = 0;
+            int lastIndex = 0;
+            Span<char> updatedDescription = buffer;
+
+            foreach (var match in _sectionsToReplace.EnumerateMatches(description))
+            {
+                var sectionToAdd = description[lastIndex..match.Index];
+
+                if (currentLength + sectionToAdd.Length > updatedDescription.Length)
+                {
+                    ResizeBuffer(ref buffer, ref updatedDescription, sectionToAdd.Length);
+                }
+
+                sectionToAdd.CopyTo(updatedDescription[currentLength..]);
+                currentLength += sectionToAdd.Length;
+
+                ReadOnlySpan<char> propString = description[match.Index..(match.Index + match.Length)];
+
+                if (!propString.StartsWith("%%") && int.TryParse(propString.Trim(['{', '}', '%']), out var propIndex))
+                {
+                    // %0 is a Windows Event Log message terminator - skip it entirely
+                    if (propIndex == 0)
+                    {
+                        lastIndex = match.Index + match.Length;
+
+                        continue;
+                    }
+
+                    if (propIndex > properties.Count)
+                    {
+                        _logger?.Debug($"{nameof(FormatDescription)}: Property index out of range - RequestedIndex={propIndex}, PropertyCount={properties.Count}, Template={descriptionTemplate}");
+
+                        // Substitute with empty string rather than failing the entire description.
+                        // This commonly occurs when a manifest template references more properties
+                        // than the event actually supplies (e.g., version mismatch or optional data).
+                        // The available properties are still correctly positional.
+                        propString = ReadOnlySpan<char>.Empty;
+                    }
+                    else
+                    {
+                        propString = properties[propIndex - 1];
+                    }
+                }
+
+                if (propString.StartsWith("%%"))
+                {
+                    int endParameterId = propString.IndexOf(' ');
+
+                    var parameterIdString = endParameterId > 2
+                        ? propString[2..endParameterId]
+                        : propString[2..];
+
+                    if (long.TryParse(parameterIdString, out long parameterId))
+                    {
+                        // Some parameters exceed int size and need to be cast from long to int
+                        // because they are actually negative numbers
+                        ReadOnlySpan<char> parameterMessage =
+                            parameters.FirstOrDefault(m => m.RawId == (int)parameterId)?.Text ?? string.Empty;
+
+                        // Fallback to system FormatMessage for Win32 error codes
+                        // when provider parameters aren't available (e.g., MTA/DB resolvers)
+                        if (parameterMessage.IsEmpty && parameterId is > 0 and <= uint.MaxValue)
+                        {
+                            parameterMessage = NativeMethods.FormatSystemMessage((uint)parameterId);
+                        }
+
+                        if (!parameterMessage.IsEmpty)
+                        {
+                            // Remove only an exact trailing "%0" terminator, not individual chars
+                            parameterMessage = parameterMessage.EndsWith("%0")
+                                ? parameterMessage[..^2]
+                                : parameterMessage;
+
+                            propString = endParameterId > 2 ?
+                                string.Concat(parameterMessage, propString[(endParameterId + 1)..]) :
+                                parameterMessage;
+                        }
+                    }
+                }
+
+                if (currentLength + propString.Length > updatedDescription.Length)
+                {
+                    ResizeBuffer(ref buffer, ref updatedDescription, propString.Length);
+                }
+
+                propString.CopyTo(updatedDescription[currentLength..]);
+                currentLength += propString.Length;
+                lastIndex = match.Index + match.Length;
+            }
+
+            if (lastIndex < description.Length)
+            {
+                ReadOnlySpan<char> sectionToAdd = description[lastIndex..];
+
+                if (currentLength + sectionToAdd.Length > updatedDescription.Length)
+                {
+                    ResizeBuffer(ref buffer, ref updatedDescription, sectionToAdd.Length);
+                }
+
+                sectionToAdd.CopyTo(updatedDescription[currentLength..]);
+                currentLength += sectionToAdd.Length;
+            }
+
+            returnDescription = new string(updatedDescription[..currentLength]);
+
+            return _cache?.GetOrAddDescription(returnDescription) ?? returnDescription;
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger?.Warning($"{nameof(FormatDescription)}: InvalidOperationException - PropertyCount={properties.Count}, Template={descriptionTemplate}, Exception={ex.Message}");
+
+            // If the regex fails to match, then we just return the original description.
+            returnDescription = description.ToString();
+
+            return _cache?.GetOrAddDescription(returnDescription) ?? returnDescription;
+        }
+        catch (Exception ex)
+        {
+            _logger?.Warning($"{nameof(FormatDescription)}: Unexpected exception - PropertyCount={properties.Count}, Template={descriptionTemplate}, Exception={ex}");
+
+            return DefaultFailedDescription;
+        }
+        finally
+        {
+            ArrayPool<char>.Shared.Return(buffer);
+
+            if (cleanupRented is not null) { ArrayPool<char>.Shared.Return(cleanupRented); }
+        }
+    }
+
+    private List<string> GetFormattedProperties(ReadOnlySpan<char> template, IReadOnlyList<object> properties)
+    {
+        ImmutableArray<string> dataNodes = default;
+        List<string> formattedValues = [];
+
+        if (!template.IsEmpty)
+        {
+            // EvtRender may or may not include hidden length-provider fields in its output.
+            // Choose the outType array whose length matches the actual property count.
+            // If neither matches, skip outType formatting to avoid misalignment.
+            var meta = _templates.Analyze(template);
+
+            if (meta.VisibleOutTypes.Length == properties.Count)
+            {
+                dataNodes = meta.VisibleOutTypes;
+            }
+            else if (meta.AllOutTypes.Length == properties.Count)
+            {
+                dataNodes = meta.AllOutTypes;
+            }
+        }
+
+        int index = 0;
+
+        foreach (object property in properties)
+        {
+            string? outType = !dataNodes.IsDefault && index < dataNodes.Length ? dataNodes[index] : null;
+
+            switch (property)
+            {
+                case bool boolValue:
+                    formattedValues.Add(boolValue ? "true" : "false");
+
+                    break;
+                case DateTime eventTime:
+                    formattedValues.Add(eventTime.ToString("yyyy-MM-ddTHH:mm:ss.fffffff00K"));
+
+                    break;
+                case byte[] bytes:
+                    formattedValues.Add(Convert.ToHexString(bytes));
+
+                    break;
+                case SecurityIdentifier sid:
+                    formattedValues.Add(sid.Value);
+
+                    break;
+                default:
+                    if (string.IsNullOrEmpty(outType))
+                    {
+                        formattedValues.Add($"{property}");
+                    }
+                    else if (s_displayAsHexTypes.Contains(outType, StringComparer.OrdinalIgnoreCase))
+                    {
+                        formattedValues.Add(property switch
+                        {
+                            byte b => $"0x{b:X}",
+                            sbyte sb => $"0x{sb:X}",
+                            short s => $"0x{s:X}",
+                            ushort us => $"0x{us:X}",
+                            int i => $"0x{i:X}",
+                            uint ui => $"0x{ui:X}",
+                            long l => $"0x{l:X}",
+                            ulong ul => $"0x{ul:X}",
+                            _ => $"{property}"
+                        });
+                    }
+                    else if (string.Equals(outType, "win:HResult", StringComparison.OrdinalIgnoreCase) && property is int hResult)
+                    {
+                        formattedValues.Add(NativeErrorResolver.GetErrorMessage((uint)hResult));
+                    }
+                    else if (string.Equals(outType, "win:NTStatus", StringComparison.OrdinalIgnoreCase))
+                    {
+                        uint statusCode = property switch
+                        {
+                            uint ui => ui,
+                            int i => (uint)i,
+                            ulong ul => (uint)ul,
+                            long l => (uint)l,
+                            ushort us => us,
+                            short s => (uint)s,
+                            byte b => b,
+                            _ => 0
+                        };
+
+                        formattedValues.Add(property is uint or int or ulong or long or ushort or short or byte
+                            ? NativeErrorResolver.GetNtStatusMessage(statusCode)
+                            : $"{property}");
+                    }
+                    else
+                    {
+                        formattedValues.Add($"{property}");
+                    }
+
+                    break;
+            }
+
+            index++;
+        }
+
+        return formattedValues;
+    }
+
+    /// <summary>
+    ///     Picks the parameter table for %%n substitutions, biased toward whichever provider supplied the description
+    ///     text. When <paramref name="descriptionFromSupplemental" /> is true, prefer supplemental's parameters and fall back
+    ///     to primary; otherwise prefer primary and fall back to supplemental (lazily loading it when not yet available).
+    /// </summary>
+    private IEnumerable<MessageModel> GetParametersForDescription(
+        ProviderDetails? primary,
+        ProviderDetails? supplementalDetails,
+        bool descriptionFromSupplemental,
+        ref ProviderDetails? supplemental,
+        EventRecord eventRecord)
+    {
+        if (descriptionFromSupplemental && supplementalDetails is not null)
+        {
+            if (supplementalDetails.Parameters.Any()) { return supplementalDetails.Parameters; }
+
+            return primary?.Parameters ?? supplementalDetails.Parameters;
+        }
+
+        if (primary is not null && primary.Parameters.Any()) { return primary.Parameters; }
+
+        supplemental ??= _supplementalProvider(eventRecord);
+
+        return supplemental?.Parameters ?? primary?.Parameters ?? [];
+    }
+}

--- a/src/EventLogExpert.Eventing/Resolvers/DescriptionFormatter.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/DescriptionFormatter.cs
@@ -50,11 +50,6 @@ internal sealed partial class DescriptionFormatter(
     private const string DefaultNoMatchingDescription = "No matching message found with loaded providers, see XML for more details.";
     private const string DefaultNoProviderDescription = "No matching provider available, see XML for more details.";
 
-    /// <summary>
-    ///     The mappings from the outType attribute in the EventModel XML template to determine if it should be displayed
-    ///     as Hex.
-    /// </summary>
-    // FrozenSet chosen over List for O(1) lookup on the per-property hot path inside GetFormattedProperties.
     private static readonly FrozenSet<string> s_displayAsHexTypes = new[]
     {
         "win:HexInt32",
@@ -76,12 +71,12 @@ internal sealed partial class DescriptionFormatter(
     public string Resolve(
         EventRecord eventRecord,
         ProviderDetails? primaryDetails,
-        ProviderDetails? details,
+        ProviderDetails? descriptionDetails,
         EventModel? modernEvent,
         ProviderDetails? supplemental,
         EventModel? supplementalModernEvent)
     {
-        if (details is null)
+        if (descriptionDetails is null)
         {
             _logger?.Debug($"{nameof(Resolve)}: No provider details available - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, RecordId={eventRecord.RecordId}");
 
@@ -90,25 +85,25 @@ internal sealed partial class DescriptionFormatter(
 
         var properties = GetFormattedProperties(modernEvent?.Template, eventRecord.Properties);
 
-        var descriptionFromSupplemental = supplemental is not null && ReferenceEquals(details, supplemental);
+        var descriptionFromSupplemental = supplemental is not null && ReferenceEquals(descriptionDetails, supplemental);
 
         if (!string.IsNullOrEmpty(modernEvent?.Description))
         {
             _logger?.Debug($"{nameof(Resolve)}: Using modern event description - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, PropertyCount={properties.Count}");
 
             return FormatDescription(properties, modernEvent.Description,
-                GetParameterLookupForDescription(primaryDetails, supplemental, descriptionFromSupplemental, ref supplemental, eventRecord));
+                GetParameterLookupForDescription(primaryDetails, descriptionFromSupplemental, ref supplemental, eventRecord));
         }
 
         // Legacy provider message lookup
-        var legacyMessages = details.GetMessagesByShortId(eventRecord.Id);
+        var legacyMessages = descriptionDetails.GetMessagesByShortId(eventRecord.Id);
 
         if (legacyMessages.Count == 1)
         {
             _logger?.Debug($"{nameof(Resolve)}: Using legacy message - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, PropertyCount={properties.Count}");
 
             return FormatDescription(properties, legacyMessages[0].Text,
-                GetParameterLookupForDescription(primaryDetails, supplemental, descriptionFromSupplemental, ref supplemental, eventRecord));
+                GetParameterLookupForDescription(primaryDetails, descriptionFromSupplemental, ref supplemental, eventRecord));
         }
 
         if (legacyMessages.Count > 1)
@@ -120,7 +115,7 @@ internal sealed partial class DescriptionFormatter(
                 _logger?.Debug($"{nameof(Resolve)}: Disambiguated legacy message - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, Level={eventRecord.Level}");
 
                 return FormatDescription(properties, bestMatch.Text,
-                    GetParameterLookupForDescription(primaryDetails, supplemental, descriptionFromSupplemental, ref supplemental, eventRecord));
+                    GetParameterLookupForDescription(primaryDetails, descriptionFromSupplemental, ref supplemental, eventRecord));
             }
 
             _logger?.Debug($"{nameof(Resolve)}: Multiple legacy messages found, could not disambiguate - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, MessageCount={legacyMessages.Count}");
@@ -128,7 +123,7 @@ internal sealed partial class DescriptionFormatter(
             // Last-resort: ambiguous primary may be resolvable via supplemental. ResolveEvent
             // pre-loads supplemental and its modern event for count > 1, so both are already
             // set here when supplemental is available.
-            if (supplemental is not null && !ReferenceEquals(supplemental, details))
+            if (supplemental is not null && !ReferenceEquals(supplemental, descriptionDetails))
             {
                 if (!string.IsNullOrEmpty(supplementalModernEvent?.Description))
                 {
@@ -139,7 +134,7 @@ internal sealed partial class DescriptionFormatter(
                     // Description came from supplemental, so resolve %%n parameter substitutions
                     // against supplemental's parameter table first.
                     return FormatDescription(supplementalProperties, supplementalModernEvent.Description,
-                        GetParameterLookupForDescription(primaryDetails, supplemental, true, ref supplemental, eventRecord));
+                        GetParameterLookupForDescription(primaryDetails, true, ref supplemental, eventRecord));
                 }
 
                 var supplementalLegacy = supplemental.GetMessagesByShortId(eventRecord.Id);
@@ -150,7 +145,7 @@ internal sealed partial class DescriptionFormatter(
                     _logger?.Debug($"{nameof(Resolve)}: Disambiguated via supplemental legacy message - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}");
 
                     return FormatDescription(properties, supplementalBest.Text,
-                        GetParameterLookupForDescription(primaryDetails, supplemental, true, ref supplemental, eventRecord));
+                        GetParameterLookupForDescription(primaryDetails, true, ref supplemental, eventRecord));
                 }
             }
         }
@@ -165,7 +160,7 @@ internal sealed partial class DescriptionFormatter(
             return FormatDescription(properties, null, s_nullLookup);
         }
 
-        if (details.IsEmpty && (supplemental is null || supplemental.IsEmpty))
+        if (descriptionDetails.IsEmpty && (supplemental is null || supplemental.IsEmpty))
         {
             _logger?.Debug($"{nameof(Resolve)}: No provider metadata available - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, Version={eventRecord.Version}, LogName={eventRecord.LogName}, RecordId={eventRecord.RecordId}, Keywords=0x{eventRecord.Keywords ?? 0:X16}");
 
@@ -595,16 +590,15 @@ internal sealed partial class DescriptionFormatter(
     /// </summary>
     private Func<long, MessageModel?> GetParameterLookupForDescription(
         ProviderDetails? primary,
-        ProviderDetails? supplementalDetails,
         bool descriptionFromSupplemental,
         ref ProviderDetails? supplemental,
         EventRecord eventRecord)
     {
-        if (descriptionFromSupplemental && supplementalDetails is not null)
+        if (descriptionFromSupplemental && supplemental is not null)
         {
-            if (supplementalDetails.Parameters.Count > 0) { return supplementalDetails.GetParameterByRawIdDelegate; }
+            if (supplemental.Parameters.Count > 0) { return supplemental.GetParameterByRawIdDelegate; }
 
-            return primary?.GetParameterByRawIdDelegate ?? supplementalDetails.GetParameterByRawIdDelegate;
+            return primary?.GetParameterByRawIdDelegate ?? supplemental.GetParameterByRawIdDelegate;
         }
 
         if (primary is not null && primary.Parameters.Count > 0) { return primary.GetParameterByRawIdDelegate; }

--- a/src/EventLogExpert.Eventing/Resolvers/DescriptionFormatter.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/DescriptionFormatter.cs
@@ -63,6 +63,8 @@ internal sealed partial class DescriptionFormatter(
         "win:Win32Error"
     }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 
+    private static readonly Func<long, MessageModel?> s_nullLookup = static _ => null;
+
     private readonly IEventResolverCache? _cache = cache;
     private readonly ITraceLogger? _logger = logger;
     private readonly ModernEventMatcher _matcher = matcher;
@@ -94,8 +96,8 @@ internal sealed partial class DescriptionFormatter(
         {
             _logger?.Debug($"{nameof(Resolve)}: Using modern event description - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, PropertyCount={properties.Count}");
 
-            return FormatDescription(properties, modernEvent!.Description,
-                GetParametersForDescription(primaryDetails, supplemental, descriptionFromSupplemental, ref supplemental, eventRecord));
+            return FormatDescription(properties, modernEvent.Description,
+                GetParameterLookupForDescription(primaryDetails, supplemental, descriptionFromSupplemental, ref supplemental, eventRecord));
         }
 
         // Legacy provider message lookup
@@ -106,7 +108,7 @@ internal sealed partial class DescriptionFormatter(
             _logger?.Debug($"{nameof(Resolve)}: Using legacy message - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, PropertyCount={properties.Count}");
 
             return FormatDescription(properties, legacyMessages[0].Text,
-                GetParametersForDescription(primaryDetails, supplemental, descriptionFromSupplemental, ref supplemental, eventRecord));
+                GetParameterLookupForDescription(primaryDetails, supplemental, descriptionFromSupplemental, ref supplemental, eventRecord));
         }
 
         if (legacyMessages.Count > 1)
@@ -118,7 +120,7 @@ internal sealed partial class DescriptionFormatter(
                 _logger?.Debug($"{nameof(Resolve)}: Disambiguated legacy message - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, Level={eventRecord.Level}");
 
                 return FormatDescription(properties, bestMatch.Text,
-                    GetParametersForDescription(primaryDetails, supplemental, descriptionFromSupplemental, ref supplemental, eventRecord));
+                    GetParameterLookupForDescription(primaryDetails, supplemental, descriptionFromSupplemental, ref supplemental, eventRecord));
             }
 
             _logger?.Debug($"{nameof(Resolve)}: Multiple legacy messages found, could not disambiguate - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, MessageCount={legacyMessages.Count}");
@@ -137,7 +139,7 @@ internal sealed partial class DescriptionFormatter(
                     // Description came from supplemental, so resolve %%n parameter substitutions
                     // against supplemental's parameter table first.
                     return FormatDescription(supplementalProperties, supplementalModernEvent.Description,
-                        GetParametersForDescription(primaryDetails, supplemental, true, ref supplemental, eventRecord));
+                        GetParameterLookupForDescription(primaryDetails, supplemental, true, ref supplemental, eventRecord));
                 }
 
                 var supplementalLegacy = supplemental.GetMessagesByShortId(eventRecord.Id);
@@ -148,7 +150,7 @@ internal sealed partial class DescriptionFormatter(
                     _logger?.Debug($"{nameof(Resolve)}: Disambiguated via supplemental legacy message - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}");
 
                     return FormatDescription(properties, supplementalBest.Text,
-                        GetParametersForDescription(primaryDetails, supplemental, true, ref supplemental, eventRecord));
+                        GetParameterLookupForDescription(primaryDetails, supplemental, true, ref supplemental, eventRecord));
                 }
             }
         }
@@ -160,7 +162,7 @@ internal sealed partial class DescriptionFormatter(
         {
             _logger?.Debug($"{nameof(Resolve)}: Using single-property description fallback - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}");
 
-            return FormatDescription(properties, null, details.Parameters);
+            return FormatDescription(properties, null, s_nullLookup);
         }
 
         if (details.IsEmpty && (supplemental is null || supplemental.IsEmpty))
@@ -275,8 +277,8 @@ internal sealed partial class DescriptionFormatter(
 
     private string BuildNoMetadataFallbackDescription(EventRecord eventRecord, List<string> properties)
     {
-        const long classicKeywordBit = 0x0080000000000000L;
-        bool isClassic = ((eventRecord.Keywords ?? 0) & classicKeywordBit) != 0;
+        const long ClassicKeywordBit = 0x0080000000000000L;
+        bool isClassic = ((eventRecord.Keywords ?? 0) & ClassicKeywordBit) != 0;
 
         string? systemMessage = null;
 
@@ -293,8 +295,7 @@ internal sealed partial class DescriptionFormatter(
         string? propertyTail = BuildEventDataTail(properties);
 
         // The propertyTail varies per event (timestamps, paths, IDs, etc.) — caching it
-        // would grow the description cache unboundedly. Only cache the low-cardinality
-        // canned strings (DefaultNoProviderDescription, systemMessage).
+        // would grow the description cache unboundedly.
         if (propertyTail is not null)
         {
             return string.IsNullOrWhiteSpace(systemMessage)
@@ -302,17 +303,18 @@ internal sealed partial class DescriptionFormatter(
                 : $"{systemMessage}\r\n\r\n{propertyTail}";
         }
 
-        string fallback = string.IsNullOrWhiteSpace(systemMessage)
-            ? DefaultNoProviderDescription
-            : systemMessage!;
+        if (string.IsNullOrWhiteSpace(systemMessage))
+        {
+            return DefaultNoProviderDescription;
+        }
 
-        return _cache?.GetOrAddDescription(fallback) ?? fallback;
+        return _cache?.GetOrAddDescription(systemMessage!) ?? systemMessage!;
     }
 
     private string FormatDescription(
         List<string> properties,
         string? descriptionTemplate,
-        IEnumerable<MessageModel> parameters)
+        Func<long, MessageModel?> parameterLookup)
     {
         string returnDescription;
 
@@ -323,19 +325,17 @@ internal sealed partial class DescriptionFormatter(
             // Found a few providers that have their properties wrapped with \r\n for some reason.
             // Multi-property fall-through is a defensive backstop (e.g. a legacy message row with
             // empty Text); DefaultFailedDescription is reserved for actual formatting exceptions.
-            returnDescription = properties.Count == 1 ?
-                properties[0].TrimEnd('\0', '\r', '\n') :
-                DefaultNoMatchingDescription;
-
-            return _cache?.GetOrAddDescription(returnDescription) ?? returnDescription;
+            return properties.Count == 1
+                ? properties[0].TrimEnd('\0', '\r', '\n')
+                : DefaultNoMatchingDescription;
         }
 
         // Guard against stack overflow from very large templates
-        const int maxStackAllocChars = 4096;
+        const int MaxStackAllocChars = 4096;
         int cleanupBufferSize = descriptionTemplate.Length * 2;
         char[]? cleanupRented = null;
 
-        Span<char> description = cleanupBufferSize <= maxStackAllocChars
+        Span<char> description = cleanupBufferSize <= MaxStackAllocChars
             ? stackalloc char[cleanupBufferSize]
             : (cleanupRented = ArrayPool<char>.Shared.Rent(cleanupBufferSize));
 
@@ -413,7 +413,7 @@ internal sealed partial class DescriptionFormatter(
                         // Some parameters exceed int size and need to be cast from long to int
                         // because they are actually negative numbers
                         ReadOnlySpan<char> parameterMessage =
-                            parameters.FirstOrDefault(m => m.RawId == (int)parameterId)?.Text ?? string.Empty;
+                            parameterLookup((int)parameterId)?.Text ?? string.Empty;
 
                         // Fallback to system FormatMessage for Win32 error codes
                         // when provider parameters aren't available (e.g., MTA/DB resolvers)
@@ -461,7 +461,7 @@ internal sealed partial class DescriptionFormatter(
 
             returnDescription = new string(updatedDescription[..currentLength]);
 
-            return _cache?.GetOrAddDescription(returnDescription) ?? returnDescription;
+            return returnDescription;
         }
         catch (InvalidOperationException ex)
         {
@@ -589,11 +589,11 @@ internal sealed partial class DescriptionFormatter(
     }
 
     /// <summary>
-    ///     Picks the parameter table for %%n substitutions, biased toward whichever provider supplied the description
+    ///     Picks the parameter lookup for %%n substitutions, biased toward whichever provider supplied the description
     ///     text. When <paramref name="descriptionFromSupplemental" /> is true, prefer supplemental's parameters and fall back
     ///     to primary; otherwise prefer primary and fall back to supplemental (lazily loading it when not yet available).
     /// </summary>
-    private IEnumerable<MessageModel> GetParametersForDescription(
+    private Func<long, MessageModel?> GetParameterLookupForDescription(
         ProviderDetails? primary,
         ProviderDetails? supplementalDetails,
         bool descriptionFromSupplemental,
@@ -602,15 +602,15 @@ internal sealed partial class DescriptionFormatter(
     {
         if (descriptionFromSupplemental && supplementalDetails is not null)
         {
-            if (supplementalDetails.Parameters.Count > 0) { return supplementalDetails.Parameters; }
+            if (supplementalDetails.Parameters.Count > 0) { return supplementalDetails.GetParameterByRawIdDelegate; }
 
-            return primary?.Parameters ?? supplementalDetails.Parameters;
+            return primary?.GetParameterByRawIdDelegate ?? supplementalDetails.GetParameterByRawIdDelegate;
         }
 
-        if (primary is not null && primary.Parameters.Count > 0) { return primary.Parameters; }
+        if (primary is not null && primary.Parameters.Count > 0) { return primary.GetParameterByRawIdDelegate; }
 
         supplemental ??= _supplementalProvider(eventRecord);
 
-        return supplemental?.Parameters ?? primary?.Parameters ?? [];
+        return supplemental?.GetParameterByRawIdDelegate ?? primary?.GetParameterByRawIdDelegate ?? s_nullLookup;
     }
 }

--- a/src/EventLogExpert.Eventing/Resolvers/DescriptionFormatter.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/DescriptionFormatter.cs
@@ -19,12 +19,12 @@ namespace EventLogExpert.Eventing.Resolvers;
 /// </summary>
 /// <remarks>
 ///     <para>
-///         Construction injects the unified <see cref="TemplateAnalyzer" /> (for outType extraction), the
-///         <see cref="ModernEventMatcher" /> (for legacy-message disambiguation when the description comes from a
-///         multi-message provider), the optional <see cref="IEventResolverCache" /> for description / value interning, the
-///         optional <see cref="ITraceLogger" /> for diagnostics, and a <see cref="Func{T, TResult}" /> delegate that
-///         exposes the owning <see cref="EventResolverBase" />'s protected virtual <c>TryGetSupplementalDetails</c> hook
-///         for the lazy-load fallback inside <c>GetParametersForDescription</c>.
+///         Construction injects the unified <see cref="TemplateAnalyzer" /> (for outType extraction), the optional
+///         <see cref="IEventResolverCache" /> for description / value interning, the optional <see cref="ITraceLogger" />
+///         for diagnostics, and a <see cref="Func{T, TResult}" /> delegate that exposes the owning
+///         <see cref="EventResolverBase" />'s protected virtual <c>TryGetSupplementalDetails</c> hook for the lazy-load
+///         fallback inside <c>PickParameterSourceForDescription</c>. Legacy-message disambiguation invokes the static
+///         <see cref="ModernEventMatcher.DisambiguateLegacyMessage" /> directly (no instance reference held).
 ///     </para>
 ///     <para>
 ///         The delegate-injection pattern captures the virtual-method slot at base-ctor time via <c>ldvirtftn</c>. When

--- a/src/EventLogExpert.Eventing/Resolvers/DescriptionFormatter.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/DescriptionFormatter.cs
@@ -6,9 +6,9 @@ using EventLogExpert.Eventing.Readers;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Provider.Models;
 using System.Buffers;
+using System.Collections.Frozen;
 using System.Collections.Immutable;
 using System.Security.Principal;
-using System.Text;
 using System.Text.RegularExpressions;
 
 namespace EventLogExpert.Eventing.Resolvers;
@@ -39,7 +39,12 @@ namespace EventLogExpert.Eventing.Resolvers;
 ///         entry-supplemental-null means no supplemental exists.
 ///     </para>
 /// </remarks>
-internal sealed partial class DescriptionFormatter
+internal sealed partial class DescriptionFormatter(
+    TemplateAnalyzer templates,
+    ModernEventMatcher matcher,
+    IEventResolverCache? cache,
+    ITraceLogger? logger,
+    Func<EventRecord, ProviderDetails?> supplementalProvider)
 {
     private const string DefaultFailedDescription = "Failed to resolve description, see XML for more details.";
     private const string DefaultNoMatchingDescription = "No matching message found with loaded providers, see XML for more details.";
@@ -49,34 +54,21 @@ internal sealed partial class DescriptionFormatter
     ///     The mappings from the outType attribute in the EventModel XML template to determine if it should be displayed
     ///     as Hex.
     /// </summary>
-    private static readonly List<string> s_displayAsHexTypes =
-    [
+    // FrozenSet chosen over List for O(1) lookup on the per-property hot path inside GetFormattedProperties.
+    private static readonly FrozenSet<string> s_displayAsHexTypes = new[]
+    {
         "win:HexInt32",
         "win:HexInt64",
         "win:Pointer",
         "win:Win32Error"
-    ];
+    }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 
-    private readonly IEventResolverCache? _cache;
-    private readonly ITraceLogger? _logger;
-    private readonly ModernEventMatcher _matcher;
+    private readonly IEventResolverCache? _cache = cache;
+    private readonly ITraceLogger? _logger = logger;
+    private readonly ModernEventMatcher _matcher = matcher;
     private readonly Regex _sectionsToReplace = WildcardWithNumberRegex();
-    private readonly Func<EventRecord, ProviderDetails?> _supplementalProvider;
-    private readonly TemplateAnalyzer _templates;
-
-    public DescriptionFormatter(
-        TemplateAnalyzer templates,
-        ModernEventMatcher matcher,
-        IEventResolverCache? cache,
-        ITraceLogger? logger,
-        Func<EventRecord, ProviderDetails?> supplementalProvider)
-    {
-        _templates = templates;
-        _matcher = matcher;
-        _cache = cache;
-        _logger = logger;
-        _supplementalProvider = supplementalProvider;
-    }
+    private readonly Func<EventRecord, ProviderDetails?> _supplementalProvider = supplementalProvider;
+    private readonly TemplateAnalyzer _templates = templates;
 
     /// <summary>Resolve event descriptions from an event record.</summary>
     public string Resolve(
@@ -187,15 +179,28 @@ internal sealed partial class DescriptionFormatter
     {
         if (properties.Count == 0) { return null; }
 
-        StringBuilder builder = new();
-        builder.Append("The following information was included with the event:\r\n");
+        const string Header = "The following information was included with the event:\r\n";
 
-        foreach (var property in properties)
+        int totalLength = Header.Length;
+
+        for (int i = 0; i < properties.Count; i++)
         {
-            builder.Append("\r\n").Append(property);
+            totalLength += 2 + properties[i].Length;
         }
 
-        return builder.ToString();
+        return string.Create(totalLength, properties, static (span, props) =>
+        {
+            Header.AsSpan().CopyTo(span);
+            int idx = Header.Length;
+
+            for (int i = 0; i < props.Count; i++)
+            {
+                span[idx++] = '\r';
+                span[idx++] = '\n';
+                props[i].AsSpan().CopyTo(span[idx..]);
+                idx += props[i].Length;
+            }
+        });
     }
 
     private static void CleanupFormatting(ReadOnlySpan<char> unformattedString, ref Span<char> buffer, out int bufferIndex)
@@ -484,7 +489,7 @@ internal sealed partial class DescriptionFormatter
     private List<string> GetFormattedProperties(ReadOnlySpan<char> template, IReadOnlyList<object> properties)
     {
         ImmutableArray<string> dataNodes = default;
-        List<string> formattedValues = [];
+        List<string> formattedValues = new(properties.Count);
 
         if (!template.IsEmpty)
         {
@@ -530,9 +535,9 @@ internal sealed partial class DescriptionFormatter
                 default:
                     if (string.IsNullOrEmpty(outType))
                     {
-                        formattedValues.Add($"{property}");
+                        formattedValues.Add(property?.ToString() ?? string.Empty);
                     }
-                    else if (s_displayAsHexTypes.Contains(outType, StringComparer.OrdinalIgnoreCase))
+                    else if (s_displayAsHexTypes.Contains(outType))
                     {
                         formattedValues.Add(property switch
                         {
@@ -544,7 +549,7 @@ internal sealed partial class DescriptionFormatter
                             uint ui => $"0x{ui:X}",
                             long l => $"0x{l:X}",
                             ulong ul => $"0x{ul:X}",
-                            _ => $"{property}"
+                            _ => property?.ToString() ?? string.Empty
                         });
                     }
                     else if (string.Equals(outType, "win:HResult", StringComparison.OrdinalIgnoreCase) && property is int hResult)
@@ -567,11 +572,11 @@ internal sealed partial class DescriptionFormatter
 
                         formattedValues.Add(property is uint or int or ulong or long or ushort or short or byte
                             ? NativeErrorResolver.GetNtStatusMessage(statusCode)
-                            : $"{property}");
+                            : property?.ToString() ?? string.Empty);
                     }
                     else
                     {
-                        formattedValues.Add($"{property}");
+                        formattedValues.Add(property?.ToString() ?? string.Empty);
                     }
 
                     break;
@@ -597,12 +602,12 @@ internal sealed partial class DescriptionFormatter
     {
         if (descriptionFromSupplemental && supplementalDetails is not null)
         {
-            if (supplementalDetails.Parameters.Any()) { return supplementalDetails.Parameters; }
+            if (supplementalDetails.Parameters.Count > 0) { return supplementalDetails.Parameters; }
 
             return primary?.Parameters ?? supplementalDetails.Parameters;
         }
 
-        if (primary is not null && primary.Parameters.Any()) { return primary.Parameters; }
+        if (primary is not null && primary.Parameters.Count > 0) { return primary.Parameters; }
 
         supplemental ??= _supplementalProvider(eventRecord);
 

--- a/src/EventLogExpert.Eventing/Resolvers/DescriptionFormatter.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/DescriptionFormatter.cs
@@ -108,7 +108,7 @@ internal sealed partial class DescriptionFormatter(
 
         if (legacyMessages.Count > 1)
         {
-            var bestMatch = _matcher.DisambiguateLegacyMessage(eventRecord, legacyMessages);
+            var bestMatch = ModernEventMatcher.DisambiguateLegacyMessage(eventRecord, legacyMessages);
 
             if (bestMatch is not null)
             {
@@ -138,7 +138,7 @@ internal sealed partial class DescriptionFormatter(
                 }
 
                 var supplementalLegacy = supplemental.GetMessagesByShortId(eventRecord.Id);
-                var supplementalBest = _matcher.DisambiguateLegacyMessage(eventRecord, supplementalLegacy);
+                var supplementalBest = ModernEventMatcher.DisambiguateLegacyMessage(eventRecord, supplementalLegacy);
 
                 if (supplementalBest is not null)
                 {

--- a/src/EventLogExpert.Eventing/Resolvers/DescriptionFormatter.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/DescriptionFormatter.cs
@@ -41,7 +41,6 @@ namespace EventLogExpert.Eventing.Resolvers;
 /// </remarks>
 internal sealed partial class DescriptionFormatter(
     TemplateAnalyzer templates,
-    ModernEventMatcher matcher,
     IEventResolverCache? cache,
     ITraceLogger? logger,
     Func<EventRecord, ProviderDetails?> supplementalProvider)
@@ -62,7 +61,6 @@ internal sealed partial class DescriptionFormatter(
 
     private readonly IEventResolverCache? _cache = cache;
     private readonly ITraceLogger? _logger = logger;
-    private readonly ModernEventMatcher _matcher = matcher;
     private readonly Regex _sectionsToReplace = WildcardWithNumberRegex();
     private readonly Func<EventRecord, ProviderDetails?> _supplementalProvider = supplementalProvider;
     private readonly TemplateAnalyzer _templates = templates;

--- a/src/EventLogExpert.Eventing/Resolvers/EventResolverBase.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/EventResolverBase.cs
@@ -29,7 +29,7 @@ public class EventResolverBase : IDisposable
         _logger = logger;
         _matcher = new ModernEventMatcher(_templates, logger);
         _taskKeywords = new TaskKeywordResolver(cache, logger);
-        _descriptions = new DescriptionFormatter(_templates, _matcher, cache, logger, TryGetSupplementalDetails);
+        _descriptions = new DescriptionFormatter(_templates, cache, logger, TryGetSupplementalDetails);
     }
 
     protected bool IsDisposed => Volatile.Read(ref _disposed) != 0;

--- a/src/EventLogExpert.Eventing/Resolvers/EventResolverBase.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/EventResolverBase.cs
@@ -8,6 +8,7 @@ using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Provider.Resolution;
 using System.Buffers;
 using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using System.Security.Principal;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -52,11 +53,9 @@ public partial class EventResolverBase : IDisposable
         new(StringComparer.OrdinalIgnoreCase);
 
     private readonly IEventResolverCache? _cache;
-    private readonly ConcurrentDictionary<string, string[]> _formattedPropertiesCache = [];
     private readonly ITraceLogger? _logger;
     private readonly Regex _sectionsToReplace = WildcardWithNumberRegex();
-    private readonly ConcurrentDictionary<string, string[]> _visibleOutTypesCache = [];
-    private readonly ConcurrentDictionary<string, int> _visiblePropertyCountCache = [];
+    private readonly TemplateAnalyzer _templates = new();
 
     private int _disposed;
 
@@ -136,7 +135,7 @@ public partial class EventResolverBase : IDisposable
         if (!disposing) { return; }
 
         // Atomically guard against double-disposal: only the first caller observes the prior 0.
-        if (Interlocked.CompareExchange(ref _disposed, 1, 0) != 0) { return; }
+        if (Interlocked.CompareExchange(ref _disposed, 1, 0) != 0) { }
     }
 
     /// <summary>
@@ -217,18 +216,6 @@ public partial class EventResolverBase : IDisposable
                     break;
             }
         }
-    }
-
-    private static string? ExtractAttribute(ReadOnlySpan<char> element, ReadOnlySpan<char> attributePrefix)
-    {
-        int index = element.IndexOf(attributePrefix, StringComparison.Ordinal);
-
-        if (index == -1) { return null; }
-
-        index += attributePrefix.Length;
-        int endIndex = element[index..].IndexOf('"');
-
-        return endIndex != -1 ? new string(element.Slice(index, endIndex)) : null;
     }
 
     /// <summary>Treats null and empty string as equivalent for LogName comparison.</summary>
@@ -367,99 +354,6 @@ public partial class EventResolverBase : IDisposable
         return _cache?.GetOrAddValue(taskName) ?? taskName;
     }
 
-    /// <summary>
-    ///     Counts the number of "visible" template properties by excluding length-prefixed binary data length fields.
-    ///     When a &lt;data&gt; element has a <c>length</c> attribute referencing another &lt;data&gt; element's <c>name</c>,
-    ///     Windows consumes the referenced length field internally and does not surface it as a user property via EvtRender.
-    /// </summary>
-    private int CountVisibleTemplateProperties(ReadOnlySpan<char> template)
-    {
-        var cache = _visiblePropertyCountCache.GetAlternateLookup<ReadOnlySpan<char>>();
-
-        if (cache.TryGetValue(template, out int cachedCount)) { return cachedCount; }
-
-        List<string> names = [];
-        HashSet<string> lengthProviderNames = new(StringComparer.OrdinalIgnoreCase);
-
-        ReadOnlySpan<char> dataTag = "<data";
-        ReadOnlySpan<char> nameAttr = "name=\"";
-        ReadOnlySpan<char> lengthAttr = "length=\"";
-
-        int searchStart = 0;
-
-        while (searchStart < template.Length)
-        {
-            int dataIndex = template[searchStart..].IndexOf(dataTag, StringComparison.OrdinalIgnoreCase);
-
-            if (dataIndex == -1) { break; }
-
-            dataIndex += searchStart;
-
-            int nextCharIndex = dataIndex + dataTag.Length;
-
-            if (nextCharIndex < template.Length)
-            {
-                char next = template[nextCharIndex];
-
-                if (next != ' ' && next != '\t' && next != '\r' && next != '\n' && next != '/' && next != '>')
-                {
-                    searchStart = nextCharIndex;
-
-                    continue;
-                }
-            }
-
-            int elementEnd = template[dataIndex..].IndexOf("/>");
-
-            if (elementEnd == -1)
-            {
-                elementEnd = template[dataIndex..].IndexOf('>');
-            }
-
-            if (elementEnd == -1) { break; }
-
-            elementEnd += dataIndex;
-
-            ReadOnlySpan<char> element = template[dataIndex..elementEnd];
-
-            names.Add(ExtractAttribute(element, nameAttr) ?? string.Empty);
-
-            // If this element has a length attribute, the referenced element is a length
-            // provider that Windows consumes internally.
-            string? lengthRef = ExtractAttribute(element, lengthAttr);
-
-            if (lengthRef is not null)
-            {
-                lengthProviderNames.Add(lengthRef);
-            }
-
-            searchStart = elementEnd + 1;
-        }
-
-        if (lengthProviderNames.Count == 0)
-        {
-            cache.TryAdd(template, names.Count);
-
-            return names.Count;
-        }
-
-        // Exclude only the length provider elements; the binary data elements
-        // themselves are still surfaced as properties by Windows.
-        int visibleCount = 0;
-
-        for (int i = 0; i < names.Count; i++)
-        {
-            if (string.IsNullOrEmpty(names[i]) || !lengthProviderNames.Contains(names[i]))
-            {
-                visibleCount++;
-            }
-        }
-
-        cache.TryAdd(template, visibleCount);
-
-        return visibleCount;
-    }
-
     private ResolvedEvent CreateEventModel(
         EventRecord eventRecord,
         EventModel? modernEvent,
@@ -485,48 +379,6 @@ public partial class EventResolverBase : IDisposable
             UserId = eventRecord.UserId,
             Xml = eventRecord.Xml ?? string.Empty
         };
-
-    /// <summary>
-    ///     Relaxed template match for exact Id+Version+LogName matches only. Allows the template to have exactly 1 more
-    ///     data node than the event has properties, which handles version mismatches where the manifest added an optional
-    ///     field in a newer version.
-    /// </summary>
-    private bool DoesTemplateApproximatelyMatchPropertyCount(ReadOnlySpan<char> template, int eventPropertyCount)
-    {
-        if (template.IsEmpty || eventPropertyCount <= 0) { return false; }
-
-        int templateCount = CountVisibleTemplateProperties(template);
-
-        if (templateCount == 0)
-        {
-            templateCount = GetOrParseTemplateDataNodes(template).Length;
-        }
-
-        int diff = templateCount - eventPropertyCount;
-
-        // Template may have exactly 1 more field than the event
-        return diff == 1;
-    }
-
-    private bool DoesTemplateMatchPropertyCount(ReadOnlySpan<char> template, int eventPropertyCount)
-    {
-        if (template.IsEmpty) { return false; }
-
-        string[] dataNodes = GetOrParseTemplateDataNodes(template);
-
-        if (dataNodes.Length == eventPropertyCount) { return true; }
-
-        // Account for length-prefixed binary data pairs that Windows does not
-        // surface as separate user properties via EvtRender.
-        return CountVisibleTemplateProperties(template) == eventPropertyCount;
-    }
-
-    private bool DoesTemplateStrictlyMatchPropertyCount(ReadOnlySpan<char> template, int eventPropertyCount)
-    {
-        if (template.IsEmpty) { return eventPropertyCount == 0; }
-
-        return DoesTemplateMatchPropertyCount(template, eventPropertyCount);
-    }
 
     private string FormatDescription(
         List<string> properties,
@@ -707,7 +559,7 @@ public partial class EventResolverBase : IDisposable
 
     private List<string> GetFormattedProperties(ReadOnlySpan<char> template, IReadOnlyList<object> properties)
     {
-        string[]? dataNodes = null;
+        ImmutableArray<string> dataNodes = default;
         List<string> formattedValues = [];
 
         if (!template.IsEmpty)
@@ -715,20 +567,15 @@ public partial class EventResolverBase : IDisposable
             // EvtRender may or may not include hidden length-provider fields in its output.
             // Choose the outType array whose length matches the actual property count.
             // If neither matches, skip outType formatting to avoid misalignment.
-            var visibleOutTypes = GetVisibleTemplateOutTypes(template);
+            var meta = _templates.Analyze(template);
 
-            if (visibleOutTypes.Length == properties.Count)
+            if (meta.VisibleOutTypes.Length == properties.Count)
             {
-                dataNodes = visibleOutTypes;
+                dataNodes = meta.VisibleOutTypes;
             }
-            else
+            else if (meta.AllOutTypes.Length == properties.Count)
             {
-                var allOutTypes = GetOrParseTemplateDataNodes(template);
-
-                if (allOutTypes.Length == properties.Count)
-                {
-                    dataNodes = allOutTypes;
-                }
+                dataNodes = meta.AllOutTypes;
             }
         }
 
@@ -736,7 +583,7 @@ public partial class EventResolverBase : IDisposable
 
         foreach (object property in properties)
         {
-            string? outType = index < dataNodes?.Length ? dataNodes[index] : null;
+            string? outType = !dataNodes.IsDefault && index < dataNodes.Length ? dataNodes[index] : null;
 
             switch (property)
             {
@@ -899,7 +746,7 @@ public partial class EventResolverBase : IDisposable
             break;
         }
 
-        if (modernEvent is not null && DoesTemplateStrictlyMatchPropertyCount(modernEvent.Template, eventPropertyCount))
+        if (modernEvent is not null && _templates.StrictlyMatchesPropertyCount(modernEvent.Template, eventPropertyCount))
         {
             Logger?.Debug($"{nameof(GetModernEvent)}: Exact match found - EventId={eventRecord.Id}, Version={eventRecord.Version}, LogName={eventRecord.LogName}");
 
@@ -910,7 +757,7 @@ public partial class EventResolverBase : IDisposable
         // more data nodes than the event supplies. This handles version mismatches where
         // the manifest added optional fields. FormatDescription handles out-of-range
         // property indices gracefully by substituting empty string.
-        if (modernEvent is not null && DoesTemplateApproximatelyMatchPropertyCount(modernEvent.Template, eventPropertyCount))
+        if (modernEvent is not null && _templates.ApproximatelyMatchesPropertyCount(modernEvent.Template, eventPropertyCount))
         {
             Logger?.Debug($"{nameof(GetModernEvent)}: Exact match with relaxed template count - EventId={eventRecord.Id}, Version={eventRecord.Version}, LogName={eventRecord.LogName}, PropertyCount={eventPropertyCount}");
 
@@ -926,7 +773,7 @@ public partial class EventResolverBase : IDisposable
         {
             if (!LogNamesMatch(@event.LogName, eventRecord.LogName)) { continue; }
 
-            if (!DoesTemplateMatchPropertyCount(@event.Template, eventPropertyCount)) { continue; }
+            if (!_templates.MatchesPropertyCount(@event.Template, eventPropertyCount)) { continue; }
 
             Logger?.Debug($"{nameof(GetModernEvent)}: Match by Id/LogName with template - EventId={eventRecord.Id}, LogName={eventRecord.LogName}, MatchedVersion={@event.Version}");
 
@@ -947,7 +794,7 @@ public partial class EventResolverBase : IDisposable
             {
                 if (@event.Id != fullRawId || @event.Version != eventRecord.Version) { continue; }
 
-                if (!DoesTemplateStrictlyMatchPropertyCount(@event.Template, eventPropertyCount)) { continue; }
+                if (!_templates.StrictlyMatchesPropertyCount(@event.Template, eventPropertyCount)) { continue; }
 
                 Logger?.Debug($"{nameof(GetModernEvent)}: Match by full RawId fallback - RawId={fullRawId:X}, Version={eventRecord.Version}");
 
@@ -966,7 +813,7 @@ public partial class EventResolverBase : IDisposable
             // entries or trigger a false ambiguity.
             if (eventRecord.Qualifiers is not null && @event.Id > ushort.MaxValue) { continue; }
 
-            if (!DoesTemplateStrictlyMatchPropertyCount(@event.Template, eventPropertyCount)) { continue; }
+            if (!_templates.StrictlyMatchesPropertyCount(@event.Template, eventPropertyCount)) { continue; }
 
             if (shortIdMatch is not null)
             {
@@ -996,7 +843,7 @@ public partial class EventResolverBase : IDisposable
         {
             if (@event.Version != eventRecord.Version) { continue; }
 
-            if (!DoesTemplateMatchPropertyCount(@event.Template, eventPropertyCount)) { continue; }
+            if (!_templates.MatchesPropertyCount(@event.Template, eventPropertyCount)) { continue; }
 
             if (logNameIgnoredMatch is not null)
             {
@@ -1019,83 +866,6 @@ public partial class EventResolverBase : IDisposable
         Logger?.Debug($"{nameof(GetModernEvent)}: No matching event found - EventId={eventRecord.Id}, Version={eventRecord.Version}, LogName={eventRecord.LogName}, PropertyCount={eventPropertyCount}, CandidateEventsWithSameId={candidateEvents.Count}");
 
         return null;
-    }
-
-    private string[] GetOrParseTemplateDataNodes(ReadOnlySpan<char> template)
-    {
-        var cache = _formattedPropertiesCache.GetAlternateLookup<ReadOnlySpan<char>>();
-
-        if (cache.TryGetValue(template, out string[]? dataNodes))
-        {
-            return dataNodes;
-        }
-
-        List<string> temp = [];
-        ReadOnlySpan<char> dataTag = "<data";
-        ReadOnlySpan<char> outTypeAttribute = "outType=\"";
-
-        int searchStart = 0;
-
-        while (searchStart < template.Length)
-        {
-            int dataIndex = template[searchStart..].IndexOf(dataTag, StringComparison.OrdinalIgnoreCase);
-
-            if (dataIndex == -1) { break; }
-
-            dataIndex += searchStart;
-
-            // Verify the character after "<data" is whitespace, '/', or '>'
-            // to avoid matching tags like "<dataSource"
-            int nextCharIndex = dataIndex + dataTag.Length;
-
-            if (nextCharIndex < template.Length)
-            {
-                char next = template[nextCharIndex];
-
-                if (next != ' ' && next != '\t' && next != '\r' && next != '\n' && next != '/' && next != '>')
-                {
-                    searchStart = nextCharIndex;
-
-                    continue;
-                }
-            }
-
-            // Find the end of this element
-            int elementEnd = template[dataIndex..].IndexOf("/>");
-
-            if (elementEnd == -1)
-            {
-                elementEnd = template[dataIndex..].IndexOf('>');
-            }
-
-            if (elementEnd == -1) { break; }
-
-            elementEnd += dataIndex;
-
-            ReadOnlySpan<char> element = template[dataIndex..elementEnd];
-            int outTypeIndex = element.IndexOf(outTypeAttribute, StringComparison.Ordinal);
-
-            if (outTypeIndex != -1)
-            {
-                outTypeIndex += outTypeAttribute.Length;
-                int endIndex = element[outTypeIndex..].IndexOf('"');
-
-                temp.Add(endIndex != -1 ?
-                    new string(element.Slice(outTypeIndex, endIndex)) :
-                    string.Empty);
-            }
-            else
-            {
-                temp.Add(string.Empty);
-            }
-
-            searchStart = elementEnd + 1;
-        }
-
-        dataNodes = [.. temp];
-        cache.TryAdd(template, dataNodes);
-
-        return dataNodes;
     }
 
     /// <summary>
@@ -1122,96 +892,6 @@ public partial class EventResolverBase : IDisposable
         supplemental ??= TryGetSupplementalDetails(eventRecord);
 
         return supplemental?.Parameters ?? primary?.Parameters ?? [];
-    }
-
-    /// <summary>
-    ///     Returns the outType values for only visible template properties, excluding hidden length-provider fields that
-    ///     Windows consumes internally. This ensures the outType array aligns correctly with the properties surfaced by
-    ///     EvtRender.
-    /// </summary>
-    private string[] GetVisibleTemplateOutTypes(ReadOnlySpan<char> template)
-    {
-        var cache = _visibleOutTypesCache.GetAlternateLookup<ReadOnlySpan<char>>();
-
-        if (cache.TryGetValue(template, out string[]? cached)) { return cached; }
-
-        List<(string name, string outType)> elements = [];
-        HashSet<string> lengthProviderNames = new(StringComparer.OrdinalIgnoreCase);
-
-        ReadOnlySpan<char> dataTag = "<data";
-        ReadOnlySpan<char> nameAttr = "name=\"";
-        ReadOnlySpan<char> outTypeAttr = "outType=\"";
-        ReadOnlySpan<char> lengthAttr = "length=\"";
-
-        int searchStart = 0;
-
-        while (searchStart < template.Length)
-        {
-            int dataIndex = template[searchStart..].IndexOf(dataTag, StringComparison.OrdinalIgnoreCase);
-
-            if (dataIndex == -1) { break; }
-
-            dataIndex += searchStart;
-
-            int nextCharIndex = dataIndex + dataTag.Length;
-
-            if (nextCharIndex < template.Length)
-            {
-                char next = template[nextCharIndex];
-
-                if (next != ' ' && next != '\t' && next != '\r' && next != '\n' && next != '/' && next != '>')
-                {
-                    searchStart = nextCharIndex;
-
-                    continue;
-                }
-            }
-
-            int elementEnd = template[dataIndex..].IndexOf("/>");
-
-            if (elementEnd == -1)
-            {
-                elementEnd = template[dataIndex..].IndexOf('>');
-            }
-
-            if (elementEnd == -1) { break; }
-
-            elementEnd += dataIndex;
-
-            ReadOnlySpan<char> element = template[dataIndex..elementEnd];
-
-            string name = ExtractAttribute(element, nameAttr) ?? string.Empty;
-            string outType = ExtractAttribute(element, outTypeAttr) ?? string.Empty;
-
-            elements.Add((name, outType));
-
-            string? lengthRef = ExtractAttribute(element, lengthAttr);
-
-            if (lengthRef is not null)
-            {
-                lengthProviderNames.Add(lengthRef);
-            }
-
-            searchStart = elementEnd + 1;
-        }
-
-        string[] result;
-
-        if (lengthProviderNames.Count == 0)
-        {
-            result = elements.Select(e => e.outType).ToArray();
-        }
-        else
-        {
-            result = elements
-                .Where(e => string.IsNullOrEmpty(e.name) || !lengthProviderNames.Contains(e.name))
-                .Select(e => e.outType)
-                .ToArray();
-        }
-
-        cache.TryAdd(template, result);
-
-        return result;
     }
 
     /// <summary>Resolve event descriptions from an event record.</summary>

--- a/src/EventLogExpert.Eventing/Resolvers/EventResolverBase.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/EventResolverBase.cs
@@ -33,28 +33,13 @@ public partial class EventResolverBase : IDisposable
         "win:Win32Error"
     ];
 
-    /// <summary>
-    ///     These are already defined in System.Diagnostics.Eventing.Reader.StandardEventKeywords. However, the names
-    ///     there do not match what is normally displayed in Event Viewer. We redefine them here so we can use our own strings.
-    /// </summary>
-    private static readonly Dictionary<long, string> s_standardKeywords = new()
-    {
-        { 0x1000000000000, "Response Time" },
-        { 0x2000000000000, "Wdi Context" },
-        { 0x4000000000000, "Wdi Diag" },
-        { 0x8000000000000, "Sqm" },
-        { 0x10000000000000, "Audit Failure" },
-        { 0x20000000000000, "Audit Success" },
-        { 0x40000000000000, "Correlation Hint" },
-        { 0x80000000000000, "Classic" }
-    };
-
     protected readonly ConcurrentDictionary<string, ProviderDetails?> ProviderDetails =
         new(StringComparer.OrdinalIgnoreCase);
 
     private readonly IEventResolverCache? _cache;
     private readonly ITraceLogger? _logger;
     private readonly Regex _sectionsToReplace = WildcardWithNumberRegex();
+    private readonly TaskKeywordResolver _taskKeywords;
     private readonly TemplateAnalyzer _templates = new();
 
     private int _disposed;
@@ -63,6 +48,7 @@ public partial class EventResolverBase : IDisposable
     {
         _cache = cache;
         _logger = logger;
+        _taskKeywords = new TaskKeywordResolver(cache, logger);
     }
 
     protected bool IsDisposed => Volatile.Read(ref _disposed) != 0;
@@ -347,13 +333,6 @@ public partial class EventResolverBase : IDisposable
         return _cache?.GetOrAddDescription(fallback) ?? fallback;
     }
 
-    private string CacheTaskName(string taskName)
-    {
-        taskName = taskName.TrimEnd('\0');
-
-        return _cache?.GetOrAddValue(taskName) ?? taskName;
-    }
-
     private ResolvedEvent CreateEventModel(
         EventRecord eventRecord,
         EventModel? modernEvent,
@@ -367,13 +346,13 @@ public partial class EventResolverBase : IDisposable
             ComputerName = _cache?.GetOrAddValue(eventRecord.ComputerName) ?? eventRecord.ComputerName,
             Description = ResolveDescription(eventRecord, details, descriptionDetails, modernEvent, supplemental, supplementalModernEvent),
             Id = eventRecord.Id,
-            Keywords = GetKeywordsFromBitmask(eventRecord, details, supplemental),
+            Keywords = _taskKeywords.GetKeywords(eventRecord, details, supplemental),
             Level = SeverityFormatter.Format(eventRecord.Level),
             LogName = _cache?.GetOrAddValue(eventRecord.LogName) ?? eventRecord.LogName,
             ProcessId = eventRecord.ProcessId,
             RecordId = eventRecord.RecordId,
             Source = _cache?.GetOrAddValue(eventRecord.ProviderName) ?? eventRecord.ProviderName,
-            TaskCategory = ResolveTaskName(eventRecord, details, modernEvent, supplemental, supplementalModernEvent),
+            TaskCategory = _taskKeywords.ResolveTaskName(eventRecord, details, modernEvent, supplemental, supplementalModernEvent),
             ThreadId = eventRecord.ThreadId,
             TimeCreated = eventRecord.TimeCreated,
             UserId = eventRecord.UserId,
@@ -659,63 +638,6 @@ public partial class EventResolverBase : IDisposable
         return formattedValues;
     }
 
-    private List<string> GetKeywordsFromBitmask(EventRecord eventRecord, ProviderDetails? details, ProviderDetails? supplemental)
-    {
-        if (eventRecord.Keywords is null or 0) { return []; }
-
-        var keywordsValue = eventRecord.Keywords.Value;
-        List<string> returnValue = [];
-
-        // Standard (Microsoft-defined) keywords live in bits 48–55. Skip the entire
-        // standard-keyword scan when the event has no bits in that range.
-        if ((keywordsValue & 0x00FF_0000_0000_0000L) != 0)
-        {
-            foreach (var (bit, name) in s_standardKeywords)
-            {
-                if ((keywordsValue & bit) != bit) { continue; }
-
-                var keyword = name.TrimEnd('\0');
-                returnValue.Add(_cache?.GetOrAddValue(keyword) ?? keyword);
-            }
-        }
-
-        // Provider-defined keywords use bits 0–47; bits 48–63 are reserved
-        // for Microsoft-defined standard keywords handled above.
-        var providerBits = keywordsValue & 0x0000_FFFF_FFFF_FFFFL;
-
-        if (providerBits == 0) { return returnValue; }
-
-        long matchedBits = 0;
-
-        if (details is not null)
-        {
-            foreach (var (bit, name) in details.Keywords)
-            {
-                if ((providerBits & bit) != bit) { continue; }
-
-                matchedBits |= bit;
-                var keyword = name.TrimEnd('\0');
-                returnValue.Add(_cache?.GetOrAddValue(keyword) ?? keyword);
-            }
-        }
-
-        // Fill remaining set bits from supplemental. Primary wins on conflicts.
-        if (supplemental is not null && !ReferenceEquals(supplemental, details))
-        {
-            foreach (var (bit, name) in supplemental.Keywords)
-            {
-                if ((providerBits & bit) != bit) { continue; }
-
-                if ((matchedBits & bit) == bit) { continue; }
-
-                var keyword = name.TrimEnd('\0');
-                returnValue.Add(_cache?.GetOrAddValue(keyword) ?? keyword);
-            }
-        }
-
-        return returnValue;
-    }
-
     private EventModel? GetModernEvent(EventRecord eventRecord, ProviderDetails details)
     {
         if (eventRecord.Version is null && string.IsNullOrEmpty(eventRecord.LogName))
@@ -997,93 +919,5 @@ public partial class EventResolverBase : IDisposable
         Logger?.Debug($"{nameof(ResolveDescription)}: No matching description found - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, Version={eventRecord.Version}, LogName={eventRecord.LogName}, RecordId={eventRecord.RecordId}");
 
         return DefaultNoMatchingDescription;
-    }
-
-    private string ResolveTaskName(
-        EventRecord eventRecord,
-        ProviderDetails? details,
-        EventModel? modernEvent,
-        ProviderDetails? supplemental,
-        EventModel? supplementalModernEvent)
-    {
-        if (TryResolveTaskNameFromDetails(eventRecord, details, modernEvent, out var taskName))
-        {
-            return CacheTaskName(taskName);
-        }
-
-        if (supplemental is not null &&
-            !ReferenceEquals(supplemental, details) &&
-            TryResolveTaskNameFromDetails(eventRecord, supplemental, supplementalModernEvent, out taskName))
-        {
-            // The primary modernEvent (if any) was already tried above against primary's tables.
-            // Use the pre-computed supplementalModernEvent so its EventModel.Task can drive
-            // supplemental's Tasks lookup.
-            return CacheTaskName(taskName);
-        }
-
-        return !eventRecord.Task.HasValue ?
-            string.Empty :
-            CacheTaskName(eventRecord.Task == 0 ? "None" : $"({eventRecord.Task})");
-    }
-
-    private bool TryResolveTaskNameFromDetails(
-        EventRecord eventRecord,
-        ProviderDetails? details,
-        EventModel? modernEvent,
-        out string taskName)
-    {
-        taskName = string.Empty;
-
-        if (details is null)
-        {
-            return false;
-        }
-
-        if (modernEvent?.Task is not null && details.Tasks.TryGetValue(modernEvent.Task, out var name))
-        {
-            taskName = name;
-            return true;
-        }
-
-        if (!eventRecord.Task.HasValue)
-        {
-            return false;
-        }
-
-        if (details.Tasks.TryGetValue(eventRecord.Task.Value, out name))
-        {
-            taskName = name;
-            return true;
-        }
-
-        var messagesByShortId = details.GetMessagesByShortId(eventRecord.Task.Value);
-
-        List<MessageModel>? potentialTaskNames = null;
-
-        foreach (var m in messagesByShortId)
-        {
-            if (m.LogLink is null || m.LogLink != eventRecord.LogName) { continue; }
-
-            potentialTaskNames ??= [];
-            potentialTaskNames.Add(m);
-        }
-
-        if (potentialTaskNames is { Count: > 0 })
-        {
-            taskName = potentialTaskNames[0].Text;
-
-            if (potentialTaskNames.Count > 1)
-            {
-                Logger?.Debug($"More than one matching task ID was found.");
-                Logger?.Debug($"  eventRecord.Task: {eventRecord.Task}");
-                Logger?.Debug($"   Potential matches:");
-
-                potentialTaskNames.ForEach(t => Logger?.Debug($"    {t.LogLink} {t.Text}"));
-            }
-
-            return true;
-        }
-
-        return false;
     }
 }

--- a/src/EventLogExpert.Eventing/Resolvers/EventResolverBase.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/EventResolverBase.cs
@@ -29,11 +29,6 @@ public class EventResolverBase : IDisposable
         _logger = logger;
         _matcher = new ModernEventMatcher(_templates, logger);
         _taskKeywords = new TaskKeywordResolver(cache, logger);
-        // Method-group capture of TryGetSupplementalDetails uses ldvirtftn semantics: the delegate's
-        // method slot resolves against the runtime type of `this`. When EventResolver's ctor calls
-        // : base(cache, logger), `this` is already EventResolver, so the captured delegate dispatches
-        // to the override. The delegate is INVOKED later during _descriptions.Resolve, after the
-        // derived ctor body has run, so override-side fields are fully initialized at invocation time.
         _descriptions = new DescriptionFormatter(_templates, _matcher, cache, logger, TryGetSupplementalDetails);
     }
 
@@ -106,13 +101,13 @@ public class EventResolverBase : IDisposable
     {
         if (!disposing) { return; }
 
-        // Atomically guard against double-disposal: only the first caller observes the prior 0.
-        if (Interlocked.CompareExchange(ref _disposed, 1, 0) != 0) { }
+        _ = Interlocked.CompareExchange(ref _disposed, 1, 0);
     }
 
     /// <summary>
-    ///     Override in derived classes to provide a supplemental ProviderDetails when the primary source (MTA/DB) has
-    ///     partial coverage for a provider. Called only when the primary provider exists but couldn't match the event.
+    ///     Override in derived classes to provide a supplemental ProviderDetails when the primary source has partial
+    ///     coverage. Called from the non-decisive primary path AND as a lazy backstop during parameter resolution when the
+    ///     primary has no parameter table.
     /// </summary>
     protected virtual ProviderDetails? TryGetSupplementalDetails(EventRecord eventRecord) => null;
 
@@ -129,7 +124,7 @@ public class EventResolverBase : IDisposable
             ComputerName = _cache?.GetOrAddValue(eventRecord.ComputerName) ?? eventRecord.ComputerName,
             Description = _descriptions.Resolve(eventRecord, details, descriptionDetails, modernEvent, supplemental, supplementalModernEvent),
             Id = eventRecord.Id,
-            Keywords = _taskKeywords.GetKeywords(eventRecord, details, supplemental),
+            Keywords = _taskKeywords.ResolveKeywords(eventRecord, details, supplemental),
             Level = SeverityFormatter.Format(eventRecord.Level),
             LogName = _cache?.GetOrAddValue(eventRecord.LogName) ?? eventRecord.LogName,
             ProcessId = eventRecord.ProcessId,

--- a/src/EventLogExpert.Eventing/Resolvers/EventResolverBase.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/EventResolverBase.cs
@@ -38,6 +38,7 @@ public partial class EventResolverBase : IDisposable
 
     private readonly IEventResolverCache? _cache;
     private readonly ITraceLogger? _logger;
+    private readonly ModernEventMatcher _matcher;
     private readonly Regex _sectionsToReplace = WildcardWithNumberRegex();
     private readonly TaskKeywordResolver _taskKeywords;
     private readonly TemplateAnalyzer _templates = new();
@@ -48,6 +49,7 @@ public partial class EventResolverBase : IDisposable
     {
         _cache = cache;
         _logger = logger;
+        _matcher = new ModernEventMatcher(_templates, logger);
         _taskKeywords = new TaskKeywordResolver(cache, logger);
     }
 
@@ -67,7 +69,7 @@ public partial class EventResolverBase : IDisposable
 
         // Resolve the modern event once and reuse for both description and task name
         ProviderDetails.TryGetValue(eventRecord.ProviderName, out var details);
-        var modernEvent = details is not null ? GetModernEvent(eventRecord, details) : null;
+        var modernEvent = details is not null ? _matcher.Match(eventRecord, details) : null;
 
         var descriptionDetails = details;
         ProviderDetails? supplemental = null;
@@ -93,7 +95,7 @@ public partial class EventResolverBase : IDisposable
         supplemental = TryGetSupplementalDetails(eventRecord);
 
         EventModel? supplementalModernEvent = supplemental is not null
-            ? GetModernEvent(eventRecord, supplemental)
+            ? _matcher.Match(eventRecord, supplemental)
             : null;
 
         if (supplemental is not null && primaryLegacyCount == 0)
@@ -204,94 +206,12 @@ public partial class EventResolverBase : IDisposable
         }
     }
 
-    /// <summary>Treats null and empty string as equivalent for LogName comparison.</summary>
-    private static bool LogNamesMatch(string? a, string? b) =>
-        string.IsNullOrEmpty(a) ? string.IsNullOrEmpty(b) : string.Equals(a, b, StringComparison.Ordinal);
-
     private static void ResizeBuffer(ref char[] buffer, ref Span<char> source, int sizeToAdd)
     {
         char[] newBuffer = ArrayPool<char>.Shared.Rent(source.Length + sizeToAdd);
         source.CopyTo(newBuffer);
         ArrayPool<char>.Shared.Return(buffer);
         source = buffer = newBuffer;
-    }
-
-    /// <summary>
-    ///     Disambiguate multiple legacy messages for the same event ID. Tries Qualifier match (high 16 bits of RawId),
-    ///     then LogLink, then severity. Returns null when the set is empty or remains ambiguous after all checks.
-    /// </summary>
-    private static MessageModel? TryDisambiguateLegacyMessage(EventRecord eventRecord, IReadOnlyList<MessageModel> legacyMessages)
-    {
-        if (legacyMessages.Count == 0) { return null; }
-
-        if (legacyMessages.Count == 1) { return legacyMessages[0]; }
-
-        // Qualifier match. For classic/legacy events, Windows encodes Qualifiers in
-        // the high 16 bits of the message ID, so RawId == (Qualifiers << 16) | EventId
-        // identifies the exact message-table entry.
-        if (eventRecord.Qualifiers.HasValue)
-        {
-            List<MessageModel>? qualifierMatches = null;
-
-            foreach (var m in legacyMessages)
-            {
-                if ((ushort)((m.RawId >> 16) & 0xFFFF) == eventRecord.Qualifiers.Value)
-                {
-                    (qualifierMatches ??= []).Add(m);
-                }
-            }
-
-            if (qualifierMatches is { Count: 1 })
-            {
-                return qualifierMatches[0];
-            }
-
-            if (qualifierMatches is { Count: > 1 })
-            {
-                legacyMessages = qualifierMatches;
-            }
-        }
-
-        // LogLink match
-        foreach (var m in legacyMessages)
-        {
-            if (m.LogLink is not null && LogNamesMatch(m.LogLink, eventRecord.LogName))
-            {
-                return m;
-            }
-        }
-
-        // Severity-based match. MC RawId bits 31-30 encode severity:
-        // 00=Success, 01=Informational, 10=Warning, 11=Error.
-        // ETW levels: 0=LogAlways, 1=Critical, 2=Error, 3=Warning, 4=Information, 5=Verbose.
-        if (eventRecord.Level is null) { return null; }
-
-        int targetSeverity = eventRecord.Level switch
-        {
-            1 or 2 => 3,
-            3 => 2,
-            4 or 5 => 1,
-            _ => 0
-        };
-
-        MessageModel? severityCandidate = null;
-
-        foreach (var m in legacyMessages)
-        {
-            int messageSeverity = (int)((m.RawId >> 30) & 0x3);
-
-            if (messageSeverity != targetSeverity) { continue; }
-
-            if (severityCandidate is not null)
-            {
-                // Multiple matches with same severity — still ambiguous
-                return null;
-            }
-
-            severityCandidate = m;
-        }
-
-        return severityCandidate;
     }
 
     [GeneratedRegex("%+[0-9]+")]
@@ -638,158 +558,6 @@ public partial class EventResolverBase : IDisposable
         return formattedValues;
     }
 
-    private EventModel? GetModernEvent(EventRecord eventRecord, ProviderDetails details)
-    {
-        if (eventRecord.Version is null && string.IsNullOrEmpty(eventRecord.LogName))
-        {
-            Logger?.Debug($"{nameof(GetModernEvent)}: Skipping modern event lookup - EventId={eventRecord.Id}, Provider={eventRecord.ProviderName} has null Version and empty LogName");
-
-            return null;
-        }
-
-        int eventPropertyCount = eventRecord.Properties.Count;
-
-        // Use indexed lookup instead of linear scan
-        var candidateEvents = details.GetEventsById(eventRecord.Id);
-
-        EventModel? modernEvent = null;
-
-        foreach (var e in candidateEvents)
-        {
-            if (e.Id != eventRecord.Id ||
-                e.Version != eventRecord.Version ||
-                !LogNamesMatch(e.LogName, eventRecord.LogName))
-            {
-                continue;
-            }
-
-            modernEvent = e;
-
-            break;
-        }
-
-        if (modernEvent is not null && _templates.StrictlyMatchesPropertyCount(modernEvent.Template, eventPropertyCount))
-        {
-            Logger?.Debug($"{nameof(GetModernEvent)}: Exact match found - EventId={eventRecord.Id}, Version={eventRecord.Version}, LogName={eventRecord.LogName}");
-
-            return modernEvent;
-        }
-
-        // For exact Id+Version+LogName matches, tolerate the template having slightly
-        // more data nodes than the event supplies. This handles version mismatches where
-        // the manifest added optional fields. FormatDescription handles out-of-range
-        // property indices gracefully by substituting empty string.
-        if (modernEvent is not null && _templates.ApproximatelyMatchesPropertyCount(modernEvent.Template, eventPropertyCount))
-        {
-            Logger?.Debug($"{nameof(GetModernEvent)}: Exact match with relaxed template count - EventId={eventRecord.Id}, Version={eventRecord.Version}, LogName={eventRecord.LogName}, PropertyCount={eventPropertyCount}");
-
-            return modernEvent;
-        }
-
-        if (modernEvent is not null)
-        {
-            Logger?.Debug($"{nameof(GetModernEvent)}: Exact match found but template property count mismatch - EventId={eventRecord.Id}, Version={eventRecord.Version}, LogName={eventRecord.LogName}, PropertyCount={eventPropertyCount}");
-        }
-
-        foreach (var @event in candidateEvents)
-        {
-            if (!LogNamesMatch(@event.LogName, eventRecord.LogName)) { continue; }
-
-            if (!_templates.MatchesPropertyCount(@event.Template, eventPropertyCount)) { continue; }
-
-            Logger?.Debug($"{nameof(GetModernEvent)}: Match by Id/LogName with template - EventId={eventRecord.Id}, LogName={eventRecord.LogName}, MatchedVersion={@event.Version}");
-
-            return @event;
-        }
-
-        // Try again forcing the long to a short and with no log name. Needed for providers
-        // such as Microsoft-Windows-Complus and Microsoft-Windows-WPDClassInstaller that store
-        // events with the full 32-bit RawId (high 16 bits = Qualifiers, low 16 bits = EventId).
-        // Strict template match accepts empty template + zero EventData properties, which is the
-        // shape WPDClassInstaller emits for its full-RawId entries. When the record carries a
-        // Qualifiers value, prefer the exact full-RawId match before the low-16 ambiguity check.
-        if (eventRecord.Qualifiers is { } qualifier)
-        {
-            var fullRawId = ((long)qualifier << 16) | eventRecord.Id;
-
-            foreach (var @event in details.Events)
-            {
-                if (@event.Id != fullRawId || @event.Version != eventRecord.Version) { continue; }
-
-                if (!_templates.StrictlyMatchesPropertyCount(@event.Template, eventPropertyCount)) { continue; }
-
-                Logger?.Debug($"{nameof(GetModernEvent)}: Match by full RawId fallback - RawId={fullRawId:X}, Version={eventRecord.Version}");
-
-                return @event;
-            }
-        }
-
-        EventModel? shortIdMatch = null;
-
-        foreach (var @event in details.Events)
-        {
-            if ((ushort)@event.Id != eventRecord.Id || @event.Version != eventRecord.Version) { continue; }
-
-            // When the record's qualifier is known, full-RawId entries with conflicting high
-            // bits would have been caught above. Skip them here so they do not mask short-only
-            // entries or trigger a false ambiguity.
-            if (eventRecord.Qualifiers is not null && @event.Id > ushort.MaxValue) { continue; }
-
-            if (!_templates.StrictlyMatchesPropertyCount(@event.Template, eventPropertyCount)) { continue; }
-
-            if (shortIdMatch is not null)
-            {
-                // Multiple matches — ambiguous
-                shortIdMatch = null;
-
-                break;
-            }
-
-            shortIdMatch = @event;
-        }
-
-        if (shortIdMatch is not null)
-        {
-            Logger?.Debug($"{nameof(GetModernEvent)}: Match by short Id/Version fallback - EventId={eventRecord.Id}, Version={eventRecord.Version}");
-
-            return shortIdMatch;
-        }
-
-        // Final fallback: match by Id+Version ignoring LogName, but only if exactly
-        // one candidate passes template validation. This handles providers that define
-        // events under diagnostic/operational channels but log to Application/System
-        // via eventlog redirects (e.g., Winlogon 6001).
-        EventModel? logNameIgnoredMatch = null;
-
-        foreach (var @event in candidateEvents)
-        {
-            if (@event.Version != eventRecord.Version) { continue; }
-
-            if (!_templates.MatchesPropertyCount(@event.Template, eventPropertyCount)) { continue; }
-
-            if (logNameIgnoredMatch is not null)
-            {
-                // Multiple candidates — ambiguous, don't guess
-                logNameIgnoredMatch = null;
-
-                break;
-            }
-
-            logNameIgnoredMatch = @event;
-        }
-
-        if (logNameIgnoredMatch is not null)
-        {
-            Logger?.Debug($"{nameof(GetModernEvent)}: Unique match by Id/Version ignoring LogName - EventId={eventRecord.Id}, Version={eventRecord.Version}, MatchedLogName={logNameIgnoredMatch.LogName}");
-
-            return logNameIgnoredMatch;
-        }
-
-        Logger?.Debug($"{nameof(GetModernEvent)}: No matching event found - EventId={eventRecord.Id}, Version={eventRecord.Version}, LogName={eventRecord.LogName}, PropertyCount={eventPropertyCount}, CandidateEventsWithSameId={candidateEvents.Count}");
-
-        return null;
-    }
-
     /// <summary>
     ///     Picks the parameter table for %%n substitutions, biased toward whichever provider supplied the description
     ///     text. When <paramref name="descriptionFromSupplemental" /> is true, prefer supplemental's parameters and fall back
@@ -857,7 +625,7 @@ public partial class EventResolverBase : IDisposable
 
         if (legacyMessages.Count > 1)
         {
-            var bestMatch = TryDisambiguateLegacyMessage(eventRecord, legacyMessages);
+            var bestMatch = _matcher.DisambiguateLegacyMessage(eventRecord, legacyMessages);
 
             if (bestMatch is not null)
             {
@@ -887,7 +655,7 @@ public partial class EventResolverBase : IDisposable
                 }
 
                 var supplementalLegacy = supplemental.GetMessagesByShortId(eventRecord.Id);
-                var supplementalBest = TryDisambiguateLegacyMessage(eventRecord, supplementalLegacy);
+                var supplementalBest = _matcher.DisambiguateLegacyMessage(eventRecord, supplementalLegacy);
 
                 if (supplementalBest is not null)
                 {

--- a/src/EventLogExpert.Eventing/Resolvers/EventResolverBase.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/EventResolverBase.cs
@@ -2,44 +2,22 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Eventing.Common.Events;
-using EventLogExpert.Eventing.Interop;
 using EventLogExpert.Eventing.Readers;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Provider.Resolution;
-using System.Buffers;
 using System.Collections.Concurrent;
-using System.Collections.Immutable;
-using System.Security.Principal;
-using System.Text;
-using System.Text.RegularExpressions;
 
 namespace EventLogExpert.Eventing.Resolvers;
 
-public partial class EventResolverBase : IDisposable
+public class EventResolverBase : IDisposable
 {
-    private const string DefaultFailedDescription = "Failed to resolve description, see XML for more details.";
-    private const string DefaultNoMatchingDescription = "No matching message found with loaded providers, see XML for more details.";
-    private const string DefaultNoProviderDescription = "No matching provider available, see XML for more details.";
-
-    /// <summary>
-    ///     The mappings from the outType attribute in the EventModel XML template to determine if it should be displayed
-    ///     as Hex.
-    /// </summary>
-    private static readonly List<string> s_displayAsHexTypes =
-    [
-        "win:HexInt32",
-        "win:HexInt64",
-        "win:Pointer",
-        "win:Win32Error"
-    ];
-
     protected readonly ConcurrentDictionary<string, ProviderDetails?> ProviderDetails =
         new(StringComparer.OrdinalIgnoreCase);
 
     private readonly IEventResolverCache? _cache;
+    private readonly DescriptionFormatter _descriptions;
     private readonly ITraceLogger? _logger;
     private readonly ModernEventMatcher _matcher;
-    private readonly Regex _sectionsToReplace = WildcardWithNumberRegex();
     private readonly TaskKeywordResolver _taskKeywords;
     private readonly TemplateAnalyzer _templates = new();
 
@@ -51,6 +29,12 @@ public partial class EventResolverBase : IDisposable
         _logger = logger;
         _matcher = new ModernEventMatcher(_templates, logger);
         _taskKeywords = new TaskKeywordResolver(cache, logger);
+        // Method-group capture of TryGetSupplementalDetails uses ldvirtftn semantics: the delegate's
+        // method slot resolves against the runtime type of `this`. When EventResolver's ctor calls
+        // : base(cache, logger), `this` is already EventResolver, so the captured delegate dispatches
+        // to the override. The delegate is INVOKED later during _descriptions.Resolve, after the
+        // derived ctor body has run, so override-side fields are fully initialized at invocation time.
+        _descriptions = new DescriptionFormatter(_templates, _matcher, cache, logger, TryGetSupplementalDetails);
     }
 
     protected bool IsDisposed => Volatile.Read(ref _disposed) != 0;
@@ -90,8 +74,8 @@ public partial class EventResolverBase : IDisposable
 
         // Primary is non-decisive: either has no match (count == 0) or has multiple ambiguous
         // legacy messages (count > 1). Load supplemental so it's available to description,
-        // task, and keyword resolution consistently. ResolveDescription will use supplemental
-        // as a disambiguation fallback in the count > 1 case.
+        // task, and keyword resolution consistently. DescriptionFormatter.Resolve uses
+        // supplemental as a disambiguation fallback in the count > 1 case.
         supplemental = TryGetSupplementalDetails(eventRecord);
 
         EventModel? supplementalModernEvent = supplemental is not null
@@ -102,7 +86,7 @@ public partial class EventResolverBase : IDisposable
         {
             // Primary has no match at all — promote supplemental as the description source
             // when it matches. For count > 1, leave primary as the description source so its
-            // disambiguation runs first; supplemental becomes a tiebreaker inside ResolveDescription.
+            // disambiguation runs first; supplemental becomes a tiebreaker inside DescriptionFormatter.Resolve.
             if (supplementalModernEvent is not null)
             {
                 modernEvent = supplementalModernEvent;
@@ -132,127 +116,6 @@ public partial class EventResolverBase : IDisposable
     /// </summary>
     protected virtual ProviderDetails? TryGetSupplementalDetails(EventRecord eventRecord) => null;
 
-    private static string? BuildEventDataTail(List<string> properties)
-    {
-        if (properties.Count == 0) { return null; }
-
-        StringBuilder builder = new();
-        builder.Append("The following information was included with the event:\r\n");
-
-        foreach (var property in properties)
-        {
-            builder.Append("\r\n").Append(property);
-        }
-
-        return builder.ToString();
-    }
-
-    private static void CleanupFormatting(ReadOnlySpan<char> unformattedString, ref Span<char> buffer, out int bufferIndex)
-    {
-        bufferIndex = 0;
-
-        for (int i = 0; i < unformattedString.Length; i++)
-        {
-            switch (unformattedString[i])
-            {
-                case '%' when i + 1 < unformattedString.Length:
-                    switch (unformattedString[i + 1])
-                    {
-                        case 'n':
-                            if (i + 2 >= unformattedString.Length || unformattedString[i + 2] != '\r')
-                            {
-                                buffer[bufferIndex++] = '\r';
-                                buffer[bufferIndex++] = '\n';
-                            }
-
-                            i++;
-
-                            break;
-                        case 't':
-                            buffer[bufferIndex++] = '\t';
-                            i++;
-
-                            break;
-                        default:
-                            buffer[bufferIndex++] = unformattedString[i];
-
-                            break;
-                    }
-
-                    break;
-                case '\r' when i + 1 < unformattedString.Length && unformattedString[i + 1] != '\n':
-                    buffer[bufferIndex++] = '\r';
-                    buffer[bufferIndex++] = '\n';
-
-                    break;
-                case '\0':
-                case '\r' when i + 1 >= unformattedString.Length:
-                case '\r' when i + 3 >= unformattedString.Length && unformattedString[i + 1] == '\n':
-                case '\r' when i + 5 >= unformattedString.Length && unformattedString[i + 2] == '\r':
-                    i++;
-
-                    break;
-                case '\r' when i + 3 < unformattedString.Length && unformattedString[i + 2] == '%' && unformattedString[i + 3] == 'n':
-                    buffer[bufferIndex++] = '\r';
-                    buffer[bufferIndex++] = '\n';
-                    i += 3;
-
-                    break;
-                default:
-                    buffer[bufferIndex++] = unformattedString[i];
-
-                    break;
-            }
-        }
-    }
-
-    private static void ResizeBuffer(ref char[] buffer, ref Span<char> source, int sizeToAdd)
-    {
-        char[] newBuffer = ArrayPool<char>.Shared.Rent(source.Length + sizeToAdd);
-        source.CopyTo(newBuffer);
-        ArrayPool<char>.Shared.Return(buffer);
-        source = buffer = newBuffer;
-    }
-
-    [GeneratedRegex("%+[0-9]+")]
-    private static partial Regex WildcardWithNumberRegex();
-
-    private string BuildNoMetadataFallbackDescription(EventRecord eventRecord, List<string> properties)
-    {
-        const long classicKeywordBit = 0x0080000000000000L;
-        bool isClassic = ((eventRecord.Keywords ?? 0) & classicKeywordBit) != 0;
-
-        string? systemMessage = null;
-
-        if (isClassic && eventRecord.Id == 0)
-        {
-            // EventId 0 with the Classic keyword bit is what mmc renders as the Win32
-            // ERROR_SUCCESS text ("The operation completed successfully."). The Win32
-            // ERROR_SUCCESS code happens to be 0 too, but we are deliberately requesting
-            // the ERROR_SUCCESS message — not treating the EventId as a Win32 error code.
-            const uint Win32ErrorSuccess = 0;
-            systemMessage = NativeMethods.FormatSystemMessage(Win32ErrorSuccess);
-        }
-
-        string? propertyTail = BuildEventDataTail(properties);
-
-        // The propertyTail varies per event (timestamps, paths, IDs, etc.) — caching it
-        // would grow the description cache unboundedly. Only cache the low-cardinality
-        // canned strings (DefaultNoProviderDescription, systemMessage).
-        if (propertyTail is not null)
-        {
-            return string.IsNullOrWhiteSpace(systemMessage)
-                ? propertyTail
-                : $"{systemMessage}\r\n\r\n{propertyTail}";
-        }
-
-        string fallback = string.IsNullOrWhiteSpace(systemMessage)
-            ? DefaultNoProviderDescription
-            : systemMessage!;
-
-        return _cache?.GetOrAddDescription(fallback) ?? fallback;
-    }
-
     private ResolvedEvent CreateEventModel(
         EventRecord eventRecord,
         EventModel? modernEvent,
@@ -264,7 +127,7 @@ public partial class EventResolverBase : IDisposable
         {
             ActivityId = eventRecord.ActivityId,
             ComputerName = _cache?.GetOrAddValue(eventRecord.ComputerName) ?? eventRecord.ComputerName,
-            Description = ResolveDescription(eventRecord, details, descriptionDetails, modernEvent, supplemental, supplementalModernEvent),
+            Description = _descriptions.Resolve(eventRecord, details, descriptionDetails, modernEvent, supplemental, supplementalModernEvent),
             Id = eventRecord.Id,
             Keywords = _taskKeywords.GetKeywords(eventRecord, details, supplemental),
             Level = SeverityFormatter.Format(eventRecord.Level),
@@ -278,414 +141,4 @@ public partial class EventResolverBase : IDisposable
             UserId = eventRecord.UserId,
             Xml = eventRecord.Xml ?? string.Empty
         };
-
-    private string FormatDescription(
-        List<string> properties,
-        string? descriptionTemplate,
-        IEnumerable<MessageModel> parameters)
-    {
-        string returnDescription;
-
-        if (string.IsNullOrWhiteSpace(descriptionTemplate))
-        {
-            // If there is only one property then this is what certain EventRecords look like
-            // when the entire description is a string literal, and there is no provider DLL needed.
-            // Found a few providers that have their properties wrapped with \r\n for some reason.
-            // Multi-property fall-through is a defensive backstop (e.g. a legacy message row with
-            // empty Text); DefaultFailedDescription is reserved for actual formatting exceptions.
-            returnDescription = properties.Count == 1 ?
-                properties[0].TrimEnd('\0', '\r', '\n') :
-                DefaultNoMatchingDescription;
-
-            return _cache?.GetOrAddDescription(returnDescription) ?? returnDescription;
-        }
-
-        // Guard against stack overflow from very large templates
-        const int maxStackAllocChars = 4096;
-        int cleanupBufferSize = descriptionTemplate.Length * 2;
-        char[]? cleanupRented = null;
-
-        Span<char> description = cleanupBufferSize <= maxStackAllocChars
-            ? stackalloc char[cleanupBufferSize]
-            : (cleanupRented = ArrayPool<char>.Shared.Rent(cleanupBufferSize));
-
-        CleanupFormatting(descriptionTemplate, ref description, out int length);
-
-        description = description[..length];
-
-        if (properties.Count <= 0 && description.IndexOf("%%".AsSpan()) < 0)
-        {
-            returnDescription = description.ToString();
-
-            if (cleanupRented is not null) { ArrayPool<char>.Shared.Return(cleanupRented); }
-
-            return _cache?.GetOrAddDescription(returnDescription) ?? returnDescription;
-        }
-
-        char[] buffer = ArrayPool<char>.Shared.Rent(description.Length * 2);
-
-        try
-        {
-            int currentLength = 0;
-            int lastIndex = 0;
-            Span<char> updatedDescription = buffer;
-
-            foreach (var match in _sectionsToReplace.EnumerateMatches(description))
-            {
-                var sectionToAdd = description[lastIndex..match.Index];
-
-                if (currentLength + sectionToAdd.Length > updatedDescription.Length)
-                {
-                    ResizeBuffer(ref buffer, ref updatedDescription, sectionToAdd.Length);
-                }
-
-                sectionToAdd.CopyTo(updatedDescription[currentLength..]);
-                currentLength += sectionToAdd.Length;
-
-                ReadOnlySpan<char> propString = description[match.Index..(match.Index + match.Length)];
-
-                if (!propString.StartsWith("%%") && int.TryParse(propString.Trim(['{', '}', '%']), out var propIndex))
-                {
-                    // %0 is a Windows Event Log message terminator - skip it entirely
-                    if (propIndex == 0)
-                    {
-                        lastIndex = match.Index + match.Length;
-
-                        continue;
-                    }
-
-                    if (propIndex > properties.Count)
-                    {
-                        Logger?.Debug($"{nameof(FormatDescription)}: Property index out of range - RequestedIndex={propIndex}, PropertyCount={properties.Count}, Template={descriptionTemplate}");
-
-                        // Substitute with empty string rather than failing the entire description.
-                        // This commonly occurs when a manifest template references more properties
-                        // than the event actually supplies (e.g., version mismatch or optional data).
-                        // The available properties are still correctly positional.
-                        propString = ReadOnlySpan<char>.Empty;
-                    }
-                    else
-                    {
-                        propString = properties[propIndex - 1];
-                    }
-                }
-
-                if (propString.StartsWith("%%"))
-                {
-                    int endParameterId = propString.IndexOf(' ');
-
-                    var parameterIdString = endParameterId > 2
-                        ? propString[2..endParameterId]
-                        : propString[2..];
-
-                    if (long.TryParse(parameterIdString, out long parameterId))
-                    {
-                        // Some parameters exceed int size and need to be cast from long to int
-                        // because they are actually negative numbers
-                        ReadOnlySpan<char> parameterMessage =
-                            parameters.FirstOrDefault(m => m.RawId == (int)parameterId)?.Text ?? string.Empty;
-
-                        // Fallback to system FormatMessage for Win32 error codes
-                        // when provider parameters aren't available (e.g., MTA/DB resolvers)
-                        if (parameterMessage.IsEmpty && parameterId is > 0 and <= uint.MaxValue)
-                        {
-                            parameterMessage = NativeMethods.FormatSystemMessage((uint)parameterId);
-                        }
-
-                        if (!parameterMessage.IsEmpty)
-                        {
-                            // Remove only an exact trailing "%0" terminator, not individual chars
-                            parameterMessage = parameterMessage.EndsWith("%0")
-                                ? parameterMessage[..^2]
-                                : parameterMessage;
-
-                            propString = endParameterId > 2 ?
-                                string.Concat(parameterMessage, propString[(endParameterId + 1)..]) :
-                                parameterMessage;
-                        }
-                    }
-                }
-
-                if (currentLength + propString.Length > updatedDescription.Length)
-                {
-                    ResizeBuffer(ref buffer, ref updatedDescription, propString.Length);
-                }
-
-                propString.CopyTo(updatedDescription[currentLength..]);
-                currentLength += propString.Length;
-                lastIndex = match.Index + match.Length;
-            }
-
-            if (lastIndex < description.Length)
-            {
-                ReadOnlySpan<char> sectionToAdd = description[lastIndex..];
-
-                if (currentLength + sectionToAdd.Length > updatedDescription.Length)
-                {
-                    ResizeBuffer(ref buffer, ref updatedDescription, sectionToAdd.Length);
-                }
-
-                sectionToAdd.CopyTo(updatedDescription[currentLength..]);
-                currentLength += sectionToAdd.Length;
-            }
-
-            returnDescription = new string(updatedDescription[..currentLength]);
-
-            return _cache?.GetOrAddDescription(returnDescription) ?? returnDescription;
-        }
-        catch (InvalidOperationException ex)
-        {
-            Logger?.Warning($"{nameof(FormatDescription)}: InvalidOperationException - PropertyCount={properties.Count}, Template={descriptionTemplate}, Exception={ex.Message}");
-
-            // If the regex fails to match, then we just return the original description.
-            returnDescription = description.ToString();
-
-            return _cache?.GetOrAddDescription(returnDescription) ?? returnDescription;
-        }
-        catch (Exception ex)
-        {
-            Logger?.Warning($"{nameof(FormatDescription)}: Unexpected exception - PropertyCount={properties.Count}, Template={descriptionTemplate}, Exception={ex}");
-
-            return DefaultFailedDescription;
-        }
-        finally
-        {
-            ArrayPool<char>.Shared.Return(buffer);
-
-            if (cleanupRented is not null) { ArrayPool<char>.Shared.Return(cleanupRented); }
-        }
-    }
-
-    private List<string> GetFormattedProperties(ReadOnlySpan<char> template, IReadOnlyList<object> properties)
-    {
-        ImmutableArray<string> dataNodes = default;
-        List<string> formattedValues = [];
-
-        if (!template.IsEmpty)
-        {
-            // EvtRender may or may not include hidden length-provider fields in its output.
-            // Choose the outType array whose length matches the actual property count.
-            // If neither matches, skip outType formatting to avoid misalignment.
-            var meta = _templates.Analyze(template);
-
-            if (meta.VisibleOutTypes.Length == properties.Count)
-            {
-                dataNodes = meta.VisibleOutTypes;
-            }
-            else if (meta.AllOutTypes.Length == properties.Count)
-            {
-                dataNodes = meta.AllOutTypes;
-            }
-        }
-
-        int index = 0;
-
-        foreach (object property in properties)
-        {
-            string? outType = !dataNodes.IsDefault && index < dataNodes.Length ? dataNodes[index] : null;
-
-            switch (property)
-            {
-                case bool boolValue:
-                    formattedValues.Add(boolValue ? "true" : "false");
-
-                    break;
-                case DateTime eventTime:
-                    formattedValues.Add(eventTime.ToString("yyyy-MM-ddTHH:mm:ss.fffffff00K"));
-
-                    break;
-                case byte[] bytes:
-                    formattedValues.Add(Convert.ToHexString(bytes));
-
-                    break;
-                case SecurityIdentifier sid:
-                    formattedValues.Add(sid.Value);
-
-                    break;
-                default:
-                    if (string.IsNullOrEmpty(outType))
-                    {
-                        formattedValues.Add($"{property}");
-                    }
-                    else if (s_displayAsHexTypes.Contains(outType, StringComparer.OrdinalIgnoreCase))
-                    {
-                        formattedValues.Add(property switch
-                        {
-                            byte b => $"0x{b:X}",
-                            sbyte sb => $"0x{sb:X}",
-                            short s => $"0x{s:X}",
-                            ushort us => $"0x{us:X}",
-                            int i => $"0x{i:X}",
-                            uint ui => $"0x{ui:X}",
-                            long l => $"0x{l:X}",
-                            ulong ul => $"0x{ul:X}",
-                            _ => $"{property}"
-                        });
-                    }
-                    else if (string.Equals(outType, "win:HResult", StringComparison.OrdinalIgnoreCase) && property is int hResult)
-                    {
-                        formattedValues.Add(NativeErrorResolver.GetErrorMessage((uint)hResult));
-                    }
-                    else if (string.Equals(outType, "win:NTStatus", StringComparison.OrdinalIgnoreCase))
-                    {
-                        uint statusCode = property switch
-                        {
-                            uint ui => ui,
-                            int i => (uint)i,
-                            ulong ul => (uint)ul,
-                            long l => (uint)l,
-                            ushort us => us,
-                            short s => (uint)s,
-                            byte b => b,
-                            _ => 0
-                        };
-
-                        formattedValues.Add(property is uint or int or ulong or long or ushort or short or byte
-                            ? NativeErrorResolver.GetNtStatusMessage(statusCode)
-                            : $"{property}");
-                    }
-                    else
-                    {
-                        formattedValues.Add($"{property}");
-                    }
-
-                    break;
-            }
-
-            index++;
-        }
-
-        return formattedValues;
-    }
-
-    /// <summary>
-    ///     Picks the parameter table for %%n substitutions, biased toward whichever provider supplied the description
-    ///     text. When <paramref name="descriptionFromSupplemental" /> is true, prefer supplemental's parameters and fall back
-    ///     to primary; otherwise prefer primary and fall back to supplemental (lazily loading it when not yet available).
-    /// </summary>
-    private IEnumerable<MessageModel> GetParametersForDescription(
-        ProviderDetails? primary,
-        ProviderDetails? supplementalDetails,
-        bool descriptionFromSupplemental,
-        ref ProviderDetails? supplemental,
-        EventRecord eventRecord)
-    {
-        if (descriptionFromSupplemental && supplementalDetails is not null)
-        {
-            if (supplementalDetails.Parameters.Any()) { return supplementalDetails.Parameters; }
-
-            return primary?.Parameters ?? supplementalDetails.Parameters;
-        }
-
-        if (primary is not null && primary.Parameters.Any()) { return primary.Parameters; }
-
-        supplemental ??= TryGetSupplementalDetails(eventRecord);
-
-        return supplemental?.Parameters ?? primary?.Parameters ?? [];
-    }
-
-    /// <summary>Resolve event descriptions from an event record.</summary>
-    private string ResolveDescription(
-        EventRecord eventRecord,
-        ProviderDetails? primaryDetails,
-        ProviderDetails? details,
-        EventModel? modernEvent,
-        ProviderDetails? supplemental,
-        EventModel? supplementalModernEvent)
-    {
-        if (details is null)
-        {
-            Logger?.Debug($"{nameof(ResolveDescription)}: No provider details available - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, RecordId={eventRecord.RecordId}");
-
-            return DefaultNoProviderDescription;
-        }
-
-        var properties = GetFormattedProperties(modernEvent?.Template, eventRecord.Properties);
-
-        var descriptionFromSupplemental = supplemental is not null && ReferenceEquals(details, supplemental);
-
-        if (!string.IsNullOrEmpty(modernEvent?.Description))
-        {
-            Logger?.Debug($"{nameof(ResolveDescription)}: Using modern event description - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, PropertyCount={properties.Count}");
-
-            return FormatDescription(properties, modernEvent!.Description,
-                GetParametersForDescription(primaryDetails, supplemental, descriptionFromSupplemental, ref supplemental, eventRecord));
-        }
-
-        // Legacy provider message lookup
-        var legacyMessages = details.GetMessagesByShortId(eventRecord.Id);
-
-        if (legacyMessages.Count == 1)
-        {
-            Logger?.Debug($"{nameof(ResolveDescription)}: Using legacy message - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, PropertyCount={properties.Count}");
-
-            return FormatDescription(properties, legacyMessages[0].Text,
-                GetParametersForDescription(primaryDetails, supplemental, descriptionFromSupplemental, ref supplemental, eventRecord));
-        }
-
-        if (legacyMessages.Count > 1)
-        {
-            var bestMatch = _matcher.DisambiguateLegacyMessage(eventRecord, legacyMessages);
-
-            if (bestMatch is not null)
-            {
-                Logger?.Debug($"{nameof(ResolveDescription)}: Disambiguated legacy message - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, Level={eventRecord.Level}");
-
-                return FormatDescription(properties, bestMatch.Text,
-                    GetParametersForDescription(primaryDetails, supplemental, descriptionFromSupplemental, ref supplemental, eventRecord));
-            }
-
-            Logger?.Debug($"{nameof(ResolveDescription)}: Multiple legacy messages found, could not disambiguate - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, MessageCount={legacyMessages.Count}");
-
-            // Last-resort: ambiguous primary may be resolvable via supplemental. ResolveEvent
-            // pre-loads supplemental and its modern event for count > 1, so both are already
-            // set here when supplemental is available.
-            if (supplemental is not null && !ReferenceEquals(supplemental, details))
-            {
-                if (!string.IsNullOrEmpty(supplementalModernEvent?.Description))
-                {
-                    Logger?.Debug($"{nameof(ResolveDescription)}: Disambiguated via supplemental modern event - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}");
-
-                    var supplementalProperties = GetFormattedProperties(supplementalModernEvent!.Template, eventRecord.Properties);
-
-                    // Description came from supplemental, so resolve %%n parameter substitutions
-                    // against supplemental's parameter table first.
-                    return FormatDescription(supplementalProperties, supplementalModernEvent.Description,
-                        GetParametersForDescription(primaryDetails, supplemental, true, ref supplemental, eventRecord));
-                }
-
-                var supplementalLegacy = supplemental.GetMessagesByShortId(eventRecord.Id);
-                var supplementalBest = _matcher.DisambiguateLegacyMessage(eventRecord, supplementalLegacy);
-
-                if (supplementalBest is not null)
-                {
-                    Logger?.Debug($"{nameof(ResolveDescription)}: Disambiguated via supplemental legacy message - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}");
-
-                    return FormatDescription(properties, supplementalBest.Text,
-                        GetParametersForDescription(primaryDetails, supplemental, true, ref supplemental, eventRecord));
-                }
-            }
-        }
-
-        // Some events store the entire description in a single property when no template exists.
-        // Only the single-property case is meaningful here; multi-property events without a template
-        // cannot be rendered into a description and would just emit a misleading constant.
-        if (properties.Count == 1)
-        {
-            Logger?.Debug($"{nameof(ResolveDescription)}: Using single-property description fallback - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}");
-
-            return FormatDescription(properties, null, details.Parameters);
-        }
-
-        if (details.IsEmpty && (supplemental is null || supplemental.IsEmpty))
-        {
-            Logger?.Debug($"{nameof(ResolveDescription)}: No provider metadata available - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, Version={eventRecord.Version}, LogName={eventRecord.LogName}, RecordId={eventRecord.RecordId}, Keywords=0x{eventRecord.Keywords ?? 0:X16}");
-
-            return BuildNoMetadataFallbackDescription(eventRecord, properties);
-        }
-
-        Logger?.Debug($"{nameof(ResolveDescription)}: No matching description found - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, Version={eventRecord.Version}, LogName={eventRecord.LogName}, RecordId={eventRecord.RecordId}");
-
-        return DefaultNoMatchingDescription;
-    }
 }

--- a/src/EventLogExpert.Eventing/Resolvers/ModernEventMatcher.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/ModernEventMatcher.cs
@@ -16,9 +16,6 @@ namespace EventLogExpert.Eventing.Resolvers;
 ///     template-property-count, then relaxed-template-count (handles version-mismatch optional fields), then Id+LogName
 ///     ignoring Version, then full-RawId+Qualifiers (for Complus / WPDClassInstaller entries), then short-Id+Version
 ///     ignoring LogName, then Id+Version ignoring LogName when exactly one candidate passes template validation.
-///     <see cref="DisambiguateLegacyMessage" /> is exposed as a public instance method so consumers that already hold a
-///     candidate set (e.g., the description formatter) can run the legacy-message disambiguation without re-running the
-///     matcher.
 /// </remarks>
 internal sealed class ModernEventMatcher(TemplateAnalyzer templates, ITraceLogger? logger)
 {
@@ -31,7 +28,7 @@ internal sealed class ModernEventMatcher(TemplateAnalyzer templates, ITraceLogge
     ///     publicly so the description formatter can run this disambiguation against a candidate set it already holds without
     ///     re-running <see cref="Match" />.
     /// </summary>
-    public MessageModel? DisambiguateLegacyMessage(EventRecord eventRecord, IReadOnlyList<MessageModel> legacyMessages)
+    public static MessageModel? DisambiguateLegacyMessage(EventRecord eventRecord, IReadOnlyList<MessageModel> legacyMessages)
     {
         if (legacyMessages.Count == 0) { return null; }
 

--- a/src/EventLogExpert.Eventing/Resolvers/ModernEventMatcher.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/ModernEventMatcher.cs
@@ -1,0 +1,268 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Readers;
+using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Provider.Models;
+
+namespace EventLogExpert.Eventing.Resolvers;
+
+/// <summary>
+///     Matches an <see cref="EventRecord" /> to its <see cref="EventModel" /> in a provider's event table, and
+///     disambiguates ambiguous legacy message tables by Qualifier / LogLink / severity.
+/// </summary>
+/// <remarks>
+///     The match procedure walks several fallback paths in order: exact Id+Version+LogName + strict
+///     template-property-count, then relaxed-template-count (handles version-mismatch optional fields), then Id+LogName
+///     ignoring Version, then full-RawId+Qualifiers (for Complus / WPDClassInstaller entries), then short-Id+Version
+///     ignoring LogName, then Id+Version ignoring LogName when exactly one candidate passes template validation.
+///     <see cref="DisambiguateLegacyMessage" /> is exposed as a public instance method so consumers that already hold a
+///     candidate set (e.g., the description formatter) can run the legacy-message disambiguation without re-running the
+///     matcher.
+/// </remarks>
+internal sealed class ModernEventMatcher(TemplateAnalyzer templates, ITraceLogger? logger)
+{
+    private readonly ITraceLogger? _logger = logger;
+    private readonly TemplateAnalyzer _templates = templates;
+
+    /// <summary>
+    ///     Disambiguates multiple legacy messages for the same event ID. Tries Qualifier match (high 16 bits of RawId),
+    ///     then LogLink, then severity. Returns null when the set is empty or remains ambiguous after all checks. Exposed
+    ///     publicly so the description formatter can run this disambiguation against a candidate set it already holds without
+    ///     re-running <see cref="Match" />.
+    /// </summary>
+    public MessageModel? DisambiguateLegacyMessage(EventRecord eventRecord, IReadOnlyList<MessageModel> legacyMessages)
+    {
+        if (legacyMessages.Count == 0) { return null; }
+
+        if (legacyMessages.Count == 1) { return legacyMessages[0]; }
+
+        // Qualifier match. For classic/legacy events, Windows encodes Qualifiers in
+        // the high 16 bits of the message ID, so RawId == (Qualifiers << 16) | EventId
+        // identifies the exact message-table entry.
+        if (eventRecord.Qualifiers.HasValue)
+        {
+            List<MessageModel>? qualifierMatches = null;
+
+            foreach (var m in legacyMessages)
+            {
+                if ((ushort)((m.RawId >> 16) & 0xFFFF) == eventRecord.Qualifiers.Value)
+                {
+                    (qualifierMatches ??= []).Add(m);
+                }
+            }
+
+            if (qualifierMatches is { Count: 1 })
+            {
+                return qualifierMatches[0];
+            }
+
+            if (qualifierMatches is { Count: > 1 })
+            {
+                legacyMessages = qualifierMatches;
+            }
+        }
+
+        // LogLink match
+        foreach (var m in legacyMessages)
+        {
+            if (m.LogLink is not null && LogNamesMatch(m.LogLink, eventRecord.LogName))
+            {
+                return m;
+            }
+        }
+
+        // Severity-based match. MC RawId bits 31-30 encode severity:
+        // 00=Success, 01=Informational, 10=Warning, 11=Error.
+        // ETW levels: 0=LogAlways, 1=Critical, 2=Error, 3=Warning, 4=Information, 5=Verbose.
+        if (eventRecord.Level is null) { return null; }
+
+        int targetSeverity = eventRecord.Level switch
+        {
+            1 or 2 => 3,
+            3 => 2,
+            4 or 5 => 1,
+            _ => 0
+        };
+
+        MessageModel? severityCandidate = null;
+
+        foreach (var m in legacyMessages)
+        {
+            int messageSeverity = (int)((m.RawId >> 30) & 0x3);
+
+            if (messageSeverity != targetSeverity) { continue; }
+
+            if (severityCandidate is not null)
+            {
+                // Multiple matches with same severity — still ambiguous
+                return null;
+            }
+
+            severityCandidate = m;
+        }
+
+        return severityCandidate;
+    }
+
+    /// <summary>
+    ///     Locates the <see cref="EventModel" /> in <paramref name="details" /> whose template matches the
+    ///     <paramref name="eventRecord" />, walking the documented fallback chain. Returns null when no candidate passes both
+    ///     Id/Version/LogName and template-property-count checks.
+    /// </summary>
+    public EventModel? Match(EventRecord eventRecord, ProviderDetails details)
+    {
+        if (eventRecord.Version is null && string.IsNullOrEmpty(eventRecord.LogName))
+        {
+            _logger?.Debug($"{nameof(Match)}: Skipping modern event lookup - EventId={eventRecord.Id}, Provider={eventRecord.ProviderName} has null Version and empty LogName");
+
+            return null;
+        }
+
+        int eventPropertyCount = eventRecord.Properties.Count;
+
+        // Use indexed lookup instead of linear scan
+        var candidateEvents = details.GetEventsById(eventRecord.Id);
+
+        EventModel? modernEvent = null;
+
+        foreach (var e in candidateEvents)
+        {
+            if (e.Id != eventRecord.Id ||
+                e.Version != eventRecord.Version ||
+                !LogNamesMatch(e.LogName, eventRecord.LogName))
+            {
+                continue;
+            }
+
+            modernEvent = e;
+
+            break;
+        }
+
+        if (modernEvent is not null && _templates.StrictlyMatchesPropertyCount(modernEvent.Template, eventPropertyCount))
+        {
+            _logger?.Debug($"{nameof(Match)}: Exact match found - EventId={eventRecord.Id}, Version={eventRecord.Version}, LogName={eventRecord.LogName}");
+
+            return modernEvent;
+        }
+
+        // For exact Id+Version+LogName matches, tolerate the template having slightly
+        // more data nodes than the event supplies. This handles version mismatches where
+        // the manifest added optional fields. FormatDescription handles out-of-range
+        // property indices gracefully by substituting empty string.
+        if (modernEvent is not null && _templates.ApproximatelyMatchesPropertyCount(modernEvent.Template, eventPropertyCount))
+        {
+            _logger?.Debug($"{nameof(Match)}: Exact match with relaxed template count - EventId={eventRecord.Id}, Version={eventRecord.Version}, LogName={eventRecord.LogName}, PropertyCount={eventPropertyCount}");
+
+            return modernEvent;
+        }
+
+        if (modernEvent is not null)
+        {
+            _logger?.Debug($"{nameof(Match)}: Exact match found but template property count mismatch - EventId={eventRecord.Id}, Version={eventRecord.Version}, LogName={eventRecord.LogName}, PropertyCount={eventPropertyCount}");
+        }
+
+        foreach (var @event in candidateEvents)
+        {
+            if (!LogNamesMatch(@event.LogName, eventRecord.LogName)) { continue; }
+
+            if (!_templates.MatchesPropertyCount(@event.Template, eventPropertyCount)) { continue; }
+
+            _logger?.Debug($"{nameof(Match)}: Match by Id/LogName with template - EventId={eventRecord.Id}, LogName={eventRecord.LogName}, MatchedVersion={@event.Version}");
+
+            return @event;
+        }
+
+        // Try again forcing the long to a short and with no log name. Needed for providers
+        // such as Microsoft-Windows-Complus and Microsoft-Windows-WPDClassInstaller that store
+        // events with the full 32-bit RawId (high 16 bits = Qualifiers, low 16 bits = EventId).
+        // Strict template match accepts empty template + zero EventData properties, which is the
+        // shape WPDClassInstaller emits for its full-RawId entries. When the record carries a
+        // Qualifiers value, prefer the exact full-RawId match before the low-16 ambiguity check.
+        if (eventRecord.Qualifiers is { } qualifier)
+        {
+            var fullRawId = ((long)qualifier << 16) | eventRecord.Id;
+
+            foreach (var @event in details.Events)
+            {
+                if (@event.Id != fullRawId || @event.Version != eventRecord.Version) { continue; }
+
+                if (!_templates.StrictlyMatchesPropertyCount(@event.Template, eventPropertyCount)) { continue; }
+
+                _logger?.Debug($"{nameof(Match)}: Match by full RawId fallback - RawId={fullRawId:X}, Version={eventRecord.Version}");
+
+                return @event;
+            }
+        }
+
+        EventModel? shortIdMatch = null;
+
+        foreach (var @event in details.Events)
+        {
+            if ((ushort)@event.Id != eventRecord.Id || @event.Version != eventRecord.Version) { continue; }
+
+            // When the record's qualifier is known, full-RawId entries with conflicting high
+            // bits would have been caught above. Skip them here so they do not mask short-only
+            // entries or trigger a false ambiguity.
+            if (eventRecord.Qualifiers is not null && @event.Id > ushort.MaxValue) { continue; }
+
+            if (!_templates.StrictlyMatchesPropertyCount(@event.Template, eventPropertyCount)) { continue; }
+
+            if (shortIdMatch is not null)
+            {
+                // Multiple matches — ambiguous
+                shortIdMatch = null;
+
+                break;
+            }
+
+            shortIdMatch = @event;
+        }
+
+        if (shortIdMatch is not null)
+        {
+            _logger?.Debug($"{nameof(Match)}: Match by short Id/Version fallback - EventId={eventRecord.Id}, Version={eventRecord.Version}");
+
+            return shortIdMatch;
+        }
+
+        // Final fallback: match by Id+Version ignoring LogName, but only if exactly
+        // one candidate passes template validation. This handles providers that define
+        // events under diagnostic/operational channels but log to Application/System
+        // via eventlog redirects (e.g., Winlogon 6001).
+        EventModel? logNameIgnoredMatch = null;
+
+        foreach (var @event in candidateEvents)
+        {
+            if (@event.Version != eventRecord.Version) { continue; }
+
+            if (!_templates.MatchesPropertyCount(@event.Template, eventPropertyCount)) { continue; }
+
+            if (logNameIgnoredMatch is not null)
+            {
+                // Multiple candidates — ambiguous, don't guess
+                logNameIgnoredMatch = null;
+
+                break;
+            }
+
+            logNameIgnoredMatch = @event;
+        }
+
+        if (logNameIgnoredMatch is not null)
+        {
+            _logger?.Debug($"{nameof(Match)}: Unique match by Id/Version ignoring LogName - EventId={eventRecord.Id}, Version={eventRecord.Version}, MatchedLogName={logNameIgnoredMatch.LogName}");
+
+            return logNameIgnoredMatch;
+        }
+
+        _logger?.Debug($"{nameof(Match)}: No matching event found - EventId={eventRecord.Id}, Version={eventRecord.Version}, LogName={eventRecord.LogName}, PropertyCount={eventPropertyCount}, CandidateEventsWithSameId={candidateEvents.Count}");
+
+        return null;
+    }
+
+    /// <summary>Treats null and empty string as equivalent for LogName comparison.</summary>
+    private static bool LogNamesMatch(string? a, string? b) =>
+        string.IsNullOrEmpty(a) ? string.IsNullOrEmpty(b) : string.Equals(a, b, StringComparison.Ordinal);
+}

--- a/src/EventLogExpert.Eventing/Resolvers/ModernEventMatcher.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/ModernEventMatcher.cs
@@ -3,7 +3,7 @@
 
 using EventLogExpert.Eventing.Readers;
 using EventLogExpert.Logging.Abstractions;
-using EventLogExpert.Provider.Models;
+using EventLogExpert.Provider.Resolution;
 
 namespace EventLogExpert.Eventing.Resolvers;
 

--- a/src/EventLogExpert.Eventing/Resolvers/ModernEventMatcher.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/ModernEventMatcher.cs
@@ -121,7 +121,6 @@ internal sealed class ModernEventMatcher(TemplateAnalyzer templates, ITraceLogge
 
         int eventPropertyCount = eventRecord.Properties.Count;
 
-        // Use indexed lookup instead of linear scan
         var candidateEvents = details.GetEventsById(eventRecord.Id);
 
         EventModel? modernEvent = null;

--- a/src/EventLogExpert.Eventing/Resolvers/ModernEventMatcher.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/ModernEventMatcher.cs
@@ -24,9 +24,7 @@ internal sealed class ModernEventMatcher(TemplateAnalyzer templates, ITraceLogge
 
     /// <summary>
     ///     Disambiguates multiple legacy messages for the same event ID. Tries Qualifier match (high 16 bits of RawId),
-    ///     then LogLink, then severity. Returns null when the set is empty or remains ambiguous after all checks. Exposed
-    ///     publicly so the description formatter can run this disambiguation against a candidate set it already holds without
-    ///     re-running <see cref="Match" />.
+    ///     then LogLink, then severity. Returns null when the set is empty or remains ambiguous after all checks.
     /// </summary>
     public static MessageModel? DisambiguateLegacyMessage(EventRecord eventRecord, IReadOnlyList<MessageModel> legacyMessages)
     {

--- a/src/EventLogExpert.Eventing/Resolvers/ModernEventMatcher.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/ModernEventMatcher.cs
@@ -149,7 +149,7 @@ internal sealed class ModernEventMatcher(TemplateAnalyzer templates, ITraceLogge
 
         // For exact Id+Version+LogName matches, tolerate the template having slightly
         // more data nodes than the event supplies. This handles version mismatches where
-        // the manifest added optional fields. FormatDescription handles out-of-range
+        // the manifest added optional fields. The description formatter handles out-of-range
         // property indices gracefully by substituting empty string.
         if (modernEvent is not null && _templates.ApproximatelyMatchesPropertyCount(modernEvent.Template, eventPropertyCount))
         {

--- a/src/EventLogExpert.Eventing/Resolvers/TaskKeywordResolver.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/TaskKeywordResolver.cs
@@ -17,10 +17,6 @@ namespace EventLogExpert.Eventing.Resolvers;
 /// </remarks>
 internal sealed class TaskKeywordResolver(IEventResolverCache? cache, ITraceLogger? logger)
 {
-    /// <summary>
-    ///     These are already defined in System.Diagnostics.Eventing.Reader.StandardEventKeywords. However, the names
-    ///     there do not match what is normally displayed in Event Viewer. We redefine them here so we can use our own strings.
-    /// </summary>
     private static readonly Dictionary<long, string> s_standardKeywords = new()
     {
         { 0x1000000000000, "Response Time" },
@@ -41,7 +37,7 @@ internal sealed class TaskKeywordResolver(IEventResolverCache? cache, ITraceLogg
     ///     standard keywords (bits 48–55) with provider-defined keywords (bits 0–47). Primary provider wins over supplemental
     ///     on bit conflicts.
     /// </summary>
-    public List<string> GetKeywords(EventRecord eventRecord, ProviderDetails? details, ProviderDetails? supplemental)
+    public List<string> ResolveKeywords(EventRecord eventRecord, ProviderDetails? details, ProviderDetails? supplemental)
     {
         if (eventRecord.Keywords is null or 0) { return []; }
 

--- a/src/EventLogExpert.Eventing/Resolvers/TaskKeywordResolver.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/TaskKeywordResolver.cs
@@ -3,7 +3,7 @@
 
 using EventLogExpert.Eventing.Readers;
 using EventLogExpert.Logging.Abstractions;
-using EventLogExpert.Provider.Models;
+using EventLogExpert.Provider.Resolution;
 
 namespace EventLogExpert.Eventing.Resolvers;
 

--- a/src/EventLogExpert.Eventing/Resolvers/TaskKeywordResolver.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/TaskKeywordResolver.cs
@@ -1,0 +1,191 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Readers;
+using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Provider.Models;
+
+namespace EventLogExpert.Eventing.Resolvers;
+
+/// <summary>
+///     Resolves the human-readable task name and keyword list for an event record from provider metadata plus the
+///     Microsoft-defined standard keyword bitmask table.
+/// </summary>
+/// <remarks>
+///     Standard keyword strings are redefined locally to match Windows Event Viewer's rendering, which uses different
+///     display names than <see cref="System.Diagnostics.Eventing.Reader.StandardEventKeywords" />.
+/// </remarks>
+internal sealed class TaskKeywordResolver(IEventResolverCache? cache, ITraceLogger? logger)
+{
+    /// <summary>
+    ///     These are already defined in System.Diagnostics.Eventing.Reader.StandardEventKeywords. However, the names
+    ///     there do not match what is normally displayed in Event Viewer. We redefine them here so we can use our own strings.
+    /// </summary>
+    private static readonly Dictionary<long, string> s_standardKeywords = new()
+    {
+        { 0x1000000000000, "Response Time" },
+        { 0x2000000000000, "Wdi Context" },
+        { 0x4000000000000, "Wdi Diag" },
+        { 0x8000000000000, "Sqm" },
+        { 0x10000000000000, "Audit Failure" },
+        { 0x20000000000000, "Audit Success" },
+        { 0x40000000000000, "Correlation Hint" },
+        { 0x80000000000000, "Classic" }
+    };
+
+    private readonly IEventResolverCache? _cache = cache;
+    private readonly ITraceLogger? _logger = logger;
+
+    /// <summary>
+    ///     Returns the keyword strings derived from the event record's keyword bitmask, combining Microsoft-defined
+    ///     standard keywords (bits 48–55) with provider-defined keywords (bits 0–47). Primary provider wins over supplemental
+    ///     on bit conflicts.
+    /// </summary>
+    public List<string> GetKeywords(EventRecord eventRecord, ProviderDetails? details, ProviderDetails? supplemental)
+    {
+        if (eventRecord.Keywords is null or 0) { return []; }
+
+        var keywordsValue = eventRecord.Keywords.Value;
+        List<string> returnValue = [];
+
+        // Standard (Microsoft-defined) keywords live in bits 48–55. Skip the entire
+        // standard-keyword scan when the event has no bits in that range.
+        if ((keywordsValue & 0x00FF_0000_0000_0000L) != 0)
+        {
+            foreach (var (bit, name) in s_standardKeywords)
+            {
+                if ((keywordsValue & bit) != bit) { continue; }
+
+                var keyword = name.TrimEnd('\0');
+                returnValue.Add(_cache?.GetOrAddValue(keyword) ?? keyword);
+            }
+        }
+
+        // Provider-defined keywords use bits 0–47; bits 48–63 are reserved
+        // for Microsoft-defined standard keywords handled above.
+        var providerBits = keywordsValue & 0x0000_FFFF_FFFF_FFFFL;
+
+        if (providerBits == 0) { return returnValue; }
+
+        long matchedBits = 0;
+
+        if (details is not null)
+        {
+            foreach (var (bit, name) in details.Keywords)
+            {
+                if ((providerBits & bit) != bit) { continue; }
+
+                matchedBits |= bit;
+                var keyword = name.TrimEnd('\0');
+                returnValue.Add(_cache?.GetOrAddValue(keyword) ?? keyword);
+            }
+        }
+
+        // Fill remaining set bits from supplemental. Primary wins on conflicts.
+        if (supplemental is not null && !ReferenceEquals(supplemental, details))
+        {
+            foreach (var (bit, name) in supplemental.Keywords)
+            {
+                if ((providerBits & bit) != bit) { continue; }
+
+                if ((matchedBits & bit) == bit) { continue; }
+
+                var keyword = name.TrimEnd('\0');
+                returnValue.Add(_cache?.GetOrAddValue(keyword) ?? keyword);
+            }
+        }
+
+        return returnValue;
+    }
+
+    /// <summary>
+    ///     Resolves the human-readable task name for the event, preferring primary provider tables then supplemental,
+    ///     falling back to a numeric placeholder when neither resolves the task.
+    /// </summary>
+    public string ResolveTaskName(
+        EventRecord eventRecord,
+        ProviderDetails? details,
+        EventModel? modernEvent,
+        ProviderDetails? supplemental,
+        EventModel? supplementalModernEvent)
+    {
+        if (TryResolveTaskNameFromDetails(eventRecord, details, modernEvent, out var taskName))
+        {
+            return CacheTaskName(taskName);
+        }
+
+        if (supplemental is not null &&
+            !ReferenceEquals(supplemental, details) &&
+            TryResolveTaskNameFromDetails(eventRecord, supplemental, supplementalModernEvent, out taskName))
+        {
+            // The primary modernEvent (if any) was already tried above against primary's tables.
+            // Use the pre-computed supplementalModernEvent so its EventModel.Task can drive
+            // supplemental's Tasks lookup.
+            return CacheTaskName(taskName);
+        }
+
+        return !eventRecord.Task.HasValue ?
+            string.Empty :
+            CacheTaskName(eventRecord.Task == 0 ? "None" : $"({eventRecord.Task})");
+    }
+
+    private string CacheTaskName(string taskName)
+    {
+        taskName = taskName.TrimEnd('\0');
+
+        return _cache?.GetOrAddValue(taskName) ?? taskName;
+    }
+
+    private bool TryResolveTaskNameFromDetails(
+        EventRecord eventRecord,
+        ProviderDetails? details,
+        EventModel? modernEvent,
+        out string taskName)
+    {
+        taskName = string.Empty;
+
+        if (details is null) { return false; }
+
+        if (modernEvent?.Task is not null && details.Tasks.TryGetValue(modernEvent.Task, out var name))
+        {
+            taskName = name;
+
+            return true;
+        }
+
+        if (!eventRecord.Task.HasValue) { return false; }
+
+        if (details.Tasks.TryGetValue(eventRecord.Task.Value, out name))
+        {
+            taskName = name;
+
+            return true;
+        }
+
+        var messagesByShortId = details.GetMessagesByShortId(eventRecord.Task.Value);
+
+        List<MessageModel>? potentialTaskNames = null;
+
+        foreach (var m in messagesByShortId)
+        {
+            if (m.LogLink is null || m.LogLink != eventRecord.LogName) { continue; }
+
+            potentialTaskNames ??= [];
+            potentialTaskNames.Add(m);
+        }
+
+        if (potentialTaskNames is not { Count: > 0 }) { return false; }
+
+        taskName = potentialTaskNames[0].Text;
+
+        if (potentialTaskNames.Count <= 1) { return true; }
+
+        _logger?.Debug($"More than one matching task ID was found.");
+        _logger?.Debug($"  eventRecord.Task: {eventRecord.Task}");
+        _logger?.Debug($"   Potential matches:");
+
+        potentialTaskNames.ForEach(t => _logger?.Debug($"    {t.LogLink} {t.Text}"));
+
+        return true;
+    }
+}

--- a/src/EventLogExpert.Eventing/Resolvers/TemplateAnalyzer.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/TemplateAnalyzer.cs
@@ -34,7 +34,7 @@ internal sealed class TemplateAnalyzer
 
     /// <summary>
     ///     Parses <paramref name="template" /> if it is not already cached and returns its
-    ///     <see cref="TemplateMetadata" />. Empty templates return <see cref="s_empty" /> without touching the cache.
+    ///     <see cref="TemplateMetadata" />. Empty templates return empty metadata without touching the cache.
     /// </summary>
     public TemplateMetadata Analyze(ReadOnlySpan<char> template)
     {

--- a/src/EventLogExpert.Eventing/Resolvers/TemplateAnalyzer.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/TemplateAnalyzer.cs
@@ -1,0 +1,242 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Runtime.InteropServices;
+
+namespace EventLogExpert.Eventing.Resolvers;
+
+/// <summary>
+///     Unified parser for Windows event manifest &lt;template&gt; XML. Replaces three independently-cached parsers
+///     (per-element name extraction, per-element outType extraction, visible-property count) with a single parse pass that
+///     produces a <see cref="TemplateMetadata" /> value cached per template string.
+/// </summary>
+/// <remarks>
+///     <para>
+///         A "visible" property is a &lt;data&gt; element Windows surfaces through EvtRender. Length-provider elements —
+///         &lt;data&gt; elements whose <c>name</c> is referenced by another element's <c>length</c> attribute — are
+///         consumed by Windows internally and do not appear as separate user properties. <see cref="Analyze" /> filters
+///         them out of <see cref="TemplateMetadata.VisibleOutTypes" /> and excludes them from
+///         <see cref="TemplateMetadata.VisiblePropertyCount" />.
+///     </para>
+///     <para>
+///         The cache is keyed by the template string but supports zero-allocation lookup from a
+///         <see cref="ReadOnlySpan{Char}" /> via <see cref="ConcurrentDictionary{TKey,TValue}.GetAlternateLookup" />.
+///     </para>
+/// </remarks>
+internal sealed class TemplateAnalyzer
+{
+    private static readonly TemplateMetadata s_empty = new(0, ImmutableArray<string>.Empty, ImmutableArray<string>.Empty);
+
+    private readonly ConcurrentDictionary<string, TemplateMetadata> _cache =
+        new(StringComparer.Ordinal);
+
+    /// <summary>
+    ///     Parses <paramref name="template" /> if it is not already cached and returns its
+    ///     <see cref="TemplateMetadata" />. Empty templates return <see cref="s_empty" /> without touching the cache.
+    /// </summary>
+    public TemplateMetadata Analyze(ReadOnlySpan<char> template)
+    {
+        if (template.IsEmpty)
+        {
+            return s_empty;
+        }
+
+        var lookup = _cache.GetAlternateLookup<ReadOnlySpan<char>>();
+
+        if (lookup.TryGetValue(template, out var cached))
+        {
+            return cached;
+        }
+
+        TemplateMetadata metadata = Parse(template);
+
+        // Cache write happens AFTER the parse loop completes; partially-built metadata is never visible
+        // to other readers (§3.8 deferred-mutations).
+        lookup.TryAdd(template, metadata);
+
+        return metadata;
+    }
+
+    /// <summary>
+    ///     Relaxed match for exact Id+Version+LogName candidates — accepts the template having exactly one MORE data node
+    ///     than the event has properties. Handles version mismatches where the manifest added an optional field in a newer
+    ///     version.
+    /// </summary>
+    /// <remarks>
+    ///     Preserves the exact semantics of the original DoesTemplateApproximatelyMatchPropertyCount, including the
+    ///     sequential fallback: visible-count first, falling back to all-node count ONLY when the visible count is zero.
+    /// </remarks>
+    public bool ApproximatelyMatchesPropertyCount(ReadOnlySpan<char> template, int eventPropertyCount)
+    {
+        if (template.IsEmpty || eventPropertyCount <= 0) { return false; }
+
+        var metadata = Analyze(template);
+
+        int templateCount = metadata.VisiblePropertyCount;
+
+        if (templateCount == 0)
+        {
+            templateCount = metadata.AllOutTypes.Length;
+        }
+
+        return templateCount - eventPropertyCount == 1;
+    }
+
+    /// <summary>
+    ///     Returns true when the template has the same number of data nodes as the event has properties. Either the full
+    ///     count or the visible-only count is accepted to handle providers that include or omit length-provider fields in
+    ///     their property output.
+    /// </summary>
+    /// <remarks>Preserves the exact semantics of the original DoesTemplateMatchPropertyCount.</remarks>
+    public bool MatchesPropertyCount(ReadOnlySpan<char> template, int eventPropertyCount)
+    {
+        if (template.IsEmpty) { return false; }
+
+        var metadata = Analyze(template);
+
+        if (metadata.AllOutTypes.Length == eventPropertyCount) { return true; }
+
+        return metadata.VisiblePropertyCount == eventPropertyCount;
+    }
+
+    /// <summary>
+    ///     Strict variant of <see cref="MatchesPropertyCount" /> — accepts an empty template only when the event has zero
+    ///     properties (which is the shape some providers emit for full-RawId entries with no EventData section).
+    /// </summary>
+    /// <remarks>Preserves the exact semantics of the original DoesTemplateStrictlyMatchPropertyCount.</remarks>
+    public bool StrictlyMatchesPropertyCount(ReadOnlySpan<char> template, int eventPropertyCount)
+    {
+        if (template.IsEmpty) { return eventPropertyCount == 0; }
+
+        return MatchesPropertyCount(template, eventPropertyCount);
+    }
+
+    private static TemplateMetadata BuildMetadata(
+        List<(string name, string outType)> elements,
+        HashSet<string> lengthProviderNames)
+    {
+        var allOutTypesArray = new string[elements.Count];
+
+        for (int i = 0; i < elements.Count; i++)
+        {
+            allOutTypesArray[i] = elements[i].outType;
+        }
+
+        // Zero-alloc wrap: takes ownership of the existing array as an ImmutableArray.
+        // Safe because allOutTypesArray is a fresh local with no other references.
+        var allOutTypes = ImmutableCollectionsMarshal.AsImmutableArray(allOutTypesArray);
+
+        if (lengthProviderNames.Count == 0)
+        {
+            // No hidden length-provider elements — visible and all are identical.
+            // ImmutableArray<string> is a struct wrapping the same backing array;
+            // both fields share the wrap so consumers cannot mutate the cache.
+            return new TemplateMetadata(elements.Count, allOutTypes, allOutTypes);
+        }
+
+        int visibleCount = 0;
+
+        foreach (var (name, _) in elements)
+        {
+            if (string.IsNullOrEmpty(name) || !lengthProviderNames.Contains(name))
+            {
+                visibleCount++;
+            }
+        }
+
+        var visibleOutTypesArray = new string[visibleCount];
+        int write = 0;
+
+        foreach (var (name, outType) in elements)
+        {
+            if (string.IsNullOrEmpty(name) || !lengthProviderNames.Contains(name))
+            {
+                visibleOutTypesArray[write++] = outType;
+            }
+        }
+
+        var visibleOutTypes = ImmutableCollectionsMarshal.AsImmutableArray(visibleOutTypesArray);
+
+        return new TemplateMetadata(visibleCount, allOutTypes, visibleOutTypes);
+    }
+
+    private static string? ExtractAttribute(ReadOnlySpan<char> element, ReadOnlySpan<char> attributePrefix)
+    {
+        int index = element.IndexOf(attributePrefix, StringComparison.Ordinal);
+
+        if (index == -1) { return null; }
+
+        index += attributePrefix.Length;
+        int endIndex = element[index..].IndexOf('"');
+
+        return endIndex != -1 ? new string(element.Slice(index, endIndex)) : null;
+    }
+
+    private static TemplateMetadata Parse(ReadOnlySpan<char> template)
+    {
+        List<(string name, string outType)> elements = [];
+        HashSet<string> lengthProviderNames = new(StringComparer.OrdinalIgnoreCase);
+
+        ReadOnlySpan<char> dataTag = "<data";
+        ReadOnlySpan<char> nameAttr = "name=\"";
+        ReadOnlySpan<char> outTypeAttr = "outType=\"";
+        ReadOnlySpan<char> lengthAttr = "length=\"";
+
+        int searchStart = 0;
+
+        while (searchStart < template.Length)
+        {
+            int dataIndex = template[searchStart..].IndexOf(dataTag, StringComparison.OrdinalIgnoreCase);
+
+            if (dataIndex == -1) { break; }
+
+            dataIndex += searchStart;
+
+            // Verify the character after "<data" is whitespace, '/', or '>'
+            // to avoid matching tags like "<dataSource"
+            int nextCharIndex = dataIndex + dataTag.Length;
+
+            if (nextCharIndex < template.Length)
+            {
+                char next = template[nextCharIndex];
+
+                if (next != ' ' && next != '\t' && next != '\r' && next != '\n' && next != '/' && next != '>')
+                {
+                    searchStart = nextCharIndex;
+
+                    continue;
+                }
+            }
+
+            int elementEnd = template[dataIndex..].IndexOf("/>");
+
+            if (elementEnd == -1)
+            {
+                elementEnd = template[dataIndex..].IndexOf('>');
+            }
+
+            if (elementEnd == -1) { break; }
+
+            elementEnd += dataIndex;
+
+            ReadOnlySpan<char> element = template[dataIndex..elementEnd];
+
+            string name = ExtractAttribute(element, nameAttr) ?? string.Empty;
+            string outType = ExtractAttribute(element, outTypeAttr) ?? string.Empty;
+            elements.Add((name, outType));
+
+            string? lengthRef = ExtractAttribute(element, lengthAttr);
+
+            if (lengthRef is not null)
+            {
+                lengthProviderNames.Add(lengthRef);
+            }
+
+            searchStart = elementEnd + 1;
+        }
+
+        return BuildMetadata(elements, lengthProviderNames);
+    }
+}

--- a/src/EventLogExpert.Eventing/Resolvers/TemplateAnalyzer.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/TemplateAnalyzer.cs
@@ -65,8 +65,8 @@ internal sealed class TemplateAnalyzer
     ///     version.
     /// </summary>
     /// <remarks>
-    ///     Preserves the exact semantics of the original DoesTemplateApproximatelyMatchPropertyCount, including the
-    ///     sequential fallback: visible-count first, falling back to all-node count ONLY when the visible count is zero.
+    ///     Uses sequential fallback — visible-only count first, falling back to the all-node count ONLY when the visible
+    ///     count is zero.
     /// </remarks>
     public bool ApproximatelyMatchesPropertyCount(ReadOnlySpan<char> template, int eventPropertyCount)
     {
@@ -89,7 +89,10 @@ internal sealed class TemplateAnalyzer
     ///     count or the visible-only count is accepted to handle providers that include or omit length-provider fields in
     ///     their property output.
     /// </summary>
-    /// <remarks>Preserves the exact semantics of the original DoesTemplateMatchPropertyCount.</remarks>
+    /// <remarks>
+    ///     Accepts either the full data-node count or the visible-only count, since EvtRender output may include or omit
+    ///     length-provider fields depending on provider.
+    /// </remarks>
     public bool MatchesPropertyCount(ReadOnlySpan<char> template, int eventPropertyCount)
     {
         if (template.IsEmpty) { return false; }
@@ -105,7 +108,10 @@ internal sealed class TemplateAnalyzer
     ///     Strict variant of <see cref="MatchesPropertyCount" /> — accepts an empty template only when the event has zero
     ///     properties (which is the shape some providers emit for full-RawId entries with no EventData section).
     /// </summary>
-    /// <remarks>Preserves the exact semantics of the original DoesTemplateStrictlyMatchPropertyCount.</remarks>
+    /// <remarks>
+    ///     Stricter than <see cref="MatchesPropertyCount" />: an empty template is accepted ONLY when the event has zero
+    ///     properties (which is the shape some providers emit for full-RawId entries with no EventData section).
+    /// </remarks>
     public bool StrictlyMatchesPropertyCount(ReadOnlySpan<char> template, int eventPropertyCount)
     {
         if (template.IsEmpty) { return eventPropertyCount == 0; }

--- a/src/EventLogExpert.Eventing/Resolvers/TemplateMetadata.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/TemplateMetadata.cs
@@ -1,0 +1,28 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Collections.Immutable;
+
+namespace EventLogExpert.Eventing.Resolvers;
+
+/// <summary>
+///     Immutable metadata for a Windows event manifest template, derived by <see cref="TemplateAnalyzer.Analyze" />
+///     in a single parse pass and cached per template string.
+/// </summary>
+/// <param name="VisiblePropertyCount">
+///     Count of template &lt;data&gt; nodes Windows surfaces as separate user properties
+///     through EvtRender. Excludes length-provider nodes that Windows consumes internally to size a sibling binary-data
+///     node.
+/// </param>
+/// <param name="AllOutTypes">
+///     The outType attribute string for every &lt;data&gt; node in the template, in document order.
+///     Empty string when a node has no outType attribute.
+/// </param>
+/// <param name="VisibleOutTypes">
+///     The outType attribute strings restricted to the visible nodes (length-provider nodes
+///     filtered out), in document order. Equals <paramref name="AllOutTypes" /> when no length-provider nodes are present.
+/// </param>
+internal readonly record struct TemplateMetadata(
+    int VisiblePropertyCount,
+    ImmutableArray<string> AllOutTypes,
+    ImmutableArray<string> VisibleOutTypes);

--- a/src/EventLogExpert.Provider.Database/Context/ProviderDbContext.cs
+++ b/src/EventLogExpert.Provider.Database/Context/ProviderDbContext.cs
@@ -266,7 +266,7 @@ public sealed class ProviderDbContext : DbContext, IProviderDetailsLookup
 
         modelBuilder.Entity<ProviderDetails>()
             .Property(e => e.Parameters)
-            .HasConversion<CompressedJsonValueConverter<IEnumerable<MessageModel>>>();
+            .HasConversion<CompressedJsonValueConverter<IReadOnlyList<MessageModel>>>();
 
         modelBuilder.Entity<ProviderDetails>()
             .Property(e => e.Events)

--- a/src/EventLogExpert.Provider.Database/Serialization/ProviderJsonContext.cs
+++ b/src/EventLogExpert.Provider.Database/Serialization/ProviderJsonContext.cs
@@ -10,7 +10,6 @@ namespace EventLogExpert.ProviderDatabase.Serialization;
 [JsonSerializable(typeof(MessageModel))]
 [JsonSerializable(typeof(EventModel))]
 [JsonSerializable(typeof(IReadOnlyList<MessageModel>))]
-[JsonSerializable(typeof(IEnumerable<MessageModel>))]
 [JsonSerializable(typeof(IReadOnlyList<EventModel>))]
 [JsonSerializable(typeof(IDictionary<long, string>))]
 [JsonSerializable(typeof(IDictionary<int, string>))]

--- a/src/EventLogExpert.Provider/Resolution/ProviderDetails.cs
+++ b/src/EventLogExpert.Provider/Resolution/ProviderDetails.cs
@@ -89,9 +89,8 @@ public sealed class ProviderDetails
     }
 
     /// <summary>
-    ///     Gets the first parameter message with the given RawId using a pre-built lookup dictionary. Returns null when
-    ///     no parameter matches. Duplicate RawIds resolve first-wins, matching the prior <c>FirstOrDefault</c> behavior on the
-    ///     <see cref="Parameters" /> list.
+    ///     Gets the first parameter message with the given RawId, or null when none matches. Duplicate RawIds resolve
+    ///     first-wins.
     /// </summary>
     public MessageModel? GetParameterByRawId(long rawId)
     {

--- a/src/EventLogExpert.Provider/Resolution/ProviderDetails.cs
+++ b/src/EventLogExpert.Provider/Resolution/ProviderDetails.cs
@@ -92,7 +92,7 @@ public sealed class ProviderDetails
     ///     Gets the first parameter message with the given RawId, or null when none matches. Duplicate RawIds resolve
     ///     first-wins.
     /// </summary>
-    public MessageModel? GetParameterByRawId(long rawId)
+    internal MessageModel? GetParameterByRawId(long rawId)
     {
         _parametersByRawIdLookup ??= BuildParametersByRawIdLookup();
 

--- a/src/EventLogExpert.Provider/Resolution/ProviderDetails.cs
+++ b/src/EventLogExpert.Provider/Resolution/ProviderDetails.cs
@@ -7,8 +7,11 @@ public sealed class ProviderDetails
 {
     private IReadOnlyList<EventModel> _events = [];
     private Dictionary<long, List<EventModel>>? _eventsByIdLookup;
+    private Func<long, MessageModel?>? _getParameterByRawIdDelegate;
     private IReadOnlyList<MessageModel> _messages = [];
     private Dictionary<int, List<MessageModel>>? _messagesByShortIdLookup;
+    private IReadOnlyList<MessageModel> _parameters = [];
+    private Dictionary<long, MessageModel>? _parametersByRawIdLookup;
 
     /// <summary>Events and related items from modern provider</summary>
     public IReadOnlyList<EventModel> Events
@@ -46,13 +49,25 @@ public sealed class ProviderDetails
     public IDictionary<int, string> Opcodes { get; set; } = new Dictionary<int, string>();
 
     /// <summary>Parameter strings from legacy provider</summary>
-    public IReadOnlyList<MessageModel> Parameters { get; set; } = [];
+    public IReadOnlyList<MessageModel> Parameters
+    {
+        get => _parameters;
+        set
+        {
+            _parameters = value;
+            _parametersByRawIdLookup = null;
+            _getParameterByRawIdDelegate = null;
+        }
+    }
 
     public string ProviderName { get; set; } = string.Empty;
 
     public string? ResolvedFromOwningPublisher { get; set; }
 
     public IDictionary<int, string> Tasks { get; set; } = new Dictionary<int, string>();
+
+    internal Func<long, MessageModel?> GetParameterByRawIdDelegate =>
+        _getParameterByRawIdDelegate ??= GetParameterByRawId;
 
     /// <summary>Gets events matching the given Id using a pre-built lookup dictionary.</summary>
     public IReadOnlyList<EventModel> GetEventsById(long id)
@@ -71,6 +86,18 @@ public sealed class ProviderDetails
         _messagesByShortIdLookup ??= BuildMessagesByShortIdLookup();
 
         return _messagesByShortIdLookup.TryGetValue(shortId, out var list) ? list : [];
+    }
+
+    /// <summary>
+    ///     Gets the first parameter message with the given RawId using a pre-built lookup dictionary. Returns null when
+    ///     no parameter matches. Duplicate RawIds resolve first-wins, matching the prior <c>FirstOrDefault</c> behavior on the
+    ///     <see cref="Parameters" /> list.
+    /// </summary>
+    public MessageModel? GetParameterByRawId(long rawId)
+    {
+        _parametersByRawIdLookup ??= BuildParametersByRawIdLookup();
+
+        return _parametersByRawIdLookup.GetValueOrDefault(rawId);
     }
 
     private Dictionary<long, List<EventModel>> BuildEventsByIdLookup()
@@ -108,6 +135,18 @@ public sealed class ProviderDetails
             }
 
             list.Add(m);
+        }
+
+        return lookup;
+    }
+
+    private Dictionary<long, MessageModel> BuildParametersByRawIdLookup()
+    {
+        var lookup = new Dictionary<long, MessageModel>(_parameters.Count);
+
+        foreach (var p in _parameters)
+        {
+            lookup.TryAdd(p.RawId, p);
         }
 
         return lookup;

--- a/src/EventLogExpert.Provider/Resolution/ProviderDetails.cs
+++ b/src/EventLogExpert.Provider/Resolution/ProviderDetails.cs
@@ -27,7 +27,7 @@ public sealed class ProviderDetails
         Keywords.Count == 0 &&
         Opcodes.Count == 0 &&
         Tasks.Count == 0 &&
-        !Parameters.Any() &&
+        Parameters.Count == 0 &&
         ResolvedFromOwningPublisher is null;
 
     public IDictionary<long, string> Keywords { get; set; } = new Dictionary<long, string>();
@@ -46,7 +46,7 @@ public sealed class ProviderDetails
     public IDictionary<int, string> Opcodes { get; set; } = new Dictionary<int, string>();
 
     /// <summary>Parameter strings from legacy provider</summary>
-    public IEnumerable<MessageModel> Parameters { get; set; } = [];
+    public IReadOnlyList<MessageModel> Parameters { get; set; } = [];
 
     public string ProviderName { get; set; } = string.Empty;
 

--- a/src/EventLogExpert.Provider/Resolution/ProviderDetails.cs
+++ b/src/EventLogExpert.Provider/Resolution/ProviderDetails.cs
@@ -7,7 +7,6 @@ public sealed class ProviderDetails
 {
     private IReadOnlyList<EventModel> _events = [];
     private Dictionary<long, List<EventModel>>? _eventsByIdLookup;
-    private Func<long, MessageModel?>? _getParameterByRawIdDelegate;
     private IReadOnlyList<MessageModel> _messages = [];
     private Dictionary<int, List<MessageModel>>? _messagesByShortIdLookup;
     private IReadOnlyList<MessageModel> _parameters = [];
@@ -56,7 +55,6 @@ public sealed class ProviderDetails
         {
             _parameters = value;
             _parametersByRawIdLookup = null;
-            _getParameterByRawIdDelegate = null;
         }
     }
 
@@ -65,9 +63,6 @@ public sealed class ProviderDetails
     public string? ResolvedFromOwningPublisher { get; set; }
 
     public IDictionary<int, string> Tasks { get; set; } = new Dictionary<int, string>();
-
-    internal Func<long, MessageModel?> GetParameterByRawIdDelegate =>
-        _getParameterByRawIdDelegate ??= GetParameterByRawId;
 
     /// <summary>Gets events matching the given Id using a pre-built lookup dictionary.</summary>
     public IReadOnlyList<EventModel> GetEventsById(long id)
@@ -92,7 +87,7 @@ public sealed class ProviderDetails
     ///     Gets the first parameter message with the given RawId, or null when none matches. Duplicate RawIds resolve
     ///     first-wins.
     /// </summary>
-    internal MessageModel? GetParameterByRawId(long rawId)
+    public MessageModel? GetParameterByRawId(long rawId)
     {
         _parametersByRawIdLookup ??= BuildParametersByRawIdLookup();
 

--- a/tests/Integration/EventLogExpert.Provider.Database.IntegrationTests/Context/ProviderDbContextTests.cs
+++ b/tests/Integration/EventLogExpert.Provider.Database.IntegrationTests/Context/ProviderDbContextTests.cs
@@ -669,9 +669,9 @@ public sealed class ProviderDbContextTests : IDisposable
         using (var context = new ProviderDbContext(dbPath, true))
         {
             var retrieved = context.ProviderDetails.First(p => p.ProviderName == "ComplexProvider");
-            Assert.Equal(3, retrieved.Messages.Count());
-            Assert.Equal(2, retrieved.Parameters.Count());
-            Assert.Equal(2, retrieved.Events.Count());
+            Assert.Equal(3, retrieved.Messages.Count);
+            Assert.Equal(2, retrieved.Parameters.Count);
+            Assert.Equal(2, retrieved.Events.Count);
             Assert.Equal(3, retrieved.Keywords.Count);
             Assert.Equal(2, retrieved.Opcodes.Count);
             Assert.Equal(3, retrieved.Tasks.Count);
@@ -1153,7 +1153,7 @@ public sealed class ProviderDbContextTests : IDisposable
             CompressedJsonValueConverter<IReadOnlyList<MessageModel>>.ConvertToCompressedJson(details.Messages));
 
         cmd.Parameters.AddWithValue("$parameters",
-            CompressedJsonValueConverter<IEnumerable<MessageModel>>.ConvertToCompressedJson(details.Parameters));
+            CompressedJsonValueConverter<IReadOnlyList<MessageModel>>.ConvertToCompressedJson(details.Parameters));
 
         cmd.Parameters.AddWithValue("$events",
             CompressedJsonValueConverter<IReadOnlyList<EventModel>>.ConvertToCompressedJson(details.Events));

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Resolvers/EventResolverBaseTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Resolvers/EventResolverBaseTests.cs
@@ -255,7 +255,7 @@ public sealed class EventResolverBaseTests
     {
         // Arrange - regression for the cross-issue case: when primary has ambiguous legacy
         // messages AND supplemental is loaded for the description fallback, supplemental's
-        // task and keyword metadata must also be visible to ResolveTaskName / GetKeywordsFromBitmask.
+        // task and keyword metadata must also be visible to the task / keyword resolution path.
         var primaryDetails = new ProviderDetails
         {
             ProviderName = Constants.TestProviderName,
@@ -1700,7 +1700,7 @@ public sealed class EventResolverBaseTests
         // The classic-emitted event has Qualifiers=0x4001 and EventID=24577 (=0x6001), but
         // the modern manifest stores it under the full 32-bit RawId (0x4001 << 16) | 0x6001
         // = 0x40016001 (1073831937). GetEventsById(24577) returns nothing, so the short-cast
-        // fallback in GetModernEvent is the only path that can match. The manifest entry has
+        // fallback in the modern-event matcher is the only path that can match. The manifest entry has
         // an empty Template and the event carries no EventData properties — the fallback's
         // template gate must accept that combination.
         var providerDetails = new ProviderDetails

--- a/tests/Unit/EventLogExpert.Provider.Database.Tests/Serialization/ProviderJsonContextTests.cs
+++ b/tests/Unit/EventLogExpert.Provider.Database.Tests/Serialization/ProviderJsonContextTests.cs
@@ -13,7 +13,6 @@ public sealed class ProviderJsonContextTests
         typeof(MessageModel),
         typeof(EventModel),
         typeof(IReadOnlyList<MessageModel>),
-        typeof(IEnumerable<MessageModel>),
         typeof(IReadOnlyList<EventModel>),
         typeof(IDictionary<long, string>),
         typeof(IDictionary<int, string>),

--- a/tests/Unit/EventLogExpert.Provider.Tests/Resolution/ProviderDetailsTests.cs
+++ b/tests/Unit/EventLogExpert.Provider.Tests/Resolution/ProviderDetailsTests.cs
@@ -133,6 +133,32 @@ public sealed class ProviderDetailsTests
     }
 
     [Fact]
+    public void GetParameterByRawId_WhenDuplicateRawIds_ReturnsFirstWinningMatch()
+    {
+        var details = EventUtils.CreateProvider(Constants.TestProviderLongName);
+        details.Parameters =
+        [
+            new MessageModel { RawId = 42, Text = "first", Tag = "A" },
+            new MessageModel { RawId = 42, Text = "second", Tag = "B" }
+        ];
+
+        var match = details.GetParameterByRawId(42);
+
+        Assert.NotNull(match);
+        Assert.Equal("first", match.Text);
+        Assert.Equal("A", match.Tag);
+    }
+
+    [Fact]
+    public void GetParameterByRawId_WhenRawIdDoesNotExist_ReturnsNull()
+    {
+        var details = EventUtils.CreateProvider(Constants.TestProviderLongName);
+        details.Parameters = [new MessageModel { RawId = 1, Text = "only" }];
+
+        Assert.Null(details.GetParameterByRawId(999));
+    }
+
+    [Fact]
     public void IsEmpty_WhenAllCollectionsEmptyAndNoFallback_ReturnsTrue()
     {
         // Arrange
@@ -239,5 +265,24 @@ public sealed class ProviderDetailsTests
         // Assert — old ShortId no longer found, new ShortId found
         Assert.Empty(details.GetMessagesByShortId(1));
         Assert.Single(details.GetMessagesByShortId(2));
+    }
+
+    [Fact]
+    public void ParametersSetter_InvalidatesCachedLookup()
+    {
+        var details = EventUtils.CreateProvider(Constants.TestProviderLongName);
+        details.Parameters = [new MessageModel { RawId = 1, Text = "original" }];
+
+        var beforeReplace = details.GetParameterByRawId(1);
+        Assert.NotNull(beforeReplace);
+        Assert.Equal("original", beforeReplace.Text);
+
+        details.Parameters = [new MessageModel { RawId = 2, Text = "replaced" }];
+
+        Assert.Null(details.GetParameterByRawId(1));
+
+        var replaced = details.GetParameterByRawId(2);
+        Assert.NotNull(replaced);
+        Assert.Equal("replaced", replaced.Text);
     }
 }


### PR DESCRIPTION
## Summary

Closes #539. Decomposes the 1409-LOC `EventResolverBase` into a thin 145-LOC coordinator plus 4 sealed-internal helpers, then applies the perf optimizations from the same audit.

## Decomposition

| Helper | Responsibility | LOC |
|---|---|---|
| `TemplateAnalyzer` | XML template parsing + cached metadata | ~246 |
| `TaskKeywordResolver` | Task/keyword resolution from provider tables | ~205 |
| `ModernEventMatcher` | Modern event matching + legacy disambiguation | ~268 |
| `DescriptionFormatter` | Description text production + parameter substitution | ~610 |

`EventResolverBase` becomes pure composition + orchestration; all 4 helpers are `sealed internal` and **composed within the constructor** (consistent with sibling coordinators in this codebase like `EventResolver` which `new`s `EventMessageProvider` inline — not formal DI, since the helpers are `internal sealed` and not mocked through interfaces). `SeverityFormatter` moves from `Resolvers/` to `Common/Events/` to co-locate with `SeverityLevel`. One new **public** method (`ProviderDetails.GetParameterByRawId`) added for O(1) parameter lookup — `public` rather than `internal` because main's `f828a8ba` commit dropped the Provider→Eventing IVT while this PR was open; the visibility was widened during the post-review Sub-C adaptation (commit `7366b245`) to keep `DescriptionFormatter` consumption working without re-introducing the IVT.

## Performance optimizations

| Scenario | Before | After | Δ |
|---|---|---|---|
| `ResolveEvent` typical modern event (5 props, 10 Parameters, `%1`+`%%1` substitution) | 741.2 ns / 624 B | 709.3 ns / 536 B | −4.3% time, −14.1% allocs |
| `ResolveEvent` legacy ambiguous event (200 Parameters, 4 `%%N` tokens at tail positions 197-200) | 308.0 ns / 448 B | 288.5 ns / 448 B | −6.3% time |
| Long-haul 100k unique events (no cache `ClearAll` mid-run) | 215 ms / 65.79 MB / cache count 100,000 | 102.7 ms / 54.94 MB / cache count **0** | **−52% wall-clock, −16.5% allocs, unbounded growth eliminated** |

**Measurement environment:** Windows 11 (10.0.26200.8457) Hyper-V VM, .NET 10.0.8 RyuJIT AVX2, BenchmarkDotNet 0.14.0 with `InProcessEmitToolchain`, default warmup + iteration count. Harness was a local throwaway project; deleted before commit.

After the post-review Sub-C adaptation, the per-event delegate allocation in the parameter-lookup pipeline went from ~80 B (cached delegate path) to **zero** (direct `ProviderDetails?` reference). The `%%`-precheck in `PickParameterSourceForDescription` also short-circuits the eager `_supplementalProvider(eventRecord)` invocation when no `%%N` substitution can fire — addresses Copilot's lazy-supplemental review concern.

## Audit findings closed

- O(1) hex-type lookup via `FrozenSet`
- O(1) parameter lookup via `ProviderDetails.GetParameterByRawId` (replaces O(N) `FirstOrDefault` scan)
- Unified template parser (3 parsers consolidated into 1)
- Description cache cardinality split — only canned defaults + template-only outputs interned; substituted descriptions return directly (eliminates unbounded growth in long-running sessions)
- 1409 → 145 LOC composition decomposition of `EventResolverBase`
- `ProviderDetails.Parameters` typed as `IReadOnlyList<MessageModel>` for `.Count`-friendly hot-path checks
- Pre-sized lists in hot paths (avoid resize allocations)
- Avoided property-value boxing in formatted output
- `StringBuilder` → `string.Create` for event-data-tail composition
- `SeverityFormatter` co-located with `SeverityLevel` enum

## Behavioral changes worth calling out

- `EventResolverCache._descriptionCache` no longer accumulates per-event substituted descriptions. The cache continues to intern low-cardinality outputs (template-only `FormatDescription` returns, Win32 `FormatSystemMessage` strings, default constants).
- `ProviderDetails.Parameters` setter now invalidates a lazy lookup dictionary (mirrors the existing `Events`/`Messages` pattern).
- `SeverityFormatter` tightened from `public` to `internal` (sole consumer was always same-asm `EventResolverBase`).
- `ProviderDetails.GetParameterByRawId` is **public** (not `internal`) — see Decomposition section above for the IVT-related rationale.

## Tests

All 3052 unit tests pass (DatabaseTools 16 + EventDbTool 3 + Eventing 230 + Filtering 872 + Logging 7 + Provider.Database 42 + Provider 38 [3 new] + Runtime 1166 + UI 635 + Windows 43). Integration tests skipped — require `EVENTLOG_CONTAINER` env var.

3 new tests pin the `ProviderDetails` parameter-lookup contract: setter invalidation, missing-key null return, duplicate-`RawId` first-wins.

## Commits

12 commits structured for reviewer-friendly bisect (extract → co-locate → perf → cleanup → post-review adaptation). Each commit individually compiles and passes unit tests.

## Post-review iterations

- **Rebased onto main** after a 53-commit advance that included Provider/Models → Provider/Resolution restructure and Provider→Eventing IVT drop (commits `f828a8ba`, `8c1378af`). Two real merge conflicts resolved (using-directive in `EventResolverBase`, `Assert.Throws` style in integration test). Auto-merged files preserved all C1 perf changes (IReadOnlyList, `.Count`, EF Core converter type).
- **Sub-C adaptation (`7366b245`)** — switched parameter-lookup pipeline from `Func<long, MessageModel?>` to direct `ProviderDetails? parameterSource`. Made `GetParameterByRawId` public (necessary because the rebase pulled main's IVT-drop). Added `%%`-precheck short-circuit that skips eager supplemental load when no substitution will fire — addresses Copilot's lazy-supplemental review concern at the source.
- **Doc refresh (`4a2fd7aa`)** — `DescriptionFormatter` class-level `<remarks>` updated to match post-adaptation design (drops stale `ModernEventMatcher` injection claim, renames helper reference).
