### PR TITLE
Build the native shell extension against a NuGet-delivered Windows SDK

### DIFF
--- a/docs/Explorer-Context-Menu.md
+++ b/docs/Explorer-Context-Menu.md
@@ -29,10 +29,10 @@ The MAUI receiving side:
 
 ## Build prerequisites
 
-The native shell extension requires the **MSVC C++ workload** + the **Windows 10/11 SDK 10.0.26100+** to build. Specifically:
+The native shell extension requires the **MSVC C++ workload** to build. The **Windows 10/11 SDK (10.0.26100+)** it compiles against is delivered as NuGet packages (`Microsoft.Windows.SDK.CPP` + `Microsoft.Windows.SDK.CPP.x64`, restored to `src/packages`), so a machine-installed Windows SDK is **not** required on build agents — the OneBranch release container ships the C++ toolset but no SDK, and the packages supply the headers, import libs, winmd, and SDK tools (`rc.exe`, `mt.exe`, `midlrt.exe`). Specifically:
 
 - Visual Studio 2026 (or 2022) with the **Desktop development with C++** workload
-- Windows SDK 10.0.26100.0 or newer (the C++/WinRT projection headers shipped with this SDK)
+- The Windows SDK NuGet packages above (restored automatically by the `BuildExplorerExtensionNative` target; see below). A locally-installed Windows SDK 10.0.26100+ is still honored as a fallback when those packages are not restored — the vcxproj's `WindowsTargetPlatformVersion` then stays a bare `10.0` (latest installed SDK).
 - `nuget.exe` on PATH. Install via `winget install Microsoft.NuGet` (dev), the `NuGetToolInstaller@1` pipeline task (ADO), or any equivalent. The `BuildExplorerExtensionNative` MSBuild target fails fast with an actionable error if not found — there is no auto-download (removed to eliminate supply-chain risk from the moving `latest` URL).
 
 `dotnet build` of the .NET solution alone does NOT exercise the C++ build — the C++ project is intentionally not in `EventLogExpert.slnx` because the .NET SDK MSBuild doesn't include `$(VCTargetsPath)`. The native build is triggered only during MSIX packaging (`/p:WindowsPackageType=MSIX`) by the `BuildExplorerExtensionNative` MSBuild target in `src/EventLogExpert/EventLogExpert.csproj`, which locates VS MSBuild via `vswhere` and invokes the vcxproj.
@@ -46,7 +46,7 @@ cd src/EventLogExpert.ExplorerExtensionNative
 nuget restore packages.config -PackagesDirectory ..\packages
 ```
 
-This populates `src/packages/Microsoft.Windows.CppWinRT.*` and `src/packages/Microsoft.Windows.ImplementationLibrary.*` (WIL). Both are gitignored.
+This populates `src/packages/` with `Microsoft.Windows.CppWinRT.*`, `Microsoft.Windows.ImplementationLibrary.*` (WIL), and the Windows SDK packages `Microsoft.Windows.SDK.CPP.*` + `Microsoft.Windows.SDK.CPP.x64.*` (the SDK packages are large — several hundred MB extracted). All are gitignored.
 
 ## Local dev install (signed MSIX)
 

--- a/src/EventLogExpert.ExplorerExtensionNative/EventLogExpert.ExplorerExtensionNative.vcxproj
+++ b/src/EventLogExpert.ExplorerExtensionNative/EventLogExpert.ExplorerExtensionNative.vcxproj
@@ -6,6 +6,21 @@
     so the manifest's <com:Class Path="EventLogExpert.ExplorerExtension.dll" ...> stays accurate.
     Build prereqs are documented in docs/Explorer-Context-Menu.md.
   -->
+  <!--
+    Windows SDK via NuGet (Microsoft.Windows.SDK.CPP[.x64]) — imported FIRST so WindowsSdkDir and
+    WindowsTargetPlatformVersion are established before Microsoft.Cpp.*.props run their SDK
+    resolution. This makes the C++/WinRT build self-contained: it resolves SDK headers, import
+    libs, and winmd from the restored packages rather than a machine-installed SDK. Without it,
+    CI containers that ship the VC++ toolset but no Windows SDK (the OneBranch vse2022 image used
+    by the release pipeline) fail with `error MSB8036: The Windows SDK version ... was not found`
+    because the bare WindowsTargetPlatformVersion '10.0' below resolves to "latest installed" and
+    nothing is installed. The Exists() guards keep the build working when the packages are not
+    restored — it then falls back to the latest machine-installed SDK via the bare '10.0'. The
+    x64 package supplies only the x64 import libs (it carries no .targets). Versions are pinned in
+    packages.config; bump in lockstep there. See docs/Explorer-Context-Menu.md.
+  -->
+  <Import Project="..\packages\Microsoft.Windows.SDK.CPP.10.0.26100.8249\build\native\Microsoft.Windows.SDK.cpp.props" Condition="Exists('..\packages\Microsoft.Windows.SDK.CPP.10.0.26100.8249\build\native\Microsoft.Windows.SDK.cpp.props')" />
+  <Import Project="..\packages\Microsoft.Windows.SDK.CPP.x64.10.0.26100.8249\build\native\Microsoft.Windows.SDK.cpp.x64.props" Condition="Exists('..\packages\Microsoft.Windows.SDK.CPP.x64.10.0.26100.8249\build\native\Microsoft.Windows.SDK.cpp.x64.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -24,7 +39,11 @@
     <ProjectGuid>{B9D2A1F3-8C47-4E2D-9F5B-6A1E2C3D4E5F}</ProjectGuid>
     <RootNamespace>EventLogExpertExplorerExtension</RootNamespace>
     <TargetName>EventLogExpert.ExplorerExtension</TargetName>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <!-- Conditional so the NuGet Windows SDK package (imported near the top of this file) wins
+         when restored — its props set WindowsTargetPlatformVersion to the package's SDK version.
+         The bare '10.0' (latest machine-installed SDK) remains the fallback for environments that
+         don't restore the SDK package. See the SDK.CPP import comment above. -->
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
 
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -131,6 +150,7 @@
 
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\packages\Microsoft.Windows.SDK.CPP.10.0.26100.8249\build\native\Microsoft.Windows.SDK.cpp.targets" Condition="Exists('..\packages\Microsoft.Windows.SDK.CPP.10.0.26100.8249\build\native\Microsoft.Windows.SDK.cpp.targets')" />
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
     <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.260126.7\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.260126.7\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
   </ImportGroup>

--- a/src/EventLogExpert.ExplorerExtensionNative/packages.config
+++ b/src/EventLogExpert.ExplorerExtensionNative/packages.config
@@ -2,4 +2,12 @@
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.250303.1" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.260126.7" targetFramework="native" />
+  <!-- Windows SDK delivered as NuGet packages so the native build resolves headers/libs/winmd
+       from the restore output instead of a machine-installed SDK. Required for CI containers
+       that ship the VC++ toolset but no Windows SDK (e.g. the OneBranch vse2022 image). The base
+       package provides headers/winmd + sets WindowsSdkDir/WindowsTargetPlatformVersion; the .x64
+       package provides the x64 import libraries. Both are required (no transitive dependency).
+       See docs/Explorer-Context-Menu.md. -->
+  <package id="Microsoft.Windows.SDK.CPP" version="10.0.26100.8249" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.x64" version="10.0.26100.8249" targetFramework="native" />
 </packages>


### PR DESCRIPTION
## Problem

The `EventLogExpert-Release` pipeline (build `20260610.1`) failed in the OneBranch `vse2022` container with:

```
error MSB8036: The Windows SDK version 10.0.17134.0 (or later) was not found.
[src/EventLogExpert.ExplorerExtensionNative/EventLogExpert.ExplorerExtensionNative.vcxproj]
```

The native C++/WinRT shell extension compiled against a bare `WindowsTargetPlatformVersion` of `10.0` (= latest *machine-installed* SDK). The OneBranch container ships the MSVC C++ toolset but **no Windows SDK**, so the resolution found nothing. GitHub's `windows-2022` PR validation builds the same commit fine only because that runner image happens to ship a Windows SDK.

## Fix

Deliver the Windows SDK as NuGet packages, matching the existing CppWinRT/WIL `packages.config` pattern, so the native build is self-contained and reproducible on any agent that has the C++ toolset.

- **`packages.config`** — add `Microsoft.Windows.SDK.CPP` + `Microsoft.Windows.SDK.CPP.x64` (`10.0.26100.8249`). The base package provides headers/winmd and sets `WindowsSdkDir` / `WindowsTargetPlatformVersion`; the `.x64` package provides the x64 import libraries. Both are required (no transitive dependency).
- **`EventLogExpert.ExplorerExtensionNative.vcxproj`** — import the SDK.CPP props first (so `Microsoft.Cpp.*.props` SDK resolution sees the package-provided `WindowsSdkDir`) plus the targets, and make `WindowsTargetPlatformVersion` conditional so the package version wins when restored while the bare `10.0` stays as the fallback for environments that don't restore the SDK package.
- **`docs/Explorer-Context-Menu.md`** — document the NuGet-delivered SDK and larger restore footprint.

## Validation (local, VS Enterprise + nuget restore)

- `WindowsSdkDir` resolves to the **package** path (not `C:\Program Files (x86)\Windows Kits\10`), `WindowsTargetPlatformVersion = 10.0.26100.0`.
- Clean `Release|x64` rebuild → **0 errors / 0 warnings**, produces `EventLogExpert.ExplorerExtension.dll`.
- Headers, x64 import libs, winmd, **and SDK tools** (`rc.exe`/`mt.exe`/`midlrt.exe`) all resolve from the packages — confirming the build works on an agent with no machine-installed SDK (the OneBranch case).
- No machine SDK needed; with the packages absent the build still falls back to a locally-installed SDK via the bare `10.0`.

## Notes

- No change to `EnsureNuGetPackageBuildImports` — the SDK packages are intentionally *not* hard-required there, preserving the machine-SDK dev fallback.
- The SDK packages are large (several hundred MB extracted); `src/packages` is gitignored.
