### PR TITLE
Add right-click filter actions on event-table cells

### DIFF
--- a/src/EventLogExpert.UI/LogTable/CellFilterBuilder.cs
+++ b/src/EventLogExpert.UI/LogTable/CellFilterBuilder.cs
@@ -1,0 +1,108 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Filtering.Basic;
+using EventLogExpert.Filtering.Common.Filtering;
+using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Runtime.LogTable;
+using System.Globalization;
+using FilterMode = EventLogExpert.Filtering.Evaluation.FilterMode;
+
+namespace EventLogExpert.UI.LogTable;
+
+internal static class CellFilterBuilder
+{
+    public static EventProperty? MapColumn(ColumnName column) =>
+        column switch
+        {
+            ColumnName.EventId => EventProperty.Id,
+            ColumnName.ActivityId => EventProperty.ActivityId,
+            ColumnName.Level => EventProperty.Level,
+            ColumnName.Keywords => EventProperty.Keywords,
+            ColumnName.Source => EventProperty.Source,
+            ColumnName.TaskCategory => EventProperty.TaskCategory,
+            ColumnName.ProcessId => EventProperty.ProcessId,
+            ColumnName.ThreadId => EventProperty.ThreadId,
+            ColumnName.User => EventProperty.UserId,
+            _ => null
+        };
+
+    public static bool TryBuild(ResolvedEvent @event, EventProperty property, bool exclude, out SavedFilter filter)
+    {
+        filter = SavedFilter.Empty;
+
+        if (BuildComparison(@event, property) is not { } comparison) { return false; }
+
+        var basicFilter = new BasicFilter(comparison, []);
+
+        if (!BasicFilterFormatter.TryFormat(basicFilter, out var comparisonText)) { return false; }
+
+        var saved = SavedFilter.TryCreate(
+            comparisonText,
+            basicFilter,
+            isExcluded: exclude,
+            isEnabled: true,
+            mode: FilterMode.Basic);
+
+        if (saved is null) { return false; }
+
+        filter = saved;
+
+        return true;
+    }
+
+    public static bool TryGetDisplayValue(ResolvedEvent @event, EventProperty property, out string value)
+    {
+        value = property switch
+        {
+            EventProperty.Id => @event.Id.ToString(CultureInfo.InvariantCulture),
+            EventProperty.ActivityId => @event.ActivityId?.ToString() ?? string.Empty,
+            EventProperty.Level => @event.Level,
+            EventProperty.Keywords => @event.KeywordsDisplayName,
+            EventProperty.Source => @event.Source,
+            EventProperty.TaskCategory => @event.TaskCategory,
+            EventProperty.ProcessId => @event.ProcessId?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
+            EventProperty.ThreadId => @event.ThreadId?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
+            EventProperty.UserId => @event.UserId?.Value ?? string.Empty,
+            _ => string.Empty
+        };
+
+        return !string.IsNullOrWhiteSpace(value);
+    }
+
+    private static FilterComparison? BuildComparison(ResolvedEvent @event, EventProperty property)
+    {
+        if (property == EventProperty.Keywords)
+        {
+            return @event.Keywords.Count switch
+            {
+                0 => null,
+                1 => new FilterComparison
+                {
+                    Property = EventProperty.Keywords,
+                    Operator = ComparisonOperator.Equals,
+                    MatchMode = MatchMode.Single,
+                    Value = @event.Keywords[0]
+                },
+                _ => new FilterComparison
+                {
+                    Property = EventProperty.Keywords,
+                    Operator = ComparisonOperator.Equals,
+                    MatchMode = MatchMode.Many,
+                    Values = [.. @event.Keywords]
+                }
+            };
+        }
+
+        if (!TryGetDisplayValue(@event, property, out var value)) { return null; }
+
+        return new FilterComparison
+        {
+            Property = property,
+            Operator = ComparisonOperator.Equals,
+            MatchMode = MatchMode.Single,
+            Value = value
+        };
+    }
+}

--- a/src/EventLogExpert.UI/LogTable/LogTablePane.razor
+++ b/src/EventLogExpert.UI/LogTable/LogTablePane.razor
@@ -18,8 +18,13 @@
              tabindex="0">
             @for (int i = 0; i < _enabledColumns.Length; i++)
             {
-                <td aria-colindex="@(i + 1)" role="gridcell">
-                    @switch (_enabledColumns[i])
+                var capturedColumn = _enabledColumns[i];
+                <td aria-colindex="@(i + 1)"
+                    @oncontextmenu="@(args => InvokeCellContextMenu(args, evt, capturedColumn))"
+                    @oncontextmenu:preventDefault="true"
+                    @oncontextmenu:stopPropagation="true"
+                    role="gridcell">
+                    @switch (capturedColumn)
                     {
                         case ColumnName.RecordId: @evt.RecordId break;
                         case ColumnName.Level:
@@ -41,7 +46,13 @@
                 </td>
             }
 
-            <td aria-colindex="@(_enabledColumns.Length + 1)" role="gridcell">@evt.Description</td>
+            <td aria-colindex="@(_enabledColumns.Length + 1)"
+                @oncontextmenu="@(args => InvokeCellContextMenu(args, evt, null))"
+                @oncontextmenu:preventDefault="true"
+                @oncontextmenu:stopPropagation="true"
+                role="gridcell">
+                @evt.Description
+            </td>
         </tr>;
 }
 

--- a/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
@@ -3,7 +3,6 @@
 
 using EventLogExpert.Eventing.Common.EventLogs;
 using EventLogExpert.Eventing.Common.Events;
-using EventLogExpert.Filtering.Basic;
 using EventLogExpert.Filtering.Common.Filtering;
 using EventLogExpert.Filtering.Compilation;
 using EventLogExpert.Filtering.Evaluation;
@@ -23,13 +22,14 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
 using System.Collections.Immutable;
-using FilterMode = EventLogExpert.Filtering.Evaluation.FilterMode;
 
 namespace EventLogExpert.UI.LogTable;
 
 public sealed partial class LogTablePane
 {
     private const int DefaultPageSize = 20;
+    private const int MenuValueMaxLength = 40;
+    private const string NoCellValueReason = "No value in this cell to filter on";
 
     private static readonly HashSet<int> s_warnedUnknownColors = [];
 
@@ -301,6 +301,56 @@ public sealed partial class LogTablePane
         return null;
     }
 
+    private static string TruncateForMenu(string value)
+    {
+        string collapsed = value.ReplaceLineEndings(" ");
+
+        if (collapsed.Length <= MenuValueMaxLength) { return collapsed; }
+
+        int limit = char.IsHighSurrogate(collapsed[MenuValueMaxLength - 1])
+            ? MenuValueMaxLength - 1
+            : MenuValueMaxLength;
+
+        return collapsed[..limit] + "...";
+    }
+
+    private void AppendCellFilterItems(List<MenuItem> items, ResolvedEvent @event, ColumnName? column)
+    {
+        if (column is not { } cellColumn) { return; }
+
+        if (CellFilterBuilder.MapColumn(cellColumn) is not { } property) { return; }
+
+        string columnLabel = cellColumn.ToFullString();
+
+        if (CellFilterBuilder.TryGetDisplayValue(@event, property, out var value))
+        {
+            string shown = TruncateForMenu(value);
+            string verb = property is EventProperty.Keywords ? "has" : "=";
+
+            items.Add(MenuItem.Item(
+                $"Include only where {columnLabel} {verb} '{shown}'",
+                () => ApplySelectedFilter(@event, property, exclude: false)));
+            items.Add(MenuItem.Item(
+                $"Exclude where {columnLabel} {verb} '{shown}'",
+                () => ApplySelectedFilter(@event, property, exclude: true)));
+        }
+        else
+        {
+            items.Add(MenuItem.Item(
+                $"Include only where {columnLabel}",
+                () => { },
+                isEnabled: false,
+                disabledReason: NoCellValueReason));
+            items.Add(MenuItem.Item(
+                $"Exclude where {columnLabel}",
+                () => { },
+                isEnabled: false,
+                disabledReason: NoCellValueReason));
+        }
+
+        items.Add(MenuItem.Separator());
+    }
+
     private void ApplyNavSelection(IReadOnlyList<ResolvedEvent> displayedEvents, ResolvedEvent targetEvent, bool shift)
     {
         if (shift)
@@ -319,39 +369,10 @@ public sealed partial class LogTablePane
 
     private void ApplySelectedFilter(ResolvedEvent selectedEvent, EventProperty property, bool exclude)
     {
-        string filterValue = property switch
+        if (CellFilterBuilder.TryBuild(selectedEvent, property, exclude, out var filter))
         {
-            EventProperty.Id => selectedEvent.Id.ToString(),
-            EventProperty.ActivityId => selectedEvent.ActivityId?.ToString() ?? string.Empty,
-            EventProperty.Level => selectedEvent.Level,
-            EventProperty.Keywords => selectedEvent.KeywordsDisplayName,
-            EventProperty.Source => selectedEvent.Source,
-            EventProperty.TaskCategory => selectedEvent.TaskCategory,
-            _ => string.Empty,
-        };
-
-        var basicFilter = new BasicFilter(
-            new FilterComparison
-            {
-                Property = property,
-                Value = filterValue,
-                Operator = ComparisonOperator.Equals,
-                MatchMode = MatchMode.Single,
-            },
-            []);
-
-        if (!BasicFilterFormatter.TryFormat(basicFilter, out var comparisonString)) { return; }
-
-        var filter = SavedFilter.TryCreate(
-            comparisonString,
-            basicFilter,
-            isExcluded: exclude,
-            isEnabled: true,
-            mode: FilterMode.Basic);
-
-        if (filter is null) { return; }
-
-        FilterPaneCommands.SetFilter(filter);
+            FilterPaneCommands.SetFilter(filter);
+        }
     }
 
     private IReadOnlyList<ResolvedEvent> BuildRange(
@@ -732,6 +753,16 @@ public sealed partial class LogTablePane
             "./_content/EventLogExpert.UI/LogTable/LogTablePane.razor.js");
 
         await _tableModule.InvokeVoidAsync("initializeTableEvents", _dotNetRef);
+    }
+
+    private void InvokeCellContextMenu(MouseEventArgs args, ResolvedEvent @event, ColumnName? column)
+    {
+        var items = new List<MenuItem>();
+
+        AppendCellFilterItems(items, @event, column);
+        items.AddRange(ShowContextMenuItems(@event));
+
+        MenuService.OpenAt(args.ClientX, args.ClientY, items);
     }
 
     private void InvokeContextMenu(MouseEventArgs args)
@@ -1244,8 +1275,12 @@ public sealed partial class LogTablePane
                 FilterPaneCommands.SetFilterDateRange(
                     new DateFilter { After = selectedEvent.TimeCreated })),
             MenuItem.Separator(),
-            MenuItem.SubMenu("Include", ShowEventFieldItems(selectedEvent, false)),
-            MenuItem.SubMenu("Exclude", ShowEventFieldItems(selectedEvent, true)),
+            MenuItem.SubMenu(
+                "More Fields",
+                [
+                    MenuItem.SubMenu("Include", ShowEventFieldItems(selectedEvent, false)),
+                    MenuItem.SubMenu("Exclude", ShowEventFieldItems(selectedEvent, true)),
+                ]),
         ];
     }
 
@@ -1258,9 +1293,13 @@ public sealed partial class LogTablePane
             if (property is EventProperty.Description or EventProperty.Xml) { continue; }
 
             var capturedProperty = property;
+            bool hasValue = CellFilterBuilder.TryGetDisplayValue(selectedEvent, property, out _);
+
             items.Add(MenuItem.Item(
                 property.ToFullString(),
-                () => ApplySelectedFilter(selectedEvent, capturedProperty, exclude)));
+                () => ApplySelectedFilter(selectedEvent, capturedProperty, exclude),
+                isEnabled: hasValue,
+                disabledReason: hasValue ? null : NoCellValueReason));
         }
 
         return items;

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/CellFilterBuilderTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/CellFilterBuilderTests.cs
@@ -1,0 +1,183 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Filtering.Common.Filtering;
+using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.UI.LogTable;
+using System.Security.Principal;
+
+namespace EventLogExpert.UI.Tests.LogTable;
+
+public sealed class CellFilterBuilderTests
+{
+    private static readonly Guid s_activityId = Guid.Parse("11111111-2222-3333-4444-555555555555");
+    private static readonly SecurityIdentifier s_userSid = new("S-1-5-21-1111111111-2222222222-3333333333-1001");
+
+    [Theory]
+    [InlineData(ColumnName.EventId, EventProperty.Id)]
+    [InlineData(ColumnName.ActivityId, EventProperty.ActivityId)]
+    [InlineData(ColumnName.Level, EventProperty.Level)]
+    [InlineData(ColumnName.Keywords, EventProperty.Keywords)]
+    [InlineData(ColumnName.Source, EventProperty.Source)]
+    [InlineData(ColumnName.TaskCategory, EventProperty.TaskCategory)]
+    [InlineData(ColumnName.ProcessId, EventProperty.ProcessId)]
+    [InlineData(ColumnName.ThreadId, EventProperty.ThreadId)]
+    [InlineData(ColumnName.User, EventProperty.UserId)]
+    public void MapColumn_SupportedColumn_ReturnsProperty(ColumnName column, EventProperty expected) =>
+        Assert.Equal(expected, CellFilterBuilder.MapColumn(column));
+
+    [Theory]
+    [InlineData(ColumnName.DateAndTime)]
+    [InlineData(ColumnName.Log)]
+    [InlineData(ColumnName.ComputerName)]
+    public void MapColumn_UnsupportedColumn_ReturnsNull(ColumnName column) =>
+        Assert.Null(CellFilterBuilder.MapColumn(column));
+
+    [Fact]
+    public void TryBuild_ActivityId_MatchesSameGuidButNotDifferent()
+    {
+        var sourceEvent = FullEvent();
+        var otherEvent = FullEvent() with { ActivityId = Guid.NewGuid() };
+
+        Assert.True(CellFilterBuilder.TryBuild(sourceEvent, EventProperty.ActivityId, exclude: false, out var filter));
+        Assert.True(filter.Compiled!.Predicate(sourceEvent));
+        Assert.False(filter.Compiled!.Predicate(otherEvent));
+    }
+
+    [Fact]
+    public void TryBuild_Exclude_SetsIsExcludedAndPredicateStillMatchesSource()
+    {
+        var sourceEvent = FullEvent();
+
+        Assert.True(CellFilterBuilder.TryBuild(sourceEvent, EventProperty.Source, exclude: true, out var filter));
+        Assert.True(filter.IsExcluded);
+        Assert.True(filter.Compiled!.Predicate(sourceEvent));
+    }
+
+    [Theory]
+    [InlineData(EventProperty.Id)]
+    [InlineData(EventProperty.ActivityId)]
+    [InlineData(EventProperty.Level)]
+    [InlineData(EventProperty.Keywords)]
+    [InlineData(EventProperty.Source)]
+    [InlineData(EventProperty.TaskCategory)]
+    [InlineData(EventProperty.ProcessId)]
+    [InlineData(EventProperty.ThreadId)]
+    [InlineData(EventProperty.UserId)]
+    public void TryBuild_IncludeFilter_MatchesSourceEvent(EventProperty property)
+    {
+        var sourceEvent = FullEvent();
+
+        Assert.True(CellFilterBuilder.TryBuild(sourceEvent, property, exclude: false, out var filter));
+        Assert.False(filter.IsExcluded);
+        Assert.NotNull(filter.Compiled);
+        Assert.True(filter.Compiled!.Predicate(sourceEvent));
+    }
+
+    [Fact]
+    public void TryBuild_MultipleKeywords_MatchesAnyOfThem()
+    {
+        var sourceEvent = FullEvent() with { Keywords = ["Classic", "Audit Success"] };
+        var sharesOneKeyword = FullEvent() with { Keywords = ["Audit Success"] };
+        var sharesNoKeyword = FullEvent() with { Keywords = ["Audit Failure"] };
+
+        Assert.True(CellFilterBuilder.TryBuild(sourceEvent, EventProperty.Keywords, exclude: false, out var filter));
+        Assert.True(filter.Compiled!.Predicate(sourceEvent));
+        Assert.True(filter.Compiled!.Predicate(sharesOneKeyword));
+        Assert.False(filter.Compiled!.Predicate(sharesNoKeyword));
+    }
+
+    [Fact]
+    public void TryBuild_ProcessId_DoesNotMatchEventWithDifferentValue()
+    {
+        var sourceEvent = FullEvent() with { ProcessId = 111 };
+        var otherEvent = FullEvent() with { ProcessId = 999 };
+
+        Assert.True(CellFilterBuilder.TryBuild(sourceEvent, EventProperty.ProcessId, exclude: false, out var filter));
+        Assert.True(filter.Compiled!.Predicate(sourceEvent));
+        Assert.False(filter.Compiled!.Predicate(otherEvent));
+    }
+
+    [Fact]
+    public void TryBuild_SingleKeyword_MatchesThatKeyword()
+    {
+        var sourceEvent = FullEvent() with { Keywords = ["Audit Success"] };
+
+        Assert.True(CellFilterBuilder.TryBuild(sourceEvent, EventProperty.Keywords, exclude: false, out var filter));
+        Assert.True(filter.Compiled!.Predicate(sourceEvent));
+    }
+
+    [Fact]
+    public void TryBuild_Source_ProducesComparisonTextReadableInAdvancedEditor()
+    {
+        var sourceEvent = FullEvent() with { Source = "Service Control Manager" };
+
+        Assert.True(CellFilterBuilder.TryBuild(sourceEvent, EventProperty.Source, exclude: false, out var filter));
+        Assert.Equal("Source == \"Service Control Manager\"", filter.ComparisonText);
+    }
+
+    [Fact]
+    public void TryBuild_UserId_MatchesSameSidButNotDifferentSid()
+    {
+        var sourceEvent = FullEvent();
+        var otherEvent = FullEvent() with { UserId = new SecurityIdentifier("S-1-5-18") };
+
+        Assert.True(CellFilterBuilder.TryBuild(sourceEvent, EventProperty.UserId, exclude: false, out var filter));
+        Assert.True(filter.Compiled!.Predicate(sourceEvent));
+        Assert.False(filter.Compiled!.Predicate(otherEvent));
+    }
+
+    [Theory]
+    [InlineData(EventProperty.ActivityId)]
+    [InlineData(EventProperty.UserId)]
+    [InlineData(EventProperty.ProcessId)]
+    [InlineData(EventProperty.ThreadId)]
+    [InlineData(EventProperty.Level)]
+    [InlineData(EventProperty.Keywords)]
+    public void TryBuild_WhenCellHasNoValue_ReturnsFalse(EventProperty property)
+    {
+        var emptyEvent = EmptyFor(property);
+
+        Assert.False(CellFilterBuilder.TryBuild(emptyEvent, property, exclude: false, out _));
+    }
+
+    [Theory]
+    [InlineData(EventProperty.ProcessId)]
+    [InlineData(EventProperty.ThreadId)]
+    [InlineData(EventProperty.UserId)]
+    public void TryGetDisplayValue_PreviouslyUnmappedProperties_ReturnNonEmptyValue(EventProperty property)
+    {
+        Assert.True(CellFilterBuilder.TryGetDisplayValue(FullEvent(), property, out var value));
+        Assert.False(string.IsNullOrWhiteSpace(value));
+    }
+
+    private static ResolvedEvent EmptyFor(EventProperty property) =>
+        property switch
+        {
+            EventProperty.ActivityId => FullEvent() with { ActivityId = null },
+            EventProperty.UserId => FullEvent() with { UserId = null },
+            EventProperty.ProcessId => FullEvent() with { ProcessId = null },
+            EventProperty.ThreadId => FullEvent() with { ThreadId = null },
+            EventProperty.Level => FullEvent() with { Level = string.Empty },
+            EventProperty.Keywords => FullEvent() with { Keywords = [] },
+            _ => FullEvent()
+        };
+
+    private static ResolvedEvent FullEvent() =>
+        new("Application", LogPathType.Channel)
+        {
+            Id = 4242,
+            ActivityId = s_activityId,
+            Level = "Warning",
+            Source = "TestSource",
+            TaskCategory = "TestCategory",
+            Keywords = ["AuditKeyword"],
+            ProcessId = 111,
+            ThreadId = 222,
+            UserId = s_userSid,
+            ComputerName = "TEST-PC",
+            Description = "test description"
+        };
+}


### PR DESCRIPTION
## Summary

Right-clicking an event-table cell now offers one-click **Include only where {Column} = {value}** and **Exclude where {Column} = {value}** actions that append a Basic filter.

## Changes

- Cell-aware Include/Exclude items at the top of the row context menu, scoped to the right-clicked cell. The actions use the clicked row directly rather than the focused selection, which avoids a stale-selection mismatch when right-clicking an unselected row.
- The previous two all-fields Include/Exclude submenus are consolidated under a single **More Fields** submenu, so filtering by a field whose column is hidden remains available (and keyboard-accessible).
- New `CellFilterBuilder` centralizes the `ColumnName` to `EventProperty` mapping, value extraction, and Basic-filter construction.
- Fixes a latent bug where the Process ID / Thread ID / User ID menu items produced an empty value and silently applied no filter.
- Empty/null cells show an informative disabled item. Multi-keyword cells use any-of semantics. Unsupported columns (Date and Time, Log, Computer Name) expose no cell action. Long values are truncated in the label, while the full value is used in the filter.
- No filter-engine change was needed: the emitter already handles nullable int/Guid fields, so the generated filters round-trip.

## Testing

- New `CellFilterBuilderTests` build each filter and evaluate the compiled predicate against the source event, covering Process ID / Thread ID, User SID, Activity GUID, and single/multi keyword round-trips, plus negative (empty-value) cases.
- UI unit tests pass (745). Solution builds with 0 warnings / 0 errors.

Closes #586
