### PR TITLE
Add RecordId column and Copy as Markdown

### DIFF
--- a/src/EventLogExpert.Runtime/Common/Clipboard/EventCopyFormat.cs
+++ b/src/EventLogExpert.Runtime/Common/Clipboard/EventCopyFormat.cs
@@ -8,5 +8,6 @@ public enum EventCopyFormat
     Default,
     Simple,
     Xml,
-    Full
+    Full,
+    Markdown
 }

--- a/src/EventLogExpert.Runtime/LogTable/ColumnDefaults.cs
+++ b/src/EventLogExpert.Runtime/LogTable/ColumnDefaults.cs
@@ -19,6 +19,7 @@ internal sealed class ColumnDefaults : ILogTableColumnDefaultsProvider
 
     private static readonly ImmutableList<ColumnName> s_order =
     [
+        ColumnName.RecordId,
         ColumnName.Level,
         ColumnName.DateAndTime,
         ColumnName.ActivityId,
@@ -35,6 +36,7 @@ internal sealed class ColumnDefaults : ILogTableColumnDefaultsProvider
 
     private static readonly FrozenDictionary<ColumnName, int> s_widths = new Dictionary<ColumnName, int>
     {
+        [ColumnName.RecordId] = 90,
         [ColumnName.Level] = 100,
         [ColumnName.DateAndTime] = 160,
         [ColumnName.ActivityId] = 270,

--- a/src/EventLogExpert.Runtime/LogTable/ColumnName.cs
+++ b/src/EventLogExpert.Runtime/LogTable/ColumnName.cs
@@ -7,6 +7,7 @@ namespace EventLogExpert.Runtime.LogTable;
 
 public enum ColumnName
 {
+    [EnumMember(Value = "Record ID")] RecordId,
     Level,
     [EnumMember(Value = "Date and Time")] DateAndTime,
     [EnumMember(Value = "Activity ID")] ActivityId,

--- a/src/EventLogExpert.Runtime/LogTable/ColumnResetMigrationFeature.cs
+++ b/src/EventLogExpert.Runtime/LogTable/ColumnResetMigrationFeature.cs
@@ -1,0 +1,55 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.LogTable;
+
+/// <summary>Build-time / static-initialization flag gating the one-time RecordId column-index reset migration.</summary>
+/// <remarks>
+///     <para>
+///         When <see cref="Enabled" /> is <see langword="true" /> (default), the real <see cref="ColumnResetMigrator" />
+///         runs once at column-load time and clears the numeric-keyed <c>enabled-event-table-columns</c> and
+///         <c>column-order</c> preferences so they fall back to defaults after <see cref="ColumnName.RecordId" /> was
+///         inserted at enum value 0 (which renumbered every other column). When <see langword="false" />, the
+///         <see cref="NoOpColumnResetMigrator" /> fills the slot and the reset never runs.
+///     </para>
+///     <para>
+///         Staged-deletion contract: once enough releases have shipped that no install predates the RecordId column, this
+///         migration can be removed. The mechanical removal procedure is:
+///         <list type="number">
+///             <item>Flip <see cref="Enabled" /> to <see langword="false" /> as a smoke test.</item>
+///             <item>
+///                 Delete the <c>if (ColumnResetMigrationFeature.IsEnabled)</c> branch in
+///                 <see cref="LogTableServiceCollectionExtensions" /> (keep the <c>NoOp</c> registration only) and the
+///                 <c>ColumnResetMigrationFeature.Enabled</c> condition added to the <c>ILegacyPreferences</c>
+///                 registration in <c>MauiProgram</c>.
+///             </item>
+///             <item>
+///                 Delete: <see cref="IColumnResetMigrator" />, <see cref="ColumnResetMigrator" />,
+///                 <see cref="NoOpColumnResetMigrator" />, the <c>AddColumnResetMigration</c> DI extension + its call in
+///                 <c>MauiProgram</c>, and the <c>columnResetMigrator</c> ctor parameter + <c>ShouldRunMigration</c>
+///                 branch in <c>Effects.HandleLoadColumns</c>.
+///             </item>
+///             <item>Delete this file.</item>
+///         </list>
+///     </para>
+/// </remarks>
+public static class ColumnResetMigrationFeature
+{
+    public static readonly bool Enabled = true;
+
+    private static readonly AsyncLocal<bool?> s_testOverride = new();
+
+    internal static bool IsEnabled => s_testOverride.Value ?? Enabled;
+
+    internal static IDisposable Override(bool value)
+    {
+        s_testOverride.Value = value;
+
+        return new OverrideScope();
+    }
+
+    private sealed class OverrideScope : IDisposable
+    {
+        public void Dispose() => s_testOverride.Value = null;
+    }
+}

--- a/src/EventLogExpert.Runtime/LogTable/ColumnResetMigrator.cs
+++ b/src/EventLogExpert.Runtime/LogTable/ColumnResetMigrator.cs
@@ -1,0 +1,46 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.FilterLibrary;
+
+namespace EventLogExpert.Runtime.LogTable;
+
+internal sealed class ColumnResetMigrator(ILegacyPreferences preferences, ITraceLogger logger) : IColumnResetMigrator
+{
+    private const string CompletedValue = "1";
+    private const string CompletionKey = "log-table-column-reset-migration-state";
+
+    public void RunMigration()
+    {
+        try
+        {
+            // Clear (not rewrite) the two numeric-keyed prefs so they fall back to defaults; column-widths is name-keyed
+            // and reorder-safe so it's left intact. Completion flag written last, so an aborted run safely retries.
+            preferences.Remove(LogTablePreferenceKeys.EnabledEventTableColumns);
+            preferences.Remove(LogTablePreferenceKeys.ColumnOrder);
+            preferences.SetString(CompletionKey, CompletedValue);
+
+            logger.Information(
+                $"RecordId column-index migration: cleared enabled-columns + column-order preferences (restored to defaults); column-widths preserved.");
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"{nameof(ColumnResetMigrator)}.{nameof(RunMigration)} failed; will retry next launch: {ex}");
+        }
+    }
+
+    public bool ShouldRunMigration()
+    {
+        try
+        {
+            return !string.Equals(preferences.GetString(CompletionKey), CompletedValue, StringComparison.Ordinal);
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"{nameof(ColumnResetMigrator)}.{nameof(ShouldRunMigration)} failed; skipping migration this launch: {ex}");
+
+            return false;
+        }
+    }
+}

--- a/src/EventLogExpert.Runtime/LogTable/Effects.cs
+++ b/src/EventLogExpert.Runtime/LogTable/Effects.cs
@@ -9,15 +9,19 @@ namespace EventLogExpert.Runtime.LogTable;
 internal sealed class Effects(
     ILogTablePreferencesProvider preferencesProvider,
     IState<LogTableState> logTableState,
-    ILogTableColumnDefaultsProvider columnDefaults)
+    ILogTableColumnDefaultsProvider columnDefaults,
+    IColumnResetMigrator columnResetMigrator)
 {
     private readonly ILogTableColumnDefaultsProvider _columnDefaults = columnDefaults;
+    private readonly IColumnResetMigrator _columnResetMigrator = columnResetMigrator;
     private readonly IState<LogTableState> _logTableState = logTableState;
     private readonly ILogTablePreferencesProvider _preferencesProvider = preferencesProvider;
 
     [EffectMethod(typeof(LoadColumnsAction))]
     public Task HandleLoadColumns(IDispatcher dispatcher)
     {
+        if (_columnResetMigrator.ShouldRunMigration()) { _columnResetMigrator.RunMigration(); }
+
         var columns = new Dictionary<ColumnName, bool>();
         var enabledColumns = _preferencesProvider.EnabledEventTableColumnsPreference;
 

--- a/src/EventLogExpert.Runtime/LogTable/IColumnResetMigrator.cs
+++ b/src/EventLogExpert.Runtime/LogTable/IColumnResetMigrator.cs
@@ -1,0 +1,11 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.LogTable;
+
+internal interface IColumnResetMigrator
+{
+    void RunMigration();
+
+    bool ShouldRunMigration();
+}

--- a/src/EventLogExpert.Runtime/LogTable/LogTablePreferenceKeys.cs
+++ b/src/EventLogExpert.Runtime/LogTable/LogTablePreferenceKeys.cs
@@ -1,0 +1,13 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.LogTable;
+
+public static class LogTablePreferenceKeys
+{
+    public const string ColumnOrder = "column-order";
+
+    public const string ColumnWidths = "column-widths";
+
+    public const string EnabledEventTableColumns = "enabled-event-table-columns";
+}

--- a/src/EventLogExpert.Runtime/LogTable/LogTableServiceCollectionExtensions.cs
+++ b/src/EventLogExpert.Runtime/LogTable/LogTableServiceCollectionExtensions.cs
@@ -1,0 +1,28 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EventLogExpert.Runtime.LogTable;
+
+public static class LogTableServiceCollectionExtensions
+{
+    extension(IServiceCollection services)
+    {
+        public IServiceCollection AddColumnResetMigration()
+        {
+            ArgumentNullException.ThrowIfNull(services);
+
+            if (ColumnResetMigrationFeature.IsEnabled)
+            {
+                services.AddSingleton<IColumnResetMigrator, ColumnResetMigrator>();
+            }
+            else
+            {
+                services.AddSingleton<IColumnResetMigrator, NoOpColumnResetMigrator>();
+            }
+
+            return services;
+        }
+    }
+}

--- a/src/EventLogExpert.Runtime/LogTable/NoOpColumnResetMigrator.cs
+++ b/src/EventLogExpert.Runtime/LogTable/NoOpColumnResetMigrator.cs
@@ -1,0 +1,11 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.LogTable;
+
+internal sealed class NoOpColumnResetMigrator : IColumnResetMigrator
+{
+    public void RunMigration() { }
+
+    public bool ShouldRunMigration() => false;
+}

--- a/src/EventLogExpert.Runtime/LogTable/ResolvedEventGroupKey.cs
+++ b/src/EventLogExpert.Runtime/LogTable/ResolvedEventGroupKey.cs
@@ -12,6 +12,7 @@ public static class ResolvedEventGroupKey
     public static string For(ColumnName column, ResolvedEvent @event) =>
         column switch
         {
+            ColumnName.RecordId => @event.RecordId?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
             ColumnName.Level => @event.Level ?? string.Empty,
             ColumnName.DateAndTime => @event.TimeCreated.Ticks.ToString(CultureInfo.InvariantCulture),
             ColumnName.ActivityId => @event.ActivityId?.ToString("D", CultureInfo.InvariantCulture) ?? string.Empty,

--- a/src/EventLogExpert.Runtime/LogTable/ResolvedEventOrdering.cs
+++ b/src/EventLogExpert.Runtime/LogTable/ResolvedEventOrdering.cs
@@ -32,6 +32,8 @@ internal static class ResolvedEventOrdering
         (a, b) => WithTieBreaker(Nullable.Compare(a.ThreadId, b.ThreadId), a, b);
     private static readonly Comparison<ResolvedEvent> s_ascByUser =
         (a, b) => WithTieBreaker(string.Compare(a.UserId?.Value, b.UserId?.Value, StringComparison.Ordinal), a, b);
+    private static readonly Comparison<ResolvedEvent> s_ascByRecordId =
+        (a, b) => WithTieBreaker(Nullable.Compare(a.RecordId, b.RecordId), a, b);
     private static readonly Comparison<ResolvedEvent> s_ascByDefault =
         (a, b) => FallbackTieBreaker(Nullable.Compare(a.RecordId, b.RecordId), a, b);
 
@@ -44,6 +46,7 @@ internal static class ResolvedEventOrdering
     private static readonly Comparison<ResolvedEvent> s_descByLevel = (a, b) => s_ascByLevel(b, a);
     private static readonly Comparison<ResolvedEvent> s_descByLog = (a, b) => s_ascByLog(b, a);
     private static readonly Comparison<ResolvedEvent> s_descByProcessId = (a, b) => s_ascByProcessId(b, a);
+    private static readonly Comparison<ResolvedEvent> s_descByRecordId = (a, b) => s_ascByRecordId(b, a);
     private static readonly Comparison<ResolvedEvent> s_descBySource = (a, b) => s_ascBySource(b, a);
     private static readonly Comparison<ResolvedEvent> s_descByTaskCategory = (a, b) => s_ascByTaskCategory(b, a);
     private static readonly Comparison<ResolvedEvent> s_descByThreadId = (a, b) => s_ascByThreadId(b, a);
@@ -66,6 +69,7 @@ internal static class ResolvedEventOrdering
     internal static int CompareColumn(ResolvedEvent a, ResolvedEvent b, ColumnName column) =>
         column switch
         {
+            ColumnName.RecordId => Nullable.Compare(a.RecordId, b.RecordId),
             ColumnName.Level => string.Compare(a.Level ?? string.Empty, b.Level ?? string.Empty, StringComparison.Ordinal),
             ColumnName.DateAndTime => a.TimeCreated.CompareTo(b.TimeCreated),
             ColumnName.ActivityId => Nullable.Compare(a.ActivityId, b.ActivityId),
@@ -85,6 +89,7 @@ internal static class ResolvedEventOrdering
         isDescending
             ? orderBy switch
             {
+                ColumnName.RecordId => s_descByRecordId,
                 ColumnName.Level => s_descByLevel,
                 ColumnName.DateAndTime => s_descByDateAndTime,
                 ColumnName.ActivityId => s_descByActivityId,
@@ -101,6 +106,7 @@ internal static class ResolvedEventOrdering
             }
             : orderBy switch
             {
+                ColumnName.RecordId => s_ascByRecordId,
                 ColumnName.Level => s_ascByLevel,
                 ColumnName.DateAndTime => s_ascByDateAndTime,
                 ColumnName.ActivityId => s_ascByActivityId,

--- a/src/EventLogExpert.UI/LogTable/LogTablePane.razor
+++ b/src/EventLogExpert.UI/LogTable/LogTablePane.razor
@@ -21,6 +21,7 @@
                 <td aria-colindex="@(i + 1)" role="gridcell">
                     @switch (_enabledColumns[i])
                     {
+                        case ColumnName.RecordId: @evt.RecordId break;
                         case ColumnName.Level:
                             <span aria-hidden="true" class="@GetLevelClass(evt.Level)"></span>
                             @evt.Level

--- a/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
@@ -479,6 +479,7 @@ public sealed partial class LogTablePane
 
         string? value = _logTableState.GroupBy switch
         {
+            ColumnName.RecordId => representative.RecordId?.ToString(),
             ColumnName.Level => representative.Level,
             ColumnName.DateAndTime => representative.TimeCreated.ConvertTimeZone(_timeZoneSettings).ToString(),
             ColumnName.ActivityId => representative.ActivityId?.ToString(),

--- a/src/EventLogExpert.UI/Menu/MenuBar.razor.cs
+++ b/src/EventLogExpert.UI/Menu/MenuBar.razor.cs
@@ -112,6 +112,9 @@ public sealed partial class MenuBar
             MenuItem.Item("Copy Selected (Full)",
                 () => Actions.CopySelectedAsync(EventCopyFormat.Full),
                 defaultCopyFormat == EventCopyFormat.Full ? "Ctrl+C" : null),
+            MenuItem.Item("Copy Selected (Markdown)",
+                () => Actions.CopySelectedAsync(EventCopyFormat.Markdown),
+                defaultCopyFormat == EventCopyFormat.Markdown ? "Ctrl+C" : null),
         ];
     }
 

--- a/src/EventLogExpert/Adapters/Clipboard/MauiClipboardService.cs
+++ b/src/EventLogExpert/Adapters/Clipboard/MauiClipboardService.cs
@@ -20,6 +20,7 @@ namespace EventLogExpert.Adapters.Clipboard;
 
 public sealed class MauiClipboardService : IClipboardService
 {
+    private readonly IStateSelection<LogTableState, ImmutableList<ColumnName>> _columnOrder;
     private readonly IStateSelection<LogTableState, ImmutableDictionary<ColumnName, bool>> _eventTableColumns;
     private readonly IStateSelection<EventLogState, ResolvedEvent?> _selectedEvent;
     private readonly IStateSelection<EventLogState, ImmutableList<ResolvedEvent>> _selectedEvents;
@@ -29,6 +30,7 @@ public sealed class MauiClipboardService : IClipboardService
 
     public MauiClipboardService(
         IStateSelection<LogTableState, ImmutableDictionary<ColumnName, bool>> eventTableColumns,
+        IStateSelection<LogTableState, ImmutableList<ColumnName>> columnOrder,
         IStateSelection<EventLogState, ImmutableList<ResolvedEvent>> selectedEvents,
         IStateSelection<EventLogState, ResolvedEvent?> selectedEvent,
         ISettingsService settings,
@@ -36,6 +38,7 @@ public sealed class MauiClipboardService : IClipboardService
         ITraceLogger traceLogger)
     {
         _eventTableColumns = eventTableColumns;
+        _columnOrder = columnOrder;
         _selectedEvents = selectedEvents;
         _selectedEvent = selectedEvent;
         _settings = settings;
@@ -43,6 +46,7 @@ public sealed class MauiClipboardService : IClipboardService
         _traceLogger = traceLogger;
 
         _eventTableColumns.Select(s => s.Columns);
+        _columnOrder.Select(s => s.ColumnOrder);
         _selectedEvents.Select(s => s.SelectedEvents);
         _selectedEvent.Select(s => s.SelectedEvent);
     }
@@ -77,6 +81,13 @@ public sealed class MauiClipboardService : IClipboardService
             _traceLogger.Error($"{nameof(MauiClipboardService)}.{nameof(CopyTextAsync)}: failed: {ex}");
         }
     }
+
+    private static string EscapeMarkdownCell(string? value) =>
+        (value ?? string.Empty)
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\r", " ", StringComparison.Ordinal)
+            .Replace("\n", " ", StringComparison.Ordinal)
+            .Replace("|", "\\|", StringComparison.Ordinal);
 
     private static string FormatXmlForCopy(string xml)
     {
@@ -185,6 +196,38 @@ public sealed class MauiClipboardService : IClipboardService
         }
     }
 
+    private string BuildMarkdownTable(IReadOnlyList<ResolvedEvent> events)
+    {
+        var enabled = _eventTableColumns.Value;
+        var order = _columnOrder.Value;
+        var columns = (order.IsEmpty
+                ? enabled.Where(column => column.Value).Select(column => column.Key)
+                : order.Where(column => enabled.TryGetValue(column, out bool isEnabled) && isEnabled))
+            .ToList();
+
+        StringBuilder builder = new();
+
+        builder.Append("| ");
+        foreach (var column in columns) { builder.Append(EscapeMarkdownCell(column.ToFullString())).Append(" | "); }
+
+        builder.AppendLine("Description |");
+
+        builder.Append('|');
+        for (int separator = 0; separator <= columns.Count; separator++) { builder.Append(" --- |"); }
+
+        builder.AppendLine();
+
+        foreach (var @event in events)
+        {
+            builder.Append("| ");
+            foreach (var column in columns) { builder.Append(EscapeMarkdownCell(GetColumnText(column, @event))).Append(" | "); }
+
+            builder.Append(EscapeMarkdownCell(@event.Description)).AppendLine(" |");
+        }
+
+        return builder.ToString().TrimEnd();
+    }
+
     private string FormatEventForCopy(EventCopyFormat format, ResolvedEvent @event, string xml)
     {
         if (format == EventCopyFormat.Xml)
@@ -199,6 +242,25 @@ public sealed class MauiClipboardService : IClipboardService
         return builder.ToString();
     }
 
+    private string GetColumnText(ColumnName column, ResolvedEvent @event) =>
+        column switch
+        {
+            ColumnName.Level => @event.Level,
+            ColumnName.DateAndTime => @event.TimeCreated.ConvertTimeZone(_settings.TimeZoneInfo).ToString(),
+            ColumnName.ActivityId => @event.ActivityId?.ToString() ?? string.Empty,
+            ColumnName.Log => GetLogShortName(@event.OwningLog),
+            ColumnName.ComputerName => @event.ComputerName,
+            ColumnName.Source => @event.Source,
+            ColumnName.EventId => @event.Id.ToString(),
+            ColumnName.TaskCategory => @event.TaskCategory,
+            ColumnName.Keywords => @event.KeywordsDisplayName,
+            ColumnName.ProcessId => @event.ProcessId?.ToString() ?? string.Empty,
+            ColumnName.ThreadId => @event.ThreadId?.ToString() ?? string.Empty,
+            ColumnName.User => @event.UserId?.ToString() ?? string.Empty,
+            ColumnName.RecordId => @event.RecordId?.ToString() ?? string.Empty,
+            _ => string.Empty
+        };
+
     private async Task<string> GetFormattedEvent(EventCopyFormat? format)
     {
         // Snapshot the selection once. Re-reading _selectedEvents.Value across awaits could see
@@ -208,6 +270,15 @@ public sealed class MauiClipboardService : IClipboardService
         var selected = _selectedEvent.Value;
 
         var resolvedFormat = format ?? _settings.CopyFormat;
+
+        if (resolvedFormat == EventCopyFormat.Markdown)
+        {
+            IReadOnlyList<ResolvedEvent> markdownEvents =
+                events.IsEmpty ? (selected is null ? [] : [selected]) : events;
+
+            return markdownEvents.Count == 0 ? string.Empty : BuildMarkdownTable(markdownEvents);
+        }
+
         bool needsXml = resolvedFormat is EventCopyFormat.Xml or EventCopyFormat.Full;
 
         // Single-event copy: prefer the selected (focused) row so right-click → copy

--- a/src/EventLogExpert/Adapters/Clipboard/MauiClipboardService.cs
+++ b/src/EventLogExpert/Adapters/Clipboard/MauiClipboardService.cs
@@ -201,7 +201,7 @@ public sealed class MauiClipboardService : IClipboardService
         var enabled = _eventTableColumns.Value;
         var order = _columnOrder.Value;
         var columns = (order.IsEmpty
-                ? enabled.Where(column => column.Value).Select(column => column.Key)
+                ? enabled.Where(column => column.Value).Select(column => column.Key).OrderBy(column => column)
                 : order.Where(column => enabled.TryGetValue(column, out bool isEnabled) && isEnabled))
             .ToList();
 

--- a/src/EventLogExpert/Adapters/Clipboard/MauiClipboardService.cs
+++ b/src/EventLogExpert/Adapters/Clipboard/MauiClipboardService.cs
@@ -106,6 +106,9 @@ public sealed class MauiClipboardService : IClipboardService
                 {
                     switch (column)
                     {
+                        case ColumnName.RecordId:
+                            builder.Append($"\"{@event.RecordId}\" ");
+                            break;
                         case ColumnName.Level:
                             builder.Append($"\"{@event.Level}\" ");
                             break;

--- a/src/EventLogExpert/Adapters/Settings/LogTablePreferencesAdapter.cs
+++ b/src/EventLogExpert/Adapters/Settings/LogTablePreferencesAdapter.cs
@@ -8,9 +8,9 @@ namespace EventLogExpert.Adapters.Settings;
 
 internal sealed class LogTablePreferencesAdapter : ILogTablePreferencesProvider
 {
-    private const string ColumnOrder = "column-order";
-    private const string ColumnWidths = "column-widths";
-    private const string EnabledEventTableColumns = "enabled-event-table-columns";
+    private const string ColumnOrder = LogTablePreferenceKeys.ColumnOrder;
+    private const string ColumnWidths = LogTablePreferenceKeys.ColumnWidths;
+    private const string EnabledEventTableColumns = LogTablePreferenceKeys.EnabledEventTableColumns;
 
     public IEnumerable<ColumnName> ColumnOrderPreference
     {

--- a/src/EventLogExpert/MauiProgram.cs
+++ b/src/EventLogExpert/MauiProgram.cs
@@ -7,6 +7,7 @@ using EventLogExpert.Eventing.Resolvers;
 using EventLogExpert.Runtime.Banner;
 using EventLogExpert.Runtime.Common.Files;
 using EventLogExpert.Runtime.FilterLibrary;
+using EventLogExpert.Runtime.LogTable;
 using EventLogExpert.UI.Banner;
 using EventLogExpert.UI.Database;
 using Fluxor;
@@ -71,13 +72,15 @@ public static class MauiProgram
 
         builder.Services.AddFilterLibraryExport();
 
-        if (LegacyMigrationFeature.Enabled || BackslashMigrationFeature.Enabled)
+        if (LegacyMigrationFeature.Enabled || BackslashMigrationFeature.Enabled || ColumnResetMigrationFeature.Enabled)
         {
             builder.Services.AddSingleton<ILegacyPreferences, MauiLegacyPreferencesAdapter>();
         }
 
+        // TODO: Disable this in the next release build
         builder.Services.AddLegacyFilterMigration();
         builder.Services.AddBackslashNameMigration();
+        builder.Services.AddColumnResetMigration();
 
         // Top-level layer registration
         builder.Services.AddEventLogFiltering();

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/ColumnResetMigratorTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/ColumnResetMigratorTests.cs
@@ -1,0 +1,81 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.FilterLibrary;
+using EventLogExpert.Runtime.LogTable;
+using NSubstitute;
+
+namespace EventLogExpert.Runtime.Tests.LogTable;
+
+public sealed class ColumnResetMigratorTests
+{
+    private const string CompletionKey = "log-table-column-reset-migration-state";
+
+    [Fact]
+    public void RunMigration_ClearsNumericListPreferencesAndMarksComplete()
+    {
+        var preferences = Substitute.For<ILegacyPreferences>();
+        var sut = new ColumnResetMigrator(preferences, Substitute.For<ITraceLogger>());
+
+        sut.RunMigration();
+
+        preferences.Received(1).Remove(LogTablePreferenceKeys.EnabledEventTableColumns);
+        preferences.Received(1).Remove(LogTablePreferenceKeys.ColumnOrder);
+        preferences.Received(1).SetString(CompletionKey, "1");
+    }
+
+    [Fact]
+    public void RunMigration_DoesNotTouchNameKeyedWidths()
+    {
+        var preferences = Substitute.For<ILegacyPreferences>();
+        var sut = new ColumnResetMigrator(preferences, Substitute.For<ITraceLogger>());
+
+        sut.RunMigration();
+
+        preferences.DidNotReceive().Remove(LogTablePreferenceKeys.ColumnWidths);
+    }
+
+    [Fact]
+    public void RunMigration_WhenPreferenceStoreThrows_DoesNotThrowAndDoesNotMarkComplete()
+    {
+        var preferences = Substitute.For<ILegacyPreferences>();
+        preferences.When(p => p.Remove(Arg.Any<string>())).Do(_ => throw new InvalidOperationException("store failure"));
+        var sut = new ColumnResetMigrator(preferences, Substitute.For<ITraceLogger>());
+
+        var exception = Record.Exception(sut.RunMigration);
+
+        Assert.Null(exception);
+        preferences.DidNotReceive().SetString(CompletionKey, Arg.Any<string>());
+    }
+
+    [Fact]
+    public void ShouldRunMigration_WhenFlagAbsent_ReturnsTrue()
+    {
+        var preferences = Substitute.For<ILegacyPreferences>();
+        preferences.GetString(CompletionKey).Returns((string?)null);
+        var sut = new ColumnResetMigrator(preferences, Substitute.For<ITraceLogger>());
+
+        Assert.True(sut.ShouldRunMigration());
+    }
+
+    [Fact]
+    public void ShouldRunMigration_WhenFlagSet_ReturnsFalse()
+    {
+        var preferences = Substitute.For<ILegacyPreferences>();
+        preferences.GetString(CompletionKey).Returns("1");
+        var sut = new ColumnResetMigrator(preferences, Substitute.For<ITraceLogger>());
+
+        Assert.False(sut.ShouldRunMigration());
+    }
+
+    [Fact]
+    public void ShouldRunMigration_WhenReadThrows_ReturnsFalse()
+    {
+        var preferences = Substitute.For<ILegacyPreferences>();
+        preferences.GetString(CompletionKey).Returns(_ => throw new InvalidOperationException("store failure"));
+        var sut = new ColumnResetMigrator(preferences, Substitute.For<ITraceLogger>());
+
+        Assert.False(sut.ShouldRunMigration());
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/EffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/EffectsTests.cs
@@ -395,7 +395,7 @@ public sealed class EffectsTests
         var mockState = Substitute.For<IState<LogTableState>>();
         mockState.Value.Returns(state ?? new LogTableState());
 
-        var effects = new Effects(mockPreferencesProvider, mockState, s_columnDefaults);
+        var effects = new Effects(mockPreferencesProvider, mockState, s_columnDefaults, new NoOpColumnResetMigrator());
         var mockDispatcher = Substitute.For<IDispatcher>();
 
         return (effects, mockDispatcher, mockPreferencesProvider);

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/ResolvedEventGroupKeyTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/ResolvedEventGroupKeyTests.cs
@@ -97,6 +97,14 @@ public sealed class ResolvedEventGroupKeyTests
     }
 
     [Fact]
+    public void For_NullRecordId_IsEmptyBucket()
+    {
+        var evt = FilterEventBuilder.CreateTestEvent(recordId: null);
+
+        Assert.Equal(string.Empty, ResolvedEventGroupKey.For(ColumnName.RecordId, evt));
+    }
+
+    [Fact]
     public void For_NullThreadId_IsEmptyBucket()
     {
         var evt = FilterEventBuilder.CreateTestEvent(threadId: null);
@@ -118,6 +126,14 @@ public sealed class ResolvedEventGroupKeyTests
         var evt = FilterEventBuilder.CreateTestEvent(processId: 4096);
 
         Assert.Equal("4096", ResolvedEventGroupKey.For(ColumnName.ProcessId, evt));
+    }
+
+    [Fact]
+    public void For_RecordId_UsesInvariantNumber()
+    {
+        var evt = FilterEventBuilder.CreateTestEvent(recordId: 4096);
+
+        Assert.Equal("4096", ResolvedEventGroupKey.For(ColumnName.RecordId, evt));
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/ResolvedEventOrderingTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/ResolvedEventOrderingTests.cs
@@ -715,6 +715,40 @@ public sealed class ResolvedEventOrderingTests
     }
 
     [Fact]
+    public void SortEvents_WhenOrderByRecordId_ShouldSortByRecordId()
+    {
+        var events = new List<ResolvedEvent>
+        {
+            FilterEventBuilder.CreateTestEvent(recordId: 30),
+            FilterEventBuilder.CreateTestEvent(recordId: 10),
+            FilterEventBuilder.CreateTestEvent(recordId: 20)
+        };
+
+        var result = events.SortEvents(ColumnName.RecordId);
+
+        Assert.Equal(10, result[0].RecordId);
+        Assert.Equal(20, result[1].RecordId);
+        Assert.Equal(30, result[2].RecordId);
+    }
+
+    [Fact]
+    public void SortEvents_WhenOrderByRecordIdDescending_ShouldSortByRecordIdDescending()
+    {
+        var events = new List<ResolvedEvent>
+        {
+            FilterEventBuilder.CreateTestEvent(recordId: 10),
+            FilterEventBuilder.CreateTestEvent(recordId: 30),
+            FilterEventBuilder.CreateTestEvent(recordId: 20)
+        };
+
+        var result = events.SortEvents(ColumnName.RecordId, true);
+
+        Assert.Equal(30, result[0].RecordId);
+        Assert.Equal(20, result[1].RecordId);
+        Assert.Equal(10, result[2].RecordId);
+    }
+
+    [Fact]
     public void SortEvents_WhenOrderBySource_ShouldSortBySource()
     {
         // Arrange


### PR DESCRIPTION
## Summary

Adds two opt-in event-table features and the one-time column-preference migration they require.

## RecordId column (#584)

- Adds `RecordId` as an optional event-table column (hidden by default) with sort, group-by, render, and copy support.
- `ColumnName.RecordId` is placed at enum index 0 because RecordId is effectively the per-log record index. The two numeric-keyed column preferences (`enabled-event-table-columns` and `column-order`) serialize by enum position, so inserting at index 0 renumbers them.

## Column-preference reset migration

- A one-time, idempotent, crash-safe migration clears those two numeric-keyed preferences so they fall back to defaults after the renumber. The name-keyed `column-widths` dictionary serializes by name, is reorder-immune, and is left untouched.
- Follows the existing `BackslashMigrationFeature` pattern: feature flag + migrator/no-op + DI extension + completion key written last. Gated behind `ColumnResetMigrationFeature` with a documented staged-deletion path for when the migration is retired.

## Copy as Markdown (#585)

- Adds a "Copy Selected (Markdown)" command that emits a GitHub-flavored Markdown table of the selected events.
- Columns follow the visible column order; cell values are GFM-escaped (backslash, pipe, and newlines handled).

## Testing

- Runtime and UI unit-test suites pass.
- Solution builds with 0 warnings / 0 errors (`TreatWarningsAsErrors=true`).

Closes #584
Closes #585
