### PR TITLE
Prevent deadlock when elevated helper is unkillable, harden pipe and regex IPC paths

### DIFF
--- a/src/EventLogExpert.DatabaseTools/Common/Ipc/RegexJsonConverter.cs
+++ b/src/EventLogExpert.DatabaseTools/Common/Ipc/RegexJsonConverter.cs
@@ -8,15 +8,49 @@ using System.Text.RegularExpressions;
 namespace EventLogExpert.DatabaseTools.Common.Ipc;
 
 /// <summary>
-///     Serializes a <see cref="Regex" /> to a JSON object preserving the original pattern, options, and match timeout
-///     so the helper-side reconstructed regex behaves identically to the UI-side compiled regex.
-///     <see cref="Regex.InfiniteMatchTimeout" /> is encoded as a JSON <c>null</c> in <c>matchTimeoutMs</c>; a null
-///     <see cref="Regex" /> reference is encoded as JSON <c>null</c> at the message level (this converter is not invoked
-///     for that case - the surrounding <see cref="JsonConverter{T}" /> infrastructure handles it via the
+///     Serializes a <see cref="Regex" /> to a JSON object preserving the original pattern, options, and (in most cases)
+///     match timeout so the helper-side reconstructed regex behaves identically to the UI-side compiled regex. One
+///     deliberate asymmetry applies: <see cref="Regex.InfiniteMatchTimeout" /> writes as JSON <c>null</c> in
+///     <c>matchTimeoutMs</c> but reads back as a bounded default (see remarks for the ReDoS-mitigation rationale).
+///     A null <see cref="Regex" /> reference is encoded as JSON <c>null</c> at the message level (this converter is not
+///     invoked for that case - the surrounding <see cref="JsonConverter{T}" /> infrastructure handles it via the
 ///     <see cref="JsonConverter{T}.HandleNull" /> protocol).
 /// </summary>
+/// <remarks>
+///     <para>
+///         <b>Asymmetric (lossy) null-timeout handling.</b> The writer encodes <see cref="Regex.InfiniteMatchTimeout" />
+///         as JSON <c>null</c> (preserving the over-the-wire shape). The reader deliberately does NOT round-trip
+///         <see cref="Regex.InfiniteMatchTimeout" />; a null <c>matchTimeoutMs</c> is mapped to a bounded default (
+///         <see cref="DefaultMatchTimeoutMs" /> ms) as a ReDoS mitigation - an unbounded regex evaluation in the high-IL
+///         helper is catastrophic when combined with a wedged-helper-can't-be-killed scenario. Production callers always
+///         emit a finite timeout via <c>FilterRegexFactory</c>, so this asymmetry is only observable for hand-crafted or
+///         defensive JSON.
+///     </para>
+///     <para>
+///         <b>Validation.</b> The reader rejects <c>RegexOptions</c> bits outside the documented
+///         <see cref="AllowedOptions" /> mask and rejects <c>matchTimeoutMs</c> values outside
+///         <c>[1, <see cref="MaxMatchTimeoutMs" />]</c>. <see cref="ArgumentException" /> from the <see cref="Regex" />
+///         constructor (invalid pattern or invalid option combinations such as <see cref="RegexOptions.ECMAScript" />
+///         combined with <see cref="RegexOptions.RightToLeft" />) is wrapped as <see cref="JsonException" /> so malformed
+///         IPC payloads consistently surface as JSON errors.
+///     </para>
+/// </remarks>
 internal sealed class RegexJsonConverter : JsonConverter<Regex>
 {
+    private const RegexOptions AllowedOptions =
+        RegexOptions.IgnoreCase
+        | RegexOptions.Multiline
+        | RegexOptions.ExplicitCapture
+        | RegexOptions.Compiled
+        | RegexOptions.Singleline
+        | RegexOptions.IgnorePatternWhitespace
+        | RegexOptions.RightToLeft
+        | RegexOptions.ECMAScript
+        | RegexOptions.CultureInvariant
+        | RegexOptions.NonBacktracking;
+    private const int DefaultMatchTimeoutMs = 1000;
+    private const int MaxMatchTimeoutMs = 5000;
+
     public override Regex? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         if (reader.TokenType == JsonTokenType.Null)
@@ -70,11 +104,37 @@ internal sealed class RegexJsonConverter : JsonConverter<Regex>
             throw new JsonException("Regex JSON object missing required 'pattern' property.");
         }
 
-        TimeSpan matchTimeout = matchTimeoutMs is null
-            ? Regex.InfiniteMatchTimeout
-            : TimeSpan.FromMilliseconds(matchTimeoutMs.Value);
+        if ((regexOptions & ~AllowedOptions) != 0)
+        {
+            throw new JsonException(
+                $"Regex 'options' contains bits outside the allowed mask: 0x{(int)(regexOptions & ~AllowedOptions):X}.");
+        }
 
-        return new Regex(pattern, regexOptions, matchTimeout);
+        TimeSpan matchTimeout;
+
+        if (matchTimeoutMs is null)
+        {
+            matchTimeout = TimeSpan.FromMilliseconds(DefaultMatchTimeoutMs);
+        }
+        else if (matchTimeoutMs.Value is < 1 or > MaxMatchTimeoutMs)
+        {
+            throw new JsonException(
+                $"Regex 'matchTimeoutMs' must be in [1, {MaxMatchTimeoutMs}]; got {matchTimeoutMs.Value}.");
+        }
+        else
+        {
+            matchTimeout = TimeSpan.FromMilliseconds(matchTimeoutMs.Value);
+        }
+
+        try
+        {
+            return new Regex(pattern, regexOptions, matchTimeout);
+        }
+        catch (ArgumentException ex)
+        {
+            throw new JsonException(
+                $"Regex construction failed (pattern={pattern}, options=0x{(int)regexOptions:X}): {ex.Message}", ex);
+        }
     }
 
     public override void Write(Utf8JsonWriter writer, Regex value, JsonSerializerOptions options)

--- a/src/EventLogExpert.Runtime/DatabaseTools/Elevation/ElevatedDatabaseToolsRunner.cs
+++ b/src/EventLogExpert.Runtime/DatabaseTools/Elevation/ElevatedDatabaseToolsRunner.cs
@@ -21,7 +21,7 @@ namespace EventLogExpert.Runtime.DatabaseTools.Elevation;
 ///     Production <see cref="IElevatedDatabaseToolsRunner" /> implementation. For each request: spawn helper -> wait
 ///     for Hello message (10s) -> send request -> drain messages through a bounded <see cref="Channel{T}" /> -> forward
 ///     Log/Progress to caller sinks + mirror to <see cref="ITraceLogger" /> with <c>[ElevatedHelper]</c> prefix -> capture
-///     terminal Result/Fatal -> await helper exit (5s grace, then force-kill) -> translate to
+///     terminal Result/Fatal -> await helper exit (5s grace, then force-kill if killable) -> translate to
 ///     <see cref="DatabaseToolsResult" />.
 /// </summary>
 /// <remarks>
@@ -29,7 +29,19 @@ namespace EventLogExpert.Runtime.DatabaseTools.Elevation;
 ///         <b>Cancellation flow:</b> caller cancels -> runner writes <see cref="CancelMessage" /> to the pipe
 ///         (best-effort) and starts a 30s grace timer. Helper observes the message, cancels its operation CTS, and emits a
 ///         <see cref="ResultMessage" /> with <see cref="DatabaseToolsOutcome.Cancelled" />. If the helper does NOT emit a
-///         result within the grace window, the runner force-kills the process and returns a synthesized Cancelled outcome.
+///         result within the grace window, the runner force-kills the process. On a successful kill the runner returns a
+///         synthesized Cancelled outcome with a "force-killed" note; if the kill itself fails (for example, a medium-IL
+///         runner cannot terminate a high-IL helper and <see cref="IElevatedHelperProcess.Kill" /> returns <c>false</c>),
+///         the runner disposes the pipe to unblock the drain loop and returns Cancelled with an explicit orphan warning
+///         so the caller can surface that the helper may continue running.
+///     </para>
+///     <para>
+///         <b>Early-return cleanup:</b> if <see cref="RunAsync" /> returns before the normal terminal-message path
+///         completes (Hello timeout, protocol mismatch, wrong-first-envelope, pipe-closed-before-Hello, cancel-while-
+///         sending-request), a centralized <c>finally</c> block disposes the pipe (graceful: helper sees EOF and exits
+///         cooperatively), bounded-waits for exit, and falls back to <see cref="IElevatedHelperProcess.Kill" /> only if
+///         the helper does not exit within the grace window. If the fallback kill also fails the helper becomes an
+///         orphan; the pipe is already closed so the runner returns without waiting further.
 ///     </para>
 ///     <para>
 ///         <b>Concurrency invariants:</b>
@@ -58,6 +70,7 @@ internal sealed class ElevatedDatabaseToolsRunner : IElevatedDatabaseToolsRunner
     internal const string ElevatedHelperTag = "[ElevatedHelper]";
 
     private const int ChannelCapacity = 1024;
+
     private static readonly UTF8Encoding s_utf8NoBom = new(encoderShouldEmitUTF8Identifier: false);
 
     private readonly TimeSpan _cancellationGrace;
@@ -90,6 +103,13 @@ internal sealed class ElevatedDatabaseToolsRunner : IElevatedDatabaseToolsRunner
         _helloTimeout = helloTimeout;
         _cancellationGrace = cancellationGrace;
         _exitGrace = exitGrace;
+    }
+
+    private enum KillDisposition
+    {
+        NotAttempted = 0,
+        Succeeded = 1,
+        Failed = 2
     }
 
     public Task<DatabaseToolsResult> CreateAsync(CreateDatabaseRequest request, IProgress<LogRecord> logSink, IProgress<DatabaseToolsProgress>? progress, CancellationToken cancellationToken, bool verbose = false)
@@ -235,8 +255,20 @@ internal sealed class ElevatedDatabaseToolsRunner : IElevatedDatabaseToolsRunner
                 await Task.Delay(_cancellationGrace, graceCts.Token);
 
                 _traceLogger.Warning($"{ElevatedHelperTag} Helper did not respond with a Result message within {_cancellationGrace.TotalSeconds:N0}s of CancelMessage - force-killing.");
-                process.Kill();
-                killState.MarkKilled();
+
+                if (process.Kill())
+                {
+                    killState.MarkKillSucceeded();
+                }
+                else
+                {
+                    killState.MarkKillFailed();
+
+                    _traceLogger.Error($"{ElevatedHelperTag} Kill returned false; helper may continue running as orphan. Disposing pipe to unblock drain loop.");
+
+                    try { await ((IAsyncDisposable)process.Pipe).DisposeAsync(); }
+                    catch { /* best effort */ }
+                }
             }
             catch (OperationCanceledException) { /* helper finished in time */ }
             catch (Exception ex)
@@ -300,6 +332,9 @@ internal sealed class ElevatedDatabaseToolsRunner : IElevatedDatabaseToolsRunner
         IElevatedHelperProcess? process = null;
         SemaphoreSlim? writeLock = null;
         CancellationTokenRegistration cancelRegistration = default;
+        Task? pipeReaderTask = null;
+        CancellationTokenSource? readerStopCts = null;
+        bool exitHandled = false;
 
         _traceLogger.Trace($"{ElevatedHelperTag} Starting {request.GetType().Name} (verbose={request.Verbose})...");
 
@@ -342,10 +377,10 @@ internal sealed class ElevatedDatabaseToolsRunner : IElevatedDatabaseToolsRunner
                     FullMode = BoundedChannelFullMode.Wait
                 });
 
-            using var readerStopCts = new CancellationTokenSource();
+            readerStopCts = new CancellationTokenSource();
 
             var pipeStream = process.Pipe;
-            var pipeReaderTask = Task.Run(
+            pipeReaderTask = Task.Run(
                 () => DrainPipeAsync(pipeStream, channel.Writer, readerStopCts.Token),
                 readerStopCts.Token);
 
@@ -458,26 +493,49 @@ internal sealed class ElevatedDatabaseToolsRunner : IElevatedDatabaseToolsRunner
             // Helper sent a terminal message (or pipe closed). Cancel the kill-timer so it doesn't fire on a clean finish.
             killState.CancelGraceTimer();
 
-            // 7) Wait for helper to exit (grace, then force-kill).
+            // 7) Wait for helper to exit (bounded by _exitGrace, then force-kill if it lingers and is killable).
             int exitCode;
             try
             {
-                using var exitCts = new CancellationTokenSource();
-                exitCts.CancelAfter(_exitGrace);
+                using var exitCts = new CancellationTokenSource(_exitGrace);
 
                 exitCode = await process.WaitForExitAsync(exitCts.Token);
             }
             catch (OperationCanceledException)
             {
-                if (!killState.HelperKilled)
+                if (killState.Disposition != KillDisposition.Failed)
                 {
                     _traceLogger.Warning($"{ElevatedHelperTag} Helper did not exit within {_exitGrace.TotalSeconds:N0}s after IPC drained - force-killing.");
-                    process.Kill();
-                    killState.MarkKilled();
+
+                    if (process.Kill())
+                    {
+                        killState.MarkKillSucceeded();
+                    }
+                    else
+                    {
+                        killState.MarkKillFailed();
+
+                        _traceLogger.Error($"{ElevatedHelperTag} Kill returned false; helper may continue running as orphan. Disposing pipe.");
+
+                        try { await ((IAsyncDisposable)process.Pipe).DisposeAsync(); }
+                        catch { /* best effort */ }
+                    }
                 }
 
-                try { exitCode = await process.WaitForExitAsync(CancellationToken.None); }
-                catch { exitCode = -1; }
+                if (killState.Disposition == KillDisposition.Failed)
+                {
+                    exitCode = -1;
+                }
+                else
+                {
+                    try
+                    {
+                        using var killWaitCts = new CancellationTokenSource(_exitGrace);
+
+                        exitCode = await process.WaitForExitAsync(killWaitCts.Token);
+                    }
+                    catch { exitCode = -1; }
+                }
             }
 
             // 8) Stop the pipe reader so it releases the StreamReader / Stream.
@@ -493,27 +551,72 @@ internal sealed class ElevatedDatabaseToolsRunner : IElevatedDatabaseToolsRunner
             _traceLogger.Trace($"{ElevatedHelperTag} Helper process exited; exit code = {exitCode}{(killState.HelperKilled ? " (force-killed)" : string.Empty)}.");
 
             // 9) Translate to DatabaseToolsResult.
-            return TranslateOutcome(result, fatal, exitCode, killState.HelperKilled, cancellationToken, stopwatch.Elapsed);
+            exitHandled = true;
+
+            return TranslateOutcome(result, fatal, exitCode, killState.Disposition, cancellationToken, stopwatch.Elapsed);
         }
         catch (Exception ex)
         {
             _traceLogger.Error($"{ElevatedHelperTag} Unhandled exception in runner: {ex}");
 
-            if (process is not null && !killState.HelperKilled)
-            {
-                try { process.Kill(); } catch { /* best effort */ }
-            }
-
             return new DatabaseToolsResult(DatabaseToolsOutcome.Failed, $"{ex.GetType().Name}: {ex.Message}", stopwatch.Elapsed);
         }
         finally
         {
+            killState.CancelGraceTimer();
+
+            if (!exitHandled && process is not null)
+            {
+                try { readerStopCts?.Cancel(); }
+                catch (ObjectDisposedException) { /* already disposed */ }
+
+                if (pipeReaderTask is not null)
+                {
+                    try { await pipeReaderTask.WaitAsync(_exitGrace); }
+                    catch { /* best effort */ }
+                }
+
+                // Graceful first: dispose pipe so helper sees EOF and exits cooperatively.
+                try { await ((IAsyncDisposable)process.Pipe).DisposeAsync(); }
+                catch { /* best effort */ }
+
+                try
+                {
+                    using var cleanupCts = new CancellationTokenSource(_exitGrace);
+
+                    await process.WaitForExitAsync(cleanupCts.Token);
+                }
+                catch
+                {
+                    // Helper didn't exit cooperatively — force-kill as last resort.
+                    if (process.Kill())
+                    {
+                        killState.MarkKillSucceeded();
+
+                        try
+                        {
+                            using var forceCts = new CancellationTokenSource(_exitGrace);
+
+                            await process.WaitForExitAsync(forceCts.Token);
+                        }
+                        catch { /* best effort */ }
+                    }
+                    else
+                    {
+                        killState.MarkKillFailed();
+                        // Kill failed → pipe already disposed, helper orphaned, nothing more to do.
+                    }
+                }
+            }
+
             killState.DisposeGraceTimer();
             writeLock?.Dispose();
+            readerStopCts?.Dispose();
 
             if (process is not null)
             {
-                await process.DisposeAsync();
+                try { await process.DisposeAsync(); }
+                catch { /* best effort */ }
             }
         }
     }
@@ -534,7 +637,7 @@ internal sealed class ElevatedDatabaseToolsRunner : IElevatedDatabaseToolsRunner
         ResultMessage? result,
         FatalMessage? fatal,
         int exitCode,
-        bool helperKilled,
+        KillDisposition killDisposition,
         CancellationToken cancellationToken,
         TimeSpan elapsed)
     {
@@ -554,29 +657,37 @@ internal sealed class ElevatedDatabaseToolsRunner : IElevatedDatabaseToolsRunner
                 elapsed);
         }
 
-        if (cancellationToken.IsCancellationRequested)
+        if (!cancellationToken.IsCancellationRequested)
         {
             return new DatabaseToolsResult(
-                DatabaseToolsOutcome.Cancelled,
-                helperKilled
-                    ? "Cancelled (helper did not respond to CancelMessage within grace window; force-killed). If you ran an Upgrade, a .bak of the original target may remain next to it - rename it to recover."
-                    : "Cancelled.",
+                DatabaseToolsOutcome.Failed,
+                $"Helper exited (code {exitCode}) without sending a Result message.",
                 elapsed);
         }
 
-        return new DatabaseToolsResult(
-            DatabaseToolsOutcome.Failed,
-            $"Helper exited (code {exitCode}) without sending a Result message.",
-            elapsed);
+        string summary = killDisposition switch
+        {
+            KillDisposition.Failed =>
+                "Cancelled (helper did not respond to cancel and could not be terminated; it may continue running as an orphan process). " +
+                "If you ran an Upgrade, a .bak of the original target may remain next to it - rename it to recover.",
+            KillDisposition.Succeeded =>
+                "Cancelled (helper did not respond to CancelMessage within grace window; force-killed). " +
+                "If you ran an Upgrade, a .bak of the original target may remain next to it - rename it to recover.",
+            _ => "Cancelled."
+        };
+
+        return new DatabaseToolsResult(DatabaseToolsOutcome.Cancelled, summary, elapsed);
     }
 
     private sealed class KillState
     {
         private int _cancelRequested;
+        private int _disposition;
         private CancellationTokenSource? _graceTimerCts;
-        private int _helperKilled;
 
-        public bool HelperKilled => Volatile.Read(ref _helperKilled) != 0;
+        public KillDisposition Disposition => (KillDisposition)Volatile.Read(ref _disposition);
+
+        public bool HelperKilled => Disposition == KillDisposition.Succeeded;
 
         public void CancelGraceTimer()
         {
@@ -592,7 +703,12 @@ internal sealed class ElevatedDatabaseToolsRunner : IElevatedDatabaseToolsRunner
 
         public bool MarkCancelRequested() => Interlocked.Exchange(ref _cancelRequested, 1) == 0;
 
-        public void MarkKilled() => Interlocked.Exchange(ref _helperKilled, 1);
+        public void MarkKillFailed() => Interlocked.CompareExchange(
+            ref _disposition,
+            (int)KillDisposition.Failed,
+            (int)KillDisposition.NotAttempted);
+
+        public void MarkKillSucceeded() => Interlocked.Exchange(ref _disposition, (int)KillDisposition.Succeeded);
 
         public void SetGraceTimer(CancellationTokenSource cts) => Volatile.Write(ref _graceTimerCts, cts);
     }

--- a/src/EventLogExpert.Runtime/DatabaseTools/Elevation/IElevatedHelperProcess.cs
+++ b/src/EventLogExpert.Runtime/DatabaseTools/Elevation/IElevatedHelperProcess.cs
@@ -21,9 +21,11 @@ namespace EventLogExpert.Runtime.DatabaseTools.Elevation;
 ///     <para>
 ///         <b>Cleanup contract:</b> implementations of <see cref="DisposeAsync" /> close the pipe but do NOT kill the
 ///         helper process. Closing the pipe will cause the helper to observe EOF on its next read/write and typically
-///         exit; if it doesn't, the caller must invoke <see cref="Kill" /> explicitly. This split avoids surprising the
-///         caller when a deliberate keep-alive-after-close pattern is desired (e.g., in tests that want to inspect the
-///         helper's exit code separately from pipe teardown).
+///         exit; if it doesn't, the caller must invoke <see cref="Kill" /> explicitly. Because <see cref="Kill" /> may
+///         fail (a medium-IL caller cannot terminate a high-IL helper, for example), callers MUST check the boolean return
+///         and fall back to closing the pipe (forcing EOF on the helper's next pipe read/write) when <see cref="Kill" />
+///         returns <c>false</c>. This split avoids surprising the caller when a deliberate keep-alive-after-close pattern
+///         is desired (e.g., in tests that want to inspect the helper's exit code separately from pipe teardown).
 ///     </para>
 /// </remarks>
 public interface IElevatedHelperProcess : IAsyncDisposable
@@ -40,10 +42,15 @@ public interface IElevatedHelperProcess : IAsyncDisposable
 
     /// <summary>
     ///     Hard-terminates the helper process. Used as the last-resort cancellation fallback when the cooperative
-    ///     <c>CancelMessage</c> + grace window does not produce a clean exit. Does NOT throw if the process has already
-    ///     exited.
+    ///     <c>CancelMessage</c> + grace window does not produce a clean exit.
     /// </summary>
-    void Kill();
+    /// <returns>
+    ///     <c>true</c> if the process was successfully killed by this call OR had already exited before the call;
+    ///     <c>false</c> if the kill attempt failed (for example, a medium-IL caller cannot terminate a high-IL helper and the
+    ///     underlying <see cref="System.ComponentModel.Win32Exception" /> is logged then surfaced as a failed attempt).
+    ///     Callers SHOULD fall back to closing <see cref="Pipe" /> when this returns <c>false</c>.
+    /// </returns>
+    bool Kill();
 
     /// <summary>Waits for the helper process to exit. Returns the OS exit code.</summary>
     Task<int> WaitForExitAsync(CancellationToken cancellationToken);

--- a/src/EventLogExpert.WindowsPlatform/Elevation/ElevatedHelperProcess.cs
+++ b/src/EventLogExpert.WindowsPlatform/Elevation/ElevatedHelperProcess.cs
@@ -31,7 +31,7 @@ internal sealed class ElevatedHelperProcess(Process process, NamedPipeServerStre
         try { process.Dispose(); } catch { /* swallowed during dispose */ }
     }
 
-    public void Kill()
+    public bool Kill()
     {
         try
         {
@@ -39,14 +39,19 @@ internal sealed class ElevatedHelperProcess(Process process, NamedPipeServerStre
             {
                 process.Kill(entireProcessTree: false);
             }
+
+            return true;
         }
         catch (InvalidOperationException)
         {
-            // Process already exited — no-op.
+            // Process already exited — treat as success per IElevatedHelperProcess.Kill contract.
+            return true;
         }
         catch (Exception ex)
         {
-            logger.Warning($"{nameof(ElevatedHelperProcess)}.{nameof(Kill)} threw: {ex}");
+            logger.Error($"{nameof(ElevatedHelperProcess)}.{nameof(Kill)} failed (process likely unkillable from this integrity level): {ex.GetType().Name}: {ex.Message}");
+
+            return false;
         }
     }
 

--- a/src/EventLogExpert.WindowsPlatform/Elevation/ElevatedHelperProcessHost.cs
+++ b/src/EventLogExpert.WindowsPlatform/Elevation/ElevatedHelperProcessHost.cs
@@ -19,9 +19,17 @@ namespace EventLogExpert.WindowsPlatform.Elevation;
 /// </summary>
 internal sealed class ElevatedHelperProcessHost(ITraceLogger logger) : IElevatedHelperProcessHost
 {
+    private const int MaxClientPidRejections = 32;
     private const int PipeBufferSize = 65536;
 
     private static readonly TimeSpan s_pipeConnectTimeout = TimeSpan.FromSeconds(30);
+
+    internal enum PidVerifyResult
+    {
+        Match = 0,
+        ClientPidMismatch = 1,
+        GetPidFailed = 2
+    }
 
     public async Task<IElevatedHelperProcess> StartAsync(IReadOnlyList<string> extraArgs, CancellationToken cancellationToken)
     {
@@ -42,7 +50,8 @@ internal sealed class ElevatedHelperProcessHost(ITraceLogger logger) : IElevated
         // Create the server pipe BEFORE spawning the helper, so we're ready to accept its connect-back without race.
         // CurrentUserOnly restricts the DACL to the current user SID; combined with PID verification below this is a
         // narrow surface — only same-user processes can even attempt to connect, and only the spawned helper's PID
-        // is accepted.
+        // is accepted. Wrong-PID connections are disconnected and the listener keeps waiting (within the connect
+        // window) so a same-user race attacker cannot DoS the legitimate helper.
         var pipeServer = new NamedPipeServerStream(
             pipeName,
             PipeDirection.InOut,
@@ -77,17 +86,13 @@ internal sealed class ElevatedHelperProcessHost(ITraceLogger logger) : IElevated
 
             try
             {
-                await pipeServer.WaitForConnectionAsync(connectCts.Token);
+                await AcceptAndVerifyClientPidAsync(pipeServer, helperProcess.Id, logger, connectCts.Token);
             }
             catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
             {
                 throw new TimeoutException(
                     $"Elevated helper PID {helperProcess.Id} did not connect to IPC pipe within {s_pipeConnectTimeout.TotalSeconds:N0}s.");
             }
-
-            // PID verification: defense-in-depth on top of the CurrentUserOnly ACL. A same-user attacker would need
-            // to race a connect to this GUID-named pipe AND already be running with our exact PID — not feasible.
-            VerifyClientPid(pipeServer, expectedPid: helperProcess.Id);
 
             var handle = new ElevatedHelperProcess(helperProcess, pipeServer, logger);
             helperProcess = null;  // Ownership transferred.
@@ -97,22 +102,80 @@ internal sealed class ElevatedHelperProcessHost(ITraceLogger logger) : IElevated
         catch
         {
             // Cleanup on any failure path BEFORE the handle is returned. The pipe + spawned process would otherwise
-            // leak. Process.Kill() on an already-exited process is a no-op (per docs).
+            // leak. Surface non-already-exited kill failures as Error logs so we don't silently leak high-IL helpers.
             try { pipeServer.Dispose(); } catch { /* swallowed during error cleanup */ }
 
-            if (helperProcess is not null)
-            {
-                try
-                {
-                    if (!helperProcess.HasExited) { helperProcess.Kill(entireProcessTree: false); }
-                }
-                catch { /* swallowed during error cleanup */ }
+            if (helperProcess is null) { throw; }
 
-                helperProcess.Dispose();
+            try
+            {
+                if (!helperProcess.HasExited) { helperProcess.Kill(entireProcessTree: false); }
             }
+            catch (InvalidOperationException) { /* already exited */ }
+            catch (Exception ex)
+            {
+                logger.Error(
+                    $"{nameof(ElevatedHelperProcessHost)}: failed to kill spawned helper PID {helperProcess.Id} during error cleanup: {ex.GetType().Name}: {ex.Message}");
+            }
+
+            helperProcess.Dispose();
 
             throw;
         }
+    }
+
+    internal static async Task AcceptAndVerifyClientPidAsync(
+        NamedPipeServerStream pipeServer,
+        int expectedPid,
+        ITraceLogger logger,
+        CancellationToken cancellationToken)
+    {
+        int rejections = 0;
+
+        while (true)
+        {
+            await pipeServer.WaitForConnectionAsync(cancellationToken);
+
+            var result = TryVerifyClientPid(pipeServer, expectedPid);
+
+            if (result == PidVerifyResult.Match) { return; }
+
+            if (result == PidVerifyResult.GetPidFailed)
+            {
+                var error = Marshal.GetLastWin32Error();
+
+                throw new InvalidOperationException($"GetNamedPipeClientProcessId failed (Win32 error {error}).");
+            }
+
+            pipeServer.Disconnect();
+            rejections++;
+
+            if (rejections >= MaxClientPidRejections)
+            {
+                throw new InvalidOperationException(
+                    $"Rejected {MaxClientPidRejections} same-user pipe connections from non-helper PIDs before the legitimate helper connected.");
+            }
+
+            if (rejections == 1)
+            {
+                logger.Information(
+                    $"{nameof(ElevatedHelperProcessHost)}: rejected pipe connection from non-helper PID (expected {expectedPid}); continuing to wait for legitimate helper.");
+            }
+            else
+            {
+                logger.Trace($"{nameof(ElevatedHelperProcessHost)}: rejected pipe connection #{rejections} from non-helper PID.");
+            }
+        }
+    }
+
+    internal static PidVerifyResult TryVerifyClientPid(NamedPipeServerStream pipeServer, int expectedPid)
+    {
+        if (!NativeMethods.GetNamedPipeClientProcessId(pipeServer.SafePipeHandle, out var clientPid))
+        {
+            return PidVerifyResult.GetPidFailed;
+        }
+
+        return clientPid == (uint)expectedPid ? PidVerifyResult.Match : PidVerifyResult.ClientPidMismatch;
     }
 
     private static string BuildArgumentString(string pipeName, IReadOnlyList<string> extraArgs)
@@ -146,21 +209,6 @@ internal sealed class ElevatedHelperProcessHost(ITraceLogger logger) : IElevated
             ?? throw new InvalidOperationException($"Cannot derive install directory from process path: {processPath}");
 
         return Path.Combine(installDir, "ElevationHelper", "eventlogexpert-elevated.exe");
-    }
-
-    private static void VerifyClientPid(NamedPipeServerStream pipeServer, int expectedPid)
-    {
-        if (!NativeMethods.GetNamedPipeClientProcessId(pipeServer.SafePipeHandle, out var clientPid))
-        {
-            var error = Marshal.GetLastWin32Error();
-            throw new InvalidOperationException($"GetNamedPipeClientProcessId failed (Win32 error {error}).");
-        }
-
-        if (clientPid != (uint)expectedPid)
-        {
-            throw new InvalidOperationException(
-                $"Pipe client PID {clientPid} does not match spawned helper PID {expectedPid}. Rejecting connection.");
-        }
     }
 
     private static class NativeMethods

--- a/tests/Integration/EventLogExpert.ElevationHelper.IntegrationTests/TestUtils/TestElevatedHelperProcessHost.cs
+++ b/tests/Integration/EventLogExpert.ElevationHelper.IntegrationTests/TestUtils/TestElevatedHelperProcessHost.cs
@@ -12,9 +12,17 @@ namespace EventLogExpert.ElevationHelper.IntegrationTests.TestUtils;
 
 internal sealed class TestElevatedHelperProcessHost(ITraceLogger logger) : IElevatedHelperProcessHost
 {
+    private const int MaxClientPidRejections = 32;
     private const int PipeBufferSize = 65536;
 
     private static readonly TimeSpan s_connectTimeout = TimeSpan.FromSeconds(15);
+
+    internal enum PidVerifyResult
+    {
+        Match = 0,
+        ClientPidMismatch = 1,
+        GetPidFailed = 2
+    }
 
     public async Task<IElevatedHelperProcess> StartAsync(IReadOnlyList<string> extraArgs, CancellationToken cancellationToken)
     {
@@ -71,15 +79,13 @@ internal sealed class TestElevatedHelperProcessHost(ITraceLogger logger) : IElev
 
             try
             {
-                await pipeServer.WaitForConnectionAsync(connectCts.Token);
+                await AcceptAndVerifyClientPidAsync(pipeServer, helperProcess.Id, logger, connectCts.Token);
             }
             catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
             {
                 throw new TimeoutException(
                     $"Elevated helper PID {helperProcess.Id} did not connect within {s_connectTimeout.TotalSeconds:N0}s.");
             }
-
-            VerifyClientPid(pipeServer, expectedPid: helperProcess.Id);
 
             var handle = new TestElevatedHelperProcess(helperProcess, pipeServer, logger);
             helperProcess = null;
@@ -90,14 +96,77 @@ internal sealed class TestElevatedHelperProcessHost(ITraceLogger logger) : IElev
         {
             try { pipeServer.Dispose(); } catch { /* swallowed during error cleanup */ }
 
-            if (helperProcess is not null)
+            if (helperProcess is null) { throw; }
+
+            try
             {
-                try { if (!helperProcess.HasExited) { helperProcess.Kill(entireProcessTree: false); } } catch { /* swallowed */ }
-                helperProcess.Dispose();
+                if (!helperProcess.HasExited) { helperProcess.Kill(entireProcessTree: false); }
             }
+            catch (InvalidOperationException) { /* already exited */ }
+            catch (Exception ex)
+            {
+                logger.Error(
+                    $"{nameof(TestElevatedHelperProcessHost)}: failed to kill spawned helper PID {helperProcess.Id} during error cleanup: {ex.GetType().Name}: {ex.Message}");
+            }
+
+            helperProcess.Dispose();
 
             throw;
         }
+    }
+
+    internal static async Task AcceptAndVerifyClientPidAsync(
+        NamedPipeServerStream pipeServer,
+        int expectedPid,
+        ITraceLogger logger,
+        CancellationToken cancellationToken)
+    {
+        int rejections = 0;
+
+        while (true)
+        {
+            await pipeServer.WaitForConnectionAsync(cancellationToken);
+
+            var result = TryVerifyClientPid(pipeServer, expectedPid);
+
+            if (result == PidVerifyResult.Match) { return; }
+
+            if (result == PidVerifyResult.GetPidFailed)
+            {
+                var error = Marshal.GetLastWin32Error();
+
+                throw new InvalidOperationException($"GetNamedPipeClientProcessId failed (Win32 error {error}).");
+            }
+
+            pipeServer.Disconnect();
+            rejections++;
+
+            if (rejections >= MaxClientPidRejections)
+            {
+                throw new InvalidOperationException(
+                    $"Rejected {MaxClientPidRejections} same-user pipe connections from non-helper PIDs before the legitimate helper connected.");
+            }
+
+            if (rejections == 1)
+            {
+                logger.Information(
+                    $"{nameof(TestElevatedHelperProcessHost)}: rejected pipe connection from non-helper PID (expected {expectedPid}); continuing to wait for legitimate helper.");
+            }
+            else
+            {
+                logger.Trace($"{nameof(TestElevatedHelperProcessHost)}: rejected pipe connection #{rejections} from non-helper PID.");
+            }
+        }
+    }
+
+    internal static PidVerifyResult TryVerifyClientPid(NamedPipeServerStream pipeServer, int expectedPid)
+    {
+        if (!NativeMethods.GetNamedPipeClientProcessId(pipeServer.SafePipeHandle, out var clientPid))
+        {
+            return PidVerifyResult.GetPidFailed;
+        }
+
+        return clientPid == (uint)expectedPid ? PidVerifyResult.Match : PidVerifyResult.ClientPidMismatch;
     }
 
     private static string BuildArgumentString(string runtimeConfigPath, string helperDllPath, string pipeName, IReadOnlyList<string> extraArgs)
@@ -119,7 +188,9 @@ internal sealed class TestElevatedHelperProcessHost(ITraceLogger logger) : IElev
     private static string QuoteIfNeeded(string arg)
     {
         if (string.IsNullOrEmpty(arg)) { return "\"\""; }
+
         if (arg.IndexOfAny([' ', '\t', '"']) < 0) { return arg; }
+
         return "\"" + arg.Replace("\"", "\\\"") + "\"";
     }
 
@@ -137,21 +208,6 @@ internal sealed class TestElevatedHelperProcessHost(ITraceLogger logger) : IElev
         }
 
         return testRuntimeConfig;
-    }
-
-    private static void VerifyClientPid(NamedPipeServerStream pipeServer, int expectedPid)
-    {
-        if (!NativeMethods.GetNamedPipeClientProcessId(pipeServer.SafePipeHandle, out var clientPid))
-        {
-            var error = Marshal.GetLastWin32Error();
-            throw new InvalidOperationException($"GetNamedPipeClientProcessId failed (Win32 error {error}).");
-        }
-
-        if (clientPid != (uint)expectedPid)
-        {
-            throw new InvalidOperationException(
-                $"Pipe client PID {clientPid} does not match spawned helper PID {expectedPid}. Rejecting connection.");
-        }
     }
 
     private static class NativeMethods
@@ -175,19 +231,27 @@ internal sealed class TestElevatedHelperProcess(Process process, NamedPipeServer
         if (Interlocked.Exchange(ref _disposed, 1) != 0) { return; }
 
         try { await pipe.DisposeAsync(); } catch { /* swallowed during dispose */ }
+
         try { process.Dispose(); } catch { /* swallowed during dispose */ }
     }
 
-    public void Kill()
+    public bool Kill()
     {
         try
         {
             if (!process.HasExited) { process.Kill(entireProcessTree: false); }
+
+            return true;
         }
-        catch (InvalidOperationException) { /* already exited */ }
+        catch (InvalidOperationException)
+        {
+            return true;
+        }
         catch (Exception ex)
         {
-            logger.Warning($"{nameof(TestElevatedHelperProcess)}.{nameof(Kill)} threw: {ex}");
+            logger.Error($"{nameof(TestElevatedHelperProcess)}.{nameof(Kill)} failed: {ex.GetType().Name}: {ex.Message}");
+
+            return false;
         }
     }
 
@@ -198,6 +262,7 @@ internal sealed class TestElevatedHelperProcess(Process process, NamedPipeServer
         async Task<int> WaitAsync()
         {
             await process.WaitForExitAsync(cancellationToken);
+
             return process.ExitCode;
         }
     }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/DatabaseTools/Elevation/ElevatedDatabaseToolsRunnerTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/DatabaseTools/Elevation/ElevatedDatabaseToolsRunnerTests.cs
@@ -464,6 +464,127 @@ public sealed class ElevatedDatabaseToolsRunnerTests
     }
 
     [Fact]
+    public async Task RunAsync_WhenHelloTimeoutAndHelperUnkillable_CentralizedFinallyCleansUpWithinBoundedTime()
+    {
+        // Early-return path: helper spawns but never sends Hello, then proves unkillable. The centralized
+        // finally must: cancel reader, await pipeReader task (bounded), dispose pipe (graceful), bounded wait,
+        // fallback Kill (returns false), exit. Must not hang.
+        var ct = TestContext.Current.CancellationToken;
+        await using var pipes = await HelperPipePair.CreateAsync(ct); var server = pipes.Server; var client = pipes.Client;
+        var fakeProcess = new FakeElevatedHelperProcess(server, processId: 4242)
+        {
+            SimulateUnkillable = true
+        };
+        var host = new FakeElevatedHelperProcessHost((_, _) => Task.FromResult<IElevatedHelperProcess>(fakeProcess));
+        var logger = new LoggerUtils.RecordingTraceLogger();
+        var runner = CreateRunner(host, logger);
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        var logSink = new ListProgress<LogRecord>();
+
+        var runTask = runner.ShowAsync(
+            new ShowProvidersRequest(null, null),
+            logSink, progress: null, cts.Token);
+
+        // Don't send Hello — let _helloTimeout (500ms) fire to trigger the early-return path. Centralized
+        // finally must clean up without hanging. Ceiling: hello-timeout + 2*exit-grace ≈ 1.5s. 10s slack.
+        var result = await runTask.WaitAsync(TimeSpan.FromSeconds(10), ct);
+
+        Assert.Equal(DatabaseToolsOutcome.Failed, result.Outcome);
+        Assert.Contains("Hello", result.FailureSummary, StringComparison.OrdinalIgnoreCase);
+        Assert.True(fakeProcess.WasKilled);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenHelperKillSucceedsAfterCancel_ReportsForceKilled()
+    {
+        // Companion to the unkillable test: when Kill returns true (succeeds), Disposition=Succeeded and
+        // TranslateOutcome emits the existing "force-killed" message (NOT the orphan message).
+        var ct = TestContext.Current.CancellationToken;
+        await using var pipes = await HelperPipePair.CreateAsync(ct); var server = pipes.Server; var client = pipes.Client;
+        var fakeProcess = new FakeElevatedHelperProcess(server, processId: 4242)
+        {
+            OnKilled = () => { try { client.Dispose(); } catch { /* test cleanup, best effort */ } }
+        };
+        var host = new FakeElevatedHelperProcessHost((_, _) => Task.FromResult<IElevatedHelperProcess>(fakeProcess));
+        var logger = new LoggerUtils.RecordingTraceLogger();
+        var runner = CreateRunner(host, logger);
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        var logSink = new ListProgress<LogRecord>();
+
+        var clientWriter = new StreamWriter(client, s_utf8NoBom, bufferSize: 4096, leaveOpen: true) { AutoFlush = true };
+        var clientReader = new StreamReader(client, s_utf8NoBom, detectEncodingFromByteOrderMarks: false, bufferSize: 4096, leaveOpen: true);
+
+        try
+        {
+            var runTask = runner.ShowAsync(
+                new ShowProvidersRequest(null, null),
+                logSink, progress: null, cts.Token);
+
+            await WriteMessageAsync(clientWriter, new HelloMessage(4242, 1), ct);
+
+            var request = await ReadRequestAsync(clientReader, ct);
+            Assert.IsType<ShowProvidersIpcRequest>(request);
+
+            cts.Cancel();
+
+            var result = await runTask.WaitAsync(TimeSpan.FromSeconds(10), ct);
+
+            Assert.Equal(DatabaseToolsOutcome.Cancelled, result.Outcome);
+            Assert.Contains("force-killed", result.FailureSummary, StringComparison.OrdinalIgnoreCase);
+            Assert.True(fakeProcess.WasKilled);
+        }
+        finally
+        {
+            DisposeSafely(clientWriter);
+            DisposeSafely(clientReader);
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenHelperUnkillableAfterCancel_DoesNotHangAndReportsOrphan()
+    {
+        // Original bug: a helper that ignores CancelMessage AND can't be force-killed (medium-IL runner trying
+        // to kill a high-IL helper). Before the fix, the runner deadlocked on the unbounded WaitForExitAsync.
+        // After the fix, the kill-timer detects Kill returned false, disposes the pipe to unblock the drain
+        // loop, marks Disposition=Failed, and TranslateOutcome reports the orphan helper to the caller.
+        var ct = TestContext.Current.CancellationToken;
+        await using var pipes = await HelperPipePair.CreateAsync(ct); var server = pipes.Server; var client = pipes.Client;
+        var fakeProcess = new FakeElevatedHelperProcess(server, processId: 4242)
+        {
+            SimulateUnkillable = true
+        };
+        var host = new FakeElevatedHelperProcessHost((_, _) => Task.FromResult<IElevatedHelperProcess>(fakeProcess));
+        var logger = new LoggerUtils.RecordingTraceLogger();
+        var runner = CreateRunner(host, logger);
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        var logSink = new ListProgress<LogRecord>();
+
+        await using var clientWriter = new StreamWriter(client, s_utf8NoBom, bufferSize: 4096, leaveOpen: true) { AutoFlush = true };
+        using var clientReader = new StreamReader(client, s_utf8NoBom, detectEncodingFromByteOrderMarks: false, bufferSize: 4096, leaveOpen: true);
+
+        var runTask = runner.ShowAsync(
+            new ShowProvidersRequest(null, null),
+            logSink, progress: null, cts.Token);
+
+        await WriteMessageAsync(clientWriter, new HelloMessage(4242, 1), ct);
+
+        var request = await ReadRequestAsync(clientReader, ct);
+        Assert.IsType<ShowProvidersIpcRequest>(request);
+
+        cts.Cancel();
+
+        // Ceiling: cancellation-grace (~500ms) + exit-grace (~500ms) for post-IPC bounded wait. 10s gives generous slack.
+        var result = await runTask.WaitAsync(TimeSpan.FromSeconds(10), ct);
+
+        Assert.Equal(DatabaseToolsOutcome.Cancelled, result.Outcome);
+        Assert.Contains("could not be terminated", result.FailureSummary, StringComparison.OrdinalIgnoreCase);
+        Assert.True(fakeProcess.WasKilled);
+    }
+
+    [Fact]
     public async Task SinkThrows_SafeReportSwallows_RunnerCompletesSucceeded()
     {
         var ct = TestContext.Current.CancellationToken;
@@ -574,6 +695,131 @@ public sealed class ElevatedDatabaseToolsRunnerTests
         var result = await runTask;
         Assert.Equal(DatabaseToolsOutcome.Succeeded, result.Outcome);
         Assert.Null(result.FailureSummary);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenProtocolMismatchAndHelperUnkillable_CentralizedFinallyCleansUpWithinBoundedTime()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var pipes = await HelperPipePair.CreateAsync(ct); var server = pipes.Server; var client = pipes.Client;
+        var fakeProcess = new FakeElevatedHelperProcess(server, processId: 4242)
+        {
+            SimulateUnkillable = true
+        };
+        var host = new FakeElevatedHelperProcessHost((_, _) => Task.FromResult<IElevatedHelperProcess>(fakeProcess));
+        var logger = new LoggerUtils.RecordingTraceLogger();
+        var runner = CreateRunner(host, logger);
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        var logSink = new ListProgress<LogRecord>();
+
+        await using var clientWriter = new StreamWriter(client, s_utf8NoBom, bufferSize: 4096, leaveOpen: true) { AutoFlush = true };
+
+        var runTask = runner.ShowAsync(
+            new ShowProvidersRequest(null, null),
+            logSink, progress: null, cts.Token);
+
+        // Send a Hello with mismatched protocol version to trigger the protocol-mismatch early return.
+        await WriteMessageAsync(clientWriter, new HelloMessage(4242, ProtocolVersion: 99), ct);
+
+        var result = await runTask.WaitAsync(TimeSpan.FromSeconds(10), ct);
+
+        Assert.Equal(DatabaseToolsOutcome.Failed, result.Outcome);
+        Assert.Contains("protocol version", result.FailureSummary, StringComparison.OrdinalIgnoreCase);
+        Assert.True(fakeProcess.WasKilled);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenFirstEnvelopeIsNotHelloAndHelperUnkillable_CentralizedFinallyCleansUpWithinBoundedTime()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var pipes = await HelperPipePair.CreateAsync(ct); var server = pipes.Server; var client = pipes.Client;
+        var fakeProcess = new FakeElevatedHelperProcess(server, processId: 4242)
+        {
+            SimulateUnkillable = true
+        };
+        var host = new FakeElevatedHelperProcessHost((_, _) => Task.FromResult<IElevatedHelperProcess>(fakeProcess));
+        var logger = new LoggerUtils.RecordingTraceLogger();
+        var runner = CreateRunner(host, logger);
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        var logSink = new ListProgress<LogRecord>();
+
+        await using var clientWriter = new StreamWriter(client, s_utf8NoBom, bufferSize: 4096, leaveOpen: true) { AutoFlush = true };
+
+        var runTask = runner.ShowAsync(
+            new ShowProvidersRequest(null, null),
+            logSink, progress: null, cts.Token);
+
+        // Send a non-Hello message first to trigger the wrong-first-envelope early return.
+        await WriteMessageAsync(clientWriter, new LogMessage(DateTime.UtcNow, LogLevel.Information, "early log"), ct);
+
+        var result = await runTask.WaitAsync(TimeSpan.FromSeconds(10), ct);
+
+        Assert.Equal(DatabaseToolsOutcome.Failed, result.Outcome);
+        Assert.Contains("HelloMessage", result.FailureSummary);
+        Assert.True(fakeProcess.WasKilled);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenCancelledBeforeHandshakeAndHelperUnkillable_CentralizedFinallyCleansUpWithinBoundedTime()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var pipes = await HelperPipePair.CreateAsync(ct); var server = pipes.Server; var client = pipes.Client;
+        var fakeProcess = new FakeElevatedHelperProcess(server, processId: 4242)
+        {
+            SimulateUnkillable = true
+        };
+        var host = new FakeElevatedHelperProcessHost((_, _) => Task.FromResult<IElevatedHelperProcess>(fakeProcess));
+        var logger = new LoggerUtils.RecordingTraceLogger();
+        var runner = CreateRunner(host, logger);
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        var logSink = new ListProgress<LogRecord>();
+
+        var runTask = runner.ShowAsync(
+            new ShowProvidersRequest(null, null),
+            logSink, progress: null, cts.Token);
+
+        // Cancel before Hello arrives — give the runner a beat to enter the Hello wait, then cancel.
+        await Task.Delay(50, ct);
+        cts.Cancel();
+
+        var result = await runTask.WaitAsync(TimeSpan.FromSeconds(10), ct);
+
+        Assert.Equal(DatabaseToolsOutcome.Cancelled, result.Outcome);
+        Assert.True(fakeProcess.WasKilled);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenPipeClosedBeforeHelloAndHelperUnkillable_CentralizedFinallyCleansUpWithinBoundedTime()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var pipes = await HelperPipePair.CreateAsync(ct); var server = pipes.Server; var client = pipes.Client;
+        var fakeProcess = new FakeElevatedHelperProcess(server, processId: 4242)
+        {
+            SimulateUnkillable = true
+        };
+        var host = new FakeElevatedHelperProcessHost((_, _) => Task.FromResult<IElevatedHelperProcess>(fakeProcess));
+        var logger = new LoggerUtils.RecordingTraceLogger();
+        var runner = CreateRunner(host, logger);
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        var logSink = new ListProgress<LogRecord>();
+
+        var runTask = runner.ShowAsync(
+            new ShowProvidersRequest(null, null),
+            logSink, progress: null, cts.Token);
+
+        // Close the helper-side pipe immediately to trigger the pipe-closed-before-Hello path.
+        await Task.Delay(50, ct);
+        await client.DisposeAsync();
+
+        var result = await runTask.WaitAsync(TimeSpan.FromSeconds(10), ct);
+
+        Assert.Equal(DatabaseToolsOutcome.Failed, result.Outcome);
+        Assert.Contains("Pipe closed", result.FailureSummary, StringComparison.OrdinalIgnoreCase);
+        Assert.True(fakeProcess.WasKilled);
     }
 
     private static ElevatedDatabaseToolsRunner CreateRunner(IElevatedHelperProcessHost host, ITraceLogger logger) =>

--- a/tests/Unit/EventLogExpert.Runtime.Tests/DatabaseTools/Elevation/RegexJsonConverterTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/DatabaseTools/Elevation/RegexJsonConverterTests.cs
@@ -30,24 +30,73 @@ public sealed class RegexJsonConverterTests
     }
 
     [Fact]
-    public void Regex_WithDefaultsAndInfiniteMatchTimeout_EmitsNullTimeoutAndRoundTripsInfinite()
+    public void Read_WithExcessiveTimeoutMs_ThrowsJsonException()
     {
-        var original = new Regex("hello");
+        const string Json = """{"pattern":"abc","options":0,"matchTimeoutMs":10000}""";
 
-        var json = JsonSerializer.Serialize(original, DatabaseToolsIpcSerializer.Options);
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize<Regex>(Json, DatabaseToolsIpcSerializer.Options));
+    }
 
-        using (var doc = JsonDocument.Parse(json))
-        {
-            Assert.Equal("hello", doc.RootElement.GetProperty("pattern").GetString());
-            Assert.Equal(0, doc.RootElement.GetProperty("options").GetInt32());
-            Assert.Equal(JsonValueKind.Null, doc.RootElement.GetProperty("matchTimeoutMs").ValueKind);
-        }
+    [Fact]
+    public void Read_WithInvalidOptionCombination_ThrowsJsonException()
+    {
+        // ECMAScript is incompatible with RightToLeft per Regex constructor docs.
+        int incompatibleOptions = (int)(RegexOptions.ECMAScript | RegexOptions.RightToLeft);
+        string json = $$"""{"pattern":"abc","options":{{incompatibleOptions}},"matchTimeoutMs":100}""";
 
-        var roundTripped = JsonSerializer.Deserialize<Regex>(json, DatabaseToolsIpcSerializer.Options);
-        Assert.NotNull(roundTripped);
-        Assert.Equal("hello", roundTripped.ToString());
-        Assert.Equal(RegexOptions.None, roundTripped.Options);
-        Assert.Equal(Regex.InfiniteMatchTimeout, roundTripped.MatchTimeout);
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize<Regex>(json, DatabaseToolsIpcSerializer.Options));
+    }
+
+    [Fact]
+    public void Read_WithInvalidPattern_ThrowsJsonException()
+    {
+        // Unmatched '(' is a malformed regex pattern.
+        const string Json = """{"pattern":"(","options":0,"matchTimeoutMs":100}""";
+
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize<Regex>(Json, DatabaseToolsIpcSerializer.Options));
+    }
+
+    [Fact]
+    public void Read_WithNegativeTimeoutMs_ThrowsJsonException()
+    {
+        const string Json = """{"pattern":"abc","options":0,"matchTimeoutMs":-5}""";
+
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize<Regex>(Json, DatabaseToolsIpcSerializer.Options));
+    }
+
+    [Fact]
+    public void Read_WithNullTimeoutMs_UsesDefaultTimeoutNotInfinite()
+    {
+        const string Json = """{"pattern":"abc","options":0,"matchTimeoutMs":null}""";
+
+        var result = JsonSerializer.Deserialize<Regex>(Json, DatabaseToolsIpcSerializer.Options);
+
+        Assert.NotNull(result);
+        Assert.Equal(TimeSpan.FromMilliseconds(1000), result.MatchTimeout);
+        Assert.NotEqual(Regex.InfiniteMatchTimeout, result.MatchTimeout);
+    }
+
+    [Fact]
+    public void Read_WithUnknownOptionsBit_ThrowsJsonException()
+    {
+        // 0x80000000 is outside the AllowedOptions mask (no defined RegexOptions flag uses this bit).
+        const string Json = """{"pattern":"abc","options":-2147483648,"matchTimeoutMs":100}""";
+
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize<Regex>(Json, DatabaseToolsIpcSerializer.Options));
+    }
+
+    [Fact]
+    public void Read_WithZeroTimeoutMs_ThrowsJsonException()
+    {
+        const string Json = """{"pattern":"abc","options":0,"matchTimeoutMs":0}""";
+
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize<Regex>(Json, DatabaseToolsIpcSerializer.Options));
     }
 
     [Fact]
@@ -65,6 +114,27 @@ public sealed class RegexJsonConverterTests
         var roundTripped = JsonSerializer.Deserialize<Regex>(json, DatabaseToolsIpcSerializer.Options);
         Assert.NotNull(roundTripped);
         Assert.Equal(TimeSpan.FromMilliseconds(1234), roundTripped.MatchTimeout);
+    }
+
+    [Fact]
+    public void Regex_WithInfiniteMatchTimeout_WriterEmitsNullAndReaderMapsToDefaultTimeout()
+    {
+        var original = new Regex("hello");
+
+        var json = JsonSerializer.Serialize(original, DatabaseToolsIpcSerializer.Options);
+
+        using (var doc = JsonDocument.Parse(json))
+        {
+            Assert.Equal("hello", doc.RootElement.GetProperty("pattern").GetString());
+            Assert.Equal(0, doc.RootElement.GetProperty("options").GetInt32());
+            Assert.Equal(JsonValueKind.Null, doc.RootElement.GetProperty("matchTimeoutMs").ValueKind);
+        }
+
+        var roundTripped = JsonSerializer.Deserialize<Regex>(json, DatabaseToolsIpcSerializer.Options);
+        Assert.NotNull(roundTripped);
+        Assert.Equal("hello", roundTripped.ToString());
+        Assert.Equal(RegexOptions.None, roundTripped.Options);
+        Assert.Equal(TimeSpan.FromMilliseconds(1000), roundTripped.MatchTimeout);
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Runtime.Tests/DatabaseTools/Elevation/TestUtils/FakeElevatedHelperProcess.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/DatabaseTools/Elevation/TestUtils/FakeElevatedHelperProcess.cs
@@ -17,6 +17,8 @@ internal sealed class FakeElevatedHelperProcess(Stream pipe, int processId) : IE
 
     public int ProcessId { get; } = processId;
 
+    public bool SimulateUnkillable { get; set; }
+
     public bool WasKilled => Volatile.Read(ref _killed) != 0;
 
     public async ValueTask DisposeAsync()
@@ -25,13 +27,32 @@ internal sealed class FakeElevatedHelperProcess(Stream pipe, int processId) : IE
         await _pipe.DisposeAsync();
     }
 
-    public void Kill()
+    public bool Kill()
     {
-        if (Interlocked.Exchange(ref _killed, 1) == 0)
+        if (_exitTcs.Task.IsCompleted)
         {
-            try { OnKilled?.Invoke(); } catch { /* tests are responsible for their own callback robustness */ }
-            _exitTcs.TrySetResult(-1);
+            // Process has already "exited" via SignalExited or a prior Kill — report success per the
+            // IElevatedHelperProcess.Kill contract ("true if the process was killed by this call OR was already exited").
+            return true;
         }
+
+        if (Interlocked.Exchange(ref _killed, 1) != 0)
+        {
+            return !SimulateUnkillable;
+        }
+
+        try { OnKilled?.Invoke(); } catch { /* tests are responsible for their own callback robustness */ }
+
+        if (SimulateUnkillable)
+        {
+            // Simulate a wedged high-IL helper: the kill attempt fails and the process keeps running so the exit
+            // TCS is intentionally NOT set. The runner is expected to fall back to closing the pipe to unblock.
+            return false;
+        }
+
+        _exitTcs.TrySetResult(-1);
+
+        return true;
     }
 
     public void SignalExited(int exitCode) => _exitTcs.TrySetResult(exitCode);

--- a/tests/Unit/EventLogExpert.Windows.Tests/Elevation/ElevatedHelperProcessHostTests.cs
+++ b/tests/Unit/EventLogExpert.Windows.Tests/Elevation/ElevatedHelperProcessHostTests.cs
@@ -1,0 +1,81 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.WindowsPlatform.Elevation;
+using NSubstitute;
+using System.IO.Pipes;
+using Xunit;
+
+namespace EventLogExpert.Windows.Tests.Elevation;
+
+public sealed class ElevatedHelperProcessHostTests
+{
+    [Fact]
+    public async Task AcceptAndVerifyClientPidAsync_WhenClientPidMatches_ReturnsWithoutError()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var pipeName = $"eventlogexpert-test-{Guid.NewGuid():N}";
+        using var server = new NamedPipeServerStream(
+            pipeName,
+            PipeDirection.InOut,
+            maxNumberOfServerInstances: 1,
+            PipeTransmissionMode.Byte,
+            PipeOptions.Asynchronous | PipeOptions.CurrentUserOnly);
+
+        var logger = Substitute.For<ITraceLogger>();
+
+        var acceptTask = ElevatedHelperProcessHost.AcceptAndVerifyClientPidAsync(
+            server,
+            expectedPid: Environment.ProcessId,
+            logger,
+            ct);
+
+        using var client = new NamedPipeClientStream(
+            ".",
+            pipeName,
+            PipeDirection.InOut,
+            PipeOptions.Asynchronous);
+
+        await client.ConnectAsync(ct);
+
+        await acceptTask.WaitAsync(TimeSpan.FromSeconds(5), ct);
+
+        Assert.True(server.IsConnected);
+    }
+
+    [Fact]
+    public async Task AcceptAndVerifyClientPidAsync_WhenClientPidMismatches_DisconnectsAndKeepsWaiting()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var pipeName = $"eventlogexpert-test-{Guid.NewGuid():N}";
+        using var server = new NamedPipeServerStream(
+            pipeName,
+            PipeDirection.InOut,
+            maxNumberOfServerInstances: 1,
+            PipeTransmissionMode.Byte,
+            PipeOptions.Asynchronous | PipeOptions.CurrentUserOnly);
+
+        var logger = Substitute.For<ITraceLogger>();
+
+        using var loopCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+
+        // Expected PID = 0 never matches a real process; loop should disconnect after each connection and keep
+        // waiting until the deadline cancels the loop.
+        var acceptTask = ElevatedHelperProcessHost.AcceptAndVerifyClientPidAsync(
+            server,
+            expectedPid: 0,
+            logger,
+            loopCts.Token);
+
+        using (var client1 = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous))
+        {
+            await client1.ConnectAsync(ct);
+        }
+
+        await Task.Delay(50, ct);
+        loopCts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => acceptTask);
+    }
+}


### PR DESCRIPTION
Fixes #568.

## Summary

The `ElevatedDatabaseToolsRunner` design assumed `Process.Kill()` reliably terminates the elevated helper process and unblocks the IPC drain loop. In the actual medium-IL → high-IL deployment, this assumption is false: a medium-IL runner generally cannot obtain `PROCESS_TERMINATE` on a high-IL process started via `ShellExecuteEx`/`runas`. `Process.Kill()` throws `Win32Exception` (Access Denied), which the wrapper used to swallow as a warning. The runner then marked the helper as killed, but the drain loop kept reading from a still-open pipe and the post-terminal `WaitForExitAsync(CancellationToken.None)` blocked forever. Net effect: a wedged elevated helper hung the runner indefinitely.

This PR fixes the deadlock and tightens four related findings in the same scope (pipe-host DoS, regex backtracking, early-return cleanup gaps, doc accuracy).

## Changes

### Deadlock fix (the primary defect)
- **`IElevatedHelperProcess.Kill()` now returns `bool`** with an explicit contract: `true` if the process was killed by this call *or* had already exited, `false` if the kill attempt failed (`Win32Exception` or any other exception). All three implementers — production `ElevatedHelperProcess`, unit-test `FakeElevatedHelperProcess`, integration-test `TestElevatedHelperProcess` — return the new bool and log non-`InvalidOperationException` failures as `Error`.
- **`ElevatedDatabaseToolsRunner` no longer trusts `Kill()`.** A new `KillDisposition { NotAttempted, Succeeded, Failed }` tri-state replaces the `bool _helperKilled` flag, with monotonic transitions (`MarkKillSucceeded` always wins via `Interlocked.Exchange`; `MarkKillFailed` only escalates from `NotAttempted` via `Interlocked.CompareExchange`).
- **All three kill call sites** (cancellation kill-timer, post-IPC exit-grace force-kill, finally fallback) check the return value. On `Kill() == false` the runner disposes the pipe asynchronously to force the drain loop's reader to see EOF, marks `Disposition = Failed`, and skips the post-terminal wait so the runner returns within `_exitGrace` instead of hanging.
- **Bounded post-terminal wait** at the former unbounded `WaitForExitAsync(CancellationToken.None)` site — now wrapped in a `CancellationTokenSource(_exitGrace)`.
- **`TranslateOutcome` accepts the `KillDisposition`** and emits distinct `FailureSummary` strings: `"Cancelled."` for the no-kill-needed case, the existing "force-killed" message for `Succeeded`, and a new explicit orphan warning ("…could not be terminated; it may continue running as an orphan process…") for `Failed`.

### Early-return cleanup safety
- New method-local `bool exitHandled = false;` is set immediately before the normal `return TranslateOutcome(...)`. Every other path through `RunAsync` (Hello timeout, protocol mismatch, wrong-first-envelope, pipe-closed-before-Hello, cancel-during-request-write, unhandled exception) leaves `exitHandled` false.
- A **centralized graceful-first `finally`** block now handles all early-return cleanup: cancels the reader, awaits the hoisted `pipeReaderTask` (bounded), disposes the pipe (helper sees EOF and exits cooperatively), bounded-waits for exit, and falls back to `Kill()` only if the helper does not exit within the grace window. If the fallback kill also fails the helper becomes an orphan; the pipe is already closed so the runner returns without waiting further.
- The catch-block's direct `process.Kill()` was removed — the centralized finally is now the sole owner of cleanup, eliminating double-kill paths.

### Pipe-host DoS mitigation
- `ElevatedHelperProcessHost` (production) and `TestElevatedHelperProcessHost` (integration tests) replace the single `WaitForConnectionAsync` + throw-on-PID-mismatch flow with an `AcceptAndVerifyClientPidAsync` loop that:
  - Disconnects wrong-PID connections and keeps waiting for the legitimate helper.
  - Returns from `TryVerifyClientPid` via a `PidVerifyResult { Match, ClientPidMismatch, GetPidFailed }` enum so wrong-PID is a normal control-flow event and native-API failures still throw.
  - Preserves the original `connectCts` deadline across all retries (no per-iteration reset).
  - Caps the rejected-connection count at 32 to bound log spam and prevent indefinite retry storms.
  - Logs the first rejection at `Information` and subsequent rejections at `Trace` to keep diagnostics useful without filling the log.

### Regex JSON converter validation
- `RegexJsonConverter.Read()` now:
  - Validates `options` against an `AllowedOptions` whitelist (only the documented `RegexOptions` flags).
  - Wraps `ArgumentException` from `new Regex(...)` as `JsonException` (catches malformed patterns and incompatible option combinations like `ECMAScript + RightToLeft`).
  - Maps a null `matchTimeoutMs` wire value to a 1000 ms default instead of `Regex.InfiniteMatchTimeout` (ReDoS mitigation; the production writer never emits null, so this only affects defensive/hand-crafted JSON).
  - Rejects explicit `matchTimeoutMs` values outside `[1, 5000]` ms.
- `Write()` is unchanged. The deliberately asymmetric (lossy) null-handling on read is documented in the class remarks.

### Tests
- `ElevatedDatabaseToolsRunnerTests` — 7 new tests:
  - Deadlock fix: `RunAsync_WhenHelperUnkillableAfterCancel_DoesNotHangAndReportsOrphan`.
  - Companion: `RunAsync_WhenHelperKillSucceedsAfterCancel_ReportsForceKilled`.
  - Early-return cleanup with unkillable helper: `HelloTimeout`, `ProtocolMismatch`, `FirstEnvelopeIsNotHello`, `CancelledBeforeHandshake`, `PipeClosedBeforeHello`.
- `RegexJsonConverterTests` — 7 new tests + 1 updated test covering null/zero/negative/excessive timeout, unknown option bits, invalid option combinations, and invalid patterns.
- New `ElevatedHelperProcessHostTests` — 2 tests covering the happy path (matching client PID returns) and wrong-PID disconnect-and-retry. The 32-rejection cap and the `GetPidFailed` throw path are exercised in production but not unit-tested because they need cross-process setup.

## Validation
- 36/36 elevation + regex tests pass (was 22 baseline, +14)
- 1,196 Runtime.Tests + 45 Windows.Tests pass
- 3,084/3,084 unit tests across the full solution pass
- Full solution builds with 0 warnings / 0 errors

## Design review
The two-pass design, `KillDisposition` semantics, centralized finally, pipe-host loop, and regex validation were validated through 4 rounds of a four-model review panel (Claude Opus xhigh, GPT-5.4, Gemini 3.1 Pro, GPT-5.3-Codex), a 3-agent post-implementation panel, and branch-wide rename / least-privilege / vertical-slice audits.
