### PR TITLE
Hide Manage Databases Select button when no databases are imported

### DIFF
--- a/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor
+++ b/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor
@@ -12,16 +12,19 @@
     <span aria-atomic="true" aria-live="polite" class="visually-hidden" role="status">@_selectionAnnouncement</span>
 
     <div class="manage-databases-import-row">
-        <button aria-pressed="@(_isSelectionModeActive ? "true" : "false")"
-            class="button manage-databases-select-btn"
-            id="manage-select-button"
-            @onclick="ToggleSelectionMode"
-            @ref="_selectButtonRef"
-            type="button">
-            <i aria-hidden="true" class="bi bi-check2-square"></i>
-            @(_isSelectionModeActive ? "Done" : "Select")
-        </button>
-        <button class="button"
+        @if (DatabaseService.Entries.Count > 0)
+        {
+            <button aria-pressed="@(_isSelectionModeActive ? "true" : "false")"
+                class="button manage-databases-select-btn"
+                id="manage-select-button"
+                @onclick="ToggleSelectionMode"
+                @ref="_selectButtonRef"
+                type="button">
+                <i aria-hidden="true" class="bi bi-check2-square"></i>
+                @(_isSelectionModeActive ? "Done" : "Select")
+            </button>
+        }
+        <button class="button manage-databases-import-btn"
             id="manage-import-button"
             @onclick="ImportDatabase"
             @ref="_importButtonRef"

--- a/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.cs
+++ b/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.cs
@@ -855,11 +855,18 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
 
         foreach (var key in deadRefs) { _rowRefs.Remove(key); }
 
-        // Auto-exit selection mode if the entries list collapses while selecting;
-        // the bulk strip would render above an empty-state placeholder otherwise.
-        if (_isSelectionModeActive && currentNames.Count == 0)
+        // When the entries list collapses to zero, the Select button and entry rows
+        // disappear from the DOM; restore focus to Import so keyboard users don't lose
+        // their anchor. Exit selection mode in the same step so the bulk strip doesn't
+        // render above an empty-state placeholder.
+        if (currentNames.Count == 0)
         {
-            ExitSelectionMode();
+            if (_isSelectionModeActive)
+            {
+                ExitSelectionMode();
+            }
+
+            _focusRestorationTarget = (string.Empty, FocusTarget.ImportButton);
         }
 
         _ = InvokeAsyncSafe();

--- a/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.css
+++ b/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.css
@@ -11,8 +11,11 @@
     flex: none;
     display: flex;
     gap: .5rem;
-    justify-content: space-between;
     padding: .5rem 1rem;
+}
+
+.manage-databases-import-btn {
+    margin-left: auto;
 }
 
 .manage-databases-selection-header {

--- a/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/Tabs/ManageDatabasesTabTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/Tabs/ManageDatabasesTabTests.cs
@@ -728,7 +728,8 @@ public sealed class ManageDatabasesTabTests : BunitContext
         _databaseService.RaiseEntriesChanged();
         await component.InvokeAsync(() => { });
 
-        Assert.Equal("false", component.Find("#manage-select-button").GetAttribute("aria-pressed"));
+        Assert.False(component.Instance.IsInSelectionMode);
+        Assert.Empty(component.FindAll("#manage-select-button"));
     }
 
     [Fact]
@@ -1072,6 +1073,16 @@ public sealed class ManageDatabasesTabTests : BunitContext
         var statusRegion = component.Find(".manage-databases-tab > span[role='status'][aria-live='polite']");
         Assert.NotNull(statusRegion);
         Assert.Equal("true", statusRegion.GetAttribute("aria-atomic"));
+    }
+
+    [Fact]
+    public void Render_SelectButton_HiddenWhenNoEntries()
+    {
+        _databaseService.Entries = [];
+
+        var component = Render<ManageDatabasesTab>();
+
+        Assert.Empty(component.FindAll("#manage-select-button"));
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #561.

## Summary

In the **Manage Databases** tab of the Database Tools modal, the **Select** toolbar button was rendered even when no databases were imported. With nothing to select, the button was non-functional and added visual noise alongside the empty-state placeholder.

## Changes

- **`ManageDatabasesTab.razor`** — wrap the Select button in `@if (DatabaseService.Entries.Count > 0)`. The button is now absent from the DOM whenever the entries list is empty (better than `disabled` for screen-reader users, since there's no actionable target).
- **`ManageDatabasesTab.razor.css`** — replace `justify-content: space-between` on `.manage-databases-import-row` with `.manage-databases-import-btn { margin-left: auto; }`. Keeps **Import database…** right-aligned whether Select is present (Select on left, Import on right) or absent (Import alone, right-aligned).
- **`ManageDatabasesTab.razor.cs`** — when `OnDatabaseEntriesChanged` auto-exits selection mode because the list collapsed to zero entries, also set `_focusRestorationTarget = (string.Empty, FocusTarget.ImportButton)`. Prevents keyboard focus loss when the focused Select button suddenly disappears (mirrors the existing `RemoveDatabasesAsync` "all entries removed" focus path).
- **`ManageDatabasesTabTests.cs`** — added regression test `Render_SelectButton_HiddenWhenNoEntries`. Updated `EntriesChanged_DuringSelection_EmptyList_AutoExitsSelectionMode` to assert `IsInSelectionMode == false` plus absence of the Select button (the prior `aria-pressed` assertion would have thrown after the Razor change).

## Tests

- 75/75 `ManageDatabasesTab` + `ManageDatabasesEmptyState` tests pass
- 636/636 UI tests pass
- 3,069/3,069 unit tests pass across the full solution
- 0 warnings / 0 errors on full solution build
