### PR TITLE
Route UI DOM-id generation through a strongly-typed ComponentId helper

### DIFF
--- a/src/EventLogExpert.UI/Alerts/PromptModal.razor.cs
+++ b/src/EventLogExpert.UI/Alerts/PromptModal.razor.cs
@@ -1,6 +1,7 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.UI.Common;
 using EventLogExpert.UI.Modal;
 using Microsoft.AspNetCore.Components;
 
@@ -13,7 +14,7 @@ namespace EventLogExpert.UI.Alerts;
 /// </summary>
 public sealed partial class PromptModal : ModalBase<string>
 {
-    private readonly string _messageId = $"prompt-modal-message-{Guid.NewGuid():N}";
+    private readonly string _messageId = ComponentId.NewUnique("prompt-modal-message").Value;
 
     private bool _focusOnNextRender = true;
     private ElementReference _inputRef;

--- a/src/EventLogExpert.UI/Common/ComponentId.cs
+++ b/src/EventLogExpert.UI/Common/ComponentId.cs
@@ -28,7 +28,10 @@ internal readonly record struct ComponentId
 
     public static ComponentId NewUnique() => NewUnique("cid");
 
-    public static ComponentId NewUnique(string prefix) => new($"{prefix}-{Guid.NewGuid():N}");
+    public static ComponentId NewUnique(string prefix) =>
+        !IsValidId(prefix) ?
+            throw new ArgumentException($"'{prefix}' is not a valid id prefix (expected {ValidIdPattern}).", nameof(prefix)) :
+            new ComponentId($"{prefix}-{Guid.NewGuid():N}");
 
     public static ComponentId For(FilterId id, ComponentIdScope scope) =>
         id.Value == Guid.Empty ? throw new ArgumentException("Filter id must not be empty.", nameof(id)) :
@@ -39,8 +42,8 @@ internal readonly record struct ComponentId
             new ComponentId($"le-{id.Value:N}");
 
     public ComponentId Suffix(string part) =>
-        string.IsNullOrWhiteSpace(part) ?
-            throw new ArgumentException("Suffix part must not be empty or whitespace.", nameof(part)) :
+        string.IsNullOrWhiteSpace(part) || !IsValidIdFragment(part) ?
+            throw new ArgumentException($"'{part}' is not a valid id suffix (expected characters in [A-Za-z0-9_-]).", nameof(part)) :
             new ComponentId($"{Value}_{part}");
 
     public override string ToString() => _value ?? string.Empty;
@@ -55,13 +58,11 @@ internal readonly record struct ComponentId
         _ => throw new ArgumentOutOfRangeException(nameof(scope), scope, "Unknown component id scope."),
     };
 
-    private static bool IsValidId(string value)
-    {
-        if (string.IsNullOrEmpty(value) || !char.IsAsciiLetter(value[0]))
-        {
-            return false;
-        }
+    private static bool IsValidId(string value) =>
+        !string.IsNullOrEmpty(value) && char.IsAsciiLetter(value[0]) && IsValidIdFragment(value);
 
+    private static bool IsValidIdFragment(string value)
+    {
         foreach (char character in value)
         {
             if (!char.IsAsciiLetterOrDigit(character) && character is not ('_' or '-'))

--- a/src/EventLogExpert.UI/Common/ComponentId.cs
+++ b/src/EventLogExpert.UI/Common/ComponentId.cs
@@ -1,0 +1,73 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Runtime.FilterLibrary;
+
+namespace EventLogExpert.UI.Common;
+
+internal readonly record struct ComponentId
+{
+    private readonly string? _value;
+
+    private ComponentId(string value)
+    {
+        if (!IsValidId(value))
+        {
+            throw new ArgumentException($"'{value}' is not a valid DOM id (expected {ValidIdPattern}).", nameof(value));
+        }
+
+        _value = value;
+    }
+
+    public const string ValidIdPattern = "^[A-Za-z][A-Za-z0-9_-]*$";
+
+    public bool IsEmpty => _value is null;
+
+    public string Value => _value ?? throw new InvalidOperationException("ComponentId is uninitialized.");
+
+    public static ComponentId NewUnique() => new($"cid-{Guid.NewGuid():N}");
+
+    public static ComponentId For(FilterId id, ComponentIdScope scope) =>
+        id.Value == Guid.Empty ? throw new ArgumentException("Filter id must not be empty.", nameof(id)) :
+            new ComponentId($"{Prefix(scope)}-{id.Value:N}");
+
+    public static ComponentId For(LibraryEntryId id) =>
+        id.Value == Guid.Empty ? throw new ArgumentException("Library entry id must not be empty.", nameof(id)) :
+            new ComponentId($"le-{id.Value:N}");
+
+    public ComponentId Suffix(string part) =>
+        string.IsNullOrWhiteSpace(part) ?
+            throw new ArgumentException("Suffix part must not be empty or whitespace.", nameof(part)) :
+            new ComponentId($"{Value}_{part}");
+
+    public override string ToString() => _value ?? string.Empty;
+
+    private static string Prefix(ComponentIdScope scope) => scope switch
+    {
+        ComponentIdScope.PaneFilter => "fp",
+        ComponentIdScope.PanePendingFilter => "fp-pending",
+        ComponentIdScope.LibraryFilter => "lef",
+        ComponentIdScope.LibraryPendingFilter => "lef-pending",
+        ComponentIdScope.Predicate => "sf",
+        _ => throw new ArgumentOutOfRangeException(nameof(scope), scope, "Unknown component id scope."),
+    };
+
+    private static bool IsValidId(string value)
+    {
+        if (string.IsNullOrEmpty(value) || !char.IsAsciiLetter(value[0]))
+        {
+            return false;
+        }
+
+        foreach (char character in value)
+        {
+            if (!char.IsAsciiLetterOrDigit(character) && character is not ('_' or '-'))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/EventLogExpert.UI/Common/ComponentId.cs
+++ b/src/EventLogExpert.UI/Common/ComponentId.cs
@@ -26,7 +26,9 @@ internal readonly record struct ComponentId
 
     public string Value => _value ?? throw new InvalidOperationException("ComponentId is uninitialized.");
 
-    public static ComponentId NewUnique() => new($"cid-{Guid.NewGuid():N}");
+    public static ComponentId NewUnique() => NewUnique("cid");
+
+    public static ComponentId NewUnique(string prefix) => new($"{prefix}-{Guid.NewGuid():N}");
 
     public static ComponentId For(FilterId id, ComponentIdScope scope) =>
         id.Value == Guid.Empty ? throw new ArgumentException("Filter id must not be empty.", nameof(id)) :

--- a/src/EventLogExpert.UI/Common/ComponentIdScope.cs
+++ b/src/EventLogExpert.UI/Common/ComponentIdScope.cs
@@ -1,0 +1,13 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.UI.Common;
+
+internal enum ComponentIdScope
+{
+    PaneFilter,
+    PanePendingFilter,
+    LibraryFilter,
+    LibraryPendingFilter,
+    Predicate,
+}

--- a/src/EventLogExpert.UI/Database/DatabaseEntryRow.razor.cs
+++ b/src/EventLogExpert.UI/Database/DatabaseEntryRow.razor.cs
@@ -6,6 +6,7 @@ using EventLogExpert.Runtime.Banner;
 using EventLogExpert.Runtime.Database;
 using EventLogExpert.Runtime.Database.Upgrade;
 using EventLogExpert.Runtime.Menu;
+using EventLogExpert.UI.Common;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
@@ -17,8 +18,8 @@ public sealed partial class DatabaseEntryRow : ComponentBase
     private static readonly IReadOnlyDictionary<string, object> s_ariaHiddenTrueAttributes =
         new Dictionary<string, object>(StringComparer.Ordinal) { ["aria-hidden"] = "true" };
 
-    private readonly string _nameButtonId = $"db-row-{Guid.NewGuid():N}-name";
-    private readonly string _pendingStatusId = $"db-row-{Guid.NewGuid():N}-pending";
+    private readonly string _nameButtonId = ComponentId.NewUnique("db-row-name").Value;
+    private readonly string _pendingStatusId = ComponentId.NewUnique("db-row-pending").Value;
 
     private ElementReference _nameButtonRef;
     private bool _shouldFocusNameAfterRender;

--- a/src/EventLogExpert.UI/DatabaseTools/Tabs/CreateDatabaseTab.razor
+++ b/src/EventLogExpert.UI/DatabaseTools/Tabs/CreateDatabaseTab.razor
@@ -95,7 +95,7 @@
             {
                 @if (IsCancelling)
                 {
-                    <button aria-disabled="true" class="button" disabled type="button">
+                    <button class="button" disabled type="button">
                         <i aria-hidden="true" class="bi bi-hourglass-split"></i> Cancelling…
                     </button>
                 }

--- a/src/EventLogExpert.UI/DatabaseTools/Tabs/DiffDatabasesTab.razor
+++ b/src/EventLogExpert.UI/DatabaseTools/Tabs/DiffDatabasesTab.razor
@@ -63,7 +63,7 @@
             {
                 @if (IsCancelling)
                 {
-                    <button aria-disabled="true" class="button" disabled type="button">
+                    <button class="button" disabled type="button">
                         <i aria-hidden="true" class="bi bi-hourglass-split"></i> Cancelling…
                     </button>
                 }

--- a/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.cs
+++ b/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.cs
@@ -8,6 +8,7 @@ using EventLogExpert.Runtime.Banner;
 using EventLogExpert.Runtime.Database;
 using EventLogExpert.Runtime.Database.Upgrade;
 using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.UI.Common;
 using EventLogExpert.UI.Database;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
@@ -22,9 +23,9 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
 
     private readonly Dictionary<string, bool> _pendingToggles = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, DatabaseEntryRow?> _rowRefs = new(StringComparer.OrdinalIgnoreCase);
-    private readonly string _saveBlockedHelpId = $"manage-save-blocked-{Guid.NewGuid():N}";
+    private readonly string _saveBlockedHelpId = ComponentId.NewUnique("manage-save-blocked").Value;
     private readonly HashSet<string> _selectedForBulk = new(StringComparer.OrdinalIgnoreCase);
-    private readonly string _upgradeBlockedHelpId = $"manage-upgrade-blocked-{Guid.NewGuid():N}";
+    private readonly string _upgradeBlockedHelpId = ComponentId.NewUnique("manage-upgrade-blocked").Value;
 
     private ElementReference _bulkRemoveButtonRef;
     private ElementReference _bulkUpgradeButtonRef;

--- a/src/EventLogExpert.UI/DatabaseTools/Tabs/MergeDatabaseTab.razor
+++ b/src/EventLogExpert.UI/DatabaseTools/Tabs/MergeDatabaseTab.razor
@@ -56,7 +56,7 @@
             {
                 @if (IsCancelling)
                 {
-                    <button aria-disabled="true" class="button" disabled type="button">
+                    <button class="button" disabled type="button">
                         <i aria-hidden="true" class="bi bi-hourglass-split"></i> Cancelling…
                     </button>
                 }

--- a/src/EventLogExpert.UI/DatabaseTools/Tabs/ShowProvidersTab.razor
+++ b/src/EventLogExpert.UI/DatabaseTools/Tabs/ShowProvidersTab.razor
@@ -63,7 +63,7 @@
             {
                 @if (IsCancelling)
                 {
-                    <button aria-disabled="true" class="button" disabled type="button">
+                    <button class="button" disabled type="button">
                         <i aria-hidden="true" class="bi bi-hourglass-split"></i> Cancelling…
                     </button>
                 }

--- a/src/EventLogExpert.UI/DatabaseTools/Tabs/UpgradeDatabaseTab.razor
+++ b/src/EventLogExpert.UI/DatabaseTools/Tabs/UpgradeDatabaseTab.razor
@@ -26,7 +26,7 @@
             {
                 @if (IsCancelling)
                 {
-                    <button aria-disabled="true" class="button" disabled type="button">
+                    <button class="button" disabled type="button">
                         <i aria-hidden="true" class="bi bi-hourglass-split"></i> Cancelling…
                     </button>
                 }

--- a/src/EventLogExpert.UI/FilterEditor/Comparison/FilterComparisonEditor.razor.cs
+++ b/src/EventLogExpert.UI/FilterEditor/Comparison/FilterComparisonEditor.razor.cs
@@ -5,6 +5,7 @@ using EventLogExpert.Filtering.Common.Filtering;
 using EventLogExpert.Filtering.Drafts;
 using EventLogExpert.Filtering.EventData;
 using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.UI.Common;
 using Fluxor;
 using Microsoft.AspNetCore.Components;
 using System.Collections.Immutable;
@@ -18,7 +19,7 @@ public sealed partial class FilterComparisonEditor : ComponentBase
 
     [Parameter][EditorRequired] public FilterComparisonDraft Comparison { get; set; } = null!;
 
-    [Parameter] public string Id { get; set; } = Guid.NewGuid().ToString();
+    [Parameter] public string Id { get; set; } = ComponentId.NewUnique().Value;
 
     /// <summary>
     ///     Fired whenever any sub-control mutates <see cref="Comparison" /> (property, operator/match-mode, or value).

--- a/src/EventLogExpert.UI/FilterEditor/Editing/FilterEditPanel.razor.cs
+++ b/src/EventLogExpert.UI/FilterEditor/Editing/FilterEditPanel.razor.cs
@@ -2,13 +2,14 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Filtering.Drafts;
+using EventLogExpert.UI.Common;
 using Microsoft.AspNetCore.Components;
 
 namespace EventLogExpert.UI.FilterEditor.Editing;
 
 public sealed partial class FilterEditPanel : ComponentBase
 {
-    private readonly string _colorDescriptionId = $"filter-edit-panel-color-desc-{Guid.NewGuid():N}";
+    private readonly string _colorDescriptionId = ComponentId.NewUnique("filter-edit-panel-color-desc").Value;
 
     [Parameter] public string CssClass { get; set; } = string.Empty;
 

--- a/src/EventLogExpert.UI/FilterEditor/Editing/FilterPredicateEditor.razor
+++ b/src/EventLogExpert.UI/FilterEditor/Editing/FilterPredicateEditor.razor
@@ -11,7 +11,9 @@
             @(Value.JoinWithAny ? "OR" : "AND")
         </button>
 
-        <FilterComparisonEditor Comparison="Value.Comparison" Id="@($"sf-{Value.Id}")" OnChanged="OnComparisonChanged" />
+        <FilterComparisonEditor Comparison="Value.Comparison"
+            Id="@ComponentId.For(Value.Id, ComponentIdScope.Predicate).Value"
+            OnChanged="OnComparisonChanged" />
 
         <button aria-label="Done editing predicate"
             class="button icon-button"

--- a/src/EventLogExpert.UI/FilterEditor/FilterEditorCore.razor.cs
+++ b/src/EventLogExpert.UI/FilterEditor/FilterEditorCore.razor.cs
@@ -6,6 +6,7 @@ using EventLogExpert.Filtering.Evaluation;
 using EventLogExpert.Filtering.Persistence;
 using EventLogExpert.Runtime.Alerts;
 using EventLogExpert.Runtime.Announcement;
+using EventLogExpert.UI.Common;
 using EventLogExpert.UI.FilterEditor.Rows;
 using Microsoft.AspNetCore.Components;
 
@@ -19,7 +20,7 @@ public sealed partial class FilterEditorCore : ComponentBase
 
     [Parameter] public IReadOnlyList<CachedFilterOption>? CachedOptions { get; set; }
 
-    [Parameter] public string Id { get; set; } = Guid.NewGuid().ToString();
+    [Parameter] public string Id { get; set; } = ComponentId.NewUnique().Value;
 
     [Parameter] public EventCallback<bool> OnExclusionChanged { get; set; }
 

--- a/src/EventLogExpert.UI/FilterEditor/FilterRowBase.cs
+++ b/src/EventLogExpert.UI/FilterEditor/FilterRowBase.cs
@@ -1,6 +1,7 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.UI.Common;
 using Microsoft.AspNetCore.Components;
 
 namespace EventLogExpert.UI.FilterEditor;
@@ -8,7 +9,7 @@ namespace EventLogExpert.UI.FilterEditor;
 /// <summary>Generic base for filter rows: stable DOM <see cref="Id" /> and a typed <see cref="Value" />.</summary>
 public abstract class FilterRowBase<TValue> : ComponentBase
 {
-    [Parameter] public string Id { get; set; } = Guid.NewGuid().ToString();
+    [Parameter] public string Id { get; set; } = ComponentId.NewUnique().Value;
 
     [Parameter] public TValue Value { get; set; } = default!;
 }

--- a/src/EventLogExpert.UI/FilterEditor/Rows/FilterRowActions.razor.cs
+++ b/src/EventLogExpert.UI/FilterEditor/Rows/FilterRowActions.razor.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.UI.Common;
 using EventLogExpert.UI.Focus;
 using Microsoft.AspNetCore.Components;
 
@@ -9,7 +10,7 @@ namespace EventLogExpert.UI.FilterEditor.Rows;
 
 public sealed partial class FilterRowActions : ComponentBase
 {
-    private readonly string _enableToggleLabelId = $"filter-row-toggle-{Guid.NewGuid():N}";
+    private readonly string _enableToggleLabelId = ComponentId.NewUnique("filter-row-toggle").Value;
 
     private ElementReference _editButtonRef;
 

--- a/src/EventLogExpert.UI/FilterEditor/Rows/FilterRowShell.razor.cs
+++ b/src/EventLogExpert.UI/FilterEditor/Rows/FilterRowShell.razor.cs
@@ -3,6 +3,7 @@
 
 using EventLogExpert.Filtering.Drafts;
 using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.UI.Common;
 using Microsoft.AspNetCore.Components;
 
 namespace EventLogExpert.UI.FilterEditor.Rows;
@@ -14,7 +15,7 @@ namespace EventLogExpert.UI.FilterEditor.Rows;
 /// </summary>
 public sealed partial class FilterRowShell : ComponentBase
 {
-    private readonly string _filterLabelId = $"filter-row-label-{Guid.NewGuid():N}";
+    private readonly string _filterLabelId = ComponentId.NewUnique("filter-row-label").Value;
 
     private FilterRowActions? _actionsRef;
 

--- a/src/EventLogExpert.UI/FilterEditor/Rows/ToggleWithLabel.razor.cs
+++ b/src/EventLogExpert.UI/FilterEditor/Rows/ToggleWithLabel.razor.cs
@@ -1,6 +1,7 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.UI.Common;
 using EventLogExpert.UI.Inputs;
 using Microsoft.AspNetCore.Components;
 
@@ -14,11 +15,11 @@ namespace EventLogExpert.UI.FilterEditor.Rows;
 /// </summary>
 public sealed partial class ToggleWithLabel : InputComponent<bool>
 {
-    private readonly string _textLabelId = $"toggle-with-label-text-{Guid.NewGuid():N}";
+    private readonly string _textLabelId = ComponentId.NewUnique("toggle-with-label-text").Value;
 
     [Parameter] public bool Disabled { get; set; }
 
-    [Parameter] public string Id { get; set; } = Guid.NewGuid().ToString();
+    [Parameter] public string Id { get; set; } = ComponentId.NewUnique().Value;
 
     /// <summary>
     ///     Visible text rendered next to the toggle (e.g. "Exclude"). When null/empty, behaves like a bare

--- a/src/EventLogExpert.UI/FilterLibrary/FilterLibraryModal.razor.cs
+++ b/src/EventLogExpert.UI/FilterLibrary/FilterLibraryModal.razor.cs
@@ -6,6 +6,7 @@ using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.Runtime.Common.Files;
 using EventLogExpert.Runtime.FilterLibrary;
 using EventLogExpert.Runtime.Modal;
+using EventLogExpert.UI.Common;
 using EventLogExpert.UI.Modal;
 using Fluxor;
 using Microsoft.AspNetCore.Components;
@@ -35,8 +36,8 @@ public sealed partial class FilterLibraryModal : ModalBase<bool>
         [LibraryTab.PreviouslyUsed] = [],
     };
 
-    private readonly string _tagManagementPanelId = $"tag-mgmt-{Guid.NewGuid():N}";
-    private readonly string _tagOverflowRegionId = $"tag-overflow-{Guid.NewGuid():N}";
+    private readonly string _tagManagementPanelId = ComponentId.NewUnique("tag-mgmt").Value;
+    private readonly string _tagOverflowRegionId = ComponentId.NewUnique("tag-overflow").Value;
 
     private LibraryTab _activeTab = LibraryTab.Saved;
     private bool _isTagManagementExpanded;

--- a/src/EventLogExpert.UI/FilterLibrary/LibraryEntryFilterEditor.razor
+++ b/src/EventLogExpert.UI/FilterLibrary/LibraryEntryFilterEditor.razor
@@ -9,7 +9,7 @@
 
             @foreach (var saved in FilterSet.Filters)
             {
-                <LibraryFilterRow Id="@($"lef-{saved.Id.Value:N}")"
+                <LibraryFilterRow Id="@ComponentId.For(saved.Id, ComponentIdScope.LibraryFilter).Value"
                     @key="saved.Id"
                     OnExclusionChanged="@(e => OnExclusionChangedForSaved(saved.Id, e))"
                     OnRemove="@(() => OnRemoveSaved(saved.Id))"
@@ -20,7 +20,7 @@
 
             @foreach (var draft in _pendingDrafts)
             {
-                <LibraryFilterRow Id="@($"lef-pending-{draft.Id.Value:N}")"
+                <LibraryFilterRow Id="@ComponentId.For(draft.Id, ComponentIdScope.LibraryPendingFilter).Value"
                     @key="draft.Id"
                     OnPendingDiscard="@(() => DiscardPendingDraft(draft))"
                     OnPendingSave="@(built => SavePendingDraft(draft, built))"

--- a/src/EventLogExpert.UI/FilterLibrary/LibraryEntryFilterEditor.razor.cs
+++ b/src/EventLogExpert.UI/FilterLibrary/LibraryEntryFilterEditor.razor.cs
@@ -5,6 +5,7 @@ using EventLogExpert.Filtering.Drafts;
 using EventLogExpert.Filtering.Evaluation;
 using EventLogExpert.Filtering.Persistence;
 using EventLogExpert.Runtime.FilterLibrary;
+using EventLogExpert.UI.Common;
 using Microsoft.AspNetCore.Components;
 using System.Collections.Immutable;
 
@@ -24,7 +25,7 @@ public sealed partial class LibraryEntryFilterEditor : ComponentBase
 
     protected override void OnInitialized()
     {
-        _filterListId = $"library-entry-filter-editor-{FilterSet.Id.Value:N}";
+        _filterListId = ComponentId.For(FilterSet.Id).Value;
     }
 
     private void AddPendingDraft() => _pendingDrafts.Add(new FilterDraft { Mode = FilterMode.Advanced });

--- a/src/EventLogExpert.UI/FilterLibrary/LibraryEntryRow.razor.cs
+++ b/src/EventLogExpert.UI/FilterLibrary/LibraryEntryRow.razor.cs
@@ -6,6 +6,7 @@ using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.Runtime.FilterLibrary;
 using EventLogExpert.Runtime.FilterPane;
 using EventLogExpert.Runtime.Menu;
+using EventLogExpert.UI.Common;
 using EventLogExpert.UI.Common.Interop;
 using EventLogExpert.UI.Focus;
 using Fluxor;
@@ -20,10 +21,9 @@ public sealed partial class LibraryEntryRow : ComponentBase, IAsyncDisposable
     private const int InlineTagChipCap = 2;
     private const int MaxVisibleTagChips = 5;
 
-    private readonly string _filterEditorRegionId = $"lefr-{Guid.NewGuid():N}";
-    private readonly string _tagsRegionId = $"library-entry-tags-{Guid.NewGuid().ToString()[..8]}";
-    private ElementReference _articleRef;
+    private readonly string _filterEditorRegionId = ComponentId.NewUnique("lefr").Value;
 
+    private ElementReference _articleRef;
     private bool _isEditingTags;
     private bool _isExpanded;
     private IJSObjectReference? _menuAnchorModule;

--- a/src/EventLogExpert.UI/FilterLibrary/LibraryFilterRow.razor.cs
+++ b/src/EventLogExpert.UI/FilterLibrary/LibraryFilterRow.razor.cs
@@ -3,6 +3,7 @@
 
 using EventLogExpert.Filtering.Drafts;
 using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.UI.Common;
 using EventLogExpert.UI.FilterEditor;
 using Microsoft.AspNetCore.Components;
 
@@ -12,7 +13,7 @@ public sealed partial class LibraryFilterRow : ComponentBase
 {
     private FilterEditorCore? _coreRef;
 
-    [Parameter] public string Id { get; set; } = Guid.NewGuid().ToString();
+    [Parameter] public string Id { get; set; } = ComponentId.NewUnique().Value;
 
     [Parameter] public EventCallback<bool> OnExclusionChanged { get; set; }
 

--- a/src/EventLogExpert.UI/FilterLibrary/LibrarySavedTabHeader.razor.cs
+++ b/src/EventLogExpert.UI/FilterLibrary/LibrarySavedTabHeader.razor.cs
@@ -6,6 +6,7 @@ using EventLogExpert.Filtering.Evaluation;
 using EventLogExpert.Filtering.Persistence;
 using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.Runtime.FilterLibrary;
+using EventLogExpert.UI.Common;
 using Fluxor;
 using Microsoft.AspNetCore.Components;
 using System.Collections.Immutable;
@@ -14,8 +15,8 @@ namespace EventLogExpert.UI.FilterLibrary;
 
 public sealed partial class LibrarySavedTabHeader : ComponentBase
 {
-    private readonly string _filterRowId = $"saved-new-row-{Guid.NewGuid():N}";
-    private readonly string _nameInputId = $"saved-new-name-{Guid.NewGuid():N}";
+    private readonly string _filterRowId = ComponentId.NewUnique("saved-new-row").Value;
+    private readonly string _nameInputId = ComponentId.NewUnique("saved-new-name").Value;
 
     private string _draftName = string.Empty;
     private ImmutableList<string> _draftTags = [];

--- a/src/EventLogExpert.UI/FilterPane/FilterPane.razor
+++ b/src/EventLogExpert.UI/FilterPane/FilterPane.razor
@@ -224,12 +224,18 @@
 
         @foreach (var item in FilterPaneState.Value.Filters)
         {
-            <FilterRow @key="item.Id" OnDisposed="@OnRowDisposed" OnRemoved="HandleRemovedFilter" @ref="_rowRefs[item.Id]" Value="item" />
+            <FilterRow Id="@ComponentId.For(item.Id, ComponentIdScope.PaneFilter).Value"
+                @key="item.Id"
+                OnDisposed="@OnRowDisposed"
+                OnRemoved="HandleRemovedFilter"
+                @ref="_rowRefs[item.Id]"
+                Value="item" />
         }
 
         @foreach (var draft in _pendingDrafts)
         {
-            <FilterRow @key="draft.Id"
+            <FilterRow Id="@ComponentId.For(draft.Id, ComponentIdScope.PanePendingFilter).Value"
+                @key="draft.Id"
                 OnPendingDiscard="() => HandlePendingDiscard(draft)"
                 OnPendingSave="filter => HandlePendingSave(draft, filter)"
                 PendingDraft="draft" />

--- a/src/EventLogExpert.UI/FilterPane/FilterPane.razor
+++ b/src/EventLogExpert.UI/FilterPane/FilterPane.razor
@@ -53,9 +53,9 @@
 
         <div class="filter-header-secondary">
             <button aria-describedby="@(HasSavableFilters ? null : "save-filters-empty-hint")"
-                aria-disabled="@(!HasSavableFilters)"
                 aria-label="Save as Filter Set"
                 class="button icon-button"
+                disabled="@(!HasSavableFilters)"
                 @onclick="SaveFiltersAsFilterSetAsync"
                 title="@(HasSavableFilters ? "Save as Filter Set..." : "No filters to save")"
                 type="button">
@@ -63,9 +63,9 @@
             </button>
 
             <button aria-describedby="@(HasClearableFilters ? null : "clear-filters-empty-hint")"
-                aria-disabled="@(!HasClearableFilters)"
                 aria-label="Clear All Filters"
                 class="button icon-button"
+                disabled="@(!HasClearableFilters)"
                 @onclick="ClearAllFiltersAsync"
                 title="@(HasClearableFilters ? "Clear All Filters..." : "No filters to clear")"
                 type="button">

--- a/src/EventLogExpert.UI/FilterPane/FilterPane.razor.css
+++ b/src/EventLogExpert.UI/FilterPane/FilterPane.razor.css
@@ -60,12 +60,12 @@
     text-align: center;
 }
 
-.icon-button[aria-disabled="true"] {
+.icon-button:disabled {
     opacity: 0.5;
     cursor: not-allowed;
 }
 
-.icon-button[aria-disabled="true"]:hover { filter: none; }
+.icon-button:disabled:hover { filter: none; }
 
 .filter-empty-state {
     color: var(--text-secondary);

--- a/src/EventLogExpert.UI/Inputs/OptionSelect.razor.cs
+++ b/src/EventLogExpert.UI/Inputs/OptionSelect.razor.cs
@@ -1,6 +1,7 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.UI.Common;
 using Microsoft.AspNetCore.Components;
 
 namespace EventLogExpert.UI.Inputs;
@@ -13,7 +14,7 @@ public sealed partial class OptionSelect : InputComponent<bool>
 
     [Parameter] public string EnabledString { get; set; } = "Enabled";
 
-    [Parameter] public string Id { get; set; } = Guid.NewGuid().ToString();
+    [Parameter] public string Id { get; set; } = ComponentId.NewUnique().Value;
 
     [Parameter] public bool UseStatusColors { get; set; }
 

--- a/src/EventLogExpert.UI/Inputs/TagPicker.razor.cs
+++ b/src/EventLogExpert.UI/Inputs/TagPicker.razor.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Runtime.FilterLibrary;
+using EventLogExpert.UI.Common;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using System.Collections.Immutable;
@@ -10,7 +11,7 @@ namespace EventLogExpert.UI.Inputs;
 
 public sealed partial class TagPicker : ComponentBase
 {
-    private readonly string _listboxId = $"tag-picker-listbox-{Guid.NewGuid().ToString()[..8]}";
+    private readonly string _listboxId = ComponentId.NewUnique("tag-picker-listbox").Value;
 
     private int _activeOptionIndex = -1;
     private IReadOnlyList<string> _filteredSuggestions = [];
@@ -19,11 +20,7 @@ public sealed partial class TagPicker : ComponentBase
     private bool _isDropdownOpen;
     private bool _isInputFocused;
 
-    private bool IsListboxOpen => _isDropdownOpen && _isInputFocused && _filteredSuggestions.Count > 0;
-
     [Parameter] public string? AriaLabel { get; set; }
-
-    private string EffectiveAriaLabel => string.IsNullOrWhiteSpace(AriaLabel) ? "Tags" : AriaLabel;
 
     [Parameter] public string? Placeholder { get; set; } = "Add tag…";
 
@@ -32,6 +29,10 @@ public sealed partial class TagPicker : ComponentBase
     [Parameter][EditorRequired] public required ImmutableList<string> Value { get; set; }
 
     [Parameter] public EventCallback<ImmutableList<string>> ValueChanged { get; set; }
+
+    private string EffectiveAriaLabel => string.IsNullOrWhiteSpace(AriaLabel) ? "Tags" : AriaLabel;
+
+    private bool IsListboxOpen => _isDropdownOpen && _isInputFocused && _filteredSuggestions.Count > 0;
 
     protected override void OnParametersSet()
     {

--- a/src/EventLogExpert.UI/Inputs/Toggle.razor.cs
+++ b/src/EventLogExpert.UI/Inputs/Toggle.razor.cs
@@ -1,6 +1,7 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.UI.Common;
 using Microsoft.AspNetCore.Components;
 
 namespace EventLogExpert.UI.Inputs;
@@ -9,7 +10,7 @@ public sealed partial class Toggle : InputComponent<bool>
 {
     [Parameter] public bool Disabled { get; set; }
 
-    [Parameter] public string Id { get; set; } = Guid.NewGuid().ToString();
+    [Parameter] public string Id { get; set; } = ComponentId.NewUnique().Value;
 
     private async Task UpdateValue(ChangeEventArgs args)
     {

--- a/src/EventLogExpert.UI/Inputs/ValueSelect.razor.cs
+++ b/src/EventLogExpert.UI/Inputs/ValueSelect.razor.cs
@@ -1,6 +1,7 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.UI.Common;
 using EventLogExpert.UI.Common.Interop;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
@@ -10,7 +11,7 @@ namespace EventLogExpert.UI.Inputs;
 
 public sealed partial class ValueSelect<T> : InputComponent<T>, IAsyncDisposable
 {
-    private readonly string _itemId = $"select_{Guid.NewGuid().ToString()[..8]}";
+    private readonly string _itemId = ComponentId.NewUnique("select").Value;
     private readonly List<ValueSelectItem<T>> _items = [];
     private readonly HashSet<T> _selectedValues = [];
 

--- a/src/EventLogExpert.UI/Inputs/ValueSelectItem.razor.cs
+++ b/src/EventLogExpert.UI/Inputs/ValueSelectItem.razor.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Runtime.Common.Display;
+using EventLogExpert.UI.Common;
 using Microsoft.AspNetCore.Components;
 
 namespace EventLogExpert.UI.Inputs;
@@ -25,7 +26,7 @@ public sealed partial class ValueSelectItem<T> : IDisposable
     [Parameter]
     public bool IsDisabled { get; set; }
 
-    public string ItemId { get; } = $"_{Guid.NewGuid().ToString()[..8]}";
+    public string ItemId { get; } = ComponentId.NewUnique().Value;
 
     [Parameter]
     public T Value { get; set; } = default!;

--- a/src/EventLogExpert.UI/LogTable/LogTabBar.razor
+++ b/src/EventLogExpert.UI/LogTable/LogTabBar.razor
@@ -5,7 +5,11 @@
         @foreach (var table in _sortedTabs)
         {
             <div class="@GetActiveTab(table)" title="@GetTabTooltip(table)">
-                <span role="button" tabindex="@(table.IsLoading ? -1 : 0)" aria-disabled="@table.IsLoading" @onmousedown="() => SetActiveLog(table)" @onkeydown="(e) => OnTabKeyDown(e, table)">
+                <span aria-disabled="@(table.IsLoading ? "true" : null)"
+                    @onkeydown="e => OnTabKeyDown(e, table)"
+                    @onmousedown="() => SetActiveLog(table)"
+                    role="button"
+                    tabindex="@(table.IsLoading ? -1 : 0)">
                     @if (table.IsLoading)
                     {
                         <i aria-label="Loading" class="spinner-border" role="status"></i>

--- a/src/EventLogExpert.UI/Modal/ModalChrome.razor.cs
+++ b/src/EventLogExpert.UI/Modal/ModalChrome.razor.cs
@@ -3,6 +3,7 @@
 
 using EventLogExpert.Runtime.Alerts;
 using EventLogExpert.UI.Banner;
+using EventLogExpert.UI.Common;
 using EventLogExpert.UI.Common.Interop;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
@@ -11,10 +12,10 @@ namespace EventLogExpert.UI.Modal;
 
 public sealed partial class ModalChrome : ComponentBase, IAsyncDisposable
 {
-    private readonly string _inlineAlertMessageId = $"modal-inline-alert-message-{Guid.NewGuid():N}";
-    private readonly string _inlineAlertTitleId = $"modal-inline-alert-title-{Guid.NewGuid():N}";
-    private readonly string _inlineAlertValidationErrorId = $"modal-inline-alert-validation-{Guid.NewGuid():N}";
-    private readonly string _titleId = $"modal-title-{Guid.NewGuid():N}";
+    private readonly string _inlineAlertMessageId = ComponentId.NewUnique("modal-inline-alert-message").Value;
+    private readonly string _inlineAlertTitleId = ComponentId.NewUnique("modal-inline-alert-title").Value;
+    private readonly string _inlineAlertValidationErrorId = ComponentId.NewUnique("modal-inline-alert-validation").Value;
+    private readonly string _titleId = ComponentId.NewUnique("modal-title").Value;
 
     private ElementReference _dialogRef;
     private ElementReference _inlineAlertAcceptButtonRef;

--- a/src/EventLogExpert.UI/Modal/SidebarTabs.razor.cs
+++ b/src/EventLogExpert.UI/Modal/SidebarTabs.razor.cs
@@ -1,6 +1,7 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.UI.Common;
 using EventLogExpert.UI.Common.Interop;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
@@ -12,7 +13,7 @@ public sealed partial class SidebarTabs<TTab> : ComponentBase, IAsyncDisposable
     where TTab : struct, Enum
 {
     private readonly Dictionary<TTab, ElementReference> _tabButtonRefs = new();
-    private readonly string _tablistId = Guid.NewGuid().ToString("N");
+    private readonly string _tablistId = ComponentId.NewUnique().Value;
 
     private TTab? _pendingFocusTab;
     private IJSObjectReference? _tabKeyModule;

--- a/src/EventLogExpert.UI/_Imports.razor
+++ b/src/EventLogExpert.UI/_Imports.razor
@@ -25,6 +25,7 @@
 @* UI (Razor component types) *@
 @using EventLogExpert.UI.Announcement
 @using EventLogExpert.UI.Banner
+@using EventLogExpert.UI.Common
 @using EventLogExpert.UI.Database
 @using EventLogExpert.UI.DetailsPane
 @using EventLogExpert.UI.FilterEditor

--- a/tests/Unit/EventLogExpert.UI.Tests/Common/ComponentIdParameterStabilityTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Common/ComponentIdParameterStabilityTests.cs
@@ -1,0 +1,38 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.UI.Common;
+using Microsoft.AspNetCore.Components;
+using System.Reflection;
+
+namespace EventLogExpert.UI.Tests.Common;
+
+public sealed class ComponentIdParameterStabilityTests
+{
+    [Fact]
+    public void NoBlazorComponentParameterIsTypedComponentId()
+    {
+        var assembly = typeof(ComponentId).Assembly;
+
+        Type?[] types;
+        try
+        {
+            types = assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            types = ex.Types;
+        }
+
+        var offenders = types
+            .Where(type => type is not null && typeof(ComponentBase).IsAssignableFrom(type))
+            .SelectMany(type => type!.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
+            .Where(property =>
+                property.GetCustomAttribute<ParameterAttribute>() is not null &&
+                (property.PropertyType == typeof(ComponentId) || property.PropertyType == typeof(ComponentId?)))
+            .Select(property => $"{property.DeclaringType!.Name}.{property.Name}")
+            .ToList();
+
+        Assert.Empty(offenders);
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/Common/ComponentIdTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Common/ComponentIdTests.cs
@@ -1,0 +1,132 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Runtime.FilterLibrary;
+using EventLogExpert.UI.Common;
+
+namespace EventLogExpert.UI.Tests.Common;
+
+public sealed class ComponentIdTests
+{
+    private static readonly Guid s_guid = Guid.Parse("0123456789abcdef0123456789abcdef");
+
+    [Fact]
+    public void Default_IsEmpty_ValueThrows_ToStringEmpty()
+    {
+        ComponentId id = default;
+
+        Assert.True(id.IsEmpty);
+        Assert.Equal(string.Empty, id.ToString());
+        Assert.Throws<InvalidOperationException>(() => id.Value);
+    }
+
+    [Fact]
+    public void For_EmptyFilterId_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => ComponentId.For(new FilterId(Guid.Empty), ComponentIdScope.PaneFilter));
+    }
+
+    [Fact]
+    public void For_EmptyLibraryEntryId_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => ComponentId.For(new LibraryEntryId(Guid.Empty)));
+    }
+
+    [Fact]
+    public void For_FilterId_FormatsScopedId()
+    {
+        var filterId = new FilterId(s_guid);
+
+        Assert.Equal("fp-0123456789abcdef0123456789abcdef", ComponentId.For(filterId, ComponentIdScope.PaneFilter).Value);
+        Assert.Equal("fp-pending-0123456789abcdef0123456789abcdef", ComponentId.For(filterId, ComponentIdScope.PanePendingFilter).Value);
+        Assert.Equal("lef-0123456789abcdef0123456789abcdef", ComponentId.For(filterId, ComponentIdScope.LibraryFilter).Value);
+        Assert.Equal("lef-pending-0123456789abcdef0123456789abcdef", ComponentId.For(filterId, ComponentIdScope.LibraryPendingFilter).Value);
+        Assert.Equal("sf-0123456789abcdef0123456789abcdef", ComponentId.For(filterId, ComponentIdScope.Predicate).Value);
+    }
+
+    [Fact]
+    public void For_LibraryEntryId_FormatsId()
+    {
+        Assert.Equal("le-0123456789abcdef0123456789abcdef", ComponentId.For(new LibraryEntryId(s_guid)).Value);
+    }
+
+    [Fact]
+    public void For_SameFilterId_DifferentScopes_ProduceDifferentIds()
+    {
+        var filterId = new FilterId(s_guid);
+
+        var pane = ComponentId.For(filterId, ComponentIdScope.PaneFilter).Value;
+        var library = ComponentId.For(filterId, ComponentIdScope.LibraryFilter).Value;
+
+        Assert.NotEqual(pane, library);
+    }
+
+    [Fact]
+    public void For_UnknownScope_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => ComponentId.For(new FilterId(s_guid), (ComponentIdScope)999));
+    }
+
+    [Fact]
+    public void NewUnique_ProducesDistinctValues()
+    {
+        var ids = Enumerable.Range(0, 1000).Select(_ => ComponentId.NewUnique().Value).ToHashSet();
+
+        Assert.Equal(1000, ids.Count);
+    }
+
+    [Fact]
+    public void NewUnique_StartsWithAlphabeticPrefix_AndIsValid()
+    {
+        var id = ComponentId.NewUnique().Value;
+
+        Assert.StartsWith("cid-", id);
+        Assert.True(char.IsAsciiLetter(id[0]));
+        Assert.DoesNotContain(' ', id);
+        Assert.Matches(ComponentId.ValidIdPattern, id);
+    }
+
+    [Fact]
+    public void Suffix_AppendsParts()
+    {
+        var id = ComponentId.For(new FilterId(s_guid), ComponentIdScope.PaneFilter)
+            .Suffix("main")
+            .Suffix("Comparison")
+            .Value;
+
+        Assert.Equal("fp-0123456789abcdef0123456789abcdef_main_Comparison", id);
+    }
+
+    [Fact]
+    public void Suffix_OnDefault_Throws()
+    {
+        ComponentId id = default;
+
+        Assert.Throws<InvalidOperationException>(() => id.Suffix("main"));
+    }
+
+    [Fact]
+    public void Suffix_WithEmptyPart_Throws()
+    {
+        var id = ComponentId.NewUnique();
+
+        Assert.Throws<ArgumentException>(() => id.Suffix(""));
+    }
+
+    [Fact]
+    public void Suffix_WithWhitespace_Throws()
+    {
+        var id = ComponentId.NewUnique();
+
+        Assert.Throws<ArgumentException>(() => id.Suffix("bad part"));
+    }
+
+    [Fact]
+    public void ToString_ReturnsValue()
+    {
+        var id = ComponentId.NewUnique();
+
+        Assert.Equal(id.Value, id.ToString());
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/Common/ComponentIdTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Common/ComponentIdTests.cs
@@ -87,6 +87,54 @@ public sealed class ComponentIdTests
         Assert.Matches(ComponentId.ValidIdPattern, id);
     }
 
+    [Theory]
+    [InlineData("1bad")]
+    [InlineData("bad space")]
+    [InlineData("")]
+    public void NewUnique_WithInvalidPrefix_Throws(string prefix)
+    {
+        Assert.Throws<ArgumentException>(() => ComponentId.NewUnique(prefix));
+    }
+
+    [Theory]
+    [InlineData("filter-row-toggle")]
+    [InlineData("filter-row-label")]
+    [InlineData("filter-edit-panel-color-desc")]
+    [InlineData("toggle-with-label-text")]
+    [InlineData("lefr")]
+    [InlineData("saved-new-row")]
+    [InlineData("saved-new-name")]
+    [InlineData("tag-mgmt")]
+    [InlineData("tag-overflow")]
+    [InlineData("tag-picker-listbox")]
+    [InlineData("select")]
+    [InlineData("prompt-modal-message")]
+    [InlineData("db-row-name")]
+    [InlineData("db-row-pending")]
+    [InlineData("manage-save-blocked")]
+    [InlineData("manage-upgrade-blocked")]
+    [InlineData("modal-inline-alert-message")]
+    [InlineData("modal-inline-alert-title")]
+    [InlineData("modal-inline-alert-validation")]
+    [InlineData("modal-title")]
+    public void NewUnique_WithMigrationPrefix_ProducesLetterFirstIdWithoutWhitespace(string prefix)
+    {
+        var id = ComponentId.NewUnique(prefix).Value;
+
+        Assert.True(char.IsAsciiLetter(id[0]));
+        Assert.DoesNotContain(id, character => char.IsWhiteSpace(character));
+        Assert.Matches(ComponentId.ValidIdPattern, id);
+    }
+
+    [Fact]
+    public void NewUnique_WithPrefix_PreservesPrefix()
+    {
+        var id = ComponentId.NewUnique("tag-mgmt").Value;
+
+        Assert.StartsWith("tag-mgmt-", id);
+        Assert.Matches(ComponentId.ValidIdPattern, id);
+    }
+
     [Fact]
     public void Suffix_AppendsParts()
     {

--- a/tests/Unit/EventLogExpert.UI.Tests/Common/ComponentIdTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Common/ComponentIdTests.cs
@@ -93,7 +93,9 @@ public sealed class ComponentIdTests
     [InlineData("")]
     public void NewUnique_WithInvalidPrefix_Throws(string prefix)
     {
-        Assert.Throws<ArgumentException>(() => ComponentId.NewUnique(prefix));
+        var ex = Assert.Throws<ArgumentException>(() => ComponentId.NewUnique(prefix));
+
+        Assert.Equal("prefix", ex.ParamName);
     }
 
     [Theory]
@@ -160,6 +162,16 @@ public sealed class ComponentIdTests
         var id = ComponentId.NewUnique();
 
         Assert.Throws<ArgumentException>(() => id.Suffix(""));
+    }
+
+    [Fact]
+    public void Suffix_WithInvalidCharacter_Throws()
+    {
+        var id = ComponentId.NewUnique();
+
+        var ex = Assert.Throws<ArgumentException>(() => id.Suffix("bad@part"));
+
+        Assert.Equal("part", ex.ParamName);
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterEditor/FilterPredicateEditorAccessibilityTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterEditor/FilterPredicateEditorAccessibilityTests.cs
@@ -1,0 +1,51 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using EventLogExpert.Filtering.Drafts;
+using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.UI.Common;
+using EventLogExpert.UI.FilterEditor.Comparison;
+using EventLogExpert.UI.FilterEditor.Editing;
+using Fluxor;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace EventLogExpert.UI.Tests.FilterEditor;
+
+public sealed class FilterPredicateEditorAccessibilityTests : BunitContext
+{
+    public FilterPredicateEditorAccessibilityTests()
+    {
+        var eventLogState = Substitute.For<IState<EventLogState>>();
+        eventLogState.Value.Returns(new EventLogState());
+        Services.AddSingleton(eventLogState);
+
+        Services.AddFluxor(options => options.ScanAssemblies(typeof(FilterComparisonEditor).Assembly));
+
+        JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    [Fact]
+    public void EditingPredicate_ComparisonLabels_UseValidScopedId_AndAriaLabelledByResolves()
+    {
+        var predicate = new FilterPredicateDraft();
+        var expectedId = ComponentId.For(predicate.Id, ComponentIdScope.Predicate).Value;
+        var comparisonLabelId = $"{expectedId}_Comparison";
+        var valueLabelId = $"{expectedId}_Value";
+
+        var component = Render<FilterPredicateEditor>(parameters => parameters
+            .Add(editor => editor.Value, predicate)
+            .Add(editor => editor.IsEditing, true));
+
+        Assert.Single(component.FindAll($"#{comparisonLabelId}"));
+        Assert.Single(component.FindAll($"#{valueLabelId}"));
+        Assert.NotEmpty(component.FindAll($"[aria-labelledby='{comparisonLabelId}']"));
+        Assert.NotEmpty(component.FindAll($"[aria-labelledby='{valueLabelId}']"));
+
+        foreach (var element in component.FindAll("[id]"))
+        {
+            Assert.DoesNotContain(' ', element.GetAttribute("id")!);
+        }
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterPane/FilterPaneTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterPane/FilterPaneTests.cs
@@ -378,6 +378,15 @@ public sealed class FilterPaneTests : BunitContext
         Assert.DoesNotContain(filter.Id, rowRefs.Keys);
     }
 
+    [Fact]
+    public void SaveAndClearButtons_WhenNoFilters_AreDisabled()
+    {
+        var component = Render<UI.FilterPane.FilterPane>();
+
+        Assert.True(component.Find("button[aria-label='Save as Filter Set']").HasAttribute("disabled"));
+        Assert.True(component.Find("button[aria-label='Clear All Filters']").HasAttribute("disabled"));
+    }
+
     private static LibraryEntryFilterSet BuildFilterSet(string name, ImmutableList<string>? tags = null) =>
         new()
         {


### PR DESCRIPTION
## Summary
Introduces ComponentId, an internal readonly record struct in EventLogExpert.UI.Common that constructs validated DOM-id strings, and routes every UI Guid.NewGuid()-based element-id site through it for consistent, letter-first, whitespace-free ids. string is kept at every Blazor [Parameter] boundary because ChangeDetection treats a custom struct parameter as changed on every render.

Stacked on the FilterRow Edit/Cancel fix.

## Changes
- Add ComponentId (factories NewUnique, For, Suffix) with constructor validation (`^[A-Za-z][A-Za-z0-9_-]*$`), plus the ComponentIdScope enum.
- Migrate all ~31 element-id sites across the filter editor, filter library, inputs, modal, database, and sidebar components to ComponentId.
- Fix a predicate aria-labelledby bug: the old `\$"sf-{Value.Id}"` interpolated a FilterId struct, producing an id containing spaces and braces; it now uses ComponentId.For(Value.Id, Predicate).
- Remove the dead LibraryEntryRow._tagsRegionId field.
- Give the FilterPane Save and Clear buttons a real disabled attribute (they previously carried only aria-disabled, so they appeared disabled but stayed focusable/clickable) and style the disabled state via :disabled.

## Tests
- ComponentIdTests (including a theory over all migration prefixes asserting letter-first, whitespace-free ids), ComponentIdParameterStabilityTests (reflection guard that no Blazor [Parameter] is typed ComponentId), and FilterPredicateEditorAccessibilityTests.
- A regression test asserts the FilterPane Save/Clear buttons are disabled when there are no filters.
- Full UI unit suite: 792 passing.