### PR TITLE
Cache current release notes and auto-enable prerelease channel

### DIFF
--- a/src/EventLogExpert.Runtime/Settings/ISettingsPreferencesProvider.cs
+++ b/src/EventLogExpert.Runtime/Settings/ISettingsPreferencesProvider.cs
@@ -8,6 +8,8 @@ namespace EventLogExpert.Runtime.Settings;
 
 public interface ISettingsPreferencesProvider
 {
+    bool HasEverEnabledPreReleasePreference { get; set; }
+
     EventCopyFormat KeyboardCopyFormatPreference { get; set; }
 
     LogLevel LogLevelPreference { get; set; }

--- a/src/EventLogExpert.Runtime/Settings/ISettingsService.cs
+++ b/src/EventLogExpert.Runtime/Settings/ISettingsService.cs
@@ -12,6 +12,8 @@ public interface ISettingsService
 
     Action? CopyFormatChanged { get; set; }
 
+    bool HasEverEnabledPreRelease { get; }
+
     bool IsPreReleaseEnabled { get; set; }
 
     LogLevel LogLevel { get; set; }

--- a/src/EventLogExpert.Runtime/Settings/SettingsService.cs
+++ b/src/EventLogExpert.Runtime/Settings/SettingsService.cs
@@ -11,6 +11,7 @@ internal sealed class SettingsService(ISettingsPreferencesProvider preferences) 
     private readonly ISettingsPreferencesProvider _preferences = preferences;
 
     private EventCopyFormat? _copyFormat;
+    private bool? _hasEverEnabledPreRelease;
     private bool? _isPreReleaseEnabled;
     private LogLevel? _logLevel;
     private Theme? _theme;
@@ -36,13 +37,37 @@ internal sealed class SettingsService(ISettingsPreferencesProvider preferences) 
 
     public Action? CopyFormatChanged { get; set; }
 
+    public bool HasEverEnabledPreRelease
+    {
+        get
+        {
+            _hasEverEnabledPreRelease ??= _preferences.HasEverEnabledPreReleasePreference;
+
+            return _hasEverEnabledPreRelease ?? false;
+        }
+        private set
+        {
+            if (_hasEverEnabledPreRelease == value) { return; }
+
+            _hasEverEnabledPreRelease = value;
+            _preferences.HasEverEnabledPreReleasePreference = value;
+        }
+    }
+
     public bool IsPreReleaseEnabled
     {
         get
         {
             _isPreReleaseEnabled ??= _preferences.PreReleasePreference;
 
-            return _isPreReleaseEnabled ?? false;
+            var enabled = _isPreReleaseEnabled ?? false;
+
+            if (enabled && !HasEverEnabledPreRelease)
+            {
+                HasEverEnabledPreRelease = true;
+            }
+
+            return enabled;
         }
         set
         {
@@ -50,6 +75,11 @@ internal sealed class SettingsService(ISettingsPreferencesProvider preferences) 
 
             _isPreReleaseEnabled = value;
             _preferences.PreReleasePreference = value;
+
+            if (value && !HasEverEnabledPreRelease)
+            {
+                HasEverEnabledPreRelease = true;
+            }
         }
     }
 

--- a/src/EventLogExpert.Runtime/Update/UpdateService.cs
+++ b/src/EventLogExpert.Runtime/Update/UpdateService.cs
@@ -5,6 +5,7 @@ using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Runtime.Alerts;
 using EventLogExpert.Runtime.Common.AppTitle;
 using EventLogExpert.Runtime.Common.Versioning;
+using EventLogExpert.Runtime.Settings;
 using EventLogExpert.Runtime.Update.Deployment;
 using EventLogExpert.Runtime.Update.ReleaseNotes;
 
@@ -16,7 +17,8 @@ internal sealed class UpdateService(
     IGitHubService githubService,
     IDeploymentService deploymentService,
     ITraceLogger traceLogger,
-    IAlertDialogService alertDialogService) : IUpdateService
+    IAlertDialogService alertDialogService,
+    ISettingsService settings) : IUpdateService
 {
     private string? _currentRawChanges;
     private int _hasAutoChecked;
@@ -51,8 +53,6 @@ internal sealed class UpdateService(
 
         try
         {
-            // Versions are based on current DateTime so this is safer than dealing with
-            // stripping the v off the Version for every release
             GitHubRelease[] releases = [.. (await githubService.GetReleases()).OrderByDescending(x => x.ReleaseDate)];
 
             if (releases.Length <= 0)
@@ -62,36 +62,75 @@ internal sealed class UpdateService(
 
             traceLogger.Debug($"{nameof(CheckForUpdates)} Found the following releases:");
 
+            GitHubRelease? currentRelease = null;
+
             foreach (var release in releases)
             {
                 traceLogger.Debug($"{nameof(CheckForUpdates)}   Version: {release.Version} " +
                     $"ReleaseDate: {release.ReleaseDate} IsPreRelease: {release.IsPreRelease}");
 
-                if (!usePreRelease && release.IsPreRelease) { continue; }
-
-                // Need to drop the v off the version number provided by GitHub
-                if (versionProvider.CurrentVersion.CompareTo(new Version(release.Version.TrimStart('v'))) != 0)
+                if (!Version.TryParse(release.Version.TrimStart('v'), out var releaseVersion))
                 {
-                    latest = release;
+                    traceLogger.Warning($"{nameof(CheckForUpdates)} skipping release with unparseable version: {release.Version}");
+
+                    continue;
+                }
+
+                if (versionProvider.CurrentVersion.CompareTo(releaseVersion) == 0)
+                {
+                    currentRelease = release;
 
                     break;
                 }
+            }
 
-                _currentRawChanges = release.RawChanges;
+            bool effectiveUsePreRelease = usePreRelease;
 
-                if (release.IsPreRelease)
+            if (currentRelease is { } current)
+            {
+                _currentRawChanges = current.RawChanges;
+
+                if (current.IsPreRelease)
                 {
                     appTitleService.SetIsPrerelease(true);
-                }
 
-                if (userInitiated)
+                    if (settings is { IsPreReleaseEnabled: false, HasEverEnabledPreRelease: false })
+                    {
+                        settings.IsPreReleaseEnabled = true;
+                        effectiveUsePreRelease = true;
+
+                        traceLogger.Debug($"{nameof(CheckForUpdates)} auto-enabled IsPreReleaseEnabled " +
+                            $"(running prerelease {current.Version}).");
+                    }
+                }
+            }
+
+            foreach (var release in releases)
+            {
+                if (!effectiveUsePreRelease && release.IsPreRelease) { continue; }
+
+                if (!Version.TryParse(release.Version.TrimStart('v'), out var releaseVersion))
                 {
-                    await alertDialogService.ShowAlert("No Updates Available",
-                        "You are currently running the latest version.",
-                        "OK");
+                    continue;
                 }
 
-                return;
+                if (versionProvider.CurrentVersion.CompareTo(releaseVersion) != 0)
+                {
+                    latest = release;
+                }
+                else
+                {
+                    if (userInitiated)
+                    {
+                        await alertDialogService.ShowAlert("No Updates Available",
+                            "You are currently running the latest version.",
+                            "OK");
+                    }
+
+                    return;
+                }
+
+                break;
             }
 
             if (!latest.HasValue)

--- a/src/EventLogExpert/Adapters/Settings/SettingsPreferencesAdapter.cs
+++ b/src/EventLogExpert/Adapters/Settings/SettingsPreferencesAdapter.cs
@@ -9,11 +9,18 @@ namespace EventLogExpert.Adapters.Settings;
 
 internal sealed class SettingsPreferencesAdapter : ISettingsPreferencesProvider
 {
+    private const string HasEverEnabledPreRelease = "has-ever-enabled-prerelease";
     private const string KeyboardCopyFormat = "keyboard-copy-format";
     private const string LoggingLevel = "logging-level";
     private const string PreReleaseEnabled = "prerelease-enabled";
     private const string ThemeName = "theme";
     private const string TimeZone = "timezone";
+
+    public bool HasEverEnabledPreReleasePreference
+    {
+        get => Preferences.Default.Get(HasEverEnabledPreRelease, false);
+        set => Preferences.Default.Set(HasEverEnabledPreRelease, value);
+    }
 
     public EventCopyFormat KeyboardCopyFormatPreference
     {

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Settings/SettingsServiceTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Settings/SettingsServiceTests.cs
@@ -174,6 +174,55 @@ public sealed class SettingsServiceTests
     }
 
     [Fact]
+    public void HasEverEnabledPreRelease_WhenAccessedMultipleTimes_ShouldCacheValue()
+    {
+        // Arrange
+        var mockPreferences = Substitute.For<ISettingsPreferencesProvider>();
+        mockPreferences.HasEverEnabledPreReleasePreference.Returns(true);
+
+        var settingsService = CreateSettingsService(mockPreferences);
+
+        // Act
+        _ = settingsService.HasEverEnabledPreRelease;
+        _ = settingsService.HasEverEnabledPreRelease;
+        _ = settingsService.HasEverEnabledPreRelease;
+
+        // Assert
+        _ = mockPreferences.Received(1).HasEverEnabledPreReleasePreference;
+    }
+
+    [Fact]
+    public void HasEverEnabledPreRelease_WhenFirstAccessed_ShouldReturnFromPreferences()
+    {
+        // Arrange
+        var mockPreferences = Substitute.For<ISettingsPreferencesProvider>();
+        mockPreferences.HasEverEnabledPreReleasePreference.Returns(true);
+
+        var settingsService = CreateSettingsService(mockPreferences);
+
+        // Act
+        var result = settingsService.HasEverEnabledPreRelease;
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void HasEverEnabledPreRelease_WhenPreferenceIsDefault_ShouldReturnFalse()
+    {
+        // Arrange
+        var mockPreferences = Substitute.For<ISettingsPreferencesProvider>();
+
+        var settingsService = CreateSettingsService(mockPreferences);
+
+        // Act
+        var result = settingsService.HasEverEnabledPreRelease;
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
     public void IsPreReleaseEnabled_WhenAccessedMultipleTimes_ShouldCacheValue()
     {
         // Arrange
@@ -223,6 +272,24 @@ public sealed class SettingsServiceTests
     }
 
     [Fact]
+    public void IsPreReleaseEnabled_WhenReadAsTrueAndStickyNotSet_ShouldCascadeStickyBit()
+    {
+        // Arrange
+        var mockPreferences = Substitute.For<ISettingsPreferencesProvider>();
+        mockPreferences.PreReleasePreference.Returns(true);
+        mockPreferences.HasEverEnabledPreReleasePreference.Returns(false);
+
+        var settingsService = CreateSettingsService(mockPreferences);
+
+        // Act
+        var result = settingsService.IsPreReleaseEnabled;
+
+        // Assert
+        Assert.True(result);
+        mockPreferences.Received(1).HasEverEnabledPreReleasePreference = true;
+    }
+
+    [Fact]
     public void IsPreReleaseEnabled_WhenSet_ShouldUpdatePreferences()
     {
         // Arrange
@@ -234,6 +301,25 @@ public sealed class SettingsServiceTests
 
         // Assert
         mockPreferences.Received(1).PreReleasePreference = true;
+    }
+
+    [Fact]
+    public void IsPreReleaseEnabled_WhenSetToFalse_ShouldNotChangeStickyBit()
+    {
+        // Arrange
+        var mockPreferences = Substitute.For<ISettingsPreferencesProvider>();
+        mockPreferences.PreReleasePreference.Returns(true);
+
+        var settingsService = CreateSettingsService(mockPreferences);
+        _ = settingsService.IsPreReleaseEnabled; // Cache the value
+        mockPreferences.ClearReceivedCalls();
+
+        // Act
+        settingsService.IsPreReleaseEnabled = false;
+
+        // Assert
+        mockPreferences.Received(1).PreReleasePreference = false;
+        mockPreferences.DidNotReceive().HasEverEnabledPreReleasePreference = Arg.Any<bool>();
     }
 
     [Fact]
@@ -252,6 +338,40 @@ public sealed class SettingsServiceTests
 
         // Assert
         mockPreferences.DidNotReceive().PreReleasePreference = Arg.Any<bool>();
+    }
+
+    [Fact]
+    public void IsPreReleaseEnabled_WhenSetToTrueAndChannelPreviouslyEnabled_ShouldNotRewriteStickyBit()
+    {
+        // Arrange
+        var mockPreferences = Substitute.For<ISettingsPreferencesProvider>();
+        mockPreferences.HasEverEnabledPreReleasePreference.Returns(true);
+
+        var settingsService = CreateSettingsService(mockPreferences);
+        _ = settingsService.HasEverEnabledPreRelease; // Cache the value
+        mockPreferences.ClearReceivedCalls();
+
+        // Act
+        settingsService.IsPreReleaseEnabled = true;
+
+        // Assert
+        mockPreferences.Received(1).PreReleasePreference = true;
+        mockPreferences.DidNotReceive().HasEverEnabledPreReleasePreference = Arg.Any<bool>();
+    }
+
+    [Fact]
+    public void IsPreReleaseEnabled_WhenSetToTrueAndChannelNeverEnabled_ShouldCascadeStickyBit()
+    {
+        // Arrange
+        var mockPreferences = Substitute.For<ISettingsPreferencesProvider>();
+        var settingsService = CreateSettingsService(mockPreferences);
+
+        // Act
+        settingsService.IsPreReleaseEnabled = true;
+
+        // Assert
+        mockPreferences.Received(1).PreReleasePreference = true;
+        mockPreferences.Received(1).HasEverEnabledPreReleasePreference = true;
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Update/UpdateServiceTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Update/UpdateServiceTests.cs
@@ -2,9 +2,11 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Logging.Abstractions.Handlers;
 using EventLogExpert.Runtime.Alerts;
 using EventLogExpert.Runtime.Common.AppTitle;
 using EventLogExpert.Runtime.Common.Versioning;
+using EventLogExpert.Runtime.Settings;
 using EventLogExpert.Runtime.Tests.TestUtils;
 using EventLogExpert.Runtime.Tests.TestUtils.Constants;
 using EventLogExpert.Runtime.Update;
@@ -603,6 +605,138 @@ public sealed class UpdateServiceTests
     }
 
     [Fact]
+    public async Task CheckForUpdates_WhenMalformedReleaseVersion_ShouldSkipAndLogWarning()
+    {
+        // Arrange
+        var mockCurrentVersionProvider = Substitute.For<ICurrentVersionProvider>();
+        mockCurrentVersionProvider.CurrentVersion.Returns(new Version(Constants.AppInstalledVersion));
+        mockCurrentVersionProvider.IsDevBuild.Returns(false);
+
+        IEnumerable<GitHubRelease> releases =
+        [
+            new GitHubRelease
+            {
+                Version = "v23.1.alpha",
+                IsPreRelease = false,
+                ReleaseDate = DateTime.Now,
+                Assets =
+                [
+                    new GitHubReleaseAsset { Name = "EventLogExpert_alpha_x64.msix", Uri = "https://example/alpha.msix" }
+                ],
+                RawChanges = "malformed"
+            },
+            new GitHubRelease
+            {
+                Version = Constants.GitHubLatestVersion,
+                IsPreRelease = false,
+                ReleaseDate = DateTime.Now.AddDays(-1),
+                Assets =
+                [
+                    new GitHubReleaseAsset { Name = Constants.GitHubLatestName, Uri = Constants.GitHubLatestUri }
+                ],
+                RawChanges = Constants.GitHubReleaseNotes
+            }
+        ];
+
+        var mockGitHubService = Substitute.For<IGitHubService>();
+        mockGitHubService.GetReleases().Returns(Task.FromResult(releases));
+
+        var mockTraceLogger = Substitute.For<ITraceLogger>();
+        var mockDeploymentService = Substitute.For<IDeploymentService>();
+
+        var updateService = CreateUpdateService(
+            mockCurrentVersionProvider,
+            gitHubService: mockGitHubService,
+            deploymentService: mockDeploymentService,
+            traceLogger: mockTraceLogger);
+
+        // Act
+        await updateService.CheckForUpdates(usePreRelease: false);
+
+        // Assert
+        mockTraceLogger.Received().Warning(
+            Arg.Is<WarningLogHandler>(h => h.ToString().Contains("skipping release") && h.ToString().Contains("v23.1.alpha")));
+
+        mockDeploymentService.Received(1).UpdateOnNextRestart(Constants.GitHubLatestUri);
+    }
+
+    [Fact]
+    public async Task CheckForUpdates_WhenRunningPreReleaseAndChannelPreviouslyEnabledThenDisabled_ShouldPromptRollback()
+    {
+        // Arrange
+        var mockCurrentVersionProvider = Substitute.For<ICurrentVersionProvider>();
+        mockCurrentVersionProvider.CurrentVersion.Returns(new Version(Constants.GitHubPrereleaseVersion[1..]));
+        mockCurrentVersionProvider.IsDevBuild.Returns(false);
+
+        var mockGitHubService = Substitute.For<IGitHubService>();
+        mockGitHubService.GetReleases().Returns(Task.FromResult(GitHubUtils.CreateGitHubReleases()));
+
+        var mockAppTitleService = Substitute.For<IAppTitleService>();
+        var mockDeploymentService = Substitute.For<IDeploymentService>();
+
+        var mockSettings = Substitute.For<ISettingsService>();
+        mockSettings.IsPreReleaseEnabled.Returns(false);
+        mockSettings.HasEverEnabledPreRelease.Returns(true);
+
+        var updateService = CreateUpdateService(
+            mockCurrentVersionProvider,
+            appTitleService: mockAppTitleService,
+            gitHubService: mockGitHubService,
+            deploymentService: mockDeploymentService,
+            settings: mockSettings);
+
+        // Act
+        await updateService.CheckForUpdates(usePreRelease: false);
+
+        // Assert
+        mockAppTitleService.Received(1).SetIsPrerelease(true);
+        mockSettings.DidNotReceive().IsPreReleaseEnabled = Arg.Any<bool>();
+
+        mockDeploymentService.Received(1).UpdateOnNextRestart(Constants.GitHubLatestUri);
+    }
+
+    [Fact]
+    public async Task CheckForUpdates_WhenRunningPreReleaseAndChannelNeverEnabled_ShouldEnableChannelAndSuppressRollbackPrompt()
+    {
+        // Arrange
+        var mockCurrentVersionProvider = Substitute.For<ICurrentVersionProvider>();
+        mockCurrentVersionProvider.CurrentVersion.Returns(new Version(Constants.GitHubPrereleaseVersion[1..]));
+        mockCurrentVersionProvider.IsDevBuild.Returns(false);
+
+        var mockGitHubService = Substitute.For<IGitHubService>();
+        mockGitHubService.GetReleases().Returns(Task.FromResult(GitHubUtils.CreateGitHubReleases()));
+
+        var mockAppTitleService = Substitute.For<IAppTitleService>();
+        var mockAlertDialogService = Substitute.For<IAlertDialogService>();
+        var mockDeploymentService = Substitute.For<IDeploymentService>();
+
+        var mockSettings = Substitute.For<ISettingsService>();
+        mockSettings.IsPreReleaseEnabled.Returns(false);
+        mockSettings.HasEverEnabledPreRelease.Returns(false);
+
+        var updateService = CreateUpdateService(
+            mockCurrentVersionProvider,
+            appTitleService: mockAppTitleService,
+            gitHubService: mockGitHubService,
+            deploymentService: mockDeploymentService,
+            alertDialogService: mockAlertDialogService,
+            settings: mockSettings);
+
+        // Act
+        await updateService.CheckForUpdates(usePreRelease: false);
+
+        // Assert
+        mockAppTitleService.Received(1).SetIsPrerelease(true);
+        mockSettings.Received(1).IsPreReleaseEnabled = true;
+
+        await mockAlertDialogService.DidNotReceive()
+            .ShowAlert("Update Available", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>());
+
+        mockDeploymentService.DidNotReceive().UpdateOnNextRestart(Arg.Any<string>(), Arg.Any<bool>());
+        mockDeploymentService.DidNotReceive().RestartNowAndUpdate(Arg.Any<string>(), Arg.Any<bool>());
+    }
+
+    [Fact]
     public async Task GetReleaseNotes_NoCurrentChanges_ShouldShowFailureAlertAndReturnNull()
     {
         // Arrange
@@ -617,6 +751,74 @@ public sealed class UpdateServiceTests
         await mockAlertDialogService.Received(1)
             .ShowAlert(Arg.Is<string>(s => s.Contains("Release Notes")), Arg.Is<string>(s => s.Contains("Failed to get release notes")), "OK");
         Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetReleaseNotes_WhenRunningOlderThanLatest_ShouldReturnNotesForCurrentVersion()
+    {
+        // Arrange
+        const string currentRawChanges = "## Notes for v23.1.1.1\r\n\r\n* abcdef1234567890abcdef1234567890abcdef12 Bug fix for current version";
+        const string newerRawChanges = "## Notes for v23.1.1.2\r\n\r\n* 1234567890abcdef1234567890abcdef12345678 Feature A for newer version";
+
+        var mockCurrentVersionProvider = Substitute.For<ICurrentVersionProvider>();
+        mockCurrentVersionProvider.CurrentVersion.Returns(new Version(Constants.AppInstalledVersion));
+        mockCurrentVersionProvider.IsDevBuild.Returns(false);
+
+        IEnumerable<GitHubRelease> releases =
+        [
+            new GitHubRelease
+            {
+                Version = Constants.GitHubLatestVersion,
+                IsPreRelease = false,
+                ReleaseDate = DateTime.Now,
+                Assets =
+                [
+                    new GitHubReleaseAsset { Name = Constants.GitHubLatestName, Uri = Constants.GitHubLatestUri }
+                ],
+                RawChanges = newerRawChanges
+            },
+            new GitHubRelease
+            {
+                Version = "v" + Constants.AppInstalledVersion,
+                IsPreRelease = false,
+                ReleaseDate = DateTime.Now.AddDays(-1),
+                Assets =
+                [
+                    new GitHubReleaseAsset
+                    {
+                        Name = "EventLogExpert_23.1.1.1_x64.msix",
+                        Uri = "https://github.com/microsoft/EventLogExpert/releases/download/v23.1.1.1/EventLogExpert_23.1.1.1_x64.msix"
+                    }
+                ],
+                RawChanges = currentRawChanges
+            }
+        ];
+
+        var mockGitHubService = Substitute.For<IGitHubService>();
+        mockGitHubService.GetReleases().Returns(Task.FromResult(releases));
+
+        var mockAlertDialogService = Substitute.For<IAlertDialogService>();
+        mockAlertDialogService
+            .ShowAlert(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
+            .Returns(Task.FromResult(false));
+
+        var updateService = CreateUpdateService(
+            mockCurrentVersionProvider,
+            gitHubService: mockGitHubService,
+            alertDialogService: mockAlertDialogService);
+
+        // Act
+        await updateService.CheckForUpdates(usePreRelease: false);
+        var result = await updateService.GetReleaseNotes();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Contains(Constants.AppInstalledVersion, result.Value.Title);
+        Assert.Contains("Bug fix for current version", result.Value.Markdown);
+        Assert.DoesNotContain("Feature A for newer version", result.Value.Markdown);
+
+        await mockAlertDialogService.DidNotReceive()
+            .ShowAlert("Release Notes Failure", Arg.Any<string>(), "OK");
     }
 
     [Fact]
@@ -658,14 +860,22 @@ public sealed class UpdateServiceTests
         IGitHubService? gitHubService = null,
         IDeploymentService? deploymentService = null,
         ITraceLogger? traceLogger = null,
-        IAlertDialogService? alertDialogService = null)
+        IAlertDialogService? alertDialogService = null,
+        ISettingsService? settings = null)
     {
+        if (settings is null)
+        {
+            settings = Substitute.For<ISettingsService>();
+            settings.HasEverEnabledPreRelease.Returns(true);
+        }
+
         return new UpdateService(
             currentVersionProvider ?? Substitute.For<ICurrentVersionProvider>(),
             appTitleService ?? Substitute.For<IAppTitleService>(),
             gitHubService ?? Substitute.For<IGitHubService>(),
             deploymentService ?? Substitute.For<IDeploymentService>(),
             traceLogger ?? Substitute.For<ITraceLogger>(),
-            alertDialogService ?? Substitute.For<IAlertDialogService>());
+            alertDialogService ?? Substitute.For<IAlertDialogService>(),
+            settings);
     }
 }


### PR DESCRIPTION
Fixes #524.

## Summary

`UpdateService.CheckForUpdates` short-circuited at the first release that differed from the running version. Because releases are sorted newest-first by date, any user running a version older than the latest release exited the loop before `_currentRawChanges` was cached — `GetReleaseNotes()` then failed its null guard and surfaced a "Release Notes Failure" alert.

This PR fixes the bug, adds an auto-enable for the prerelease channel when a prerelease build is detected, and preserves the two intentional rollback mechanisms.

## Changes

### Bug fix (#524)
- `UpdateService.CheckForUpdates` now uses a **two-pass** structure:
  - **Pass 1** locates the running version's release (`cmp == 0`) so `_currentRawChanges` is always cached for `GetReleaseNotes()`.
  - **Pass 2** preserves the original short-circuit semantics (first applicable release that differs from current → install prompt).

### Preserved rollback semantics
The original `CompareTo(...) != 0` check serves two intentional rollback paths, both retained:
- **Admin-pushed rollback**: republish an older release with the newest `ReleaseDate` → all users prompted to install it.
- **User-driven channel-exit rollback**: toggling `IsPreReleaseEnabled` off while on a prerelease prompts install of the latest stable.

### New: auto-enable prerelease channel for manual installs
Users who manually download/install a prerelease MSIX from the GitHub Releases page previously had `IsPreReleaseEnabled = false`, so the next update check would prompt them to "downgrade" to the latest stable. This PR introduces a sticky bit `HasEverEnabledPreRelease` (persisted via MAUI Preferences as `"has-ever-enabled-prerelease"`) that records whether the channel has ever been enabled (by manual toggle OR by auto-enable).

When `CheckForUpdates` detects the running version is a prerelease AND `!IsPreReleaseEnabled && !HasEverEnabledPreRelease`, it enables the channel for this call (preventing the rollback prompt) and persists the change. The sticky bit then prevents future auto-enables, so if the user explicitly toggles off later, the rollback fires as designed.

### Setter cascade for case-A (power user) + migration
`SettingsService.IsPreReleaseEnabled`:
- **Setter cascade**: setting to `true` also sets `HasEverEnabledPreRelease = true`, so an explicit user opt-in records the sticky bit. This ensures a subsequent toggle-off correctly triggers rollback.
- **Getter cascade**: reading `true` when sticky is not set also sets the sticky bit. This migrates existing users (who had `IsPreReleaseEnabled = true` from prior versions) on first read after upgrade, so their next toggle-off correctly triggers rollback.

## Hot-path performance
`CheckForUpdates` is awaited inline from `MainLayout.razor.cs` during app initialization. The two-pass loop adds ~50 µs of CPU work — negligible against the ~100–300 ms HTTP fetch. Zero new allocations.

## Tests
- 1 regression test for #524: `GetReleaseNotes_WhenRunningOlderThanLatest_ShouldReturnNotesForCurrentVersion`
- 3 new behavioral tests covering malformed versions, auto-enable, and the post-opt-out rollback prompt
- 4 new `SettingsService` tests covering setter cascade, getter cascade (migration), and idempotency
- All 3,079 existing unit tests still pass

## Design review
The two-pass design and cascade semantics were validated through multiple rounds with a four-model review panel (Claude Opus, GPT-5.4, Gemini, GPT-5.3-Codex) plus branch-wide rename / least-privilege / vertical-slice audits.
