### PR TITLE
Add built-in scenario engine, channel-presence probe, and scenario launch services

### DIFF
--- a/EventLogExpert.slnx
+++ b/EventLogExpert.slnx
@@ -20,6 +20,7 @@
     <Project Path="src/EventLogExpert.Provider/EventLogExpert.Provider.csproj" />
     <Project Path="src/EventLogExpert.EventDbTool/EventLogExpert.EventDbTool.csproj" />
     <Project Path="src/EventLogExpert.Filtering/EventLogExpert.Filtering.csproj" />
+    <Project Path="src/EventLogExpert.Scenarios/EventLogExpert.Scenarios.csproj" />
     <Project Path="src/EventLogExpert.Provider.Database/EventLogExpert.Provider.Database.csproj" />
     <Project Path="src/EventLogExpert.DatabaseTools/EventLogExpert.DatabaseTools.csproj" />
     <Project Path="src/EventLogExpert.ElevationHelper/EventLogExpert.ElevationHelper.csproj" />
@@ -42,6 +43,7 @@
     <Project Path="tests/Unit/EventLogExpert.Logging.Tests/EventLogExpert.Logging.Tests.csproj" />
     <Project Path="tests/Unit/EventLogExpert.Runtime.Tests/EventLogExpert.Runtime.Tests.csproj" />
     <Project Path="tests/Unit/EventLogExpert.Filtering.Tests/EventLogExpert.Filtering.Tests.csproj" />
+    <Project Path="tests/Unit/EventLogExpert.Scenarios.Tests/EventLogExpert.Scenarios.Tests.csproj" />
     <Project Path="tests/Unit/EventLogExpert.Provider.Database.Tests/EventLogExpert.Provider.Database.Tests.csproj" />
     <Project Path="tests/Unit/EventLogExpert.Provider.Tests/EventLogExpert.Provider.Tests.csproj" />
   </Folder>

--- a/src/EventLogExpert.Runtime/DependencyInjection/RuntimeServiceCollectionExtensions.cs
+++ b/src/EventLogExpert.Runtime/DependencyInjection/RuntimeServiceCollectionExtensions.cs
@@ -20,9 +20,11 @@ using EventLogExpert.Runtime.FilterPane;
 using EventLogExpert.Runtime.LogTable;
 using EventLogExpert.Runtime.Menu;
 using EventLogExpert.Runtime.Modal;
+using EventLogExpert.Runtime.Scenarios;
 using EventLogExpert.Runtime.Settings;
 using EventLogExpert.Runtime.Update;
 using EventLogExpert.Runtime.Update.Deployment;
+using EventLogExpert.Scenarios.Catalog;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.Extensions.DependencyInjection;
@@ -116,6 +118,10 @@ public static class RuntimeServiceCollectionExtensions
         ///             SQLite-backed store via <c>services.AddFilterLibrarySqliteStore(<i>dbPath</i>)</c>, or supply a custom
         ///             implementation.
         ///         </item>
+        ///         <item>
+        ///             <c>IMenuActionService</c> - the scenario launch service depends on it to open a scenario's channels. The
+        ///             host registers the concrete implementation (e.g., <c>MauiMenuActionService</c>).
+        ///         </item>
         ///     </list>
         ///     Omitting any of these produces a DI resolution failure when the dependent services are first activated.
         /// </summary>
@@ -178,6 +184,14 @@ public static class RuntimeServiceCollectionExtensions
             // DatabaseTools service (CLI-equivalent operations exposed to the UI).
             services.AddDatabaseToolsServices();
             services.TryAddSingleton<IDatabaseToolsService, DatabaseToolsService>();
+
+            // Built-in scenarios: the immutable embedded catalog + presence/query/launch services. The registry
+            // aggregates every registered IScenarioSource (PR1 ships only the built-in source).
+            services.AddSingleton<IScenarioSource, BuiltInScenarioSource>();
+            services.AddSingleton<BuiltInScenarioRegistry>();
+            services.AddSingleton<IChannelPresenceProbe, ChannelPresenceProbe>();
+            services.AddSingleton<IScenarioQueryService, ScenarioQueryService>();
+            services.AddSingleton<IScenarioLaunchService, ScenarioLaunchService>();
 
             return services;
         }

--- a/src/EventLogExpert.Runtime/EventLogExpert.Runtime.csproj
+++ b/src/EventLogExpert.Runtime/EventLogExpert.Runtime.csproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="..\EventLogExpert.DatabaseTools\EventLogExpert.DatabaseTools.csproj" />
     <ProjectReference Include="..\EventLogExpert.Eventing\EventLogExpert.Eventing.csproj" />
     <ProjectReference Include="..\EventLogExpert.Filtering\EventLogExpert.Filtering.csproj" />
+    <ProjectReference Include="..\EventLogExpert.Scenarios\EventLogExpert.Scenarios.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EventLogExpert.Runtime/Menu/IMenuActionService.cs
+++ b/src/EventLogExpert.Runtime/Menu/IMenuActionService.cs
@@ -35,6 +35,8 @@ public interface IMenuActionService
 
     Task OpenLiveLogAsync(string logName, bool combineLog);
 
+    Task<OpenLogsBatchResult> OpenLiveLogsAsync(IEnumerable<string> logNames, bool combineLog);
+
     Task<bool> OpenSettingsAsync();
 
     Task SaveFiltersAsFilterSetAsync();

--- a/src/EventLogExpert.Runtime/Menu/OpenLogsBatchResult.cs
+++ b/src/EventLogExpert.Runtime/Menu/OpenLogsBatchResult.cs
@@ -1,0 +1,18 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Collections.Immutable;
+
+namespace EventLogExpert.Runtime.Menu;
+
+public sealed record OpenLogsBatchResult(
+    int Opened,
+    int Empty,
+    int Failed,
+    int Skipped,
+    ImmutableArray<string> EmptyNames)
+{
+    public static OpenLogsBatchResult None { get; } = new(0, 0, 0, 0, []);
+
+    public bool AnyOpened => Opened > 0;
+}

--- a/src/EventLogExpert.Runtime/Scenarios/ChannelPresenceProbe.cs
+++ b/src/EventLogExpert.Runtime/Scenarios/ChannelPresenceProbe.cs
@@ -1,0 +1,74 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Readers;
+using EventLogExpert.Logging.Abstractions;
+using System.Collections.Frozen;
+
+namespace EventLogExpert.Runtime.Scenarios;
+
+internal sealed class ChannelPresenceProbe : IChannelPresenceProbe
+{
+    private static readonly IReadOnlySet<string> s_empty = FrozenSet<string>.Empty;
+
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly Func<IEnumerable<string>> _readChannels;
+    private readonly ITraceLogger _traceLogger;
+
+    private IReadOnlySet<string>? _cache;
+
+    public ChannelPresenceProbe(ITraceLogger traceLogger)
+        : this(traceLogger, static () => EventLogSession.GlobalSession.GetLogNames()) { }
+
+    internal ChannelPresenceProbe(ITraceLogger traceLogger, Func<IEnumerable<string>> readChannels)
+    {
+        ArgumentNullException.ThrowIfNull(traceLogger);
+        ArgumentNullException.ThrowIfNull(readChannels);
+
+        _traceLogger = traceLogger;
+        _readChannels = readChannels;
+    }
+
+    public IReadOnlySet<string> GetPresentChannels()
+    {
+        var cached = _cache;
+
+        if (cached is not null) { return cached; }
+
+        _gate.Wait();
+
+        try
+        {
+            if (_cache is not null) { return _cache; }
+
+            var loaded = TryReadChannels();
+
+            // A failed read is not cached, so the next read retries.
+            if (loaded is not null) { _cache = loaded; }
+
+            return loaded ?? s_empty;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public bool IsPresent(string logName) => GetPresentChannels().Contains(logName);
+
+    public Task PrimeAsync() => Task.Run(GetPresentChannels);
+
+    private IReadOnlySet<string>? TryReadChannels()
+    {
+        try
+        {
+            return _readChannels().ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+        }
+        catch (Exception exception)
+        {
+            _traceLogger.Warning($"ChannelPresenceProbe: failed to read channel names: {exception.Message}");
+
+            return null;
+        }
+    }
+}

--- a/src/EventLogExpert.Runtime/Scenarios/IChannelPresenceProbe.cs
+++ b/src/EventLogExpert.Runtime/Scenarios/IChannelPresenceProbe.cs
@@ -1,0 +1,16 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Scenarios;
+
+/// <summary>Reports which event-log channels exist on this host, cached per session.</summary>
+internal interface IChannelPresenceProbe
+{
+    /// <summary>Present channel names; empty if the channel set could not be read.</summary>
+    IReadOnlySet<string> GetPresentChannels();
+
+    bool IsPresent(string logName);
+
+    /// <summary>Warms the cache on a background thread.</summary>
+    Task PrimeAsync();
+}

--- a/src/EventLogExpert.Runtime/Scenarios/IScenarioLaunchService.cs
+++ b/src/EventLogExpert.Runtime/Scenarios/IScenarioLaunchService.cs
@@ -1,0 +1,17 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Evaluation;
+using EventLogExpert.Scenarios.Catalog;
+
+namespace EventLogExpert.Runtime.Scenarios;
+
+/// <summary>Launches a scenario: applies its filter set and opens its channels.</summary>
+public interface IScenarioLaunchService
+{
+    /// <summary>
+    ///     Applies the scenario's filters, then opens its channels. A null <paramref name="dateWindow" /> clears the date
+    ///     filter; <paramref name="combineLog" /> false opens a fresh view, true merges into the active workspace.
+    /// </summary>
+    Task<ScenarioLaunchResult> LaunchAsync(ScenarioDefinition scenario, DateFilter? dateWindow, bool combineLog = false);
+}

--- a/src/EventLogExpert.Runtime/Scenarios/IScenarioQueryService.cs
+++ b/src/EventLogExpert.Runtime/Scenarios/IScenarioQueryService.cs
@@ -1,0 +1,16 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Scenarios.Catalog;
+
+namespace EventLogExpert.Runtime.Scenarios;
+
+/// <summary>Selects which scenarios to surface on the splash dashboard and in-app.</summary>
+public interface IScenarioQueryService
+{
+    /// <summary>Scenarios whose channels match a currently-loaded log name.</summary>
+    IReadOnlyList<ScenarioDefinition> GetInAppScenarios(IReadOnlyCollection<string> loadedLogNames);
+
+    /// <summary>Scenarios with at least one required channel present on the host.</summary>
+    IReadOnlyList<ScenarioDefinition> GetSplashScenarios();
+}

--- a/src/EventLogExpert.Runtime/Scenarios/ScenarioLaunchResult.cs
+++ b/src/EventLogExpert.Runtime/Scenarios/ScenarioLaunchResult.cs
@@ -1,0 +1,12 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Scenarios;
+
+/// <summary>Outcome of launching a scenario: how its channels opened.</summary>
+public sealed record ScenarioLaunchResult(int Opened, int Empty, int Failed)
+{
+    public static ScenarioLaunchResult None { get; } = new(0, 0, 0);
+
+    public bool AnyOpened => Opened > 0;
+}

--- a/src/EventLogExpert.Runtime/Scenarios/ScenarioLaunchService.cs
+++ b/src/EventLogExpert.Runtime/Scenarios/ScenarioLaunchService.cs
@@ -1,0 +1,43 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Evaluation;
+using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.FilterPane;
+using EventLogExpert.Runtime.Menu;
+using EventLogExpert.Scenarios.Catalog;
+using Fluxor;
+
+namespace EventLogExpert.Runtime.Scenarios;
+
+internal sealed class ScenarioLaunchService(
+    BuiltInScenarioRegistry registry,
+    IMenuActionService menuActionService,
+    IDispatcher dispatcher) : IScenarioLaunchService
+{
+    private readonly IDispatcher _dispatcher = dispatcher;
+    private readonly IMenuActionService _menuActionService = menuActionService;
+    private readonly BuiltInScenarioRegistry _registry = registry;
+
+    public async Task<ScenarioLaunchResult> LaunchAsync(
+        ScenarioDefinition scenario,
+        DateFilter? dateWindow,
+        bool combineLog = false)
+    {
+        ArgumentNullException.ThrowIfNull(scenario);
+
+        var filters = _registry.BuildFilterSet(scenario);
+
+        _dispatcher.Dispatch(new ReplaceFiltersAction(filters));
+        _dispatcher.Dispatch(new SetFilterDateRangeAction(dateWindow));
+
+        var result = await _menuActionService.OpenLiveLogsAsync(scenario.Channels, combineLog);
+
+        if (result.Opened == 0 && !combineLog)
+        {
+            _dispatcher.Dispatch(new CloseAllLogsAction());
+        }
+
+        return new ScenarioLaunchResult(result.Opened, result.Empty, result.Failed);
+    }
+}

--- a/src/EventLogExpert.Runtime/Scenarios/ScenarioQueryService.cs
+++ b/src/EventLogExpert.Runtime/Scenarios/ScenarioQueryService.cs
@@ -1,0 +1,33 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Scenarios.Catalog;
+
+namespace EventLogExpert.Runtime.Scenarios;
+
+internal sealed class ScenarioQueryService(BuiltInScenarioRegistry registry, IChannelPresenceProbe presenceProbe)
+    : IScenarioQueryService
+{
+    private readonly IChannelPresenceProbe _presenceProbe = presenceProbe;
+    private readonly BuiltInScenarioRegistry _registry = registry;
+
+    public IReadOnlyList<ScenarioDefinition> GetInAppScenarios(IReadOnlyCollection<string> loadedLogNames)
+    {
+        ArgumentNullException.ThrowIfNull(loadedLogNames);
+
+        var loaded = loadedLogNames.ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        return [.._registry.Scenarios.Where(scenario => scenario.Channels.Any(loaded.Contains))];
+    }
+
+    public IReadOnlyList<ScenarioDefinition> GetSplashScenarios()
+    {
+        var present = _presenceProbe.GetPresentChannels();
+
+        return [
+            .._registry.Scenarios
+                .Where(scenario => scenario.Gating == ScenarioGating.ChannelPresence)
+                .Where(scenario => scenario.Channels.Any(present.Contains))
+        ];
+    }
+}

--- a/src/EventLogExpert.Scenarios/Catalog/BuiltInScenarioRegistry.cs
+++ b/src/EventLogExpert.Scenarios/Catalog/BuiltInScenarioRegistry.cs
@@ -1,0 +1,77 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Basic;
+using EventLogExpert.Filtering.Evaluation;
+using EventLogExpert.Filtering.Persistence;
+using System.Collections.Immutable;
+
+namespace EventLogExpert.Scenarios.Catalog;
+
+/// <summary>Aggregates scenario sources into the immutable catalog and materialises filter sets.</summary>
+public sealed class BuiltInScenarioRegistry
+{
+    private readonly ImmutableList<ScenarioDefinition> _scenarios;
+
+    public BuiltInScenarioRegistry(IEnumerable<IScenarioSource> sources)
+    {
+        ArgumentNullException.ThrowIfNull(sources);
+
+        var builder = ImmutableList.CreateBuilder<ScenarioDefinition>();
+        var seenIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var errors = ImmutableList.CreateBuilder<string>();
+
+        foreach (var source in sources)
+        {
+            foreach (var scenario in source.GetScenarios())
+            {
+                if (seenIds.Add(scenario.Id))
+                {
+                    builder.Add(scenario);
+                }
+                else
+                {
+                    errors.Add($"Scenario id '{scenario.Id}' is provided by more than one source (packs may not shadow built-ins).");
+                }
+            }
+        }
+
+        if (errors.Count > 0) { throw new ScenarioCatalogException(errors.ToImmutable()); }
+
+        _scenarios =
+        [
+            .. builder
+                .OrderBy(scenario => scenario.Group)
+                .ThenBy(scenario => scenario.Priority)
+                .ThenBy(scenario => scenario.Order)
+                .ThenBy(scenario => scenario.Id, StringComparer.Ordinal)
+        ];
+    }
+
+    public IReadOnlyList<ScenarioDefinition> Scenarios => _scenarios;
+
+    /// <summary>Materialises a scenario's rows into an applyable Basic <c>SavedFilter</c> set.</summary>
+    public ImmutableList<SavedFilter> BuildFilterSet(ScenarioDefinition scenario)
+    {
+        ArgumentNullException.ThrowIfNull(scenario);
+
+        var builder = ImmutableList.CreateBuilder<SavedFilter>();
+
+        foreach (var row in scenario.Filters)
+        {
+            if (!BasicFilterFormatter.TryFormat(row.Filter, strictPredicates: true, out var comparisonText))
+            {
+                throw new InvalidOperationException(
+                    $"Scenario '{scenario.Id}' has a filter row that could not be formatted; the catalog should reject it at load.");
+            }
+
+            var saved = SavedFilter.TryCreate(comparisonText, row.Filter, isExcluded: row.IsExcluded, isEnabled: true, mode: FilterMode.Basic)
+                ?? throw new InvalidOperationException(
+                    $"Scenario '{scenario.Id}' has a filter row '{comparisonText}' that could not be compiled; the catalog should reject it at load.");
+
+            builder.Add(saved);
+        }
+
+        return builder.ToImmutable();
+    }
+}

--- a/src/EventLogExpert.Scenarios/Catalog/BuiltInScenarioSource.cs
+++ b/src/EventLogExpert.Scenarios/Catalog/BuiltInScenarioSource.cs
@@ -1,0 +1,16 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Scenarios.Serialization;
+using System.Collections.Immutable;
+
+namespace EventLogExpert.Scenarios.Catalog;
+
+/// <summary>The built-in source: scenarios embedded in this assembly, validated at load.</summary>
+public sealed class BuiltInScenarioSource : IScenarioSource
+{
+    private readonly ImmutableList<ScenarioDefinition> _scenarios =
+        ScenarioCatalogLoader.Load(typeof(BuiltInScenarioSource).Assembly);
+
+    public IReadOnlyList<ScenarioDefinition> GetScenarios() => _scenarios;
+}

--- a/src/EventLogExpert.Scenarios/Catalog/IScenarioSource.cs
+++ b/src/EventLogExpert.Scenarios/Catalog/IScenarioSource.cs
@@ -1,0 +1,10 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Scenarios.Catalog;
+
+/// <summary>A source of <see cref="ScenarioDefinition" />s aggregated by the registry.</summary>
+public interface IScenarioSource
+{
+    IReadOnlyList<ScenarioDefinition> GetScenarios();
+}

--- a/src/EventLogExpert.Scenarios/Catalog/ScenarioCatalogException.cs
+++ b/src/EventLogExpert.Scenarios/Catalog/ScenarioCatalogException.cs
@@ -1,0 +1,33 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Collections.Immutable;
+
+namespace EventLogExpert.Scenarios.Catalog;
+
+/// <summary>Thrown when the scenario catalog fails to load; carries every error found.</summary>
+public sealed class ScenarioCatalogException : Exception
+{
+    public ScenarioCatalogException(ImmutableList<string> errors)
+        : base(BuildMessage(errors)) =>
+        Errors = errors;
+
+    public ScenarioCatalogException()
+        : this([]) { }
+
+    public ScenarioCatalogException(string message)
+        : base(message) =>
+        Errors = [message];
+
+    public ScenarioCatalogException(string message, Exception innerException)
+        : base(message, innerException) =>
+        Errors = [message];
+
+    public ImmutableList<string> Errors { get; } = [];
+
+    private static string BuildMessage(ImmutableList<string> errors) =>
+        errors.IsEmpty
+            ? "The built-in scenario catalog failed to load."
+            : $"The built-in scenario catalog has {errors.Count} error(s):{Environment.NewLine}" +
+              string.Join(Environment.NewLine, errors.Select(error => $"  - {error}"));
+}

--- a/src/EventLogExpert.Scenarios/Catalog/ScenarioDefinition.cs
+++ b/src/EventLogExpert.Scenarios/Catalog/ScenarioDefinition.cs
@@ -1,0 +1,51 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Scenarios.Common;
+using System.Collections.Immutable;
+
+namespace EventLogExpert.Scenarios.Catalog;
+
+/// <summary>An immutable, validated built-in scenario: a named filter set tied to one or more channels.</summary>
+public sealed record ScenarioDefinition
+{
+    /// <summary>Stable, kebab-case identity, unique across the catalog.</summary>
+    public required string Id { get; init; }
+
+    public required string Name { get; init; }
+
+    public required string Purpose { get; init; }
+
+    public required ScenarioGroup Group { get; init; }
+
+    public ImmutableArray<string> Tags { get; init; } = [];
+
+    /// <summary>Required channels; more than one denotes a combined scenario.</summary>
+    public required ImmutableArray<string> Channels { get; init; }
+
+    /// <summary>Optional channels that never gate visibility.</summary>
+    public ImmutableArray<string> OptionalChannels { get; init; } = [];
+
+    public ScenarioGating Gating { get; init; } = ScenarioGating.ChannelPresence;
+
+    /// <summary>Source/publisher names gated on for <see cref="ScenarioGating.SourceRegistration" />.</summary>
+    public ImmutableArray<string> SourceGates { get; init; } = [];
+
+    /// <summary>True when any required channel needs process elevation to read.</summary>
+    public bool RequiresAdmin { get; init; }
+
+    /// <summary>The ordered filter rows, each materialising to one Basic filter.</summary>
+    public required ImmutableArray<ScenarioFilterRow> Filters { get; init; }
+
+    /// <summary>0 = starter set, 1 = full catalog; lower sorts first.</summary>
+    public int Priority { get; init; }
+
+    public int Order { get; init; }
+
+    public int Version { get; init; } = 1;
+
+    public ScenarioOrigin Origin { get; init; } = ScenarioOrigin.BuiltIn;
+
+    /// <summary>Deterministic name-based identity (RFC 4122 v5 over <see cref="Id" />).</summary>
+    public Guid StableGuid => DeterministicGuid.Create(DeterministicGuid.ScenarioNamespace, Id);
+}

--- a/src/EventLogExpert.Scenarios/Catalog/ScenarioFilterRow.cs
+++ b/src/EventLogExpert.Scenarios/Catalog/ScenarioFilterRow.cs
@@ -1,0 +1,9 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Basic;
+
+namespace EventLogExpert.Scenarios.Catalog;
+
+/// <summary>One row of a scenario's filter set; maps to one Basic <c>SavedFilter</c>.</summary>
+public sealed record ScenarioFilterRow(BasicFilter Filter, bool IsExcluded = false);

--- a/src/EventLogExpert.Scenarios/Catalog/ScenarioGating.cs
+++ b/src/EventLogExpert.Scenarios/Catalog/ScenarioGating.cs
@@ -1,0 +1,14 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Scenarios.Catalog;
+
+/// <summary>How a scenario decides whether it is present (and therefore surfaced) on a given machine.</summary>
+public enum ScenarioGating
+{
+    /// <summary>Hide unless the scenario's dedicated channel(s) exist in the host's log-name set.</summary>
+    ChannelPresence,
+
+    /// <summary>Hide unless the product's Source/publisher is registered on the always-present Application log.</summary>
+    SourceRegistration
+}

--- a/src/EventLogExpert.Scenarios/Catalog/ScenarioGroup.cs
+++ b/src/EventLogExpert.Scenarios/Catalog/ScenarioGroup.cs
@@ -1,0 +1,18 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Scenarios.Catalog;
+
+/// <summary>Scenario grouping; declaration order is the dashboard render order.</summary>
+public enum ScenarioGroup
+{
+    SystemHealth,
+    Applications,
+    Security,
+    ThreatsAndIncidentResponse,
+    Network,
+    Storage,
+    UpdatesAndPolicy,
+    ServerRoles,
+    MicrosoftProducts
+}

--- a/src/EventLogExpert.Scenarios/Catalog/ScenarioOrigin.cs
+++ b/src/EventLogExpert.Scenarios/Catalog/ScenarioOrigin.cs
@@ -1,0 +1,14 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Scenarios.Catalog;
+
+/// <summary>Where a scenario came from.</summary>
+public enum ScenarioOrigin
+{
+    /// <summary>Shipped with the app as an immutable embedded resource.</summary>
+    BuiltIn,
+
+    /// <summary>Contributed by an additive community or user pack.</summary>
+    Pack
+}

--- a/src/EventLogExpert.Scenarios/Common/DeterministicGuid.cs
+++ b/src/EventLogExpert.Scenarios/Common/DeterministicGuid.cs
@@ -1,0 +1,48 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Security.Cryptography;
+using System.Text;
+
+namespace EventLogExpert.Scenarios.Common;
+
+/// <summary>Deterministic, name-based GUIDs per RFC 4122 v5 (SHA-1).</summary>
+internal static class DeterministicGuid
+{
+    internal static readonly Guid ScenarioNamespace = new("7d9d3f2a-6c1e-4b8a-9b1d-2f0a6c5e4d31");
+
+    internal static Guid Create(Guid namespaceId, string name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+
+        byte[] namespaceBytes = namespaceId.ToByteArray();
+        SwapToBigEndian(namespaceBytes);
+
+        byte[] nameBytes = Encoding.UTF8.GetBytes(name);
+
+        byte[] combined = new byte[namespaceBytes.Length + nameBytes.Length];
+        Buffer.BlockCopy(namespaceBytes, 0, combined, 0, namespaceBytes.Length);
+        Buffer.BlockCopy(nameBytes, 0, combined, namespaceBytes.Length, nameBytes.Length);
+
+#pragma warning disable CA5350 // v5 GUID requires SHA-1; identity hash, not security
+        byte[] hash = SHA1.HashData(combined);
+#pragma warning restore CA5350
+
+        byte[] result = new byte[16];
+        Array.Copy(hash, result, 16);
+
+        result[6] = (byte)((result[6] & 0x0F) | 0x50);
+        result[8] = (byte)((result[8] & 0x3F) | 0x80);
+
+        SwapToBigEndian(result);
+        return new Guid(result);
+    }
+
+    private static void SwapToBigEndian(byte[] guid)
+    {
+        (guid[0], guid[3]) = (guid[3], guid[0]);
+        (guid[1], guid[2]) = (guid[2], guid[1]);
+        (guid[4], guid[5]) = (guid[5], guid[4]);
+        (guid[6], guid[7]) = (guid[7], guid[6]);
+    }
+}

--- a/src/EventLogExpert.Scenarios/EventLogExpert.Scenarios.csproj
+++ b/src/EventLogExpert.Scenarios/EventLogExpert.Scenarios.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <SingleProject>true</SingleProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EventLogExpert.Eventing\EventLogExpert.Eventing.csproj" />
+    <ProjectReference Include="..\EventLogExpert.Filtering\EventLogExpert.Filtering.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Scenarios\built-in\*.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="EventLogExpert.Scenarios.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/system-health.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/system-health.json
@@ -1,0 +1,112 @@
+{
+  "schemaVersion": 1,
+  "scenarios": [
+    {
+      "id": "recent-critical-and-error-events",
+      "name": "Recent Critical & Error Events",
+      "purpose": "Surface the most severe System-log events first.",
+      "group": "SystemHealth",
+      "tags": [ "system", "sysadmin", "failures" ],
+      "channels": [ "System" ],
+      "requiresAdmin": false,
+      "priority": 0,
+      "order": 0,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Level", "matchMode": "Many", "values": [ "Critical", "Error" ] }
+        }
+      ]
+    },
+    {
+      "id": "failed-services-at-boot",
+      "name": "Failed services at boot",
+      "purpose": "Service Control Manager failures that block services from starting.",
+      "group": "SystemHealth",
+      "tags": [ "system", "sysadmin", "failures" ],
+      "channels": [ "System" ],
+      "requiresAdmin": false,
+      "priority": 0,
+      "order": 1,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Service Control Manager" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "7000", "7001", "7022", "7023", "7024", "7026" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "newly-installed-services",
+      "name": "Newly installed services",
+      "purpose": "A new service was installed (Service Control Manager event 7045); also a threat signal.",
+      "group": "SystemHealth",
+      "tags": [ "system", "sysadmin", "audit" ],
+      "channels": [ "System" ],
+      "requiresAdmin": false,
+      "priority": 0,
+      "order": 2,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Service Control Manager" },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "7045" } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "unexpected-restart-power-loss-bsod",
+      "name": "Unexpected restart / power loss / BSOD",
+      "purpose": "Dirty shutdowns: Kernel-Power 41, BugCheck 1001, and EventLog 6008.",
+      "group": "SystemHealth",
+      "tags": [ "system", "sysadmin", "failures" ],
+      "channels": [ "System" ],
+      "requiresAdmin": false,
+      "priority": 0,
+      "order": 3,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Microsoft-Windows-Kernel-Power" },
+          "predicates": [
+            { "joinWithAny": false, "comparison": { "property": "Id", "value": "41" } },
+            { "joinWithAny": true, "comparison": { "property": "Source", "value": "BugCheck" } },
+            { "joinWithAny": false, "comparison": { "property": "Id", "value": "1001" } },
+            { "joinWithAny": true, "comparison": { "property": "Source", "value": "EventLog" } },
+            { "joinWithAny": false, "comparison": { "property": "Id", "value": "6008" } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "service-install-and-control-audit",
+      "name": "Service install & control audit",
+      "purpose": "Correlate service installs across the System log (7045) and the Security audit log (4697).",
+      "group": "SystemHealth",
+      "tags": [ "system", "security", "audit" ],
+      "channels": [ "System", "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 4,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "LogName", "value": "System" },
+          "predicates": [
+            { "joinWithAny": false, "comparison": { "property": "Id", "value": "7045" } }
+          ]
+        },
+        {
+          "comparison": { "property": "LogName", "value": "Security" },
+          "predicates": [
+            { "joinWithAny": false, "comparison": { "property": "Id", "value": "4697" } }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/EventLogExpert.Scenarios/Serialization/ComparisonDto.cs
+++ b/src/EventLogExpert.Scenarios/Serialization/ComparisonDto.cs
@@ -1,0 +1,17 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Scenarios.Serialization;
+
+internal sealed class ComparisonDto
+{
+    public string? MatchMode { get; set; }
+
+    public string? Operator { get; set; }
+
+    public string? Property { get; set; }
+
+    public string? Value { get; set; }
+
+    public List<string>? Values { get; set; }
+}

--- a/src/EventLogExpert.Scenarios/Serialization/PredicateDto.cs
+++ b/src/EventLogExpert.Scenarios/Serialization/PredicateDto.cs
@@ -1,0 +1,11 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Scenarios.Serialization;
+
+internal sealed class PredicateDto
+{
+    public ComparisonDto? Comparison { get; set; }
+
+    public bool JoinWithAny { get; set; }
+}

--- a/src/EventLogExpert.Scenarios/Serialization/ScenarioCatalogLoadResult.cs
+++ b/src/EventLogExpert.Scenarios/Serialization/ScenarioCatalogLoadResult.cs
@@ -1,0 +1,12 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Scenarios.Catalog;
+using System.Collections.Immutable;
+
+namespace EventLogExpert.Scenarios.Serialization;
+
+/// <summary>Outcome of a catalog load: the validated scenarios plus every error found.</summary>
+internal sealed record ScenarioCatalogLoadResult(
+    ImmutableList<ScenarioDefinition> Scenarios,
+    ImmutableList<string> Errors);

--- a/src/EventLogExpert.Scenarios/Serialization/ScenarioCatalogLoader.cs
+++ b/src/EventLogExpert.Scenarios/Serialization/ScenarioCatalogLoader.cs
@@ -1,0 +1,405 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Filtering.Basic;
+using EventLogExpert.Filtering.Common.Filtering;
+using EventLogExpert.Filtering.Evaluation;
+using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Scenarios.Catalog;
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace EventLogExpert.Scenarios.Serialization;
+
+/// <summary>Reads and strictly validates the embedded scenario JSON catalog.</summary>
+internal static partial class ScenarioCatalogLoader
+{
+    private const int SupportedSchemaVersion = 1;
+
+    private static readonly ResolvedEvent[] s_evaluationProbes =
+    [
+        new("probe", LogPathType.Channel),
+        new("probe", LogPathType.Channel)
+        {
+            Id = 7045,
+            LogName = LogChannelNames.SystemLog,
+            Source = "Service Control Manager",
+            Level = "Error",
+            ProcessId = 4,
+            ThreadId = 8,
+            RecordId = 15,
+            ActivityId = Guid.Empty
+        }
+    ];
+
+    /// <summary>Loads + validates the catalog from an assembly's embedded resources, throwing on any error.</summary>
+    internal static ImmutableList<ScenarioDefinition> Load(Assembly assembly)
+    {
+        var result = TryLoad(assembly);
+
+        return !result.Errors.IsEmpty ? throw new ScenarioCatalogException(result.Errors) : result.Scenarios;
+    }
+
+    /// <summary>Loads + validates without throwing; returns scenarios and the full error list.</summary>
+    internal static ScenarioCatalogLoadResult TryLoad(Assembly assembly)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+
+        var sources = assembly.GetManifestResourceNames()
+            .Where(name => name.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .Select(name => (name, ReadResource(assembly, name)))
+            .ToList();
+
+        return TryLoad(sources);
+    }
+
+    internal static ScenarioCatalogLoadResult TryLoad(IEnumerable<(string Name, byte[] Content)> sources)
+    {
+        ArgumentNullException.ThrowIfNull(sources);
+
+        var scenarios = ImmutableList.CreateBuilder<ScenarioDefinition>();
+        var errors = ImmutableList.CreateBuilder<string>();
+        var seenIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var seenGuids = new HashSet<Guid>();
+
+        foreach (var (name, content) in sources)
+        {
+            ScenarioFileDto? file;
+
+            try
+            {
+                file = JsonSerializer.Deserialize(content, ScenarioJsonContext.Default.ScenarioFileDto);
+            }
+            catch (JsonException exception)
+            {
+                errors.Add($"{name}: invalid JSON - {exception.Message}");
+
+                continue;
+            }
+
+            if (file is null)
+            {
+                errors.Add($"{name}: deserialized to null.");
+
+                continue;
+            }
+
+            if (file.SchemaVersion != SupportedSchemaVersion)
+            {
+                errors.Add($"{name}: unsupported schemaVersion {file.SchemaVersion} (expected {SupportedSchemaVersion}).");
+
+                continue;
+            }
+
+            if (file.Scenarios is null || file.Scenarios.Count == 0)
+            {
+                errors.Add($"{name}: contains no scenarios.");
+
+                continue;
+            }
+
+            for (var index = 0; index < file.Scenarios.Count; index++)
+            {
+                ProcessScenario(name, index, file.Scenarios[index], scenarios, errors, seenIds, seenGuids);
+            }
+        }
+
+        return new ScenarioCatalogLoadResult(scenarios.ToImmutable(), errors.ToImmutable());
+    }
+
+    private static List<ScenarioFilterRow> BuildRows(List<ScenarioFilterRowDto>? dtos, string context, List<string> errors)
+    {
+        List<ScenarioFilterRow> rows = [];
+
+        if (dtos is null) { return rows; }
+
+        for (var i = 0; i < dtos.Count; i++)
+        {
+            var rowContext = $"{context} row[{i}]";
+            var dto = dtos[i];
+
+            if (!TryBuildComparison(dto.Comparison, $"{rowContext}.comparison", errors, out var root)) { continue; }
+
+            var predicates = ImmutableList.CreateBuilder<FilterPredicate>();
+            var predicatesOk = true;
+
+            if (dto.Predicates is not null)
+            {
+                for (var p = 0; p < dto.Predicates.Count; p++)
+                {
+                    if (TryBuildComparison(dto.Predicates[p].Comparison, $"{rowContext}.predicates[{p}]", errors, out var pc))
+                    {
+                        predicates.Add(new FilterPredicate(pc, dto.Predicates[p].JoinWithAny));
+                    }
+                    else
+                    {
+                        predicatesOk = false;
+                    }
+                }
+            }
+
+            if (predicatesOk)
+            {
+                rows.Add(new ScenarioFilterRow(new BasicFilter(root, predicates.ToImmutable()), dto.IsExcluded));
+            }
+        }
+
+        return rows;
+    }
+
+    [GeneratedRegex("^[a-z0-9]+(-[a-z0-9]+)*$")]
+    private static partial Regex KebabCaseRegex();
+
+    private static TEnum ParseEnum<TEnum>(
+        string? token,
+        string context,
+        string field,
+        bool required,
+        List<string> errors,
+        TEnum fallback) where TEnum : struct, Enum
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            if (required) { errors.Add($"{context}: missing {field}."); }
+
+            return fallback;
+        }
+
+        // Case-sensitive name membership rejects typos and display values.
+        if (Enum.IsDefined(typeof(TEnum), token))
+        {
+            return Enum.Parse<TEnum>(token);
+        }
+
+        errors.Add($"{context}: '{token}' is not a valid {field} (expected one of: {string.Join(", ", Enum.GetNames<TEnum>())}).");
+
+        return fallback;
+    }
+
+    private static TEnum ParseEnum<TEnum>(
+        string? token,
+        string context,
+        string field,
+        bool required,
+        List<string> errors,
+        out bool ok) where TEnum : struct, Enum
+    {
+        var before = errors.Count;
+        var value = ParseEnum(token, context, field, required, errors, default(TEnum));
+        ok = errors.Count == before;
+
+        return value;
+    }
+
+    private static void ProcessScenario(
+        string source,
+        int index,
+        ScenarioDto dto,
+        ImmutableList<ScenarioDefinition>.Builder scenarios,
+        ImmutableList<string>.Builder errors,
+        HashSet<string> seenIds,
+        HashSet<Guid> seenGuids)
+    {
+        var label = string.IsNullOrWhiteSpace(dto.Id) ? $"{source}[{index}]" : $"'{dto.Id}'";
+        List<string> local = [];
+
+        if (string.IsNullOrWhiteSpace(dto.Id)) { local.Add($"scenario {label}: missing id."); }
+        else if (!KebabCaseRegex().IsMatch(dto.Id)) { local.Add($"scenario {label}: id is not kebab-case."); }
+
+        if (string.IsNullOrWhiteSpace(dto.Name)) { local.Add($"scenario {label}: missing name."); }
+
+        if (string.IsNullOrWhiteSpace(dto.Purpose)) { local.Add($"scenario {label}: missing purpose."); }
+
+        var group = ParseEnum<ScenarioGroup>(dto.Group, $"scenario {label}", "group", required: true, local, out _);
+        var origin = ParseEnum(dto.Origin, $"scenario {label}", "origin", required: false, local, ScenarioOrigin.BuiltIn);
+        var gating = ParseEnum(dto.Gating, $"scenario {label}", "gating", required: false, local, ScenarioGating.ChannelPresence);
+
+        if (gating == ScenarioGating.SourceRegistration)
+        {
+            local.Add($"scenario {label}: gating 'SourceRegistration' is not supported in a built-in scenario yet.");
+        }
+
+        ValidateChannels(dto.Channels, $"scenario {label}", "channels", required: true, local);
+        ValidateChannels(dto.OptionalChannels, $"scenario {label}", "optionalChannels", required: false, local);
+
+        if (dto.Filters is null || dto.Filters.Count == 0)
+        {
+            local.Add($"scenario {label}: must declare at least one filter row.");
+        }
+
+        var rows = BuildRows(dto.Filters, $"scenario {label}", local);
+
+        if (local.Count == 0)
+        {
+            var definition = new ScenarioDefinition
+            {
+                Id = dto.Id!,
+                Name = dto.Name!,
+                Purpose = dto.Purpose!,
+                Group = group,
+                Tags = [.. dto.Tags ?? []],
+                Channels = [.. dto.Channels!],
+                OptionalChannels = [.. dto.OptionalChannels ?? []],
+                Gating = gating,
+                SourceGates = [.. dto.SourceGates ?? []],
+                RequiresAdmin = dto.RequiresAdmin,
+                Filters = [.. rows],
+                Priority = dto.Priority,
+                Order = dto.Order,
+                Version = dto.Version,
+                Origin = origin
+            };
+
+            ValidateDefinition(definition, $"scenario {label}", local);
+
+            if (!seenIds.Add(definition.Id)) { local.Add($"scenario {label}: duplicate id."); }
+
+            if (!seenGuids.Add(definition.StableGuid)) { local.Add($"scenario {label}: duplicate StableGuid."); }
+
+            if (local.Count == 0) { scenarios.Add(definition); }
+        }
+
+        errors.AddRange(local);
+    }
+
+    private static byte[] ReadResource(Assembly assembly, string name)
+    {
+        using var stream = assembly.GetManifestResourceStream(name)
+            ?? throw new InvalidOperationException($"Embedded resource '{name}' could not be opened.");
+        using var memory = new MemoryStream();
+        stream.CopyTo(memory);
+
+        return memory.ToArray();
+    }
+
+    private static bool RowReferencesLogName(ScenarioFilterRow row) =>
+        row.Filter.Comparison.Property == EventProperty.LogName ||
+        row.Filter.Predicates.Any(predicate => predicate.Comparison.Property == EventProperty.LogName);
+
+    private static bool TryBuildComparison(
+        ComparisonDto? dto,
+        string context,
+        List<string> errors,
+        out FilterComparison comparison)
+    {
+        comparison = new FilterComparison();
+
+        if (dto is null)
+        {
+            errors.Add($"{context}: comparison is missing.");
+
+            return false;
+        }
+
+        var property = ParseEnum<EventProperty>(dto.Property, context, "property", required: true, errors, out var propertyOk);
+        var op = ParseEnum(dto.Operator, context, "operator", required: false, errors, ComparisonOperator.Equals);
+        var matchMode = ParseEnum(dto.MatchMode, context, "matchMode", required: false, errors, MatchMode.Single);
+
+        if (!propertyOk) { return false; }
+
+        comparison = new FilterComparison
+        {
+            Property = property,
+            Operator = op,
+            MatchMode = matchMode,
+            Value = dto.Value,
+            Values = dto.Values is null ? [] : [.. dto.Values]
+        };
+
+        return true;
+    }
+
+    private static void ValidateChannels(List<string>? channels, string context, string field, bool required, List<string> errors)
+    {
+        if (channels is null || channels.Count == 0)
+        {
+            if (required) { errors.Add($"{context}: {field} must list at least one channel."); }
+
+            return;
+        }
+
+        foreach (var channel in channels)
+        {
+            if (string.IsNullOrWhiteSpace(channel)) { errors.Add($"{context}: {field} contains a blank channel name."); }
+            else if (channel.Contains('*')) { errors.Add($"{context}: {field} channel '{channel}' must not contain a wildcard."); }
+        }
+    }
+
+    private static void ValidateDefinition(ScenarioDefinition definition, string context, List<string> errors)
+    {
+        var requiresAdmin = definition.Channels.Any(LogChannelNames.AdminOnlyLiveChannels.Contains);
+
+        if (requiresAdmin && !definition.RequiresAdmin)
+        {
+            errors.Add($"{context}: targets an admin-only channel but requiresAdmin is false.");
+        }
+
+        var isCombined = definition.Channels.Length > 1;
+
+        for (var i = 0; i < definition.Filters.Length; i++)
+        {
+            var row = definition.Filters[i];
+            var rowContext = $"{context} row[{i}]";
+
+            if (isCombined && !RowReferencesLogName(row))
+            {
+                errors.Add($"{rowContext}: combined scenario rows must be LogName-scoped.");
+            }
+
+            ValidateRow(row, rowContext, errors);
+        }
+    }
+
+    private static void ValidateRow(ScenarioFilterRow row, string context, List<string> errors)
+    {
+        if (!BasicFilterFormatter.TryFormat(row.Filter, strictPredicates: true, out var text))
+        {
+            errors.Add($"{context}: filter did not format (a comparison or predicate is incomplete).");
+
+            return;
+        }
+
+        var saved = SavedFilter.TryCreate(text, row.Filter, isExcluded: row.IsExcluded, mode: FilterMode.Basic);
+
+        if (saved?.Compiled is null)
+        {
+            errors.Add($"{context}: filter '{text}' did not compile.");
+
+            return;
+        }
+
+        foreach (var probe in s_evaluationProbes)
+        {
+            try
+            {
+                _ = saved.Compiled.Predicate(probe);
+            }
+            catch (Exception exception)
+            {
+                errors.Add($"{context}: filter '{text}' threw on evaluation - {exception.Message}");
+
+                return;
+            }
+        }
+
+        var roundTripped = SavedFilter.TryCreate(text, basicFilter: null, mode: FilterMode.Basic);
+
+        if (roundTripped?.BasicFilter is null)
+        {
+            errors.Add($"{context}: filter '{text}' did not round-trip to a Basic filter.");
+
+            return;
+        }
+
+        if (!BasicFilterFormatter.TryFormat(roundTripped.BasicFilter, strictPredicates: true, out var reformatted) ||
+            !string.Equals(reformatted, text, StringComparison.Ordinal))
+        {
+            errors.Add($"{context}: filter '{text}' is not canonical (reformats to '{reformatted}').");
+        }
+    }
+}

--- a/src/EventLogExpert.Scenarios/Serialization/ScenarioDto.cs
+++ b/src/EventLogExpert.Scenarios/Serialization/ScenarioDto.cs
@@ -1,0 +1,37 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Scenarios.Serialization;
+
+internal sealed class ScenarioDto
+{
+    public List<string>? Channels { get; set; }
+
+    public List<ScenarioFilterRowDto>? Filters { get; set; }
+
+    public string? Gating { get; set; }
+
+    public string? Group { get; set; }
+
+    public string? Id { get; set; }
+
+    public string? Name { get; set; }
+
+    public List<string>? OptionalChannels { get; set; }
+
+    public int Order { get; set; }
+
+    public string? Origin { get; set; }
+
+    public int Priority { get; set; }
+
+    public string? Purpose { get; set; }
+
+    public bool RequiresAdmin { get; set; }
+
+    public List<string>? SourceGates { get; set; }
+
+    public List<string>? Tags { get; set; }
+
+    public int Version { get; set; }
+}

--- a/src/EventLogExpert.Scenarios/Serialization/ScenarioFileDto.cs
+++ b/src/EventLogExpert.Scenarios/Serialization/ScenarioFileDto.cs
@@ -1,0 +1,12 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Scenarios.Serialization;
+
+/// <summary>Wire shape for the embedded scenario JSON; strictly parsed by the loader.</summary>
+internal sealed class ScenarioFileDto
+{
+    public List<ScenarioDto>? Scenarios { get; set; }
+
+    public int SchemaVersion { get; set; }
+}

--- a/src/EventLogExpert.Scenarios/Serialization/ScenarioFilterRowDto.cs
+++ b/src/EventLogExpert.Scenarios/Serialization/ScenarioFilterRowDto.cs
@@ -1,0 +1,13 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Scenarios.Serialization;
+
+internal sealed class ScenarioFilterRowDto
+{
+    public ComparisonDto? Comparison { get; set; }
+
+    public bool IsExcluded { get; set; }
+
+    public List<PredicateDto>? Predicates { get; set; }
+}

--- a/src/EventLogExpert.Scenarios/Serialization/ScenarioJsonContext.cs
+++ b/src/EventLogExpert.Scenarios/Serialization/ScenarioJsonContext.cs
@@ -1,0 +1,17 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace EventLogExpert.Scenarios.Serialization;
+
+/// <summary>Source-generated JSON context for the scenario wire DTOs.</summary>
+[JsonSourceGenerationOptions(
+    GenerationMode = JsonSourceGenerationMode.Metadata,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    PropertyNameCaseInsensitive = true,
+    ReadCommentHandling = JsonCommentHandling.Skip,
+    AllowTrailingCommas = true)]
+[JsonSerializable(typeof(ScenarioFileDto))]
+internal sealed partial class ScenarioJsonContext : JsonSerializerContext;

--- a/src/EventLogExpert/Adapters/Menu/MauiMenuActionService.cs
+++ b/src/EventLogExpert/Adapters/Menu/MauiMenuActionService.cs
@@ -22,6 +22,7 @@ using EventLogExpert.UI.Modal;
 using EventLogExpert.UI.Settings;
 using EventLogExpert.WindowsPlatform.Activation;
 using Fluxor;
+using System.Collections.Immutable;
 using Application = Microsoft.Maui.Controls.Application;
 using IDispatcher = Fluxor.IDispatcher;
 using MauiFilePicker = Microsoft.Maui.Storage.FilePicker;
@@ -215,7 +216,14 @@ public sealed class MauiMenuActionService(
     public Task OpenIssueAsync() => OpenBrowserAsync("https://github.com/microsoft/EventLogExpert/issues/new");
 
     public Task OpenLiveLogAsync(string logName, bool combineLog) =>
-        OpenLogsBatchAsync([(logName, LogPathType.Channel)], combineLog);
+        OpenLogsBatchCoreAsync([(logName, LogPathType.Channel)], combineLog);
+
+    public Task<OpenLogsBatchResult> OpenLiveLogsAsync(IEnumerable<string> logNames, bool combineLog)
+    {
+        ArgumentNullException.ThrowIfNull(logNames);
+
+        return OpenLogsBatchCoreAsync(logNames.Select(name => (name, LogPathType.Channel)), combineLog);
+    }
 
     public async Task<OpenLogStatus> OpenLogAsync(string logPath, LogPathType pathType, bool combineLog = false)
     {
@@ -265,44 +273,8 @@ public sealed class MauiMenuActionService(
         return OpenLogStatus.Opened;
     }
 
-    /// <summary>
-    ///     Opens each log in <paramref name="logs" /> sequentially and surfaces a single banner alert at the end naming
-    ///     every log that contained zero events. <paramref name="combineLog" /> controls whether the first successful open
-    ///     closes existing logs first; subsequent opens within the batch always coalesce with the new state. Use this from any
-    ///     call site that may open multiple logs in one user gesture (multi-file picker, folder open, drag-drop, command line)
-    ///     so the user sees one batched alert instead of one popup per empty file.
-    /// </summary>
-    public async Task OpenLogsBatchAsync(IEnumerable<(string Path, LogPathType Type)> logs, bool combineLog)
-    {
-        ArgumentNullException.ThrowIfNull(logs);
-
-        List<string>? emptyDisplayNames = null;
-        var combineForCall = combineLog;
-
-        foreach (var (path, type) in logs)
-        {
-            // Only Opened consumed the close-existing semantics; Skipped/Failed/Empty did not,
-            // so combineForCall must NOT flip until a real open happens.
-            switch (await OpenLogAsync(path, type, combineForCall))
-            {
-                case OpenLogStatus.Opened:
-                    combineForCall = true;
-                    break;
-                case OpenLogStatus.Empty:
-                    (emptyDisplayNames ??= []).Add(GetEmptyLogDisplayName(path, type));
-                    break;
-            }
-        }
-
-        if (emptyDisplayNames is { Count: > 0 })
-        {
-            await _dialogService.ShowAlert(
-                "Empty log",
-                EmptyLogAlertFormatter.BuildMessage(emptyDisplayNames),
-                "Ok",
-                AlertPresentation.Banner);
-        }
-    }
+    public Task OpenLogsBatchAsync(IEnumerable<(string Path, LogPathType Type)> logs, bool combineLog) =>
+        OpenLogsBatchCoreAsync(logs, combineLog);
 
     public Task<bool> OpenSettingsAsync() =>
         TryOpenModalAsync(_modalCoordinator.OpenSettingsAsync, nameof(SettingsModal));
@@ -366,6 +338,57 @@ public sealed class MauiMenuActionService(
         {
             await _dialogService.ShowAlert("Failed to launch browser", ex.Message, "Ok");
         }
+    }
+
+    private async Task<OpenLogsBatchResult> OpenLogsBatchCoreAsync(
+        IEnumerable<(string Path, LogPathType Type)> logs,
+        bool combineLog)
+    {
+        ArgumentNullException.ThrowIfNull(logs);
+
+        List<string>? emptyDisplayNames = null;
+        var combineForCall = combineLog;
+        var opened = 0;
+        var failed = 0;
+        var skipped = 0;
+
+        foreach (var (path, type) in logs)
+        {
+            // Only Opened consumed the close-existing semantics; Skipped/Failed/Empty did not,
+            // so combineForCall must NOT flip until a real open happens.
+            switch (await OpenLogAsync(path, type, combineForCall))
+            {
+                case OpenLogStatus.Opened:
+                    opened++;
+                    combineForCall = true;
+                    break;
+                case OpenLogStatus.Empty:
+                    (emptyDisplayNames ??= []).Add(GetEmptyLogDisplayName(path, type));
+                    break;
+                case OpenLogStatus.Failed:
+                    failed++;
+                    break;
+                case OpenLogStatus.Skipped:
+                    skipped++;
+                    break;
+            }
+        }
+
+        if (emptyDisplayNames is { Count: > 0 })
+        {
+            await _dialogService.ShowAlert(
+                "Empty log",
+                EmptyLogAlertFormatter.BuildMessage(emptyDisplayNames),
+                "Ok",
+                AlertPresentation.Banner);
+        }
+
+        return new OpenLogsBatchResult(
+            opened,
+            emptyDisplayNames?.Count ?? 0,
+            failed,
+            skipped,
+            emptyDisplayNames?.ToImmutableArray() ?? []);
     }
 
     private async Task<bool> TryOpenModalAsync(Func<Task<ModalOpenResult<bool>>> open, string modalName)

--- a/tests/Unit/EventLogExpert.Runtime.Tests/DependencyInjection/RuntimeServiceCollectionExtensionsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/DependencyInjection/RuntimeServiceCollectionExtensionsTests.cs
@@ -23,9 +23,11 @@ using EventLogExpert.Runtime.FilterPane;
 using EventLogExpert.Runtime.LogTable;
 using EventLogExpert.Runtime.Menu;
 using EventLogExpert.Runtime.Modal;
+using EventLogExpert.Runtime.Scenarios;
 using EventLogExpert.Runtime.Settings;
 using EventLogExpert.Runtime.Update;
 using EventLogExpert.Runtime.Update.Deployment;
+using EventLogExpert.Scenarios.Catalog;
 using Fluxor;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
@@ -170,6 +172,10 @@ public sealed class RuntimeServiceCollectionExtensionsTests
     [InlineData(typeof(IPackageDeploymentService))]
     [InlineData(typeof(IPackageVersionProvider))]
     [InlineData(typeof(IUpdateService))]
+    // Built-in scenarios.
+    [InlineData(typeof(BuiltInScenarioRegistry))]
+    [InlineData(typeof(IScenarioQueryService))]
+    [InlineData(typeof(IScenarioLaunchService))]
     public async Task AddEventLogRuntime_ShouldResolveHostFacingAbstraction(Type serviceType)
     {
         // Arrange
@@ -194,6 +200,7 @@ public sealed class RuntimeServiceCollectionExtensionsTests
         services.AddSingleton(Substitute.For<IStateSelection<EventLogState, bool>>());
         services.AddSingleton(new FileLocationOptions(Path.Combine(Path.GetTempPath(), "EventLogExpertTests")));
         services.AddSingleton<HttpClient>();
+        services.AddSingleton(Substitute.For<IMenuActionService>());
 
         services.AddEventLogRuntime();
 
@@ -225,5 +232,6 @@ public sealed class RuntimeServiceCollectionExtensionsTests
         services.AddSingleton(Substitute.For<IStateSelection<EventLogState, bool>>());
         services.AddSingleton(new FileLocationOptions(Path.Combine(Path.GetTempPath(), "EventLogExpertTests")));
         services.AddSingleton<HttpClient>();
+        services.AddSingleton(Substitute.For<IMenuActionService>());
     }
 }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Menu/OpenLogsBatchResultTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Menu/OpenLogsBatchResultTests.cs
@@ -1,0 +1,22 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.Menu;
+
+namespace EventLogExpert.Runtime.Tests.Menu;
+
+public sealed class OpenLogsBatchResultTests
+{
+    [Fact]
+    public void AnyOpened_IsFalse_WhenNothingOpened()
+    {
+        Assert.False(new OpenLogsBatchResult(0, 3, 1, 2, ["a", "b", "c"]).AnyOpened);
+        Assert.False(OpenLogsBatchResult.None.AnyOpened);
+    }
+
+    [Fact]
+    public void AnyOpened_IsTrue_WhenOpenedIsPositive()
+    {
+        Assert.True(new OpenLogsBatchResult(1, 0, 0, 0, []).AnyOpened);
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/ChannelPresenceProbeTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/ChannelPresenceProbeTests.cs
@@ -1,0 +1,61 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.Scenarios;
+using NSubstitute;
+
+namespace EventLogExpert.Runtime.Tests.Scenarios;
+
+public sealed class ChannelPresenceProbeTests
+{
+    [Fact]
+    public void FailedRead_DoesNotCacheEmpty_AndRetries()
+    {
+        var calls = 0;
+
+        var probe = new ChannelPresenceProbe(Logger(), () =>
+        {
+            calls++;
+
+            return calls == 1
+                ? throw new InvalidOperationException("event log service unavailable")
+                : ["System"];
+        });
+
+        Assert.Empty(probe.GetPresentChannels());
+
+        Assert.Contains("System", probe.GetPresentChannels());
+        Assert.Equal(2, calls);
+    }
+
+    [Fact]
+    public void GetPresentChannels_ReadsOnceThenCaches()
+    {
+        var calls = 0;
+
+        var probe = new ChannelPresenceProbe(Logger(), () =>
+        {
+            calls++;
+
+            return ["System"];
+        });
+
+        _ = probe.GetPresentChannels();
+        _ = probe.GetPresentChannels();
+
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void IsPresent_IsCaseInsensitive()
+    {
+        var probe = new ChannelPresenceProbe(Logger(), static () => ["System", "Security"]);
+
+        Assert.True(probe.IsPresent("system"));
+        Assert.True(probe.IsPresent("SECURITY"));
+        Assert.False(probe.IsPresent("Application"));
+    }
+
+    private static ITraceLogger Logger() => Substitute.For<ITraceLogger>();
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/ScenarioApplyIntegrationTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/ScenarioApplyIntegrationTests.cs
@@ -1,0 +1,65 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.FilterPane;
+using Fluxor;
+using NSubstitute;
+using EventLogReducers = EventLogExpert.Runtime.EventLog.Reducers;
+using FilterPaneEffects = EventLogExpert.Runtime.FilterPane.Effects;
+using FilterPaneReducers = EventLogExpert.Runtime.FilterPane.Reducers;
+
+namespace EventLogExpert.Runtime.Tests.Scenarios;
+
+public sealed class ScenarioApplyIntegrationTests
+{
+    [Fact]
+    public void MergeFiltersAction_ReapplyingScenario_IsIdempotent()
+    {
+        var registry = ScenarioTestData.Registry(ScenarioTestData.Single("a", "System", 1000));
+        var filters = registry.BuildFilterSet(registry.Scenarios[0]);
+
+        var afterFirst = FilterPaneReducers.ReduceMergeFilters(new FilterPaneState(), new MergeFiltersAction(filters));
+        var afterSecond = FilterPaneReducers.ReduceMergeFilters(afterFirst, new MergeFiltersAction(filters));
+
+        Assert.Single(afterFirst.Filters);
+        Assert.Equal(afterFirst.Filters.Count, afterSecond.Filters.Count);
+    }
+
+    [Fact]
+    public async Task ReplaceFiltersAction_FromScenario_LandsOnAppliedFilter()
+    {
+        var registry = ScenarioTestData.Registry(ScenarioTestData.Single("a", "System", 1000));
+        var filters = registry.BuildFilterSet(registry.Scenarios[0]);
+
+        var paneState = FilterPaneReducers.ReduceReplaceFilters(new FilterPaneState(), new ReplaceFiltersAction(filters));
+
+        Assert.Single(paneState.Filters);
+        Assert.True(paneState.Filters[0].IsEnabled);
+
+        var paneStateAccessor = Substitute.For<IState<FilterPaneState>>();
+        paneStateAccessor.Value.Returns(paneState);
+
+        var appliedFilter = Substitute.For<IStateSelection<EventLogState, Filter>>();
+        appliedFilter.Value.Returns(new Filter(null, []));
+
+        var eventDateRange = Substitute.For<IStateSelection<EventLogState, (DateTime After, DateTime Before)?>>();
+        eventDateRange.Value.Returns(((DateTime, DateTime)?)null);
+
+        var effects = new FilterPaneEffects(appliedFilter, eventDateRange, paneStateAccessor);
+        var dispatcher = Substitute.For<IDispatcher>();
+
+        ApplyFilterAction? captured = null;
+        dispatcher.When(target => target.Dispatch(Arg.Any<ApplyFilterAction>()))
+            .Do(call => captured = (ApplyFilterAction)call[0]);
+
+        await effects.HandleReplaceFilters(dispatcher);
+
+        Assert.NotNull(captured);
+
+        var eventLogState = EventLogReducers.ReduceApplyFilter(new EventLogState(), captured);
+
+        Assert.Single(eventLogState.AppliedFilter.Filters);
+        Assert.Equal("Id == 1000", eventLogState.AppliedFilter.Filters[0].ComparisonText);
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/ScenarioLaunchServiceTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/ScenarioLaunchServiceTests.cs
@@ -1,0 +1,98 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.FilterPane;
+using EventLogExpert.Runtime.Menu;
+using EventLogExpert.Runtime.Scenarios;
+using EventLogExpert.Scenarios.Catalog;
+using Fluxor;
+using NSubstitute;
+
+namespace EventLogExpert.Runtime.Tests.Scenarios;
+
+public sealed class ScenarioLaunchServiceTests
+{
+    [Fact]
+    public async Task LaunchAsync_AppliesFiltersThenDate_BeforeOpening()
+    {
+        var (service, dispatcher, menu, scenario) = Create(new OpenLogsBatchResult(1, 0, 0, 0, []));
+        var window = new DateFilter { After = DateTime.UtcNow.AddDays(-7), Before = DateTime.UtcNow };
+
+        await service.LaunchAsync(scenario, window);
+
+        Received.InOrder(() =>
+        {
+            dispatcher.Dispatch(Arg.Any<ReplaceFiltersAction>());
+            dispatcher.Dispatch(Arg.Any<SetFilterDateRangeAction>());
+            _ = menu.OpenLiveLogsAsync(Arg.Any<IEnumerable<string>>(), false);
+        });
+    }
+
+    [Fact]
+    public async Task LaunchAsync_NullWindow_ClearsDateFilter()
+    {
+        var (service, dispatcher, _, scenario) = Create(new OpenLogsBatchResult(1, 0, 0, 0, []));
+
+        await service.LaunchAsync(scenario, dateWindow: null);
+
+        dispatcher.Received().Dispatch(Arg.Is<SetFilterDateRangeAction>(action => action.DateFilter == null));
+    }
+
+    [Fact]
+    public async Task LaunchAsync_ReturnsOpenCounts()
+    {
+        var (service, _, _, scenario) = Create(new OpenLogsBatchResult(2, 1, 0, 0, []));
+
+        var result = await service.LaunchAsync(scenario, dateWindow: null);
+
+        Assert.Equal(2, result.Opened);
+        Assert.Equal(1, result.Empty);
+        Assert.True(result.AnyOpened);
+    }
+
+    [Fact]
+    public async Task LaunchAsync_SomethingOpened_DoesNotDispatchCloseAll()
+    {
+        var (service, dispatcher, _, scenario) = Create(new OpenLogsBatchResult(1, 0, 0, 0, []));
+
+        await service.LaunchAsync(scenario, dateWindow: null);
+
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<CloseAllLogsAction>());
+    }
+
+    [Fact]
+    public async Task LaunchAsync_ZeroOpenButCombining_DoesNotDispatchCloseAll()
+    {
+        var (service, dispatcher, _, scenario) = Create(new OpenLogsBatchResult(0, 0, 1, 0, []));
+
+        await service.LaunchAsync(scenario, dateWindow: null, combineLog: true);
+
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<CloseAllLogsAction>());
+    }
+
+    [Fact]
+    public async Task LaunchAsync_ZeroOpenFreshView_DispatchesCloseAll()
+    {
+        var (service, dispatcher, _, scenario) = Create(new OpenLogsBatchResult(0, 1, 0, 0, ["System"]));
+
+        await service.LaunchAsync(scenario, dateWindow: null);
+
+        dispatcher.Received(1).Dispatch(Arg.Any<CloseAllLogsAction>());
+    }
+
+    private static (IScenarioLaunchService Service, IDispatcher Dispatcher, IMenuActionService Menu, ScenarioDefinition Scenario)
+        Create(OpenLogsBatchResult openResult)
+    {
+        var scenario = ScenarioTestData.Single("a", "System", 1000);
+        var registry = ScenarioTestData.Registry(scenario);
+
+        var menu = Substitute.For<IMenuActionService>();
+        menu.OpenLiveLogsAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<bool>()).Returns(openResult);
+
+        var dispatcher = Substitute.For<IDispatcher>();
+        var service = new ScenarioLaunchService(registry, menu, dispatcher);
+
+        return (service, dispatcher, menu, scenario);
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/ScenarioQueryServiceTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/ScenarioQueryServiceTests.cs
@@ -1,0 +1,57 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.Scenarios;
+using NSubstitute;
+
+namespace EventLogExpert.Runtime.Tests.Scenarios;
+
+public sealed class ScenarioQueryServiceTests
+{
+    [Fact]
+    public void GetInAppScenarios_ExcludesScenario_WhenNoChannelLoaded()
+    {
+        var registry = ScenarioTestData.Registry(ScenarioTestData.Single("system", "System", 1000));
+
+        var service = new ScenarioQueryService(registry, Substitute.For<IChannelPresenceProbe>());
+
+        Assert.Empty(service.GetInAppScenarios(["Application"]));
+    }
+
+    [Fact]
+    public void GetInAppScenarios_MatchesLoadedLogName_CaseInsensitive()
+    {
+        var registry = ScenarioTestData.Registry(
+            ScenarioTestData.Single("system", "System", 1000),
+            ScenarioTestData.Single("application", "Application", 1001));
+
+        var service = new ScenarioQueryService(registry, Substitute.For<IChannelPresenceProbe>());
+
+        Assert.Equal(["system"], service.GetInAppScenarios(["system"]).Select(scenario => scenario.Id));
+    }
+
+    [Fact]
+    public void GetInAppScenarios_ShowsCombinedScenario_WhenAnyChannelLoaded()
+    {
+        var registry = ScenarioTestData.Registry(ScenarioTestData.Combined("combined", "System", "Security"));
+
+        var service = new ScenarioQueryService(registry, Substitute.For<IChannelPresenceProbe>());
+
+        Assert.Single(service.GetInAppScenarios(["Security"]));
+    }
+
+    [Fact]
+    public void GetSplashScenarios_HidesScenariosWhoseChannelsAreAbsent()
+    {
+        var probe = Substitute.For<IChannelPresenceProbe>();
+        probe.GetPresentChannels().Returns(new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "System" });
+
+        var registry = ScenarioTestData.Registry(
+            ScenarioTestData.Single("present", "System", 1000),
+            ScenarioTestData.Single("absent", "Microsoft-Windows-DNS-Client/Operational", 1014));
+
+        var service = new ScenarioQueryService(registry, probe);
+
+        Assert.Equal(["present"], service.GetSplashScenarios().Select(scenario => scenario.Id));
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/ScenarioTestData.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/ScenarioTestData.cs
@@ -1,0 +1,74 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Scenarios.Catalog;
+
+namespace EventLogExpert.Runtime.Tests.Scenarios;
+
+internal static class ScenarioTestData
+{
+    public static ScenarioDefinition Combined(string id, params string[] channels) => new()
+    {
+        Id = id,
+        Name = id,
+        Purpose = "p",
+        Group = ScenarioGroup.SystemHealth,
+        Channels = [.. channels],
+        RequiresAdmin = channels.Any(IsAdminChannel),
+        Filters = [.. channels.Select(channel => LogNameRow(channel, 1000))]
+    };
+
+    public static BuiltInScenarioRegistry Registry(params ScenarioDefinition[] scenarios) =>
+        new([new FakeSource(scenarios)]);
+
+    public static ScenarioDefinition Single(string id, string channel, int eventId) => new()
+    {
+        Id = id,
+        Name = id,
+        Purpose = "p",
+        Group = ScenarioGroup.SystemHealth,
+        Channels = [channel],
+        RequiresAdmin = IsAdminChannel(channel),
+        Filters = [IdRow(eventId)]
+    };
+
+    private static ScenarioFilterRow IdRow(int eventId) =>
+        new(new BasicFilter(
+            new FilterComparison
+            {
+                Property = EventProperty.Id,
+                Operator = ComparisonOperator.Equals,
+                MatchMode = MatchMode.Single,
+                Value = eventId.ToString()
+            },
+            []));
+
+    private static bool IsAdminChannel(string channel) =>
+        channel is "Security" or "State";
+
+    private static ScenarioFilterRow LogNameRow(string channel, int eventId) =>
+        new(new BasicFilter(
+            new FilterComparison
+            {
+                Property = EventProperty.LogName,
+                Operator = ComparisonOperator.Equals,
+                MatchMode = MatchMode.Single,
+                Value = channel
+            },
+            [
+                new FilterPredicate(
+                    new FilterComparison
+                    {
+                        Property = EventProperty.Id,
+                        Operator = ComparisonOperator.Equals,
+                        MatchMode = MatchMode.Single,
+                        Value = eventId.ToString()
+                    },
+                    JoinWithAny: false)
+            ]));
+
+    private sealed class FakeSource(params ScenarioDefinition[] scenarios) : IScenarioSource
+    {
+        public IReadOnlyList<ScenarioDefinition> GetScenarios() => scenarios;
+    }
+}

--- a/tests/Unit/EventLogExpert.Scenarios.Tests/BuiltInCatalogValidationTests.cs
+++ b/tests/Unit/EventLogExpert.Scenarios.Tests/BuiltInCatalogValidationTests.cs
@@ -1,0 +1,96 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Filtering.Basic;
+using EventLogExpert.Filtering.Common.Filtering;
+using EventLogExpert.Filtering.Evaluation;
+using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Scenarios.Catalog;
+
+namespace EventLogExpert.Scenarios.Tests;
+
+public sealed class BuiltInCatalogValidationTests
+{
+    private static readonly BuiltInScenarioRegistry s_registry = new([new BuiltInScenarioSource()]);
+
+    public static TheoryData<string> AllScenarioIds()
+    {
+        var data = new TheoryData<string>();
+
+        foreach (var scenario in s_registry.Scenarios) { data.Add(scenario.Id); }
+
+        return data;
+    }
+
+    [Fact]
+    public void Catalog_IdsAreUniqueAndKebabCase()
+    {
+        var ids = s_registry.Scenarios.Select(scenario => scenario.Id).ToList();
+
+        Assert.Equal(ids.Count, ids.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+        Assert.All(ids, id => Assert.Matches("^[a-z0-9]+(-[a-z0-9]+)*$", id));
+    }
+
+    [Fact]
+    public void Catalog_LoadsWithScenarios()
+    {
+        Assert.NotEmpty(s_registry.Scenarios);
+    }
+
+    [Fact]
+    public void Catalog_StableGuidsAreUnique()
+    {
+        var guids = s_registry.Scenarios.Select(scenario => scenario.StableGuid).ToList();
+
+        Assert.Equal(guids.Count, guids.Distinct().Count());
+        Assert.DoesNotContain(Guid.Empty, guids);
+    }
+
+    [Fact]
+    public void CombinedScenarios_RowsAreLogNameScoped()
+    {
+        var combined = s_registry.Scenarios.Where(scenario => scenario.Channels.Length > 1).ToList();
+
+        Assert.All(combined, scenario => Assert.All(scenario.Filters, row =>
+            Assert.True(
+                row.Filter.Comparison.Property is EventProperty.LogName ||
+                row.Filter.Predicates.Any(predicate => predicate.Comparison.Property is EventProperty.LogName),
+                $"Combined scenario '{scenario.Id}' has a row that is not LogName-scoped.")));
+    }
+
+    [Theory]
+    [MemberData(nameof(AllScenarioIds))]
+    public void Scenario_FilterSet_CompilesCanonicalAndBasic(string id)
+    {
+        var scenario = s_registry.Scenarios.Single(scenario => scenario.Id == id);
+
+        var filterSet = s_registry.BuildFilterSet(scenario);
+
+        Assert.Equal(scenario.Filters.Length, filterSet.Count);
+
+        Assert.All(filterSet, saved =>
+        {
+            Assert.NotNull(saved.Compiled);
+            Assert.Equal(FilterMode.Basic, saved.Mode);
+
+            var roundTripped = SavedFilter.TryCreate(saved.ComparisonText, basicFilter: null, mode: FilterMode.Basic);
+
+            Assert.NotNull(roundTripped?.BasicFilter);
+            Assert.True(BasicFilterFormatter.TryFormat(roundTripped.BasicFilter, strictPredicates: true, out var reformatted));
+            Assert.Equal(saved.ComparisonText, reformatted);
+        });
+    }
+
+    [Theory]
+    [MemberData(nameof(AllScenarioIds))]
+    public void Scenario_RequiresAdmin_ConsistentWithChannels(string id)
+    {
+        var scenario = s_registry.Scenarios.Single(scenario => scenario.Id == id);
+
+        if (scenario.Channels.Any(LogChannelNames.AdminOnlyLiveChannels.Contains))
+        {
+            Assert.True(scenario.RequiresAdmin);
+        }
+    }
+}

--- a/tests/Unit/EventLogExpert.Scenarios.Tests/BuiltInScenarioRegistryTests.cs
+++ b/tests/Unit/EventLogExpert.Scenarios.Tests/BuiltInScenarioRegistryTests.cs
@@ -1,0 +1,77 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Basic;
+using EventLogExpert.Filtering.Common.Filtering;
+using EventLogExpert.Filtering.Evaluation;
+using EventLogExpert.Scenarios.Catalog;
+
+namespace EventLogExpert.Scenarios.Tests;
+
+public sealed class BuiltInScenarioRegistryTests
+{
+    [Fact]
+    public void BuildFilterSet_ProducesOneCompiledBasicFilterPerRow()
+    {
+        var registry = new BuiltInScenarioRegistry([new FakeSource(Make("a", "1000", "1001"))]);
+
+        var filterSet = registry.BuildFilterSet(registry.Scenarios[0]);
+
+        Assert.Equal(2, filterSet.Count);
+        Assert.All(filterSet, saved =>
+        {
+            Assert.NotNull(saved.Compiled);
+            Assert.Equal(FilterMode.Basic, saved.Mode);
+            Assert.NotNull(saved.BasicFilter);
+        });
+    }
+
+    [Fact]
+    public void Registry_AggregatesAllSources()
+    {
+        var registry = new BuiltInScenarioRegistry([new FakeSource(Make("a")), new FakeSource(Make("b"))]);
+
+        Assert.Equal(["a", "b"], registry.Scenarios.Select(scenario => scenario.Id));
+    }
+
+    [Fact]
+    public void Registry_DuplicateIdAcrossSources_Throws()
+    {
+        var exception = Assert.Throws<ScenarioCatalogException>(() =>
+            new BuiltInScenarioRegistry([new FakeSource(Make("dup")), new FakeSource(Make("dup"))]));
+
+        Assert.Contains(exception.Errors, error => error.Contains("more than one source"));
+    }
+
+    private static ScenarioDefinition Make(string id, params string[] ids)
+    {
+        var values = ids.Length == 0 ? ["1000"] : ids;
+
+        return new ScenarioDefinition
+        {
+            Id = id,
+            Name = id,
+            Purpose = "p",
+            Group = ScenarioGroup.SystemHealth,
+            Channels = ["System"],
+            Filters =
+            [
+                .. values.Select(value => new ScenarioFilterRow(
+                    new BasicFilter(
+                        new FilterComparison
+                        {
+                            Property = EventProperty.Id,
+                            Operator = ComparisonOperator.Equals,
+                            MatchMode = MatchMode.Single,
+                            Value = value
+                        },
+                        [])))
+            ]
+        };
+    }
+
+    private sealed class FakeSource(params ScenarioDefinition[] scenarios) : IScenarioSource
+    {
+        public IReadOnlyList<ScenarioDefinition> GetScenarios() => scenarios;
+    }
+}

--- a/tests/Unit/EventLogExpert.Scenarios.Tests/DeterministicGuidTests.cs
+++ b/tests/Unit/EventLogExpert.Scenarios.Tests/DeterministicGuidTests.cs
@@ -1,0 +1,49 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Scenarios.Common;
+
+namespace EventLogExpert.Scenarios.Tests;
+
+public sealed class DeterministicGuidTests
+{
+    [Fact]
+    public void Create_DiffersByName()
+    {
+        var first = DeterministicGuid.Create(DeterministicGuid.ScenarioNamespace, "scenario-a");
+        var second = DeterministicGuid.Create(DeterministicGuid.ScenarioNamespace, "scenario-b");
+
+        Assert.NotEqual(first, second);
+    }
+
+    [Fact]
+    public void Create_IsDeterministic()
+    {
+        var first = DeterministicGuid.Create(DeterministicGuid.ScenarioNamespace, "newly-installed-services");
+        var second = DeterministicGuid.Create(DeterministicGuid.ScenarioNamespace, "newly-installed-services");
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void Create_MatchesPublishedRfc4122Version5Vector()
+    {
+        // Published RFC 4122 v5 vector: DNS namespace + www.example.com.
+        var dnsNamespace = new Guid("6ba7b810-9dad-11d1-80b4-00c04fd430c8");
+
+        var result = DeterministicGuid.Create(dnsNamespace, "www.example.com");
+
+        Assert.Equal(new Guid("2ed6657d-e927-568b-95e1-2665a8aea6a2"), result);
+    }
+
+    [Fact]
+    public void Create_ProducesVersion5Variant10()
+    {
+        var result = DeterministicGuid.Create(DeterministicGuid.ScenarioNamespace, "anything");
+        var bytes = result.ToByteArray();
+
+        // .NET layout: version in byte[7] high nibble, variant in byte[8].
+        Assert.Equal(0x50, bytes[7] & 0xF0);
+        Assert.Equal(0x80, bytes[8] & 0xC0);
+    }
+}

--- a/tests/Unit/EventLogExpert.Scenarios.Tests/EventLogExpert.Scenarios.Tests.csproj
+++ b/tests/Unit/EventLogExpert.Scenarios.Tests/EventLogExpert.Scenarios.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\EventLogExpert.Scenarios\EventLogExpert.Scenarios.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Unit/EventLogExpert.Scenarios.Tests/GlobalUsings.cs
+++ b/tests/Unit/EventLogExpert.Scenarios.Tests/GlobalUsings.cs
@@ -1,0 +1,4 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+global using Xunit;

--- a/tests/Unit/EventLogExpert.Scenarios.Tests/ScenarioCatalogLoaderTests.cs
+++ b/tests/Unit/EventLogExpert.Scenarios.Tests/ScenarioCatalogLoaderTests.cs
@@ -1,0 +1,208 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Scenarios.Serialization;
+using System.Text;
+
+namespace EventLogExpert.Scenarios.Tests;
+
+public sealed class ScenarioCatalogLoaderTests
+{
+    [Fact]
+    public void Load_AdminChannelWithoutRequiresAdmin_IsError()
+    {
+        var result = Load(Wrap("""
+            { "id": "x", "name": "X", "purpose": "p", "group": "Security",
+              "channels": [ "Security" ],
+              "filters": [ { "comparison": { "property": "Id", "value": "4624" } } ] }
+            """));
+
+        Assert.Contains(result.Errors, error => error.Contains("requiresAdmin"));
+    }
+
+    [Fact]
+    public void Load_AggregatesEveryError()
+    {
+        var result = Load(Wrap("""
+            { "id": "", "name": "", "purpose": "", "group": "SystemHealth", "channels": [ "System" ],
+              "filters": [ { "comparison": { "property": "Id", "value": "1" } } ] }
+            """));
+
+        Assert.True(result.Errors.Count >= 3, $"Expected >= 3 errors, got: {string.Join("; ", result.Errors)}");
+    }
+
+    [Theory]
+    [InlineData("\"property\": \"LogNam\"")]
+    [InlineData("\"property\": \"Log Name\"")]
+    [InlineData("\"property\": \"Id\", \"operator\": \"Not Equal\"")]
+    [InlineData("\"property\": \"Id\", \"matchMode\": \"Multi\"")]
+    public void Load_BadEnumToken_IsError(string fragment)
+    {
+        var result = Load(Wrap($$"""
+            { "id": "x", "name": "X", "purpose": "p", "group": "SystemHealth",
+              "channels": [ "System" ],
+              "filters": [ { "comparison": { {{fragment}}, "value": "1" } } ] }
+            """));
+
+        Assert.NotEmpty(result.Errors);
+        Assert.Empty(result.Scenarios);
+    }
+
+    [Fact]
+    public void Load_BadGroupToken_IsError()
+    {
+        var result = Load(Wrap("""
+            { "id": "x", "name": "X", "purpose": "p", "group": "NotARealGroup",
+              "channels": [ "System" ],
+              "filters": [ { "comparison": { "property": "Id", "value": "1" } } ] }
+            """));
+
+        Assert.Contains(result.Errors, error => error.Contains("group"));
+    }
+
+    [Theory]
+    [InlineData("\"id\": \"\"", "missing id")]
+    [InlineData("\"id\": \"Not Kebab\"", "kebab")]
+    public void Load_BadId_IsError(string idFragment, string expected)
+    {
+        var result = Load(Wrap($$"""
+            { {{idFragment}}, "name": "X", "purpose": "p", "group": "SystemHealth",
+              "channels": [ "System" ],
+              "filters": [ { "comparison": { "property": "Id", "value": "1" } } ] }
+            """));
+
+        Assert.Contains(result.Errors, error => error.Contains(expected));
+    }
+
+    [Fact]
+    public void Load_CombinedScenarioNotLogNameScoped_IsError()
+    {
+        var result = Load(Wrap("""
+            { "id": "x", "name": "X", "purpose": "p", "group": "SystemHealth", "requiresAdmin": true,
+              "channels": [ "System", "Security" ],
+              "filters": [ { "comparison": { "property": "Id", "value": "1" } } ] }
+            """));
+
+        Assert.Contains(result.Errors, error => error.Contains("LogName-scoped"));
+    }
+
+    [Fact]
+    public void Load_CommentsAndTrailingCommas_AreTolerated()
+    {
+        var result = Load("""
+            {
+              "schemaVersion": 1,
+              // a leading comment
+              "scenarios": [
+                { "id": "x", "name": "X", "purpose": "p", "group": "SystemHealth",
+                  "channels": [ "System" ],
+                  "filters": [ { "comparison": { "property": "Id", "value": "1000" } } ], }
+              ],
+            }
+            """);
+
+        Assert.Empty(result.Errors);
+        Assert.Single(result.Scenarios);
+    }
+
+    [Fact]
+    public void Load_DuplicateId_IsError()
+    {
+        var result = Load("""
+            { "schemaVersion": 1, "scenarios": [
+              { "id": "dup", "name": "A", "purpose": "p", "group": "SystemHealth", "channels": ["System"],
+                "filters": [ { "comparison": { "property": "Id", "value": "1" } } ] },
+              { "id": "dup", "name": "B", "purpose": "p", "group": "SystemHealth", "channels": ["System"],
+                "filters": [ { "comparison": { "property": "Id", "value": "2" } } ] }
+            ] }
+            """);
+
+        Assert.Contains(result.Errors, error => error.Contains("duplicate id"));
+    }
+
+    [Fact]
+    public void Load_MalformedJson_IsAggregatedError_NotThrow()
+    {
+        var result = Load("{ this is not json");
+
+        Assert.Empty(result.Scenarios);
+        Assert.Contains(result.Errors, error => error.Contains("invalid JSON"));
+    }
+
+    [Fact]
+    public void Load_MinimalValidScenario_Succeeds()
+    {
+        var result = Load(Wrap("""
+            { "id": "x", "name": "X", "purpose": "p", "group": "SystemHealth",
+              "channels": [ "System" ],
+              "filters": [ { "comparison": { "property": "Id", "value": "1000" } } ] }
+            """));
+
+        Assert.Empty(result.Errors);
+        Assert.Single(result.Scenarios);
+        Assert.Equal("x", result.Scenarios[0].Id);
+    }
+
+    [Fact]
+    public void Load_MissingChannels_IsError()
+    {
+        var result = Load(Wrap("""
+            { "id": "x", "name": "X", "purpose": "p", "group": "SystemHealth",
+              "filters": [ { "comparison": { "property": "Id", "value": "1" } } ] }
+            """));
+
+        Assert.Contains(result.Errors, error => error.Contains("channels"));
+    }
+
+    [Fact]
+    public void Load_MissingFilters_IsError()
+    {
+        var result = Load(Wrap("""
+            { "id": "x", "name": "X", "purpose": "p", "group": "SystemHealth",
+              "channels": [ "System" ], "filterRows": [ { "comparison": { "property": "Id", "value": "1" } } ] }
+            """));
+
+        Assert.Empty(result.Scenarios);
+        Assert.Contains(result.Errors, error => error.Contains("at least one filter row"));
+    }
+
+    [Fact]
+    public void Load_SourceRegistrationGating_IsRejected()
+    {
+        var result = Load(Wrap("""
+            { "id": "x", "name": "X", "purpose": "p", "group": "Applications", "gating": "SourceRegistration",
+              "channels": [ "Application" ],
+              "filters": [ { "comparison": { "property": "Id", "value": "1" } } ] }
+            """));
+
+        Assert.Contains(result.Errors, error => error.Contains("SourceRegistration"));
+    }
+
+    [Fact]
+    public void Load_UnknownMembers_AreIgnored()
+    {
+        var result = Load(Wrap("""
+            { "id": "x", "name": "X", "purpose": "p", "group": "SystemHealth",
+              "channels": [ "System" ], "futureField": { "nested": true }, "anotherUnknown": 5,
+              "filters": [ { "comparison": { "property": "Id", "value": "1000" } } ] }
+            """));
+
+        Assert.Empty(result.Errors);
+        Assert.Single(result.Scenarios);
+    }
+
+    [Fact]
+    public void Load_UnsupportedSchemaVersion_IsError()
+    {
+        var result = Load("""{ "schemaVersion": 999, "scenarios": [] }""");
+
+        Assert.Empty(result.Scenarios);
+        Assert.Contains(result.Errors, error => error.Contains("schemaVersion"));
+    }
+
+    private static ScenarioCatalogLoadResult Load(string json) =>
+        ScenarioCatalogLoader.TryLoad([("test.json", Encoding.UTF8.GetBytes(json))]);
+
+    private static string Wrap(string scenarioJson) =>
+        $$"""{ "schemaVersion": 1, "scenarios": [ {{scenarioJson}} ] }""";
+}


### PR DESCRIPTION
## PR1 of the built-in scenarios stack (#587/#588) — headless engine

Stacked on PR0 (#594, `jschick/filter-logname-emission`). Base updates to `main` when #594 merges.

Adds the **headless** engine for built-in event-log "scenario" filter sets. No UI yet — the splash dashboard (PR3) and in-app dropdown (PR4) consume these services.

### New `EventLogExpert.Scenarios` assembly (references Filtering + Eventing)
- `Catalog/` — `ScenarioDefinition` model + `BuiltInScenarioRegistry` + `IScenarioSource`/`BuiltInScenarioSource` seam (additive packs may never shadow a built-in id) + `ScenarioCatalogException`.
- `Serialization/` — strict-DTO JSON loader: structural-first validation, case-sensitive enum membership (rejects typos + `[EnumMember]` display values), strict-predicate format, compile-via-emitter, predicate evaluation (incl. null `LogName`), canonical round-trip, combined-rows-must-be-LogName-scoped, admin/kebab/dedup, `SourceRegistration` rejected. Source-generated `JsonSerializerContext`.
- `Common/DeterministicGuid` — real RFC-4122 v5 (SHA-1); .NET 10 has no `Guid.CreateVersion5`. Verified against the published DNS vector.
- Embedded `Scenarios/built-in/system-health.json` — 5 starter scenarios (single-row, any-of, predicate-OR, and a combined `System`+`Security` LogName-scoped pair).

### Runtime wiring
- `IChannelPresenceProbe` — caches `EventLogSession.GetLogNames()`; a failed read is not cached (retries), guarded by `SemaphoreSlim`.
- `IScenarioQueryService` — splash (presence-gated) + in-app (any-channel-loaded) selection.
- `IMenuActionService.OpenLiveLogsAsync` — returns `OpenLogsBatchResult`; extracted a shared core so `OpenLogsBatchAsync` keeps its `Task` signature (no method-group break).
- `IScenarioLaunchService` — apply-first (`ReplaceFiltersAction` + `SetFilterDateRangeAction`, null clears the date) then open; `CloseAllLogsAction` corrective on a zero-open fresh launch.

### Tests
New `EventLogExpert.Scenarios.Tests` (40) — the data-driven catalog validation gate + loader negative paths + deterministic-GUID vector. New Runtime scenario tests (+20) — probe failure-cache, query semantics, launch ordering/corrective, real-reducer apply-lands integration, merge idempotency, DI resolution.

Build 0/0 (TreatWarningsAsErrors). Filtering 901 / UI 708 / Runtime 1281 / Scenarios 40 green.
