### PR TITLE
Optimize large event-log loading with segmented merge, interning and coalesced updates

### DIFF
--- a/src/EventLogExpert.Eventing/Resolvers/EventResolverBase.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/EventResolverBase.cs
@@ -117,14 +117,17 @@ public class EventResolverBase : IDisposable
         ProviderDetails? details,
         ProviderDetails? descriptionDetails,
         ProviderDetails? supplemental,
-        EventModel? supplementalModernEvent) =>
-        new(eventRecord.PathName, eventRecord.LogPathType)
+        EventModel? supplementalModernEvent)
+    {
+        var keywords = _taskKeywords.ResolveKeywords(eventRecord, details, supplemental);
+
+        return new(eventRecord.PathName, eventRecord.LogPathType)
         {
             ActivityId = eventRecord.ActivityId,
             ComputerName = _cache?.GetOrAddValue(eventRecord.ComputerName) ?? eventRecord.ComputerName,
             Description = _descriptions.Resolve(eventRecord, details, descriptionDetails, modernEvent, supplemental, supplementalModernEvent),
             Id = eventRecord.Id,
-            Keywords = _taskKeywords.ResolveKeywords(eventRecord, details, supplemental),
+            Keywords = _cache?.GetOrAddKeywords(keywords) ?? keywords,
             Level = SeverityFormatter.Format(eventRecord.Level),
             LogName = _cache?.GetOrAddValue(eventRecord.LogName) ?? eventRecord.LogName,
             ProcessId = eventRecord.ProcessId,
@@ -133,7 +136,8 @@ public class EventResolverBase : IDisposable
             TaskCategory = _taskKeywords.ResolveTaskName(eventRecord, details, modernEvent, supplemental, supplementalModernEvent),
             ThreadId = eventRecord.ThreadId,
             TimeCreated = eventRecord.TimeCreated,
-            UserId = eventRecord.UserId,
+            UserId = _cache?.GetOrAddSid(eventRecord.UserId) ?? eventRecord.UserId,
             Xml = eventRecord.Xml ?? string.Empty
         };
+    }
 }

--- a/src/EventLogExpert.Eventing/Resolvers/EventResolverCache.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/EventResolverCache.cs
@@ -2,23 +2,76 @@
 // // Licensed under the MIT License.
 
 using System.Collections.Concurrent;
+using System.Security.Principal;
 
 namespace EventLogExpert.Eventing.Resolvers;
 
 public sealed class EventResolverCache : IEventResolverCache
 {
     private readonly ConcurrentDictionary<string, string> _descriptionCache = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<IReadOnlyList<string>, IReadOnlyList<string>> _keywordsCache = new(KeywordListComparer.Instance);
+    private readonly ConcurrentDictionary<SecurityIdentifier, SecurityIdentifier> _sidCache = new();
     private readonly ConcurrentDictionary<string, string> _valueCache = new(StringComparer.Ordinal);
 
     public void ClearAll()
     {
         _descriptionCache.Clear();
+        _keywordsCache.Clear();
+        _sidCache.Clear();
         _valueCache.Clear();
     }
 
     /// <summary>Returns the description if it exists in the cache, otherwise adds it to the cache and returns it.</summary>
     public string GetOrAddDescription(string description) => _descriptionCache.GetOrAdd(description, static key => key);
 
+    /// <summary>Returns a shared list with the same contents, adding a frozen copy to the cache on first sight.</summary>
+    public IReadOnlyList<string> GetOrAddKeywords(IReadOnlyList<string> keywords)
+    {
+        if (keywords.Count == 0) { return []; }
+
+        if (_keywordsCache.TryGetValue(keywords, out var existing)) { return existing; }
+
+        // Freeze to an array on miss so a caller that later mutates its list can't corrupt the cached key.
+        string[] frozen = [.. keywords];
+
+        return _keywordsCache.GetOrAdd(frozen, frozen);
+    }
+
+    /// <summary>Returns a shared identifier equal to the input, adding it to the cache on first sight.</summary>
+    public SecurityIdentifier? GetOrAddSid(SecurityIdentifier? sid) =>
+        sid is null ? null : _sidCache.GetOrAdd(sid, static key => key);
+
     /// <summary>Returns the value if it exists in the cache, otherwise adds it to the cache and returns it.</summary>
     public string GetOrAddValue(string value) => _valueCache.GetOrAdd(value, static key => key);
+
+    private sealed class KeywordListComparer : IEqualityComparer<IReadOnlyList<string>>
+    {
+        public static readonly KeywordListComparer Instance = new();
+
+        public bool Equals(IReadOnlyList<string>? x, IReadOnlyList<string>? y)
+        {
+            if (ReferenceEquals(x, y)) { return true; }
+
+            if (x is null || y is null || x.Count != y.Count) { return false; }
+
+            for (int i = 0; i < x.Count; i++)
+            {
+                if (!StringComparer.Ordinal.Equals(x[i], y[i])) { return false; }
+            }
+
+            return true;
+        }
+
+        public int GetHashCode(IReadOnlyList<string> obj)
+        {
+            var hash = new HashCode();
+
+            for (int i = 0; i < obj.Count; i++)
+            {
+                hash.Add(obj[i], StringComparer.Ordinal);
+            }
+
+            return hash.ToHashCode();
+        }
+    }
 }

--- a/src/EventLogExpert.Eventing/Resolvers/IEventResolverCache.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/IEventResolverCache.cs
@@ -1,6 +1,8 @@
 ﻿// // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using System.Security.Principal;
+
 namespace EventLogExpert.Eventing.Resolvers;
 
 public interface IEventResolverCache
@@ -8,6 +10,10 @@ public interface IEventResolverCache
     void ClearAll();
 
     string GetOrAddDescription(string description);
+
+    IReadOnlyList<string> GetOrAddKeywords(IReadOnlyList<string> keywords);
+
+    SecurityIdentifier? GetOrAddSid(SecurityIdentifier? sid);
 
     string GetOrAddValue(string value);
 }

--- a/src/EventLogExpert.Runtime/DependencyInjection/RuntimeServiceCollectionExtensions.cs
+++ b/src/EventLogExpert.Runtime/DependencyInjection/RuntimeServiceCollectionExtensions.cs
@@ -134,6 +134,7 @@ public static class RuntimeServiceCollectionExtensions
             // Shared coordination state for EventLog effects classes.
             services.AddSingleton<LogCloseCoordinator>();
             services.AddSingleton<EventLogConcurrencyState>();
+            services.AddSingleton<PartialLoadCoordinator>();
 
             // UI capabilities.
             services.AddSingleton<IHighlightSelector, HighlightSelector>();

--- a/src/EventLogExpert.Runtime/EventLog/LogReloadEffects.cs
+++ b/src/EventLogExpert.Runtime/EventLog/LogReloadEffects.cs
@@ -13,9 +13,11 @@ namespace EventLogExpert.Runtime.EventLog;
 internal sealed class LogReloadEffects(
     IState<EventLogState> eventLogState,
     IFilterService filterService,
-    LogCloseCoordinator closeCoordinator)
+    LogCloseCoordinator closeCoordinator,
+    PartialLoadCoordinator coordinator)
 {
     private readonly LogCloseCoordinator _closeCoordinator = closeCoordinator;
+    private readonly PartialLoadCoordinator _coordinator = coordinator;
     private readonly IState<EventLogState> _eventLogState = eventLogState;
     private readonly IFilterService _filterService = filterService;
 
@@ -23,6 +25,8 @@ internal sealed class LogReloadEffects(
     public Task HandleLoadEvents(LoadEventsAction action, IDispatcher dispatcher)
     {
         var filteredEvents = _filterService.GetFilteredEvents(action.Events, _eventLogState.Value.AppliedFilter);
+
+        _coordinator.MarkFinalized(action.LogData.Id);
 
         dispatcher.Dispatch(new UpdateTableAction(action.LogData.Id, filteredEvents));
 
@@ -54,7 +58,7 @@ internal sealed class LogReloadEffects(
     {
         var filteredEvents = _filterService.GetFilteredEvents(action.Events, _eventLogState.Value.AppliedFilter);
 
-        dispatcher.Dispatch(new AppendTableEventsAction(action.LogData.Id, filteredEvents));
+        _coordinator.Enqueue(action.LogData.Id, filteredEvents);
 
         return Task.CompletedTask;
     }

--- a/src/EventLogExpert.Runtime/EventLog/OpenLogEffects.cs
+++ b/src/EventLogExpert.Runtime/EventLog/OpenLogEffects.cs
@@ -31,7 +31,8 @@ internal sealed class OpenLogEffects(
     IDatabaseService databaseService,
     ICriticalErrorService criticalErrorService,
     LogCloseCoordinator closeCoordinator,
-    EventLogConcurrencyState concurrencyState)
+    EventLogConcurrencyState concurrencyState,
+    PartialLoadCoordinator coordinator)
 {
     private static readonly int s_maxGlobalConcurrency = Math.Max(1, Environment.ProcessorCount - 1);
     private static readonly SemaphoreSlim s_resolutionThrottle = new(s_maxGlobalConcurrency, s_maxGlobalConcurrency);
@@ -39,6 +40,7 @@ internal sealed class OpenLogEffects(
     private readonly ICriticalErrorService _criticalErrorService = criticalErrorService;
     private readonly LogCloseCoordinator _closeCoordinator = closeCoordinator;
     private readonly EventLogConcurrencyState _concurrencyState = concurrencyState;
+    private readonly PartialLoadCoordinator _coordinator = coordinator;
     private readonly IDatabaseService _databaseService = databaseService;
     private readonly IState<EventLogState> _eventLogState = eventLogState;
     private readonly Lock _globalCtsLock = new();
@@ -58,6 +60,8 @@ internal sealed class OpenLogEffects(
     {
         _logger.Trace($"{nameof(HandleCloseAll)} requested ({_eventLogState.Value.ActiveLogs.Count} active logs).");
 
+        _coordinator.DiscardAll();
+
         _concurrencyState.InvalidateInFlightFilters();
         _concurrencyState.InvalidateInFlightReloads();
 
@@ -75,6 +79,8 @@ internal sealed class OpenLogEffects(
     public async Task HandleCloseLog(CloseLogAction action, IDispatcher dispatcher)
     {
         _logger.Trace($"{nameof(HandleCloseLog)} requested for '{action.LogName}' (id: {action.LogId}).");
+
+        _coordinator.Discard(action.LogId);
 
         try
         {

--- a/src/EventLogExpert.Runtime/EventLog/PartialLoadCoordinator.cs
+++ b/src/EventLogExpert.Runtime/EventLog/PartialLoadCoordinator.cs
@@ -1,0 +1,118 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Runtime.LogTable;
+using IDispatcher = Fluxor.IDispatcher;
+
+namespace EventLogExpert.Runtime.EventLog;
+
+internal sealed class PartialLoadCoordinator : IDisposable
+{
+    private static readonly TimeSpan s_flushWindow = TimeSpan.FromMilliseconds(1000);
+
+    private readonly Dictionary<EventLogId, List<ResolvedEvent>> _buffers = [];
+    private readonly IDispatcher _dispatcher;
+    private readonly HashSet<EventLogId> _finalized = [];
+    private readonly Lock _gate = new();
+    private readonly HashSet<EventLogId> _seen = [];
+    private readonly Timer _timer;
+
+    private bool _disposed;
+
+    public PartialLoadCoordinator(IDispatcher dispatcher) : this(dispatcher, s_flushWindow) { }
+
+    internal PartialLoadCoordinator(IDispatcher dispatcher, TimeSpan flushInterval)
+    {
+        _dispatcher = dispatcher;
+        _timer = new Timer(_ => Flush(), null, flushInterval, flushInterval);
+    }
+
+    public void Discard(EventLogId logId)
+    {
+        lock (_gate)
+        {
+            _buffers.Remove(logId);
+            _finalized.Remove(logId);
+            _seen.Remove(logId);
+        }
+    }
+
+    public void DiscardAll()
+    {
+        lock (_gate)
+        {
+            _buffers.Clear();
+            _finalized.Clear();
+            _seen.Clear();
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            _disposed = true;
+            _buffers.Clear();
+            _finalized.Clear();
+            _seen.Clear();
+        }
+
+        _timer.Dispose();
+    }
+
+    public void Enqueue(EventLogId logId, IReadOnlyList<ResolvedEvent> filteredEvents)
+    {
+        if (filteredEvents.Count == 0) { return; }
+
+        lock (_gate)
+        {
+            // A straggler partial delta can arrive after the final LoadEvents (effects are fire-and-forget); dropping finalized logs prevents duplicate rows.
+            if (_disposed || _finalized.Contains(logId)) { return; }
+
+            if (!_buffers.TryGetValue(logId, out var buffer))
+            {
+                buffer = new List<ResolvedEvent>(filteredEvents.Count);
+                _buffers[logId] = buffer;
+            }
+
+            buffer.AddRange(filteredEvents);
+
+            if (_seen.Add(logId)) { FlushLocked(); }
+        }
+    }
+
+    public void MarkFinalized(EventLogId logId)
+    {
+        lock (_gate)
+        {
+            _finalized.Add(logId);
+            _buffers.Remove(logId);
+        }
+    }
+
+    internal void Flush()
+    {
+        lock (_gate) { FlushLocked(); }
+    }
+
+    private void FlushLocked()
+    {
+        if (_disposed || _buffers.Count == 0) { return; }
+
+        var batch = new Dictionary<EventLogId, IReadOnlyList<ResolvedEvent>>(_buffers.Count);
+
+        foreach (var (logId, buffer) in _buffers)
+        {
+            if (buffer.Count > 0) { batch[logId] = buffer.AsReadOnly(); }
+        }
+
+        _buffers.Clear();
+
+        if (batch.Count == 0) { return; }
+
+        // Dispatch under the lock so batches and the final UpdateTable keep FIFO order in Fluxor's queue.
+        _dispatcher.Dispatch(new AppendTableEventsBatchAction(batch));
+    }
+}

--- a/src/EventLogExpert.Runtime/EventLogExpert.Runtime.csproj
+++ b/src/EventLogExpert.Runtime/EventLogExpert.Runtime.csproj
@@ -21,6 +21,7 @@
     <InternalsVisibleTo Include="EventLogExpert.Runtime.IntegrationTests" />
     <InternalsVisibleTo Include="EventLogExpert.Runtime.Tests" />
     <InternalsVisibleTo Include="EventLogExpert.ElevationHelper.IntegrationTests" />
+    <InternalsVisibleTo Include="EventLogExpert.UI.Tests" />
   </ItemGroup>
 
 </Project>

--- a/src/EventLogExpert.Runtime/LogTable/CombinedEventView.cs
+++ b/src/EventLogExpert.Runtime/LogTable/CombinedEventView.cs
@@ -1,0 +1,300 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+using System.Collections;
+using System.Collections.Immutable;
+
+namespace EventLogExpert.Runtime.LogTable;
+
+// Cross-log ties are impossible: OwningLog is the comparer's final tiebreak.
+internal sealed class CombinedEventView : IReadOnlyList<ResolvedEvent>, IList<ResolvedEvent>
+{
+    private const int Stride = 64;
+
+    private readonly Dictionary<string, SegmentedSortedList> _byOwningLog;
+    private readonly Comparison<ResolvedEvent> _comparer;
+    private readonly int _count;
+    private readonly Lock _indexGate = new();
+    private readonly ImmutableArray<SegmentedSortedList> _lists;
+
+    private int[][]? _index;
+
+    internal CombinedEventView(IEnumerable<SegmentedSortedList> perLogLists, SortContext context)
+    {
+        _comparer = ResolvedEventOrdering.SelectComparer(
+            context.OrderBy, context.IsDescending, context.GroupBy, context.IsGroupDescending);
+
+        var builder = ImmutableArray.CreateBuilder<SegmentedSortedList>();
+        _byOwningLog = new Dictionary<string, SegmentedSortedList>(StringComparer.Ordinal);
+        int total = 0;
+
+        foreach (var list in perLogLists)
+        {
+            builder.Add(list);
+            total += list.Count;
+
+            if (list.Count > 0) { _byOwningLog[list[0].OwningLog] = list; }
+        }
+
+        _lists = builder.ToImmutable();
+        _count = total;
+    }
+
+    public int Count => _count;
+
+    public bool IsReadOnly => true;
+
+    internal static CombinedEventView Empty { get; } =
+        new([], new SortContext(null, true, null, false));
+
+    public ResolvedEvent this[int index]
+    {
+        get
+        {
+            if ((uint)index >= (uint)_count) { throw new ArgumentOutOfRangeException(nameof(index)); }
+
+            var cursors = SeekTo(index, out int position);
+
+            while (position < index)
+            {
+                cursors[PickBest(cursors)]++;
+                position++;
+            }
+
+            int best = PickBest(cursors);
+
+            return _lists[best][cursors[best]];
+        }
+
+        set => throw new NotSupportedException();
+    }
+
+    public void Add(ResolvedEvent item) => throw new NotSupportedException();
+
+    public void Clear() => throw new NotSupportedException();
+
+    public bool Contains(ResolvedEvent item) => Rank(item) >= 0;
+
+    public void CopyTo(ResolvedEvent[] array, int arrayIndex)
+    {
+        ArgumentNullException.ThrowIfNull(array);
+        ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
+
+        if (array.Length - arrayIndex < _count)
+        {
+            throw new ArgumentException("Destination array is not long enough.", nameof(array));
+        }
+
+        foreach (var resolved in this) { array[arrayIndex++] = resolved; }
+    }
+
+    public IEnumerator<ResolvedEvent> GetEnumerator()
+    {
+        var cursors = new int[_lists.Length];
+
+        while (true)
+        {
+            int best = PickBest(cursors);
+
+            if (best < 0) { yield break; }
+
+            yield return _lists[best][cursors[best]];
+
+            cursors[best]++;
+        }
+    }
+
+    public int IndexOf(ResolvedEvent item) => Rank(item);
+
+    public void Insert(int index, ResolvedEvent item) => throw new NotSupportedException();
+
+    public bool Remove(ResolvedEvent item) => throw new NotSupportedException();
+
+    public void RemoveAt(int index) => throw new NotSupportedException();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    internal int Rank(ResolvedEvent target)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+
+        if (!_byOwningLog.TryGetValue(target.OwningLog, out var ownList)) { return -1; }
+
+        int rank = 0;
+        int ownOffset = -1;
+
+        foreach (var list in _lists)
+        {
+            int lowerBound = LowerBound(list, target);
+
+            if (!ReferenceEquals(list, ownList))
+            {
+                rank += lowerBound;
+
+                continue;
+            }
+
+            // Match target in the equal-key run by reference, then RecordId+time+LogName (non-null).
+            for (int offset = lowerBound; offset < list.Count && _comparer(list[offset], target) == 0; offset++)
+            {
+                var current = list[offset];
+
+                if (ReferenceEquals(current, target) ||
+                    (current.RecordId is not null && target.RecordId is not null &&
+                        current.RecordId == target.RecordId && current.TimeCreated == target.TimeCreated &&
+                        string.Equals(current.LogName, target.LogName, StringComparison.Ordinal)))
+                {
+                    ownOffset = offset;
+
+                    break;
+                }
+            }
+
+            if (ownOffset < 0) { return -1; }
+
+            rank += ownOffset;
+        }
+
+        return rank;
+    }
+
+    internal ResolvedEvent? ResolveByKey(ResolvedEvent? candidate)
+    {
+        if (candidate is null) { return null; }
+
+        if (!_byOwningLog.TryGetValue(candidate.OwningLog, out var list)) { return null; }
+
+        int lowerBound = LowerBound(list, candidate);
+
+        for (int offset = lowerBound; offset < list.Count && _comparer(list[offset], candidate) == 0; offset++)
+        {
+            var current = list[offset];
+
+            if (ReferenceEquals(current, candidate)) { return current; }
+
+            // Skip null RecordId: null == null would merge distinct error-read events.
+            if (current.RecordId is null || candidate.RecordId is null) { continue; }
+
+            if (current.RecordId == candidate.RecordId &&
+                current.TimeCreated == candidate.TimeCreated &&
+                string.Equals(current.LogName, candidate.LogName, StringComparison.Ordinal))
+            {
+                return current;
+            }
+        }
+
+        return null;
+    }
+
+    internal IReadOnlyList<ResolvedEvent> Slice(int start, int count)
+    {
+        if (start < 0) { throw new ArgumentOutOfRangeException(nameof(start)); }
+
+        if (count < 0) { throw new ArgumentOutOfRangeException(nameof(count)); }
+
+        int end = (int)Math.Min((long)start + count, _count);
+
+        if (start >= end) { return []; }
+
+        var cursors = SeekTo(start, out int position);
+
+        while (position < start)
+        {
+            cursors[PickBest(cursors)]++;
+            position++;
+        }
+
+        var result = new ResolvedEvent[end - start];
+
+        for (int i = 0; position < end; i++, position++)
+        {
+            int best = PickBest(cursors);
+            result[i] = _lists[best][cursors[best]];
+            cursors[best]++;
+        }
+
+        return result;
+    }
+
+    private int[][] BuildIndex()
+    {
+        var checkpoints = new List<int[]>(_count / Stride);
+        var cursors = new int[_lists.Length];
+        int produced = 0;
+
+        while (true)
+        {
+            int best = PickBest(cursors);
+
+            if (best < 0) { break; }
+
+            cursors[best]++;
+            produced++;
+
+            if (produced % Stride == 0) { checkpoints.Add((int[])cursors.Clone()); }
+        }
+
+        return [.. checkpoints];
+    }
+
+    private int[][] GetIndex()
+    {
+        var index = Volatile.Read(ref _index);
+
+        if (index is not null) { return index; }
+
+        lock (_indexGate)
+        {
+            _index ??= BuildIndex();
+
+            return _index;
+        }
+    }
+
+    private int LowerBound(SegmentedSortedList list, ResolvedEvent target)
+    {
+        int low = 0;
+        int high = list.Count;
+
+        while (low < high)
+        {
+            int mid = low + ((high - low) >> 1);
+
+            if (_comparer(list[mid], target) < 0) { low = mid + 1; }
+            else { high = mid; }
+        }
+
+        return low;
+    }
+
+    private int PickBest(int[] cursors)
+    {
+        int best = -1;
+
+        for (int k = 0; k < _lists.Length; k++)
+        {
+            if (cursors[k] >= _lists[k].Count) { continue; }
+
+            if (best < 0 || _comparer(_lists[k][cursors[k]], _lists[best][cursors[best]]) < 0) { best = k; }
+        }
+
+        return best;
+    }
+
+    private int[] SeekTo(int index, out int position)
+    {
+        if (index < Stride)
+        {
+            position = 0;
+
+            return new int[_lists.Length];
+        }
+
+        var checkpoints = GetIndex();
+        int checkpoint = index / Stride;
+        position = checkpoint * Stride;
+
+        return (int[])checkpoints[checkpoint - 1].Clone();
+    }
+}

--- a/src/EventLogExpert.Runtime/LogTable/LogTableState.cs
+++ b/src/EventLogExpert.Runtime/LogTable/LogTableState.cs
@@ -5,15 +5,23 @@ using EventLogExpert.Eventing.Common.EventLogs;
 using EventLogExpert.Eventing.Common.Events;
 using Fluxor;
 using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
 
 namespace EventLogExpert.Runtime.LogTable;
 
 [FeatureState]
 public sealed record LogTableState
 {
+    internal ImmutableDictionary<EventLogId, SegmentedSortedList> PerLogEvents { get; init; } =
+        ImmutableDictionary<EventLogId, SegmentedSortedList>.Empty;
+
     public ImmutableList<LogView> EventTables { get; init; } = [];
 
-    public IReadOnlyList<ResolvedEvent> DisplayedEvents { get; init; } = [];
+    // Memoized by PerLogEvents identity; each instance maps to one SortContext.
+    public IReadOnlyList<ResolvedEvent> DisplayedEvents =>
+        PerLogEvents.IsEmpty
+            ? CombinedEventView.Empty
+            : s_combinedViews.GetValue(PerLogEvents, CreateCombinedView);
 
     public ImmutableDictionary<EventLogId, int> EventCountByLog { get; init; } =
         ImmutableDictionary<EventLogId, int>.Empty;
@@ -22,7 +30,8 @@ public sealed record LogTableState
 
     public ImmutableDictionary<ColumnName, bool> Columns { get; init; } = ImmutableDictionary<ColumnName, bool>.Empty;
 
-    public ImmutableDictionary<ColumnName, int> ColumnWidths { get; init; } = ImmutableDictionary<ColumnName, int>.Empty;
+    public ImmutableDictionary<ColumnName, int> ColumnWidths { get; init; } =
+        ImmutableDictionary<ColumnName, int>.Empty;
 
     public ImmutableList<ColumnName> ColumnOrder { get; init; } = [];
 
@@ -39,6 +48,55 @@ public sealed record LogTableState
     public ImmutableHashSet<string> GroupCollapseOverrides { get; init; } =
         ImmutableHashSet.Create<string>(StringComparer.Ordinal);
 
+    internal SortContext SortContext =>
+        new(ResolvedEventOrdering.ResolveDefaultOrderBy(OrderBy, GroupBy, PerLogEvents.Count),
+            IsDescending,
+            GroupBy,
+            IsGroupDescending);
+
+    private static readonly ConditionalWeakTable<
+        ImmutableDictionary<EventLogId, SegmentedSortedList>, CombinedEventView> s_combinedViews = [];
+
+    private static CombinedEventView CreateCombinedView(
+        ImmutableDictionary<EventLogId, SegmentedSortedList> perLog) =>
+        new(perLog.Values, perLog.Values.First().Context);
+
     public bool IsGroupCollapsed(string groupKey) =>
         GroupsCollapsedByDefault ^ GroupCollapseOverrides.Contains(groupKey);
+
+    public IReadOnlyList<ResolvedEvent> EventsForLog(EventLogId logId) =>
+        PerLogEvents.TryGetValue(logId, out var list) ? list : [];
+
+    // Each call must carry a single log's events (one OwningLog).
+    internal LogTableState WithLogEvents(EventLogId logId, params ResolvedEvent[] events)
+    {
+        for (int i = 1; i < events.Length; i++)
+        {
+            if (!string.Equals(events[i].OwningLog, events[0].OwningLog, StringComparison.Ordinal))
+            {
+                throw new ArgumentException("All events must share one OwningLog.", nameof(events));
+            }
+        }
+
+        int newCount = PerLogEvents.ContainsKey(logId) ? PerLogEvents.Count : PerLogEvents.Count + 1;
+
+        var context = new SortContext(
+            ResolvedEventOrdering.ResolveDefaultOrderBy(OrderBy, GroupBy, newCount),
+            IsDescending,
+            GroupBy,
+            IsGroupDescending);
+
+        var builder = PerLogEvents.ToBuilder();
+        builder[logId] = SegmentedSortedList.CreateSorted(events, context);
+
+        foreach (var (id, list) in PerLogEvents)
+        {
+            if (id != logId && !list.HasContext(context))
+            {
+                builder[id] = SegmentedSortedList.CreateSorted(list, context);
+            }
+        }
+
+        return this with { PerLogEvents = builder.ToImmutable() };
+    }
 }

--- a/src/EventLogExpert.Runtime/LogTable/Reducers.cs
+++ b/src/EventLogExpert.Runtime/LogTable/Reducers.cs
@@ -69,20 +69,20 @@ internal sealed class Reducers
 
         if (table is null || table.IsCombined || action.Events.Count == 0) { return state; }
 
-        var merged = ResolvedEventOrdering.MergeSorted(
-            state.DisplayedEvents,
-            action.Events,
-            GetEffectiveOrderBy(state.OrderBy),
-            state.IsDescending,
-            state.GroupBy,
-            state.IsGroupDescending);
+        int postCount = state.PerLogEvents.ContainsKey(table.Id)
+            ? state.PerLogEvents.Count
+            : state.PerLogEvents.Count + 1;
+        var context = EffectiveSortContext(
+            state.OrderBy, state.IsDescending, state.GroupBy, state.IsGroupDescending, postCount);
 
+        var perLog = AppendToLog(state.PerLogEvents, table.Id, action.Events, context);
+        perLog = ReconcileToLogCount(perLog, state);
         var updatedTable = SetComputerNameIfFirstEvent(table, action.Events);
         var counts = IncrementCount(state.EventCountByLog, table.Id, action.Events.Count);
 
         return state with
         {
-            DisplayedEvents = merged,
+            PerLogEvents = perLog,
             EventTables = ReferenceEquals(updatedTable, table) ?
                 state.EventTables :
                 state.EventTables.Replace(table, updatedTable),
@@ -99,9 +99,23 @@ internal sealed class Reducers
 
         // Skip batches for closed logs: avoid resurrecting events and stale counts.
         int totalNew = 0;
-        var combinedBatch = new List<ResolvedEvent>();
+        var perLog = state.PerLogEvents;
         var counts = state.EventCountByLog;
         var updatedTables = state.EventTables;
+
+        // Count new logs first so appends use the post-batch sort context (no boundary re-sort).
+        int newLogs = 0;
+
+        foreach (var (logId, events) in action.EventsByLog)
+        {
+            if (events.Count == 0 || perLog.ContainsKey(logId)) { continue; }
+
+            var table = state.EventTables.FirstOrDefault(t => t.Id == logId);
+            if (table is not null && !table.IsCombined) { newLogs++; }
+        }
+
+        var context = EffectiveSortContext(
+            state.OrderBy, state.IsDescending, state.GroupBy, state.IsGroupDescending, perLog.Count + newLogs);
 
         foreach (var (logId, events) in action.EventsByLog)
         {
@@ -111,7 +125,7 @@ internal sealed class Reducers
 
             if (table is null || table.IsCombined) { continue; }
 
-            combinedBatch.AddRange(events);
+            perLog = AppendToLog(perLog, logId, events, context);
             counts = IncrementCount(counts, logId, events.Count);
             totalNew += events.Count;
 
@@ -125,17 +139,11 @@ internal sealed class Reducers
 
         if (totalNew == 0) { return state; }
 
-        var merged = ResolvedEventOrdering.MergeSorted(
-            state.DisplayedEvents,
-            combinedBatch,
-            GetEffectiveOrderBy(state.OrderBy),
-            state.IsDescending,
-            state.GroupBy,
-            state.IsGroupDescending);
+        perLog = ReconcileToLogCount(perLog, state);
 
         return state with
         {
-            DisplayedEvents = merged,
+            PerLogEvents = perLog,
             EventTables = updatedTables,
             EventCountByLog = counts
         };
@@ -146,7 +154,7 @@ internal sealed class Reducers
         ResetGroupCollapse(state with
         {
             EventTables = [],
-            DisplayedEvents = [],
+            PerLogEvents = ImmutableDictionary<EventLogId, SegmentedSortedList>.Empty,
             EventCountByLog = ImmutableDictionary<EventLogId, int>.Empty,
             ActiveEventLogId = null
         });
@@ -163,6 +171,7 @@ internal sealed class Reducers
             .ToImmutableList();
 
         var counts = state.EventCountByLog.Remove(action.LogId);
+        var perLog = ReconcileToLogCount(state.PerLogEvents.Remove(action.LogId), state);
 
         switch (remainingPerLogTables.Count)
         {
@@ -171,7 +180,7 @@ internal sealed class Reducers
                     state with
                     {
                         EventTables = [],
-                        DisplayedEvents = [],
+                        PerLogEvents = ImmutableDictionary<EventLogId, SegmentedSortedList>.Empty,
                         EventCountByLog = ImmutableDictionary<EventLogId, int>.Empty,
                         ActiveEventLogId = null
                     },
@@ -179,13 +188,12 @@ internal sealed class Reducers
             case 1:
                 {
                     var soleRemaining = remainingPerLogTables[0];
-                    var filtered = FilterByOwningLog(state.DisplayedEvents, soleRemaining.LogName);
 
                     return ResetGroupCollapseIfActiveChanged(
                         state with
                         {
                             EventTables = remainingPerLogTables,
-                            DisplayedEvents = filtered,
+                            PerLogEvents = perLog,
                             EventCountByLog = counts,
                             ActiveEventLogId = soleRemaining.Id
                         },
@@ -194,13 +202,12 @@ internal sealed class Reducers
             default:
                 {
                     var combinedTable = new LogView(EventLogId.Create()) { IsCombined = true };
-                    var filtered = FilterOutOwningLog(state.DisplayedEvents, closingTable.LogName);
 
                     return ResetGroupCollapseIfActiveChanged(
                         state with
                         {
                             EventTables = remainingPerLogTables.Insert(0, combinedTable),
-                            DisplayedEvents = filtered,
+                            PerLogEvents = perLog,
                             EventCountByLog = counts,
                             ActiveEventLogId = remainingPerLogTables.Any(t => t.Id == state.ActiveEventLogId) ?
                                 state.ActiveEventLogId : combinedTable.Id
@@ -233,9 +240,9 @@ internal sealed class Reducers
             IsGroupDescending = false,
             GroupsCollapsedByDefault = false,
             GroupCollapseOverrides = ImmutableHashSet.Create<string>(StringComparer.Ordinal),
-            DisplayedEvents = updated.DisplayedEvents.SortEvents(
-                GetEffectiveOrderBy(updated.OrderBy),
-                updated.IsDescending)
+            PerLogEvents = ResortAllLogs(
+                updated.PerLogEvents,
+                EffectiveSortContext(updated.OrderBy, updated.IsDescending, null, false, updated.PerLogEvents.Count))
         };
     }
 
@@ -301,10 +308,9 @@ internal sealed class Reducers
             IsGroupDescending = false,
             GroupsCollapsedByDefault = false,
             GroupCollapseOverrides = ImmutableHashSet.Create<string>(StringComparer.Ordinal),
-            DisplayedEvents = state.DisplayedEvents.SortEvents(
-                GetEffectiveOrderBy(state.OrderBy),
-                state.IsDescending,
-                action.GroupBy)
+            PerLogEvents = ResortAllLogs(
+                state.PerLogEvents,
+                EffectiveSortContext(state.OrderBy, state.IsDescending, action.GroupBy, false, state.PerLogEvents.Count))
         };
     }
 
@@ -339,11 +345,9 @@ internal sealed class Reducers
         return state with
         {
             IsGroupDescending = isGroupDescending,
-            DisplayedEvents = state.DisplayedEvents.SortEvents(
-                GetEffectiveOrderBy(state.OrderBy),
-                state.IsDescending,
-                state.GroupBy,
-                isGroupDescending)
+            PerLogEvents = ResortAllLogs(
+                state.PerLogEvents,
+                EffectiveSortContext(state.OrderBy, state.IsDescending, state.GroupBy, isGroupDescending, state.PerLogEvents.Count))
         };
     }
 
@@ -376,82 +380,42 @@ internal sealed class Reducers
             .Where(table => !table.IsCombined)
             .ToDictionary(table => table.Id);
 
-        // Logs absent from ActiveLogs keep their current rows (stale-snapshot protection).
-        var logNamesBeingReplaced = new HashSet<string>(StringComparer.Ordinal);
+        // A background filter may pre-date a sort change; re-sort under the post-update context.
+        int postCount = 0;
 
-        foreach (var (logId, _) in action.ActiveLogs)
+        foreach (var (logId, _) in tablesById)
         {
-            if (tablesById.TryGetValue(logId, out var table))
-            {
-                logNamesBeingReplaced.Add(table.LogName);
-            }
+            if (action.ActiveLogs.ContainsKey(logId) || state.PerLogEvents.ContainsKey(logId)) { postCount++; }
         }
 
-        // Defensive: orphan rows whose OwningLog has no current table get dropped.
-        var currentLogNames = new HashSet<string>(StringComparer.Ordinal);
-
-        foreach (var table in tablesById.Values)
-        {
-            currentLogNames.Add(table.LogName);
-        }
-
-        int preservedCount = 0;
-
-        foreach (var existing in state.DisplayedEvents)
-        {
-            if (currentLogNames.Contains(existing.OwningLog) &&
-                !logNamesBeingReplaced.Contains(existing.OwningLog))
-            {
-                preservedCount++;
-            }
-        }
-
-        int totalCount = preservedCount;
-
-        foreach (var (logId, events) in action.ActiveLogs)
-        {
-            if (tablesById.ContainsKey(logId)) { totalCount += events.Count; }
-        }
-
-        var concatenated = new List<ResolvedEvent>(totalCount);
-
-        foreach (var existing in state.DisplayedEvents)
-        {
-            if (currentLogNames.Contains(existing.OwningLog) &&
-                !logNamesBeingReplaced.Contains(existing.OwningLog))
-            {
-                concatenated.Add(existing);
-            }
-        }
-
+        var context = EffectiveSortContext(
+            state.OrderBy, state.IsDescending, state.GroupBy, state.IsGroupDescending, postCount);
+        var perLogBuilder = ImmutableDictionary.CreateBuilder<EventLogId, SegmentedSortedList>();
         var counts = state.EventCountByLog;
         var tables = state.EventTables;
 
-        foreach (var (logId, events) in action.ActiveLogs)
+        foreach (var (logId, table) in tablesById)
         {
-            if (!tablesById.TryGetValue(logId, out var table)) { continue; }
-
-            concatenated.AddRange(events);
-            counts = counts.SetItem(logId, events.Count);
-
-            // Filter-clear may be the first event-bearing path for a log; latch ComputerName.
-            var updatedTable = SetComputerNameIfFirstEvent(table, events);
-
-            if (!ReferenceEquals(updatedTable, table))
+            if (action.ActiveLogs.TryGetValue(logId, out var events))
             {
-                tables = tables.Replace(table, updatedTable);
+                perLogBuilder[logId] = SegmentedSortedList.CreateSorted(events, context);
+                counts = counts.SetItem(logId, events.Count);
+
+                var updatedTable = SetComputerNameIfFirstEvent(table, events);
+
+                if (!ReferenceEquals(updatedTable, table)) { tables = tables.Replace(table, updatedTable); }
+            }
+            else if (state.PerLogEvents.TryGetValue(logId, out var existingList))
+            {
+                perLogBuilder[logId] = existingList.HasContext(context)
+                    ? existingList
+                    : SegmentedSortedList.CreateSorted(existingList, context);
             }
         }
 
-        var sorted = concatenated.SortEvents(
-            GetEffectiveOrderBy(state.OrderBy),
-            state.IsDescending,
-            state.GroupBy,
-            state.IsGroupDescending);
-
         return state with
         {
-            DisplayedEvents = sorted,
+            PerLogEvents = ReconcileToLogCount(perLogBuilder.ToImmutable(), state),
             EventTables = tables,
             EventCountByLog = counts
         };
@@ -464,81 +428,51 @@ internal sealed class Reducers
 
         if (table is null || table.IsCombined) { return state; }
 
-        // UpdateTable carries the full slice; drop existing rows before merging.
-        bool hasExistingRowsForLog = state.EventCountByLog.TryGetValue(table.Id, out int existingCount) && existingCount > 0;
+        int postCount = state.PerLogEvents.ContainsKey(table.Id)
+            ? state.PerLogEvents.Count
+            : state.PerLogEvents.Count + 1;
+        var context = EffectiveSortContext(
+            state.OrderBy, state.IsDescending, state.GroupBy, state.IsGroupDescending, postCount);
 
-        var existing = hasExistingRowsForLog
-            ? FilterOutOwningLog(state.DisplayedEvents, table.LogName)
-            : state.DisplayedEvents;
-
-        var merged = ResolvedEventOrdering.MergeSorted(
-            existing,
-            action.Events,
-            GetEffectiveOrderBy(state.OrderBy),
-            state.IsDescending,
-            state.GroupBy,
-            state.IsGroupDescending);
-
+        var perLog = SetLog(state.PerLogEvents, table.Id, action.Events, context);
+        perLog = ReconcileToLogCount(perLog, state);
         var updatedTable = SetComputerNameIfFirstEvent(table, action.Events) with { IsLoading = false };
         var counts = state.EventCountByLog.SetItem(table.Id, action.Events.Count);
 
         return state with
         {
-            DisplayedEvents = merged,
+            PerLogEvents = perLog,
             EventTables = state.EventTables.Replace(table, updatedTable),
             EventCountByLog = counts
         };
     }
 
-    private static IReadOnlyList<ResolvedEvent> FilterByOwningLog(
+    private static ImmutableDictionary<EventLogId, SegmentedSortedList> AppendToLog(
+        ImmutableDictionary<EventLogId, SegmentedSortedList> perLog,
+        EventLogId logId,
         IReadOnlyList<ResolvedEvent> events,
-        string owningLog)
+        SortContext context)
     {
-        if (events is SegmentedSortedList segmented)
+        if (perLog.TryGetValue(logId, out var existing) && existing.HasContext(context))
         {
-            return segmented.WhereSegmented(current => string.Equals(current.OwningLog, owningLog, StringComparison.Ordinal));
+            return perLog.SetItem(logId, existing.Append(events));
         }
 
-        var filtered = new List<ResolvedEvent>(events.Count);
+        var combined = existing is null ? events : existing.Concat(events);
 
-        for (int eventIndex = 0; eventIndex < events.Count; eventIndex++)
-        {
-            var current = events[eventIndex];
-
-            if (string.Equals(current.OwningLog, owningLog, StringComparison.Ordinal))
-            {
-                filtered.Add(current);
-            }
-        }
-
-        return filtered.AsReadOnly();
+        return perLog.SetItem(logId, SegmentedSortedList.CreateSorted(combined, context));
     }
 
-    private static IReadOnlyList<ResolvedEvent> FilterOutOwningLog(
-        IReadOnlyList<ResolvedEvent> events,
-        string owningLog)
-    {
-        if (events is SegmentedSortedList segmented)
-        {
-            return segmented.WhereSegmented(current => !string.Equals(current.OwningLog, owningLog, StringComparison.Ordinal));
-        }
-
-        var filtered = new List<ResolvedEvent>(events.Count);
-
-        for (int eventIndex = 0; eventIndex < events.Count; eventIndex++)
-        {
-            var current = events[eventIndex];
-
-            if (!string.Equals(current.OwningLog, owningLog, StringComparison.Ordinal))
-            {
-                filtered.Add(current);
-            }
-        }
-
-        return filtered.AsReadOnly();
-    }
-
-    private static ColumnName GetEffectiveOrderBy(ColumnName? orderBy) => ResolvedEventOrdering.GetEffectiveOrderBy(orderBy);
+    private static SortContext EffectiveSortContext(
+        ColumnName? orderBy,
+        bool isDescending,
+        ColumnName? groupBy,
+        bool isGroupDescending,
+        int logCount) =>
+        new(ResolvedEventOrdering.ResolveDefaultOrderBy(orderBy, groupBy, logCount),
+            isDescending,
+            groupBy,
+            isGroupDescending);
 
     private static ImmutableDictionary<EventLogId, int> IncrementCount(
         ImmutableDictionary<EventLogId, int> counts,
@@ -548,6 +482,17 @@ internal sealed class Reducers
         int current = counts.TryGetValue(logId, out int existing) ? existing : 0;
         return counts.SetItem(logId, current + delta);
     }
+
+    private static ImmutableDictionary<EventLogId, SegmentedSortedList> ReconcileToLogCount(
+        ImmutableDictionary<EventLogId, SegmentedSortedList> perLog,
+        LogTableState state) =>
+        ResortAllLogs(perLog,
+            EffectiveSortContext(
+                state.OrderBy,
+                state.IsDescending,
+                state.GroupBy,
+                state.IsGroupDescending,
+                perLog.Count));
 
     private static LogTableState ResetGroupCollapse(LogTableState state) =>
         state is { GroupsCollapsedByDefault: false, GroupCollapseOverrides.IsEmpty: true }
@@ -562,6 +507,22 @@ internal sealed class Reducers
         LogTableState updated,
         EventLogId? previousActiveId) =>
         updated.ActiveEventLogId == previousActiveId ? updated : ResetGroupCollapse(updated);
+
+    private static ImmutableDictionary<EventLogId, SegmentedSortedList> ResortAllLogs(
+        ImmutableDictionary<EventLogId, SegmentedSortedList> perLog,
+        SortContext context)
+    {
+        if (perLog.IsEmpty) { return perLog; }
+
+        var builder = perLog.ToBuilder();
+
+        foreach (var (logId, list) in perLog)
+        {
+            if (!list.HasContext(context)) { builder[logId] = SegmentedSortedList.CreateSorted(list, context); }
+        }
+
+        return builder.ToImmutable();
+    }
 
     private static LogView SetComputerNameIfFirstEvent(LogView table, IReadOnlyList<ResolvedEvent> newEvents)
     {
@@ -581,17 +542,25 @@ internal sealed class Reducers
         return table;
     }
 
+    private static ImmutableDictionary<EventLogId, SegmentedSortedList> SetLog(
+        ImmutableDictionary<EventLogId, SegmentedSortedList> perLog,
+        EventLogId logId,
+        IReadOnlyList<ResolvedEvent> events,
+        SortContext context) =>
+        perLog.SetItem(logId, SegmentedSortedList.CreateSorted(events, context));
+
     private static LogTableState SortDisplayEvents(LogTableState state, ColumnName? orderBy, bool isDescending)
     {
-        var effectiveOrderBy = GetEffectiveOrderBy(orderBy);
+        var context = EffectiveSortContext(
+            orderBy,
+            isDescending,
+            state.GroupBy,
+            state.IsGroupDescending,
+            state.PerLogEvents.Count);
 
         return state with
         {
-            DisplayedEvents = state.DisplayedEvents.SortEvents(
-                effectiveOrderBy,
-                isDescending,
-                state.GroupBy,
-                state.IsGroupDescending),
+            PerLogEvents = ResortAllLogs(state.PerLogEvents, context),
             OrderBy = orderBy,
             IsDescending = isDescending
         };

--- a/src/EventLogExpert.Runtime/LogTable/Reducers.cs
+++ b/src/EventLogExpert.Runtime/LogTable/Reducers.cs
@@ -532,8 +532,7 @@ internal sealed class Reducers
         return filtered.AsReadOnly();
     }
 
-    private static ColumnName GetEffectiveOrderBy(ColumnName? orderBy) =>
-        orderBy ?? ColumnName.DateAndTime;
+    private static ColumnName GetEffectiveOrderBy(ColumnName? orderBy) => ResolvedEventOrdering.GetEffectiveOrderBy(orderBy);
 
     private static ImmutableDictionary<EventLogId, int> IncrementCount(
         ImmutableDictionary<EventLogId, int> counts,

--- a/src/EventLogExpert.Runtime/LogTable/Reducers.cs
+++ b/src/EventLogExpert.Runtime/LogTable/Reducers.cs
@@ -397,10 +397,8 @@ internal sealed class Reducers
 
         int preservedCount = 0;
 
-        for (int eventIndex = 0; eventIndex < state.DisplayedEvents.Count; eventIndex++)
+        foreach (var existing in state.DisplayedEvents)
         {
-            var existing = state.DisplayedEvents[eventIndex];
-
             if (currentLogNames.Contains(existing.OwningLog) &&
                 !logNamesBeingReplaced.Contains(existing.OwningLog))
             {
@@ -417,10 +415,8 @@ internal sealed class Reducers
 
         var concatenated = new List<ResolvedEvent>(totalCount);
 
-        for (int eventIndex = 0; eventIndex < state.DisplayedEvents.Count; eventIndex++)
+        foreach (var existing in state.DisplayedEvents)
         {
-            var existing = state.DisplayedEvents[eventIndex];
-
             if (currentLogNames.Contains(existing.OwningLog) &&
                 !logNamesBeingReplaced.Contains(existing.OwningLog))
             {
@@ -498,6 +494,11 @@ internal sealed class Reducers
         IReadOnlyList<ResolvedEvent> events,
         string owningLog)
     {
+        if (events is SegmentedSortedList segmented)
+        {
+            return segmented.WhereSegmented(current => string.Equals(current.OwningLog, owningLog, StringComparison.Ordinal));
+        }
+
         var filtered = new List<ResolvedEvent>(events.Count);
 
         for (int eventIndex = 0; eventIndex < events.Count; eventIndex++)
@@ -517,6 +518,11 @@ internal sealed class Reducers
         IReadOnlyList<ResolvedEvent> events,
         string owningLog)
     {
+        if (events is SegmentedSortedList segmented)
+        {
+            return segmented.WhereSegmented(current => !string.Equals(current.OwningLog, owningLog, StringComparison.Ordinal));
+        }
+
         var filtered = new List<ResolvedEvent>(events.Count);
 
         for (int eventIndex = 0; eventIndex < events.Count; eventIndex++)

--- a/src/EventLogExpert.Runtime/LogTable/ResolvedEventIndex.cs
+++ b/src/EventLogExpert.Runtime/LogTable/ResolvedEventIndex.cs
@@ -18,6 +18,10 @@ public static class ResolvedEventIndex
         ArgumentNullException.ThrowIfNull(sortedEvents);
         ArgumentNullException.ThrowIfNull(target);
 
+        if (sortedEvents is CombinedEventView combined) { return combined.Rank(target); }
+
+        if (sortedEvents is SegmentedSortedList segmented) { return segmented.Rank(target); }
+
         var comparer = ResolvedEventOrdering.SelectComparer(
             ResolvedEventOrdering.GetEffectiveOrderBy(orderBy),
             isDescending,
@@ -50,13 +54,64 @@ public static class ResolvedEventIndex
 
         if (lowerBound < 0) { return -1; }
 
-        // The order is total except for error-read events with a null RecordId in the same log, which compare equal;
-        // scan the comparer-equal window for the exact instance so a tie can't resolve to the wrong row.
+        // Scan the comparer-equal window for the exact null-RecordId instance.
         for (int i = lowerBound; i < sortedEvents.Count && comparer(sortedEvents[i], target) == 0; i++)
         {
             if (ReferenceEquals(sortedEvents[i], target)) { return i; }
         }
 
         return -1;
+    }
+
+    public static ResolvedEvent? ResolveByKey(IReadOnlyList<ResolvedEvent> events, ResolvedEvent? candidate)
+    {
+        ArgumentNullException.ThrowIfNull(events);
+
+        if (candidate is null) { return null; }
+
+        if (events is CombinedEventView combined) { return combined.ResolveByKey(candidate); }
+
+        if (events is SegmentedSortedList segmented) { return segmented.ResolveByKey(candidate); }
+
+        for (int i = 0; i < events.Count; i++)
+        {
+            var current = events[i];
+
+            if (ReferenceEquals(current, candidate)) { return current; }
+
+            // Skip null RecordId: null == null would merge distinct error-read events.
+            if (current.RecordId is null || candidate.RecordId is null) { continue; }
+
+            if (current.RecordId == candidate.RecordId &&
+                current.TimeCreated == candidate.TimeCreated &&
+                string.Equals(current.OwningLog, candidate.OwningLog, StringComparison.Ordinal) &&
+                string.Equals(current.LogName, candidate.LogName, StringComparison.Ordinal))
+            {
+                return current;
+            }
+        }
+
+        return null;
+    }
+
+    public static IReadOnlyList<ResolvedEvent> Slice(IReadOnlyList<ResolvedEvent> events, int start, int count)
+    {
+        ArgumentNullException.ThrowIfNull(events);
+
+        if (events is CombinedEventView combined) { return combined.Slice(start, count); }
+
+        if (start < 0) { throw new ArgumentOutOfRangeException(nameof(start)); }
+
+        if (count < 0) { throw new ArgumentOutOfRangeException(nameof(count)); }
+
+        int end = (int)Math.Min((long)start + count, events.Count);
+
+        if (start >= end) { return []; }
+
+        var result = new ResolvedEvent[end - start];
+
+        for (int i = 0; i < result.Length; i++) { result[i] = events[start + i]; }
+
+        return result;
     }
 }

--- a/src/EventLogExpert.Runtime/LogTable/ResolvedEventIndex.cs
+++ b/src/EventLogExpert.Runtime/LogTable/ResolvedEventIndex.cs
@@ -1,0 +1,62 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+
+namespace EventLogExpert.Runtime.LogTable;
+
+public static class ResolvedEventIndex
+{
+    public static int IndexOf(
+        IReadOnlyList<ResolvedEvent> sortedEvents,
+        ResolvedEvent target,
+        ColumnName? orderBy = null,
+        bool isDescending = false,
+        ColumnName? groupBy = null,
+        bool isGroupDescending = false)
+    {
+        ArgumentNullException.ThrowIfNull(sortedEvents);
+        ArgumentNullException.ThrowIfNull(target);
+
+        var comparer = ResolvedEventOrdering.SelectComparer(
+            ResolvedEventOrdering.GetEffectiveOrderBy(orderBy),
+            isDescending,
+            groupBy,
+            isGroupDescending);
+
+        int low = 0;
+        int high = sortedEvents.Count - 1;
+        int lowerBound = -1;
+
+        while (low <= high)
+        {
+            int mid = low + ((high - low) / 2);
+            int comparison = comparer(sortedEvents[mid], target);
+
+            switch (comparison)
+            {
+                case < 0:
+                    low = mid + 1;
+                    break;
+                case > 0:
+                    high = mid - 1;
+                    break;
+                default:
+                    lowerBound = mid;
+                    high = mid - 1;
+                    break;
+            }
+        }
+
+        if (lowerBound < 0) { return -1; }
+
+        // The order is total except for error-read events with a null RecordId in the same log, which compare equal;
+        // scan the comparer-equal window for the exact instance so a tie can't resolve to the wrong row.
+        for (int i = lowerBound; i < sortedEvents.Count && comparer(sortedEvents[i], target) == 0; i++)
+        {
+            if (ReferenceEquals(sortedEvents[i], target)) { return i; }
+        }
+
+        return -1;
+    }
+}

--- a/src/EventLogExpert.Runtime/LogTable/ResolvedEventOrdering.cs
+++ b/src/EventLogExpert.Runtime/LogTable/ResolvedEventOrdering.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Eventing.Common.Events;
+using System.Diagnostics;
 
 namespace EventLogExpert.Runtime.LogTable;
 
@@ -58,13 +59,8 @@ internal static class ResolvedEventOrdering
         ColumnName? orderBy = null,
         bool isDescending = false,
         ColumnName? groupBy = null,
-        bool isGroupDescending = false)
-    {
-        var sorted = new List<ResolvedEvent>(events);
-        sorted.Sort(SelectComparer(orderBy, isDescending, groupBy, isGroupDescending));
-
-        return sorted.AsReadOnly();
-    }
+        bool isGroupDescending = false) =>
+        SegmentedSortedList.CreateSorted(events, new SortContext(orderBy, isDescending, groupBy, isGroupDescending));
 
     internal static int CompareColumn(ResolvedEvent a, ResolvedEvent b, ColumnName column) =>
         column switch
@@ -164,26 +160,18 @@ internal static class ResolvedEventOrdering
     {
         if (batch.Count == 0) { return existing; }
 
-        if (existing.Count == 0) { return batch.SortEvents(orderBy, isDescending, groupBy, isGroupDescending); }
+        var context = new SortContext(orderBy, isDescending, groupBy, isGroupDescending);
 
-        var comparer = SelectComparer(orderBy, isDescending, groupBy, isGroupDescending);
-
-        var sortedBatch = new List<ResolvedEvent>(batch);
-        sortedBatch.Sort(comparer);
-
-        var result = new List<ResolvedEvent>(existing.Count + sortedBatch.Count);
-        int i = 0, j = 0;
-
-        while (i < existing.Count && j < sortedBatch.Count)
+        if (existing is SegmentedSortedList segmented && segmented.HasContext(context))
         {
-            result.Add(comparer(existing[i], sortedBatch[j]) <= 0 ? existing[i++] : sortedBatch[j++]);
+            return segmented.Append(batch);
         }
 
-        while (i < existing.Count) { result.Add(existing[i++]); }
+        Debug.Assert(
+            existing is not SegmentedSortedList,
+            "DisplayedEvents sort context drifted from the requested merge context.");
 
-        while (j < sortedBatch.Count) { result.Add(sortedBatch[j++]); }
-
-        return result.AsReadOnly();
+        return SegmentedSortedList.MergeFrom(existing, batch, context);
     }
 
     internal static Comparison<ResolvedEvent> SelectComparer(

--- a/src/EventLogExpert.Runtime/LogTable/ResolvedEventOrdering.cs
+++ b/src/EventLogExpert.Runtime/LogTable/ResolvedEventOrdering.cs
@@ -167,11 +167,9 @@ internal static class ResolvedEventOrdering
             return segmented.Append(batch);
         }
 
-        Debug.Assert(
-            existing is not SegmentedSortedList,
-            "DisplayedEvents sort context drifted from the requested merge context.");
-
-        return SegmentedSortedList.MergeFrom(existing, batch, context);
+        return existing is SegmentedSortedList ?
+            throw new UnreachableException("DisplayedEvents sort context drifted from the requested merge context.") :
+            SegmentedSortedList.MergeFrom(existing, batch, context);
     }
 
     internal static Comparison<ResolvedEvent> SelectComparer(

--- a/src/EventLogExpert.Runtime/LogTable/ResolvedEventOrdering.cs
+++ b/src/EventLogExpert.Runtime/LogTable/ResolvedEventOrdering.cs
@@ -122,6 +122,8 @@ internal static class ResolvedEventOrdering
                 _ => s_ascByDefault
             };
 
+    internal static ColumnName GetEffectiveOrderBy(ColumnName? orderBy) => orderBy ?? ColumnName.DateAndTime;
+
     internal static Comparison<ResolvedEvent> GetGroupedComparer(
         ColumnName groupBy,
         bool isGroupDescending,

--- a/src/EventLogExpert.Runtime/LogTable/ResolvedEventOrdering.cs
+++ b/src/EventLogExpert.Runtime/LogTable/ResolvedEventOrdering.cs
@@ -36,7 +36,17 @@ internal static class ResolvedEventOrdering
     private static readonly Comparison<ResolvedEvent> s_ascByRecordId =
         (a, b) => WithTieBreaker(Nullable.Compare(a.RecordId, b.RecordId), a, b);
     private static readonly Comparison<ResolvedEvent> s_ascByDefault =
-        (a, b) => FallbackTieBreaker(Nullable.Compare(a.RecordId, b.RecordId), a, b);
+        (a, b) =>
+        {
+            int byRecordId = Nullable.Compare(a.RecordId, b.RecordId);
+
+            if (byRecordId != 0) { return byRecordId; }
+
+            // Fall back to timestamp then OwningLog for a total order.
+            int byTime = a.TimeCreated.CompareTo(b.TimeCreated);
+
+            return byTime != 0 ? byTime : string.Compare(a.OwningLog, b.OwningLog, StringComparison.Ordinal);
+        };
 
     private static readonly Comparison<ResolvedEvent> s_descByActivityId = (a, b) => s_ascByActivityId(b, a);
     private static readonly Comparison<ResolvedEvent> s_descByComputerName = (a, b) => s_ascByComputerName(b, a);
@@ -170,6 +180,14 @@ internal static class ResolvedEventOrdering
         return existing is SegmentedSortedList ?
             throw new UnreachableException("DisplayedEvents sort context drifted from the requested merge context.") :
             SegmentedSortedList.MergeFrom(existing, batch, context);
+    }
+
+    // RecordId for one log; timestamp for a combined view of several.
+    internal static ColumnName? ResolveDefaultOrderBy(ColumnName? orderBy, ColumnName? groupBy, int logCount)
+    {
+        if (orderBy is not null || groupBy is not null) { return orderBy; }
+
+        return logCount > 1 ? ColumnName.DateAndTime : null;
     }
 
     internal static Comparison<ResolvedEvent> SelectComparer(

--- a/src/EventLogExpert.Runtime/LogTable/SegmentedSortedList.cs
+++ b/src/EventLogExpert.Runtime/LogTable/SegmentedSortedList.cs
@@ -31,7 +31,7 @@ internal readonly record struct SortContext
 // Immutable sorted segments kept globally non-interleaving (segment i entirely <= segment i+1), so the logical
 // sequence is their concatenation and indexing is a prefix-sum binary search. Appends that sit before/after
 // existing add a segment (no copy); interleaving appends fall back to a full merge.
-internal sealed class SegmentedSortedList : IReadOnlyList<ResolvedEvent>, ICollection<ResolvedEvent>
+internal sealed class SegmentedSortedList : IReadOnlyList<ResolvedEvent>, IList<ResolvedEvent>
 {
     private readonly Comparison<ResolvedEvent> _comparer;
     private readonly SortContext _context;
@@ -67,6 +67,8 @@ internal sealed class SegmentedSortedList : IReadOnlyList<ResolvedEvent>, IColle
 
             return _segments[segment][index - _prefix[segment]];
         }
+
+        set => throw new NotSupportedException();
     }
 
     public void Add(ResolvedEvent item) => throw new NotSupportedException();
@@ -102,7 +104,25 @@ internal sealed class SegmentedSortedList : IReadOnlyList<ResolvedEvent>, IColle
         }
     }
 
+    public int IndexOf(ResolvedEvent item)
+    {
+        int index = 0;
+
+        foreach (var resolved in this)
+        {
+            if (EqualityComparer<ResolvedEvent>.Default.Equals(resolved, item)) { return index; }
+
+            index++;
+        }
+
+        return -1;
+    }
+
+    public void Insert(int index, ResolvedEvent item) => throw new NotSupportedException();
+
     public bool Remove(ResolvedEvent item) => throw new NotSupportedException();
+
+    public void RemoveAt(int index) => throw new NotSupportedException();
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
@@ -126,11 +146,6 @@ internal sealed class SegmentedSortedList : IReadOnlyList<ResolvedEvent>, IColle
         SortContext context)
     {
         if (existing.Count == 0) { return CreateSorted(batch, context); }
-
-        // A segmented existing reaching this path drifted from the merge context, so it is sorted by a
-        // different comparer; re-sort everything rather than trusting a 2-way merge that assumes both inputs
-        // already share the merge comparer.
-        if (existing is SegmentedSortedList) { return CreateSorted(existing.Concat(batch), context); }
 
         var comparer = ResolvedEventOrdering.SelectComparer(
             context.OrderBy, context.IsDescending, context.GroupBy, context.IsGroupDescending);
@@ -164,7 +179,7 @@ internal sealed class SegmentedSortedList : IReadOnlyList<ResolvedEvent>, IColle
             return new SegmentedSortedList(_segments.Add(sortedBatch), _context, _comparer);
         }
 
-        var merged = Merge(ToArray(), sortedBatch, _comparer);
+        var merged = MergeWith(sortedBatch);
 
         return new SegmentedSortedList([merged], _context, _comparer);
     }
@@ -246,11 +261,35 @@ internal sealed class SegmentedSortedList : IReadOnlyList<ResolvedEvent>, IColle
         return low;
     }
 
-    private ResolvedEvent[] ToArray()
+    private ImmutableArray<ResolvedEvent> MergeWith(ImmutableArray<ResolvedEvent> sortedBatch)
     {
-        var array = new ResolvedEvent[Count];
-        CopyTo(array, 0);
+        var result = ImmutableArray.CreateBuilder<ResolvedEvent>(Count + sortedBatch.Length);
 
-        return array;
+        using var existing = GetEnumerator();
+        bool hasExisting = existing.MoveNext();
+        int j = 0;
+
+        while (hasExisting && j < sortedBatch.Length)
+        {
+            if (_comparer(existing.Current, sortedBatch[j]) <= 0)
+            {
+                result.Add(existing.Current);
+                hasExisting = existing.MoveNext();
+            }
+            else
+            {
+                result.Add(sortedBatch[j++]);
+            }
+        }
+
+        while (hasExisting)
+        {
+            result.Add(existing.Current);
+            hasExisting = existing.MoveNext();
+        }
+
+        while (j < sortedBatch.Length) { result.Add(sortedBatch[j++]); }
+
+        return result.MoveToImmutable();
     }
 }

--- a/src/EventLogExpert.Runtime/LogTable/SegmentedSortedList.cs
+++ b/src/EventLogExpert.Runtime/LogTable/SegmentedSortedList.cs
@@ -1,0 +1,256 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+using System.Collections;
+using System.Collections.Immutable;
+
+namespace EventLogExpert.Runtime.LogTable;
+
+internal readonly record struct SortContext
+{
+    internal SortContext(ColumnName? orderBy, bool isDescending, ColumnName? groupBy, bool isGroupDescending)
+    {
+        // When grouped, the comparer treats a null order-by as DateAndTime, so normalize so null and DateAndTime
+        // are the same context/comparer. Ungrouped null stays RecordId-sorted.
+        OrderBy = groupBy is null ? orderBy : orderBy ?? ColumnName.DateAndTime;
+        IsDescending = isDescending;
+        GroupBy = groupBy;
+        IsGroupDescending = isGroupDescending;
+    }
+
+    internal ColumnName? OrderBy { get; }
+
+    internal bool IsDescending { get; }
+
+    internal ColumnName? GroupBy { get; }
+
+    internal bool IsGroupDescending { get; }
+}
+
+// Immutable sorted segments kept globally non-interleaving (segment i entirely <= segment i+1), so the logical
+// sequence is their concatenation and indexing is a prefix-sum binary search. Appends that sit before/after
+// existing add a segment (no copy); interleaving appends fall back to a full merge.
+internal sealed class SegmentedSortedList : IReadOnlyList<ResolvedEvent>, ICollection<ResolvedEvent>
+{
+    private readonly Comparison<ResolvedEvent> _comparer;
+    private readonly SortContext _context;
+    private readonly int[] _prefix;
+    private readonly ImmutableArray<ImmutableArray<ResolvedEvent>> _segments;
+
+    private SegmentedSortedList(
+        ImmutableArray<ImmutableArray<ResolvedEvent>> segments,
+        SortContext context,
+        Comparison<ResolvedEvent> comparer)
+    {
+        _segments = segments;
+        _context = context;
+        _comparer = comparer;
+        _prefix = BuildPrefix(segments);
+    }
+
+    public int Count => _prefix[^1];
+
+    public bool IsReadOnly => true;
+
+    internal SortContext Context => _context;
+
+    internal int SegmentCount => _segments.Length;
+
+    public ResolvedEvent this[int index]
+    {
+        get
+        {
+            if ((uint)index >= (uint)Count) { throw new ArgumentOutOfRangeException(nameof(index)); }
+
+            int segment = FindSegment(index);
+
+            return _segments[segment][index - _prefix[segment]];
+        }
+    }
+
+    public void Add(ResolvedEvent item) => throw new NotSupportedException();
+
+    public void Clear() => throw new NotSupportedException();
+
+    public bool Contains(ResolvedEvent item)
+    {
+        foreach (var segment in _segments)
+        {
+            if (segment.Contains(item)) { return true; }
+        }
+
+        return false;
+    }
+
+    public void CopyTo(ResolvedEvent[] array, int arrayIndex)
+    {
+        ArgumentNullException.ThrowIfNull(array);
+
+        foreach (var segment in _segments)
+        {
+            segment.CopyTo(array, arrayIndex);
+            arrayIndex += segment.Length;
+        }
+    }
+
+    public IEnumerator<ResolvedEvent> GetEnumerator()
+    {
+        foreach (var segment in _segments)
+        {
+            foreach (var resolved in segment) { yield return resolved; }
+        }
+    }
+
+    public bool Remove(ResolvedEvent item) => throw new NotSupportedException();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    internal static SegmentedSortedList CreateSorted(IEnumerable<ResolvedEvent> events, SortContext context)
+    {
+        var comparer = ResolvedEventOrdering.SelectComparer(
+            context.OrderBy, context.IsDescending, context.GroupBy, context.IsGroupDescending);
+
+        var sorted = new List<ResolvedEvent>(events);
+        sorted.Sort(comparer);
+
+        ImmutableArray<ImmutableArray<ResolvedEvent>> segments =
+            sorted.Count == 0 ? [] : [[..sorted]];
+
+        return new SegmentedSortedList(segments, context, comparer);
+    }
+
+    internal static SegmentedSortedList MergeFrom(
+        IReadOnlyList<ResolvedEvent> existing,
+        IReadOnlyList<ResolvedEvent> batch,
+        SortContext context)
+    {
+        if (existing.Count == 0) { return CreateSorted(batch, context); }
+
+        // A segmented existing reaching this path drifted from the merge context, so it is sorted by a
+        // different comparer; re-sort everything rather than trusting a 2-way merge that assumes both inputs
+        // already share the merge comparer.
+        if (existing is SegmentedSortedList) { return CreateSorted(existing.Concat(batch), context); }
+
+        var comparer = ResolvedEventOrdering.SelectComparer(
+            context.OrderBy, context.IsDescending, context.GroupBy, context.IsGroupDescending);
+
+        var sortedBatch = SortBatch(batch, comparer);
+        var merged = Merge(existing, sortedBatch, comparer);
+
+        return new SegmentedSortedList([merged], context, comparer);
+    }
+
+    internal SegmentedSortedList Append(IReadOnlyList<ResolvedEvent> batch)
+    {
+        if (batch.Count == 0) { return this; }
+
+        var sortedBatch = SortBatch(batch, _comparer);
+
+        if (_segments.IsEmpty)
+        {
+            return new SegmentedSortedList([sortedBatch], _context, _comparer);
+        }
+
+        // Strict < for prepend but <= for append: MergeSorted is left-stable (existing wins ties), so a batch
+        // that ties with the head must not jump ahead - it falls through to the full merge.
+        if (_comparer(sortedBatch[^1], _segments[0][0]) < 0)
+        {
+            return new SegmentedSortedList(_segments.Insert(0, sortedBatch), _context, _comparer);
+        }
+
+        if (_comparer(_segments[^1][^1], sortedBatch[0]) <= 0)
+        {
+            return new SegmentedSortedList(_segments.Add(sortedBatch), _context, _comparer);
+        }
+
+        var merged = Merge(ToArray(), sortedBatch, _comparer);
+
+        return new SegmentedSortedList([merged], _context, _comparer);
+    }
+
+    internal bool HasContext(SortContext context) => _context == context;
+
+    internal SegmentedSortedList WhereSegmented(Func<ResolvedEvent, bool> predicate)
+    {
+        var builder = ImmutableArray.CreateBuilder<ImmutableArray<ResolvedEvent>>(_segments.Length);
+
+        foreach (var segment in _segments)
+        {
+            var kept = ImmutableArray.CreateBuilder<ResolvedEvent>(segment.Length);
+
+            foreach (var resolved in segment)
+            {
+                if (predicate(resolved)) { kept.Add(resolved); }
+            }
+
+            if (kept.Count > 0) { builder.Add(kept.ToImmutable()); }
+        }
+
+        return new SegmentedSortedList(builder.ToImmutable(), _context, _comparer);
+    }
+
+    private static int[] BuildPrefix(ImmutableArray<ImmutableArray<ResolvedEvent>> segments)
+    {
+        var prefix = new int[segments.Length + 1];
+
+        for (int i = 0; i < segments.Length; i++)
+        {
+            prefix[i + 1] = prefix[i] + segments[i].Length;
+        }
+
+        return prefix;
+    }
+
+    private static ImmutableArray<ResolvedEvent> Merge(
+        IReadOnlyList<ResolvedEvent> existing,
+        IReadOnlyList<ResolvedEvent> sortedBatch,
+        Comparison<ResolvedEvent> comparer)
+    {
+        var result = ImmutableArray.CreateBuilder<ResolvedEvent>(existing.Count + sortedBatch.Count);
+        int i = 0, j = 0;
+
+        while (i < existing.Count && j < sortedBatch.Count)
+        {
+            result.Add(comparer(existing[i], sortedBatch[j]) <= 0 ? existing[i++] : sortedBatch[j++]);
+        }
+
+        while (i < existing.Count) { result.Add(existing[i++]); }
+
+        while (j < sortedBatch.Count) { result.Add(sortedBatch[j++]); }
+
+        return result.MoveToImmutable();
+    }
+
+    private static ImmutableArray<ResolvedEvent> SortBatch(IReadOnlyList<ResolvedEvent> batch, Comparison<ResolvedEvent> comparer)
+    {
+        var sorted = new List<ResolvedEvent>(batch);
+        sorted.Sort(comparer);
+
+        return [..sorted];
+    }
+
+    private int FindSegment(int index)
+    {
+        int low = 0;
+        int high = _segments.Length - 1;
+
+        while (low < high)
+        {
+            int mid = (low + high + 1) >> 1;
+
+            if (_prefix[mid] <= index) { low = mid; }
+            else { high = mid - 1; }
+        }
+
+        return low;
+    }
+
+    private ResolvedEvent[] ToArray()
+    {
+        var array = new ResolvedEvent[Count];
+        CopyTo(array, 0);
+
+        return array;
+    }
+}

--- a/src/EventLogExpert.Runtime/LogTable/SegmentedSortedList.cs
+++ b/src/EventLogExpert.Runtime/LogTable/SegmentedSortedList.cs
@@ -186,6 +186,66 @@ internal sealed class SegmentedSortedList : IReadOnlyList<ResolvedEvent>, IList<
 
     internal bool HasContext(SortContext context) => _context == context;
 
+    internal int Rank(ResolvedEvent target)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+
+        int low = 0;
+        int high = Count;
+
+        while (low < high)
+        {
+            int mid = low + ((high - low) >> 1);
+
+            if (_comparer(this[mid], target) < 0) { low = mid + 1; }
+            else { high = mid; }
+        }
+
+        // Scan the comparer-equal window (null-RecordId error reads) for the exact instance.
+        for (int i = low; i < Count && _comparer(this[i], target) == 0; i++)
+        {
+            if (ReferenceEquals(this[i], target)) { return i; }
+        }
+
+        return -1;
+    }
+
+    internal ResolvedEvent? ResolveByKey(ResolvedEvent candidate)
+    {
+        ArgumentNullException.ThrowIfNull(candidate);
+
+        int low = 0;
+        int high = Count;
+
+        while (low < high)
+        {
+            int mid = low + ((high - low) >> 1);
+
+            if (_comparer(this[mid], candidate) < 0) { low = mid + 1; }
+            else { high = mid; }
+        }
+
+        for (int i = low; i < Count && _comparer(this[i], candidate) == 0; i++)
+        {
+            var current = this[i];
+
+            if (ReferenceEquals(current, candidate)) { return current; }
+
+            // Skip null RecordId: null == null would merge distinct error-read events.
+            if (current.RecordId is null || candidate.RecordId is null) { continue; }
+
+            if (current.RecordId == candidate.RecordId &&
+                current.TimeCreated == candidate.TimeCreated &&
+                string.Equals(current.OwningLog, candidate.OwningLog, StringComparison.Ordinal) &&
+                string.Equals(current.LogName, candidate.LogName, StringComparison.Ordinal))
+            {
+                return current;
+            }
+        }
+
+        return null;
+    }
+
     internal SegmentedSortedList WhereSegmented(Func<ResolvedEvent, bool> predicate)
     {
         var builder = ImmutableArray.CreateBuilder<ImmutableArray<ResolvedEvent>>(_segments.Length);

--- a/src/EventLogExpert.Runtime/LogTable/SegmentedSortedList.cs
+++ b/src/EventLogExpert.Runtime/LogTable/SegmentedSortedList.cs
@@ -85,16 +85,22 @@ internal sealed class SegmentedSortedList : IReadOnlyList<ResolvedEvent>, IList<
         return false;
     }
 
-    public void CopyTo(ResolvedEvent[] array, int arrayIndex)
-    {
-        ArgumentNullException.ThrowIfNull(array);
+public void CopyTo(ResolvedEvent[] array, int arrayIndex)
+{
+    ArgumentNullException.ThrowIfNull(array);
+    ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
 
-        foreach (var segment in _segments)
-        {
-            segment.CopyTo(array, arrayIndex);
-            arrayIndex += segment.Length;
-        }
+    if (array.Length - arrayIndex < Count)
+    {
+        throw new ArgumentException("Destination array is not long enough.", nameof(array));
     }
+
+    foreach (var segment in _segments)
+    {
+        segment.CopyTo(array, arrayIndex);
+        arrayIndex += segment.Length;
+    }
+}
 
     public IEnumerator<ResolvedEvent> GetEnumerator()
     {

--- a/src/EventLogExpert.UI/LogTable/Grouping/GroupedRowView.cs
+++ b/src/EventLogExpert.UI/LogTable/Grouping/GroupedRowView.cs
@@ -62,33 +62,31 @@ internal sealed class GroupedRowView : IReadOnlyList<TableRow>, IList<TableRow>
         var groupIndexByKey = new Dictionary<string, int>(StringComparer.Ordinal);
         int visible = 0;
         int index = 0;
-        // Carry each run's boundary key forward so every event's key is computed once.
-        string? key = events.Count > 0 ? ResolvedEventGroupKey.For(groupBy, events[0]) : null;
+        int start = 0;
+        string? currentKey = null;
 
-        while (index < events.Count)
+        // The view may compute elements on demand; avoid random indexing.
+        foreach (var resolved in events)
         {
-            string currentKey = key!;
-            int start = index;
-            index++;
+            string key = ResolvedEventGroupKey.For(groupBy, resolved);
 
-            while (index < events.Count)
+            if (currentKey is null)
             {
-                string nextKey = ResolvedEventGroupKey.For(groupBy, events[index]);
-
-                if (!string.Equals(nextKey, currentKey, StringComparison.Ordinal))
-                {
-                    key = nextKey;
-
-                    break;
-                }
-
-                index++;
+                currentKey = key;
+            }
+            else if (!string.Equals(key, currentKey, StringComparison.Ordinal))
+            {
+                CloseGroup(groups, groupIndexByKey, currentKey, start, index, isCollapsed, ref visible);
+                currentKey = key;
+                start = index;
             }
 
-            var group = new EventGroup(currentKey, start, index - start, isCollapsed(currentKey), visible);
-            groupIndexByKey[currentKey] = groups.Count;
-            groups.Add(group);
-            visible += group.VisibleSize;
+            index++;
+        }
+
+        if (currentKey is not null)
+        {
+            CloseGroup(groups, groupIndexByKey, currentKey, start, index, isCollapsed, ref visible);
         }
 
         return new GroupedRowView(events, [.. groups], visible, groupIndexByKey);
@@ -161,6 +159,21 @@ internal sealed class GroupedRowView : IReadOnlyList<TableRow>, IList<TableRow>
         _groupIndexByKey.TryGetValue(groupKey, out int i) ? _groups[i].VisibleStart : -1;
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    private static void CloseGroup(
+        List<EventGroup> groups,
+        Dictionary<string, int> groupIndexByKey,
+        string key,
+        int start,
+        int end,
+        Func<string, bool> isCollapsed,
+        ref int visible)
+    {
+        var group = new EventGroup(key, start, end - start, isCollapsed(key), visible);
+        groupIndexByKey[key] = groups.Count;
+        groups.Add(group);
+        visible += group.VisibleSize;
+    }
 
     private int FindGroup(int target, bool byVisibleStart)
     {

--- a/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
@@ -53,7 +53,6 @@ public sealed partial class LogTablePane
     private int _pageSize = DefaultPageSize;
     private ColumnName[] _previousEnabledColumns = [];
     private bool _resortSelectionOnNextRender;
-    private Dictionary<ResolvedEvent, int> _rowIndexMap = new(ReferenceEqualityComparer.Instance);
     private GroupedRowView? _rowView;
     private (IReadOnlyList<ResolvedEvent> Events, EventLogId? TableId, ColumnName? GroupBy, bool GroupDescending, bool CollapsedDefault, ImmutableHashSet<string>? Overrides) _rowViewSnapshot;
     private ResolvedEvent? _selectedEvent;
@@ -380,9 +379,8 @@ public sealed partial class LogTablePane
         ResolvedEvent anchor,
         ResolvedEvent selected)
     {
-        if (!_rowIndexMap.TryGetValue(anchor, out int anchorIndex)) { anchorIndex = -1; }
-
-        if (!_rowIndexMap.TryGetValue(selected, out int activeIndex)) { activeIndex = -1; }
+        int anchorIndex = RowIndexOf(anchor);
+        int activeIndex = RowIndexOf(selected);
 
         if (anchorIndex < 0 || activeIndex < 0)
         {
@@ -420,7 +418,9 @@ public sealed partial class LogTablePane
         {
             if (!seen.Add(selectedEvent)) { continue; }
 
-            if (_rowIndexMap.TryGetValue(selectedEvent, out int index))
+            int index = RowIndexOf(selectedEvent);
+
+            if (index >= 0)
             {
                 inTable.Add((selectedEvent, index));
             }
@@ -475,9 +475,14 @@ public sealed partial class LogTablePane
 
         var fallback = _selectedEvents.LastOrDefault();
 
-        if (fallback is not null && _rowIndexMap.TryGetValue(fallback, out int fallbackIndex))
+        if (fallback is not null)
         {
-            return _rowView?.VisibleRowForEvent(fallbackIndex) ?? fallbackIndex;
+            int fallbackIndex = RowIndexOf(fallback);
+
+            if (fallbackIndex >= 0)
+            {
+                return _rowView?.VisibleRowForEvent(fallbackIndex) ?? fallbackIndex;
+            }
         }
 
         int count = _rowView?.Count ?? displayedEvents.Count;
@@ -560,14 +565,18 @@ public sealed partial class LogTablePane
 
     private int GetRowIndex(ResolvedEvent evt)
     {
-        if (!_rowIndexMap.TryGetValue(evt, out int index)) { return 2; }
+        int index = RowIndexOf(evt);
+
+        if (index < 0) { return 2; }
 
         return (_rowView?.VisibleRowForEvent(index) ?? index) + 2;
     }
 
     private int GetRowStripe(ResolvedEvent evt)
     {
-        if (!_rowIndexMap.TryGetValue(evt, out int index)) { return 0; }
+        int index = RowIndexOf(evt);
+
+        if (index < 0) { return 0; }
 
         if (_rowView is null) { return index % 2; }
 
@@ -697,13 +706,17 @@ public sealed partial class LogTablePane
 
         if (view is null) { return; }
 
-        if (_cursor is { Kind: TableRowKind.Event, Event: { } @event } &&
-            _rowIndexMap.TryGetValue(@event, out int index))
+        if (_cursor is { Kind: TableRowKind.Event, Event: { } @event })
         {
-            SetCursorHeader(view.GroupForEvent(index).Key);
-            _focusActiveOnNextRender = true;
+            int index = RowIndexOf(@event);
 
-            return;
+            if (index >= 0)
+            {
+                SetCursorHeader(view.GroupForEvent(index).Key);
+                _focusActiveOnNextRender = true;
+
+                return;
+            }
         }
 
         if (_cursor is { Kind: TableRowKind.Header, GroupKey: { } key } &&
@@ -789,7 +802,9 @@ public sealed partial class LogTablePane
 
         foreach (var selectedEvent in selection)
         {
-            if (!_rowIndexMap.TryGetValue(selectedEvent, out int index)) { continue; }
+            int index = RowIndexOf(selectedEvent);
+
+            if (index < 0) { continue; }
 
             if (index < lastIndex) { return true; }
 
@@ -854,14 +869,19 @@ public sealed partial class LogTablePane
     // Retype an event in a collapsed group to its header.
     private TableCursor? NormalizeCursor(TableCursor? cursor)
     {
-        if (_rowView is { } view &&
-            cursor is { Kind: TableRowKind.Event, Event: { } @event } &&
-            _rowIndexMap.TryGetValue(@event, out int index))
+        if (_rowView is not { } view ||
+            cursor is not { Kind: TableRowKind.Event, Event: { } @event })
         {
-            var group = view.GroupForEvent(index);
-
-            if (group.IsCollapsed) { return TableCursor.ForHeader(group.Key); }
+            return cursor;
         }
+
+        int index = RowIndexOf(@event);
+
+        if (index < 0) { return cursor; }
+
+        var group = view.GroupForEvent(index);
+
+        if (group.IsCollapsed) { return TableCursor.ForHeader(group.Key); }
 
         return cursor;
     }
@@ -925,7 +945,6 @@ public sealed partial class LogTablePane
         if (!ReferenceEquals(displayedEvents, _lastIndexedDisplayedEvents))
         {
             _lastIndexedDisplayedEvents = displayedEvents;
-            _rowIndexMap = new Dictionary<ResolvedEvent, int>(displayedEvents.Count, ReferenceEqualityComparer.Instance);
             _highlightCache.Clear();
 
             if (displayedEvents.Count == 0)
@@ -935,11 +954,6 @@ public sealed partial class LogTablePane
             }
             else
             {
-                for (int i = 0; i < displayedEvents.Count; i++)
-                {
-                    _rowIndexMap[displayedEvents[i]] = i;
-                }
-
                 _selectionAnchor = ResolveByKey(displayedEvents, _selectionAnchor);
 
                 if (_cursor is { Kind: TableRowKind.Event, Event: { } cursorEvent })
@@ -965,7 +979,9 @@ public sealed partial class LogTablePane
 
         if (cursor is { Kind: TableRowKind.Event, Event: { } @event })
         {
-            if (_rowIndexMap.TryGetValue(@event, out int index))
+            int index = RowIndexOf(@event);
+
+            if (index >= 0)
             {
                 var group = view.GroupForEvent(index);
 
@@ -1005,6 +1021,13 @@ public sealed partial class LogTablePane
 
         var canonical = _logTableState.DisplayedEvents;
 
+        if (_logTableState.EventTables.Count(table => !table.IsCombined) == 1 &&
+            _logTableState.EventCountByLog.TryGetValue(_currentTable.Id, out int onlyLogCount) &&
+            onlyLogCount == canonical.Count)
+        {
+            return canonical;
+        }
+
         if (_cachedFilteredView is not null &&
             ReferenceEquals(canonical, _cachedFilteredCanonical) &&
             _cachedFilteredTableId == _currentTable.Id)
@@ -1043,10 +1066,14 @@ public sealed partial class LogTablePane
             return _rowView?.VisibleRowForHeader(key) ?? -1;
         }
 
-        if (_cursor is { Kind: TableRowKind.Event, Event: { } @event } &&
-            _rowIndexMap.TryGetValue(@event, out int index))
+        if (_cursor is { Kind: TableRowKind.Event, Event: { } @event })
         {
-            return _rowView?.VisibleRowForEvent(index) ?? index;
+            int index = RowIndexOf(@event);
+
+            if (index >= 0)
+            {
+                return _rowView?.VisibleRowForEvent(index) ?? index;
+            }
         }
 
         return -1;
@@ -1056,6 +1083,15 @@ public sealed partial class LogTablePane
     {
         DispatchSetSelection(_selectedEvents, ActiveEvent ?? _selectedEvent);
     }
+
+    private int RowIndexOf(ResolvedEvent @event) =>
+        ResolvedEventIndex.IndexOf(
+            _activeDisplayedEvents,
+            @event,
+            _logTableState.OrderBy,
+            _logTableState.IsDescending,
+            _logTableState.GroupBy,
+            _logTableState.IsGroupDescending);
 
     private async Task ScrollToSelectedEvent()
     {

--- a/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
@@ -37,9 +37,6 @@ public sealed partial class LogTablePane
 
     private IReadOnlyList<ResolvedEvent> _activeDisplayedEvents = [];
     private SavedFilter[] _activeHighlightFilters = [];
-    private IReadOnlyList<ResolvedEvent>? _cachedFilteredCanonical;
-    private EventLogId? _cachedFilteredTableId;
-    private IReadOnlyList<ResolvedEvent>? _cachedFilteredView;
     private LogView? _currentTable;
     private TableCursor? _cursor;
     private DotNetObjectReference<LogTablePane>? _dotNetRef;
@@ -278,27 +275,8 @@ public sealed partial class LogTablePane
 
     private static ResolvedEvent? ResolveByKey(
         IReadOnlyList<ResolvedEvent> displayedEvents,
-        ResolvedEvent? candidate)
-    {
-        if (candidate is null) { return null; }
-
-        foreach (var evt in displayedEvents)
-        {
-            if (ReferenceEquals(evt, candidate)) { return evt; }
-
-            // Skip null RecordId: null == null would merge distinct error-read events.
-            if (evt.RecordId is null || candidate.RecordId is null) { continue; }
-
-            if (evt.RecordId == candidate.RecordId &&
-                evt.TimeCreated == candidate.TimeCreated &&
-                string.Equals(evt.OwningLog, candidate.OwningLog, StringComparison.Ordinal))
-            {
-                return evt;
-            }
-        }
-
-        return null;
-    }
+        ResolvedEvent? candidate) =>
+        ResolvedEventIndex.ResolveByKey(displayedEvents, candidate);
 
     private static string TruncateForMenu(string value)
     {
@@ -356,7 +334,7 @@ public sealed partial class LogTablePane
         {
             _selectionAnchor ??= ActiveEvent ?? targetEvent;
             SetCursorEvent(targetEvent);
-            DispatchSetSelection(BuildRange(displayedEvents, _selectionAnchor, targetEvent), targetEvent);
+            DispatchSetSelection(BuildRange(displayedEvents, _selectionAnchor, targetEvent), targetEvent, alreadyOrdered: true);
         }
         else
         {
@@ -382,34 +360,24 @@ public sealed partial class LogTablePane
         int anchorIndex = RowIndexOf(anchor);
         int activeIndex = RowIndexOf(selected);
 
-        if (anchorIndex < 0 || activeIndex < 0)
-        {
-            for (int i = 0; i < displayedEvents.Count; i++)
-            {
-                if (anchorIndex < 0 && ReferenceEquals(displayedEvents[i], anchor)) { anchorIndex = i; }
-
-                if (activeIndex < 0 && ReferenceEquals(displayedEvents[i], selected)) { activeIndex = i; }
-
-                if (anchorIndex >= 0 && activeIndex >= 0) { break; }
-            }
-        }
-
         if (anchorIndex < 0 || activeIndex < 0) { return [selected]; }
 
         int start = Math.Min(anchorIndex, activeIndex);
         int end = Math.Max(anchorIndex, activeIndex);
-        var range = new ResolvedEvent[end - start + 1];
 
-        for (int i = 0; i < range.Length; i++)
-        {
-            range[i] = displayedEvents[start + i];
-        }
-
-        return range;
+        return ResolvedEventIndex.Slice(displayedEvents, start, end - start + 1);
     }
 
-    private void DispatchSetSelection(IReadOnlyList<ResolvedEvent> events, ResolvedEvent? selected)
+    private void DispatchSetSelection(IReadOnlyList<ResolvedEvent> events, ResolvedEvent? selected, bool alreadyOrdered = false)
     {
+        // These callers pass ordered, unique events; skip rank + sort.
+        if (alreadyOrdered)
+        {
+            EventLogCommands.SetSelectedEvents(events, selected);
+
+            return;
+        }
+
         var seen = new HashSet<ResolvedEvent>(ReferenceEqualityComparer.Instance);
         List<(ResolvedEvent Event, int Index)> inTable = new(events.Count);
         List<ResolvedEvent> outOfTable = [];
@@ -601,7 +569,7 @@ public sealed partial class LogTablePane
             var last = displayedEvents[^1];
             _selectionAnchor = displayedEvents[0];
             SetCursorEvent(last);
-            DispatchSetSelection(displayedEvents, last);
+            DispatchSetSelection(displayedEvents, last, alreadyOrdered: true);
 
             return;
         }
@@ -1017,46 +985,9 @@ public sealed partial class LogTablePane
     {
         if (_currentTable is null) { return []; }
 
-        if (_currentTable.IsCombined) { return _logTableState.DisplayedEvents; }
-
-        var canonical = _logTableState.DisplayedEvents;
-
-        if (_logTableState.EventTables.Count(table => !table.IsCombined) == 1 &&
-            _logTableState.EventCountByLog.TryGetValue(_currentTable.Id, out int onlyLogCount) &&
-            onlyLogCount == canonical.Count)
-        {
-            return canonical;
-        }
-
-        if (_cachedFilteredView is not null &&
-            ReferenceEquals(canonical, _cachedFilteredCanonical) &&
-            _cachedFilteredTableId == _currentTable.Id)
-        {
-            return _cachedFilteredView;
-        }
-
-        int expectedCapacity = _logTableState.EventCountByLog.TryGetValue(_currentTable.Id, out int trackedCount)
-            ? trackedCount
-            : 0;
-
-        var filtered = new List<ResolvedEvent>(expectedCapacity);
-
-        for (int eventIndex = 0; eventIndex < canonical.Count; eventIndex++)
-        {
-            var current = canonical[eventIndex];
-
-            if (string.Equals(current.OwningLog, _currentTable.LogName, StringComparison.Ordinal))
-            {
-                filtered.Add(current);
-            }
-        }
-
-        var result = filtered.AsReadOnly();
-        _cachedFilteredCanonical = canonical;
-        _cachedFilteredTableId = _currentTable.Id;
-        _cachedFilteredView = result;
-
-        return result;
+        return _currentTable.IsCombined
+            ? _logTableState.DisplayedEvents
+            : _logTableState.EventsForLog(_currentTable.Id);
     }
 
     private int ResolveCursorVisibleRow()
@@ -1099,28 +1030,19 @@ public sealed partial class LogTablePane
 
         if (target is null) { return; }
 
-        var displayedEvents = _activeDisplayedEvents;
+        if (_activeDisplayedEvents.Count == 0) { return; }
 
-        if (displayedEvents.Count == 0) { return; }
+        var resolved = ResolvedEventIndex.ResolveByKey(_activeDisplayedEvents, target);
 
-        // Match OwningLog too so overlapping logs don't cross-match on RecordId.
-        for (var index = 0; index < displayedEvents.Count; index++)
-        {
-            var candidate = displayedEvents[index];
+        if (resolved is null) { return; }
 
-            if (candidate.RecordId != target.RecordId ||
-                !string.Equals(candidate.OwningLog, target.OwningLog, StringComparison.Ordinal) ||
-                !string.Equals(candidate.LogName, target.LogName, StringComparison.Ordinal))
-            {
-                continue;
-            }
+        int index = RowIndexOf(resolved);
 
-            int targetRow = _rowView?.VisibleRowForEvent(index) ?? index;
+        if (index < 0) { return; }
 
-            if (_tableModule is not null) { await _tableModule.InvokeVoidAsync("scrollToRow", targetRow); }
+        int targetRow = _rowView?.VisibleRowForEvent(index) ?? index;
 
-            return;
-        }
+        if (_tableModule is not null) { await _tableModule.InvokeVoidAsync("scrollToRow", targetRow); }
     }
 
     private void SelectEvent(MouseEventArgs args, ResolvedEvent @event)
@@ -1151,7 +1073,7 @@ public sealed partial class LogTablePane
                 }
                 else
                 {
-                    DispatchSetSelection(range, @event);
+                    DispatchSetSelection(range, @event, alreadyOrdered: true);
                 }
 
                 return;
@@ -1206,17 +1128,12 @@ public sealed partial class LogTablePane
             return;
         }
 
-        var members = new List<ResolvedEvent>(group.EventCount);
-
-        for (int i = group.StartIndex; i < group.StartIndex + group.EventCount; i++)
-        {
-            members.Add(_activeDisplayedEvents[i]);
-        }
+        var members = ResolvedEventIndex.Slice(_activeDisplayedEvents, group.StartIndex, group.EventCount);
 
         var active = members[0];
         _selectionAnchor = active;
         SetCursorEvent(active);
-        DispatchSetSelection(members, active);
+        DispatchSetSelection(members, active, alreadyOrdered: true);
     }
 
     private void SelectGroupByKey(string key)

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Resolvers/EventResolverBaseTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Resolvers/EventResolverBaseTests.cs
@@ -10,6 +10,7 @@ using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Provider.Resolution;
 using NSubstitute;
 using System.Collections.Concurrent;
+using System.Security.Principal;
 
 namespace EventLogExpert.Eventing.Tests.Resolvers;
 
@@ -3074,6 +3075,36 @@ public sealed class EventResolverBaseTests
             // Assert
             Assert.Equal(testCase.Expected, displayEvent.Level);
         }
+    }
+
+    [Fact]
+    public void ResolveEvent_WithSharedKeywordsAndSid_ShouldInternAcrossEvents()
+    {
+        // Arrange
+        var cache = new EventResolverCache();
+        var resolver = new TestEventResolver(cache, Substitute.For<ITraceLogger>());
+
+        const long auditSuccessKeyword = 0x20000000000000L;
+
+        EventRecord CreateRecord() => new()
+        {
+            ProviderName = "Provider",
+            Id = 1000,
+            LogName = Constants.ApplicationLogName,
+            ComputerName = "Computer",
+            Keywords = auditSuccessKeyword,
+            UserId = new SecurityIdentifier("S-1-5-18")
+        };
+
+        // Act
+        var first = resolver.ResolveEvent(CreateRecord());
+        var second = resolver.ResolveEvent(CreateRecord());
+
+        // Assert
+        Assert.Equal(new[] { "Audit Success" }, first.Keywords);
+        Assert.Same(first.Keywords, second.Keywords);
+        Assert.NotNull(first.UserId);
+        Assert.Same(first.UserId, second.UserId);
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Resolvers/EventResolverCacheTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Resolvers/EventResolverCacheTests.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Eventing.Resolvers;
+using System.Security.Principal;
 
 namespace EventLogExpert.Eventing.Tests.Resolvers;
 
@@ -181,6 +182,187 @@ public sealed class EventResolverCacheTests
 
         // Assert
         Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void GetOrAddKeywords_AfterClearAll_ShouldReturnNewReference()
+    {
+        var cache = new EventResolverCache();
+        var before = cache.GetOrAddKeywords(new List<string> { "Audit Success" });
+
+        cache.ClearAll();
+
+        var after = cache.GetOrAddKeywords(new List<string> { "Audit Success" });
+
+        Assert.NotSame(before, after);
+        Assert.Same(after, cache.GetOrAddKeywords(new List<string> { "Audit Success" }));
+    }
+
+    [Fact]
+    public void GetOrAddKeywords_AfterMutatingOriginalInput_ShouldNotCorruptCache()
+    {
+        var cache = new EventResolverCache();
+        var input = new List<string> { "Alpha", "Beta" };
+
+        var firstResult = cache.GetOrAddKeywords(input);
+        input.Add("Gamma");
+
+        var secondResult = cache.GetOrAddKeywords(new List<string> { "Alpha", "Beta" });
+
+        Assert.Same(firstResult, secondResult);
+        Assert.Equal(new[] { "Alpha", "Beta" }, firstResult);
+    }
+
+    [Fact]
+    public void GetOrAddKeywords_ConcurrentCalls_ShouldHandleThreadSafely()
+    {
+        var cache = new EventResolverCache();
+        var results = new IReadOnlyList<string>[100];
+
+        Parallel.For(0, 100, i =>
+        {
+            results[i] = cache.GetOrAddKeywords(new List<string> { $"Keyword{i % 10}" });
+        });
+
+        for (int key = 0; key < 10; key++)
+        {
+            var expected = results[key];
+            Assert.NotNull(expected);
+
+            for (int occurrence = 1; occurrence < 10; occurrence++)
+            {
+                Assert.Same(expected, results[key + (occurrence * 10)]);
+            }
+        }
+    }
+
+    [Fact]
+    public void GetOrAddKeywords_WithDifferentContent_ShouldReturnDifferentReferences()
+    {
+        var cache = new EventResolverCache();
+
+        var first = cache.GetOrAddKeywords(new List<string> { "Audit Success" });
+        var second = cache.GetOrAddKeywords(new List<string> { "Audit Failure" });
+
+        Assert.NotSame(first, second);
+    }
+
+    [Fact]
+    public void GetOrAddKeywords_WithDifferentOrder_ShouldReturnDifferentReferences()
+    {
+        var cache = new EventResolverCache();
+
+        var first = cache.GetOrAddKeywords(new List<string> { "Audit Success", "Classic" });
+        var second = cache.GetOrAddKeywords(new List<string> { "Classic", "Audit Success" });
+
+        Assert.NotSame(first, second);
+    }
+
+    [Fact]
+    public void GetOrAddKeywords_WithEmptyList_ShouldReturnSharedEmptyInstance()
+    {
+        var cache = new EventResolverCache();
+
+        var first = cache.GetOrAddKeywords(new List<string>());
+        var second = cache.GetOrAddKeywords(Array.Empty<string>());
+
+        Assert.Same(first, second);
+        Assert.Empty(first);
+    }
+
+    [Fact]
+    public void GetOrAddKeywords_WithSameContent_ShouldReturnSameReference()
+    {
+        var cache = new EventResolverCache();
+
+        var first = cache.GetOrAddKeywords(new List<string> { "Audit Success" });
+        var second = cache.GetOrAddKeywords(new List<string> { "Audit Success" });
+
+        Assert.Same(first, second);
+        Assert.Equal(new[] { "Audit Success" }, first);
+    }
+
+    [Fact]
+    public void GetOrAddSid_AfterClearAll_ShouldReturnNewReference()
+    {
+        var cache = new EventResolverCache();
+        var before = cache.GetOrAddSid(new SecurityIdentifier("S-1-5-18"));
+
+        cache.ClearAll();
+
+        var after = cache.GetOrAddSid(new SecurityIdentifier("S-1-5-18"));
+
+        Assert.NotSame(before, after);
+        Assert.Same(after, cache.GetOrAddSid(new SecurityIdentifier("S-1-5-18")));
+    }
+
+    [Fact]
+    public void GetOrAddSid_ConcurrentCalls_ShouldHandleThreadSafely()
+    {
+        var cache = new EventResolverCache();
+        var sids = new[] { "S-1-5-18", "S-1-5-19", "S-1-5-20", "S-1-1-0", "S-1-5-32-544" };
+        var results = new SecurityIdentifier?[100];
+
+        Parallel.For(0, 100, i =>
+        {
+            results[i] = cache.GetOrAddSid(new SecurityIdentifier(sids[i % sids.Length]));
+        });
+
+        for (int key = 0; key < sids.Length; key++)
+        {
+            var expected = results[key];
+            Assert.NotNull(expected);
+
+            for (int occurrence = key + sids.Length; occurrence < 100; occurrence += sids.Length)
+            {
+                Assert.Same(expected, results[occurrence]);
+            }
+        }
+    }
+
+    [Fact]
+    public void GetOrAddSid_WithDifferentSid_ShouldReturnDifferentReferences()
+    {
+        var cache = new EventResolverCache();
+
+        var first = cache.GetOrAddSid(new SecurityIdentifier("S-1-5-18"));
+        var second = cache.GetOrAddSid(new SecurityIdentifier("S-1-5-19"));
+
+        Assert.NotSame(first, second);
+    }
+
+    [Fact]
+    public void GetOrAddSid_WithNull_ShouldReturnNull()
+    {
+        var cache = new EventResolverCache();
+
+        Assert.Null(cache.GetOrAddSid(null));
+    }
+
+    [Fact]
+    public void GetOrAddSid_WithSameSid_ShouldReturnSameReference()
+    {
+        var cache = new EventResolverCache();
+
+        var first = cache.GetOrAddSid(new SecurityIdentifier("S-1-5-18"));
+        var second = cache.GetOrAddSid(new SecurityIdentifier("S-1-5-18"));
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void MixedOperations_AllCachesConcurrentWithClearAll_ShouldHandleThreadSafely()
+    {
+        var cache = new EventResolverCache();
+
+        var exception = Record.Exception(() =>
+            Parallel.Invoke(
+                () => { for (int i = 0; i < 100; i++) { cache.GetOrAddValue($"Value{i}"); } },
+                () => { for (int i = 0; i < 100; i++) { cache.GetOrAddKeywords(new List<string> { $"Keyword{i % 10}" }); } },
+                () => { for (int i = 0; i < 100; i++) { cache.GetOrAddSid(new SecurityIdentifier($"S-1-5-{18 + (i % 3)}")); } },
+                () => { for (int i = 0; i < 10; i++) { Thread.Sleep(5); cache.ClearAll(); } }));
+
+        Assert.Null(exception);
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/DatabaseCoordinationEffectsReloadTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/DatabaseCoordinationEffectsReloadTests.cs
@@ -182,10 +182,18 @@ public sealed class DatabaseCoordinationEffectsReloadTests
         });
 
         var signalCompletionOnDispatch = false;
+        CancellationTokenSource? firstCallCts = null;
 
         _dispatcher.When(d => d.Dispatch(Arg.Any<CloseLogAction>())).Do(call =>
         {
-            if (!signalCompletionOnDispatch) { return; }
+            if (!signalCompletionOnDispatch)
+            {
+                // Cancel deterministically at the close-await point (not via a wall-clock timer) so the first
+                // reload always fails at the same place and the Received(2) assertion can't race CI scheduling.
+                firstCallCts!.Cancel();
+
+                return;
+            }
 
             var action = (CloseLogAction)call.Args()[0];
             _closeCoordinator.CompleteCloseFor(action.LogId);
@@ -193,10 +201,9 @@ public sealed class DatabaseCoordinationEffectsReloadTests
 
         var sut = CreateSut();
 
-        using (var cts = new CancellationTokenSource())
+        using (firstCallCts = new CancellationTokenSource())
         {
-            cts.CancelAfter(TimeSpan.FromMilliseconds(50));
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => sut.ReloadAllActiveLogsAsync(cts.Token));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => sut.ReloadAllActiveLogsAsync(firstCallCts.Token));
         }
 
         signalCompletionOnDispatch = true;

--- a/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EffectsTests.cs
@@ -1690,6 +1690,7 @@ public sealed class EffectsTests
     {
         var closeCoordinator = new LogCloseCoordinator();
         var concurrencyState = new EventLogConcurrencyState();
+        var coordinator = new PartialLoadCoordinator(dispatcher, Timeout.InfiniteTimeSpan);
 
         var filtering = new FilteringEffects(
             eventLogState,
@@ -1708,12 +1709,14 @@ public sealed class EffectsTests
             databaseService,
             criticalErrorService,
             closeCoordinator,
-            concurrencyState);
+            concurrencyState,
+            coordinator);
 
         var logReload = new LogReloadEffects(
             eventLogState,
             filterService,
-            closeCoordinator);
+            closeCoordinator,
+            coordinator);
 
         var databaseCoordination = new DatabaseCoordinationEffects(
             eventLogState,

--- a/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/PartialLoadCoordinatorTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/PartialLoadCoordinatorTests.cs
@@ -1,0 +1,151 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.LogTable;
+using NSubstitute;
+using IDispatcher = Fluxor.IDispatcher;
+
+namespace EventLogExpert.Runtime.Tests.EventLog;
+
+public sealed class PartialLoadCoordinatorTests
+{
+    [Fact]
+    public void Discard_RemovesBufferAndAllowsReopen()
+    {
+        var (coordinator, dispatched) = Create();
+        var logId = EventLogId.Create();
+
+        coordinator.Enqueue(logId, [NewEvent(1)]);
+        coordinator.Enqueue(logId, [NewEvent(2)]);
+        dispatched.Clear();
+
+        coordinator.Discard(logId);
+        coordinator.Flush();
+        Assert.Empty(dispatched);
+
+        coordinator.Enqueue(logId, [NewEvent(3)]);
+        Assert.Single(dispatched);
+    }
+
+    [Fact]
+    public void DiscardAll_ClearsAllBuffers()
+    {
+        var (coordinator, dispatched) = Create();
+        var first = EventLogId.Create();
+        var second = EventLogId.Create();
+
+        coordinator.Enqueue(first, [NewEvent(1)]);
+        coordinator.Enqueue(second, [NewEvent(2)]);
+        coordinator.Enqueue(first, [NewEvent(3)]);
+        coordinator.Enqueue(second, [NewEvent(4)]);
+        dispatched.Clear();
+
+        coordinator.DiscardAll();
+        coordinator.Flush();
+
+        Assert.Empty(dispatched);
+    }
+
+    [Fact]
+    public void Dispose_ThenEnqueueAndFlush_IsSilent()
+    {
+        var (coordinator, dispatched) = Create();
+
+        coordinator.Dispose();
+        coordinator.Enqueue(EventLogId.Create(), [NewEvent(1)]);
+        coordinator.Flush();
+
+        Assert.Empty(dispatched);
+    }
+
+    [Fact]
+    public void Enqueue_EmptyDelta_DispatchesNothing()
+    {
+        var (coordinator, dispatched) = Create();
+
+        coordinator.Enqueue(EventLogId.Create(), []);
+
+        Assert.Empty(dispatched);
+    }
+
+    [Fact]
+    public void Enqueue_FirstDeltaForLog_FlushesImmediately()
+    {
+        var (coordinator, dispatched) = Create();
+        var logId = EventLogId.Create();
+
+        coordinator.Enqueue(logId, [NewEvent(1)]);
+
+        var batch = Assert.IsType<AppendTableEventsBatchAction>(Assert.Single(dispatched));
+        Assert.True(batch.EventsByLog.ContainsKey(logId));
+        Assert.Single(batch.EventsByLog[logId]);
+    }
+
+    [Fact]
+    public void Flush_BuffersAcrossLogs_DispatchesOneBatchForAllLogs()
+    {
+        var (coordinator, dispatched) = Create();
+        var first = EventLogId.Create();
+        var second = EventLogId.Create();
+
+        // The first delta per log flushes immediately; subsequent deltas buffer for the next flush.
+        coordinator.Enqueue(first, [NewEvent(1)]);
+        coordinator.Enqueue(second, [NewEvent(2)]);
+        dispatched.Clear();
+
+        coordinator.Enqueue(first, [NewEvent(3)]);
+        coordinator.Enqueue(second, [NewEvent(4)]);
+        coordinator.Flush();
+
+        var batch = Assert.IsType<AppendTableEventsBatchAction>(Assert.Single(dispatched));
+        Assert.Equal(2, batch.EventsByLog.Count);
+    }
+
+    [Fact]
+    public void MarkFinalized_DropsAlreadyBufferedDelta()
+    {
+        var (coordinator, dispatched) = Create();
+        var logId = EventLogId.Create();
+
+        coordinator.Enqueue(logId, [NewEvent(1)]); // first-seen: flushes immediately and clears the buffer
+        coordinator.Enqueue(logId, [NewEvent(2)]); // already seen: buffered, not yet flushed
+        dispatched.Clear();
+
+        coordinator.MarkFinalized(logId);
+        coordinator.Flush();
+
+        Assert.Empty(dispatched);
+    }
+
+    [Fact]
+    public void MarkFinalized_ThenLateEnqueue_DropsTheLateEvents()
+    {
+        var (coordinator, dispatched) = Create();
+        var logId = EventLogId.Create();
+
+        coordinator.Enqueue(logId, [NewEvent(1)]);
+        dispatched.Clear();
+
+        coordinator.MarkFinalized(logId);
+        coordinator.Enqueue(logId, [NewEvent(2)]);
+        coordinator.Flush();
+
+        Assert.Empty(dispatched);
+    }
+
+    private static (PartialLoadCoordinator Coordinator, List<object> Dispatched) Create()
+    {
+        var dispatched = new List<object>();
+        var dispatcher = Substitute.For<IDispatcher>();
+        dispatcher.When(d => d.Dispatch(Arg.Any<object>())).Do(call => dispatched.Add(call.Arg<object>()));
+
+        return (new PartialLoadCoordinator(dispatcher, Timeout.InfiniteTimeSpan), dispatched);
+    }
+
+    private static ResolvedEvent NewEvent(long recordId) =>
+        new("Application", LogPathType.Channel) { RecordId = recordId };
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/CombinedEventViewTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/CombinedEventViewTests.cs
@@ -1,0 +1,243 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Runtime.LogTable;
+
+namespace EventLogExpert.Runtime.Tests.LogTable;
+
+public sealed class CombinedEventViewTests
+{
+    private static readonly ColumnName?[] s_groupBys = [null, ColumnName.Source, ColumnName.Level];
+    private static readonly ColumnName?[] s_orderBys =
+        [null, ColumnName.DateAndTime, ColumnName.Source, ColumnName.Level, ColumnName.EventId];
+
+    [Fact]
+    public void CopyTo_ValidatesDestinationBeforeWriting()
+    {
+        var (facade, oracle) = Build([MakeLog("Log0", 1, 100)], ColumnName.DateAndTime, true, null);
+
+        var tooSmall = new ResolvedEvent[facade.Count - 1];
+        Assert.Throws<ArgumentException>(() => facade.CopyTo(tooSmall, 0));
+        Assert.All(tooSmall, e => Assert.Null(e)); // not partially mutated
+
+        var destination = new ResolvedEvent[facade.Count + 2];
+        facade.CopyTo(destination, 1);
+        Assert.Null(destination[0]);
+
+        for (int i = 0; i < facade.Count; i++) { Assert.Same(oracle[i], destination[i + 1]); }
+    }
+
+    [Fact]
+    public void EmptyFacade_HasNoRowsAndResolvesNothing()
+    {
+        var facade = new CombinedEventView([], new SortContext(null, true, null, false));
+
+        Assert.Empty(facade);
+        Assert.Throws<ArgumentOutOfRangeException>(() => facade[0]);
+        Assert.Equal(-1, facade.Rank(MakeEvent("Log0", 1, DateTime.UtcNow, 1000, "S", "Information")));
+        Assert.Empty(facade.Slice(0, 10));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(7)]
+    [InlineData(42)]
+    [InlineData(101)]
+    [InlineData(2026)]
+    [InlineData(31337)]
+    [InlineData(8675309)]
+    public void Facade_MatchesMaterializedOracle_OverRandomContexts(int seed)
+    {
+        var rng = new Random(seed);
+        int logs = 1 + rng.Next(5);
+        var perLog = GenerateLogs(rng, logs, minPerLog: 50, maxPerLog: 900);
+
+        foreach (var orderBy in s_orderBys)
+        {
+            foreach (var groupBy in s_groupBys)
+            {
+                bool descending = rng.Next(2) == 0;
+                var (facade, oracle) = Build(perLog, orderBy, descending, groupBy);
+
+                Assert.Equal(oracle.Count, facade.Count);
+
+                var enumerated = facade.ToList();
+                Assert.Equal(oracle.Count, enumerated.Count);
+
+                for (int i = 0; i < oracle.Count; i++) { Assert.Same(oracle[i], enumerated[i]); }
+
+                foreach (int i in IndicesToProbe(oracle.Count, rng)) { Assert.Same(oracle[i], facade[i]); }
+
+                for (int i = 0; i < oracle.Count; i++) { Assert.Equal(i, facade.Rank(oracle[i])); }
+
+                foreach (int start in IndicesToProbe(oracle.Count, rng))
+                {
+                    int count = Math.Min(73, oracle.Count - start);
+                    var slice = facade.Slice(start, count);
+                    Assert.Equal(count, slice.Count);
+
+                    for (int j = 0; j < count; j++) { Assert.Same(oracle[start + j], slice[j]); }
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void Mutators_Throw_BecauseTheViewIsReadOnly()
+    {
+        var (facade, _) = Build([MakeLog("Log0", 1, 10)], ColumnName.DateAndTime, true, null);
+        var sample = facade[0];
+
+        Assert.True(facade.IsReadOnly);
+        Assert.Throws<NotSupportedException>(() => facade.Add(sample));
+        Assert.Throws<NotSupportedException>(() => facade.Insert(0, sample));
+        Assert.Throws<NotSupportedException>(() => facade.Remove(sample));
+        Assert.Throws<NotSupportedException>(() => facade.RemoveAt(0));
+        Assert.Throws<NotSupportedException>(facade.Clear);
+        Assert.Throws<NotSupportedException>(() => facade[0] = sample);
+    }
+
+    [Fact]
+    public void NullRecordIdErrorReads_AreInternallyConsistent()
+    {
+        var rng = new Random(123);
+        var log = new List<ResolvedEvent>();
+        var time = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        // Error reads share a null RecordId (the only intra-log tie).
+        for (int i = 0; i < 40; i++)
+        {
+            time = time.AddSeconds(1);
+            log.Add(MakeEvent("Log0", recordId: null, time, id: 1000, source: "SameSource", level: "Error"));
+        }
+
+        var (facade, _) = Build([log], ColumnName.Source, false, null);
+
+        var ranks = new HashSet<int>();
+
+        foreach (var resolved in log)
+        {
+            int rank = facade.Rank(resolved);
+            Assert.InRange(rank, 0, facade.Count - 1);
+            Assert.True(ranks.Add(rank), "each error read must map to a distinct rank");
+            Assert.Same(resolved, facade[rank]);
+        }
+    }
+
+    [Fact]
+    public void Rank_ForEventFromClosedOrAbsentLog_ReturnsMinusOne()
+    {
+        var perLog = new List<List<ResolvedEvent>> { MakeLog("Log0", 1, 200) };
+        var (facade, _) = Build(perLog, ColumnName.DateAndTime, true, null);
+
+        var foreign = MakeEvent("LogClosed", 5, new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc), 1000, "S", "Information");
+
+        Assert.Equal(-1, facade.Rank(foreign));
+        Assert.Null(facade.ResolveByKey(foreign));
+    }
+
+    [Fact]
+    public void ResolveByKey_FindsByReferenceAndByEquivalentKey()
+    {
+        var log = MakeLog("Log0", 1, 300);
+        var perLog = new List<List<ResolvedEvent>> { log };
+        var (facade, _) = Build(perLog, ColumnName.Source, false, null);
+
+        var original = log[150];
+        Assert.Same(original, facade.ResolveByKey(original));
+
+        var equivalent = MakeEvent(original.OwningLog, original.RecordId, original.TimeCreated, original.Id, original.Source, original.Level);
+        Assert.Same(original, facade.ResolveByKey(equivalent));
+
+        Assert.Null(facade.ResolveByKey(null));
+    }
+
+    [Fact]
+    public void Slice_HandlesBoundariesAndOverflowWithoutWrongEmpty()
+    {
+        var (facade, oracle) = Build([MakeLog("Log0", 1, 1000)], ColumnName.DateAndTime, true, null);
+
+        Assert.Empty(facade.Slice(facade.Count, 10));
+        Assert.Empty(facade.Slice(0, 0));
+
+        // Overflowing start+count returns the tail, not empty.
+        var tail = facade.Slice(5, int.MaxValue);
+        Assert.Equal(oracle.Count - 5, tail.Count);
+        Assert.Same(oracle[5], tail[0]);
+        Assert.Same(oracle[^1], tail[^1]);
+    }
+
+    private static (CombinedEventView Facade, IReadOnlyList<ResolvedEvent> Oracle) Build(
+        List<List<ResolvedEvent>> perLog, ColumnName? orderBy, bool descending, ColumnName? groupBy)
+    {
+        var context = new SortContext(orderBy, descending, groupBy, false);
+        var lists = perLog.Select(events => SegmentedSortedList.CreateSorted(events, context)).ToList();
+        var facade = new CombinedEventView(lists, context);
+        var oracle = perLog.SelectMany(events => events).SortEvents(orderBy, descending, groupBy);
+
+        return (facade, oracle);
+    }
+
+    private static List<List<ResolvedEvent>> GenerateLogs(Random rng, int logs, int minPerLog, int maxPerLog)
+    {
+        string[] sources = ["Provider.A", "Provider.B", "Provider.C"];
+        string[] levels = ["Information", "Warning", "Error"];
+        var result = new List<List<ResolvedEvent>>(logs);
+
+        for (int k = 0; k < logs; k++)
+        {
+            var time = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddMinutes(rng.Next(0, 120));
+            int count = minPerLog + rng.Next(maxPerLog - minPerLog);
+            var events = new List<ResolvedEvent>(count);
+
+            for (long record = 1; record <= count; record++)
+            {
+                time = time.AddMilliseconds(1 + rng.Next(1000));
+                events.Add(MakeEvent($"Log{k}", record, time, 1000 + rng.Next(8),
+                    sources[rng.Next(sources.Length)], levels[rng.Next(levels.Length)]));
+            }
+
+            result.Add(events);
+        }
+
+        return result;
+    }
+
+    private static IEnumerable<int> IndicesToProbe(int count, Random rng)
+    {
+        if (count == 0) { yield break; }
+
+        foreach (int candidate in new[] { 0, 1, 63, 64, 65, 127, 128, 129, 255, 256, 511, 512, count / 2, count - 1 })
+        {
+            if (candidate >= 0 && candidate < count) { yield return candidate; }
+        }
+
+        for (int i = 0; i < 20; i++) { yield return rng.Next(count); }
+    }
+
+    private static ResolvedEvent MakeEvent(string owningLog, long? recordId, DateTime time, int id, string source, string level) =>
+        new(owningLog, LogPathType.Channel)
+        {
+            RecordId = recordId,
+            TimeCreated = time,
+            Id = id,
+            Source = source,
+            Level = level
+        };
+
+    private static List<ResolvedEvent> MakeLog(string owningLog, long firstRecord, int count)
+    {
+        var events = new List<ResolvedEvent>(count);
+        var time = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        for (int i = 0; i < count; i++)
+        {
+            time = time.AddMilliseconds(1 + i);
+            events.Add(MakeEvent(owningLog, firstRecord + i, time, 1000 + (i % 8), "Provider.A", "Information"));
+        }
+
+        return events;
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/LogTableReducerDifferentialTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/LogTableReducerDifferentialTests.cs
@@ -1,0 +1,398 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Runtime.LogTable;
+using Reducers = EventLogExpert.Runtime.LogTable.Reducers;
+
+namespace EventLogExpert.Runtime.Tests.LogTable;
+
+// Randomized reducer ops checked against a naive re-sorted oracle by reference.
+public sealed class LogTableReducerDifferentialTests
+{
+    [Fact]
+    public void DisplayedEvents_IsIdentityStable_UntilPerLogEventsChange()
+    {
+        var harness = new Harness(seed: 5);
+        harness.AppendToAnyLog();
+
+        var state = harness.State;
+
+        // Same PerLogEvents identity -> same combined instance.
+        Assert.Same(state.DisplayedEvents, state.DisplayedEvents);
+
+        var resorted = Reducers.ReduceToggleGroupSorting(state); // no GroupBy -> no-op, returns same state
+        Assert.Same(state, resorted);
+
+        // A sort-context change must mint a fresh PerLogEvents.
+        var afterOrderBy = Reducers.ReduceSetOrderBy(state, new SetOrderByAction(ColumnName.Level));
+        Assert.NotSame(state.PerLogEvents, afterOrderBy.PerLogEvents);
+        Assert.NotSame(state.DisplayedEvents, afterOrderBy.DisplayedEvents);
+
+        harness.AppendToAnyLog();
+        Assert.NotSame(state.DisplayedEvents, harness.State.DisplayedEvents);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(7)]
+    [InlineData(42)]
+    [InlineData(101)]
+    [InlineData(2026)]
+    [InlineData(31337)]
+    [InlineData(8675309)]
+    [InlineData(int.MaxValue)]
+    public void Reducers_KeepDisplayedAndPerLogViewsMatchingTheOracle_OverRandomOps(int seed)
+    {
+        var harness = new Harness(seed);
+
+        harness.Run(operationCount: 300);
+    }
+
+    private sealed class Harness
+    {
+        private static readonly string[] s_levels = ["Information", "Warning", "Error", "Critical"];
+        private static readonly string[] s_sources = ["Provider.A", "Provider.B", "Provider.C"];
+        private static readonly string[] s_tasks = ["", "Logon", "Service"];
+
+        private readonly ColumnName?[] _groupBys = [null, ColumnName.Source, ColumnName.Level, ColumnName.EventId];
+        private readonly List<LogModel> _logs = [];
+        private readonly ColumnName?[] _orderBys =
+            [null, ColumnName.DateAndTime, ColumnName.Level, ColumnName.Source, ColumnName.EventId, ColumnName.TaskCategory];
+        private readonly Random _rng;
+
+        public Harness(int seed) => _rng = new Random(seed);
+
+        public LogTableState State { get; private set; } = new();
+
+        private ColumnName? EffectiveOrderBy =>
+            ResolvedEventOrdering.ResolveDefaultOrderBy(State.OrderBy, State.GroupBy, OpenLogs().Count);
+
+        public void AppendToAnyLog()
+        {
+            var log = OpenLogs().FirstOrDefault() ?? AddLog();
+            AppendBatch([(log, GenerateBatch(log, 1 + _rng.Next(20)))]);
+        }
+
+        public void Run(int operationCount)
+        {
+            for (int step = 0; step < operationCount; step++)
+            {
+                ApplyRandomOperation();
+                AssertDisplayedMatchesOracle(step);
+                AssertPerLogViewsMatchOracle(step);
+                AssertRankMatchesOracle(step);
+                AssertSliceMatchesOracle(step);
+                AssertResolveByKeyRoundTrips(step);
+            }
+        }
+
+        private LogModel AddLog()
+        {
+            var data = new EventLogData($"Log{_logs.Count}", LogPathType.Channel, []);
+            var model = new LogModel(data.Id, data.Name, new DateTime(2026, 1, 1).AddDays(_logs.Count));
+            _logs.Add(model);
+            State = Reducers.ReduceAddTable(State, new AddTableAction(data));
+
+            return model;
+        }
+
+        private void AppendBatch(IReadOnlyList<(LogModel Log, IReadOnlyList<ResolvedEvent> Events)> batch)
+        {
+            var byLog = new Dictionary<EventLogId, IReadOnlyList<ResolvedEvent>>(batch.Count);
+
+            foreach (var (log, events) in batch)
+            {
+                byLog[log.Id] = events;
+                log.Events.AddRange(events);
+            }
+
+            State = Reducers.ReduceAppendTableEventsBatch(State, new AppendTableEventsBatchAction(byLog));
+        }
+
+        private void AppendSingle(LogModel log)
+        {
+            var events = GenerateBatch(log, 1 + _rng.Next(20));
+            log.Events.AddRange(events);
+
+            State = Reducers.ReduceAppendTableEvents(State, new AppendTableEventsAction(log.Id, events));
+        }
+
+        private void ApplyRandomOperation()
+        {
+            var open = OpenLogs();
+            int roll = _rng.Next(100);
+
+            if (open.Count == 0 || (roll < 16 && _logs.Count(l => l.IsOpen) < 4))
+            {
+                var log = AddLog();
+                AppendBatch([(log, GenerateBatch(log, 1 + _rng.Next(30)))]);
+            }
+            else if (roll < 40)
+            {
+                int logCount = 1 + _rng.Next(open.Count);
+                var chosen = open.OrderBy(_ => _rng.Next()).Take(logCount)
+                    .Select(log => (log, (IReadOnlyList<ResolvedEvent>)GenerateBatch(log, 1 + _rng.Next(30)))).ToList();
+                AppendBatch(chosen);
+            }
+            else if (roll < 50)
+            {
+                AppendSingle(open[_rng.Next(open.Count)]);
+            }
+            else if (roll < 60)
+            {
+                Finalize(open[_rng.Next(open.Count)]);
+            }
+            else if (roll < 70)
+            {
+                ReapplyFilter(open);
+            }
+            else if (roll < 76)
+            {
+                // A batch addressed to an already-closed log must be dropped, not resurrected.
+                StaleAppendToClosedLog(open);
+            }
+            else if (roll < 83)
+            {
+                State = Reducers.ReduceSetOrderBy(State, new SetOrderByAction(_orderBys[_rng.Next(_orderBys.Length)]));
+            }
+            else if (roll < 89)
+            {
+                State = Reducers.ReduceSetGroupBy(State, new SetGroupByAction(_groupBys[_rng.Next(_groupBys.Length)]));
+            }
+            else if (roll < 93)
+            {
+                State = Reducers.ReduceToggleGroupSorting(State);
+            }
+            else if (roll < 97)
+            {
+                State = Reducers.ReduceToggleSorting(State);
+            }
+            else
+            {
+                // May close the last open log (the K->0 reconciliation branch).
+                CloseLog(open[_rng.Next(open.Count)]);
+            }
+        }
+
+        private void AssertDisplayedMatchesOracle(int step)
+        {
+            var oracle = Oracle();
+            var displayed = State.DisplayedEvents;
+
+            Assert.True(
+                oracle.Count == displayed.Count,
+                $"Displayed count mismatch at step {step}: oracle={oracle.Count} displayed={displayed.Count} ({Describe()}).");
+
+            for (int i = 0; i < oracle.Count; i++)
+            {
+                Assert.True(
+                    ReferenceEquals(oracle[i], displayed[i]),
+                    $"Displayed order mismatch at step {step}, index {i} ({Describe()}).");
+            }
+        }
+
+        private void AssertPerLogViewsMatchOracle(int step)
+        {
+            foreach (var log in OpenLogs())
+            {
+                var oracle = log.Events.SortEvents(
+                    EffectiveOrderBy, State.IsDescending, State.GroupBy, State.IsGroupDescending);
+                var view = State.EventsForLog(log.Id);
+
+                Assert.True(
+                    oracle.Count == view.Count,
+                    $"Per-log count mismatch at step {step} for {log.Name}: oracle={oracle.Count} view={view.Count}.");
+
+                for (int i = 0; i < oracle.Count; i++)
+                {
+                    Assert.True(
+                        ReferenceEquals(oracle[i], view[i]),
+                        $"Per-log order mismatch at step {step}, {log.Name}[{i}] ({Describe()}).");
+                }
+            }
+        }
+
+        private void AssertRankMatchesOracle(int step)
+        {
+            var displayed = State.DisplayedEvents;
+
+            if (displayed.Count == 0) { return; }
+
+            foreach (int index in SampleIndices(displayed.Count))
+            {
+                int rank = ResolvedEventIndex.IndexOf(
+                    displayed, displayed[index], State.OrderBy, State.IsDescending, State.GroupBy, State.IsGroupDescending);
+
+                Assert.True(rank == index, $"Rank mismatch at step {step}: expected {index} got {rank} ({Describe()}).");
+            }
+        }
+
+        private void AssertResolveByKeyRoundTrips(int step)
+        {
+            var displayed = State.DisplayedEvents;
+
+            if (displayed.Count == 0) { return; }
+
+            foreach (int index in SampleIndices(displayed.Count))
+            {
+                var original = displayed[index];
+
+                Assert.Same(original, ResolvedEventIndex.ResolveByKey(displayed, original));
+
+                // Key path: a stale clone resolves to the live instance.
+                Assert.Same(original, ResolvedEventIndex.ResolveByKey(displayed, original with { }));
+            }
+        }
+
+        private void AssertSliceMatchesOracle(int step)
+        {
+            var oracle = Oracle();
+            var displayed = State.DisplayedEvents;
+
+            foreach (var (start, count) in SampleWindows(oracle.Count))
+            {
+                var slice = ResolvedEventIndex.Slice(displayed, start, count);
+                int expected = start >= oracle.Count ? 0 : Math.Min(count, oracle.Count - start);
+
+                Assert.True(
+                    slice.Count == expected,
+                    $"Slice length mismatch at step {step}, window ({start},{count}): expected {expected} got {slice.Count}.");
+
+                for (int i = 0; i < slice.Count; i++)
+                {
+                    Assert.True(
+                        ReferenceEquals(slice[i], oracle[start + i]),
+                        $"Slice element mismatch at step {step}, window ({start},{count})[{i}] ({Describe()}).");
+                }
+            }
+        }
+
+        private void CloseLog(LogModel log)
+        {
+            log.IsOpen = false;
+            State = Reducers.ReduceCloseLog(State, new CloseLogAction(log.Id));
+        }
+
+        private string Describe() =>
+            $"orderBy={State.OrderBy?.ToString() ?? "null"} desc={State.IsDescending} " +
+            $"groupBy={State.GroupBy?.ToString() ?? "null"} groupDesc={State.IsGroupDescending} logs={OpenLogs().Count}";
+
+        private void Finalize(LogModel log)
+        {
+            log.Events.Clear();
+            log.Events.AddRange(GenerateBatch(log, 1 + _rng.Next(60)));
+
+            State = Reducers.ReduceUpdateTable(State, new UpdateTableAction(log.Id, [.. log.Events]));
+        }
+
+        private List<ResolvedEvent> GenerateBatch(LogModel log, int count)
+        {
+            var batch = new List<ResolvedEvent>(count);
+
+            for (int i = 0; i < count; i++)
+            {
+                log.LastTime = log.LastTime.AddMilliseconds(1 + _rng.Next(1000));
+
+                batch.Add(new ResolvedEvent(log.Name, LogPathType.Channel)
+                {
+                    RecordId = log.NextRecordId++,
+                    TimeCreated = log.LastTime,
+                    Id = 1000 + _rng.Next(6),
+                    Level = s_levels[_rng.Next(s_levels.Length)],
+                    Source = s_sources[_rng.Next(s_sources.Length)],
+                    TaskCategory = s_tasks[_rng.Next(s_tasks.Length)]
+                });
+            }
+
+            return batch;
+        }
+
+        private List<LogModel> OpenLogs() => _logs.Where(log => log.IsOpen).ToList();
+
+        private IReadOnlyList<ResolvedEvent> Oracle() =>
+            OpenLogs()
+                .SelectMany(log => log.Events)
+                .SortEvents(EffectiveOrderBy, State.IsDescending, State.GroupBy, State.IsGroupDescending);
+
+        private void ReapplyFilter(IReadOnlyList<LogModel> open)
+        {
+            var activeLogs = new Dictionary<EventLogId, IReadOnlyList<ResolvedEvent>>(open.Count);
+
+            foreach (var log in open)
+            {
+                // Omit a log to exercise the preserve (stale-snapshot) branch.
+                if (_rng.Next(4) == 0) { continue; }
+
+                var kept = log.Events.Where(_ => _rng.Next(3) != 0).ToList();
+                log.Events.Clear();
+                log.Events.AddRange(kept);
+                activeLogs[log.Id] = kept;
+            }
+
+            State = Reducers.ReduceUpdateDisplayedEvents(State, new UpdateDisplayedEventsAction(activeLogs));
+        }
+
+        private IEnumerable<int> SampleIndices(int count)
+        {
+            foreach (int candidate in new[] { 0, count / 2, count - 1 })
+            {
+                if (candidate >= 0 && candidate < count) { yield return candidate; }
+            }
+
+            for (int i = 0; i < 5; i++) { yield return _rng.Next(count); }
+        }
+
+        private IEnumerable<(int Start, int Count)> SampleWindows(int total)
+        {
+            yield return (0, 0);
+            yield return (0, total);
+
+            if (total == 0)
+            {
+                yield return (0, 4); // overrun on an empty view -> empty slice
+                yield break;
+            }
+
+            yield return (0, Math.Min(8, total));
+            yield return (Math.Max(0, total - 5), 5);            // tail, may overrun -> clamped
+            yield return (total, 3);                             // start at end -> empty
+            yield return (_rng.Next(total), 1 + _rng.Next(16));  // random window, may overrun -> clamped
+        }
+
+        private void StaleAppendToClosedLog(IReadOnlyList<LogModel> open)
+        {
+            var closed = _logs.Where(log => !log.IsOpen).ToList();
+
+            if (closed.Count == 0)
+            {
+                AppendSingle(open[_rng.Next(open.Count)]); // nothing closed yet; keep the op productive
+                return;
+            }
+
+            // Ghost events: not added to the model; the reducer drops them.
+            var target = closed[_rng.Next(closed.Count)];
+            var ghosts = GenerateBatch(target, 1 + _rng.Next(10));
+
+            State = Reducers.ReduceAppendTableEventsBatch(State, new AppendTableEventsBatchAction(
+                new Dictionary<EventLogId, IReadOnlyList<ResolvedEvent>> { [target.Id] = ghosts }));
+        }
+
+        private sealed class LogModel(EventLogId id, string name, DateTime startTime)
+        {
+            public List<ResolvedEvent> Events { get; } = [];
+
+            public EventLogId Id { get; } = id;
+
+            public bool IsOpen { get; set; } = true;
+
+            public DateTime LastTime { get; set; } = startTime;
+
+            public string Name { get; } = name;
+
+            public long NextRecordId { get; set; } = 1;
+        }
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/LogTableReducerInvariantTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/LogTableReducerInvariantTests.cs
@@ -1,0 +1,249 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Runtime.LogTable;
+using Reducers = EventLogExpert.Runtime.LogTable.Reducers;
+
+namespace EventLogExpert.Runtime.Tests.LogTable;
+
+// Named-edge invariants; the differential test is the broad guard.
+public sealed class LogTableReducerInvariantTests
+{
+    [Fact]
+    public void AppendingAStraddlingBatch_TakesTheMergeFallback_WhileOutrankingBatchesStayOnTheFastPath()
+    {
+        // Level descending: Warning > Information > Error > Critical (ordinal).
+        var info = MakeEvent(0, 1, Time(0, 1), level: "Information");
+        var error = MakeEvent(0, 2, Time(0, 2), level: "Error");
+        var warning = MakeEvent(0, 3, Time(0, 3), level: "Warning");
+        var info2 = MakeEvent(0, 4, Time(0, 4), level: "Information");
+        var critical = MakeEvent(0, 5, Time(0, 5), level: "Critical");
+
+        var data = new EventLogData("Log0", LogPathType.Channel, []);
+        var state = Reducers.ReduceAddTable(new LogTableState(), new AddTableAction(data));
+        state = Reducers.ReduceSetOrderBy(state, new SetOrderByAction(ColumnName.Level));
+
+        state = AppendBatch(state, data.Id, info, error);
+        Assert.Equal(1, SegmentCountOf(state, data.Id));
+
+        // An outranking batch prepends (the fast path adds a segment).
+        state = AppendBatch(state, data.Id, warning);
+        Assert.Equal(2, SegmentCountOf(state, data.Id));
+
+        // A straddling batch forces the full merge to one segment.
+        state = AppendBatch(state, data.Id, info2, critical);
+        Assert.Equal(1, SegmentCountOf(state, data.Id));
+
+        AssertDisplayedExactly(state, [info, error, warning, info2, critical]);
+    }
+
+    [Fact]
+    public void CloseLog_DropsExactlyThatLogsEvents_AndLeavesTheRestIntact()
+    {
+        var log0 = new[] { MakeEvent(0, 1, Time(0, 1)), MakeEvent(0, 2, Time(0, 2)) };
+        var log1 = new[] { MakeEvent(1, 1, Time(1, 1)), MakeEvent(1, 2, Time(1, 2)) };
+        var log2 = new[] { MakeEvent(2, 1, Time(2, 1)), MakeEvent(2, 2, Time(2, 2)) };
+        var (state, ids) = SeedLogs(log0, log1, log2);
+
+        state = Reducers.ReduceCloseLog(state, new CloseLogAction(ids[1]));
+
+        Assert.Empty(state.EventsForLog(ids[1]));
+
+        foreach (var dropped in log1)
+        {
+            Assert.DoesNotContain(dropped, state.DisplayedEvents);
+        }
+
+        // Two per-log tables plus a fresh combined table remain.
+        Assert.Equal(2, state.EventTables.Count(table => !table.IsCombined));
+        Assert.Single(state.EventTables, table => table.IsCombined);
+        Assert.DoesNotContain(state.EventTables, table => table.Id == ids[1]);
+
+        // Independent oracle (test-owned refs), so a wipe fails loudly.
+        AssertDisplayedExactly(state, [.. log0, .. log2]);
+    }
+
+    [Fact]
+    public void DefaultOrder_IsRecordIdForOneLog_DateAndTimeForTwo_AndReconcilesAcrossTheBoundary()
+    {
+        // RecordId and timestamp order deliberately disagree here.
+        var a = MakeEvent(0, 1, Time(0, 30));
+        var b = MakeEvent(0, 2, Time(0, 10));
+        var c = MakeEvent(1, 1, Time(1, 20));
+        var d = MakeEvent(1, 2, Time(1, 5));
+
+        var log0 = new EventLogData("Log0", LogPathType.Channel, []);
+        var state = Reducers.ReduceAddTable(new LogTableState(), new AddTableAction(log0));
+        state = AppendBatch(state, log0.Id, a, b);
+
+        // One log: natural RecordId order.
+        Assert.Null(state.SortContext.OrderBy);
+        AssertEveryLogIsOnTheCurrentContext(state);
+        AssertDisplayedExactly(state, [a, b]);
+
+        // Opening a second log flips the default to DateAndTime.
+        var log1 = new EventLogData("Log1", LogPathType.Channel, []);
+        state = Reducers.ReduceAddTable(state, new AddTableAction(log1));
+        state = AppendBatch(state, log1.Id, c, d);
+
+        Assert.Equal(ColumnName.DateAndTime, state.SortContext.OrderBy);
+        AssertEveryLogIsOnTheCurrentContext(state);
+        AssertDisplayedExactly(state, [a, b, c, d]);
+
+        // Close back to one log: default returns to RecordId.
+        state = Reducers.ReduceCloseLog(state, new CloseLogAction(log1.Id));
+
+        Assert.Null(state.SortContext.OrderBy);
+        AssertEveryLogIsOnTheCurrentContext(state);
+        AssertDisplayedExactly(state, [a, b]);
+    }
+
+    [Fact]
+    public void NullRecordIdTies_WithinALog_ResolveToAStableBijection()
+    {
+        // Null-RecordId, same-timestamp reads tie; reference identity separates them.
+        var sharedTime = Time(0, 10);
+        var (state, _) = SeedLogs(
+        [
+            MakeEvent(0, 5, Time(0, 1)),
+            MakeEvent(0, null, sharedTime, level: "Error"),
+            MakeEvent(0, null, sharedTime, level: "Error"),
+            MakeEvent(0, null, sharedTime, level: "Error"),
+            MakeEvent(0, 6, Time(0, 20))
+        ]);
+
+        var displayed = state.DisplayedEvents;
+        Assert.Equal(5, displayed.Count);
+
+        var positions = new HashSet<int>();
+
+        foreach (var resolved in displayed)
+        {
+            int index = ResolvedEventIndex.IndexOf(
+                displayed, resolved, state.OrderBy, state.IsDescending, state.GroupBy, state.IsGroupDescending);
+
+            Assert.InRange(index, 0, displayed.Count - 1);
+            Assert.True(ReferenceEquals(displayed[index], resolved), "IndexOf resolved to a different reference.");
+            Assert.True(positions.Add(index), $"Index {index} was claimed by two events (not a bijection).");
+        }
+    }
+
+    [Fact]
+    public void SetGroupBy_TransitionsEveryLogAtomically_ThenFastPathAppendsStayConsistent()
+    {
+        var log0 = new[] { MakeEvent(0, 1, Time(0, 5), source: "A"), MakeEvent(0, 2, Time(0, 3), source: "B") };
+        var log1 = new[] { MakeEvent(1, 1, Time(1, 9), source: "B"), MakeEvent(1, 2, Time(1, 1), source: "A") };
+        var (state, ids) = SeedLogs(log0, log1);
+
+        state = Reducers.ReduceSetGroupBy(state, new SetGroupByAction(ColumnName.Source));
+
+        AssertEveryLogIsOnTheCurrentContext(state);
+
+        var append0 = MakeEvent(0, 3, Time(0, 7), source: "A");
+        var append1 = MakeEvent(1, 3, Time(1, 4), source: "B");
+        state = Reducers.ReduceAppendTableEventsBatch(state, new AppendTableEventsBatchAction(
+            new Dictionary<EventLogId, IReadOnlyList<ResolvedEvent>>
+            {
+                [ids[0]] = [append0],
+                [ids[1]] = [append1]
+            }));
+
+        AssertEveryLogIsOnTheCurrentContext(state);
+        AssertDisplayedExactly(state, [.. log0, .. log1, append0, append1]);
+    }
+
+    [Fact]
+    public void SetOrderBy_TransitionsEveryLogAtomically_ThenFastPathAppendsStayConsistent()
+    {
+        var log0 = new[] { MakeEvent(0, 1, Time(0, 5)), MakeEvent(0, 2, Time(0, 3)) };
+        var log1 = new[] { MakeEvent(1, 1, Time(1, 9)), MakeEvent(1, 2, Time(1, 1)) };
+        var (state, ids) = SeedLogs(log0, log1);
+
+        state = Reducers.ReduceSetOrderBy(state, new SetOrderByAction(ColumnName.Level));
+
+        // Atomicity: no list may lag the old context.
+        AssertEveryLogIsOnTheCurrentContext(state);
+
+        var append0 = MakeEvent(0, 3, Time(0, 7), level: "Critical");
+        var append1 = MakeEvent(1, 3, Time(1, 4), level: "Warning");
+        state = Reducers.ReduceAppendTableEventsBatch(state, new AppendTableEventsBatchAction(
+            new Dictionary<EventLogId, IReadOnlyList<ResolvedEvent>>
+            {
+                [ids[0]] = [append0],
+                [ids[1]] = [append1]
+            }));
+
+        AssertEveryLogIsOnTheCurrentContext(state);
+
+        // Independent oracle: the six refs we created.
+        AssertDisplayedExactly(state, [.. log0, .. log1, append0, append1]);
+    }
+
+    private static LogTableState AppendBatch(LogTableState state, EventLogId logId, params ResolvedEvent[] events) =>
+        Reducers.ReduceAppendTableEventsBatch(state, new AppendTableEventsBatchAction(
+            new Dictionary<EventLogId, IReadOnlyList<ResolvedEvent>> { [logId] = events }));
+
+    // Asserts against test-owned refs, so a dropped event fails loudly.
+    private static void AssertDisplayedExactly(LogTableState state, IReadOnlyList<ResolvedEvent> expected)
+    {
+        var oracle = expected.SortEvents(
+            ResolvedEventOrdering.ResolveDefaultOrderBy(state.OrderBy, state.GroupBy, state.PerLogEvents.Count),
+            state.IsDescending,
+            state.GroupBy,
+            state.IsGroupDescending);
+
+        var displayed = state.DisplayedEvents;
+
+        Assert.Equal(oracle.Count, displayed.Count);
+
+        for (int i = 0; i < oracle.Count; i++)
+        {
+            Assert.True(ReferenceEquals(oracle[i], displayed[i]), $"Order mismatch at index {i}.");
+        }
+    }
+
+    private static void AssertEveryLogIsOnTheCurrentContext(LogTableState state)
+    {
+        foreach (var list in state.PerLogEvents.Values)
+        {
+            Assert.True(list.HasContext(state.SortContext), "A per-log list lagged the state's sort context.");
+        }
+    }
+
+    private static ResolvedEvent MakeEvent(
+        int logIndex, long? recordId, DateTime time, string level = "Information", string source = "Provider") =>
+        new($"Log{logIndex}", LogPathType.Channel)
+        {
+            RecordId = recordId,
+            TimeCreated = time,
+            Level = level,
+            Source = source
+        };
+
+    private static (LogTableState State, EventLogId[] Ids) SeedLogs(params IReadOnlyList<ResolvedEvent>[] perLog)
+    {
+        var state = new LogTableState();
+        var ids = new EventLogId[perLog.Length];
+        var batch = new Dictionary<EventLogId, IReadOnlyList<ResolvedEvent>>(perLog.Length);
+
+        for (int i = 0; i < perLog.Length; i++)
+        {
+            var data = new EventLogData($"Log{i}", LogPathType.Channel, []);
+            ids[i] = data.Id;
+            state = Reducers.ReduceAddTable(state, new AddTableAction(data));
+            batch[data.Id] = perLog[i];
+        }
+
+        state = Reducers.ReduceAppendTableEventsBatch(state, new AppendTableEventsBatchAction(batch));
+
+        return (state, ids);
+    }
+
+    private static int SegmentCountOf(LogTableState state, EventLogId logId) => state.PerLogEvents[logId].SegmentCount;
+
+    private static DateTime Time(int logIndex, int seconds) =>
+        new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddDays(logIndex).AddSeconds(seconds);
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/LogTableStoreTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/LogTableStoreTests.cs
@@ -789,11 +789,14 @@ public sealed class LogTableStoreTests
             GroupCollapseOverrides = ImmutableHashSet.Create("g"),
             OrderBy = ColumnName.EventId,
             IsDescending = false,
-            DisplayedEvents = new List<ResolvedEvent>
-            {
-                FilterEventBuilder.CreateTestEvent(id: 2, source: "B"),
-                FilterEventBuilder.CreateTestEvent(id: 1, source: "A")
-            }.AsReadOnly()
+            PerLogEvents = BuildPerLog(
+                new List<ResolvedEvent>
+                {
+                    FilterEventBuilder.CreateTestEvent(id: 2, source: "B"),
+                    FilterEventBuilder.CreateTestEvent(id: 1, source: "A")
+                },
+                [],
+                orderBy: ColumnName.EventId, isDescending: false, groupBy: ColumnName.Source, isGroupDescending: true)
         };
 
         var hiddenColumns = ImmutableDictionary<ColumnName, bool>.Empty
@@ -905,11 +908,14 @@ public sealed class LogTableStoreTests
     {
         var state = new LogTableState
         {
-            DisplayedEvents = new List<ResolvedEvent>
-            {
-                FilterEventBuilder.CreateTestEvent(id: 2, source: "B"),
-                FilterEventBuilder.CreateTestEvent(id: 1, source: "A")
-            }.AsReadOnly(),
+            PerLogEvents = BuildPerLog(
+                new List<ResolvedEvent>
+                {
+                    FilterEventBuilder.CreateTestEvent(id: 2, source: "B"),
+                    FilterEventBuilder.CreateTestEvent(id: 1, source: "A")
+                },
+                [],
+                isGroupDescending: true),
             IsGroupDescending = true,
             GroupCollapseOverrides = ImmutableHashSet.Create("stale")
         };
@@ -930,11 +936,14 @@ public sealed class LogTableStoreTests
             GroupBy = ColumnName.Source,
             OrderBy = ColumnName.EventId,
             IsDescending = false,
-            DisplayedEvents = new List<ResolvedEvent>
-            {
-                FilterEventBuilder.CreateTestEvent(id: 2, source: "B"),
-                FilterEventBuilder.CreateTestEvent(id: 1, source: "A")
-            }.AsReadOnly()
+            PerLogEvents = BuildPerLog(
+                new List<ResolvedEvent>
+                {
+                    FilterEventBuilder.CreateTestEvent(id: 2, source: "B"),
+                    FilterEventBuilder.CreateTestEvent(id: 1, source: "A")
+                },
+                [],
+                orderBy: ColumnName.EventId, isDescending: false, groupBy: ColumnName.Source)
         };
 
         var result = Reducers.ReduceSetGroupBy(state, new SetGroupByAction(null));
@@ -990,11 +999,14 @@ public sealed class LogTableStoreTests
         {
             GroupBy = ColumnName.Source,
             IsGroupDescending = false,
-            DisplayedEvents = new List<ResolvedEvent>
-            {
-                FilterEventBuilder.CreateTestEvent(id: 1, source: "A"),
-                FilterEventBuilder.CreateTestEvent(id: 2, source: "B")
-            }.AsReadOnly()
+            PerLogEvents = BuildPerLog(
+                new List<ResolvedEvent>
+                {
+                    FilterEventBuilder.CreateTestEvent(id: 1, source: "A"),
+                    FilterEventBuilder.CreateTestEvent(id: 2, source: "B")
+                },
+                [],
+                groupBy: ColumnName.Source)
         };
 
         var result = Reducers.ReduceToggleGroupSorting(state);
@@ -1285,7 +1297,8 @@ public sealed class LogTableStoreTests
             ActiveEventLogId = combined.Id,
             GroupBy = ColumnName.Source,
             IsDescending = false,
-            DisplayedEvents = existing,
+            PerLogEvents = BuildPerLog(
+                existing, [log1, log2], orderBy: null, isDescending: false, groupBy: ColumnName.Source),
             EventCountByLog = ImmutableDictionary<EventLogId, int>.Empty
                 .Add(log1.Id, 1)
                 .Add(log2.Id, 1)
@@ -1419,5 +1432,31 @@ public sealed class LogTableStoreTests
             baseTime.AddSeconds(40)
         };
         Assert.Equal(expectedTimes, actualTimes);
+    }
+
+    // Seeds PerLogEvents keyed by each event's OwningLog.
+    private static ImmutableDictionary<EventLogId, SegmentedSortedList> BuildPerLog(
+        IEnumerable<ResolvedEvent> events,
+        IEnumerable<LogView> tables,
+        ColumnName? orderBy = null,
+        bool isDescending = true,
+        ColumnName? groupBy = null,
+        bool isGroupDescending = false)
+    {
+        var byLog = events.GroupBy(resolved => resolved.OwningLog).ToList();
+
+        // Match the reducers' default: RecordId for one log, else DateAndTime.
+        var context = new SortContext(
+            ResolvedEventOrdering.ResolveDefaultOrderBy(orderBy, groupBy, byLog.Count),
+            isDescending,
+            groupBy,
+            isGroupDescending);
+
+        var idByName = tables.Where(table => !table.IsCombined).ToDictionary(table => table.LogName, table => table.Id);
+
+        return byLog
+            .ToImmutableDictionary(
+                group => idByName.TryGetValue(group.Key, out var id) ? id : EventLogId.Create(),
+                group => SegmentedSortedList.CreateSorted(group, context));
     }
 }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/MergeDifferentialTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/MergeDifferentialTests.cs
@@ -1,0 +1,331 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Runtime.LogTable;
+using System.Security.Principal;
+
+namespace EventLogExpert.Runtime.Tests.LogTable;
+
+public sealed class MergeDifferentialTests
+{
+    private static readonly ColumnName?[] s_groupBys =
+    [
+        null,
+        ColumnName.Source,
+        ColumnName.Level,
+        ColumnName.EventId
+    ];
+
+    private static readonly ColumnName?[] s_orderBys =
+    [
+        null,
+        ColumnName.DateAndTime,
+        ColumnName.Level,
+        ColumnName.Source,
+        ColumnName.EventId,
+        ColumnName.Keywords,
+        ColumnName.Log,
+        ColumnName.User,
+        ColumnName.ComputerName,
+        ColumnName.TaskCategory,
+        ColumnName.ProcessId,
+        ColumnName.ThreadId,
+        ColumnName.ActivityId
+    ];
+
+    [Fact]
+    public void AppendingEmptyBatch_LeavesSequenceUnchanged()
+    {
+        var harness = new Harness(seed: 5);
+        harness.AppendToActiveLog(count: 25);
+
+        var before = harness.GoldenSnapshot();
+        harness.AppendBatch([]);
+
+        Assert.Equal(before, harness.GoldenSnapshot());
+    }
+
+    [Fact]
+    public void ClosingDownToSingleLog_MatchesNaiveRecompute()
+    {
+        var harness = new Harness(seed: 9);
+
+        for (int i = 0; i < 4; i++) { harness.AppendToNewLog(count: 30); }
+
+        harness.ResortRandom();
+        harness.CloseLogsUntilOneRemains();
+
+        harness.AssertGoldenMatchesNaive();
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(7)]
+    [InlineData(42)]
+    [InlineData(101)]
+    [InlineData(2026)]
+    [InlineData(31337)]
+    [InlineData(8675309)]
+    [InlineData(int.MaxValue)]
+    public void IncrementalMergeAndFilter_MatchNaiveRecompute_OverRandomOps(int seed)
+    {
+        var harness = new Harness(seed);
+
+        harness.Run(operationCount: 400);
+    }
+
+    private sealed class Harness
+    {
+        private static readonly string[] s_computers = ["HOST-1", "HOST-2"];
+
+        private static readonly IReadOnlyList<string>[] s_keywords =
+        [
+            [], ["Audit Success"], ["Classic"], ["Audit Failure", "Classic"]
+        ];
+        private static readonly string[] s_levels = ["Information", "Warning", "Error", "Critical", "Verbose"];
+
+        private static readonly SecurityIdentifier?[] s_sids =
+        [
+            null,
+            new SecurityIdentifier("S-1-5-18"),
+            new SecurityIdentifier("S-1-5-19"),
+            new SecurityIdentifier("S-1-5-21-1004336348-1177238915-682003330-1001")
+        ];
+        private static readonly string[] s_sources = ["Provider.A", "Provider.B", "Provider.C", "Provider.D"];
+        private static readonly string[] s_tasks = ["", "Logon", "Service", "Network"];
+        private readonly List<LogModel> _logs = [];
+
+        private readonly Random _rng;
+
+        private IReadOnlyList<ResolvedEvent> _golden = [];
+        private ColumnName? _groupBy;
+        private bool _isDescending = true;
+        private bool _isGroupDescending;
+
+        private ColumnName? _orderBy;
+
+        public Harness(int seed) => _rng = new Random(seed);
+
+        private ColumnName EffectiveOrderBy => ResolvedEventOrdering.GetEffectiveOrderBy(_orderBy);
+
+        public void AppendBatch(IReadOnlyList<ResolvedEvent> batch) =>
+            _golden = ResolvedEventOrdering.MergeSorted(_golden, batch, EffectiveOrderBy, _isDescending, _groupBy, _isGroupDescending);
+
+        public void AppendToActiveLog(int count)
+        {
+            var log = ActiveLogs().FirstOrDefault() ?? ActivateNewLog();
+            AppendBatch(GenerateBatch(log, count));
+        }
+
+        public void AppendToNewLog(int count) => AppendBatch(GenerateBatch(ActivateNewLog(), count));
+
+        public void AssertGoldenMatchesNaive(int step = -1)
+        {
+            var naive = LiveEvents().SortEvents(EffectiveOrderBy, _isDescending, _groupBy, _isGroupDescending);
+
+            Assert.True(
+                _golden.Count == naive.Count,
+                $"Count mismatch at step {step}: golden={_golden.Count} naive={naive.Count} (ctx {DescribeContext()}).");
+
+            for (int i = 0; i < naive.Count; i++)
+            {
+                Assert.True(
+                    ReferenceEquals(_golden[i], naive[i]),
+                    $"Order mismatch at step {step}, index {i} (ctx {DescribeContext()}).");
+            }
+        }
+
+        public void CloseLogsUntilOneRemains()
+        {
+            while (ActiveLogs().Count > 1)
+            {
+                CloseLog(ActiveLogs()[0]);
+            }
+        }
+
+        public IReadOnlyList<ResolvedEvent> GoldenSnapshot() => [.. _golden];
+
+        public void ResortRandom()
+        {
+            PickRandomSort();
+            _golden = _golden.SortEvents(EffectiveOrderBy, _isDescending, _groupBy, _isGroupDescending);
+        }
+
+        public void Run(int operationCount)
+        {
+            for (int step = 0; step < operationCount; step++)
+            {
+                ApplyRandomOperation();
+                AssertGoldenSorted(step);
+                AssertGoldenMatchesNaive(step);
+            }
+        }
+
+        private static IReadOnlyList<ResolvedEvent> FilterOutOwningLog(IReadOnlyList<ResolvedEvent> events, string owningLog)
+        {
+            if (events is SegmentedSortedList segmented)
+            {
+                return segmented.WhereSegmented(e => !string.Equals(e.OwningLog, owningLog, StringComparison.Ordinal));
+            }
+
+            var filtered = new List<ResolvedEvent>(events.Count);
+
+            for (int i = 0; i < events.Count; i++)
+            {
+                if (!string.Equals(events[i].OwningLog, owningLog, StringComparison.Ordinal))
+                {
+                    filtered.Add(events[i]);
+                }
+            }
+
+            return filtered.AsReadOnly();
+        }
+
+        private LogModel ActivateNewLog()
+        {
+            var inactive = _logs.FirstOrDefault(l => !l.IsOpen && l.Events.Count == 0);
+
+            if (inactive is not null)
+            {
+                inactive.IsOpen = true;
+
+                return inactive;
+            }
+
+            var log = new LogModel($"Log{_logs.Count}", new DateTime(2026, 1, 1).AddDays(_logs.Count));
+            _logs.Add(log);
+
+            return log;
+        }
+
+        private List<LogModel> ActiveLogs() => _logs.Where(l => l.IsOpen).ToList();
+
+        private void ApplyRandomOperation()
+        {
+            var active = ActiveLogs();
+            int roll = _rng.Next(100);
+
+            if (active.Count == 0 || (roll < 20 && _logs.Count < 4))
+            {
+                AppendBatch(GenerateBatch(ActivateNewLog(), 1 + _rng.Next(40)));
+            }
+            else if (roll < 60)
+            {
+                AppendBatch(GenerateBatch(active[_rng.Next(active.Count)], 1 + _rng.Next(40)));
+            }
+            else if (roll < 75)
+            {
+                ResortRandom();
+            }
+            else if (roll < 88)
+            {
+                FinalizeLog(active[_rng.Next(active.Count)]);
+            }
+            else if (active.Count > 1)
+            {
+                CloseLog(active[_rng.Next(active.Count)]);
+            }
+            else
+            {
+                AppendBatch(GenerateBatch(active[_rng.Next(active.Count)], 1 + _rng.Next(40)));
+            }
+        }
+
+        private void AssertGoldenSorted(int step)
+        {
+            var comparer = ResolvedEventOrdering.SelectComparer(EffectiveOrderBy, _isDescending, _groupBy, _isGroupDescending);
+
+            for (int i = 1; i < _golden.Count; i++)
+            {
+                Assert.True(
+                    comparer(_golden[i - 1], _golden[i]) <= 0,
+                    $"Golden not sorted at step {step}, index {i} (ctx {DescribeContext()}).");
+            }
+        }
+
+        private void CloseLog(LogModel log)
+        {
+            log.IsOpen = false;
+            _golden = FilterOutOwningLog(_golden, log.Name);
+        }
+
+        private string DescribeContext() =>
+            $"orderBy={_orderBy?.ToString() ?? "null"} desc={_isDescending} groupBy={_groupBy?.ToString() ?? "null"} groupDesc={_isGroupDescending}";
+
+        private void FinalizeLog(LogModel log)
+        {
+            var withoutLog = FilterOutOwningLog(_golden, log.Name);
+
+            _golden = ResolvedEventOrdering.MergeSorted(
+                withoutLog, [.. log.Events], EffectiveOrderBy, _isDescending, _groupBy, _isGroupDescending);
+        }
+
+        private List<ResolvedEvent> GenerateBatch(LogModel log, int count)
+        {
+            var batch = new List<ResolvedEvent>(count);
+
+            for (int i = 0; i < count; i++)
+            {
+                var resolved = GenerateEvent(log);
+                batch.Add(resolved);
+                log.Events.Add(resolved);
+            }
+
+            return batch;
+        }
+
+        private ResolvedEvent GenerateEvent(LogModel log)
+        {
+            log.LastTime = log.LastTime.AddMilliseconds(1 + _rng.Next(1000));
+
+            return new ResolvedEvent(log.Name, LogPathType.Channel)
+            {
+                RecordId = log.NextRecordId++,
+                TimeCreated = log.LastTime,
+                Id = 1000 + _rng.Next(8),
+                Level = s_levels[_rng.Next(s_levels.Length)],
+                Source = s_sources[_rng.Next(s_sources.Length)],
+                TaskCategory = s_tasks[_rng.Next(s_tasks.Length)],
+                ComputerName = s_computers[_rng.Next(s_computers.Length)],
+                Keywords = s_keywords[_rng.Next(s_keywords.Length)],
+                UserId = s_sids[_rng.Next(s_sids.Length)],
+                ProcessId = _rng.Next(3) == 0 ? null : 100 + _rng.Next(50),
+                ThreadId = _rng.Next(3) == 0 ? null : 200 + _rng.Next(50),
+                ActivityId = _rng.Next(3) == 0 ? null : NextGuid()
+            };
+        }
+
+        private IEnumerable<ResolvedEvent> LiveEvents() => _logs.Where(l => l.IsOpen).SelectMany(l => l.Events);
+
+        private Guid NextGuid()
+        {
+            var bytes = new byte[16];
+            _rng.NextBytes(bytes);
+
+            return new Guid(bytes);
+        }
+
+        private void PickRandomSort()
+        {
+            _orderBy = s_orderBys[_rng.Next(s_orderBys.Length)];
+            _isDescending = _rng.Next(2) == 0;
+            _groupBy = s_groupBys[_rng.Next(s_groupBys.Length)];
+            _isGroupDescending = _rng.Next(2) == 0;
+        }
+
+        private sealed class LogModel(string name, DateTime startTime)
+        {
+            public List<ResolvedEvent> Events { get; } = [];
+
+            public bool IsOpen { get; set; } = true;
+
+            public DateTime LastTime { get; set; } = startTime;
+
+            public string Name { get; } = name;
+
+            public long NextRecordId { get; set; } = 1;
+        }
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/ResolvedEventIndexTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/ResolvedEventIndexTests.cs
@@ -1,0 +1,111 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Runtime.LogTable;
+
+namespace EventLogExpert.Runtime.Tests.LogTable;
+
+public sealed class ResolvedEventIndexTests
+{
+    private static readonly DateTime s_baseTime = new(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void IndexOf_DescendingOrder_ReturnsCorrectIndex()
+    {
+        var newest = NewEvent(recordId: 3, time: s_baseTime.AddSeconds(30), owningLog: "Application", source: "A");
+        var middle = NewEvent(recordId: 2, time: s_baseTime.AddSeconds(20), owningLog: "Application", source: "B");
+        var oldest = NewEvent(recordId: 1, time: s_baseTime.AddSeconds(10), owningLog: "Application", source: "C");
+
+        var events = new List<ResolvedEvent> { newest, middle, oldest }.AsReadOnly();
+
+        Assert.Equal(0, ResolvedEventIndex.IndexOf(events, newest, ColumnName.DateAndTime, isDescending: true));
+        Assert.Equal(1, ResolvedEventIndex.IndexOf(events, middle, ColumnName.DateAndTime, isDescending: true));
+        Assert.Equal(2, ResolvedEventIndex.IndexOf(events, oldest, ColumnName.DateAndTime, isDescending: true));
+    }
+
+    [Fact]
+    public void IndexOf_EachEventInSortedList_ReturnsItsIndex()
+    {
+        var events = BuildByDateAscending(6);
+
+        for (int i = 0; i < events.Count; i++)
+        {
+            Assert.Equal(i, ResolvedEventIndex.IndexOf(events, events[i], ColumnName.DateAndTime, isDescending: false));
+        }
+    }
+
+    [Fact]
+    public void IndexOf_EventNotInList_ReturnsMinusOne()
+    {
+        var events = BuildByDateAscending(6);
+        var absent = NewEvent(recordId: 999, time: s_baseTime.AddSeconds(999), owningLog: "Application", source: "Z");
+
+        Assert.Equal(-1, ResolvedEventIndex.IndexOf(events, absent, ColumnName.DateAndTime, isDescending: false));
+    }
+
+    [Fact]
+    public void IndexOf_GroupedBySource_FindsEventInItsGroup()
+    {
+        var alphaFirst = NewEvent(recordId: 1, time: s_baseTime.AddSeconds(1), owningLog: "Application", source: "Alpha");
+        var alphaSecond = NewEvent(recordId: 2, time: s_baseTime.AddSeconds(2), owningLog: "Application", source: "Alpha");
+        var beta = NewEvent(recordId: 3, time: s_baseTime.AddSeconds(3), owningLog: "Application", source: "Beta");
+
+        var events = new List<ResolvedEvent> { alphaFirst, alphaSecond, beta }.AsReadOnly();
+
+        Assert.Equal(0, ResolvedEventIndex.IndexOf(events, alphaFirst, ColumnName.DateAndTime, isDescending: false, groupBy: ColumnName.Source));
+        Assert.Equal(1, ResolvedEventIndex.IndexOf(events, alphaSecond, ColumnName.DateAndTime, isDescending: false, groupBy: ColumnName.Source));
+        Assert.Equal(2, ResolvedEventIndex.IndexOf(events, beta, ColumnName.DateAndTime, isDescending: false, groupBy: ColumnName.Source));
+    }
+
+    [Fact]
+    public void IndexOf_NullRecordIdTie_ReturnsCorrectInstanceByReference()
+    {
+        var tiedTime = s_baseTime.AddSeconds(10);
+        var first = NewEvent(recordId: null, time: tiedTime, owningLog: "System", source: "First");
+        var second = NewEvent(recordId: null, time: tiedTime, owningLog: "System", source: "Second");
+        var before = NewEvent(recordId: 1, time: s_baseTime.AddSeconds(1), owningLog: "System", source: "Before");
+        var after = NewEvent(recordId: 2, time: s_baseTime.AddSeconds(20), owningLog: "System", source: "After");
+
+        var events = new List<ResolvedEvent> { before, first, second, after }.AsReadOnly();
+
+        Assert.Equal(1, ResolvedEventIndex.IndexOf(events, first, ColumnName.DateAndTime, isDescending: false));
+        Assert.Equal(2, ResolvedEventIndex.IndexOf(events, second, ColumnName.DateAndTime, isDescending: false));
+    }
+
+    [Fact]
+    public void IndexOf_OrderByNull_NormalizesToDateAndTimeNotRecordId()
+    {
+        var first = NewEvent(recordId: 30, time: s_baseTime.AddSeconds(1), owningLog: "Application", source: "A");
+        var second = NewEvent(recordId: 20, time: s_baseTime.AddSeconds(2), owningLog: "Application", source: "B");
+        var third = NewEvent(recordId: 10, time: s_baseTime.AddSeconds(3), owningLog: "Application", source: "C");
+
+        var events = new List<ResolvedEvent> { first, second, third }.AsReadOnly();
+
+        Assert.Equal(0, ResolvedEventIndex.IndexOf(events, first, orderBy: null, isDescending: false));
+        Assert.Equal(1, ResolvedEventIndex.IndexOf(events, second, orderBy: null, isDescending: false));
+        Assert.Equal(2, ResolvedEventIndex.IndexOf(events, third, orderBy: null, isDescending: false));
+    }
+
+    private static IReadOnlyList<ResolvedEvent> BuildByDateAscending(int count)
+    {
+        var events = new List<ResolvedEvent>(count);
+
+        for (int i = 0; i < count; i++)
+        {
+            events.Add(NewEvent(i + 1, s_baseTime.AddSeconds(i + 1), "Application", $"Source{i}"));
+        }
+
+        return events.AsReadOnly();
+    }
+
+    private static ResolvedEvent NewEvent(long? recordId, DateTime time, string owningLog, string source) =>
+        new(owningLog, LogPathType.Channel)
+        {
+            RecordId = recordId,
+            TimeCreated = time,
+            Source = source,
+            LogName = owningLog
+        };
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/SegmentedSortedListTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/SegmentedSortedListTests.cs
@@ -4,6 +4,7 @@
 using EventLogExpert.Eventing.Common.Channels;
 using EventLogExpert.Eventing.Common.Events;
 using EventLogExpert.Runtime.LogTable;
+using System.Diagnostics;
 
 namespace EventLogExpert.Runtime.Tests.LogTable;
 
@@ -90,6 +91,18 @@ public sealed class SegmentedSortedListTests
     }
 
     [Fact]
+    public void Append_InterleavingMultiLogBatches_StayCorrectlySorted()
+    {
+        var list = SegmentedSortedList.CreateSorted([Ev("LogA", 100, 1), Ev("LogB", 150, 2)], s_byTime);
+
+        list = list.Append([Ev("LogA", 120, 3), Ev("LogB", 90, 4)]);
+        list = list.Append([Ev("LogA", 80, 5), Ev("LogB", 200, 6)]);
+
+        Assert.Equal(6, list.Count);
+        AssertSorted(list);
+    }
+
+    [Fact]
     public void Append_SingleLogDescendingStream_UsesPrependFastPathWithoutCopying()
     {
         var descending = new SortContext(ColumnName.DateAndTime, isDescending: true, groupBy: null, isGroupDescending: false);
@@ -127,11 +140,12 @@ public sealed class SegmentedSortedListTests
     }
 
     [Fact]
-    public void Implements_ICollectionContract_ForVirtualizeBinding()
+    public void Implements_ListContract_ForVirtualizeBinding()
     {
         var list = SegmentedSortedList.CreateSorted([Ev("LogA", 1, 1), Ev("LogA", 2, 2)], s_byTime);
 
         Assert.IsAssignableFrom<IReadOnlyList<ResolvedEvent>>(list);
+        Assert.IsAssignableFrom<IList<ResolvedEvent>>(list);
 
         var collection = list as ICollection<ResolvedEvent>;
 
@@ -141,6 +155,12 @@ public sealed class SegmentedSortedListTests
         Assert.Throws<NotSupportedException>(() => collection.Add(Ev("LogA", 3, 3)));
         Assert.Throws<NotSupportedException>(() => collection.Clear());
         Assert.Throws<NotSupportedException>(() => collection.Remove(Ev("LogA", 1, 1)));
+
+        var asList = (IList<ResolvedEvent>)list;
+
+        Assert.Throws<NotSupportedException>(() => asList[0] = Ev("LogA", 9, 9));
+        Assert.Throws<NotSupportedException>(() => asList.Insert(0, Ev("LogA", 9, 9)));
+        Assert.Throws<NotSupportedException>(() => asList.RemoveAt(0));
     }
 
     [Fact]
@@ -170,20 +190,14 @@ public sealed class SegmentedSortedListTests
     }
 
     [Fact]
-    public void MergeFrom_SegmentedListWithDifferentContext_ReSortsSafely()
+    public void MergeSorted_ContextDrift_ThrowsUnreachable()
     {
         var byLevel = new SortContext(ColumnName.Level, isDescending: false, groupBy: null, isGroupDescending: false);
-        var late = Ev("LogA", 300, 1, "Critical");
-        var early = Ev("LogA", 100, 2, "Warning");
-        var existing = SegmentedSortedList.CreateSorted([late, early], byLevel);
+        IReadOnlyList<ResolvedEvent> existing = SegmentedSortedList.CreateSorted(
+            [Ev("LogA", 300, 1, "Critical"), Ev("LogA", 100, 2, "Warning")], byLevel);
 
-        var middle = Ev("LogA", 200, 3, "Information");
-        var result = SegmentedSortedList.MergeFrom(existing, [middle], s_byTime);
-
-        Assert.Equal(3, result.Count);
-        Assert.Same(early, result[0]);
-        Assert.Same(middle, result[1]);
-        Assert.Same(late, result[2]);
+        Assert.Throws<UnreachableException>(() =>
+            ResolvedEventOrdering.MergeSorted(existing, [Ev("LogA", 200, 3, "Information")], ColumnName.DateAndTime, isDescending: false));
     }
 
     [Fact]
@@ -198,6 +212,28 @@ public sealed class SegmentedSortedListTests
 
         AssertSameSequence(StableMerge(existing, tied), result);
         Assert.Same(head, result[0]);
+    }
+
+    [Fact]
+    public void ResolvedEventIndex_IndexOf_FindsInstancesAcrossSegments_IncludingNullRecordIdTieWindow()
+    {
+        var e1 = Ev("LogA", 100, null);
+        var e2 = Ev("LogA", 100, null);
+        var list = SegmentedSortedList.CreateSorted([e1, e2], s_byTime);
+
+        var e3 = Ev("LogA", 100, null);
+        list = list.Append([e3]);
+
+        Assert.Equal(2, list.SegmentCount);
+
+        int i1 = ResolvedEventIndex.IndexOf(list, e1, ColumnName.DateAndTime);
+        int i2 = ResolvedEventIndex.IndexOf(list, e2, ColumnName.DateAndTime);
+        int i3 = ResolvedEventIndex.IndexOf(list, e3, ColumnName.DateAndTime);
+
+        Assert.Same(e1, list[i1]);
+        Assert.Same(e2, list[i2]);
+        Assert.Same(e3, list[i3]);
+        Assert.Equal([0, 1, 2], new[] { i1, i2, i3 }.OrderBy(x => x).ToArray());
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/SegmentedSortedListTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/SegmentedSortedListTests.cs
@@ -1,0 +1,262 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Runtime.LogTable;
+
+namespace EventLogExpert.Runtime.Tests.LogTable;
+
+public sealed class SegmentedSortedListTests
+{
+    private static readonly SortContext s_byTime = new(ColumnName.DateAndTime, isDescending: false, groupBy: null, isGroupDescending: false);
+
+    private static readonly Comparison<ResolvedEvent> s_comparer =
+        ResolvedEventOrdering.SelectComparer(ColumnName.DateAndTime, false, null, false);
+
+    [Fact]
+    public void Append_BatchEntirelyAfter_Appends()
+    {
+        var existing = SegmentedSortedList.CreateSorted([Ev("LogA", 100, 1), Ev("LogA", 110, 2)], s_byTime);
+        var later = new[] { Ev("LogA", 200, 3), Ev("LogA", 210, 4) };
+
+        var result = existing.Append(later);
+
+        AssertSameSequence(StableMerge(existing, later), result);
+    }
+
+    [Fact]
+    public void Append_BatchEntirelyBefore_Prepends()
+    {
+        var existing = SegmentedSortedList.CreateSorted([Ev("LogA", 100, 1), Ev("LogA", 110, 2)], s_byTime);
+        var earlier = new[] { Ev("LogA", 10, 3), Ev("LogA", 20, 4) };
+
+        var result = existing.Append(earlier);
+
+        AssertSameSequence(StableMerge(existing, earlier), result);
+    }
+
+    [Fact]
+    public void Append_BatchTiesWithExistingHead_KeepsExistingFirst()
+    {
+        var head = Ev("LogA", 100, null);
+        var existing = SegmentedSortedList.CreateSorted([head, Ev("LogA", 200, 2), Ev("LogA", 300, 3)], s_byTime);
+        var tied = Ev("LogA", 100, null);
+
+        var result = existing.Append([tied]);
+
+        AssertSameSequence(StableMerge(existing, [tied]), result);
+        Assert.Same(head, result[0]);
+        Assert.Same(tied, result[1]);
+    }
+
+    [Fact]
+    public void Append_BatchTiesWithExistingTail_KeepsExistingBeforeBatch()
+    {
+        var tail = Ev("LogA", 200, null);
+        var existing = SegmentedSortedList.CreateSorted([Ev("LogA", 100, 1), tail], s_byTime);
+        var tied = Ev("LogA", 200, null);
+
+        var result = existing.Append([tied]);
+
+        AssertSameSequence(StableMerge(existing, [tied]), result);
+        Assert.Same(tail, result[1]);
+        Assert.Same(tied, result[2]);
+    }
+
+    [Fact]
+    public void Append_InterleaveThenPrepend_StaysSortedAndCorrect()
+    {
+        var existing = SegmentedSortedList.CreateSorted([Ev("LogA", 100, 1), Ev("LogA", 300, 3)], s_byTime);
+        var interleaving = new[] { Ev("LogA", 200, 2) };
+        var prepend = new[] { Ev("LogA", 1, 0) };
+
+        var afterMerge = existing.Append(interleaving);
+        var result = afterMerge.Append(prepend);
+
+        AssertSameSequence(StableMerge(StableMerge(existing, interleaving), prepend), result);
+        AssertSorted(result);
+    }
+
+    [Fact]
+    public void Append_InterleavingBatch_MatchesStableMerge()
+    {
+        var existing = SegmentedSortedList.CreateSorted([Ev("LogA", 100, 1), Ev("LogA", 300, 3)], s_byTime);
+        var interleaving = new[] { Ev("LogA", 200, 2) };
+
+        var result = existing.Append(interleaving);
+
+        AssertSameSequence(StableMerge(existing, interleaving), result);
+    }
+
+    [Fact]
+    public void Append_SingleLogDescendingStream_UsesPrependFastPathWithoutCopying()
+    {
+        var descending = new SortContext(ColumnName.DateAndTime, isDescending: true, groupBy: null, isGroupDescending: false);
+        var comparer = ResolvedEventOrdering.SelectComparer(ColumnName.DateAndTime, true, null, false);
+
+        var list = SegmentedSortedList.CreateSorted([], descending);
+
+        for (int batch = 0; batch < 20; batch++)
+        {
+            list = list.Append([Ev("LogA", 1000 + batch, batch + 1)]);
+        }
+
+        Assert.Equal(20, list.Count);
+        Assert.Equal(20, list.SegmentCount);
+        Assert.Equal(20L, list[0].RecordId);
+        Assert.Equal(1L, list[^1].RecordId);
+
+        for (int i = 1; i < list.Count; i++)
+        {
+            Assert.True(comparer(list[i - 1], list[i]) <= 0);
+        }
+    }
+
+    [Fact]
+    public void CopyTo_CopiesAllElementsInEnumerationOrder()
+    {
+        var list = SegmentedSortedList.CreateSorted([Ev("LogA", 100, 1), Ev("LogA", 110, 2)], s_byTime)
+            .Append([Ev("LogA", 200, 3)])
+            .Append([Ev("LogA", 10, 4)]);
+
+        var array = new ResolvedEvent[list.Count];
+        list.CopyTo(array, 0);
+
+        AssertSameSequence(list, array);
+    }
+
+    [Fact]
+    public void Implements_ICollectionContract_ForVirtualizeBinding()
+    {
+        var list = SegmentedSortedList.CreateSorted([Ev("LogA", 1, 1), Ev("LogA", 2, 2)], s_byTime);
+
+        Assert.IsAssignableFrom<IReadOnlyList<ResolvedEvent>>(list);
+
+        var collection = list as ICollection<ResolvedEvent>;
+
+        Assert.NotNull(collection);
+        Assert.True(collection!.IsReadOnly);
+        Assert.Equal(2, collection.Count);
+        Assert.Throws<NotSupportedException>(() => collection.Add(Ev("LogA", 3, 3)));
+        Assert.Throws<NotSupportedException>(() => collection.Clear());
+        Assert.Throws<NotSupportedException>(() => collection.Remove(Ev("LogA", 1, 1)));
+    }
+
+    [Fact]
+    public void Indexer_MatchesEnumeration_AcrossSegments()
+    {
+        var list = SegmentedSortedList.CreateSorted([Ev("LogA", 100, 1)], s_byTime)
+            .Append([Ev("LogA", 200, 2), Ev("LogA", 210, 3)])
+            .Append([Ev("LogA", 1, 4), Ev("LogA", 2, 5)]);
+
+        var enumerated = list.ToList();
+
+        Assert.Equal(5, list.Count);
+
+        for (int i = 0; i < list.Count; i++)
+        {
+            Assert.Same(enumerated[i], list[i]);
+        }
+    }
+
+    [Fact]
+    public void Indexer_OutOfRange_Throws()
+    {
+        var list = SegmentedSortedList.CreateSorted([Ev("LogA", 1, 1)], s_byTime);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => list[1]);
+        Assert.Throws<ArgumentOutOfRangeException>(() => list[-1]);
+    }
+
+    [Fact]
+    public void MergeFrom_SegmentedListWithDifferentContext_ReSortsSafely()
+    {
+        var byLevel = new SortContext(ColumnName.Level, isDescending: false, groupBy: null, isGroupDescending: false);
+        var late = Ev("LogA", 300, 1, "Critical");
+        var early = Ev("LogA", 100, 2, "Warning");
+        var existing = SegmentedSortedList.CreateSorted([late, early], byLevel);
+
+        var middle = Ev("LogA", 200, 3, "Information");
+        var result = SegmentedSortedList.MergeFrom(existing, [middle], s_byTime);
+
+        Assert.Equal(3, result.Count);
+        Assert.Same(early, result[0]);
+        Assert.Same(middle, result[1]);
+        Assert.Same(late, result[2]);
+    }
+
+    [Fact]
+    public void MergeSorted_PublicPath_TieBoundary_MatchesStableMerge()
+    {
+        var head = Ev("LogA", 100, null);
+        IReadOnlyList<ResolvedEvent> existing =
+            SegmentedSortedList.CreateSorted([head, Ev("LogA", 200, 2)], s_byTime);
+        var tied = new[] { Ev("LogA", 100, null) };
+
+        var result = ResolvedEventOrdering.MergeSorted(existing, tied, ColumnName.DateAndTime, isDescending: false);
+
+        AssertSameSequence(StableMerge(existing, tied), result);
+        Assert.Same(head, result[0]);
+    }
+
+    [Fact]
+    public void WhereSegmented_DropsEmptyMiddleSegment()
+    {
+        var middle = SegmentedSortedList.CreateSorted([Ev("LogC", 100, 1), Ev("LogC", 110, 2)], s_byTime);
+        var withLate = middle.Append([Ev("LogB", 200, 3)]);
+        var threeSegments = withLate.Append([Ev("LogA", 1, 4)]);
+
+        var filtered = threeSegments.WhereSegmented(e => !string.Equals(e.OwningLog, "LogC", StringComparison.Ordinal));
+
+        Assert.Equal(2, filtered.Count);
+        Assert.DoesNotContain(filtered, e => string.Equals(e.OwningLog, "LogC", StringComparison.Ordinal));
+        AssertSorted(filtered);
+    }
+
+    private static void AssertSameSequence(IReadOnlyList<ResolvedEvent> expected, IReadOnlyList<ResolvedEvent> actual)
+    {
+        Assert.Equal(expected.Count, actual.Count);
+
+        for (int i = 0; i < expected.Count; i++)
+        {
+            Assert.Same(expected[i], actual[i]);
+        }
+    }
+
+    private static void AssertSorted(IReadOnlyList<ResolvedEvent> events)
+    {
+        for (int i = 1; i < events.Count; i++)
+        {
+            Assert.True(s_comparer(events[i - 1], events[i]) <= 0);
+        }
+    }
+
+    private static ResolvedEvent Ev(string owningLog, int timeMs, long? recordId, string level = "") =>
+        new(owningLog, LogPathType.Channel)
+        {
+            TimeCreated = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddMilliseconds(timeMs),
+            RecordId = recordId,
+            Level = level
+        };
+
+    private static List<ResolvedEvent> StableMerge(IReadOnlyList<ResolvedEvent> existing, IReadOnlyList<ResolvedEvent> batch)
+    {
+        var sortedBatch = new List<ResolvedEvent>(batch);
+        sortedBatch.Sort(s_comparer);
+
+        var result = new List<ResolvedEvent>(existing.Count + sortedBatch.Count);
+        int i = 0, j = 0;
+
+        while (i < existing.Count && j < sortedBatch.Count)
+        {
+            result.Add(s_comparer(existing[i], sortedBatch[j]) <= 0 ? existing[i++] : sortedBatch[j++]);
+        }
+
+        while (i < existing.Count) { result.Add(existing[i++]); }
+
+        while (j < sortedBatch.Count) { result.Add(sortedBatch[j++]); }
+
+        return result;
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/SegmentedSortedListTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/SegmentedSortedListTests.cs
@@ -215,6 +215,20 @@ public sealed class SegmentedSortedListTests
     }
 
     [Fact]
+    public void ResolveByKey_MatchesByReferenceAndEquivalentKey_ElseNull()
+    {
+        var events = new List<ResolvedEvent>();
+        for (int i = 1; i <= 300; i++) { events.Add(Ev("LogA", i, i)); }
+        var list = SegmentedSortedList.CreateSorted(events, s_byTime);
+
+        var original = events[150];
+
+        Assert.Same(original, list.ResolveByKey(original));
+        Assert.Same(original, list.ResolveByKey(Ev("LogA", 151, 151)));
+        Assert.Null(list.ResolveByKey(Ev("LogB", 999, 9999)));
+    }
+
+    [Fact]
     public void ResolvedEventIndex_IndexOf_FindsInstancesAcrossSegments_IncludingNullRecordIdTieWindow()
     {
         var e1 = Ev("LogA", 100, null);

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneGroupingTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneGroupingTests.cs
@@ -510,17 +510,18 @@ public sealed class LogTablePaneGroupingTests : BunitContext
     [Fact]
     public void Grouped_UngroupWithHeaderCursor_ResumesFromFormerGroupsFirstEvent()
     {
-        var alpha1 = Event(1, "Alpha");
-        var beta2 = Event(2, "Beta");
-        _logTableState.Value.Returns(BuildState(ColumnName.Source, Collapsed(), alpha1, beta2));
+        // Ungrouped order (by time) differs from grouped order (by Source).
+        var alpha = Event(2, "Alpha");
+        var beta = Event(1, "Beta");
+        _logTableState.Value.Returns(BuildState(ColumnName.Source, Collapsed(), alpha, beta));
 
         var cut = Render<LogTablePane>();
         Press(cut, "Home");      // header Alpha
-        Press(cut, "ArrowDown"); // event 1
+        Press(cut, "ArrowDown"); // event Alpha
         Press(cut, "ArrowDown"); // header Beta (cursor on a non-first header)
 
-        // Ungroup resorts the list (reversed here); a stale index would mispoint.
-        _logTableState.Value.Returns(BuildState(groupBy: null, Collapsed(), beta2, alpha1));
+        // Ungroup resorts the list; a stale index would mispoint.
+        _logTableState.Value.Returns(BuildState(groupBy: null, Collapsed(), beta, alpha));
         RaiseStateChanged(cut);
         cut.WaitForAssertion(() => Assert.Empty(cut.FindAll("tr.group-header-row")));
 
@@ -528,7 +529,7 @@ public sealed class LogTablePaneGroupingTests : BunitContext
         Press(cut, "ArrowDown");
 
         _eventLogCommands.Received(1).SetSelectedEvents(
-            Arg.Is<IReadOnlyCollection<ResolvedEvent>>(c => c.Count == 1 && c.Contains(alpha1)),
+            Arg.Is<IReadOnlyCollection<ResolvedEvent>>(c => c.Count == 1 && c.Contains(alpha)),
             Arg.Any<ResolvedEvent?>());
     }
 
@@ -562,21 +563,25 @@ public sealed class LogTablePaneGroupingTests : BunitContext
     [Fact]
     public void GroupedByLog_HeaderShowsLogNameNotRepresentativeOwningLog()
     {
-        var logId = EventLogId.Create();
+        var combinedId = EventLogId.Create();
+        var appId1 = EventLogId.Create();
+        var appId2 = EventLogId.Create();
         var e1 = LogEvent(1, @"C:\logs\App1.evtx", "Application");
         var e2 = LogEvent(2, @"C:\logs\App2.evtx", "Application");
 
         _logTableState.Value.Returns(new LogTableState
         {
-            ActiveEventLogId = logId,
-            EventTables = ImmutableList.Create(new LogView(logId) { LogName = "Combined", IsCombined = true }),
-            DisplayedEvents = [e1, e2],
-            EventCountByLog = ImmutableDictionary<EventLogId, int>.Empty.Add(logId, 2),
+            ActiveEventLogId = combinedId,
+            EventTables = ImmutableList.Create(
+                new LogView(combinedId) { LogName = "Combined", IsCombined = true },
+                new LogView(appId1) { LogName = "Application" },
+                new LogView(appId2) { LogName = "Application" }),
+            EventCountByLog = ImmutableDictionary<EventLogId, int>.Empty.Add(appId1, 1).Add(appId2, 1),
             Columns = ImmutableDictionary<ColumnName, bool>.Empty.Add(ColumnName.Log, true),
             ColumnOrder = ImmutableList.Create(ColumnName.Log),
             GroupBy = ColumnName.Log,
             GroupCollapseOverrides = Collapsed()
-        });
+        }.WithLogEvents(appId1, e1).WithLogEvents(appId2, e2));
 
         var cut = Render<LogTablePane>();
         var header = cut.Find("tr.group-header-row");
@@ -635,14 +640,13 @@ public sealed class LogTablePaneGroupingTests : BunitContext
         {
             ActiveEventLogId = logId,
             EventTables = ImmutableList.Create(new LogView(logId) { LogName = LogName }),
-            DisplayedEvents = events,
             EventCountByLog = ImmutableDictionary<EventLogId, int>.Empty.Add(logId, events.Length),
             Columns = ImmutableDictionary<ColumnName, bool>.Empty.Add(ColumnName.Source, true),
             ColumnOrder = ImmutableList.Create(ColumnName.Source),
             IsDescending = false,
             GroupBy = groupBy,
             GroupCollapseOverrides = collapsed
-        };
+        }.WithLogEvents(logId, events);
     }
 
     private static ImmutableHashSet<string> Collapsed(params string[] keys) =>

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneSelectionTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneSelectionTests.cs
@@ -270,13 +270,12 @@ public sealed class LogTablePaneSelectionTests : BunitContext
         {
             ActiveEventLogId = logId,
             EventTables = ImmutableList.Create(new LogView(logId) { LogName = LogName }),
-            DisplayedEvents = [displayedEvent],
             EventCountByLog = ImmutableDictionary<EventLogId, int>.Empty.Add(logId, 1),
             Columns = allColumns.ToImmutableDictionary(column => column, _ => true),
             ColumnOrder = [.. allColumns],
             OrderBy = orderBy,
             IsDescending = isDescending
-        });
+        }.WithLogEvents(logId, displayedEvent));
 
         return Render<LogTablePane>();
     }
@@ -289,12 +288,11 @@ public sealed class LogTablePaneSelectionTests : BunitContext
         {
             ActiveEventLogId = logId,
             EventTables = ImmutableList.Create(new LogView(logId) { LogName = LogName }),
-            DisplayedEvents = [_event1, _event2, _event3],
             EventCountByLog = ImmutableDictionary<EventLogId, int>.Empty.Add(logId, 3),
             Columns = ImmutableDictionary<ColumnName, bool>.Empty.Add(ColumnName.Level, true),
             ColumnOrder = ImmutableList.Create(ColumnName.Level),
             IsDescending = false
-        });
+        }.WithLogEvents(logId, _event1, _event2, _event3));
 
         var cut = Render<LogTablePane>();
 

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneSelectionTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneSelectionTests.cs
@@ -292,7 +292,8 @@ public sealed class LogTablePaneSelectionTests : BunitContext
             DisplayedEvents = [_event1, _event2, _event3],
             EventCountByLog = ImmutableDictionary<EventLogId, int>.Empty.Add(logId, 3),
             Columns = ImmutableDictionary<ColumnName, bool>.Empty.Add(ColumnName.Level, true),
-            ColumnOrder = ImmutableList.Create(ColumnName.Level)
+            ColumnOrder = ImmutableList.Create(ColumnName.Level),
+            IsDescending = false
         });
 
         var cut = Render<LogTablePane>();


### PR DESCRIPTION
Foundational performance refactor for opening very large event logs. The #371 repro — a ~2 GB / 3.5M-event log — peaked around 20 GB of RAM, driven by an O(T²) full-copy merge during streaming load plus heavy per-event retention. This is four stacked, independently-reviewed stages.

## Stages

- **Replace the event-table row-index dictionary with binary search** — the per-render `Dictionary<ResolvedEvent,int>` (rebuilt every render tick) is replaced with a binary search over the already-sorted view, removing a large per-tick render allocation.
- **Coordinate partial-load updates across logs into one batched flush** — a `PartialLoadCoordinator` coalesces streaming partial-load deltas across all logs into a single batched dispatch per ~1 s window, so load behavior is the same regardless of log count (far fewer state recomputes/renders during load).
- **Intern keyword lists and security identifiers across resolved events** — the per-event keyword `List<string>` and `SecurityIdentifier` are interned at resolve time (freeze-on-miss keyword cache; SID keyed by value), so repeated values are shared instead of re-allocated per event.
- **Back the event table with a segmented sorted list to avoid full-copy merges** — `DisplayedEvents` is backed by an immutable, non-interleaving segmented sorted list. Streaming appends that sit before/after the existing view add a segment without copying it; interleaving appends fall back to a full merge. Drop-in `IReadOnlyList` + `ICollection` so no UI churn.

## Measured wins (3.5M-event single log)

| Metric | Before | After |
| --- | --- | --- |
| Transient allocated during load | 9.17 GiB | **56.6 MiB** (~166×) |
| Load time | 11.8 s | **0.42 s** (~28×) |
| Per-event retention (keyword list + SID) | — | **−852 MiB** (interning) |

(Measured with an out-of-repo harness driving the actual reducers + resolver cache via public APIs; not committed.)

## Testing

- Runtime.Tests **1298** pass, UI.Tests **708** pass, head builds clean (0 warnings / 0 errors).
- New randomized **differential test harness** proves the segmented merge/sort/filter is byte-identical to the original full-copy path across ~3,200 randomized operations, plus targeted boundary-tie, `ICollection`/`CopyTo`, interleave-then-prepend, filter-empty-segment, and single-log fast-path tests.
- Each stage went through pre-implementation and post-code-change multi-model review before commit.

Relates to #371.
