### PR TITLE
Add inline event grouping to the event table

### DIFF
--- a/docs/Keyboard-And-Copy.md
+++ b/docs/Keyboard-And-Copy.md
@@ -34,6 +34,22 @@ The menu bar follows WAI-ARIA menubar conventions. Once a menu-bar button has fo
 
 Hovering a different top-level menu while a menu is open switches to that menu — same as Win32 menubars.
 
+### Grouped event table
+
+When the event table is [grouped](Viewing-Events.md#grouping) it behaves as a tree grid. Alongside the normal selection keys:
+
+| Key | Action |
+| --- | --- |
+| `ArrowUp` / `ArrowDown` | Move through visible rows, stopping on group headers as well as events. Landing on an event selects it; landing on a header only moves focus, leaving the current selection unchanged. |
+| `ArrowLeft` | On an event, move focus to its group header. On an expanded header, collapse the group. |
+| `ArrowRight` | On a collapsed header, expand the group. On an expanded header, move to and select its first event. |
+| `Enter` | Toggle the focused group header between expanded and collapsed. |
+| `Home` / `End` | Move to the first / last visible row, which may be a header (focus only). |
+| `Shift` + `ArrowUp` / `ArrowDown` | Extend the selection to the next / previous event, skipping over headers. A range that spans a collapsed group includes that group's hidden events. |
+| `Ctrl+A` | Select every event in the table, including events inside collapsed groups. |
+
+Flat (ungrouped) tables keep the standard arrow behavior; `ArrowLeft` / `ArrowRight` are not intercepted there.
+
 ### Other shortcuts
 
 | Shortcut | Action |

--- a/docs/Viewing-Events.md
+++ b/docs/Viewing-Events.md
@@ -30,13 +30,29 @@ The current sort indicator (a caret) appears in the active column header; clicki
 
 **Per-row highlighting.** When a filter has a `Highlight Color` set, every event matching that filter is rendered with that background color. The configured colors live alongside the filter — see [Filtering](Filtering.md). When several enabled, non-excluded filters could highlight the same row, the first one in pane order wins.
 
-**Selection.** Click to select. Ctrl+Click toggles individual rows. Shift+Click selects a range from the anchor to the clicked row. Ctrl+Shift+Click extends the selection additively from the anchor to the clicked row without dropping rows you've already selected elsewhere. Arrow keys, Page Up / Page Down, Home, and End move within the table; Shift + those keys extends the selection. `Ctrl+A` selects every visible row; `Escape` clears the selection. The selection drives both the `Ctrl+C` clipboard copy (see [Keyboard and Copy](Keyboard-And-Copy.md)) and the Details pane.
+**Selection.** Click to select. Ctrl+Click toggles individual rows. Shift+Click selects a range from the anchor to the clicked row. Ctrl+Shift+Click extends the selection additively from the anchor to the clicked row without dropping rows you've already selected elsewhere. Arrow keys, Page Up / Page Down, Home, and End move within the table; Shift + those keys extends the selection. `Ctrl+A` selects every event in the table (including events hidden inside collapsed groups — see [Grouping](#grouping)); `Escape` clears the selection. The selection drives both the `Ctrl+C` clipboard copy (see [Keyboard and Copy](Keyboard-And-Copy.md)) and the Details pane.
 
 **Right-click on a row.** Opens a context menu:
 
 - `Copy Selected` / `Copy Selected (Simple)` / `Copy Selected (XML)` / `Copy Selected (Full)` — same four formats as the `Edit` menu.
 - `Exclude Events Before` / `Exclude Events After` — sets a date filter using the right-clicked event's timestamp as the boundary.
 - `Include` and `Exclude` submenus — each lists the field comparisons applicable to a single right-clicked event. Picking one creates a new basic filter (or exclusion) for that field equal to the right-clicked event's value. `Description` and `Xml` are not present in the submenu. Today this works for `Event ID`, `Activity ID`, `Level`, `Keywords`, `Source`, and `Task Category`; the `Process ID`, `Thread ID`, and `User ID` items are present in the menu but produce empty filter values, so they currently no-op.
+
+### Grouping
+
+Group the table by any column except `Description` so related events fold under a shared header row. Grouping is most useful for an identifier such as `Activity ID`, but works for every column in the `Group By` submenu.
+
+**Turning grouping on.** Right-click a column header and pick a column from the `Group By` submenu; `(none)` turns grouping off. Groups are ordered by the grouped value, and events within each group keep the current `Order By` sort. Each header row shows the column name, the group value (or `(none)` when that value is empty), and the event count — for example `Activity ID: {guid} (42)`.
+
+**Group direction.** `Group Descending` (on the group header's right-click menu) flips the order of the groups themselves between ascending and descending. It does not change the per-event `Order By` direction.
+
+**Expanding and collapsing.**
+
+- Click a group header, click its chevron, or press `Enter` while the header is focused to toggle that one group. `ArrowLeft` / `ArrowRight` also collapse / expand a focused header — see [Keyboard and Copy](Keyboard-And-Copy.md#grouped-event-table).
+- `Expand All Groups` and `Collapse All Groups` are on both the group header's right-click menu and the `View` menu.
+- Collapse state is **transient**: it is not persisted and resets whenever you switch to a different log tab.
+
+**Selecting a group.** Right-click a group header and choose `Select Group` to select every event in that group, including events hidden by a collapse. `Ctrl+A` still selects every event in the table, also including those inside collapsed groups.
 
 ### Details pane
 

--- a/src/EventLogExpert.Runtime/LogTable/ILogTableCommands.cs
+++ b/src/EventLogExpert.Runtime/LogTable/ILogTableCommands.cs
@@ -19,14 +19,26 @@ public interface ILogTableCommands
     /// <summary>Activates the tab for <paramref name="logId" /> (focuses its rows in the table).</summary>
     void SetActiveTable(EventLogId logId);
 
+    /// <summary>Collapses or expands every group at once, clearing per-group overrides.</summary>
+    void SetAllGroupsCollapsed(bool collapsed);
+
     /// <summary>Sets the persisted width of <paramref name="column" /> to <paramref name="width" /> pixels.</summary>
     void SetColumnWidth(ColumnName column, int width);
+
+    /// <summary>Groups rows by <paramref name="groupBy" /> (<see langword="null" /> clears grouping).</summary>
+    void SetGroupBy(ColumnName? groupBy);
 
     /// <summary>Sets the current sort column to <paramref name="orderBy" /> (<see langword="null" /> clears the sort).</summary>
     void SetOrderBy(ColumnName? orderBy);
 
     /// <summary>Toggles whether <paramref name="column" /> is visible in the log table.</summary>
     void ToggleColumn(ColumnName column);
+
+    /// <summary>Toggles the collapsed state of the group identified by <paramref name="groupKey" />.</summary>
+    void ToggleGroupCollapsed(string groupKey);
+
+    /// <summary>Flips the order direction of the group headers when grouping is active.</summary>
+    void ToggleGroupSortDirection();
 
     /// <summary>Flips the current sort direction on the active sort column.</summary>
     void ToggleSortDirection();

--- a/src/EventLogExpert.Runtime/LogTable/LogTableCommands.cs
+++ b/src/EventLogExpert.Runtime/LogTable/LogTableCommands.cs
@@ -19,11 +19,19 @@ internal sealed class LogTableCommands(IDispatcher dispatcher) : ILogTableComman
 
     public void SetActiveTable(EventLogId logId) => _dispatcher.Dispatch(new SetActiveTableAction(logId));
 
+    public void SetAllGroupsCollapsed(bool collapsed) => _dispatcher.Dispatch(new SetAllGroupsCollapsedAction(collapsed));
+
     public void SetColumnWidth(ColumnName column, int width) => _dispatcher.Dispatch(new SetColumnWidthAction(column, width));
+
+    public void SetGroupBy(ColumnName? groupBy) => _dispatcher.Dispatch(new SetGroupByAction(groupBy));
 
     public void SetOrderBy(ColumnName? orderBy) => _dispatcher.Dispatch(new SetOrderByAction(orderBy));
 
     public void ToggleColumn(ColumnName column) => _dispatcher.Dispatch(new ToggleColumnAction(column));
+
+    public void ToggleGroupCollapsed(string groupKey) => _dispatcher.Dispatch(new ToggleGroupCollapsedAction(groupKey));
+
+    public void ToggleGroupSortDirection() => _dispatcher.Dispatch(new ToggleGroupSortingAction());
 
     public void ToggleSortDirection() => _dispatcher.Dispatch(new ToggleSortingAction());
 }

--- a/src/EventLogExpert.Runtime/LogTable/LogTableState.cs
+++ b/src/EventLogExpert.Runtime/LogTable/LogTableState.cs
@@ -29,4 +29,16 @@ public sealed record LogTableState
     public ColumnName? OrderBy { get; init; }
 
     public bool IsDescending { get; init; } = true;
+
+    public ColumnName? GroupBy { get; init; }
+
+    public bool IsGroupDescending { get; init; }
+
+    public bool GroupsCollapsedByDefault { get; init; }
+
+    public ImmutableHashSet<string> GroupCollapseOverrides { get; init; } =
+        ImmutableHashSet.Create<string>(StringComparer.Ordinal);
+
+    public bool IsGroupCollapsed(string groupKey) =>
+        GroupsCollapsedByDefault ^ GroupCollapseOverrides.Contains(groupKey);
 }

--- a/src/EventLogExpert.Runtime/LogTable/Reducers.cs
+++ b/src/EventLogExpert.Runtime/LogTable/Reducers.cs
@@ -291,8 +291,11 @@ internal sealed class Reducers
         state with { ColumnWidths = state.ColumnWidths.SetItem(action.ColumnName, action.Width) };
 
     [ReducerMethod]
-    public static LogTableState ReduceSetGroupBy(LogTableState state, SetGroupByAction action) =>
-        state with
+    public static LogTableState ReduceSetGroupBy(LogTableState state, SetGroupByAction action)
+    {
+        if (state.GroupBy == action.GroupBy) { return state; }
+
+        return state with
         {
             GroupBy = action.GroupBy,
             IsGroupDescending = false,
@@ -303,6 +306,7 @@ internal sealed class Reducers
                 state.IsDescending,
                 action.GroupBy)
         };
+    }
 
     [ReducerMethod]
     public static LogTableState ReduceSetOrderBy(LogTableState state, SetOrderByAction action) =>

--- a/src/EventLogExpert.Runtime/LogTable/Reducers.cs
+++ b/src/EventLogExpert.Runtime/LogTable/Reducers.cs
@@ -273,14 +273,18 @@ internal sealed class Reducers
     [ReducerMethod]
     public static LogTableState ReduceSetAllGroupsCollapsed(
         LogTableState state,
-        SetAllGroupsCollapsedAction action) =>
-        state.GroupsCollapsedByDefault == action.Collapsed && state.GroupCollapseOverrides.IsEmpty ?
+        SetAllGroupsCollapsedAction action)
+    {
+        if (state.GroupBy is null) { return state; }
+
+        return state.GroupsCollapsedByDefault == action.Collapsed && state.GroupCollapseOverrides.IsEmpty ?
             state :
             state with
             {
                 GroupsCollapsedByDefault = action.Collapsed,
                 GroupCollapseOverrides = ImmutableHashSet.Create<string>(StringComparer.Ordinal)
             };
+    }
 
     [ReducerMethod]
     public static LogTableState ReduceSetColumnWidth(LogTableState state, SetColumnWidthAction action) =>
@@ -309,13 +313,17 @@ internal sealed class Reducers
     [ReducerMethod]
     public static LogTableState ReduceToggleGroupCollapsed(
         LogTableState state,
-        ToggleGroupCollapsedAction action) =>
-        state with
+        ToggleGroupCollapsedAction action)
+    {
+        if (state.GroupBy is null) { return state; }
+
+        return state with
         {
             GroupCollapseOverrides = state.GroupCollapseOverrides.Contains(action.GroupKey) ?
                 state.GroupCollapseOverrides.Remove(action.GroupKey) :
                 state.GroupCollapseOverrides.Add(action.GroupKey)
         };
+    }
 
     [ReducerMethod(typeof(ToggleGroupSortingAction))]
     public static LogTableState ReduceToggleGroupSorting(LogTableState state)

--- a/src/EventLogExpert.Runtime/LogTable/Reducers.cs
+++ b/src/EventLogExpert.Runtime/LogTable/Reducers.cs
@@ -27,12 +27,14 @@ internal sealed class Reducers
 
         if (state.EventTables.IsEmpty)
         {
-            return state with
-            {
-                EventTables = state.EventTables.Add(newTable),
-                EventCountByLog = counts,
-                ActiveEventLogId = newTable.Id
-            };
+            return ResetGroupCollapseIfActiveChanged(
+                state with
+                {
+                    EventTables = state.EventTables.Add(newTable),
+                    EventCountByLog = counts,
+                    ActiveEventLogId = newTable.Id
+                },
+                state.ActiveEventLogId);
         }
 
         var combinedTable = state.EventTables.FirstOrDefault(table => table.IsCombined);
@@ -48,14 +50,16 @@ internal sealed class Reducers
 
         combinedTable = new LogView(EventLogId.Create()) { IsCombined = true };
 
-        return state with
-        {
-            EventTables = state.EventTables
-                .Add(combinedTable)
-                .Add(newTable),
-            EventCountByLog = counts,
-            ActiveEventLogId = combinedTable.Id
-        };
+        return ResetGroupCollapseIfActiveChanged(
+            state with
+            {
+                EventTables = state.EventTables
+                    .Add(combinedTable)
+                    .Add(newTable),
+                EventCountByLog = counts,
+                ActiveEventLogId = combinedTable.Id
+            },
+            state.ActiveEventLogId);
     }
 
     [ReducerMethod]
@@ -69,7 +73,9 @@ internal sealed class Reducers
             state.DisplayedEvents,
             action.Events,
             GetEffectiveOrderBy(state.OrderBy),
-            state.IsDescending);
+            state.IsDescending,
+            state.GroupBy,
+            state.IsGroupDescending);
 
         var updatedTable = SetComputerNameIfFirstEvent(table, action.Events);
         var counts = IncrementCount(state.EventCountByLog, table.Id, action.Events.Count);
@@ -123,7 +129,9 @@ internal sealed class Reducers
             state.DisplayedEvents,
             combinedBatch,
             GetEffectiveOrderBy(state.OrderBy),
-            state.IsDescending);
+            state.IsDescending,
+            state.GroupBy,
+            state.IsGroupDescending);
 
         return state with
         {
@@ -135,13 +143,13 @@ internal sealed class Reducers
 
     [ReducerMethod(typeof(CloseAllLogsAction))]
     public static LogTableState ReduceCloseAll(LogTableState state) =>
-        state with
+        ResetGroupCollapse(state with
         {
             EventTables = [],
             DisplayedEvents = [],
             EventCountByLog = ImmutableDictionary<EventLogId, int>.Empty,
             ActiveEventLogId = null
-        };
+        });
 
     [ReducerMethod]
     public static LogTableState ReduceCloseLog(LogTableState state, CloseLogAction action)
@@ -159,39 +167,45 @@ internal sealed class Reducers
         switch (remainingPerLogTables.Count)
         {
             case <= 0:
-                return state with
-                {
-                    EventTables = [],
-                    DisplayedEvents = [],
-                    EventCountByLog = ImmutableDictionary<EventLogId, int>.Empty,
-                    ActiveEventLogId = null
-                };
+                return ResetGroupCollapseIfActiveChanged(
+                    state with
+                    {
+                        EventTables = [],
+                        DisplayedEvents = [],
+                        EventCountByLog = ImmutableDictionary<EventLogId, int>.Empty,
+                        ActiveEventLogId = null
+                    },
+                    state.ActiveEventLogId);
             case 1:
                 {
                     var soleRemaining = remainingPerLogTables[0];
                     var filtered = FilterByOwningLog(state.DisplayedEvents, soleRemaining.LogName);
 
-                    return state with
-                    {
-                        EventTables = remainingPerLogTables,
-                        DisplayedEvents = filtered,
-                        EventCountByLog = counts,
-                        ActiveEventLogId = soleRemaining.Id
-                    };
+                    return ResetGroupCollapseIfActiveChanged(
+                        state with
+                        {
+                            EventTables = remainingPerLogTables,
+                            DisplayedEvents = filtered,
+                            EventCountByLog = counts,
+                            ActiveEventLogId = soleRemaining.Id
+                        },
+                        state.ActiveEventLogId);
                 }
             default:
                 {
                     var combinedTable = new LogView(EventLogId.Create()) { IsCombined = true };
                     var filtered = FilterOutOwningLog(state.DisplayedEvents, closingTable.LogName);
 
-                    return state with
-                    {
-                        EventTables = remainingPerLogTables.Insert(0, combinedTable),
-                        DisplayedEvents = filtered,
-                        EventCountByLog = counts,
-                        ActiveEventLogId = remainingPerLogTables.Any(t => t.Id == state.ActiveEventLogId) ?
-                            state.ActiveEventLogId : combinedTable.Id
-                    };
+                    return ResetGroupCollapseIfActiveChanged(
+                        state with
+                        {
+                            EventTables = remainingPerLogTables.Insert(0, combinedTable),
+                            DisplayedEvents = filtered,
+                            EventCountByLog = counts,
+                            ActiveEventLogId = remainingPerLogTables.Any(t => t.Id == state.ActiveEventLogId) ?
+                                state.ActiveEventLogId : combinedTable.Id
+                        },
+                        state.ActiveEventLogId);
                 }
         }
     }
@@ -199,13 +213,31 @@ internal sealed class Reducers
     [ReducerMethod]
     public static LogTableState ReduceLoadColumnsCompleted(
         LogTableState state,
-        LoadColumnsCompletedAction action) =>
-        state with
+        LoadColumnsCompletedAction action)
+    {
+        var updated = state with
         {
             Columns = action.LoadedColumns,
             ColumnWidths = action.ColumnWidths,
             ColumnOrder = action.ColumnOrder
         };
+
+        bool groupColumnHidden = updated.GroupBy is { } groupColumn &&
+            (!action.LoadedColumns.TryGetValue(groupColumn, out bool isVisible) || !isVisible);
+
+        if (!groupColumnHidden) { return updated; }
+
+        return updated with
+        {
+            GroupBy = null,
+            IsGroupDescending = false,
+            GroupsCollapsedByDefault = false,
+            GroupCollapseOverrides = ImmutableHashSet.Create<string>(StringComparer.Ordinal),
+            DisplayedEvents = updated.DisplayedEvents.SortEvents(
+                GetEffectiveOrderBy(updated.OrderBy),
+                updated.IsDescending)
+        };
+    }
 
     [ReducerMethod]
     public static LogTableState ReduceReorderColumn(LogTableState state, ReorderColumnAction action)
@@ -233,18 +265,75 @@ internal sealed class Reducers
 
         if (activeTable is null) { return state; }
 
-        return state with { ActiveEventLogId = activeTable.Id };
+        return ResetGroupCollapseIfActiveChanged(
+            state with { ActiveEventLogId = activeTable.Id },
+            state.ActiveEventLogId);
     }
+
+    [ReducerMethod]
+    public static LogTableState ReduceSetAllGroupsCollapsed(
+        LogTableState state,
+        SetAllGroupsCollapsedAction action) =>
+        state.GroupsCollapsedByDefault == action.Collapsed && state.GroupCollapseOverrides.IsEmpty ?
+            state :
+            state with
+            {
+                GroupsCollapsedByDefault = action.Collapsed,
+                GroupCollapseOverrides = ImmutableHashSet.Create<string>(StringComparer.Ordinal)
+            };
 
     [ReducerMethod]
     public static LogTableState ReduceSetColumnWidth(LogTableState state, SetColumnWidthAction action) =>
         state with { ColumnWidths = state.ColumnWidths.SetItem(action.ColumnName, action.Width) };
 
     [ReducerMethod]
+    public static LogTableState ReduceSetGroupBy(LogTableState state, SetGroupByAction action) =>
+        state with
+        {
+            GroupBy = action.GroupBy,
+            IsGroupDescending = false,
+            GroupsCollapsedByDefault = false,
+            GroupCollapseOverrides = ImmutableHashSet.Create<string>(StringComparer.Ordinal),
+            DisplayedEvents = state.DisplayedEvents.SortEvents(
+                GetEffectiveOrderBy(state.OrderBy),
+                state.IsDescending,
+                action.GroupBy)
+        };
+
+    [ReducerMethod]
     public static LogTableState ReduceSetOrderBy(LogTableState state, SetOrderByAction action) =>
         state.OrderBy.Equals(action.OrderBy) ?
             SortDisplayEvents(state, null, true) :
             SortDisplayEvents(state, action.OrderBy, state.IsDescending);
+
+    [ReducerMethod]
+    public static LogTableState ReduceToggleGroupCollapsed(
+        LogTableState state,
+        ToggleGroupCollapsedAction action) =>
+        state with
+        {
+            GroupCollapseOverrides = state.GroupCollapseOverrides.Contains(action.GroupKey) ?
+                state.GroupCollapseOverrides.Remove(action.GroupKey) :
+                state.GroupCollapseOverrides.Add(action.GroupKey)
+        };
+
+    [ReducerMethod(typeof(ToggleGroupSortingAction))]
+    public static LogTableState ReduceToggleGroupSorting(LogTableState state)
+    {
+        if (state.GroupBy is null) { return state; }
+
+        bool isGroupDescending = !state.IsGroupDescending;
+
+        return state with
+        {
+            IsGroupDescending = isGroupDescending,
+            DisplayedEvents = state.DisplayedEvents.SortEvents(
+                GetEffectiveOrderBy(state.OrderBy),
+                state.IsDescending,
+                state.GroupBy,
+                isGroupDescending)
+        };
+    }
 
     [ReducerMethod]
     public static LogTableState ReduceToggleLoading(LogTableState state, ToggleLoadingAction action)
@@ -346,7 +435,11 @@ internal sealed class Reducers
             }
         }
 
-        var sorted = concatenated.SortEvents(GetEffectiveOrderBy(state.OrderBy), state.IsDescending);
+        var sorted = concatenated.SortEvents(
+            GetEffectiveOrderBy(state.OrderBy),
+            state.IsDescending,
+            state.GroupBy,
+            state.IsGroupDescending);
 
         return state with
         {
@@ -374,7 +467,9 @@ internal sealed class Reducers
             existing,
             action.Events,
             GetEffectiveOrderBy(state.OrderBy),
-            state.IsDescending);
+            state.IsDescending,
+            state.GroupBy,
+            state.IsGroupDescending);
 
         var updatedTable = SetComputerNameIfFirstEvent(table, action.Events) with { IsLoading = false };
         var counts = state.EventCountByLog.SetItem(table.Id, action.Events.Count);
@@ -437,6 +532,20 @@ internal sealed class Reducers
         return counts.SetItem(logId, current + delta);
     }
 
+    private static LogTableState ResetGroupCollapse(LogTableState state) =>
+        state is { GroupsCollapsedByDefault: false, GroupCollapseOverrides.IsEmpty: true }
+            ? state
+            : state with
+            {
+                GroupsCollapsedByDefault = false,
+                GroupCollapseOverrides = ImmutableHashSet.Create<string>(StringComparer.Ordinal)
+            };
+
+    private static LogTableState ResetGroupCollapseIfActiveChanged(
+        LogTableState updated,
+        EventLogId? previousActiveId) =>
+        updated.ActiveEventLogId == previousActiveId ? updated : ResetGroupCollapse(updated);
+
     private static LogView SetComputerNameIfFirstEvent(LogView table, IReadOnlyList<ResolvedEvent> newEvents)
     {
         if (!string.IsNullOrEmpty(table.ComputerName) || newEvents.Count == 0) { return table; }
@@ -461,7 +570,11 @@ internal sealed class Reducers
 
         return state with
         {
-            DisplayedEvents = state.DisplayedEvents.SortEvents(effectiveOrderBy, isDescending),
+            DisplayedEvents = state.DisplayedEvents.SortEvents(
+                effectiveOrderBy,
+                isDescending,
+                state.GroupBy,
+                state.IsGroupDescending),
             OrderBy = orderBy,
             IsDescending = isDescending
         };

--- a/src/EventLogExpert.Runtime/LogTable/ResolvedEventGroupKey.cs
+++ b/src/EventLogExpert.Runtime/LogTable/ResolvedEventGroupKey.cs
@@ -7,20 +7,20 @@ using System.Globalization;
 namespace EventLogExpert.Runtime.LogTable;
 
 /// <summary>Per-column grouping key mirroring the field each grouped comparer reads; "" is the no-value bucket.</summary>
-internal static class ResolvedEventGroupKey
+public static class ResolvedEventGroupKey
 {
     public static string For(ColumnName column, ResolvedEvent @event) =>
         column switch
         {
-            ColumnName.Level => @event.Level,
+            ColumnName.Level => @event.Level ?? string.Empty,
             ColumnName.DateAndTime => @event.TimeCreated.Ticks.ToString(CultureInfo.InvariantCulture),
             ColumnName.ActivityId => @event.ActivityId?.ToString("D", CultureInfo.InvariantCulture) ?? string.Empty,
-            ColumnName.Log => @event.LogName,
-            ColumnName.ComputerName => @event.ComputerName,
-            ColumnName.Source => @event.Source,
+            ColumnName.Log => @event.LogName ?? string.Empty,
+            ColumnName.ComputerName => @event.ComputerName ?? string.Empty,
+            ColumnName.Source => @event.Source ?? string.Empty,
             ColumnName.EventId => @event.Id.ToString(CultureInfo.InvariantCulture),
-            ColumnName.TaskCategory => @event.TaskCategory,
-            ColumnName.Keywords => @event.KeywordsDisplayName,
+            ColumnName.TaskCategory => @event.TaskCategory ?? string.Empty,
+            ColumnName.Keywords => @event.KeywordsDisplayName ?? string.Empty,
             ColumnName.ProcessId => @event.ProcessId?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
             ColumnName.ThreadId => @event.ThreadId?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
             ColumnName.User => @event.UserId?.Value ?? string.Empty,

--- a/src/EventLogExpert.Runtime/LogTable/ResolvedEventGroupKey.cs
+++ b/src/EventLogExpert.Runtime/LogTable/ResolvedEventGroupKey.cs
@@ -1,0 +1,29 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+using System.Globalization;
+
+namespace EventLogExpert.Runtime.LogTable;
+
+/// <summary>Per-column grouping key mirroring the field each grouped comparer reads; "" is the no-value bucket.</summary>
+internal static class ResolvedEventGroupKey
+{
+    public static string For(ColumnName column, ResolvedEvent @event) =>
+        column switch
+        {
+            ColumnName.Level => @event.Level,
+            ColumnName.DateAndTime => @event.TimeCreated.Ticks.ToString(CultureInfo.InvariantCulture),
+            ColumnName.ActivityId => @event.ActivityId?.ToString("D", CultureInfo.InvariantCulture) ?? string.Empty,
+            ColumnName.Log => @event.LogName,
+            ColumnName.ComputerName => @event.ComputerName,
+            ColumnName.Source => @event.Source,
+            ColumnName.EventId => @event.Id.ToString(CultureInfo.InvariantCulture),
+            ColumnName.TaskCategory => @event.TaskCategory,
+            ColumnName.Keywords => @event.KeywordsDisplayName,
+            ColumnName.ProcessId => @event.ProcessId?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
+            ColumnName.ThreadId => @event.ThreadId?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
+            ColumnName.User => @event.UserId?.Value ?? string.Empty,
+            _ => string.Empty
+        };
+}

--- a/src/EventLogExpert.Runtime/LogTable/ResolvedEventOrdering.cs
+++ b/src/EventLogExpert.Runtime/LogTable/ResolvedEventOrdering.cs
@@ -66,15 +66,15 @@ internal static class ResolvedEventOrdering
     internal static int CompareColumn(ResolvedEvent a, ResolvedEvent b, ColumnName column) =>
         column switch
         {
-            ColumnName.Level => string.Compare(a.Level, b.Level, StringComparison.Ordinal),
+            ColumnName.Level => string.Compare(a.Level ?? string.Empty, b.Level ?? string.Empty, StringComparison.Ordinal),
             ColumnName.DateAndTime => a.TimeCreated.CompareTo(b.TimeCreated),
             ColumnName.ActivityId => Nullable.Compare(a.ActivityId, b.ActivityId),
-            ColumnName.Log => string.Compare(a.LogName, b.LogName, StringComparison.Ordinal),
-            ColumnName.ComputerName => string.Compare(a.ComputerName, b.ComputerName, StringComparison.Ordinal),
-            ColumnName.Source => string.Compare(a.Source, b.Source, StringComparison.Ordinal),
+            ColumnName.Log => string.Compare(a.LogName ?? string.Empty, b.LogName ?? string.Empty, StringComparison.Ordinal),
+            ColumnName.ComputerName => string.Compare(a.ComputerName ?? string.Empty, b.ComputerName ?? string.Empty, StringComparison.Ordinal),
+            ColumnName.Source => string.Compare(a.Source ?? string.Empty, b.Source ?? string.Empty, StringComparison.Ordinal),
             ColumnName.EventId => a.Id.CompareTo(b.Id),
-            ColumnName.TaskCategory => string.Compare(a.TaskCategory, b.TaskCategory, StringComparison.Ordinal),
-            ColumnName.Keywords => string.Compare(a.KeywordsDisplayName, b.KeywordsDisplayName, StringComparison.Ordinal),
+            ColumnName.TaskCategory => string.Compare(a.TaskCategory ?? string.Empty, b.TaskCategory ?? string.Empty, StringComparison.Ordinal),
+            ColumnName.Keywords => string.Compare(a.KeywordsDisplayName ?? string.Empty, b.KeywordsDisplayName ?? string.Empty, StringComparison.Ordinal),
             ColumnName.ProcessId => Nullable.Compare(a.ProcessId, b.ProcessId),
             ColumnName.ThreadId => Nullable.Compare(a.ThreadId, b.ThreadId),
             ColumnName.User => string.Compare(a.UserId?.Value ?? string.Empty, b.UserId?.Value ?? string.Empty, StringComparison.Ordinal),

--- a/src/EventLogExpert.Runtime/LogTable/ResolvedEventOrdering.cs
+++ b/src/EventLogExpert.Runtime/LogTable/ResolvedEventOrdering.cs
@@ -53,13 +53,33 @@ internal static class ResolvedEventOrdering
     public static IReadOnlyList<ResolvedEvent> SortEvents(
         this IEnumerable<ResolvedEvent> events,
         ColumnName? orderBy = null,
-        bool isDescending = false)
+        bool isDescending = false,
+        ColumnName? groupBy = null,
+        bool isGroupDescending = false)
     {
         var sorted = new List<ResolvedEvent>(events);
-        sorted.Sort(GetComparer(orderBy, isDescending));
+        sorted.Sort(SelectComparer(orderBy, isDescending, groupBy, isGroupDescending));
 
         return sorted.AsReadOnly();
     }
+
+    internal static int CompareColumn(ResolvedEvent a, ResolvedEvent b, ColumnName column) =>
+        column switch
+        {
+            ColumnName.Level => string.Compare(a.Level, b.Level, StringComparison.Ordinal),
+            ColumnName.DateAndTime => a.TimeCreated.CompareTo(b.TimeCreated),
+            ColumnName.ActivityId => Nullable.Compare(a.ActivityId, b.ActivityId),
+            ColumnName.Log => string.Compare(a.LogName, b.LogName, StringComparison.Ordinal),
+            ColumnName.ComputerName => string.Compare(a.ComputerName, b.ComputerName, StringComparison.Ordinal),
+            ColumnName.Source => string.Compare(a.Source, b.Source, StringComparison.Ordinal),
+            ColumnName.EventId => a.Id.CompareTo(b.Id),
+            ColumnName.TaskCategory => string.Compare(a.TaskCategory, b.TaskCategory, StringComparison.Ordinal),
+            ColumnName.Keywords => string.Compare(a.KeywordsDisplayName, b.KeywordsDisplayName, StringComparison.Ordinal),
+            ColumnName.ProcessId => Nullable.Compare(a.ProcessId, b.ProcessId),
+            ColumnName.ThreadId => Nullable.Compare(a.ThreadId, b.ThreadId),
+            ColumnName.User => string.Compare(a.UserId?.Value ?? string.Empty, b.UserId?.Value ?? string.Empty, StringComparison.Ordinal),
+            _ => 0
+        };
 
     internal static Comparison<ResolvedEvent> GetComparer(ColumnName? orderBy, bool isDescending) =>
         isDescending
@@ -96,17 +116,49 @@ internal static class ResolvedEventOrdering
                 _ => s_ascByDefault
             };
 
+    internal static Comparison<ResolvedEvent> GetGroupedComparer(
+        ColumnName groupBy,
+        bool isGroupDescending,
+        ColumnName? orderBy,
+        bool isDescending)
+    {
+        var withinGroup = orderBy ?? ColumnName.DateAndTime;
+
+        return (a, b) =>
+        {
+            int group = CompareColumn(a, b, groupBy);
+
+            if (group != 0) { return isGroupDescending ? -Math.Sign(group) : group; }
+
+            int within = CompareColumn(a, b, withinGroup);
+
+            if (within == 0 && withinGroup != ColumnName.DateAndTime)
+            {
+                within = CompareColumn(a, b, ColumnName.DateAndTime);
+            }
+
+            if (within == 0)
+            {
+                within = FallbackTieBreaker(Nullable.Compare(a.RecordId, b.RecordId), a, b);
+            }
+
+            return isDescending ? -Math.Sign(within) : within;
+        };
+    }
+
     internal static IReadOnlyList<ResolvedEvent> MergeSorted(
         IReadOnlyList<ResolvedEvent> existing,
         IReadOnlyList<ResolvedEvent> batch,
         ColumnName? orderBy,
-        bool isDescending)
+        bool isDescending,
+        ColumnName? groupBy = null,
+        bool isGroupDescending = false)
     {
         if (batch.Count == 0) { return existing; }
 
-        if (existing.Count == 0) { return batch.SortEvents(orderBy, isDescending); }
+        if (existing.Count == 0) { return batch.SortEvents(orderBy, isDescending, groupBy, isGroupDescending); }
 
-        var comparer = GetComparer(orderBy, isDescending);
+        var comparer = SelectComparer(orderBy, isDescending, groupBy, isGroupDescending);
 
         var sortedBatch = new List<ResolvedEvent>(batch);
         sortedBatch.Sort(comparer);
@@ -125,6 +177,15 @@ internal static class ResolvedEventOrdering
 
         return result.AsReadOnly();
     }
+
+    internal static Comparison<ResolvedEvent> SelectComparer(
+        ColumnName? orderBy,
+        bool isDescending,
+        ColumnName? groupBy,
+        bool isGroupDescending) =>
+        groupBy is null
+            ? GetComparer(orderBy, isDescending)
+            : GetGroupedComparer(groupBy.Value, isGroupDescending, orderBy, isDescending);
 
     /// <summary>Falls back to RecordId, then OwningLog (for combined logs) to guarantee a total order for List.Sort stability.</summary>
     private static int FallbackTieBreaker(int recordIdResult, ResolvedEvent a, ResolvedEvent b) =>

--- a/src/EventLogExpert.Runtime/LogTable/SetAllGroupsCollapsedAction.cs
+++ b/src/EventLogExpert.Runtime/LogTable/SetAllGroupsCollapsedAction.cs
@@ -1,0 +1,6 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.LogTable;
+
+internal sealed record SetAllGroupsCollapsedAction(bool Collapsed);

--- a/src/EventLogExpert.Runtime/LogTable/SetGroupByAction.cs
+++ b/src/EventLogExpert.Runtime/LogTable/SetGroupByAction.cs
@@ -1,0 +1,6 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.LogTable;
+
+internal sealed record SetGroupByAction(ColumnName? GroupBy);

--- a/src/EventLogExpert.Runtime/LogTable/ToggleGroupCollapsedAction.cs
+++ b/src/EventLogExpert.Runtime/LogTable/ToggleGroupCollapsedAction.cs
@@ -1,0 +1,6 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.LogTable;
+
+internal sealed record ToggleGroupCollapsedAction(string GroupKey);

--- a/src/EventLogExpert.Runtime/LogTable/ToggleGroupSortingAction.cs
+++ b/src/EventLogExpert.Runtime/LogTable/ToggleGroupSortingAction.cs
@@ -1,0 +1,6 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.LogTable;
+
+internal sealed record ToggleGroupSortingAction;

--- a/src/EventLogExpert.Runtime/Menu/IMenuActionService.cs
+++ b/src/EventLogExpert.Runtime/Menu/IMenuActionService.cs
@@ -39,11 +39,15 @@ public interface IMenuActionService
 
     Task SaveFiltersAsFilterSetAsync();
 
+    void SetAllGroupsCollapsed(bool collapsed);
+
     void SetContinuouslyUpdate(bool value);
 
     Task ShowDebugLogsAsync();
 
     Task ShowReleaseNotesAsync();
+
+    void ToggleGroupSortDirection();
 
     void ToggleShowAllEvents();
 }

--- a/src/EventLogExpert.UI/LogTable/Grouping/EventGroup.cs
+++ b/src/EventLogExpert.UI/LogTable/Grouping/EventGroup.cs
@@ -1,0 +1,14 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.UI.LogTable.Grouping;
+
+internal readonly record struct EventGroup(
+    string Key,
+    int StartIndex,
+    int EventCount,
+    bool IsCollapsed,
+    int VisibleStart)
+{
+    public int VisibleSize => IsCollapsed ? 1 : 1 + EventCount;
+}

--- a/src/EventLogExpert.UI/LogTable/Grouping/GroupedRowView.cs
+++ b/src/EventLogExpert.UI/LogTable/Grouping/GroupedRowView.cs
@@ -1,0 +1,173 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Runtime.LogTable;
+using System.Collections;
+
+namespace EventLogExpert.UI.LogTable.Grouping;
+
+/// <summary>
+///     Virtual row-view over an already group-sorted event list: header and event rows resolved on demand via O(log
+///     groups) binary search over an <see cref="EventGroup" /> prefix-sum, with no per-row materialization.
+/// </summary>
+internal sealed class GroupedRowView : IReadOnlyList<TableRow>, IList<TableRow>
+{
+    private readonly IReadOnlyList<ResolvedEvent> _events;
+    private readonly EventGroup[] _groups;
+
+    private GroupedRowView(IReadOnlyList<ResolvedEvent> events, EventGroup[] groups, int count)
+    {
+        _events = events;
+        _groups = groups;
+        Count = count;
+    }
+
+    public int Count { get; }
+
+    public IReadOnlyList<EventGroup> Groups => _groups;
+
+    public bool IsReadOnly => true;
+
+    public TableRow this[int index]
+    {
+        get
+        {
+            if ((uint)index >= (uint)Count) { throw new ArgumentOutOfRangeException(nameof(index)); }
+
+            int groupIndex = FindGroupByVisibleRow(index);
+            var group = _groups[groupIndex];
+
+            return index == group.VisibleStart
+                ? TableRow.ForHeader(groupIndex)
+                : TableRow.ForEvent(group.StartIndex + (index - group.VisibleStart - 1), groupIndex);
+        }
+        set => throw new NotSupportedException();
+    }
+
+    public static GroupedRowView Build(
+        IReadOnlyList<ResolvedEvent> events,
+        ColumnName groupBy,
+        Func<string, bool> isCollapsed)
+    {
+        var groups = new List<EventGroup>();
+        int visible = 0;
+        int index = 0;
+
+        while (index < events.Count)
+        {
+            string key = ResolvedEventGroupKey.For(groupBy, events[index]);
+            int start = index;
+            index++;
+
+            while (index < events.Count &&
+                string.Equals(ResolvedEventGroupKey.For(groupBy, events[index]), key, StringComparison.Ordinal))
+            {
+                index++;
+            }
+
+            var group = new EventGroup(key, start, index - start, isCollapsed(key), visible);
+            groups.Add(group);
+            visible += group.VisibleSize;
+        }
+
+        return new GroupedRowView(events, [.. groups], visible);
+    }
+
+    public void Add(TableRow item) => throw new NotSupportedException();
+
+    public void Clear() => throw new NotSupportedException();
+
+    public bool Contains(TableRow item) => IndexOf(item) >= 0;
+
+    public void CopyTo(TableRow[] array, int arrayIndex)
+    {
+        for (int i = 0; i < Count; i++) { array[arrayIndex + i] = this[i]; }
+    }
+
+    public ResolvedEvent EventAt(TableRow row) => _events[row.EventIndex];
+
+    public IEnumerator<TableRow> GetEnumerator()
+    {
+        for (int i = 0; i < Count; i++) { yield return this[i]; }
+    }
+
+    public EventGroup GroupAt(TableRow row) => _groups[row.GroupIndex];
+
+    public EventGroup GroupForEvent(int eventIndex) => _groups[FindGroupByEventIndex(eventIndex)];
+
+    public int IndexOf(TableRow item)
+    {
+        for (int i = 0; i < Count; i++)
+        {
+            if (this[i] == item) { return i; }
+        }
+
+        return -1;
+    }
+
+    public void Insert(int index, TableRow item) => throw new NotSupportedException();
+
+    public bool Remove(TableRow item) => throw new NotSupportedException();
+
+    public void RemoveAt(int index) => throw new NotSupportedException();
+
+    public bool TryGetGroupByKey(string key, out EventGroup group)
+    {
+        for (int i = 0; i < _groups.Length; i++)
+        {
+            if (string.Equals(_groups[i].Key, key, StringComparison.Ordinal))
+            {
+                group = _groups[i];
+
+                return true;
+            }
+        }
+
+        group = default;
+
+        return false;
+    }
+
+    public int VisibleRowForEvent(int eventIndex)
+    {
+        var group = _groups[FindGroupByEventIndex(eventIndex)];
+
+        return group.IsCollapsed
+            ? group.VisibleStart
+            : group.VisibleStart + 1 + (eventIndex - group.StartIndex);
+    }
+
+    public int VisibleRowForHeader(string groupKey)
+    {
+        for (int i = 0; i < _groups.Length; i++)
+        {
+            if (string.Equals(_groups[i].Key, groupKey, StringComparison.Ordinal)) { return _groups[i].VisibleStart; }
+        }
+
+        return -1;
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    private int FindGroup(int target, bool byVisibleStart)
+    {
+        int low = 0;
+        int high = _groups.Length - 1;
+
+        while (low < high)
+        {
+            int mid = low + ((high - low + 1) / 2);
+            int midStart = byVisibleStart ? _groups[mid].VisibleStart : _groups[mid].StartIndex;
+
+            if (midStart <= target) { low = mid; }
+            else { high = mid - 1; }
+        }
+
+        return low;
+    }
+
+    private int FindGroupByEventIndex(int eventIndex) => FindGroup(eventIndex, byVisibleStart: false);
+
+    private int FindGroupByVisibleRow(int visibleRow) => FindGroup(visibleRow, byVisibleStart: true);
+}

--- a/src/EventLogExpert.UI/LogTable/Grouping/GroupedRowView.cs
+++ b/src/EventLogExpert.UI/LogTable/Grouping/GroupedRowView.cs
@@ -97,6 +97,8 @@ internal sealed class GroupedRowView : IReadOnlyList<TableRow>, IList<TableRow>
 
     public ResolvedEvent EventAt(TableRow row) => _events[row.EventIndex];
 
+    public ResolvedEvent FirstEventOf(EventGroup group) => _events[group.StartIndex];
+
     public IEnumerator<TableRow> GetEnumerator()
     {
         for (int i = 0; i < Count; i++) { yield return this[i]; }

--- a/src/EventLogExpert.UI/LogTable/Grouping/GroupedRowView.cs
+++ b/src/EventLogExpert.UI/LogTable/Grouping/GroupedRowView.cs
@@ -9,18 +9,25 @@ namespace EventLogExpert.UI.LogTable.Grouping;
 
 /// <summary>
 ///     Virtual row-view over an already group-sorted event list: header and event rows resolved on demand via O(log
-///     groups) binary search over an <see cref="EventGroup" /> prefix-sum, with no per-row materialization.
+///     groups) binary search over an <see cref="EventGroup" /> prefix-sum (and O(1) group lookup by key), with no per-row
+///     materialization.
 /// </summary>
 internal sealed class GroupedRowView : IReadOnlyList<TableRow>, IList<TableRow>
 {
     private readonly IReadOnlyList<ResolvedEvent> _events;
+    private readonly Dictionary<string, int> _groupIndexByKey;
     private readonly EventGroup[] _groups;
 
-    private GroupedRowView(IReadOnlyList<ResolvedEvent> events, EventGroup[] groups, int count)
+    private GroupedRowView(
+        IReadOnlyList<ResolvedEvent> events,
+        EventGroup[] groups,
+        int count,
+        Dictionary<string, int> groupIndexByKey)
     {
         _events = events;
         _groups = groups;
         Count = count;
+        _groupIndexByKey = groupIndexByKey;
     }
 
     public int Count { get; }
@@ -51,6 +58,8 @@ internal sealed class GroupedRowView : IReadOnlyList<TableRow>, IList<TableRow>
         Func<string, bool> isCollapsed)
     {
         var groups = new List<EventGroup>();
+        // Keys are unique per run, so a key->index map gives O(1) header lookup.
+        var groupIndexByKey = new Dictionary<string, int>(StringComparer.Ordinal);
         int visible = 0;
         int index = 0;
 
@@ -67,11 +76,12 @@ internal sealed class GroupedRowView : IReadOnlyList<TableRow>, IList<TableRow>
             }
 
             var group = new EventGroup(key, start, index - start, isCollapsed(key), visible);
+            groupIndexByKey[key] = groups.Count;
             groups.Add(group);
             visible += group.VisibleSize;
         }
 
-        return new GroupedRowView(events, [.. groups], visible);
+        return new GroupedRowView(events, [.. groups], visible, groupIndexByKey);
     }
 
     public void Add(TableRow item) => throw new NotSupportedException();
@@ -114,14 +124,11 @@ internal sealed class GroupedRowView : IReadOnlyList<TableRow>, IList<TableRow>
 
     public bool TryGetGroupByKey(string key, out EventGroup group)
     {
-        for (int i = 0; i < _groups.Length; i++)
+        if (_groupIndexByKey.TryGetValue(key, out int i))
         {
-            if (string.Equals(_groups[i].Key, key, StringComparison.Ordinal))
-            {
-                group = _groups[i];
+            group = _groups[i];
 
-                return true;
-            }
+            return true;
         }
 
         group = default;
@@ -138,15 +145,8 @@ internal sealed class GroupedRowView : IReadOnlyList<TableRow>, IList<TableRow>
             : group.VisibleStart + 1 + (eventIndex - group.StartIndex);
     }
 
-    public int VisibleRowForHeader(string groupKey)
-    {
-        for (int i = 0; i < _groups.Length; i++)
-        {
-            if (string.Equals(_groups[i].Key, groupKey, StringComparison.Ordinal)) { return _groups[i].VisibleStart; }
-        }
-
-        return -1;
-    }
+    public int VisibleRowForHeader(string groupKey) =>
+        _groupIndexByKey.TryGetValue(groupKey, out int i) ? _groups[i].VisibleStart : -1;
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 

--- a/src/EventLogExpert.UI/LogTable/Grouping/GroupedRowView.cs
+++ b/src/EventLogExpert.UI/LogTable/Grouping/GroupedRowView.cs
@@ -62,21 +62,31 @@ internal sealed class GroupedRowView : IReadOnlyList<TableRow>, IList<TableRow>
         var groupIndexByKey = new Dictionary<string, int>(StringComparer.Ordinal);
         int visible = 0;
         int index = 0;
+        // Carry each run's boundary key forward so every event's key is computed once.
+        string? key = events.Count > 0 ? ResolvedEventGroupKey.For(groupBy, events[0]) : null;
 
         while (index < events.Count)
         {
-            string key = ResolvedEventGroupKey.For(groupBy, events[index]);
+            string currentKey = key!;
             int start = index;
             index++;
 
-            while (index < events.Count &&
-                string.Equals(ResolvedEventGroupKey.For(groupBy, events[index]), key, StringComparison.Ordinal))
+            while (index < events.Count)
             {
+                string nextKey = ResolvedEventGroupKey.For(groupBy, events[index]);
+
+                if (!string.Equals(nextKey, currentKey, StringComparison.Ordinal))
+                {
+                    key = nextKey;
+
+                    break;
+                }
+
                 index++;
             }
 
-            var group = new EventGroup(key, start, index - start, isCollapsed(key), visible);
-            groupIndexByKey[key] = groups.Count;
+            var group = new EventGroup(currentKey, start, index - start, isCollapsed(currentKey), visible);
+            groupIndexByKey[currentKey] = groups.Count;
             groups.Add(group);
             visible += group.VisibleSize;
         }

--- a/src/EventLogExpert.UI/LogTable/Grouping/TableCursor.cs
+++ b/src/EventLogExpert.UI/LogTable/Grouping/TableCursor.cs
@@ -1,0 +1,15 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+
+namespace EventLogExpert.UI.LogTable.Grouping;
+
+// Identity cursor for keyboard focus/nav: an event cursor carries the event, a header
+// cursor the stable group key. The visible row is derived on demand, never stored.
+internal readonly record struct TableCursor(TableRowKind Kind, ResolvedEvent? Event, string? GroupKey)
+{
+    public static TableCursor ForEvent(ResolvedEvent @event) => new(TableRowKind.Event, @event, null);
+
+    public static TableCursor ForHeader(string groupKey) => new(TableRowKind.Header, null, groupKey);
+}

--- a/src/EventLogExpert.UI/LogTable/Grouping/TableRow.cs
+++ b/src/EventLogExpert.UI/LogTable/Grouping/TableRow.cs
@@ -1,0 +1,11 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.UI.LogTable.Grouping;
+
+internal readonly record struct TableRow(TableRowKind Kind, int EventIndex, int GroupIndex)
+{
+    public static TableRow ForHeader(int groupIndex) => new(TableRowKind.Header, -1, groupIndex);
+
+    public static TableRow ForEvent(int eventIndex, int groupIndex) => new(TableRowKind.Event, eventIndex, groupIndex);
+}

--- a/src/EventLogExpert.UI/LogTable/Grouping/TableRowKind.cs
+++ b/src/EventLogExpert.UI/LogTable/Grouping/TableRowKind.cs
@@ -1,0 +1,10 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.UI.LogTable.Grouping;
+
+internal enum TableRowKind
+{
+    Header,
+    Event
+}

--- a/src/EventLogExpert.UI/LogTable/LogTablePane.razor
+++ b/src/EventLogExpert.UI/LogTable/LogTablePane.razor
@@ -117,9 +117,8 @@
                             role="row"
                             tabindex="0">
                             <td colspan="@(_enabledColumns.Length + 1)" role="gridcell">
-                                <span class="group-chevron"
-                                    data-collapsed="@group.IsCollapsed.ToString().ToLower()">
-                                    <i class="bi bi-caret-right"></i>
+                                <span class="group-chevron" data-collapsed="@group.IsCollapsed.ToString().ToLower()">
+                                    <i aria-hidden="true" class="bi bi-caret-right"></i>
                                 </span>
                                 <span class="group-name">@GetGroupName():</span>
                                 <span class="group-value">@GetGroupValueText(group)</span>

--- a/src/EventLogExpert.UI/LogTable/LogTablePane.razor
+++ b/src/EventLogExpert.UI/LogTable/LogTablePane.razor
@@ -1,12 +1,73 @@
 @using EventLogExpert.Eventing.Common.Events
+@using EventLogExpert.UI.LogTable.Grouping
 @inherits FluxorComponent
 
 <LogTabBar />
 
+@{
+    RenderFragment<ResolvedEvent> renderEventRow = evt =>
+        @<tr aria-rowindex="@GetRowIndex(evt)"
+             aria-selected="@(_selectedSet.Contains(evt).ToString().ToLower())"
+             class="@GetCss(evt)"
+             data-highlight="@GetHighlight(evt)"
+             data-stripe="@(GetRowStripe(evt))"
+             @key="@($"{evt.OwningLog}_{evt.RecordId}_{evt.TimeCreated:O}")"
+             @onmousedown="args => SelectEvent(args, evt)"
+             role="row"
+             tabindex="0">
+            @for (int i = 0; i < _enabledColumns.Length; i++)
+            {
+                <td aria-colindex="@(i + 1)" role="gridcell">
+                    @switch (_enabledColumns[i])
+                    {
+                        case ColumnName.Level:
+                            <text><span aria-hidden="true" class="@GetLevelClass(evt.Level)"></span> @evt.Level</text>
+                            break;
+                        case ColumnName.DateAndTime:
+                            @evt.TimeCreated.ConvertTimeZone(_timeZoneSettings)
+                            break;
+                        case ColumnName.ActivityId:
+                            @evt.ActivityId
+                            break;
+                        case ColumnName.Log:
+                            @GetLogShortName(evt.OwningLog)
+                            break;
+                        case ColumnName.ComputerName:
+                            @evt.ComputerName
+                            break;
+                        case ColumnName.Source:
+                            @evt.Source
+                            break;
+                        case ColumnName.EventId:
+                            @evt.Id
+                            break;
+                        case ColumnName.TaskCategory:
+                            @evt.TaskCategory
+                            break;
+                        case ColumnName.Keywords:
+                            @evt.KeywordsDisplayName
+                            break;
+                        case ColumnName.ProcessId:
+                            @evt.ProcessId
+                            break;
+                        case ColumnName.ThreadId:
+                            @evt.ThreadId
+                            break;
+                        case ColumnName.User:
+                            @evt.UserId
+                            break;
+                    }
+                </td>
+            }
+
+            <td aria-colindex="@(_enabledColumns.Length + 1)" role="gridcell">@evt.Description</td>
+        </tr>;
+}
+
 <div aria-labelledby="eventTable" class="table-container" @onkeydown="HandleKeyDown" role="region" tabindex="0">
     <table aria-label="Event Log Table"
         aria-multiselectable="true"
-        aria-rowcount="@(_activeDisplayedEvents.Count + 1)"
+        aria-rowcount="@GetAriaRowCount()"
         id="eventTable"
         role="grid">
         <thead @oncontextmenu="InvokeTableColumnMenu" @oncontextmenu:preventDefault="true" @oncontextmenu:stopPropagation="true">
@@ -47,63 +108,50 @@
         <tbody @oncontextmenu="InvokeContextMenu" @oncontextmenu:preventDefault="true" @oncontextmenu:stopPropagation="true">
         @if (_currentTable is not null)
         {
-            <Virtualize Context="evt" Items="@(_activeDisplayedEvents as ICollection<ResolvedEvent> ?? [])">
-                <tr aria-rowindex="@GetRowIndex(evt)"
-                    aria-selected="@(_selectedSet.Contains(evt).ToString().ToLower())"
-                    class="@GetCss(evt)"
-                    data-highlight="@GetHighlight(evt)"
-                    @key="@($"{evt.OwningLog}_{evt.RecordId}_{evt.TimeCreated:O}")"
-                    @onmousedown="args => SelectEvent(args, evt)"
-                    role="row"
-                    tabindex="0">
-                    @for (int i = 0; i < _enabledColumns.Length; i++)
-                    {
-                        <td aria-colindex="@(i + 1)" role="gridcell">
-                            @switch (_enabledColumns[i])
-                            {
-                                case ColumnName.Level:
-                                    <text><span aria-hidden="true" class="@GetLevelClass(evt.Level)"></span> @evt.Level</text>
-                                    break;
-                                case ColumnName.DateAndTime:
-                                    @evt.TimeCreated.ConvertTimeZone(_timeZoneSettings)
-                                    break;
-                                case ColumnName.ActivityId:
-                                    @evt.ActivityId
-                                    break;
-                                case ColumnName.Log:
-                                    @GetLogShortName(evt.OwningLog)
-                                    break;
-                                case ColumnName.ComputerName:
-                                    @evt.ComputerName
-                                    break;
-                                case ColumnName.Source:
-                                    @evt.Source
-                                    break;
-                                case ColumnName.EventId:
-                                    @evt.Id
-                                    break;
-                                case ColumnName.TaskCategory:
-                                    @evt.TaskCategory
-                                    break;
-                                case ColumnName.Keywords:
-                                    @evt.KeywordsDisplayName
-                                    break;
-                                case ColumnName.ProcessId:
-                                    @evt.ProcessId
-                                    break;
-                                case ColumnName.ThreadId:
-                                    @evt.ThreadId
-                                    break;
-                                case ColumnName.User:
-                                    @evt.UserId
-                                    break;
-                            }
-                        </td>
-                    }
+            @if (_rowView is null)
+            {
+                <Virtualize Context="evt" Items="@(_activeDisplayedEvents as ICollection<ResolvedEvent> ?? [])">
+                    @renderEventRow(evt)
+                </Virtualize>
+            }
+            else
+            {
+                var view = _rowView;
 
-                    <td aria-colindex="@(_enabledColumns.Length + 1)" role="gridcell">@evt.Description</td>
-                </tr>
-            </Virtualize>
+                <Virtualize Context="row" Items="view">
+                    @if (row.Kind == TableRowKind.Header)
+                    {
+                        var group = view.GroupAt(row);
+
+                        <tr aria-expanded="@((!group.IsCollapsed).ToString().ToLower())"
+                            aria-rowindex="@(group.VisibleStart + 2)"
+                            class="group-header-row"
+                            data-collapsed="@group.IsCollapsed.ToString().ToLower()"
+                            @key="@($"hdr:{group.Key}")"
+                            @onclick="() => ToggleGroupCollapsed(group.Key)"
+                            @oncontextmenu="args => InvokeGroupContextMenu(args, group)"
+                            @oncontextmenu:preventDefault="true"
+                            @oncontextmenu:stopPropagation="true"
+                            @onkeydown="args => HandleGroupHeaderKeyDown(args, group.Key)"
+                            role="row"
+                            tabindex="0">
+                            <td colspan="@(_enabledColumns.Length + 1)" role="gridcell">
+                                <span class="group-chevron"
+                                    data-collapsed="@group.IsCollapsed.ToString().ToLower()">
+                                    <i class="bi bi-caret-right"></i>
+                                </span>
+                                <span class="group-name">@GetGroupName():</span>
+                                <span class="group-value">@GetGroupValueText(group)</span>
+                                <span class="group-count">(@group.EventCount)</span>
+                            </td>
+                        </tr>
+                    }
+                    else
+                    {
+                        @renderEventRow(view.EventAt(row))
+                    }
+                </Virtualize>
+            }
         }
         </tbody>
     </table>

--- a/src/EventLogExpert.UI/LogTable/LogTablePane.razor
+++ b/src/EventLogExpert.UI/LogTable/LogTablePane.razor
@@ -5,12 +5,13 @@
 <LogTabBar />
 
 @{
-    RenderFragment<ResolvedEvent> renderEventRow = evt =>
-        @<tr aria-rowindex="@GetRowIndex(evt)"
-             aria-selected="@(_selectedSet.Contains(evt).ToString().ToLower())"
+    RenderFragment RenderEventRow(ResolvedEvent evt) =>
+        @<tr aria-level="@(_rowView is null ? null : "2")"
+             aria-rowindex="@GetRowIndex(evt)"
+             aria-selected="@_selectedSet.Contains(evt).ToString().ToLower()"
              class="@GetCss(evt)"
              data-highlight="@GetHighlight(evt)"
-             data-stripe="@(GetRowStripe(evt))"
+             data-stripe="@GetRowStripe(evt)"
              @key="@($"{evt.OwningLog}_{evt.RecordId}_{evt.TimeCreated:O}")"
              @onmousedown="args => SelectEvent(args, evt)"
              role="row"
@@ -21,41 +22,20 @@
                     @switch (_enabledColumns[i])
                     {
                         case ColumnName.Level:
-                            <text><span aria-hidden="true" class="@GetLevelClass(evt.Level)"></span> @evt.Level</text>
+                            <span aria-hidden="true" class="@GetLevelClass(evt.Level)"></span>
+                            @evt.Level
                             break;
-                        case ColumnName.DateAndTime:
-                            @evt.TimeCreated.ConvertTimeZone(_timeZoneSettings)
-                            break;
-                        case ColumnName.ActivityId:
-                            @evt.ActivityId
-                            break;
-                        case ColumnName.Log:
-                            @GetLogShortName(evt.OwningLog)
-                            break;
-                        case ColumnName.ComputerName:
-                            @evt.ComputerName
-                            break;
-                        case ColumnName.Source:
-                            @evt.Source
-                            break;
-                        case ColumnName.EventId:
-                            @evt.Id
-                            break;
-                        case ColumnName.TaskCategory:
-                            @evt.TaskCategory
-                            break;
-                        case ColumnName.Keywords:
-                            @evt.KeywordsDisplayName
-                            break;
-                        case ColumnName.ProcessId:
-                            @evt.ProcessId
-                            break;
-                        case ColumnName.ThreadId:
-                            @evt.ThreadId
-                            break;
-                        case ColumnName.User:
-                            @evt.UserId
-                            break;
+                        case ColumnName.DateAndTime: @evt.TimeCreated.ConvertTimeZone(_timeZoneSettings) break;
+                        case ColumnName.ActivityId: @evt.ActivityId break;
+                        case ColumnName.Log: @GetLogShortName(evt.OwningLog) break;
+                        case ColumnName.ComputerName: @evt.ComputerName break;
+                        case ColumnName.Source: @evt.Source break;
+                        case ColumnName.EventId: @evt.Id break;
+                        case ColumnName.TaskCategory: @evt.TaskCategory break;
+                        case ColumnName.Keywords: @evt.KeywordsDisplayName break;
+                        case ColumnName.ProcessId: @evt.ProcessId break;
+                        case ColumnName.ThreadId: @evt.ThreadId break;
+                        case ColumnName.User: @evt.UserId break;
                     }
                 </td>
             }
@@ -69,7 +49,7 @@
         aria-multiselectable="true"
         aria-rowcount="@GetAriaRowCount()"
         id="eventTable"
-        role="grid">
+        role="@(_rowView is null ? "grid" : "treegrid")">
         <thead @oncontextmenu="InvokeTableColumnMenu" @oncontextmenu:preventDefault="true" @oncontextmenu:stopPropagation="true">
         <tr role="row">
             @for (int columnIndex = 0; columnIndex < _enabledColumns.Length; columnIndex++)
@@ -111,7 +91,7 @@
             @if (_rowView is null)
             {
                 <Virtualize Context="evt" Items="@(_activeDisplayedEvents as ICollection<ResolvedEvent> ?? [])">
-                    @renderEventRow(evt)
+                    @RenderEventRow(evt)
                 </Virtualize>
             }
             else
@@ -124,6 +104,7 @@
                         var group = view.GroupAt(row);
 
                         <tr aria-expanded="@((!group.IsCollapsed).ToString().ToLower())"
+                            aria-level="1"
                             aria-rowindex="@(group.VisibleStart + 2)"
                             class="group-header-row"
                             data-collapsed="@group.IsCollapsed.ToString().ToLower()"
@@ -132,7 +113,7 @@
                             @oncontextmenu="args => InvokeGroupContextMenu(args, group)"
                             @oncontextmenu:preventDefault="true"
                             @oncontextmenu:stopPropagation="true"
-                            @onkeydown="args => HandleGroupHeaderKeyDown(args, group.Key)"
+                            @onfocus="() => SetCursorHeader(group.Key)"
                             role="row"
                             tabindex="0">
                             <td colspan="@(_enabledColumns.Length + 1)" role="gridcell">
@@ -148,7 +129,7 @@
                     }
                     else
                     {
-                        @renderEventRow(view.EventAt(row))
+                        @RenderEventRow(view.EventAt(row))
                     }
                 </Virtualize>
             }

--- a/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
@@ -482,7 +482,7 @@ public sealed partial class LogTablePane
             ColumnName.Level => representative.Level,
             ColumnName.DateAndTime => representative.TimeCreated.ConvertTimeZone(_timeZoneSettings).ToString(),
             ColumnName.ActivityId => representative.ActivityId?.ToString(),
-            ColumnName.Log => GetLogShortName(representative.OwningLog),
+            ColumnName.Log => representative.LogName,
             ColumnName.ComputerName => representative.ComputerName,
             ColumnName.Source => representative.Source,
             ColumnName.EventId => representative.Id.ToString(),

--- a/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
@@ -41,6 +41,7 @@ public sealed partial class LogTablePane
     private EventLogId? _cachedFilteredTableId;
     private IReadOnlyList<ResolvedEvent>? _cachedFilteredView;
     private LogView? _currentTable;
+    private TableCursor? _cursor;
     private DotNetObjectReference<LogTablePane>? _dotNetRef;
     private ColumnName[] _enabledColumns = null!;
     private ImmutableList<SavedFilter> _filters = [];
@@ -48,12 +49,6 @@ public sealed partial class LogTablePane
     private bool _focusActiveOnNextRender;
     private string _headerName = string.Empty;
     private IReadOnlyList<ResolvedEvent>? _lastIndexedDisplayedEvents;
-    // View-local cursor: the row that is the moving end of a range selection within the
-    // current table. May briefly diverge from _selectedEvent during local keyboard nav
-    // (advanced before the dispatch round-trip) and after RebuildRowMaps rebinds it
-    // to the equivalent row in a freshly built DisplayedEvents list. Defaults to the
-    // same row as _selectionAnchor for single-row selections.
-    private ResolvedEvent? _localCursor;
     private LogTableState _logTableState = null!;
     private int _pageSize = DefaultPageSize;
     private ColumnName[] _previousEnabledColumns = [];
@@ -64,12 +59,12 @@ public sealed partial class LogTablePane
     private ResolvedEvent? _selectedEvent;
     private ImmutableList<ResolvedEvent> _selectedEvents = [];
     private HashSet<ResolvedEvent> _selectedSet = new(ReferenceEqualityComparer.Instance);
-    // The fixed end of a range selection - set on plain click, Ctrl+Click,
-    // and any keyboard nav that establishes a single selection. Reused for
-    // Shift+Click and Shift+Arrow to compute the range.
     private ResolvedEvent? _selectionAnchor;
     private IJSObjectReference? _tableModule;
     private TimeZoneInfo _timeZoneSettings = null!;
+
+    private ResolvedEvent? ActiveEvent =>
+        _cursor is { Kind: TableRowKind.Event, Event: { } @event } ? @event : null;
 
     [Inject] private IClipboardService ClipboardService { get; init; } = null!;
 
@@ -138,8 +133,6 @@ public sealed partial class LogTablePane
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        // Reinitialize JS when columns change (add/remove/reorder). This
-        // ensures resize dividers and event listeners target the current DOM.
         if (firstRender || !_enabledColumns.SequenceEqual(_previousEnabledColumns))
         {
             _previousEnabledColumns = _enabledColumns.ToArray();
@@ -200,7 +193,7 @@ public sealed partial class LogTablePane
         _currentTable = _logTableState.EventTables.FirstOrDefault(x => x.Id == _logTableState.ActiveEventLogId);
         _enabledColumns = GetOrderedEnabledColumns();
         _selectedEvent = SelectedEvent.Value;
-        _localCursor = _selectedEvent;
+        SetCursorEvent(_selectedEvent);
         _selectedEvents = SelectedEvents.Value;
         _selectedSet = new HashSet<ResolvedEvent>(_selectedEvents, ReferenceEqualityComparer.Instance);
         var initialPaneState = FilterPaneState.Value;
@@ -218,15 +211,14 @@ public sealed partial class LogTablePane
 
     protected override bool ShouldRender()
     {
-        // Snapshot once so the short-circuit check and the Property assignment
-        // below see the same reference even if Fluxor publishes a new state
-        // mid-method.
         var currentPaneState = FilterPaneState.Value;
         var currentFilters = currentPaneState.Filters;
         bool filtersChanged = !ReferenceEquals(currentFilters, _filters);
         bool selectedEventChanged = !ReferenceEquals(SelectedEvent.Value, _selectedEvent);
 
-        if (ReferenceEquals(LogTableState.Value, _logTableState) &&
+        // Also render on a pending focus move, which changes no Fluxor state.
+        if (!_focusActiveOnNextRender &&
+            ReferenceEquals(LogTableState.Value, _logTableState) &&
             ReferenceEquals(SelectedEvents.Value, _selectedEvents) &&
             !selectedEventChanged &&
             !filtersChanged &&
@@ -242,22 +234,14 @@ public sealed partial class LogTablePane
         if (selectionChanged)
         {
             _selectedEvents = SelectedEvents.Value;
-            // Reference equality is intentional. Even though ResolvedEvent is
-            // now a fully immutable record (no mutating ResolveXml() workaround),
-            // value-equality requires hashing every string Property on every selection
-            // mutation. Reference equality keeps selection bookkeeping O(1) and
-            // also avoids any chance that two distinct event instances that happen
-            // to be value-equal would collapse into a single selected row.
+            // Reference equality, not value: value-equality would hash strings per change.
             _selectedSet = new HashSet<ResolvedEvent>(_selectedEvents, ReferenceEqualityComparer.Instance);
         }
 
         if (selectedEventChanged)
         {
             _selectedEvent = SelectedEvent.Value;
-            // Reconcile the local cursor with the store. Without this, store-side
-            // updates (reload restore, close-log clearing) would not propagate to
-            // the keyboard-nav cursor.
-            _localCursor = _selectedEvent;
+            SetCursorEvent(_selectedEvent);
         }
 
         if (filtersChanged)
@@ -303,9 +287,7 @@ public sealed partial class LogTablePane
         {
             if (ReferenceEquals(evt, candidate)) { return evt; }
 
-            // Skip key-based matching when either side has no RecordId -
-            // null == null is true for nullable longs, which would falsely
-            // collapse distinct error-read events that share TimeCreated.
+            // Skip null RecordId: null == null would merge distinct error-read events.
             if (evt.RecordId is null || candidate.RecordId is null) { continue; }
 
             if (evt.RecordId == candidate.RecordId &&
@@ -317,6 +299,22 @@ public sealed partial class LogTablePane
         }
 
         return null;
+    }
+
+    private void ApplyNavSelection(IReadOnlyList<ResolvedEvent> displayedEvents, ResolvedEvent targetEvent, bool shift)
+    {
+        if (shift)
+        {
+            _selectionAnchor ??= ActiveEvent ?? targetEvent;
+            SetCursorEvent(targetEvent);
+            DispatchSetSelection(BuildRange(displayedEvents, _selectionAnchor, targetEvent), targetEvent);
+        }
+        else
+        {
+            _selectionAnchor = targetEvent;
+            SetCursorEvent(targetEvent);
+            DispatchSetSelection([targetEvent], targetEvent);
+        }
     }
 
     private void ApplySelectedFilter(ResolvedEvent selectedEvent, EventProperty property, bool exclude)
@@ -361,8 +359,6 @@ public sealed partial class LogTablePane
         ResolvedEvent anchor,
         ResolvedEvent selected)
     {
-        // O(1) lookups via _rowIndexMap; fall back to a linear scan only if
-        // the map is stale (e.g., during a render between table rebuilds).
         if (!_rowIndexMap.TryGetValue(anchor, out int anchorIndex)) { anchorIndex = -1; }
 
         if (!_rowIndexMap.TryGetValue(selected, out int activeIndex)) { activeIndex = -1; }
@@ -395,10 +391,6 @@ public sealed partial class LogTablePane
 
     private void DispatchSetSelection(IReadOnlyList<ResolvedEvent> events, ResolvedEvent? selected)
     {
-        // Sort the selection by current row-index for events in this table; events
-        // belonging to other open logs (not in _rowIndexMap) preserve their existing
-        // relative order at the tail. De-dupe by reference identity throughout so
-        // SetSelectedEvents never has to re-process duplicates.
         var seen = new HashSet<ResolvedEvent>(ReferenceEqualityComparer.Instance);
         List<(ResolvedEvent Event, int Index)> inTable = new(events.Count);
         List<ResolvedEvent> outOfTable = [];
@@ -430,38 +422,20 @@ public sealed partial class LogTablePane
 
     private async Task FocusActiveRow()
     {
-        if (_localCursor is null) { return; }
+        int visibleRow = ResolveCursorVisibleRow();
 
-        if (!_rowIndexMap.TryGetValue(_localCursor, out int index)) { return; }
+        // A negative index would target aria-rowindex=1 (the header row).
+        if (visibleRow < 0) { return; }
 
         try
         {
-            if (_tableModule is not null) { await _tableModule.InvokeVoidAsync("focusEventTableRow", index); }
+            if (_tableModule is not null) { await _tableModule.InvokeVoidAsync("focusEventTableRow", visibleRow); }
         }
         catch (JSDisconnectedException) { /* Circuit gone - focus best-effort during teardown. */ }
         catch (Exception e)
         {
             TraceLogger.Warning($"Failed to focus active table row: {e}");
         }
-    }
-
-    private int GetActiveIndex(IReadOnlyList<ResolvedEvent> displayedEvents)
-    {
-        if (_localCursor is not null && _rowIndexMap.TryGetValue(_localCursor, out int idx))
-        {
-            return idx;
-        }
-
-        // Fall back to last selected; without that, anchor on the first row
-        // so the first ArrowDown selects the second row, not nothing.
-        var fallback = _selectedEvents.LastOrDefault();
-
-        if (fallback is not null && _rowIndexMap.TryGetValue(fallback, out int fallbackIndex))
-        {
-            return fallbackIndex;
-        }
-
-        return displayedEvents.Count > 0 ? 0 : -1;
     }
 
     private int GetAriaRowCount() => (_rowView?.Count ?? _activeDisplayedEvents.Count) + 1;
@@ -471,6 +445,24 @@ public sealed partial class LogTablePane
 
     private string GetCss(ResolvedEvent @event) =>
         _selectedSet.Contains(@event) ? "table-row selected" : "table-row";
+
+    private int GetCurrentVisibleRow(IReadOnlyList<ResolvedEvent> displayedEvents)
+    {
+        int cursorRow = ResolveCursorVisibleRow();
+
+        if (cursorRow >= 0) { return cursorRow; }
+
+        var fallback = _selectedEvents.LastOrDefault();
+
+        if (fallback is not null && _rowIndexMap.TryGetValue(fallback, out int fallbackIndex))
+        {
+            return _rowView?.VisibleRowForEvent(fallbackIndex) ?? fallbackIndex;
+        }
+
+        int count = _rowView?.Count ?? displayedEvents.Count;
+
+        return count > 0 ? 0 : -1;
+    }
 
     private string GetDateColumnHeader() =>
         Settings.TimeZoneInfo.Equals(TimeZoneInfo.Local) ?
@@ -507,8 +499,6 @@ public sealed partial class LogTablePane
 
     private string? GetHighlight(ResolvedEvent @event)
     {
-        // Selected rows show selection styling (.selected wins via !important);
-        // skip cache writes so deselecting doesn't require a refill.
         if (_selectedSet.Contains(@event)) { return null; }
 
         if (_highlightCache.TryGetValue(@event, out var cached)) { return cached; }
@@ -538,8 +528,6 @@ public sealed partial class LogTablePane
 
         if (_logTableState.ColumnOrder.IsEmpty)
         {
-            // Use ColumnDefaults.ColumnOrder for a deterministic fallback rather than
-            // HashSet iteration order, which is not guaranteed.
             return ColumnDefaults.ColumnOrder.Where(enabledSet.Contains).ToArray();
         }
 
@@ -564,18 +552,12 @@ public sealed partial class LogTablePane
         return (index - _rowView.GroupForEvent(index).StartIndex) % 2;
     }
 
-    private void HandleGroupHeaderKeyDown(KeyboardEventArgs args, string groupKey)
-    {
-        if (args.Key == "Enter") { ToggleGroupCollapsed(groupKey); }
-    }
-
     private async Task HandleKeyDown(KeyboardEventArgs args)
     {
         var displayedEvents = _activeDisplayedEvents;
 
         if (displayedEvents.Count == 0) { return; }
 
-        // Ctrl+C copies the active selection regardless of focused row.
         if (args is { CtrlKey: true, Code: "KeyC" })
         {
             await ClipboardService.CopySelectedEvent();
@@ -583,81 +565,160 @@ public sealed partial class LogTablePane
             return;
         }
 
-        // Ctrl+A: select all displayed events. Anchor=first, active=last.
         if (args is { CtrlKey: true, Code: "KeyA" })
         {
+            var last = displayedEvents[^1];
             _selectionAnchor = displayedEvents[0];
-            _localCursor = displayedEvents[^1];
-            DispatchSetSelection(displayedEvents, _localCursor);
+            SetCursorEvent(last);
+            DispatchSetSelection(displayedEvents, last);
 
             return;
         }
 
-        // Escape: clear selection entirely.
         if (args.Code == "Escape")
         {
             _selectionAnchor = null;
-            _localCursor = null;
+            SetCursor(null);
             DispatchSetSelection([], null);
 
             return;
         }
 
-        // Navigation keys: ArrowUp/Down, Home/End, PageUp/Down.
-        int currentIndex = GetActiveIndex(displayedEvents);
-        int targetIndex;
+        if (_rowView is not null)
+        {
+            if (args.Code is "ArrowLeft")
+            {
+                HandleTreegridLeft();
+
+                return;
+            }
+
+            if (args.Code is "ArrowRight")
+            {
+                HandleTreegridRight();
+
+                return;
+            }
+
+            if (args.Key is "Enter")
+            {
+                if (_cursor is { Kind: TableRowKind.Header, GroupKey: { } enterKey })
+                {
+                    ToggleGroupCollapsed(enterKey);
+                    _focusActiveOnNextRender = true;
+                }
+
+                return;
+            }
+        }
+
+        int count = _rowView?.Count ?? displayedEvents.Count;
+        int currentRow = GetCurrentVisibleRow(displayedEvents);
+        int targetRow;
+        int scanDirection;
 
         switch (args.Code)
         {
             case "ArrowUp":
-                targetIndex = Math.Max(0, currentIndex - 1);
+                targetRow = Math.Max(0, currentRow - 1);
+                scanDirection = -1;
                 break;
             case "ArrowDown":
-                targetIndex = Math.Min(displayedEvents.Count - 1, currentIndex + 1);
+                targetRow = Math.Min(count - 1, currentRow + 1);
+                scanDirection = 1;
                 break;
             case "PageUp":
             case "PageDown":
-                // Refresh page size on each press so window/splitter resizes
-                // don't leave the cached value stale for the rest of the
-                // session.
                 int liveStep = await TryRefreshPageSize();
                 int step = liveStep > 0 ? liveStep : _pageSize;
 
-                targetIndex = args.Code == "PageUp"
-                    ? Math.Max(0, currentIndex - step)
-                    : Math.Min(displayedEvents.Count - 1, currentIndex + step);
+                if (args.Code == "PageUp")
+                {
+                    targetRow = Math.Max(0, currentRow - step);
+                    scanDirection = -1;
+                }
+                else
+                {
+                    targetRow = Math.Min(count - 1, currentRow + step);
+                    scanDirection = 1;
+                }
+
                 break;
             case "Home":
-                targetIndex = 0;
+                targetRow = 0;
+                scanDirection = 1;
                 break;
             case "End":
-                targetIndex = displayedEvents.Count - 1;
+                targetRow = count - 1;
+                scanDirection = -1;
                 break;
             default:
                 return;
         }
 
-        if (targetIndex == currentIndex && _localCursor is not null) { return; }
+        if (targetRow == currentRow && _cursor is not null) { return; }
 
-        var targetEvent = displayedEvents[targetIndex];
+        if (_rowView is null)
+        {
+            ApplyNavSelection(displayedEvents, displayedEvents[targetRow], args.ShiftKey);
+            _focusActiveOnNextRender = true;
 
-        if (args.ShiftKey)
-        {
-            // Extend the range from the anchor to the new active row. If we
-            // have no anchor (e.g., first navigation into an empty selection),
-            // anchor on the previous active or the new target row.
-            _selectionAnchor ??= _localCursor ?? targetEvent;
-            _localCursor = targetEvent;
-            DispatchSetSelection(BuildRange(displayedEvents, _selectionAnchor, targetEvent), targetEvent);
-        }
-        else
-        {
-            _selectionAnchor = targetEvent;
-            _localCursor = targetEvent;
-            DispatchSetSelection([targetEvent], targetEvent);
+            return;
         }
 
-        _focusActiveOnNextRender = true;
+        NavigateGroupedTo(displayedEvents, targetRow, scanDirection, args.ShiftKey);
+    }
+
+    private void HandleTreegridLeft()
+    {
+        var view = _rowView;
+
+        if (view is null) { return; }
+
+        if (_cursor is { Kind: TableRowKind.Event, Event: { } @event } &&
+            _rowIndexMap.TryGetValue(@event, out int index))
+        {
+            SetCursorHeader(view.GroupForEvent(index).Key);
+            _focusActiveOnNextRender = true;
+
+            return;
+        }
+
+        if (_cursor is { Kind: TableRowKind.Header, GroupKey: { } key } &&
+            view.TryGetGroupByKey(key, out var group) && !group.IsCollapsed)
+        {
+            ToggleGroupCollapsed(key);
+            _focusActiveOnNextRender = true;
+        }
+    }
+
+    private void HandleTreegridRight()
+    {
+        var view = _rowView;
+
+        if (view is null ||
+            _cursor is not { Kind: TableRowKind.Header, GroupKey: { } key } ||
+            !view.TryGetGroupByKey(key, out var group))
+        {
+            return;
+        }
+
+        if (group.IsCollapsed)
+        {
+            ToggleGroupCollapsed(key);
+            _focusActiveOnNextRender = true;
+
+            return;
+        }
+
+        if (group.EventCount > 0)
+        {
+            var first = _activeDisplayedEvents[group.StartIndex];
+            _selectionAnchor = first;
+            SetCursorEvent(first);
+            DispatchSetSelection([first], first);
+            _focusActiveOnNextRender = true;
+        }
     }
 
     private async Task InitializeTableEventHandlers()
@@ -674,10 +735,6 @@ public sealed partial class LogTablePane
 
     private void InvokeContextMenu(MouseEventArgs args)
     {
-        // Snapshot the currently selected event into the closures so a subsequent selection change
-        // (e.g. user clicks elsewhere while the menu is open) doesn't retarget the action. Note:
-        // selection follows the right-click in LogTablePane, so SelectedEvent.Value matches the row
-        // under the pointer at invocation time.
         var clicked = SelectedEvent.Value;
 
         if (clicked is null) { return; }
@@ -685,8 +742,11 @@ public sealed partial class LogTablePane
         MenuService.OpenAt(args.ClientX, args.ClientY, ShowContextMenuItems(clicked));
     }
 
-    private void InvokeGroupContextMenu(MouseEventArgs args, EventGroup group) =>
+    private void InvokeGroupContextMenu(MouseEventArgs args, EventGroup group)
+    {
+        SetCursorHeader(group.Key);
         MenuService.OpenAt(args.ClientX, args.ClientY, ShowGroupContextMenuItems(group));
+    }
 
     private void InvokeTableColumnMenu(MouseEventArgs args) =>
         MenuService.OpenAt(args.ClientX, args.ClientY, ShowColumnMenuItems());
@@ -707,6 +767,73 @@ public sealed partial class LogTablePane
         return false;
     }
 
+    private void NavigateGroupedTo(
+        IReadOnlyList<ResolvedEvent> displayedEvents,
+        int targetRow,
+        int scanDirection,
+        bool shift)
+    {
+        var view = _rowView!;
+        var row = view[targetRow];
+
+        if (row.Kind == TableRowKind.Event)
+        {
+            ApplyNavSelection(displayedEvents, view.EventAt(row), shift);
+            _focusActiveOnNextRender = true;
+
+            return;
+        }
+
+        if (!shift)
+        {
+            SetCursorHeader(view.GroupAt(row).Key);
+            _focusActiveOnNextRender = true;
+
+            return;
+        }
+
+        int probe = targetRow;
+
+        while (probe >= 0 && probe < view.Count && view[probe].Kind == TableRowKind.Header)
+        {
+            probe += scanDirection;
+        }
+
+        if (probe < 0 || probe >= view.Count) { return; }
+
+        ApplyNavSelection(displayedEvents, view.EventAt(view[probe]), shift: true);
+        _focusActiveOnNextRender = true;
+    }
+
+    private TableCursor? NearestHeaderCursor(int priorVisibleRow)
+    {
+        var groups = _rowView!.Groups;
+
+        if (groups.Count == 0) { return null; }
+
+        foreach (var group in groups)
+        {
+            if (group.VisibleStart >= priorVisibleRow) { return TableCursor.ForHeader(group.Key); }
+        }
+
+        return TableCursor.ForHeader(groups[^1].Key);
+    }
+
+    // Retype an event in a collapsed group to its header.
+    private TableCursor? NormalizeCursor(TableCursor? cursor)
+    {
+        if (_rowView is { } view &&
+            cursor is { Kind: TableRowKind.Event, Event: { } @event } &&
+            _rowIndexMap.TryGetValue(@event, out int index))
+        {
+            var group = view.GroupForEvent(index);
+
+            if (group.IsCollapsed) { return TableCursor.ForHeader(group.Key); }
+        }
+
+        return cursor;
+    }
+
     private async void OnSetActiveTable(SetActiveTableAction action)
     {
         try
@@ -725,8 +852,22 @@ public sealed partial class LogTablePane
 
         if (state.GroupBy is not { } groupBy)
         {
+            int firstEventIndex = -1;
+
+            if (_rowView is { } priorView &&
+                _cursor is { Kind: TableRowKind.Header, GroupKey: { } headerKey } &&
+                priorView.TryGetGroupByKey(headerKey, out var priorGroup) && priorGroup.EventCount > 0)
+            {
+                firstEventIndex = priorGroup.StartIndex;
+            }
+
             _rowView = null;
             _rowViewSnapshot = default;
+
+            if (firstEventIndex >= 0 && firstEventIndex < displayedEvents.Count)
+            {
+                SetCursorEvent(displayedEvents[firstEventIndex]);
+            }
 
             return;
         }
@@ -736,8 +877,12 @@ public sealed partial class LogTablePane
 
         if (_rowView is not null && _rowViewSnapshot.Equals(snapshot)) { return; }
 
+        int priorHeaderRow = _cursor is { Kind: TableRowKind.Header } ? ResolveCursorVisibleRow() : -1;
+
         _rowViewSnapshot = snapshot;
         _rowView = GroupedRowView.Build(displayedEvents, groupBy, state.IsGroupCollapsed);
+
+        ReconcileGroupedCursor(priorHeaderRow);
     }
 
     private void RebuildRowMaps()
@@ -749,14 +894,12 @@ public sealed partial class LogTablePane
         {
             _lastIndexedDisplayedEvents = displayedEvents;
             _rowIndexMap = new Dictionary<ResolvedEvent, int>(displayedEvents.Count, ReferenceEqualityComparer.Instance);
-            // New event-list reference means stored ResolvedEvent instances
-            // are stale; clearing prevents memory growth across log reloads.
             _highlightCache.Clear();
 
             if (displayedEvents.Count == 0)
             {
                 _selectionAnchor = null;
-                _localCursor = null;
+                _cursor = null;
             }
             else
             {
@@ -765,17 +908,14 @@ public sealed partial class LogTablePane
                     _rowIndexMap[displayedEvents[i]] = i;
                 }
 
-                // Re-resolve anchor/active by stable key when DisplayedEvents has
-                // been replaced (sort/filter/reload). Reference equality alone would
-                // drop them on every list rebuild even when the same logical event
-                // is still visible.
                 _selectionAnchor = ResolveByKey(displayedEvents, _selectionAnchor);
-                _localCursor = ResolveByKey(displayedEvents, _localCursor);
 
-                // Detect when the existing selection no longer matches sort order so
-                // OnAfterRenderAsync can dispatch a re-sorted SetSelectedEvents.
-                // Events outside the current displayed table preserve their relative
-                // position and never trigger a re-sort by themselves.
+                if (_cursor is { Kind: TableRowKind.Event, Event: { } cursorEvent })
+                {
+                    var resolved = ResolveByKey(displayedEvents, cursorEvent);
+                    _cursor = resolved is null ? null : TableCursor.ForEvent(resolved);
+                }
+
                 if (IsSelectionOutOfSortOrder(_selectedEvents))
                 {
                     _resortSelectionOnNextRender = true;
@@ -783,10 +923,34 @@ public sealed partial class LogTablePane
             }
         }
 
-        // The grouped row-view rebuilds on any grouping-state change, including
-        // collapse toggles that keep the same DisplayedEvents reference (so the
-        // events-ref guard above would skip them).
+        // Outside the events-ref guard: collapse toggles keep the same reference.
         RebuildGroupedRowView(displayedEvents);
+    }
+
+    private void ReconcileGroupedCursor(int priorHeaderRow)
+    {
+        if (_rowView is not { } view || _cursor is not { } cursor) { return; }
+
+        if (cursor is { Kind: TableRowKind.Event, Event: { } @event })
+        {
+            if (_rowIndexMap.TryGetValue(@event, out int index))
+            {
+                var group = view.GroupForEvent(index);
+
+                if (group.IsCollapsed) { _cursor = TableCursor.ForHeader(group.Key); }
+            }
+            else
+            {
+                _cursor = null;
+            }
+
+            return;
+        }
+
+        if (cursor is { Kind: TableRowKind.Header, GroupKey: { } key } && !view.TryGetGroupByKey(key, out _))
+        {
+            _cursor = NearestHeaderCursor(priorHeaderRow);
+        }
     }
 
     private async void RescrollToSelected()
@@ -840,21 +1004,30 @@ public sealed partial class LogTablePane
         return result;
     }
 
+    private int ResolveCursorVisibleRow()
+    {
+        if (_cursor is { Kind: TableRowKind.Header, GroupKey: { } key })
+        {
+            return _rowView?.VisibleRowForHeader(key) ?? -1;
+        }
+
+        if (_cursor is { Kind: TableRowKind.Event, Event: { } @event } &&
+            _rowIndexMap.TryGetValue(@event, out int index))
+        {
+            return _rowView?.VisibleRowForEvent(index) ?? index;
+        }
+
+        return -1;
+    }
+
     private void ResortSelectionForCurrentTable()
     {
-        // Re-publish the current selection in the new sort order. The dispatch
-        // is idempotent - ReduceSetSelectedEvents short-circuits when both the
-        // selection and active event are unchanged by reference, so this is
-        // safe to call after every DisplayedEvents reference change.
-        DispatchSetSelection(_selectedEvents, _localCursor ?? _selectedEvent);
+        DispatchSetSelection(_selectedEvents, ActiveEvent ?? _selectedEvent);
     }
 
     private async Task ScrollToSelectedEvent()
     {
-        // Target the active event (focused row) rather than the last selected
-        // event - selection is now in sort order, so "last in selection" no
-        // longer corresponds to "the row the user is interacting with".
-        var target = _localCursor ?? _selectedEvent ?? _selectedEvents.LastOrDefault();
+        var target = ActiveEvent ?? _selectedEvent ?? _selectedEvents.LastOrDefault();
 
         if (target is null) { return; }
 
@@ -862,12 +1035,7 @@ public sealed partial class LogTablePane
 
         if (displayedEvents.Count == 0) { return; }
 
-        // Match on OwningLog (the per-source identifier - file path for
-        // exported logs, channel name for live logs) in addition to LogName
-        // and RecordId so we don't scroll to a value-equal row from a
-        // different open log when multiple sources share the same channel
-        // name and overlapping record-id ranges. Single pass over the list
-        // returns both the row and its index without re-scanning via IndexOf.
+        // Match OwningLog too so overlapping logs don't cross-match on RecordId.
         for (var index = 0; index < displayedEvents.Count; index++)
         {
             var candidate = displayedEvents[index];
@@ -879,7 +1047,9 @@ public sealed partial class LogTablePane
                 continue;
             }
 
-            if (_tableModule is not null) { await _tableModule.InvokeVoidAsync("scrollToRow", index); }
+            int targetRow = _rowView?.VisibleRowForEvent(index) ?? index;
+
+            if (_tableModule is not null) { await _tableModule.InvokeVoidAsync("scrollToRow", targetRow); }
 
             return;
         }
@@ -892,26 +1062,20 @@ public sealed partial class LogTablePane
         switch (args)
         {
             case { ShiftKey: true } when displayedEvents.Count > 0:
-                // Shift+Click: range from anchor to clicked. Anchor stays put.
-                // Without an anchor (first interaction), treat as a plain
-                // click so we have something to extend from on the next click.
                 if (_selectionAnchor is null)
                 {
                     _selectionAnchor = @event;
-                    _localCursor = @event;
+                    SetCursorEvent(@event);
                     DispatchSetSelection([@event], @event);
 
                     return;
                 }
 
-                _localCursor = @event;
+                SetCursorEvent(@event);
                 var range = BuildRange(displayedEvents, _selectionAnchor, @event);
 
                 if (args.CtrlKey)
                 {
-                    // Ctrl+Shift+Click: additive range. Merge existing
-                    // selection with the new range. Dedupe by reference is
-                    // handled centrally inside DispatchSetSelection.
                     var merged = new List<ResolvedEvent>(_selectedEvents.Count + range.Count);
                     merged.AddRange(_selectedEvents);
                     merged.AddRange(range);
@@ -925,11 +1089,8 @@ public sealed partial class LogTablePane
                 return;
 
             case { CtrlKey: true }:
-                // Ctrl+Click toggles a single row and moves the anchor to it.
-                // Active stays on the clicked row even if it was deselected
-                // (Explorer-style focus semantics).
                 _selectionAnchor = @event;
-                _localCursor = @event;
+                SetCursorEvent(@event);
 
                 if (_selectedSet.Contains(@event))
                 {
@@ -953,22 +1114,16 @@ public sealed partial class LogTablePane
                 return;
 
             default:
-                // Right-click on a row that's already part of a multi-selection
-                // should preserve the selection and only move focus to the
-                // clicked row, matching Windows Explorer behavior so the
-                // context menu can act on the existing selection. Left/middle
-                // clicks (and right-clicks on a non-selected row) replace the
-                // selection with just the clicked row.
                 if (args.Button == 2 && _selectedSet.Contains(@event))
                 {
-                    _localCursor = @event;
+                    SetCursorEvent(@event);
                     DispatchSetSelection(_selectedEvents, @event);
 
                     return;
                 }
 
                 _selectionAnchor = @event;
-                _localCursor = @event;
+                SetCursorEvent(@event);
                 DispatchSetSelection([@event], @event);
 
                 return;
@@ -992,7 +1147,7 @@ public sealed partial class LogTablePane
 
         var active = members[0];
         _selectionAnchor = active;
-        _localCursor = active;
+        SetCursorEvent(active);
         DispatchSetSelection(members, active);
     }
 
@@ -1002,6 +1157,13 @@ public sealed partial class LogTablePane
 
         SelectGroup(group);
     }
+
+    private void SetCursor(TableCursor? cursor) => _cursor = NormalizeCursor(cursor);
+
+    private void SetCursorEvent(ResolvedEvent? @event) =>
+        SetCursor(@event is null ? null : TableCursor.ForEvent(@event));
+
+    private void SetCursorHeader(string groupKey) => SetCursor(TableCursor.ForHeader(groupKey));
 
     private void SetGroupCollapsed(string key, bool collapse)
     {

--- a/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
@@ -852,21 +852,21 @@ public sealed partial class LogTablePane
 
         if (state.GroupBy is not { } groupBy)
         {
-            int firstEventIndex = -1;
+            ResolvedEvent? formerGroupFirstEvent = null;
 
             if (_rowView is { } priorView &&
                 _cursor is { Kind: TableRowKind.Header, GroupKey: { } headerKey } &&
                 priorView.TryGetGroupByKey(headerKey, out var priorGroup) && priorGroup.EventCount > 0)
             {
-                firstEventIndex = priorGroup.StartIndex;
+                formerGroupFirstEvent = priorView.FirstEventOf(priorGroup);
             }
 
             _rowView = null;
             _rowViewSnapshot = default;
 
-            if (firstEventIndex >= 0 && firstEventIndex < displayedEvents.Count)
+            if (formerGroupFirstEvent is not null)
             {
-                SetCursorEvent(displayedEvents[firstEventIndex]);
+                SetCursorEvent(formerGroupFirstEvent);
             }
 
             return;

--- a/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
@@ -17,6 +17,7 @@ using EventLogExpert.Runtime.LogTable;
 using EventLogExpert.Runtime.Menu;
 using EventLogExpert.Runtime.Settings;
 using EventLogExpert.UI.Common.Interop;
+using EventLogExpert.UI.LogTable.Grouping;
 using Fluxor;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
@@ -49,7 +50,7 @@ public sealed partial class LogTablePane
     private IReadOnlyList<ResolvedEvent>? _lastIndexedDisplayedEvents;
     // View-local cursor: the row that is the moving end of a range selection within the
     // current table. May briefly diverge from _selectedEvent during local keyboard nav
-    // (advanced before the dispatch round-trip) and after RebuildRowIndexMap rebinds it
+    // (advanced before the dispatch round-trip) and after RebuildRowMaps rebinds it
     // to the equivalent row in a freshly built DisplayedEvents list. Defaults to the
     // same row as _selectionAnchor for single-row selections.
     private ResolvedEvent? _localCursor;
@@ -58,6 +59,8 @@ public sealed partial class LogTablePane
     private ColumnName[] _previousEnabledColumns = [];
     private bool _resortSelectionOnNextRender;
     private Dictionary<ResolvedEvent, int> _rowIndexMap = new(ReferenceEqualityComparer.Instance);
+    private GroupedRowView? _rowView;
+    private (IReadOnlyList<ResolvedEvent> Events, EventLogId? TableId, ColumnName? GroupBy, bool GroupDescending, bool CollapsedDefault, ImmutableHashSet<string>? Overrides) _rowViewSnapshot;
     private ResolvedEvent? _selectedEvent;
     private ImmutableList<ResolvedEvent> _selectedEvents = [];
     private HashSet<ResolvedEvent> _selectedSet = new(ReferenceEqualityComparer.Instance);
@@ -207,7 +210,8 @@ public sealed partial class LogTablePane
         _timeZoneSettings = Settings.TimeZoneInfo;
 
         WarnOnUnknownFilterColors(_filters);
-        RebuildRowIndexMap();
+
+        RebuildRowMaps();
 
         await base.OnInitializedAsync();
     }
@@ -272,7 +276,7 @@ public sealed partial class LogTablePane
 
         _timeZoneSettings = Settings.TimeZoneInfo;
 
-        RebuildRowIndexMap();
+        RebuildRowMaps();
 
         return true;
     }
@@ -460,6 +464,8 @@ public sealed partial class LogTablePane
         return displayedEvents.Count > 0 ? 0 : -1;
     }
 
+    private int GetAriaRowCount() => (_rowView?.Count ?? _activeDisplayedEvents.Count) + 1;
+
     private int GetColumnWidth(ColumnName column) =>
         _logTableState.ColumnWidths.TryGetValue(column, out int width) ? width : ColumnDefaults.GetColumnWidth(column);
 
@@ -470,6 +476,34 @@ public sealed partial class LogTablePane
         Settings.TimeZoneInfo.Equals(TimeZoneInfo.Local) ?
             "Date and Time" :
             $"Date and Time {Settings.TimeZoneInfo.DisplayName.Split(" ").First()}";
+
+    private string GetGroupName() => _logTableState.GroupBy?.ToFullString() ?? string.Empty;
+
+    private string GetGroupValueText(EventGroup group)
+    {
+        if (group.EventCount == 0) { return "(none)"; }
+
+        var representative = _activeDisplayedEvents[group.StartIndex];
+
+        string? value = _logTableState.GroupBy switch
+        {
+            ColumnName.Level => representative.Level,
+            ColumnName.DateAndTime => representative.TimeCreated.ConvertTimeZone(_timeZoneSettings).ToString(),
+            ColumnName.ActivityId => representative.ActivityId?.ToString(),
+            ColumnName.Log => GetLogShortName(representative.OwningLog),
+            ColumnName.ComputerName => representative.ComputerName,
+            ColumnName.Source => representative.Source,
+            ColumnName.EventId => representative.Id.ToString(),
+            ColumnName.TaskCategory => representative.TaskCategory,
+            ColumnName.Keywords => representative.KeywordsDisplayName,
+            ColumnName.ProcessId => representative.ProcessId?.ToString(),
+            ColumnName.ThreadId => representative.ThreadId?.ToString(),
+            ColumnName.User => representative.UserId?.ToString(),
+            _ => null
+        };
+
+        return string.IsNullOrEmpty(value) ? "(none)" : value;
+    }
 
     private string? GetHighlight(ResolvedEvent @event)
     {
@@ -514,8 +548,26 @@ public sealed partial class LogTablePane
             .ToArray();
     }
 
-    private int GetRowIndex(ResolvedEvent evt) =>
-        _rowIndexMap.TryGetValue(evt, out int index) ? index + 2 : 2;
+    private int GetRowIndex(ResolvedEvent evt)
+    {
+        if (!_rowIndexMap.TryGetValue(evt, out int index)) { return 2; }
+
+        return (_rowView?.VisibleRowForEvent(index) ?? index) + 2;
+    }
+
+    private int GetRowStripe(ResolvedEvent evt)
+    {
+        if (!_rowIndexMap.TryGetValue(evt, out int index)) { return 0; }
+
+        if (_rowView is null) { return index % 2; }
+
+        return (index - _rowView.GroupForEvent(index).StartIndex) % 2;
+    }
+
+    private void HandleGroupHeaderKeyDown(KeyboardEventArgs args, string groupKey)
+    {
+        if (args.Key == "Enter") { ToggleGroupCollapsed(groupKey); }
+    }
 
     private async Task HandleKeyDown(KeyboardEventArgs args)
     {
@@ -633,6 +685,9 @@ public sealed partial class LogTablePane
         MenuService.OpenAt(args.ClientX, args.ClientY, ShowContextMenuItems(clicked));
     }
 
+    private void InvokeGroupContextMenu(MouseEventArgs args, EventGroup group) =>
+        MenuService.OpenAt(args.ClientX, args.ClientY, ShowGroupContextMenuItems(group));
+
     private void InvokeTableColumnMenu(MouseEventArgs args) =>
         MenuService.OpenAt(args.ClientX, args.ClientY, ShowColumnMenuItems());
 
@@ -664,47 +719,74 @@ public sealed partial class LogTablePane
         }
     }
 
-    private void RebuildRowIndexMap()
+    private void RebuildGroupedRowView(IReadOnlyList<ResolvedEvent> displayedEvents)
     {
-        var displayedEvents = ResolveActiveDisplayedEvents();
-        _activeDisplayedEvents = displayedEvents;
+        var state = _logTableState;
 
-        if (ReferenceEquals(displayedEvents, _lastIndexedDisplayedEvents)) { return; }
-
-        _lastIndexedDisplayedEvents = displayedEvents;
-        _rowIndexMap = new Dictionary<ResolvedEvent, int>(displayedEvents.Count, ReferenceEqualityComparer.Instance);
-        // New event-list reference means stored ResolvedEvent instances
-        // are stale; clearing prevents memory growth across log reloads.
-        _highlightCache.Clear();
-
-        if (displayedEvents.Count == 0)
+        if (state.GroupBy is not { } groupBy)
         {
-            _selectionAnchor = null;
-            _localCursor = null;
+            _rowView = null;
+            _rowViewSnapshot = default;
 
             return;
         }
 
-        for (int i = 0; i < displayedEvents.Count; i++)
+        var snapshot = (displayedEvents, _currentTable?.Id, state.GroupBy, state.IsGroupDescending,
+            state.GroupsCollapsedByDefault, (ImmutableHashSet<string>?)state.GroupCollapseOverrides);
+
+        if (_rowView is not null && _rowViewSnapshot.Equals(snapshot)) { return; }
+
+        _rowViewSnapshot = snapshot;
+        _rowView = GroupedRowView.Build(displayedEvents, groupBy, state.IsGroupCollapsed);
+    }
+
+    private void RebuildRowMaps()
+    {
+        var displayedEvents = ResolveActiveDisplayedEvents();
+        _activeDisplayedEvents = displayedEvents;
+
+        if (!ReferenceEquals(displayedEvents, _lastIndexedDisplayedEvents))
         {
-            _rowIndexMap[displayedEvents[i]] = i;
+            _lastIndexedDisplayedEvents = displayedEvents;
+            _rowIndexMap = new Dictionary<ResolvedEvent, int>(displayedEvents.Count, ReferenceEqualityComparer.Instance);
+            // New event-list reference means stored ResolvedEvent instances
+            // are stale; clearing prevents memory growth across log reloads.
+            _highlightCache.Clear();
+
+            if (displayedEvents.Count == 0)
+            {
+                _selectionAnchor = null;
+                _localCursor = null;
+            }
+            else
+            {
+                for (int i = 0; i < displayedEvents.Count; i++)
+                {
+                    _rowIndexMap[displayedEvents[i]] = i;
+                }
+
+                // Re-resolve anchor/active by stable key when DisplayedEvents has
+                // been replaced (sort/filter/reload). Reference equality alone would
+                // drop them on every list rebuild even when the same logical event
+                // is still visible.
+                _selectionAnchor = ResolveByKey(displayedEvents, _selectionAnchor);
+                _localCursor = ResolveByKey(displayedEvents, _localCursor);
+
+                // Detect when the existing selection no longer matches sort order so
+                // OnAfterRenderAsync can dispatch a re-sorted SetSelectedEvents.
+                // Events outside the current displayed table preserve their relative
+                // position and never trigger a re-sort by themselves.
+                if (IsSelectionOutOfSortOrder(_selectedEvents))
+                {
+                    _resortSelectionOnNextRender = true;
+                }
+            }
         }
 
-        // Re-resolve anchor/active by stable key when DisplayedEvents has
-        // been replaced (sort/filter/reload). Reference equality alone would
-        // drop them on every list rebuild even when the same logical event
-        // is still visible.
-        _selectionAnchor = ResolveByKey(displayedEvents, _selectionAnchor);
-        _localCursor = ResolveByKey(displayedEvents, _localCursor);
-
-        // Detect when the existing selection no longer matches sort order so
-        // OnAfterRenderAsync can dispatch a re-sorted SetSelectedEvents.
-        // Events outside the current displayed table preserve their relative
-        // position and never trigger a re-sort by themselves.
-        if (IsSelectionOutOfSortOrder(_selectedEvents))
-        {
-            _resortSelectionOnNextRender = true;
-        }
+        // The grouped row-view rebuilds on any grouping-state change, including
+        // collapse toggles that keep the same DisplayedEvents reference (so the
+        // events-ref guard above would skip them).
+        RebuildGroupedRowView(displayedEvents);
     }
 
     private async void RescrollToSelected()
@@ -893,6 +975,44 @@ public sealed partial class LogTablePane
         }
     }
 
+    private void SelectGroup(EventGroup group)
+    {
+        if (group.EventCount == 0 ||
+            group.StartIndex + group.EventCount > _activeDisplayedEvents.Count)
+        {
+            return;
+        }
+
+        var members = new List<ResolvedEvent>(group.EventCount);
+
+        for (int i = group.StartIndex; i < group.StartIndex + group.EventCount; i++)
+        {
+            members.Add(_activeDisplayedEvents[i]);
+        }
+
+        var active = members[0];
+        _selectionAnchor = active;
+        _localCursor = active;
+        DispatchSetSelection(members, active);
+    }
+
+    private void SelectGroupByKey(string key)
+    {
+        if (_rowView is null || !_rowView.TryGetGroupByKey(key, out var group)) { return; }
+
+        SelectGroup(group);
+    }
+
+    private void SetGroupCollapsed(string key, bool collapse)
+    {
+        if (_rowView is null || !_rowView.TryGetGroupByKey(key, out _)) { return; }
+
+        if (LogTableState.Value.IsGroupCollapsed(key) != collapse)
+        {
+            LogTableCommands.ToggleGroupCollapsed(key);
+        }
+    }
+
     private IReadOnlyList<MenuItem> ShowColumnMenuItems()
     {
         var state = LogTableState.Value;
@@ -920,6 +1040,23 @@ public sealed partial class LogTablePane
         }
 
         items.Add(MenuItem.SubMenu("Order By", orderItems));
+
+        var groupItems = new List<MenuItem>
+        {
+            MenuItem.Item("(none)", () => LogTableCommands.SetGroupBy(null), isChecked: state.GroupBy is null)
+        };
+
+        foreach (var (column, _) in state.Columns)
+        {
+            var capturedColumn = column;
+            groupItems.Add(MenuItem.Item(
+                column.ToFullString(),
+                () => LogTableCommands.SetGroupBy(capturedColumn),
+                isChecked: state.GroupBy.Equals(capturedColumn)));
+        }
+
+        items.Add(MenuItem.SubMenu("Group By", groupItems));
+
         items.Add(MenuItem.Separator());
         items.Add(MenuItem.Item(
             "Reset Column Defaults",
@@ -965,6 +1102,29 @@ public sealed partial class LogTablePane
 
         return items;
     }
+
+    private IReadOnlyList<MenuItem> ShowGroupContextMenuItems(EventGroup group)
+    {
+        bool collapsedNow = LogTableState.Value.IsGroupCollapsed(group.Key);
+
+        return
+        [
+            MenuItem.Item(
+                collapsedNow ? "Expand Group" : "Collapse Group",
+                () => SetGroupCollapsed(group.Key, !collapsedNow)),
+            MenuItem.Item("Expand All Groups", () => LogTableCommands.SetAllGroupsCollapsed(false)),
+            MenuItem.Item("Collapse All Groups", () => LogTableCommands.SetAllGroupsCollapsed(true)),
+            MenuItem.Separator(),
+            MenuItem.Item(
+                "Group Descending",
+                () => LogTableCommands.ToggleGroupSortDirection(),
+                isChecked: LogTableState.Value.IsGroupDescending),
+            MenuItem.Separator(),
+            MenuItem.Item("Select Group", () => SelectGroupByKey(group.Key)),
+        ];
+    }
+
+    private void ToggleGroupCollapsed(string groupKey) => LogTableCommands.ToggleGroupCollapsed(groupKey);
 
     private void ToggleSorting() => LogTableCommands.ToggleSortDirection();
 

--- a/src/EventLogExpert.UI/LogTable/LogTablePane.razor.css
+++ b/src/EventLogExpert.UI/LogTable/LogTablePane.razor.css
@@ -129,6 +129,13 @@ tr {
     background-color: var(--background-darkgray);
 }
 
+/* Header focus ring. outline-offset insets it so border-collapse doesn't clip the <tr>
+   outline in WebView2. */
+.group-header-row:focus-visible {
+    outline: 2px solid var(--clr-lightblue);
+    outline-offset: -2px;
+}
+
 .group-chevron {
     display: inline-block;
     width: 1rem;

--- a/src/EventLogExpert.UI/LogTable/LogTablePane.razor.css
+++ b/src/EventLogExpert.UI/LogTable/LogTablePane.razor.css
@@ -15,7 +15,7 @@ table {
     table-layout: fixed;
 }
 
-tr:nth-child(odd) { background-color: var(--background-darkgray); }
+tr[data-stripe="1"] { background-color: var(--background-darkgray); }
 
 th {
     position: sticky;
@@ -68,7 +68,7 @@ tr {
 /* Single rule applies any highlight color via the [data-highlight] palette
    defined in app.css. Bg/fg pair guarantees WCAG-compliant contrast.
    Specificity (.table-row[data-highlight] = 0,2,0) beats
-   tr:nth-child(odd) (0,1,1) without needing !important. The inset
+   the tr[data-stripe] zebra (0,1,1) without needing !important. The inset
    box-shadow mirrors .selected's non-color cue so highlighted rows remain
    distinguishable in forced-colors / high-contrast modes that strip bg/fg. */
 .table-row[data-highlight] {
@@ -119,6 +119,34 @@ tr {
 }
 
 .description { width: 100%; }
+
+.group-header-row { cursor: pointer; }
+
+.group-header-row > td {
+    border-top: 1px solid var(--clr-lightblue);
+    border-right: none;
+    font-weight: 600;
+    background-color: var(--background-darkgray);
+}
+
+.group-chevron {
+    display: inline-block;
+    width: 1rem;
+    text-align: center;
+    color: var(--text-secondary);
+    transition: transform 0.1s ease-in-out;
+
+    &[data-collapsed="false"] { transform: rotate(90deg); }
+}
+
+.group-count {
+    margin-left: .25rem;
+    color: var(--text-secondary);
+}
+
+.group-name { color: var(--text-secondary); }
+
+.group-value { color: var(--toggle-accent); }
 
 th.dragging {
     opacity: 0.5;

--- a/src/EventLogExpert.UI/LogTable/LogTablePane.razor.js
+++ b/src/EventLogExpert.UI/LogTable/LogTablePane.razor.js
@@ -388,6 +388,14 @@ function registerKeyHandlers(table, signal) {
                 return;
             }
 
+            // ArrowLeft/Right drive the treegrid only when grouped; suppress horizontal
+            // scroll there. Flat mode (role="grid") keeps native behavior.
+            if ((e.key === "ArrowLeft" || e.key === "ArrowRight") &&
+                table.getAttribute("role") === "treegrid") {
+                e.preventDefault();
+                return;
+            }
+
             // Ctrl+A: prevent the WebView's native Select-All so the
             // table's own Ctrl+A handler in HandleKeyDown owns the gesture.
             if (e.ctrlKey && (e.key === "a" || e.key === "A")) {

--- a/src/EventLogExpert.UI/Menu/MenuBar.razor.cs
+++ b/src/EventLogExpert.UI/Menu/MenuBar.razor.cs
@@ -6,6 +6,7 @@ using EventLogExpert.Runtime.Common.Clipboard;
 using EventLogExpert.Runtime.Common.Versioning;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.Runtime.FilterPane;
+using EventLogExpert.Runtime.LogTable;
 using EventLogExpert.Runtime.Menu;
 using EventLogExpert.Runtime.Settings;
 using EventLogExpert.UI.Common.Interop;
@@ -19,6 +20,8 @@ namespace EventLogExpert.UI.Menu;
 
 public sealed partial class MenuBar
 {
+    private const string GroupDisabledReason = "Group events first (column header > Group By)";
+
     private readonly List<TopLevel> _bars = [];
 
     private ElementReference[] _barElements = [];
@@ -40,6 +43,12 @@ public sealed partial class MenuBar
 
     [Inject]
     private IStateSelection<EventLogState, bool> HasActiveLogs { get; init; } = null!;
+
+    [Inject]
+    private IStateSelection<LogTableState, bool> IsGroupDescending { get; init; } = null!;
+
+    [Inject]
+    private IStateSelection<LogTableState, bool> IsGrouping { get; init; } = null!;
 
     [Inject] private IJSRuntime JSRuntime { get; init; } = null!;
 
@@ -70,6 +79,8 @@ public sealed partial class MenuBar
         ContinuouslyUpdate.Select(state => state.ContinuouslyUpdate);
         FilterPaneIsEnabled.Select(state => state.IsEnabled);
         HasActiveLogs.Select(state => !state.ActiveLogs.IsEmpty);
+        IsGroupDescending.Select(state => state.IsGroupDescending);
+        IsGrouping.Select(state => state.GroupBy is not null);
 
         Settings.CopyFormatChanged += OnSettingsChanged;
         MenuService.StateChanged += OnMenuServiceStateChanged;
@@ -224,6 +235,8 @@ public sealed partial class MenuBar
         // Snapshot state at open time. Live updates aren't pushed into an open menu - the next open will reflect any change.
         bool isFilterEnabled = FilterPaneIsEnabled.Value;
         bool isContinuouslyUpdating = ContinuouslyUpdate.Value;
+        bool isGrouping = IsGrouping.Value;
+        bool isGroupDescending = IsGroupDescending.Value;
 
         return
         [
@@ -237,6 +250,23 @@ public sealed partial class MenuBar
                 "Continuously Update",
                 () => Actions.SetContinuouslyUpdate(!isContinuouslyUpdating),
                 isChecked: isContinuouslyUpdating),
+            MenuItem.Separator(),
+            MenuItem.Item(
+                "Group Descending",
+                Actions.ToggleGroupSortDirection,
+                isChecked: isGroupDescending,
+                isEnabled: isGrouping,
+                disabledReason: isGrouping ? null : GroupDisabledReason),
+            MenuItem.Item(
+                "Expand All Groups",
+                () => Actions.SetAllGroupsCollapsed(false),
+                isEnabled: isGrouping,
+                disabledReason: isGrouping ? null : GroupDisabledReason),
+            MenuItem.Item(
+                "Collapse All Groups",
+                () => Actions.SetAllGroupsCollapsed(true),
+                isEnabled: isGrouping,
+                disabledReason: isGrouping ? null : GroupDisabledReason),
         ];
     }
 

--- a/src/EventLogExpert/Adapters/Menu/MauiMenuActionService.cs
+++ b/src/EventLogExpert/Adapters/Menu/MauiMenuActionService.cs
@@ -11,6 +11,7 @@ using EventLogExpert.Runtime.Common.Versioning;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.Runtime.FilterLibrary;
 using EventLogExpert.Runtime.FilterPane;
+using EventLogExpert.Runtime.LogTable;
 using EventLogExpert.Runtime.Menu;
 using EventLogExpert.Runtime.Modal;
 using EventLogExpert.Runtime.Settings;
@@ -38,6 +39,7 @@ public sealed class MauiMenuActionService(
     IEventLogCommands eventLogCommands,
     IFilterLibraryCommands filterLibraryCommands,
     IFilterPaneCommands filterPaneCommands,
+    ILogTableCommands logTableCommands,
     IClipboardService clipboardService,
     IAlertDialogService dialogService,
     IModalCoordinator modalCoordinator,
@@ -58,6 +60,7 @@ public sealed class MauiMenuActionService(
     private readonly IFilterPaneCommands _filterPaneCommands = filterPaneCommands;
     private readonly IFolderPickerService _folderPickerService = folderPickerService;
     private readonly SemaphoreSlim _logNamesLock = new(1, 1);
+    private readonly ILogTableCommands _logTableCommands = logTableCommands;
     private readonly IModalCoordinator _modalCoordinator = modalCoordinator;
     private readonly ISettingsService _settings = settings;
     private readonly ITraceLogger _traceLogger = traceLogger;
@@ -316,6 +319,8 @@ public sealed class MauiMenuActionService(
         _filterLibraryCommands.SavePaneAsFilterSet(filterSetName);
     }
 
+    public void SetAllGroupsCollapsed(bool collapsed) => _logTableCommands.SetAllGroupsCollapsed(collapsed);
+
     public void SetContinuouslyUpdate(bool value) =>
         _eventLogCommands.SetContinuouslyUpdate(value);
 
@@ -337,6 +342,8 @@ public sealed class MauiMenuActionService(
             _traceLogger.Error($"Failed to display release notes: {ex}");
         }
     }
+
+    public void ToggleGroupSortDirection() => _logTableCommands.ToggleGroupSortDirection();
 
     public void ToggleShowAllEvents() => _filterPaneCommands.ToggleFilteringEnabled();
 

--- a/tests/Shared/EventLogExpert.Filtering.TestUtils/FilterEventBuilder.cs
+++ b/tests/Shared/EventLogExpert.Filtering.TestUtils/FilterEventBuilder.cs
@@ -23,8 +23,9 @@ public static class FilterEventBuilder
         int? processId = null,
         int? threadId = null,
         SecurityIdentifier? userId = null,
-        IReadOnlyList<string>? keywords = null) =>
-        new("TestLog", LogPathType.Channel)
+        IReadOnlyList<string>? keywords = null,
+        string owningLog = "TestLog") =>
+        new(owningLog, LogPathType.Channel)
         {
             Id = id,
             Source = source,

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/LogTableStoreTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/LogTableStoreTests.cs
@@ -944,6 +944,22 @@ public sealed class LogTableStoreTests
     }
 
     [Fact]
+    public void ReduceSetGroupBy_WhenSameColumn_PreservesDirectionAndCollapse()
+    {
+        var state = new LogTableState
+        {
+            GroupBy = ColumnName.Source,
+            IsGroupDescending = true,
+            GroupCollapseOverrides = ImmutableHashSet.Create("kept")
+        };
+
+        var result = Reducers.ReduceSetGroupBy(state, new SetGroupByAction(ColumnName.Source));
+
+        Assert.True(result.IsGroupDescending);
+        Assert.Contains("kept", result.GroupCollapseOverrides);
+    }
+
+    [Fact]
     public void ReduceToggleGroupCollapsed_TogglesKey()
     {
         var collapsed = Reducers.ReduceToggleGroupCollapsed(

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/LogTableStoreTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/LogTableStoreTests.cs
@@ -881,12 +881,23 @@ public sealed class LogTableStoreTests
     [Fact]
     public void ReduceSetAllGroupsCollapsed_SetsDefaultAndClearsOverrides()
     {
-        var state = new LogTableState { GroupCollapseOverrides = ImmutableHashSet.Create("x") };
+        var state = new LogTableState { GroupBy = ColumnName.Source, GroupCollapseOverrides = ImmutableHashSet.Create("x") };
 
         var result = Reducers.ReduceSetAllGroupsCollapsed(state, new SetAllGroupsCollapsedAction(true));
 
         Assert.True(result.GroupsCollapsedByDefault);
         Assert.Empty(result.GroupCollapseOverrides);
+    }
+
+    [Fact]
+    public void ReduceSetAllGroupsCollapsed_WhenNotGrouping_NoOps()
+    {
+        var state = new LogTableState { GroupCollapseOverrides = ImmutableHashSet.Create("x") };
+
+        var result = Reducers.ReduceSetAllGroupsCollapsed(state, new SetAllGroupsCollapsedAction(true));
+
+        Assert.Same(state, result);
+        Assert.False(result.GroupsCollapsedByDefault);
     }
 
     [Fact]
@@ -936,7 +947,7 @@ public sealed class LogTableStoreTests
     public void ReduceToggleGroupCollapsed_TogglesKey()
     {
         var collapsed = Reducers.ReduceToggleGroupCollapsed(
-            new LogTableState(),
+            new LogTableState { GroupBy = ColumnName.Source },
             new ToggleGroupCollapsedAction("grp"));
 
         Assert.Contains("grp", collapsed.GroupCollapseOverrides);
@@ -944,6 +955,16 @@ public sealed class LogTableStoreTests
         var expanded = Reducers.ReduceToggleGroupCollapsed(collapsed, new ToggleGroupCollapsedAction("grp"));
 
         Assert.DoesNotContain("grp", expanded.GroupCollapseOverrides);
+    }
+
+    [Fact]
+    public void ReduceToggleGroupCollapsed_WhenNotGrouping_NoOps()
+    {
+        var state = new LogTableState();
+
+        var result = Reducers.ReduceToggleGroupCollapsed(state, new ToggleGroupCollapsedAction("grp"));
+
+        Assert.Same(state, result);
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/LogTableStoreTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/LogTableStoreTests.cs
@@ -243,6 +243,23 @@ public sealed class LogTableStoreTests
         Assert.DoesNotContain(state.EventTables, t => t.Id == logData2.Id);
     }
 
+    [Theory]
+    [InlineData(false, false, false)]
+    [InlineData(false, true, true)]
+    [InlineData(true, false, true)]
+    [InlineData(true, true, false)]
+    public void IsGroupCollapsed_XorsDefaultAndOverride(bool collapsedByDefault, bool hasOverride, bool expected)
+    {
+        var overrides = hasOverride ? ImmutableHashSet.Create("g") : ImmutableHashSet<string>.Empty;
+        var state = new LogTableState
+        {
+            GroupsCollapsedByDefault = collapsedByDefault,
+            GroupCollapseOverrides = overrides
+        };
+
+        Assert.Equal(expected, state.IsGroupCollapsed("g"));
+    }
+
     [Fact]
     public void LogTableState_DefaultState_ShouldHaveCorrectDefaults()
     {
@@ -361,6 +378,24 @@ public sealed class LogTableStoreTests
     }
 
     [Fact]
+    public void ReduceAddTable_WhenFirstLogSetsActive_ResetsCollapse()
+    {
+        var state = new LogTableState
+        {
+            GroupsCollapsedByDefault = true,
+            GroupCollapseOverrides = ImmutableHashSet.Create("g")
+        };
+
+        var result = Reducers.ReduceAddTable(
+            state,
+            new AddTableAction(new EventLogData("Application", LogPathType.Channel, [])));
+
+        Assert.NotNull(result.ActiveEventLogId);
+        Assert.False(result.GroupsCollapsedByDefault);
+        Assert.Empty(result.GroupCollapseOverrides);
+    }
+
+    [Fact]
     public void ReduceAddTable_WhenFirstTable_ShouldBeLoading()
     {
         // Arrange
@@ -424,6 +459,28 @@ public sealed class LogTableStoreTests
         Assert.Null(newState.EventTables.First().FileName);
         Assert.Equal(Constants.LogNameApplication, newState.EventTables.First().LogName);
         Assert.Equal(LogPathType.Channel, newState.EventTables.First().LogPathType);
+    }
+
+    [Fact]
+    public void ReduceAddTable_WhenSecondLogSwitchesToCombined_ResetsCollapse()
+    {
+        var state = Reducers.ReduceAddTable(
+            new LogTableState(),
+            new AddTableAction(new EventLogData("First", LogPathType.Channel, [])));
+        state = state with
+        {
+            GroupsCollapsedByDefault = true,
+            GroupCollapseOverrides = ImmutableHashSet.Create("g")
+        };
+
+        var result = Reducers.ReduceAddTable(
+            state,
+            new AddTableAction(new EventLogData("Second", LogPathType.Channel, [])));
+
+        Assert.Contains(result.EventTables, t => t.IsCombined);
+        Assert.Equal(result.EventTables.First(t => t.IsCombined).Id, result.ActiveEventLogId);
+        Assert.False(result.GroupsCollapsedByDefault);
+        Assert.Empty(result.GroupCollapseOverrides);
     }
 
     [Fact]
@@ -563,6 +620,38 @@ public sealed class LogTableStoreTests
     }
 
     [Fact]
+    public void ReduceAppendTableEvents_WhenGrouped_MergesIntoExistingAndNewGroups()
+    {
+        var baseTime = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        var table = new LogView(EventLogId.Create()) { LogName = "Application" };
+        var state = new LogTableState
+        {
+            EventTables = ImmutableList.Create(table),
+            ActiveEventLogId = table.Id,
+            GroupBy = ColumnName.Source,
+            IsDescending = false,
+            EventCountByLog = ImmutableDictionary<EventLogId, int>.Empty.Add(table.Id, 0)
+        };
+
+        IReadOnlyList<ResolvedEvent> batch1 =
+        [
+            FilterEventBuilder.CreateTestEvent(id: 100, source: "A", timeCreated: baseTime.AddSeconds(1)),
+            FilterEventBuilder.CreateTestEvent(id: 200, source: "B", timeCreated: baseTime.AddSeconds(2))
+        ];
+        state = Reducers.ReduceAppendTableEvents(state, new AppendTableEventsAction(table.Id, batch1));
+
+        IReadOnlyList<ResolvedEvent> batch2 =
+        [
+            FilterEventBuilder.CreateTestEvent(id: 300, source: "A", timeCreated: baseTime.AddSeconds(3)),
+            FilterEventBuilder.CreateTestEvent(id: 500, source: "C", timeCreated: baseTime.AddSeconds(5))
+        ];
+        var result = Reducers.ReduceAppendTableEvents(state, new AppendTableEventsAction(table.Id, batch2));
+
+        Assert.Equal(new[] { "A", "A", "B", "C" }, result.DisplayedEvents.Select(e => e.Source));
+        Assert.Equal(new[] { 100, 300, 200, 500 }, result.DisplayedEvents.Select(e => e.Id));
+    }
+
+    [Fact]
     public void ReduceAppendTableEvents_WhenTableNotFound_ShouldReturnUnchangedState()
     {
         // Arrange
@@ -608,6 +697,283 @@ public sealed class LogTableStoreTests
         Assert.Equal(1L, newState.DisplayedEvents[0].RecordId);
         Assert.False(newState.EventCountByLog.ContainsKey(staleLogId));
         Assert.Equal(1, newState.EventCountByLog[openLog.Id]);
+    }
+
+    [Fact]
+    public void ReduceAppendTableEventsBatch_WhenGrouped_MergesIntoExistingGroups()
+    {
+        var baseTime = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        var table = new LogView(EventLogId.Create()) { LogName = "Application" };
+        var state = new LogTableState
+        {
+            EventTables = ImmutableList.Create(table),
+            ActiveEventLogId = table.Id,
+            GroupBy = ColumnName.Source,
+            IsDescending = false,
+            EventCountByLog = ImmutableDictionary<EventLogId, int>.Empty.Add(table.Id, 0)
+        };
+
+        state = Reducers.ReduceAppendTableEvents(
+            state,
+            new AppendTableEventsAction(table.Id,
+            [
+                FilterEventBuilder.CreateTestEvent(id: 100, source: "A", timeCreated: baseTime.AddSeconds(1)),
+                FilterEventBuilder.CreateTestEvent(id: 200, source: "B", timeCreated: baseTime.AddSeconds(2))
+            ]));
+
+        var byLog = new Dictionary<EventLogId, IReadOnlyList<ResolvedEvent>>
+        {
+            [table.Id] =
+            [
+                FilterEventBuilder.CreateTestEvent(id: 300, source: "A", timeCreated: baseTime.AddSeconds(3)),
+                FilterEventBuilder.CreateTestEvent(id: 500, source: "C", timeCreated: baseTime.AddSeconds(5))
+            ]
+        };
+
+        var result = Reducers.ReduceAppendTableEventsBatch(state, new AppendTableEventsBatchAction(byLog));
+
+        Assert.Equal(new[] { "A", "A", "B", "C" }, result.DisplayedEvents.Select(e => e.Source));
+        Assert.Equal(new[] { 100, 300, 200, 500 }, result.DisplayedEvents.Select(e => e.Id));
+    }
+
+    [Fact]
+    public void ReduceCloseAll_ResetsCollapse()
+    {
+        var table = new LogView(EventLogId.Create()) { LogName = "A" };
+        var state = new LogTableState
+        {
+            EventTables = ImmutableList.Create(table),
+            ActiveEventLogId = table.Id,
+            GroupsCollapsedByDefault = true,
+            GroupCollapseOverrides = ImmutableHashSet.Create("g")
+        };
+
+        var result = Reducers.ReduceCloseAll(state);
+
+        Assert.Null(result.ActiveEventLogId);
+        Assert.False(result.GroupsCollapsedByDefault);
+        Assert.Empty(result.GroupCollapseOverrides);
+    }
+
+    [Fact]
+    public void ReduceCloseLog_WhenActiveChanges_ResetsCollapse()
+    {
+        var tableA = new LogView(EventLogId.Create()) { LogName = "A" };
+        var tableB = new LogView(EventLogId.Create()) { LogName = "B" };
+        var combined = new LogView(EventLogId.Create()) { IsCombined = true };
+        var state = new LogTableState
+        {
+            EventTables = ImmutableList.Create(combined, tableA, tableB),
+            ActiveEventLogId = combined.Id,
+            EventCountByLog = ImmutableDictionary<EventLogId, int>.Empty
+                .Add(tableA.Id, 0)
+                .Add(tableB.Id, 0),
+            GroupsCollapsedByDefault = true,
+            GroupCollapseOverrides = ImmutableHashSet.Create("g")
+        };
+
+        var result = Reducers.ReduceCloseLog(state, new CloseLogAction(tableB.Id));
+
+        Assert.Equal(tableA.Id, result.ActiveEventLogId);
+        Assert.False(result.GroupsCollapsedByDefault);
+        Assert.Empty(result.GroupCollapseOverrides);
+    }
+
+    [Fact]
+    public void ReduceLoadColumnsCompleted_WhenGroupColumnHidden_ClearsGroupAndResortsUngrouped()
+    {
+        var state = new LogTableState
+        {
+            GroupBy = ColumnName.Source,
+            IsGroupDescending = true,
+            GroupCollapseOverrides = ImmutableHashSet.Create("g"),
+            OrderBy = ColumnName.EventId,
+            IsDescending = false,
+            DisplayedEvents = new List<ResolvedEvent>
+            {
+                FilterEventBuilder.CreateTestEvent(id: 2, source: "B"),
+                FilterEventBuilder.CreateTestEvent(id: 1, source: "A")
+            }.AsReadOnly()
+        };
+
+        var hiddenColumns = ImmutableDictionary<ColumnName, bool>.Empty
+            .Add(ColumnName.Source, false)
+            .Add(ColumnName.EventId, true);
+
+        var result = Reducers.ReduceLoadColumnsCompleted(
+            state,
+            new LoadColumnsCompletedAction(hiddenColumns, ImmutableDictionary<ColumnName, int>.Empty, []));
+
+        Assert.Null(result.GroupBy);
+        Assert.False(result.IsGroupDescending);
+        Assert.Empty(result.GroupCollapseOverrides);
+        Assert.Equal(new[] { 1, 2 }, result.DisplayedEvents.Select(e => e.Id));
+    }
+
+    [Fact]
+    public void ReduceLoadColumnsCompleted_WhenGroupColumnStaysVisible_KeepsGroup()
+    {
+        var state = new LogTableState { GroupBy = ColumnName.Source };
+
+        var visibleColumns = ImmutableDictionary<ColumnName, bool>.Empty
+            .Add(ColumnName.Source, true)
+            .Add(ColumnName.Level, false);
+
+        var result = Reducers.ReduceLoadColumnsCompleted(
+            state,
+            new LoadColumnsCompletedAction(visibleColumns, ImmutableDictionary<ColumnName, int>.Empty, []));
+
+        Assert.Equal(ColumnName.Source, result.GroupBy);
+    }
+
+    [Fact]
+    public void ReduceLoadColumnsCompleted_WhenResetDefaultsHidesGroupColumn_ClearsGroup()
+    {
+        var state = new LogTableState { GroupBy = ColumnName.ActivityId };
+
+        var defaults = ImmutableDictionary<ColumnName, bool>.Empty
+            .Add(ColumnName.Level, true)
+            .Add(ColumnName.DateAndTime, true);
+
+        var result = Reducers.ReduceLoadColumnsCompleted(
+            state,
+            new LoadColumnsCompletedAction(defaults, ImmutableDictionary<ColumnName, int>.Empty, []));
+
+        Assert.Null(result.GroupBy);
+    }
+
+    [Fact]
+    public void ReduceSetActiveTable_WhenActiveChanges_ResetsCollapse()
+    {
+        var tableA = new LogView(EventLogId.Create()) { LogName = "A" };
+        var tableB = new LogView(EventLogId.Create()) { LogName = "B" };
+        var state = new LogTableState
+        {
+            EventTables = ImmutableList.Create(tableA, tableB),
+            ActiveEventLogId = tableA.Id,
+            GroupsCollapsedByDefault = true,
+            GroupCollapseOverrides = ImmutableHashSet.Create("g")
+        };
+
+        var result = Reducers.ReduceSetActiveTable(state, new SetActiveTableAction(tableB.Id));
+
+        Assert.Equal(tableB.Id, result.ActiveEventLogId);
+        Assert.False(result.GroupsCollapsedByDefault);
+        Assert.Empty(result.GroupCollapseOverrides);
+    }
+
+    [Fact]
+    public void ReduceSetActiveTable_WhenActiveUnchanged_PreservesCollapse()
+    {
+        var tableA = new LogView(EventLogId.Create()) { LogName = "A" };
+        var state = new LogTableState
+        {
+            EventTables = ImmutableList.Create(tableA),
+            ActiveEventLogId = tableA.Id,
+            GroupCollapseOverrides = ImmutableHashSet.Create("g")
+        };
+
+        var result = Reducers.ReduceSetActiveTable(state, new SetActiveTableAction(tableA.Id));
+
+        Assert.Contains("g", result.GroupCollapseOverrides);
+    }
+
+    [Fact]
+    public void ReduceSetAllGroupsCollapsed_SetsDefaultAndClearsOverrides()
+    {
+        var state = new LogTableState { GroupCollapseOverrides = ImmutableHashSet.Create("x") };
+
+        var result = Reducers.ReduceSetAllGroupsCollapsed(state, new SetAllGroupsCollapsedAction(true));
+
+        Assert.True(result.GroupsCollapsedByDefault);
+        Assert.Empty(result.GroupCollapseOverrides);
+    }
+
+    [Fact]
+    public void ReduceSetGroupBy_SetsGroupResortsAndResetsDirectionAndCollapse()
+    {
+        var state = new LogTableState
+        {
+            DisplayedEvents = new List<ResolvedEvent>
+            {
+                FilterEventBuilder.CreateTestEvent(id: 2, source: "B"),
+                FilterEventBuilder.CreateTestEvent(id: 1, source: "A")
+            }.AsReadOnly(),
+            IsGroupDescending = true,
+            GroupCollapseOverrides = ImmutableHashSet.Create("stale")
+        };
+
+        var result = Reducers.ReduceSetGroupBy(state, new SetGroupByAction(ColumnName.Source));
+
+        Assert.Equal(ColumnName.Source, result.GroupBy);
+        Assert.False(result.IsGroupDescending);
+        Assert.Empty(result.GroupCollapseOverrides);
+        Assert.Equal(new[] { "A", "B" }, result.DisplayedEvents.Select(e => e.Source));
+    }
+
+    [Fact]
+    public void ReduceSetGroupBy_WhenNull_ClearsGroupingAndResortsUngrouped()
+    {
+        var state = new LogTableState
+        {
+            GroupBy = ColumnName.Source,
+            OrderBy = ColumnName.EventId,
+            IsDescending = false,
+            DisplayedEvents = new List<ResolvedEvent>
+            {
+                FilterEventBuilder.CreateTestEvent(id: 2, source: "B"),
+                FilterEventBuilder.CreateTestEvent(id: 1, source: "A")
+            }.AsReadOnly()
+        };
+
+        var result = Reducers.ReduceSetGroupBy(state, new SetGroupByAction(null));
+
+        Assert.Null(result.GroupBy);
+        Assert.Equal(new[] { 1, 2 }, result.DisplayedEvents.Select(e => e.Id));
+    }
+
+    [Fact]
+    public void ReduceToggleGroupCollapsed_TogglesKey()
+    {
+        var collapsed = Reducers.ReduceToggleGroupCollapsed(
+            new LogTableState(),
+            new ToggleGroupCollapsedAction("grp"));
+
+        Assert.Contains("grp", collapsed.GroupCollapseOverrides);
+
+        var expanded = Reducers.ReduceToggleGroupCollapsed(collapsed, new ToggleGroupCollapsedAction("grp"));
+
+        Assert.DoesNotContain("grp", expanded.GroupCollapseOverrides);
+    }
+
+    [Fact]
+    public void ReduceToggleGroupSorting_WhenGrouped_FlipsDirectionAndResorts()
+    {
+        var state = new LogTableState
+        {
+            GroupBy = ColumnName.Source,
+            IsGroupDescending = false,
+            DisplayedEvents = new List<ResolvedEvent>
+            {
+                FilterEventBuilder.CreateTestEvent(id: 1, source: "A"),
+                FilterEventBuilder.CreateTestEvent(id: 2, source: "B")
+            }.AsReadOnly()
+        };
+
+        var result = Reducers.ReduceToggleGroupSorting(state);
+
+        Assert.True(result.IsGroupDescending);
+        Assert.Equal(new[] { "B", "A" }, result.DisplayedEvents.Select(e => e.Source));
+    }
+
+    [Fact]
+    public void ReduceToggleGroupSorting_WhenNotGrouped_IsNoOp()
+    {
+        var state = new LogTableState { GroupBy = null, IsGroupDescending = false };
+
+        var result = Reducers.ReduceToggleGroupSorting(state);
+
+        Assert.Same(state, result);
     }
 
     [Fact]
@@ -860,6 +1226,44 @@ public sealed class LogTableStoreTests
         Assert.Equal(3L, state.DisplayedEvents[1].RecordId);
         Assert.Equal(2L, state.DisplayedEvents[2].RecordId);
         Assert.Equal(1L, state.DisplayedEvents[3].RecordId);
+    }
+
+    [Fact]
+    public void ReduceUpdateTable_WhenGrouped_ReplacesLogSliceAndRetainsOtherLogGrouped()
+    {
+        var baseTime = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        var log1 = new LogView(EventLogId.Create()) { LogName = "Log1" };
+        var log2 = new LogView(EventLogId.Create()) { LogName = "Log2" };
+        var combined = new LogView(EventLogId.Create()) { IsCombined = true };
+
+        var existing = new List<ResolvedEvent>
+        {
+            FilterEventBuilder.CreateTestEvent(id: 1, source: "A", timeCreated: baseTime.AddSeconds(1), owningLog: "Log1"),
+            FilterEventBuilder.CreateTestEvent(id: 2, source: "A", timeCreated: baseTime.AddSeconds(2), owningLog: "Log2")
+        }.SortEvents(orderBy: null, isDescending: false, groupBy: ColumnName.Source);
+
+        var state = new LogTableState
+        {
+            EventTables = ImmutableList.Create(combined, log1, log2),
+            ActiveEventLogId = combined.Id,
+            GroupBy = ColumnName.Source,
+            IsDescending = false,
+            DisplayedEvents = existing,
+            EventCountByLog = ImmutableDictionary<EventLogId, int>.Empty
+                .Add(log1.Id, 1)
+                .Add(log2.Id, 1)
+        };
+
+        IReadOnlyList<ResolvedEvent> log1Replacement =
+        [
+            FilterEventBuilder.CreateTestEvent(id: 3, source: "A", timeCreated: baseTime.AddSeconds(3), owningLog: "Log1")
+        ];
+
+        var result = Reducers.ReduceUpdateTable(state, new UpdateTableAction(log1.Id, log1Replacement));
+
+        Assert.Equal(new[] { 2, 3 }, result.DisplayedEvents.Select(e => e.Id).OrderBy(id => id));
+        Assert.DoesNotContain(result.DisplayedEvents, e => e.Id == 1);
+        Assert.Equal(new[] { "A", "A" }, result.DisplayedEvents.Select(e => e.Source));
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/ResolvedEventGroupKeyTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/ResolvedEventGroupKeyTests.cs
@@ -1,0 +1,155 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.TestUtils;
+using EventLogExpert.Runtime.LogTable;
+using System.Globalization;
+using System.Security.Principal;
+
+namespace EventLogExpert.Runtime.Tests.LogTable;
+
+public sealed class ResolvedEventGroupKeyTests
+{
+    [Fact]
+    public void For_ActivityId_UsesInvariantDFormat()
+    {
+        var id = Guid.NewGuid();
+        var evt = FilterEventBuilder.CreateTestEvent(activityId: id);
+
+        Assert.Equal(
+            id.ToString("D", CultureInfo.InvariantCulture),
+            ResolvedEventGroupKey.For(ColumnName.ActivityId, evt));
+    }
+
+    [Fact]
+    public void For_ComputerName_UsesComputerNameValue()
+    {
+        var evt = FilterEventBuilder.CreateTestEvent(computerName: "HOST-01");
+
+        Assert.Equal("HOST-01", ResolvedEventGroupKey.For(ColumnName.ComputerName, evt));
+    }
+
+    [Fact]
+    public void For_DateAndTime_UsesInvariantTicks()
+    {
+        var time = new DateTime(2024, 6, 1, 8, 30, 0, DateTimeKind.Utc);
+        var evt = FilterEventBuilder.CreateTestEvent(timeCreated: time);
+
+        Assert.Equal(
+            time.Ticks.ToString(CultureInfo.InvariantCulture),
+            ResolvedEventGroupKey.For(ColumnName.DateAndTime, evt));
+    }
+
+    [Fact]
+    public void For_EventId_UsesInvariantNumber()
+    {
+        var evt = FilterEventBuilder.CreateTestEvent(id: 4242);
+
+        Assert.Equal("4242", ResolvedEventGroupKey.For(ColumnName.EventId, evt));
+    }
+
+    [Fact]
+    public void For_Keywords_UsesDisplayName()
+    {
+        var evt = FilterEventBuilder.CreateTestEvent(keywords: ["Audit", "Classic"]);
+
+        Assert.Equal("Audit, Classic", ResolvedEventGroupKey.For(ColumnName.Keywords, evt));
+    }
+
+    [Fact]
+    public void For_Level_UsesLevelValue()
+    {
+        var evt = FilterEventBuilder.CreateTestEvent(level: "Warning");
+
+        Assert.Equal("Warning", ResolvedEventGroupKey.For(ColumnName.Level, evt));
+    }
+
+    [Fact]
+    public void For_Log_UsesLogName()
+    {
+        var evt = FilterEventBuilder.CreateTestEvent(logName: "Security");
+
+        Assert.Equal("Security", ResolvedEventGroupKey.For(ColumnName.Log, evt));
+    }
+
+    [Fact]
+    public void For_NullActivityId_IsEmptyBucket()
+    {
+        var evt = FilterEventBuilder.CreateTestEvent(activityId: null);
+
+        Assert.Equal(string.Empty, ResolvedEventGroupKey.For(ColumnName.ActivityId, evt));
+    }
+
+    [Fact]
+    public void For_NullComputerName_IsEmptyBucket()
+    {
+        var evt = FilterEventBuilder.CreateTestEvent(computerName: null!);
+
+        Assert.Equal(string.Empty, ResolvedEventGroupKey.For(ColumnName.ComputerName, evt));
+    }
+
+    [Fact]
+    public void For_NullProcessId_IsEmptyBucket()
+    {
+        var evt = FilterEventBuilder.CreateTestEvent(processId: null);
+
+        Assert.Equal(string.Empty, ResolvedEventGroupKey.For(ColumnName.ProcessId, evt));
+    }
+
+    [Fact]
+    public void For_NullThreadId_IsEmptyBucket()
+    {
+        var evt = FilterEventBuilder.CreateTestEvent(threadId: null);
+
+        Assert.Equal(string.Empty, ResolvedEventGroupKey.For(ColumnName.ThreadId, evt));
+    }
+
+    [Fact]
+    public void For_NullUser_IsEmptyBucket()
+    {
+        var evt = FilterEventBuilder.CreateTestEvent(userId: null);
+
+        Assert.Equal(string.Empty, ResolvedEventGroupKey.For(ColumnName.User, evt));
+    }
+
+    [Fact]
+    public void For_ProcessId_UsesInvariantNumber()
+    {
+        var evt = FilterEventBuilder.CreateTestEvent(processId: 4096);
+
+        Assert.Equal("4096", ResolvedEventGroupKey.For(ColumnName.ProcessId, evt));
+    }
+
+    [Fact]
+    public void For_Source_UsesSourceValue()
+    {
+        var evt = FilterEventBuilder.CreateTestEvent(source: "Kernel-Power");
+
+        Assert.Equal("Kernel-Power", ResolvedEventGroupKey.For(ColumnName.Source, evt));
+    }
+
+    [Fact]
+    public void For_TaskCategory_UsesTaskCategoryValue()
+    {
+        var evt = FilterEventBuilder.CreateTestEvent(taskCategory: "Logon");
+
+        Assert.Equal("Logon", ResolvedEventGroupKey.For(ColumnName.TaskCategory, evt));
+    }
+
+    [Fact]
+    public void For_ThreadId_UsesInvariantNumber()
+    {
+        var evt = FilterEventBuilder.CreateTestEvent(threadId: 88);
+
+        Assert.Equal("88", ResolvedEventGroupKey.For(ColumnName.ThreadId, evt));
+    }
+
+    [Fact]
+    public void For_User_UsesSidValue()
+    {
+        var sid = new SecurityIdentifier("S-1-5-18");
+        var evt = FilterEventBuilder.CreateTestEvent(userId: sid);
+
+        Assert.Equal(sid.Value, ResolvedEventGroupKey.For(ColumnName.User, evt));
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/ResolvedEventOrderingTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/ResolvedEventOrderingTests.cs
@@ -11,6 +11,18 @@ namespace EventLogExpert.Runtime.Tests.LogTable;
 public sealed class ResolvedEventOrderingTests
 {
     [Fact]
+    public void CompareColumn_NullStringColumn_TreatedAsEmptyToMatchGroupKey()
+    {
+        var nullValue = FilterEventBuilder.CreateTestEvent(computerName: null!);
+        var emptyValue = FilterEventBuilder.CreateTestEvent(computerName: string.Empty);
+
+        Assert.Equal(
+            ResolvedEventGroupKey.For(ColumnName.ComputerName, nullValue),
+            ResolvedEventGroupKey.For(ColumnName.ComputerName, emptyValue));
+        Assert.Equal(0, ResolvedEventOrdering.CompareColumn(nullValue, emptyValue, ColumnName.ComputerName));
+    }
+
+    [Fact]
     public void MergeSorted_WhenBatchIsEmpty_ShouldReturnExistingUnchanged()
     {
         var existing = new List<ResolvedEvent>

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/ResolvedEventOrderingTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/ResolvedEventOrderingTests.cs
@@ -187,6 +187,154 @@ public sealed class ResolvedEventOrderingTests
     }
 
     [Fact]
+    public void SortEvents_WhenGroupByEqualsOrderBy_UsesDateAndTimeChronologyBeforeRecordId()
+    {
+        var baseTime = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        var events = new List<ResolvedEvent>
+        {
+            FilterEventBuilder.CreateTestEvent(level: "Information", recordId: 1, timeCreated: baseTime.AddSeconds(2)),
+            FilterEventBuilder.CreateTestEvent(level: "Information", recordId: 2, timeCreated: baseTime.AddSeconds(1))
+        };
+
+        var result = events.SortEvents(ColumnName.Level, false, ColumnName.Level);
+
+        Assert.Equal(new long?[] { 2L, 1L }, result.Select(e => e.RecordId));
+    }
+
+    [Fact]
+    public void SortEvents_WhenGroupByNull_MatchesUngroupedSort()
+    {
+        var events = new List<ResolvedEvent>
+        {
+            FilterEventBuilder.CreateTestEvent(id: 3),
+            FilterEventBuilder.CreateTestEvent(id: 1),
+            FilterEventBuilder.CreateTestEvent(id: 2)
+        };
+
+        var grouped = events.SortEvents(ColumnName.EventId);
+
+        Assert.Equal(new[] { 1, 2, 3 }, grouped.Select(e => e.Id));
+    }
+
+    [Fact]
+    public void SortEvents_WhenGroupDescending_OrdersEmptyBucketAfterValuedGroup()
+    {
+        var events = new List<ResolvedEvent>
+        {
+            FilterEventBuilder.CreateTestEvent(id: 2, computerName: null!),
+            FilterEventBuilder.CreateTestEvent(id: 1, computerName: "X")
+        };
+
+        var result = events.SortEvents(
+            orderBy: ColumnName.EventId,
+            isDescending: false,
+            groupBy: ColumnName.ComputerName,
+            isGroupDescending: true);
+
+        Assert.Equal(new[] { 1, 2 }, result.Select(e => e.Id));
+        Assert.Equal("X", result[0].ComputerName);
+        Assert.True(string.IsNullOrEmpty(result[1].ComputerName));
+    }
+
+    [Fact]
+    public void SortEvents_WhenGroupDescending_OrdersGroupsDescendingButWithinGroupAscending()
+    {
+        var events = new List<ResolvedEvent>
+        {
+            FilterEventBuilder.CreateTestEvent(id: 2, source: "B"),
+            FilterEventBuilder.CreateTestEvent(id: 5, source: "A"),
+            FilterEventBuilder.CreateTestEvent(id: 1, source: "B"),
+            FilterEventBuilder.CreateTestEvent(id: 3, source: "A")
+        };
+
+        var result = events.SortEvents(ColumnName.EventId, false, ColumnName.Source, true);
+
+        Assert.Equal(new[] { "B", "B", "A", "A" }, result.Select(e => e.Source));
+        Assert.Equal(new[] { 1, 2, 3, 5 }, result.Select(e => e.Id));
+    }
+
+    [Fact]
+    public void SortEvents_WhenGrouped_KeepsGroupsContiguousAndSortsWithinGroupByOrderBy()
+    {
+        var events = new List<ResolvedEvent>
+        {
+            FilterEventBuilder.CreateTestEvent(id: 2, source: "B", recordId: 1),
+            FilterEventBuilder.CreateTestEvent(id: 5, source: "A", recordId: 2),
+            FilterEventBuilder.CreateTestEvent(id: 1, source: "B", recordId: 3),
+            FilterEventBuilder.CreateTestEvent(id: 3, source: "A", recordId: 4)
+        };
+
+        var result = events.SortEvents(ColumnName.EventId, false, ColumnName.Source);
+
+        Assert.Equal(new[] { "A", "A", "B", "B" }, result.Select(e => e.Source));
+        Assert.Equal(new[] { 3, 5, 1, 2 }, result.Select(e => e.Id));
+    }
+
+    [Fact]
+    public void SortEvents_WhenGrouped_NullAndEmptyComputerNameShareOneBucket()
+    {
+        var events = new List<ResolvedEvent>
+        {
+            FilterEventBuilder.CreateTestEvent(id: 1, computerName: "X"),
+            FilterEventBuilder.CreateTestEvent(id: 2, computerName: null!),
+            FilterEventBuilder.CreateTestEvent(id: 3, computerName: "")
+        };
+
+        var result = events.SortEvents(ColumnName.EventId, false, ColumnName.ComputerName);
+
+        Assert.True(string.IsNullOrEmpty(result[0].ComputerName));
+        Assert.True(string.IsNullOrEmpty(result[1].ComputerName));
+        Assert.Equal("X", result[2].ComputerName);
+        Assert.Equal(new[] { 2, 3, 1 }, result.Select(e => e.Id));
+    }
+
+    [Fact]
+    public void SortEvents_WhenGroupedAcrossLogs_OrdersWithinGroupByTimeNotRecordId()
+    {
+        var baseTime = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        var events = new List<ResolvedEvent>
+        {
+            FilterEventBuilder.CreateTestEvent(id: 1, source: "A", timeCreated: baseTime.AddSeconds(2), recordId: 1, owningLog: "LogA"),
+            FilterEventBuilder.CreateTestEvent(id: 2, source: "A", timeCreated: baseTime.AddSeconds(1), recordId: 999, owningLog: "LogB")
+        };
+
+        var result = events.SortEvents(orderBy: null, isDescending: false, groupBy: ColumnName.Source);
+
+        Assert.Equal(new[] { 2, 1 }, result.Select(e => e.Id));
+        Assert.Equal(new[] { "LogB", "LogA" }, result.Select(e => e.OwningLog));
+    }
+
+    [Fact]
+    public void SortEvents_WhenGroupedAndSameTick_FallsBackToRecordIdDeterministically()
+    {
+        var time = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        var events = new List<ResolvedEvent>
+        {
+            FilterEventBuilder.CreateTestEvent(id: 1, source: "A", timeCreated: time, recordId: 2),
+            FilterEventBuilder.CreateTestEvent(id: 2, source: "A", timeCreated: time, recordId: 1)
+        };
+
+        var result = events.SortEvents(orderBy: null, isDescending: false, groupBy: ColumnName.Source);
+
+        Assert.Equal(new long?[] { 1L, 2L }, result.Select(e => e.RecordId));
+    }
+
+    [Fact]
+    public void SortEvents_WhenGroupedByHighCardinalityColumn_EachEventIsItsOwnGroupInOrder()
+    {
+        var events = new List<ResolvedEvent>
+        {
+            FilterEventBuilder.CreateTestEvent(id: 3),
+            FilterEventBuilder.CreateTestEvent(id: 1),
+            FilterEventBuilder.CreateTestEvent(id: 2)
+        };
+
+        var result = events.SortEvents(orderBy: null, isDescending: false, groupBy: ColumnName.EventId);
+
+        Assert.Equal(new[] { 1, 2, 3 }, result.Select(e => e.Id));
+    }
+
+    [Fact]
     public void SortEvents_WhenInputMutatedAfterCall_ShouldReturnIndependentList()
     {
         var events = new List<ResolvedEvent>
@@ -795,5 +943,36 @@ public sealed class ResolvedEventOrderingTests
         Assert.Equal(3L, result[0].RecordId);
         Assert.Equal(2L, result[1].RecordId);
         Assert.Equal(1L, result[2].RecordId);
+    }
+
+    [Fact]
+    public void SortEvents_WhenWithinGroupDescending_IsIndependentOfGroupDirection()
+    {
+        var events = new List<ResolvedEvent>
+        {
+            FilterEventBuilder.CreateTestEvent(id: 2, source: "B"),
+            FilterEventBuilder.CreateTestEvent(id: 5, source: "A"),
+            FilterEventBuilder.CreateTestEvent(id: 1, source: "B"),
+            FilterEventBuilder.CreateTestEvent(id: 3, source: "A")
+        };
+
+        var result = events.SortEvents(ColumnName.EventId, true, ColumnName.Source);
+
+        Assert.Equal(new[] { "A", "A", "B", "B" }, result.Select(e => e.Source));
+        Assert.Equal(new[] { 5, 3, 2, 1 }, result.Select(e => e.Id));
+    }
+
+    [Fact]
+    public void SortEvents_WhenWithinGroupDescending_ReversesRecordIdTiebreak()
+    {
+        var events = new List<ResolvedEvent>
+        {
+            FilterEventBuilder.CreateTestEvent(id: 9, source: "A", recordId: 10),
+            FilterEventBuilder.CreateTestEvent(id: 9, source: "A", recordId: 11)
+        };
+
+        var result = events.SortEvents(ColumnName.EventId, true, ColumnName.Source);
+
+        Assert.Equal(new long?[] { 11L, 10L }, result.Select(e => e.RecordId));
     }
 }

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/Grouping/GroupedRowViewTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/Grouping/GroupedRowViewTests.cs
@@ -1,0 +1,212 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.UI.LogTable.Grouping;
+
+namespace EventLogExpert.UI.Tests.LogTable.Grouping;
+
+public sealed class GroupedRowViewTests
+{
+    [Fact]
+    public void Build_WhenAllExpanded_CountIsEventsPlusGroups()
+    {
+        var view = Build(Events("A", "A", "B"), Collapsed());
+
+        Assert.Equal(5, view.Count);
+        Assert.Equal(2, view.Groups.Count);
+    }
+
+    [Fact]
+    public void Indexer_WhenExpanded_ReturnsHeaderAtGroupStartThenEvents()
+    {
+        var view = Build(Events("A", "A", "B"), Collapsed());
+
+        Assert.Equal(TableRowKind.Header, view[0].Kind);
+        Assert.Equal("A", view.GroupAt(view[0]).Key);
+        Assert.Equal(TableRowKind.Event, view[1].Kind);
+        Assert.Equal(0, view[1].EventIndex);
+        Assert.Equal(TableRowKind.Event, view[2].Kind);
+        Assert.Equal(1, view[2].EventIndex);
+        Assert.Equal(TableRowKind.Header, view[3].Kind);
+        Assert.Equal("B", view.GroupAt(view[3]).Key);
+        Assert.Equal(TableRowKind.Event, view[4].Kind);
+        Assert.Equal(2, view[4].EventIndex);
+    }
+
+    [Fact]
+    public void Build_WhenGroupCollapsed_HidesEventsAndReducesCount()
+    {
+        var view = Build(Events("A", "A", "B"), Collapsed("A"));
+
+        Assert.Equal(3, view.Count);
+        Assert.Equal(TableRowKind.Header, view[0].Kind);
+        Assert.Equal("A", view.GroupAt(view[0]).Key);
+        Assert.True(view.GroupAt(view[0]).IsCollapsed);
+        Assert.Equal(TableRowKind.Header, view[1].Kind);
+        Assert.Equal("B", view.GroupAt(view[1]).Key);
+        Assert.Equal(TableRowKind.Event, view[2].Kind);
+    }
+
+    [Fact]
+    public void VisibleRowForEvent_WhenExpanded_ReturnsEventRow()
+    {
+        var view = Build(Events("A", "A", "B"), Collapsed());
+
+        Assert.Equal(1, view.VisibleRowForEvent(0));
+        Assert.Equal(2, view.VisibleRowForEvent(1));
+        Assert.Equal(4, view.VisibleRowForEvent(2));
+    }
+
+    [Fact]
+    public void VisibleRowForEvent_WhenCollapsed_ReturnsParentHeaderRow()
+    {
+        var view = Build(Events("A", "A", "B"), Collapsed("A"));
+
+        Assert.Equal(0, view.VisibleRowForEvent(0));
+        Assert.Equal(0, view.VisibleRowForEvent(1));
+        Assert.Equal(2, view.VisibleRowForEvent(2));
+    }
+
+    [Fact]
+    public void GroupForEvent_ReturnsContainingGroup()
+    {
+        var view = Build(Events("A", "A", "B"), Collapsed());
+
+        Assert.Equal("A", view.GroupForEvent(0).Key);
+        Assert.Equal("A", view.GroupForEvent(1).Key);
+        Assert.Equal("B", view.GroupForEvent(2).Key);
+    }
+
+    [Fact]
+    public void VisibleRowForHeader_ReturnsHeaderVisibleRow()
+    {
+        var view = Build(Events("A", "A", "B"), Collapsed());
+
+        Assert.Equal(0, view.VisibleRowForHeader("A"));
+        Assert.Equal(3, view.VisibleRowForHeader("B"));
+        Assert.Equal(-1, view.VisibleRowForHeader("missing"));
+    }
+
+    [Fact]
+    public void TryGetGroupByKey_ReturnsGroupForKnownKeyAndFailsForMissing()
+    {
+        var view = Build(Events("A", "A", "B"), Collapsed());
+
+        Assert.True(view.TryGetGroupByKey("B", out var group));
+        Assert.Equal("B", group.Key);
+        Assert.Equal(2, group.StartIndex);
+        Assert.Equal(1, group.EventCount);
+
+        Assert.False(view.TryGetGroupByKey("missing", out var missing));
+        Assert.Equal(0, missing.EventCount);
+    }
+
+    [Fact]
+    public void Build_WhenEmpty_IsEmpty()
+    {
+        var view = Build([], Collapsed());
+
+        Assert.Empty(view);
+        Assert.Empty(view.Groups);
+    }
+
+    [Fact]
+    public void Build_WhenAllCollapsed_CountEqualsGroupCount()
+    {
+        var view = Build(Events("A", "A", "B", "C", "C"), Collapsed("A", "B", "C"));
+
+        Assert.Equal(3, view.Count);
+        Assert.All(view, row => Assert.Equal(TableRowKind.Header, row.Kind));
+    }
+
+    [Fact]
+    public void BinarySearch_AcrossManyGroups_EveryVisibleRowResolvesCorrectly()
+    {
+        var sources = new List<string>();
+
+        for (int g = 0; g < 100; g++)
+        {
+            sources.Add($"g{g:000}");
+            sources.Add($"g{g:000}");
+        }
+
+        var view = Build(Events([.. sources]), Collapsed());
+
+        Assert.Equal(300, view.Count);
+
+        for (int v = 0; v < view.Count; v++)
+        {
+            var row = view[v];
+
+            if (v % 3 == 0)
+            {
+                Assert.Equal(TableRowKind.Header, row.Kind);
+                Assert.Equal(v / 3, row.GroupIndex);
+            }
+            else
+            {
+                Assert.Equal(TableRowKind.Event, row.Kind);
+                Assert.Equal(view.GroupForEvent(row.EventIndex).Key, view.GroupAt(row).Key);
+            }
+        }
+    }
+
+    [Fact]
+    public void SkipTake_ProducesCorrectWindow()
+    {
+        var view = Build(Events("A", "A", "B"), Collapsed());
+
+        var window = view.Skip(1).Take(2).ToList();
+
+        Assert.Equal(2, window.Count);
+        Assert.Equal(view[1], window[0]);
+        Assert.Equal(view[2], window[1]);
+    }
+
+    [Fact]
+    public void IsReadOnly_AndMutatorsThrow()
+    {
+        var view = Build(Events("A"), Collapsed());
+
+        Assert.True(view.IsReadOnly);
+        Assert.Throws<NotSupportedException>(() => view.Add(default));
+        Assert.Throws<NotSupportedException>(() => view.Clear());
+        Assert.Throws<NotSupportedException>(() => view.Insert(0, default));
+        Assert.Throws<NotSupportedException>(() => view.RemoveAt(0));
+        Assert.Throws<NotSupportedException>(() => view.Remove(default));
+        Assert.Throws<NotSupportedException>(() => view[0] = default);
+    }
+
+    [Fact]
+    public void Indexer_OutOfRange_Throws()
+    {
+        var view = Build(Events("A"), Collapsed());
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => view[view.Count]);
+        Assert.Throws<ArgumentOutOfRangeException>(() => view[-1]);
+    }
+
+    private static GroupedRowView Build(IReadOnlyList<ResolvedEvent> events, HashSet<string> collapsed) =>
+        GroupedRowView.Build(events, ColumnName.Source, collapsed.Contains);
+
+    private static HashSet<string> Collapsed(params string[] keys) => new(keys, StringComparer.Ordinal);
+
+    private static IReadOnlyList<ResolvedEvent> Events(params string[] sources)
+    {
+        var events = new List<ResolvedEvent>(sources.Length);
+
+        for (int i = 0; i < sources.Length; i++)
+        {
+            events.Add(new ResolvedEvent("TestLog", LogPathType.Channel)
+            {
+                Id = i,
+                Source = sources[i]
+            });
+        }
+
+        return events;
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneGroupingTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneGroupingTests.cs
@@ -551,6 +551,33 @@ public sealed class LogTablePaneGroupingTests : BunitContext
     }
 
     [Fact]
+    public void GroupedByLog_HeaderShowsLogNameNotRepresentativeOwningLog()
+    {
+        var logId = EventLogId.Create();
+        var e1 = LogEvent(1, @"C:\logs\App1.evtx", "Application");
+        var e2 = LogEvent(2, @"C:\logs\App2.evtx", "Application");
+
+        _logTableState.Value.Returns(new LogTableState
+        {
+            ActiveEventLogId = logId,
+            EventTables = ImmutableList.Create(new LogView(logId) { LogName = "Combined", IsCombined = true }),
+            DisplayedEvents = [e1, e2],
+            EventCountByLog = ImmutableDictionary<EventLogId, int>.Empty.Add(logId, 2),
+            Columns = ImmutableDictionary<ColumnName, bool>.Empty.Add(ColumnName.Log, true),
+            ColumnOrder = ImmutableList.Create(ColumnName.Log),
+            GroupBy = ColumnName.Log,
+            GroupCollapseOverrides = Collapsed()
+        });
+
+        var cut = Render<LogTablePane>();
+        var header = cut.Find("tr.group-header-row");
+
+        Assert.Contains("Application", header.TextContent);
+        Assert.DoesNotContain("App1.evtx", header.TextContent);
+        Assert.DoesNotContain("App2.evtx", header.TextContent);
+    }
+
+    [Fact]
     public void Ungrouped_ArrowDown_SelectsNextEvent()
     {
         _logTableState.Value.Returns(BuildState(groupBy: null, Collapsed(), Event(1, "Alpha"), Event(2, "Beta")));
@@ -618,6 +645,16 @@ public sealed class LogTablePaneGroupingTests : BunitContext
             Id = id,
             RecordId = id,
             Source = source,
+            TimeCreated = new DateTime(2024, 1, 1, 0, 0, id, DateTimeKind.Utc),
+            Description = $"event {id}"
+        };
+
+    private static ResolvedEvent LogEvent(int id, string owningLog, string logName) =>
+        new(owningLog, LogPathType.Channel)
+        {
+            Id = id,
+            RecordId = id,
+            LogName = logName,
             TimeCreated = new DateTime(2024, 1, 1, 0, 0, id, DateTimeKind.Utc),
             Description = $"event {id}"
         };

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneGroupingTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneGroupingTests.cs
@@ -511,12 +511,13 @@ public sealed class LogTablePaneGroupingTests : BunitContext
         Press(cut, "ArrowDown"); // event 1
         Press(cut, "ArrowDown"); // header Beta (cursor on a non-first header)
 
-        _logTableState.Value.Returns(BuildState(groupBy: null, Collapsed(), alpha1, beta2));
+        // Ungroup resorts the list (reversed here); a stale index would mispoint.
+        _logTableState.Value.Returns(BuildState(groupBy: null, Collapsed(), beta2, alpha1));
         RaiseStateChanged(cut);
         cut.WaitForAssertion(() => Assert.Empty(cut.FindAll("tr.group-header-row")));
 
         _eventLogCommands.ClearReceivedCalls();
-        Press(cut, "ArrowUp");
+        Press(cut, "ArrowDown");
 
         _eventLogCommands.Received(1).SetSelectedEvents(
             Arg.Is<IReadOnlyCollection<ResolvedEvent>>(c => c.Count == 1 && c.Contains(alpha1)),

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneGroupingTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneGroupingTests.cs
@@ -202,6 +202,14 @@ public sealed class LogTablePaneGroupingTests : BunitContext
     }
 
     [Fact]
+    public void Grouped_HeaderChevronIcon_IsAriaHidden()
+    {
+        var cut = RenderGrouped(Collapsed(), Event(1, "Alpha"));
+
+        Assert.Equal("true", cut.Find("tr.group-header-row .group-chevron i").GetAttribute("aria-hidden"));
+    }
+
+    [Fact]
     public void Grouped_HeaderEnterKey_TogglesCollapse()
     {
         var cut = RenderGrouped(Collapsed(), Event(1, "Alpha"));

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneGroupingTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneGroupingTests.cs
@@ -30,6 +30,8 @@ public sealed class LogTablePaneGroupingTests : BunitContext
     private readonly IEventLogCommands _eventLogCommands = Substitute.For<IEventLogCommands>();
     private readonly IState<FilterPaneState> _filterPaneState = Substitute.For<IState<FilterPaneState>>();
     private readonly IHighlightSelector _highlightSelector = Substitute.For<IHighlightSelector>();
+
+    private readonly BunitJSModuleInterop _jsModule;
     private readonly ILogTableCommands _logTableCommands = Substitute.For<ILogTableCommands>();
     private readonly IState<LogTableState> _logTableState = Substitute.For<IState<LogTableState>>();
     private readonly IMenuService _menuService = Substitute.For<IMenuService>();
@@ -41,7 +43,7 @@ public sealed class LogTablePaneGroupingTests : BunitContext
     {
         CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
         JSInterop.Mode = JSRuntimeMode.Loose;
-        JSInterop.SetupModule("./_content/EventLogExpert.UI/LogTable/LogTablePane.razor.js");
+        _jsModule = JSInterop.SetupModule("./_content/EventLogExpert.UI/LogTable/LogTablePane.razor.js");
 
         _columnDefaults.ColumnOrder.Returns(ImmutableList.Create(ColumnName.Source));
         _filterPaneState.Value.Returns(new FilterPaneState());
@@ -67,6 +69,34 @@ public sealed class LogTablePaneGroupingTests : BunitContext
     }
 
     [Fact]
+    public void Grouped_AllCollapsed_ArrowDown_MovesFocusBetweenHeadersWithoutSelecting()
+    {
+        var cut = RenderGrouped(Collapsed("Alpha", "Beta"), Event(1, "Alpha"), Event(2, "Beta"));
+
+        Press(cut, "Home"); // header Alpha
+        _eventLogCommands.ClearReceivedCalls();
+        Press(cut, "ArrowDown"); // header Beta (visible row 1) - focus only
+
+        _eventLogCommands.DidNotReceive().SetSelectedEvents(
+            Arg.Any<IReadOnlyCollection<ResolvedEvent>>(), Arg.Any<ResolvedEvent?>());
+        _logTableCommands.DidNotReceive().ToggleGroupCollapsed(Arg.Any<string>());
+        Assert.Equal(1, LastFocusedRow());
+    }
+
+    [Fact]
+    public void Grouped_AllCollapsed_ShiftArrowDown_IsNoOp()
+    {
+        var cut = RenderGrouped(Collapsed("Alpha", "Beta"), Event(1, "Alpha"), Event(2, "Beta"));
+
+        Press(cut, "Home"); // header Alpha
+        _eventLogCommands.ClearReceivedCalls();
+        Press(cut, "ArrowDown", shift: true); // no event to extend to
+
+        _eventLogCommands.DidNotReceive().SetSelectedEvents(
+            Arg.Any<IReadOnlyCollection<ResolvedEvent>>(), Arg.Any<ResolvedEvent?>());
+    }
+
+    [Fact]
     public void Grouped_CollapsedHeader_HasAriaExpandedFalse()
     {
         var cut = RenderGrouped(
@@ -77,6 +107,33 @@ public sealed class LogTablePaneGroupingTests : BunitContext
 
         Assert.Equal("false", header.GetAttribute("aria-expanded"));
         Assert.Equal("true", header.QuerySelector(".group-chevron")!.GetAttribute("data-collapsed"));
+    }
+
+    [Fact]
+    public void Grouped_EventBelowCollapsedGroup_HasVisibleRowAriaRowIndex()
+    {
+        // Event 2 sits at visible row 2 (Alpha collapsed, Beta header, event 2) -> aria-rowindex 4.
+        var cut = RenderGrouped(Collapsed("Alpha"), Event(1, "Alpha"), Event(2, "Beta"));
+
+        var eventRow = cut.Find("tbody tr.table-row");
+
+        Assert.Equal("4", eventRow.GetAttribute("aria-rowindex"));
+    }
+
+    [Fact]
+    public void Grouped_EventCursorInCollapsedGroup_ReconcilesToHeader()
+    {
+        // The selected event sits in a collapsed group, so the cursor must retype to its
+        // header on build - proven by Right expanding the group.
+        var alpha1 = Event(1, "Alpha");
+        _selectedEvent.Value.Returns(alpha1);
+        _logTableState.Value.Returns(
+            BuildState(ColumnName.Source, Collapsed("Alpha"), alpha1, Event(2, "Beta")));
+
+        var cut = Render<LogTablePane>();
+        Press(cut, "ArrowRight");
+
+        _logTableCommands.Received(1).ToggleGroupCollapsed("Alpha");
     }
 
     [Fact]
@@ -134,7 +191,8 @@ public sealed class LogTablePaneGroupingTests : BunitContext
     {
         var cut = RenderGrouped(Collapsed(), Event(1, "Alpha"));
 
-        cut.Find("tr.group-header-row").KeyDown(new KeyboardEventArgs { Key = "Enter" });
+        Press(cut, "Home");  // focus the first header
+        Press(cut, "Enter");
 
         _logTableCommands.Received(1).ToggleGroupCollapsed("Alpha");
     }
@@ -149,6 +207,14 @@ public sealed class LogTablePaneGroupingTests : BunitContext
         _logTableCommands.Received(1).ToggleGroupCollapsed("Alpha");
         _eventLogCommands.DidNotReceive()
             .SetSelectedEvents(Arg.Any<IReadOnlyCollection<ResolvedEvent>>(), Arg.Any<ResolvedEvent?>());
+    }
+
+    [Fact]
+    public void Grouped_HeaderOmitsAriaSelected()
+    {
+        var cut = RenderGrouped(Collapsed(), Event(1, "Alpha"));
+
+        Assert.False(cut.Find("tr.group-header-row").HasAttribute("aria-selected"));
     }
 
     [Fact]
@@ -175,6 +241,123 @@ public sealed class LogTablePaneGroupingTests : BunitContext
         Assert.Contains("Source", header.TextContent);
         Assert.Contains("Alpha", header.TextContent);
         Assert.Contains("(2)", header.TextContent);
+    }
+
+    [Fact]
+    public void Grouped_Home_FocusesFirstHeaderWithoutSelecting()
+    {
+        var cut = RenderGrouped(Collapsed(), Event(1, "Alpha"), Event(2, "Alpha"));
+
+        _eventLogCommands.ClearReceivedCalls();
+        Press(cut, "Home"); // first visible row is a header - focus only
+
+        _eventLogCommands.DidNotReceive().SetSelectedEvents(
+            Arg.Any<IReadOnlyCollection<ResolvedEvent>>(), Arg.Any<ResolvedEvent?>());
+        Assert.Equal(0, LastFocusedRow());
+    }
+
+    [Fact]
+    public void Grouped_LeftOnCollapsedHeader_DoesNothing()
+    {
+        var cut = RenderGrouped(Collapsed("Alpha"), Event(1, "Alpha"), Event(2, "Beta"));
+
+        Press(cut, "Home");      // header Alpha (already collapsed)
+        Press(cut, "ArrowLeft"); // no-op
+
+        _logTableCommands.DidNotReceive().ToggleGroupCollapsed(Arg.Any<string>());
+    }
+
+    [Fact]
+    public void Grouped_LeftOnEvent_FocusesParentHeaderWithoutChangingSelection()
+    {
+        var cut = RenderGrouped(Collapsed(), Event(1, "Alpha"), Event(2, "Alpha"));
+
+        Press(cut, "Home");
+        Press(cut, "ArrowDown"); // event 1 selected
+        _eventLogCommands.ClearReceivedCalls();
+        Press(cut, "ArrowLeft"); // focus parent header (visible row 0); selection unchanged
+
+        _eventLogCommands.DidNotReceive().SetSelectedEvents(
+            Arg.Any<IReadOnlyCollection<ResolvedEvent>>(), Arg.Any<ResolvedEvent?>());
+        _logTableCommands.DidNotReceive().ToggleGroupCollapsed(Arg.Any<string>());
+        Assert.Equal(0, LastFocusedRow());
+    }
+
+    [Fact]
+    public void Grouped_LeftOnExpandedHeader_Collapses()
+    {
+        var cut = RenderGrouped(Collapsed(), Event(1, "Alpha"));
+
+        Press(cut, "Home");      // header Alpha (expanded)
+        Press(cut, "ArrowLeft"); // collapse
+
+        _logTableCommands.Received(1).ToggleGroupCollapsed("Alpha");
+    }
+
+    [Fact]
+    public void Grouped_PageDown_MovesToLastVisibleEvent()
+    {
+        var cut = RenderGrouped(Collapsed(), Event(1, "Alpha"), Event(2, "Beta"));
+        // rows: header Alpha(0), event 1(1), header Beta(2), event 2(3)
+        Press(cut, "Home");
+        _eventLogCommands.ClearReceivedCalls();
+        Press(cut, "PageDown"); // clamps to the last visible row (event 2)
+
+        _eventLogCommands.Received(1).SetSelectedEvents(
+            Arg.Is<IReadOnlyCollection<ResolvedEvent>>(c => c.Count == 1),
+            Arg.Any<ResolvedEvent?>());
+        Assert.Equal(3, LastFocusedRow());
+    }
+
+    [Fact]
+    public void Grouped_PlainArrowOntoEvent_SelectsEvent()
+    {
+        var cut = RenderGrouped(Collapsed(), Event(1, "Alpha"), Event(2, "Alpha"));
+
+        Press(cut, "Home");      // focus header (focus-only)
+        _eventLogCommands.ClearReceivedCalls();
+        Press(cut, "ArrowDown"); // land on the first event
+
+        _eventLogCommands.Received(1).SetSelectedEvents(
+            Arg.Is<IReadOnlyCollection<ResolvedEvent>>(c => c.Count == 1),
+            Arg.Any<ResolvedEvent?>());
+    }
+
+    [Fact]
+    public void Grouped_PlainArrowOntoHeader_FocusesOnlyWithoutSelecting()
+    {
+        var cut = RenderGrouped(Collapsed(), Event(1, "Alpha"), Event(2, "Beta"));
+
+        Press(cut, "Home");      // header Alpha
+        Press(cut, "ArrowDown"); // event 1 (selects it)
+        _eventLogCommands.ClearReceivedCalls();
+        Press(cut, "ArrowDown"); // header Beta (visible row 2) - focus only
+
+        _eventLogCommands.DidNotReceive().SetSelectedEvents(
+            Arg.Any<IReadOnlyCollection<ResolvedEvent>>(), Arg.Any<ResolvedEvent?>());
+        Assert.Equal(2, LastFocusedRow());
+    }
+
+    [Fact]
+    public async Task Grouped_ReactiveScroll_TargetsVisibleRowNotEventIndex()
+    {
+        // Event 2 is at event index 1 but visible row 3, so a reactive scroll must target 3.
+        var alpha1 = Event(1, "Alpha");
+        var beta2 = Event(2, "Beta");
+        _selectedEvent.Value.Returns(beta2);
+        _logTableState.Value.Returns(BuildState(ColumnName.Source, Collapsed(), alpha1, beta2));
+
+        var cut = Render<LogTablePane>();
+        await cut.InvokeAsync(() => Services.GetRequiredService<IStore>().InitializeAsync());
+        await cut.InvokeAsync(() =>
+            Services.GetRequiredService<IDispatcher>().Dispatch(new SetActiveTableAction(EventLogId.Create())));
+
+        cut.WaitForAssertion(() =>
+        {
+            var scrolls = _jsModule.Invocations["scrollToRow"];
+            Assert.NotEmpty(scrolls);
+            Assert.Equal(3, (int)scrolls.Last().Arguments[0]!);
+        });
     }
 
     [Fact]
@@ -210,6 +393,75 @@ public sealed class LogTablePaneGroupingTests : BunitContext
     }
 
     [Fact]
+    public void Grouped_RightOnCollapsedHeader_Expands()
+    {
+        var cut = RenderGrouped(Collapsed("Alpha"), Event(1, "Alpha"), Event(2, "Beta"));
+
+        Press(cut, "Home");       // header Alpha (collapsed)
+        Press(cut, "ArrowRight"); // expand
+
+        _logTableCommands.Received(1).ToggleGroupCollapsed("Alpha");
+    }
+
+    [Fact]
+    public void Grouped_RightOnExpandedHeader_SelectsFirstChild()
+    {
+        var cut = RenderGrouped(Collapsed(), Event(1, "Alpha"), Event(2, "Alpha"));
+
+        Press(cut, "Home"); // header Alpha (expanded)
+        _eventLogCommands.ClearReceivedCalls();
+        Press(cut, "ArrowRight"); // focus + select first child
+
+        _eventLogCommands.Received(1).SetSelectedEvents(
+            Arg.Is<IReadOnlyCollection<ResolvedEvent>>(c => c.Count == 1),
+            Arg.Any<ResolvedEvent?>());
+        _logTableCommands.DidNotReceive().ToggleGroupCollapsed(Arg.Any<string>());
+    }
+
+    [Fact]
+    public void Grouped_ShiftArrowDown_AcrossCollapsedGroup_IncludesHiddenEvents()
+    {
+        var cut = RenderGrouped(
+            Collapsed("Beta"),
+            Event(1, "Alpha"), Event(2, "Beta"), Event(3, "Beta"), Event(4, "Gamma"));
+
+        Press(cut, "Home");      // header Alpha
+        Press(cut, "ArrowDown"); // event 1 (anchor)
+        _eventLogCommands.ClearReceivedCalls();
+        Press(cut, "ArrowDown", shift: true); // skips the collapsed Beta header to event 4
+
+        _eventLogCommands.Received(1).SetSelectedEvents(
+            Arg.Is<IReadOnlyCollection<ResolvedEvent>>(c => c.Count == 4),
+            Arg.Any<ResolvedEvent?>());
+    }
+
+    [Fact]
+    public void Grouped_ShiftArrowUp_AcrossCollapsedGroup_IncludesHiddenEvents()
+    {
+        var cut = RenderGrouped(
+            Collapsed("Beta"),
+            Event(1, "Alpha"), Event(2, "Beta"), Event(3, "Beta"), Event(4, "Gamma"));
+
+        Press(cut, "End"); // event 4 (anchor)
+        _eventLogCommands.ClearReceivedCalls();
+        Press(cut, "ArrowUp", shift: true); // skips the collapsed Beta header to event 1
+
+        _eventLogCommands.Received(1).SetSelectedEvents(
+            Arg.Is<IReadOnlyCollection<ResolvedEvent>>(c => c.Count == 4),
+            Arg.Any<ResolvedEvent?>());
+    }
+
+    [Fact]
+    public void Grouped_TableHasTreegridRoleAndAriaLevels()
+    {
+        var cut = RenderGrouped(Collapsed(), Event(1, "Alpha"));
+
+        Assert.Equal("treegrid", cut.Find("table#eventTable").GetAttribute("role"));
+        Assert.Equal("1", cut.Find("tr.group-header-row").GetAttribute("aria-level"));
+        Assert.Equal("2", cut.Find("tbody tr.table-row").GetAttribute("aria-level"));
+    }
+
+    [Fact]
     public void Grouped_WhenAllExpanded_RendersEveryEventRow()
     {
         var cut = RenderGrouped(
@@ -237,6 +489,22 @@ public sealed class LogTablePaneGroupingTests : BunitContext
     }
 
     [Fact]
+    public void Ungrouped_ArrowDown_SelectsNextEvent()
+    {
+        _logTableState.Value.Returns(BuildState(groupBy: null, Collapsed(), Event(1, "Alpha"), Event(2, "Beta")));
+
+        var cut = Render<LogTablePane>();
+
+        Press(cut, "Home");      // flat Home selects the first event
+        _eventLogCommands.ClearReceivedCalls();
+        Press(cut, "ArrowDown"); // selects the next event
+
+        _eventLogCommands.Received(1).SetSelectedEvents(
+            Arg.Is<IReadOnlyCollection<ResolvedEvent>>(c => c.Count == 1),
+            Arg.Any<ResolvedEvent?>());
+    }
+
+    [Fact]
     public void Ungrouped_RendersNoGroupHeaders()
     {
         _logTableState.Value.Returns(BuildState(groupBy: null, Collapsed(), Event(1, "Alpha"), Event(2, "Beta")));
@@ -245,6 +513,17 @@ public sealed class LogTablePaneGroupingTests : BunitContext
 
         Assert.Empty(cut.FindAll("tr.group-header-row"));
         Assert.Equal(2, cut.FindAll("tbody tr.table-row").Count);
+    }
+
+    [Fact]
+    public void Ungrouped_TableHasGridRoleAndNoEventAriaLevel()
+    {
+        _logTableState.Value.Returns(BuildState(groupBy: null, Collapsed(), Event(1, "Alpha"), Event(2, "Beta")));
+
+        var cut = Render<LogTablePane>();
+
+        Assert.Equal("grid", cut.Find("table#eventTable").GetAttribute("role"));
+        Assert.False(cut.Find("tbody tr.table-row").HasAttribute("aria-level"));
     }
 
     private static LogTableState BuildState(
@@ -280,6 +559,19 @@ public sealed class LogTablePaneGroupingTests : BunitContext
             TimeCreated = new DateTime(2024, 1, 1, 0, 0, id, DateTimeKind.Utc),
             Description = $"event {id}"
         };
+
+    private static void Press(IRenderedComponent<LogTablePane> cut, string code, bool shift = false) =>
+        cut.Find(".table-container").KeyDown(new KeyboardEventArgs { Code = code, Key = code, ShiftKey = shift });
+
+    // Visible-row index of the most recent programmatic focus (proves DOM focus moved).
+    private int LastFocusedRow()
+    {
+        var invocations = _jsModule.Invocations["focusEventTableRow"];
+
+        Assert.NotEmpty(invocations);
+
+        return (int)invocations.Last().Arguments[0]!;
+    }
 
     private IRenderedComponent<LogTablePane> RenderGrouped(ImmutableHashSet<string> collapsed, params ResolvedEvent[] events)
     {

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneGroupingTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneGroupingTests.cs
@@ -30,7 +30,6 @@ public sealed class LogTablePaneGroupingTests : BunitContext
     private readonly IEventLogCommands _eventLogCommands = Substitute.For<IEventLogCommands>();
     private readonly IState<FilterPaneState> _filterPaneState = Substitute.For<IState<FilterPaneState>>();
     private readonly IHighlightSelector _highlightSelector = Substitute.For<IHighlightSelector>();
-
     private readonly BunitJSModuleInterop _jsModule;
     private readonly ILogTableCommands _logTableCommands = Substitute.For<ILogTableCommands>();
     private readonly IState<LogTableState> _logTableState = Substitute.For<IState<LogTableState>>();
@@ -149,6 +148,22 @@ public sealed class LogTablePaneGroupingTests : BunitContext
     }
 
     [Fact]
+    public void Grouped_ExternalSelectionIntoCollapsedGroup_RetypesCursorWithoutRebuild()
+    {
+        var alpha1 = Event(1, "Alpha");
+        _logTableState.Value.Returns(BuildState(ColumnName.Source, Collapsed("Alpha"), alpha1, Event(2, "Beta")));
+
+        var cut = Render<LogTablePane>();
+
+        _selectedEvent.Value.Returns(alpha1);
+        RaiseStateChanged(cut);
+
+        Press(cut, "ArrowRight");
+
+        _logTableCommands.Received(1).ToggleGroupCollapsed("Alpha");
+    }
+
+    [Fact]
     public async Task Grouped_GroupContextMenu_CollapseAll_DispatchesCommand()
     {
         IReadOnlyList<MenuItem>? items = null;
@@ -195,6 +210,29 @@ public sealed class LogTablePaneGroupingTests : BunitContext
         Press(cut, "Enter");
 
         _logTableCommands.Received(1).ToggleGroupCollapsed("Alpha");
+    }
+
+    [Fact]
+    public void Grouped_HeaderGroupVanishes_FallsBackToNearestSurvivingHeader()
+    {
+        var alpha1 = Event(1, "Alpha");
+        var beta2 = Event(2, "Beta");
+        var gamma3 = Event(3, "Gamma");
+        _logTableState.Value.Returns(BuildState(ColumnName.Source, Collapsed(), alpha1, beta2, gamma3));
+
+        var cut = Render<LogTablePane>();
+        Press(cut, "Home");      // header Alpha
+        Press(cut, "ArrowDown"); // event 1
+        Press(cut, "ArrowDown"); // header Beta (cursor on the middle header)
+
+        _logTableState.Value.Returns(BuildState(ColumnName.Source, Collapsed(), alpha1, gamma3));
+        RaiseStateChanged(cut);
+        cut.WaitForAssertion(() => Assert.Equal(2, cut.FindAll("tr.group-header-row").Count));
+
+        Press(cut, "Enter");
+
+        _logTableCommands.Received(1).ToggleGroupCollapsed("Gamma");
+        _logTableCommands.DidNotReceive().ToggleGroupCollapsed("Beta");
     }
 
     [Fact]
@@ -462,6 +500,30 @@ public sealed class LogTablePaneGroupingTests : BunitContext
     }
 
     [Fact]
+    public void Grouped_UngroupWithHeaderCursor_ResumesFromFormerGroupsFirstEvent()
+    {
+        var alpha1 = Event(1, "Alpha");
+        var beta2 = Event(2, "Beta");
+        _logTableState.Value.Returns(BuildState(ColumnName.Source, Collapsed(), alpha1, beta2));
+
+        var cut = Render<LogTablePane>();
+        Press(cut, "Home");      // header Alpha
+        Press(cut, "ArrowDown"); // event 1
+        Press(cut, "ArrowDown"); // header Beta (cursor on a non-first header)
+
+        _logTableState.Value.Returns(BuildState(groupBy: null, Collapsed(), alpha1, beta2));
+        RaiseStateChanged(cut);
+        cut.WaitForAssertion(() => Assert.Empty(cut.FindAll("tr.group-header-row")));
+
+        _eventLogCommands.ClearReceivedCalls();
+        Press(cut, "ArrowUp");
+
+        _eventLogCommands.Received(1).SetSelectedEvents(
+            Arg.Is<IReadOnlyCollection<ResolvedEvent>>(c => c.Count == 1 && c.Contains(alpha1)),
+            Arg.Any<ResolvedEvent?>());
+    }
+
+    [Fact]
     public void Grouped_WhenAllExpanded_RendersEveryEventRow()
     {
         var cut = RenderGrouped(
@@ -572,6 +634,11 @@ public sealed class LogTablePaneGroupingTests : BunitContext
 
         return (int)invocations.Last().Arguments[0]!;
     }
+
+    // Re-render the component against the latest substituted state (after updating a
+    // _logTableState/_selectedEvent return value mid-test).
+    private void RaiseStateChanged(IRenderedComponent<LogTablePane> cut) =>
+        cut.InvokeAsync(() => _logTableState.StateChanged += Raise.Event<EventHandler>(_logTableState, EventArgs.Empty));
 
     private IRenderedComponent<LogTablePane> RenderGrouped(ImmutableHashSet<string> collapsed, params ResolvedEvent[] events)
     {

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneGroupingTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneGroupingTests.cs
@@ -1,0 +1,290 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.FilterPane;
+using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.Runtime.Menu;
+using EventLogExpert.Runtime.Settings;
+using EventLogExpert.UI.LogTable;
+using EventLogExpert.UI.Tests.TestUtils;
+using Fluxor;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using System.Collections.Immutable;
+using System.Globalization;
+
+namespace EventLogExpert.UI.Tests.LogTable;
+
+public sealed class LogTablePaneGroupingTests : BunitContext
+{
+    private const string LogName = "Application";
+
+    private readonly ILogTableColumnDefaultsProvider _columnDefaults = Substitute.For<ILogTableColumnDefaultsProvider>();
+    private readonly IEventLogCommands _eventLogCommands = Substitute.For<IEventLogCommands>();
+    private readonly IState<FilterPaneState> _filterPaneState = Substitute.For<IState<FilterPaneState>>();
+    private readonly IHighlightSelector _highlightSelector = Substitute.For<IHighlightSelector>();
+    private readonly ILogTableCommands _logTableCommands = Substitute.For<ILogTableCommands>();
+    private readonly IState<LogTableState> _logTableState = Substitute.For<IState<LogTableState>>();
+    private readonly IMenuService _menuService = Substitute.For<IMenuService>();
+    private readonly IStateSelection<EventLogState, ResolvedEvent?> _selectedEvent = Substitute.For<IStateSelection<EventLogState, ResolvedEvent?>>();
+    private readonly IStateSelection<EventLogState, ImmutableList<ResolvedEvent>> _selectedEvents = Substitute.For<IStateSelection<EventLogState, ImmutableList<ResolvedEvent>>>();
+    private readonly ISettingsService _settings = Substitute.For<ISettingsService>();
+
+    public LogTablePaneGroupingTests()
+    {
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        JSInterop.SetupModule("./_content/EventLogExpert.UI/LogTable/LogTablePane.razor.js");
+
+        _columnDefaults.ColumnOrder.Returns(ImmutableList.Create(ColumnName.Source));
+        _filterPaneState.Value.Returns(new FilterPaneState());
+        _highlightSelector.Select(Arg.Any<ImmutableList<SavedFilter>>()).Returns([]);
+        _highlightSelector.ComputeHighlightKey(Arg.Any<ImmutableList<SavedFilter>>()).Returns(0);
+        _settings.TimeZoneInfo.Returns(TimeZoneInfo.Utc);
+        _selectedEvent.Value.Returns((ResolvedEvent?)null);
+        _selectedEvents.Value.Returns(ImmutableList<ResolvedEvent>.Empty);
+
+        Services.AddLogTablePaneDependencies();
+        Services.AddSingleton(_columnDefaults);
+        Services.AddSingleton(_eventLogCommands);
+        Services.AddSingleton(_filterPaneState);
+        Services.AddSingleton(_highlightSelector);
+        Services.AddSingleton(_logTableState);
+        Services.AddSingleton(_selectedEvent);
+        Services.AddSingleton(_selectedEvents);
+        Services.AddSingleton(_settings);
+        Services.AddSingleton(_logTableCommands);
+        Services.AddSingleton(_menuService);
+
+        Services.AddFluxor(options => options.ScanAssemblies(typeof(LogTablePane).Assembly));
+    }
+
+    [Fact]
+    public void Grouped_CollapsedHeader_HasAriaExpandedFalse()
+    {
+        var cut = RenderGrouped(
+            Collapsed("Alpha"),
+            Event(1, "Alpha"));
+
+        var header = cut.Find("tr.group-header-row");
+
+        Assert.Equal("false", header.GetAttribute("aria-expanded"));
+        Assert.Equal("true", header.QuerySelector(".group-chevron")!.GetAttribute("data-collapsed"));
+    }
+
+    [Fact]
+    public void Grouped_EventRowStripe_ResetsPerGroup()
+    {
+        var cut = RenderGrouped(Collapsed(), Event(1, "Alpha"), Event(2, "Alpha"), Event(3, "Beta"));
+
+        var rows = cut.FindAll("tbody tr.table-row");
+
+        Assert.Equal("0", rows[0].GetAttribute("data-stripe"));
+        Assert.Equal("1", rows[1].GetAttribute("data-stripe"));
+        Assert.Equal("0", rows[2].GetAttribute("data-stripe"));
+    }
+
+    [Fact]
+    public async Task Grouped_GroupContextMenu_CollapseAll_DispatchesCommand()
+    {
+        IReadOnlyList<MenuItem>? items = null;
+        _menuService
+            .When(m => m.OpenAt(
+                Arg.Any<double>(), Arg.Any<double>(), Arg.Any<IReadOnlyList<MenuItem>>(),
+                Arg.Any<bool>(), Arg.Any<bool>()))
+            .Do(call => items = call.Arg<IReadOnlyList<MenuItem>>());
+
+        var cut = RenderGrouped(Collapsed(), Event(1, "Alpha"));
+        cut.Find("tr.group-header-row").TriggerEvent("oncontextmenu", new MouseEventArgs());
+
+        await items!.First(m => m.Label == "Collapse All Groups").OnClickAsync!();
+
+        _logTableCommands.Received(1).SetAllGroupsCollapsed(true);
+    }
+
+    [Fact]
+    public async Task Grouped_GroupContextMenu_SelectGroup_SelectsGroupedEvents()
+    {
+        IReadOnlyList<MenuItem>? items = null;
+        _menuService
+            .When(m => m.OpenAt(
+                Arg.Any<double>(), Arg.Any<double>(), Arg.Any<IReadOnlyList<MenuItem>>(),
+                Arg.Any<bool>(), Arg.Any<bool>()))
+            .Do(call => items = call.Arg<IReadOnlyList<MenuItem>>());
+
+        var cut = RenderGrouped(Collapsed(), Event(1, "Alpha"), Event(2, "Alpha"), Event(3, "Beta"));
+        cut.Find("tr.group-header-row").TriggerEvent("oncontextmenu", new MouseEventArgs());
+
+        await items!.First(item => item.Label == "Select Group").OnClickAsync!();
+
+        _eventLogCommands.Received(1).SetSelectedEvents(
+            Arg.Is<IReadOnlyCollection<ResolvedEvent>>(c => c.Count == 2),
+            Arg.Any<ResolvedEvent?>());
+    }
+
+    [Fact]
+    public void Grouped_HeaderEnterKey_TogglesCollapse()
+    {
+        var cut = RenderGrouped(Collapsed(), Event(1, "Alpha"));
+
+        cut.Find("tr.group-header-row").KeyDown(new KeyboardEventArgs { Key = "Enter" });
+
+        _logTableCommands.Received(1).ToggleGroupCollapsed("Alpha");
+    }
+
+    [Fact]
+    public void Grouped_HeaderLeftClick_TogglesCollapseWithoutSelecting()
+    {
+        var cut = RenderGrouped(Collapsed(), Event(1, "Alpha"), Event(2, "Alpha"));
+
+        cut.Find("tr.group-header-row").Click();
+
+        _logTableCommands.Received(1).ToggleGroupCollapsed("Alpha");
+        _eventLogCommands.DidNotReceive()
+            .SetSelectedEvents(Arg.Any<IReadOnlyCollection<ResolvedEvent>>(), Arg.Any<ResolvedEvent?>());
+    }
+
+    [Fact]
+    public void Grouped_HeaderRightClick_DoesNotSelect()
+    {
+        var cut = RenderGrouped(Collapsed(), Event(1, "Alpha"), Event(2, "Alpha"));
+
+        cut.Find("tr.group-header-row").TriggerEvent("oncontextmenu", new MouseEventArgs());
+
+        _eventLogCommands.DidNotReceive()
+            .SetSelectedEvents(Arg.Any<IReadOnlyCollection<ResolvedEvent>>(), Arg.Any<ResolvedEvent?>());
+    }
+
+    [Fact]
+    public void Grouped_HeaderShowsGroupNameValueAndCount()
+    {
+        var cut = RenderGrouped(
+            Collapsed(),
+            Event(1, "Alpha"),
+            Event(2, "Alpha"));
+
+        var header = cut.FindAll("tr.group-header-row")[0];
+
+        Assert.Contains("Source", header.TextContent);
+        Assert.Contains("Alpha", header.TextContent);
+        Assert.Contains("(2)", header.TextContent);
+    }
+
+    [Fact]
+    public void Grouped_RendersOneHeaderRowPerGroup()
+    {
+        var cut = RenderGrouped(
+            Collapsed(),
+            Event(1, "Alpha"),
+            Event(2, "Alpha"),
+            Event(3, "Beta"));
+
+        Assert.Equal(2, cut.FindAll("tr.group-header-row").Count);
+    }
+
+    [Fact]
+    public void Grouped_RightClickHeader_OpensGroupContextMenuWithActions()
+    {
+        IReadOnlyList<MenuItem>? items = null;
+        _menuService
+            .When(m => m.OpenAt(
+                Arg.Any<double>(), Arg.Any<double>(), Arg.Any<IReadOnlyList<MenuItem>>(),
+                Arg.Any<bool>(), Arg.Any<bool>()))
+            .Do(call => items = call.Arg<IReadOnlyList<MenuItem>>());
+
+        var cut = RenderGrouped(Collapsed(), Event(1, "Alpha"), Event(2, "Alpha"));
+        cut.Find("tr.group-header-row").TriggerEvent("oncontextmenu", new MouseEventArgs());
+
+        Assert.NotNull(items);
+        Assert.Contains(items!, m => m.Label == "Expand All Groups");
+        Assert.Contains(items!, m => m.Label == "Collapse All Groups");
+        Assert.Contains(items!, m => m.Label == "Group Descending");
+        Assert.Contains(items!, m => m.Label == "Select Group");
+    }
+
+    [Fact]
+    public void Grouped_WhenAllExpanded_RendersEveryEventRow()
+    {
+        var cut = RenderGrouped(
+            Collapsed(),
+            Event(1, "Alpha"),
+            Event(2, "Alpha"),
+            Event(3, "Beta"));
+
+        Assert.Equal(3, cut.FindAll("tbody tr.table-row").Count);
+    }
+
+    [Fact]
+    public void Grouped_WhenGroupCollapsed_HidesOnlyThatGroupsEvents()
+    {
+        var cut = RenderGrouped(
+            Collapsed("Alpha"),
+            Event(1, "Alpha"),
+            Event(2, "Alpha"),
+            Event(3, "Beta"));
+
+        Assert.Equal(2, cut.FindAll("tr.group-header-row").Count);
+        var eventRows = cut.FindAll("tbody tr.table-row");
+        Assert.Single(eventRows);
+        Assert.Contains("Beta", eventRows[0].TextContent);
+    }
+
+    [Fact]
+    public void Ungrouped_RendersNoGroupHeaders()
+    {
+        _logTableState.Value.Returns(BuildState(groupBy: null, Collapsed(), Event(1, "Alpha"), Event(2, "Beta")));
+
+        var cut = Render<LogTablePane>();
+
+        Assert.Empty(cut.FindAll("tr.group-header-row"));
+        Assert.Equal(2, cut.FindAll("tbody tr.table-row").Count);
+    }
+
+    private static LogTableState BuildState(
+        ColumnName? groupBy,
+        ImmutableHashSet<string> collapsed,
+        params ResolvedEvent[] events)
+    {
+        var logId = EventLogId.Create();
+
+        return new LogTableState
+        {
+            ActiveEventLogId = logId,
+            EventTables = ImmutableList.Create(new LogView(logId) { LogName = LogName }),
+            DisplayedEvents = events,
+            EventCountByLog = ImmutableDictionary<EventLogId, int>.Empty.Add(logId, events.Length),
+            Columns = ImmutableDictionary<ColumnName, bool>.Empty.Add(ColumnName.Source, true),
+            ColumnOrder = ImmutableList.Create(ColumnName.Source),
+            IsDescending = false,
+            GroupBy = groupBy,
+            GroupCollapseOverrides = collapsed
+        };
+    }
+
+    private static ImmutableHashSet<string> Collapsed(params string[] keys) =>
+        ImmutableHashSet.Create(StringComparer.Ordinal, keys);
+
+    private static ResolvedEvent Event(int id, string source) =>
+        new(LogName, LogPathType.Channel)
+        {
+            Id = id,
+            RecordId = id,
+            Source = source,
+            TimeCreated = new DateTime(2024, 1, 1, 0, 0, id, DateTimeKind.Utc),
+            Description = $"event {id}"
+        };
+
+    private IRenderedComponent<LogTablePane> RenderGrouped(ImmutableHashSet<string> collapsed, params ResolvedEvent[] events)
+    {
+        _logTableState.Value.Returns(BuildState(ColumnName.Source, collapsed, events));
+
+        return Render<LogTablePane>();
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/Menu/MenuBarGroupingTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Menu/MenuBarGroupingTests.cs
@@ -1,0 +1,108 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using EventLogExpert.Runtime.Common.Versioning;
+using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.FilterPane;
+using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.Runtime.Menu;
+using EventLogExpert.Runtime.Settings;
+using EventLogExpert.UI.Menu;
+using Fluxor;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace EventLogExpert.UI.Tests.Menu;
+
+public sealed class MenuBarGroupingTests : BunitContext
+{
+    private const string DisabledReason = "Group events first (column header > Group By)";
+
+    private readonly IMenuActionService _actions = Substitute.For<IMenuActionService>();
+    private readonly IStateSelection<EventLogState, bool> _eventLogSelection = Substitute.For<IStateSelection<EventLogState, bool>>();
+    private readonly IStateSelection<FilterPaneState, bool> _filterPaneIsEnabled = Substitute.For<IStateSelection<FilterPaneState, bool>>();
+    private readonly IStateSelection<LogTableState, bool> _groupingSelection = Substitute.For<IStateSelection<LogTableState, bool>>();
+    private readonly IMenuService _menuService = Substitute.For<IMenuService>();
+    private readonly ISettingsService _settings = Substitute.For<ISettingsService>();
+    private readonly ICurrentVersionProvider _versionProvider = Substitute.For<ICurrentVersionProvider>();
+
+    public MenuBarGroupingTests()
+    {
+        Services.AddSingleton(_actions);
+        Services.AddSingleton(_eventLogSelection);
+        Services.AddSingleton(_filterPaneIsEnabled);
+        Services.AddSingleton(_groupingSelection);
+        Services.AddSingleton(_menuService);
+        Services.AddSingleton(_settings);
+        Services.AddSingleton(_versionProvider);
+
+        Services.AddFluxor(options => options.ScanAssemblies(typeof(MenuBar).Assembly));
+
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        JSInterop.SetupModule("./_content/EventLogExpert.UI/Menu/MenuAnchor.js")
+            .Setup<MenuAnchorRect>("getMenuElementRect", _ => true)
+            .SetResult(new MenuAnchorRect(0, 0, 0, 0, 0, 0));
+    }
+
+    [Fact]
+    public void Render_SubscribesBothGroupingSelections()
+    {
+        Render<MenuBar>();
+
+        _groupingSelection.Received(2).Select(Arg.Any<Func<LogTableState, bool>>());
+    }
+
+    [Fact]
+    public async Task View_WhenGrouping_GroupActionsEnabledAndDescendingChecked()
+    {
+        _groupingSelection.Value.Returns(true);
+
+        var items = await OpenViewMenu();
+
+        Assert.True(Item(items, "Expand All Groups").IsEnabled);
+        Assert.True(Item(items, "Collapse All Groups").IsEnabled);
+
+        var descending = Item(items, "Group Descending");
+        Assert.True(descending.IsEnabled);
+        Assert.True(descending.IsChecked);
+    }
+
+    [Fact]
+    public async Task View_WhenNotGrouping_GroupActionsDisabledWithReason()
+    {
+        _groupingSelection.Value.Returns(false);
+
+        var items = await OpenViewMenu();
+
+        foreach (var label in new[] { "Expand All Groups", "Collapse All Groups", "Group Descending" })
+        {
+            var item = Item(items, label);
+            Assert.False(item.IsEnabled);
+            Assert.Equal(DisabledReason, item.DisabledReason);
+        }
+    }
+
+    private static MenuItem Item(IReadOnlyList<MenuItem> items, string label) =>
+        items.Single(item => item.Label == label);
+
+    private async Task<IReadOnlyList<MenuItem>> OpenViewMenu()
+    {
+        IReadOnlyList<MenuItem>? items = null;
+        _menuService
+            .When(m => m.OpenAt(
+                Arg.Any<double>(), Arg.Any<double>(), Arg.Any<IReadOnlyList<MenuItem>>(),
+                Arg.Any<bool>(), Arg.Any<bool>()))
+            .Do(call => items = call.Arg<IReadOnlyList<MenuItem>>());
+
+        var cut = Render<MenuBar>();
+        await cut.FindAll("button.menu-bar-item")
+            .Single(button => button.TextContent.Trim() == "View")
+            .ClickAsync(new MouseEventArgs());
+
+        Assert.NotNull(items);
+
+        return items!;
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/Menu/MenuBarGroupingTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Menu/MenuBarGroupingTests.cs
@@ -23,17 +23,19 @@ public sealed class MenuBarGroupingTests : BunitContext
     private readonly IMenuActionService _actions = Substitute.For<IMenuActionService>();
     private readonly IStateSelection<EventLogState, bool> _eventLogSelection = Substitute.For<IStateSelection<EventLogState, bool>>();
     private readonly IStateSelection<FilterPaneState, bool> _filterPaneIsEnabled = Substitute.For<IStateSelection<FilterPaneState, bool>>();
-    private readonly IStateSelection<LogTableState, bool> _groupingSelection = Substitute.For<IStateSelection<LogTableState, bool>>();
+    private readonly List<IStateSelection<LogTableState, bool>> _logTableSelections = [];
     private readonly IMenuService _menuService = Substitute.For<IMenuService>();
     private readonly ISettingsService _settings = Substitute.For<ISettingsService>();
     private readonly ICurrentVersionProvider _versionProvider = Substitute.For<ICurrentVersionProvider>();
+
+    private LogTableState _logTableState = new();
 
     public MenuBarGroupingTests()
     {
         Services.AddSingleton(_actions);
         Services.AddSingleton(_eventLogSelection);
         Services.AddSingleton(_filterPaneIsEnabled);
-        Services.AddSingleton(_groupingSelection);
+        Services.AddTransient<IStateSelection<LogTableState, bool>>(_ => CreateLogTableSelection());
         Services.AddSingleton(_menuService);
         Services.AddSingleton(_settings);
         Services.AddSingleton(_versionProvider);
@@ -51,13 +53,25 @@ public sealed class MenuBarGroupingTests : BunitContext
     {
         Render<MenuBar>();
 
-        _groupingSelection.Received(2).Select(Arg.Any<Func<LogTableState, bool>>());
+        Assert.Equal(2, _logTableSelections.Count);
+        Assert.All(_logTableSelections, s => s.Received(1).Select(Arg.Any<Func<LogTableState, bool>>()));
     }
 
     [Fact]
-    public async Task View_WhenGrouping_GroupActionsEnabledAndDescendingChecked()
+    public async Task View_WhenGroupingAscending_DescendingEnabledButUnchecked()
     {
-        _groupingSelection.Value.Returns(true);
+        _logTableState = new LogTableState { GroupBy = ColumnName.Source, IsGroupDescending = false };
+
+        var descending = Item(await OpenViewMenu(), "Group Descending");
+
+        Assert.True(descending.IsEnabled);
+        Assert.False(descending.IsChecked);
+    }
+
+    [Fact]
+    public async Task View_WhenGroupingDescending_GroupActionsEnabledAndDescendingChecked()
+    {
+        _logTableState = new LogTableState { GroupBy = ColumnName.Source, IsGroupDescending = true };
 
         var items = await OpenViewMenu();
 
@@ -72,7 +86,7 @@ public sealed class MenuBarGroupingTests : BunitContext
     [Fact]
     public async Task View_WhenNotGrouping_GroupActionsDisabledWithReason()
     {
-        _groupingSelection.Value.Returns(false);
+        _logTableState = new LogTableState { GroupBy = null };
 
         var items = await OpenViewMenu();
 
@@ -86,6 +100,19 @@ public sealed class MenuBarGroupingTests : BunitContext
 
     private static MenuItem Item(IReadOnlyList<MenuItem> items, string label) =>
         items.Single(item => item.Label == label);
+
+    // Distinct substitute per selection; Value applies its own projection to _logTableState.
+    private IStateSelection<LogTableState, bool> CreateLogTableSelection()
+    {
+        var selection = Substitute.For<IStateSelection<LogTableState, bool>>();
+        Func<LogTableState, bool>? selector = null;
+        selection.When(s => s.Select(Arg.Any<Func<LogTableState, bool>>()))
+            .Do(call => selector = call.Arg<Func<LogTableState, bool>>());
+        selection.Value.Returns(_ => selector is not null && selector(_logTableState));
+        _logTableSelections.Add(selection);
+
+        return selection;
+    }
 
     private async Task<IReadOnlyList<MenuItem>> OpenViewMenu()
     {


### PR DESCRIPTION
## Summary

Adds inline grouping to the event table: group by any column (except Description/Xml) with expandable group-header rows sorted by the group key, while events *within* a group keep the current Order By sort. Performance is preserved via a virtual row-view over the already-sorted, per-tab-filtered events — no event duplication, no per-row materialization.

## How it works

- **Group axis is independent of within-group sort.** Group order = `GroupBy` (+ `Group Descending`); within-group order = the existing `OrderBy`/direction.
- **Virtual row-view (`GroupedRowView`)** — a custom `IList<TableRow>` over `_activeDisplayedEvents`. Header/event rows resolve on demand via O(log groups) binary search over an `EventGroup` prefix-sum (O(1) group lookup by key); `Virtualize` only realizes the visible window. No `TableRow` list or `event→row` dictionary is materialized, so collapse/expand stays cheap.
- **Collapse state is transient** — tracked per group-key, reset on Group By change and on any active-table change.
- **Contiguity invariant** — `ResolvedEventGroupKey.For` mirrors the field each `ResolvedEventOrdering` comparer reads, so equal sort-key ⟺ equal group-key ⟺ contiguous run (null/empty coalesced identically on both sides).

## UX

- **Group By** / **Group Descending** / **Expand All** / **Collapse All** in the column and group-header context menus and the View menu.
- **Tree grid keyboard navigation** (`role="treegrid"`, `aria-level`): visible-row arrows that skip collapsed events and stop on headers; `Left`/`Right` move to parent / collapse / expand / first child; `Enter` toggles a focused header. Headers are focus-only (selection stays on events). `Ctrl+A` selects all events including those in collapsed groups; Shift-range skips headers and spans any crossed collapsed group.
- **Select Group** (group-header context menu) selects all of a group's events.

## Implementation notes

- A single keyboard cursor (`TableCursor`, identity-based) is the sole source of focus + selection. One reconciliation pass runs on each row-view rebuild (collapse retype, vanished-event / vanished-group fallback, ungroup conversion), plus a normalize-on-write that also covers no-rebuild selection paths.
- Flat (ungrouped) mode is behaviorally unchanged: `role="grid"`, no tree attributes, `Left`/`Right` not intercepted.

## Testing

- Runtime 1260 tests, UI 689 tests (grouped nav, treegrid keys, reconciliation transitions, all-collapsed boundaries, flat-mode parity, ARIA attributes), MAUI head builds clean (0 warnings).

## Docs

- `docs/Viewing-Events.md` (Grouping section) and `docs/Keyboard-And-Copy.md` (grouped-table keyboard reference).
