### PR TITLE
Add built-in scenario catalog, per-row highlight colors, and dev scenario export

### DIFF
--- a/src/EventLogExpert.Runtime/DependencyInjection/RuntimeServiceCollectionExtensions.cs
+++ b/src/EventLogExpert.Runtime/DependencyInjection/RuntimeServiceCollectionExtensions.cs
@@ -193,6 +193,7 @@ public static class RuntimeServiceCollectionExtensions
             services.AddSingleton<IChannelPresenceProbe, ChannelPresenceProbe>();
             services.AddSingleton<IScenarioQueryService, ScenarioQueryService>();
             services.AddSingleton<IScenarioLaunchService, ScenarioLaunchService>();
+            services.AddSingleton<IScenarioAuthoringService, ScenarioAuthoringService>();
 
             return services;
         }

--- a/src/EventLogExpert.Runtime/Scenarios/IScenarioAuthoringService.cs
+++ b/src/EventLogExpert.Runtime/Scenarios/IScenarioAuthoringService.cs
@@ -1,0 +1,18 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Scenarios.Catalog;
+
+namespace EventLogExpert.Runtime.Scenarios;
+
+/// <summary>Exports live Basic filter rows from the filter pane into scenario-catalog JSON (dev authoring aid).</summary>
+public interface IScenarioAuthoringService
+{
+    /// <summary>
+    ///     Resolves each saved filter to a Basic filter (directly, or by decomposing its expression) and exports the
+    ///     resolvable rows as one scenario, scoped to <paramref name="channels" />. Rows that cannot be expressed as a Basic
+    ///     filter are skipped and reported in the result's warnings.
+    /// </summary>
+    ScenarioExportResult ExportRows(IReadOnlyList<SavedFilter> rows, IReadOnlyList<string> channels);
+}

--- a/src/EventLogExpert.Runtime/Scenarios/ScenarioAuthoringOptions.cs
+++ b/src/EventLogExpert.Runtime/Scenarios/ScenarioAuthoringOptions.cs
@@ -1,0 +1,10 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Scenarios;
+
+/// <summary>
+///     Gates the dev-only scenario authoring / export UI. Enabled in DEBUG builds, or in RELEASE when the
+///     <c>/EnableScenarioAuthoring</c> command-line switch is passed (set in <c>MauiProgram</c>).
+/// </summary>
+public sealed record ScenarioAuthoringOptions(bool Enabled);

--- a/src/EventLogExpert.Runtime/Scenarios/ScenarioAuthoringService.cs
+++ b/src/EventLogExpert.Runtime/Scenarios/ScenarioAuthoringService.cs
@@ -1,0 +1,43 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Evaluation;
+using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Scenarios.Catalog;
+
+namespace EventLogExpert.Runtime.Scenarios;
+
+internal sealed class ScenarioAuthoringService : IScenarioAuthoringService
+{
+    public ScenarioExportResult ExportRows(IReadOnlyList<SavedFilter> rows, IReadOnlyList<string> channels)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+        ArgumentNullException.ThrowIfNull(channels);
+
+        var exportRows = new List<ScenarioExportRow>(rows.Count);
+        var skipped = 0;
+
+        foreach (var row in rows)
+        {
+            var basicFilter = row.BasicFilter
+                ?? SavedFilter.TryCreate(row.ComparisonText, mode: FilterMode.Basic)?.BasicFilter;
+
+            if (basicFilter is null)
+            {
+                skipped++;
+
+                continue;
+            }
+
+            exportRows.Add(new ScenarioExportRow(basicFilter, row.IsExcluded, row.Color));
+        }
+
+        var result = ScenarioExporter.Export(
+            exportRows,
+            new ScenarioExportMetadata(Id: null, Name: null, Purpose: null, Group: null, channels));
+
+        return skipped == 0
+            ? result
+            : result with { Warnings = result.Warnings.Add($"{skipped} row(s) skipped: not expressible as a Basic filter.") };
+    }
+}

--- a/src/EventLogExpert.Scenarios/Catalog/BuiltInScenarioRegistry.cs
+++ b/src/EventLogExpert.Scenarios/Catalog/BuiltInScenarioRegistry.cs
@@ -65,8 +65,13 @@ public sealed class BuiltInScenarioRegistry
                     $"Scenario '{scenario.Id}' has a filter row that could not be formatted; the catalog should reject it at load.");
             }
 
-            var saved = SavedFilter.TryCreate(comparisonText, row.Filter, isExcluded: row.IsExcluded, isEnabled: true, mode: FilterMode.Basic)
-                ?? throw new InvalidOperationException(
+            var saved = SavedFilter.TryCreate(comparisonText,
+                    row.Filter,
+                    color: row.Color,
+                    isExcluded: row.IsExcluded,
+                    isEnabled: true,
+                    mode: FilterMode.Basic) ??
+                throw new InvalidOperationException(
                     $"Scenario '{scenario.Id}' has a filter row '{comparisonText}' that could not be compiled; the catalog should reject it at load.");
 
             builder.Add(saved);

--- a/src/EventLogExpert.Scenarios/Catalog/ScenarioDefinition.cs
+++ b/src/EventLogExpert.Scenarios/Catalog/ScenarioDefinition.cs
@@ -18,8 +18,6 @@ public sealed record ScenarioDefinition
 
     public required ScenarioGroup Group { get; init; }
 
-    public ImmutableArray<string> Tags { get; init; } = [];
-
     /// <summary>Required channels; more than one denotes a combined scenario.</summary>
     public required ImmutableArray<string> Channels { get; init; }
 

--- a/src/EventLogExpert.Scenarios/Catalog/ScenarioExportMetadata.cs
+++ b/src/EventLogExpert.Scenarios/Catalog/ScenarioExportMetadata.cs
@@ -1,0 +1,15 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Scenarios.Catalog;
+
+/// <summary>Author-supplied scenario metadata for an export; null fields become editable TODO placeholders.</summary>
+public sealed record ScenarioExportMetadata(
+    string? Id,
+    string? Name,
+    string? Purpose,
+    ScenarioGroup? Group,
+    IReadOnlyList<string> Channels)
+{
+    public IReadOnlyList<string> Channels { get; init; } = Channels ?? throw new ArgumentNullException(nameof(Channels));
+}

--- a/src/EventLogExpert.Scenarios/Catalog/ScenarioExportResult.cs
+++ b/src/EventLogExpert.Scenarios/Catalog/ScenarioExportResult.cs
@@ -1,0 +1,8 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Collections.Immutable;
+
+namespace EventLogExpert.Scenarios.Catalog;
+
+public sealed record ScenarioExportResult(string Json, ImmutableList<string> Warnings, int EmittedRowCount);

--- a/src/EventLogExpert.Scenarios/Catalog/ScenarioExportRow.cs
+++ b/src/EventLogExpert.Scenarios/Catalog/ScenarioExportRow.cs
@@ -1,0 +1,13 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Basic;
+using EventLogExpert.Filtering.Persistence;
+
+namespace EventLogExpert.Scenarios.Catalog;
+
+/// <summary>One row to export: its Basic filter, exclusion flag, and highlight color.</summary>
+public sealed record ScenarioExportRow(BasicFilter Filter, bool IsExcluded, HighlightColor Color)
+{
+    public BasicFilter Filter { get; init; } = Filter ?? throw new ArgumentNullException(nameof(Filter));
+}

--- a/src/EventLogExpert.Scenarios/Catalog/ScenarioExporter.cs
+++ b/src/EventLogExpert.Scenarios/Catalog/ScenarioExporter.cs
@@ -1,0 +1,130 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Filtering.Basic;
+using EventLogExpert.Filtering.Common.Filtering;
+using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Scenarios.Serialization;
+using System.Collections.Immutable;
+using System.Text;
+using System.Text.Json;
+
+namespace EventLogExpert.Scenarios.Catalog;
+
+/// <summary>
+///     Inverts the catalog loader: turns live Basic filter rows into ready-to-edit scenario-catalog JSON. A developer
+///     authoring aid - the emitted skeleton uses TODO placeholders for unknown metadata, and the returned warnings surface
+///     any row that would not load (canonicalization, color, or scoping issues).
+/// </summary>
+public static class ScenarioExporter
+{
+    public const string NoLiveChannelsWarning =
+        "No live channels detected; the skeleton's channels[] is empty - fill it in before adding to the catalog.";
+
+    public static ScenarioExportResult Export(IReadOnlyList<ScenarioExportRow> rows, ScenarioExportMetadata metadata)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+        ArgumentNullException.ThrowIfNull(metadata);
+
+        var channels = metadata.Channels.ToList();
+        var requiresAdmin = channels.Any(LogChannelNames.AdminOnlyLiveChannels.Contains);
+        var rowDtos = rows.Select(ToRowDto).ToList();
+
+        var emit = new ScenarioDto
+        {
+            Id = metadata.Id ?? "TODO-scenario-id",
+            Name = metadata.Name ?? "TODO name",
+            Purpose = metadata.Purpose ?? "TODO purpose",
+            Group = metadata.Group?.ToString() ?? "TODO",
+            Channels = channels,
+            RequiresAdmin = requiresAdmin,
+            Priority = 0,
+            Order = 0,
+            Version = 1,
+            Filters = rowDtos
+        };
+
+        var json = JsonSerializer.Serialize(
+            new ScenarioFileDto { SchemaVersion = 1, Scenarios = [emit] },
+            ScenarioJsonContext.Default.ScenarioFileDto);
+
+        var warnings = ImmutableList.CreateBuilder<string>();
+        warnings.AddRange(SelfValidate(metadata, channels, requiresAdmin, rowDtos));
+
+        if (channels.Count == 0)
+        {
+            warnings.Add(NoLiveChannelsWarning);
+        }
+
+        return new ScenarioExportResult(json, warnings.ToImmutable(), rowDtos.Count);
+    }
+
+    /// <summary>
+    ///     Loads the emitted rows under VALID sentinel metadata (kebab id, real group, a non-empty channel set) so the
+    ///     loader's errors are about the ROWS - canonicalization, single-row color, excluded-row color, combined-channel
+    ///     LogName scoping - rather than the human-facing TODO placeholders.
+    /// </summary>
+    private static IReadOnlyList<string> SelfValidate(
+        ScenarioExportMetadata metadata,
+        List<string> channels,
+        bool requiresAdmin,
+        List<ScenarioFilterRowDto> rowDtos)
+    {
+        if (rowDtos.Count == 0) { return []; }
+
+        var validationChannels = channels.Count > 0 ? channels : ["Application"];
+
+        var validation = new ScenarioDto
+        {
+            Id = "todo-scenario-id",
+            Name = "TODO name",
+            Purpose = "TODO purpose",
+            Group = (metadata.Group ?? ScenarioGroup.SystemHealth).ToString(),
+            Channels = validationChannels,
+            RequiresAdmin = channels.Count > 0 && requiresAdmin,
+            Priority = 0,
+            Order = 0,
+            Version = 1,
+            Filters = rowDtos
+        };
+
+        var validationJson = JsonSerializer.Serialize(
+            new ScenarioFileDto { SchemaVersion = 1, Scenarios = [validation] },
+            ScenarioJsonContext.Default.ScenarioFileDto);
+
+        return ScenarioCatalogLoader.TryLoad([("export.json", Encoding.UTF8.GetBytes(validationJson))]).Errors;
+    }
+
+    private static ComparisonDto ToComparisonDto(FilterComparison comparison)
+    {
+        var isMany = comparison.MatchMode == MatchMode.Many;
+
+        return new ComparisonDto
+        {
+            Property = comparison.Property.ToString(),
+            Operator = isMany || comparison.Operator == ComparisonOperator.Equals ? null : comparison.Operator.ToString(),
+            MatchMode = isMany ? comparison.MatchMode.ToString() : null,
+            Value = isMany ? null : comparison.Value,
+            Values = isMany && comparison.Values.Count > 0 ? [.. comparison.Values] : null
+        };
+    }
+
+    private static ScenarioFilterRowDto ToRowDto(ScenarioExportRow row) =>
+        new()
+        {
+            Color = row.Color == HighlightColor.None ? null : row.Color.ToString(),
+            Comparison = ToComparisonDto(row.Filter.Comparison),
+            IsExcluded = row.IsExcluded ? true : null,
+            Predicates = row.Filter.Predicates.Count == 0
+                ? null
+                :
+                [
+                    .. row.Filter.Predicates.Select(predicate => new PredicateDto
+                    {
+                        Comparison = ToComparisonDto(predicate.Comparison),
+                        JoinWithAny = predicate.JoinWithAny
+                    })
+                ]
+        };
+}

--- a/src/EventLogExpert.Scenarios/Catalog/ScenarioFilterRow.cs
+++ b/src/EventLogExpert.Scenarios/Catalog/ScenarioFilterRow.cs
@@ -2,8 +2,12 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Filtering.Basic;
+using EventLogExpert.Filtering.Persistence;
 
 namespace EventLogExpert.Scenarios.Catalog;
 
 /// <summary>One row of a scenario's filter set; maps to one Basic <c>SavedFilter</c>.</summary>
-public sealed record ScenarioFilterRow(BasicFilter Filter, bool IsExcluded = false);
+public sealed record ScenarioFilterRow(
+    BasicFilter Filter,
+    bool IsExcluded = false,
+    HighlightColor Color = HighlightColor.None);

--- a/src/EventLogExpert.Scenarios/Catalog/ScenarioGroup.cs
+++ b/src/EventLogExpert.Scenarios/Catalog/ScenarioGroup.cs
@@ -13,6 +13,17 @@ public enum ScenarioGroup
     Network,
     Storage,
     UpdatesAndPolicy,
-    ServerRoles,
-    MicrosoftProducts
+    ActiveDirectory,
+    DnsServer,
+    DhcpServer,
+    NpsAndRras,
+    Wins,
+    WebAndIis,
+    VirtualizationAndClustering,
+    FilePrintAndStorage,
+    SqlServer,
+    Exchange,
+    SharePoint,
+    DefenderForEndpoint,
+    Office
 }

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/active-directory.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/active-directory.json
@@ -1,0 +1,312 @@
+{
+  "schemaVersion": 1,
+  "scenarios": [
+    {
+      "id": "ad-replication-failures",
+      "name": "AD replication failures",
+      "purpose": "Active Directory replication errors between domain controllers (NTDS Replication 1311, 1865, 1925, 1988, 2042, 2087, 2088).",
+      "group": "ActiveDirectory",
+      "channels": [ "Directory Service" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 0,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1311", "1865", "1925", "1988", "2042", "2087", "2088" ] }
+        }
+      ]
+    },
+    {
+      "id": "directory-service-errors",
+      "name": "Directory Service critical / errors",
+      "purpose": "All critical and error events from the Active Directory Directory Service.",
+      "group": "ActiveDirectory",
+      "channels": [ "Directory Service" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 1,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Level", "matchMode": "Many", "values": [ "Critical", "Error" ] } }
+      ]
+    },
+    {
+      "id": "dfsr-sysvol-failures",
+      "name": "DFSR SYSVOL failures",
+      "purpose": "DFS Replication failures affecting SYSVOL (DFS Replication 2213, 4012, 5002, 5008, 5014).",
+      "group": "ActiveDirectory",
+      "channels": [ "DFS Replication" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 2,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Id", "matchMode": "Many", "values": [ "2213", "4012", "5002", "5008", "5014" ] }
+        }
+      ]
+    },
+    {
+      "id": "netlogon-secure-channel-failures",
+      "name": "Netlogon secure-channel failures",
+      "purpose": "Domain secure-channel and trust failures reported by Netlogon (5719, 5722, 5723).",
+      "group": "ActiveDirectory",
+      "channels": [ "System" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 3,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Netlogon" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "5719", "5722", "5723" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "zerologon-vulnerable-netlogon",
+      "name": "Vulnerable Netlogon connections (ZeroLogon)",
+      "purpose": "Netlogon vulnerable secure-channel connections denied or allowed (5827, 5828, 5829); 5829 indicates CVE-2020-1472 exploitation risk.",
+      "group": "ActiveDirectory",
+      "channels": [ "System" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 4,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Netlogon" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "5827", "5828", "5829" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "kdc-kerberos-errors",
+      "name": "KDC / Kerberos encryption-type errors",
+      "purpose": "Key Distribution Center encryption-type errors (Kerberos-Key-Distribution-Center 16, 27).",
+      "group": "ActiveDirectory",
+      "channels": [ "System" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 5,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Microsoft-Windows-Kerberos-Key-Distribution-Center" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "16", "27" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "kdc-certificate-no-strong-mapping",
+      "name": "KDC certificate no strong mapping (PKINIT)",
+      "purpose": "The KDC issued a ticket from a certificate with no strong account mapping (39, 41); relates to CVE-2022-26923.",
+      "group": "ActiveDirectory",
+      "channels": [ "System" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 6,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Microsoft-Windows-Kerberos-Key-Distribution-Center" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "39", "41" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ldap-expensive-insecure-binds",
+      "name": "LDAP expensive / insecure binds",
+      "purpose": "Expensive and insecure (unsigned or cleartext) LDAP binds against the directory (1644, 2886, 2887, 2889).",
+      "group": "ActiveDirectory",
+      "channels": [ "Directory Service" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 7,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1644", "2886", "2887", "2889" ] } }
+      ]
+    },
+    {
+      "id": "adws-failures",
+      "name": "AD Web Services failures",
+      "purpose": "Active Directory Web Services errors that block PowerShell and tooling access (1202, 1206, 1401, or any error).",
+      "group": "ActiveDirectory",
+      "channels": [ "Active Directory Web Services" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 8,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1206", "1401" ] },
+          "predicates": [
+            { "joinWithAny": true, "comparison": { "property": "Level", "matchMode": "Many", "values": [ "Critical", "Error" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "adcs-enrollment-denied",
+      "name": "AD CS enrollment request denied",
+      "purpose": "The certification authority denied a certificate enrollment request (CertificationAuthority 53).",
+      "group": "ActiveDirectory",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 9,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Microsoft-Windows-CertificationAuthority" },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "53" } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "adcs-template-security-changes",
+      "name": "AD CS certificate-template security changes",
+      "purpose": "Certificate template load and update events that can introduce ESC-family vulnerabilities (4898, 4899).",
+      "group": "ActiveDirectory",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 10,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "4898", "4899" ] } }
+      ]
+    },
+    {
+      "id": "adfs-authentication-failures",
+      "name": "AD FS authentication failures",
+      "purpose": "AD FS token, credential, password-change, and sign-out failures (1201, 1203, 1205, 1207).",
+      "group": "ActiveDirectory",
+      "channels": [ "AD FS/Admin" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 11,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1201", "1203", "1205", "1207" ] } }
+      ]
+    },
+    {
+      "id": "ad-object-changes",
+      "name": "Active Directory object changes",
+      "purpose": "Directory object create, modify, and delete audit events (5136, 5137, 5141); requires Directory Service Changes auditing.",
+      "group": "ActiveDirectory",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 12,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "5136", "5137", "5141" ] } }
+      ]
+    },
+    {
+      "id": "domain-trust-changes",
+      "name": "Domain trust changes",
+      "purpose": "Domain and forest trust create, remove, and modify audit events (4706, 4707, 4716, 4865, 4866, 4867).",
+      "group": "ActiveDirectory",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 13,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "4706", "4707", "4716", "4865", "4866", "4867" ] } }
+      ]
+    },
+    {
+      "id": "kerberos-policy-change",
+      "name": "Kerberos policy change",
+      "purpose": "Kerberos policy modifications such as ticket lifetime and encryption types (4713).",
+      "group": "ActiveDirectory",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 14,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "4713" } }
+      ]
+    },
+    {
+      "id": "kerberos-preauth-failures",
+      "name": "Kerberos pre-authentication failures",
+      "purpose": "Kerberos pre-authentication failures that reveal password spraying and bad-password attacks (4771).",
+      "group": "ActiveDirectory",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 15,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "4771" } }
+      ]
+    },
+    {
+      "id": "ntlm-operational",
+      "name": "NTLM operational activity",
+      "purpose": "Legacy and blocked NTLM authentication events from the NTLM operational log (8001, 8002, 8003, 8004).",
+      "group": "ActiveDirectory",
+      "channels": [ "Microsoft-Windows-NTLM/Operational" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 16,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "8001", "8002", "8003", "8004" ] } }
+      ]
+    },
+    {
+      "id": "ntlmv1-downgrade",
+      "name": "NTLMv1 downgrade",
+      "purpose": "NTLMv1 negotiation reported by LsaSrv (6038, 6039); NTLMv1 hashes are weak and relayable.",
+      "group": "ActiveDirectory",
+      "channels": [ "System" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 17,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "LsaSrv" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "6038", "6039" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ntds-partition-backup-age",
+      "name": "NTDS partition backup age",
+      "purpose": "An AD partition has not been backed up within the tombstone lifetime (NTDS General 2089).",
+      "group": "ActiveDirectory",
+      "channels": [ "Directory Service" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 18,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Id", "value": "2089" }
+        }
+      ]
+    }
+  ]
+}

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/active-directory.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/active-directory.json
@@ -49,8 +49,8 @@
     },
     {
       "id": "netlogon-secure-channel-failures",
-      "name": "Netlogon secure-channel failures",
-      "purpose": "Domain secure-channel and trust failures reported by Netlogon (5719, 5722, 5723).",
+      "name": "Netlogon secure-channel timeline",
+      "purpose": "Color-coded Netlogon secure-channel health (System; Source Netlogon): healthy machine-account password change (5823), no domain controller available (5719), and session-setup / trust failures (5722, 5723).",
       "group": "ActiveDirectory",
       "channels": [ "System" ],
       "requiresAdmin": false,
@@ -58,12 +58,9 @@
       "order": 3,
       "version": 1,
       "filters": [
-        {
-          "comparison": { "property": "Source", "value": "Netlogon" },
-          "predicates": [
-            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "5719", "5722", "5723" ] } }
-          ]
-        }
+        { "color": "Blue", "comparison": { "property": "Source", "value": "Netlogon" }, "predicates": [ { "comparison": { "property": "Id", "value": "5823" } } ] },
+        { "color": "Orange", "comparison": { "property": "Source", "value": "Netlogon" }, "predicates": [ { "comparison": { "property": "Id", "value": "5719" } } ] },
+        { "color": "Red", "comparison": { "property": "Source", "value": "Netlogon" }, "predicates": [ { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "5722", "5723" ] } } ] }
       ]
     },
     {

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/applications.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/applications.json
@@ -1,0 +1,248 @@
+{
+  "schemaVersion": 1,
+  "scenarios": [
+    {
+      "id": "application-crashes",
+      "name": "Application crashes",
+      "purpose": "User-mode application faults reported by Windows Error Reporting (Application Error 1000).",
+      "group": "Applications",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 0,
+      "order": 0,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Application Error" },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "1000" } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "application-hangs",
+      "name": "Application hangs",
+      "purpose": "Applications that stopped responding (Application Hang 1002).",
+      "group": "Applications",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 0,
+      "order": 1,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Application Hang" },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "1002" } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "windows-error-reports",
+      "name": "Windows Error Reports (WER)",
+      "purpose": "Windows Error Reporting fault buckets (1001).",
+      "group": "Applications",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 2,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Windows Error Reporting" },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "1001" } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "faults-triage",
+      "name": "Faults triage (crash, hang, WER)",
+      "purpose": "Combined application crashes (1000), hangs (1002), and Windows Error Reports (1001).",
+      "group": "Applications",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 3,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Application Error" },
+          "predicates": [
+            { "joinWithAny": false, "comparison": { "property": "Id", "value": "1000" } },
+            { "joinWithAny": true, "comparison": { "property": "Source", "value": "Application Hang" } },
+            { "joinWithAny": false, "comparison": { "property": "Id", "value": "1002" } },
+            { "joinWithAny": true, "comparison": { "property": "Source", "value": "Windows Error Reporting" } },
+            { "joinWithAny": false, "comparison": { "property": "Id", "value": "1001" } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "dotnet-unhandled-exceptions",
+      "name": ".NET unhandled exceptions",
+      "purpose": "Unhandled managed exceptions from the .NET runtime (1026).",
+      "group": "Applications",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 0,
+      "order": 4,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": ".NET Runtime" },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "1026" } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "all-dotnet-runtime-errors",
+      "name": "All .NET Runtime errors",
+      "purpose": "Every error and critical event from the .NET runtime.",
+      "group": "Applications",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 5,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": ".NET Runtime" },
+          "predicates": [
+            { "comparison": { "property": "Level", "matchMode": "Many", "values": [ "Error", "Critical" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "all-application-errors-and-criticals",
+      "name": "All Application errors & criticals",
+      "purpose": "Catch-all for every error and critical event in the Application log.",
+      "group": "Applications",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 6,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Level", "matchMode": "Many", "values": [ "Error", "Critical" ] }
+        }
+      ]
+    },
+    {
+      "id": "msi-installation-failures",
+      "name": "MSI installation failures",
+      "purpose": "Windows Installer operation and service-start failures (MsiInstaller 11708, 11920).",
+      "group": "Applications",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 7,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "MsiInstaller" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "11708", "11920" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "msi-all-activity",
+      "name": "MSI all activity",
+      "purpose": "Every Windows Installer event for install and patch auditing.",
+      "group": "Applications",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 8,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "MsiInstaller" }
+        }
+      ]
+    },
+    {
+      "id": "msix-appx-deployment-failures",
+      "name": "MSIX / AppX deployment failures",
+      "purpose": "Modern app package deployment failures (AppXDeploymentServer 404, 409, 465, 602).",
+      "group": "Applications",
+      "channels": [ "Microsoft-Windows-AppXDeploymentServer/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 9,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Id", "matchMode": "Many", "values": [ "404", "409", "465", "602" ] },
+          "predicates": [
+            { "comparison": { "property": "Level", "matchMode": "Many", "values": [ "Error", "Critical" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "appmodel-runtime-errors",
+      "name": "AppModel runtime errors",
+      "purpose": "Packaged-app runtime errors and criticals from the AppModel runtime.",
+      "group": "Applications",
+      "channels": [ "Microsoft-Windows-AppModel-Runtime/Admin" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 10,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Level", "matchMode": "Many", "values": [ "Error", "Critical" ] }
+        }
+      ]
+    },
+    {
+      "id": "dcom-permission-errors",
+      "name": "DCOM permission errors",
+      "purpose": "DistributedCOM launch and activation permission errors (10016).",
+      "group": "Applications",
+      "channels": [ "System" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 11,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Microsoft-Windows-DistributedCOM" },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "10016" } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "user-profile-load-issues",
+      "name": "User profile load issues",
+      "purpose": "Roaming and local user profile load failures (User Profiles Service 1500, 1511, 1515, 1530, 1542).",
+      "group": "Applications",
+      "channels": [ "Application" ],
+      "optionalChannels": [ "Microsoft-Windows-User Profile Service/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 12,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "operator": "Contains", "value": "User Profile" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1500", "1511", "1515", "1530", "1542" ] } }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/defender-for-endpoint.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/defender-for-endpoint.json
@@ -1,0 +1,178 @@
+{
+  "schemaVersion": 1,
+  "scenarios": [
+    {
+      "id": "mde-sensor-health",
+      "name": "MDE sensor onboarding / health failures",
+      "purpose": "Microsoft Defender for Endpoint sensor onboarding and health failures (SENSE).",
+      "group": "DefenderForEndpoint",
+      "channels": [ "Microsoft-Windows-SENSE/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 0,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Id", "matchMode": "Many", "values": [ "3", "5", "6", "7", "9", "10", "12", "15", "17", "25", "26", "27", "28", "30", "34" ] },
+          "predicates": [
+            { "joinWithAny": true, "comparison": { "property": "Level", "matchMode": "Many", "values": [ "Error", "Warning" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "mde-sensor-onboard-offboard",
+      "name": "MDE sensor onboard / offboard",
+      "purpose": "Defender for Endpoint sensor onboarding and offboarding completion events (SENSE 11, 44).",
+      "group": "DefenderForEndpoint",
+      "channels": [ "Microsoft-Windows-SENSE/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 1,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "11", "44" ] } }
+      ]
+    },
+    {
+      "id": "mde-auto-investigation-errors",
+      "name": "MDE automated investigation errors",
+      "purpose": "Defender for Endpoint automated investigation (SenseIR) errors and warnings.",
+      "group": "DefenderForEndpoint",
+      "channels": [ "Microsoft-Windows-SenseIR/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 2,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Level", "matchMode": "Many", "values": [ "Error", "Warning" ] } }
+      ]
+    },
+    {
+      "id": "defender-realtime-protection",
+      "name": "Defender real-time protection failure & recovery",
+      "purpose": "Microsoft Defender real-time protection failed or recovered (3002, 3007).",
+      "group": "DefenderForEndpoint",
+      "channels": [ "Microsoft-Windows-Windows Defender/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 3,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "3002", "3007" ] } }
+      ]
+    },
+    {
+      "id": "defender-signature-update-health",
+      "name": "Defender signature update health",
+      "purpose": "Defender security-intelligence update success and failure (2000, 2001).",
+      "group": "DefenderForEndpoint",
+      "channels": [ "Microsoft-Windows-Windows Defender/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 4,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "2000", "2001" ] } }
+      ]
+    },
+    {
+      "id": "defender-engine-platform-update",
+      "name": "Defender engine & platform update health",
+      "purpose": "Defender engine and platform update success and failure (2002, 2003, 2006).",
+      "group": "DefenderForEndpoint",
+      "channels": [ "Microsoft-Windows-Windows Defender/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 5,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "2002", "2003", "2006" ] } }
+      ]
+    },
+    {
+      "id": "defender-definition-reversion",
+      "name": "Defender definition load failure",
+      "purpose": "Defender failed to load definitions and reverted to the last-known-good set (2004).",
+      "group": "DefenderForEndpoint",
+      "channels": [ "Microsoft-Windows-Windows Defender/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 6,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "2004" } }
+      ]
+    },
+    {
+      "id": "defender-engine-crash",
+      "name": "Defender engine crash or hang",
+      "purpose": "The Defender antimalware engine terminated unexpectedly (5008).",
+      "group": "DefenderForEndpoint",
+      "channels": [ "Microsoft-Windows-Windows Defender/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 7,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "5008" } }
+      ]
+    },
+    {
+      "id": "defender-tamper-protection-block",
+      "name": "Defender tamper protection block",
+      "purpose": "Tamper protection blocked a change to Microsoft Defender Antivirus (5013); an evasion attempt.",
+      "group": "DefenderForEndpoint",
+      "channels": [ "Microsoft-Windows-Windows Defender/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 8,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "5013" } }
+      ]
+    },
+    {
+      "id": "defender-platform-expiry",
+      "name": "Defender platform expiry",
+      "purpose": "The Defender platform entered its grace period or expired, disabling protection (5100, 5101).",
+      "group": "DefenderForEndpoint",
+      "channels": [ "Microsoft-Windows-Windows Defender/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 9,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "5100", "5101" ] } }
+      ]
+    },
+    {
+      "id": "defender-scan-lifecycle",
+      "name": "Defender scan lifecycle",
+      "purpose": "Defender antimalware scan started, completed, and cancelled events (1000, 1001, 1002).",
+      "group": "DefenderForEndpoint",
+      "channels": [ "Microsoft-Windows-Windows Defender/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 10,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1000", "1001", "1002" ] } }
+      ]
+    },
+    {
+      "id": "defender-controlled-folder-access",
+      "name": "Defender Controlled Folder Access block",
+      "purpose": "Controlled Folder Access blocked an untrusted process from modifying protected disk sectors (1127).",
+      "group": "DefenderForEndpoint",
+      "channels": [ "Microsoft-Windows-Windows Defender/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 11,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "1127" } }
+      ]
+    }
+  ]
+}

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/defender-for-endpoint.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/defender-for-endpoint.json
@@ -173,6 +173,24 @@
       "filters": [
         { "comparison": { "property": "Id", "value": "1127" } }
       ]
+    },
+    {
+      "id": "defender-protection-timeline",
+      "name": "Defender protection status",
+      "purpose": "Color-coded Microsoft Defender Antivirus operational status: healthy activity (real-time protection on 5000, scan complete 1001, threat remediated 1117, signatures updated 2000); scan/config activity (scan started 1000, configuration changed 5007); warnings (scan cancelled 1002, signature update failed 2001); threats and protection-off (malware detected 1116, real-time protection disabled 5001); and remediation failures (1118, 1119).",
+      "group": "DefenderForEndpoint",
+      "channels": [ "Microsoft-Windows-Windows Defender/Operational" ],
+      "requiresAdmin": false,
+      "priority": 0,
+      "order": 12,
+      "version": 1,
+      "filters": [
+        { "color": "Green", "comparison": { "property": "Id", "matchMode": "Many", "values": [ "5000", "1001", "1117", "2000" ] } },
+        { "color": "Blue", "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1000", "5007" ] } },
+        { "color": "Orange", "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1002", "2001" ] } },
+        { "color": "Red", "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1116", "5001" ] } },
+        { "color": "DarkRed", "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1118", "1119" ] } }
+      ]
     }
   ]
 }

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/dhcp-server.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/dhcp-server.json
@@ -1,0 +1,89 @@
+{
+  "schemaVersion": 1,
+  "scenarios": [
+    {
+      "id": "dhcp-authorization-failures",
+      "name": "DHCP authorization failures (rogue server)",
+      "purpose": "DHCP service determined not authorized in Active Directory (1045, 1046, 1051); blocks lease issuance.",
+      "group": "DhcpServer",
+      "channels": [ "DhcpAdminEvents" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 0,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1045", "1046", "1051" ] } }
+      ]
+    },
+    {
+      "id": "dhcp-service-startup-failures",
+      "name": "DHCP service startup failures",
+      "purpose": "Fatal DHCP service initialization failures (1001, 1002, 1004, 1006, 1008).",
+      "group": "DhcpServer",
+      "channels": [ "DhcpAdminEvents" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 1,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1001", "1002", "1004", "1006", "1008" ] } }
+      ]
+    },
+    {
+      "id": "dhcp-callout-dll-injection",
+      "name": "DHCP callout DLL injection",
+      "purpose": "DHCP callout DLL load and fault events that can signal a persistence vector (1031, 1032, 1033, 1034).",
+      "group": "DhcpServer",
+      "channels": [ "DhcpAdminEvents" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 2,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1031", "1032", "1033", "1034" ] } }
+      ]
+    },
+    {
+      "id": "dhcp-scope-lifecycle",
+      "name": "DHCP scope lifecycle changes",
+      "purpose": "DHCP scope configured, modified, deleted, activated, and deactivated (70-74).",
+      "group": "DhcpServer",
+      "channels": [ "Microsoft-Windows-Dhcp-Server/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 3,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "70", "71", "72", "73", "74" ] } }
+      ]
+    },
+    {
+      "id": "dhcp-reservation-changes",
+      "name": "DHCP reservation add / remove",
+      "purpose": "Static DHCP reservation creation and deletion (106, 107).",
+      "group": "DhcpServer",
+      "channels": [ "Microsoft-Windows-Dhcp-Server/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 4,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "106", "107" ] } }
+      ]
+    },
+    {
+      "id": "dhcp-failover-partner-lost",
+      "name": "DHCP failover partner lost",
+      "purpose": "DHCP failover partner time-sync and connectivity loss (20253, 20254, 20255).",
+      "group": "DhcpServer",
+      "channels": [ "Microsoft-Windows-Dhcp-Server/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 5,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "20253", "20254", "20255" ] } }
+      ]
+    }
+  ]
+}

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/dns-server.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/dns-server.json
@@ -1,0 +1,122 @@
+{
+  "schemaVersion": 1,
+  "scenarios": [
+    {
+      "id": "dns-server-errors-zone-health",
+      "name": "DNS Server errors & zone health",
+      "purpose": "DNS Server errors and warnings plus key zone-health events (4004, 4015, 4016, 6522, 6702).",
+      "group": "DnsServer",
+      "channels": [ "DNS Server" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 0,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Level", "matchMode": "Many", "values": [ "Error", "Warning" ] },
+          "predicates": [
+            { "joinWithAny": true, "comparison": { "property": "Id", "matchMode": "Many", "values": [ "4004", "4015", "4016", "6522", "6702" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "dns-server-plugin-dll-load",
+      "name": "DNS Server plugin DLL load",
+      "purpose": "DNS server-level plugin DLL load events (150, 770, 771); the mechanism of the DnsAdmins-to-DC escalation.",
+      "group": "DnsServer",
+      "channels": [ "DNS Server" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 1,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "150", "770", "771" ] } }
+      ]
+    },
+    {
+      "id": "dns-unauthorized-zone-transfer",
+      "name": "DNS unauthorized zone transfer",
+      "purpose": "Zone-transfer requests for non-authoritative zones (6004); a reconnaissance signal.",
+      "group": "DnsServer",
+      "channels": [ "DNS Server" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 2,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "6004" } }
+      ]
+    },
+    {
+      "id": "dns-zone-record-changes-audit",
+      "name": "DNS zone & record changes (audit)",
+      "purpose": "DNS zone and resource-record change auditing (513-523).",
+      "group": "DnsServer",
+      "channels": [ "Microsoft-Windows-DNS-Server/Audit" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 3,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "513", "514", "515", "516", "517", "518", "519", "520", "521", "522", "523" ] } }
+      ]
+    },
+    {
+      "id": "dns-server-config-changes-audit",
+      "name": "DNS server config changes (audit)",
+      "purpose": "DNS server-level configuration changes such as forwarders, root hints, and scopes (537, 540-543, 548, 557).",
+      "group": "DnsServer",
+      "channels": [ "Microsoft-Windows-DNS-Server/Audit" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 4,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "537", "540", "541", "542", "543", "548", "557" ] } }
+      ]
+    },
+    {
+      "id": "dnssec-signing-key-rollover",
+      "name": "DNSSEC signing & key rollover",
+      "purpose": "DNSSEC zone sign, unsign, re-sign, and key rollover events (525-531, 533).",
+      "group": "DnsServer",
+      "channels": [ "Microsoft-Windows-DNS-Server/Audit" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 5,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "525", "526", "527", "528", "529", "530", "531", "533" ] } }
+      ]
+    },
+    {
+      "id": "dns-response-policy-changes",
+      "name": "DNS response-policy & client-subnet changes",
+      "purpose": "DNS policy and client-subnet record changes that can redirect resolution (574-582).",
+      "group": "DnsServer",
+      "channels": [ "Microsoft-Windows-DNS-Server/Audit" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 6,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "574", "575", "576", "577", "578", "579", "580", "581", "582" ] } }
+      ]
+    },
+    {
+      "id": "dns-analytic-query-failures",
+      "name": "DNS analytic query failures",
+      "purpose": "Query-level DNS resolution failures from the Analytical log when it is enabled (258, 259, 262).",
+      "group": "DnsServer",
+      "channels": [ "Microsoft-Windows-DNS-Server/Analytical" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 7,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Level", "value": "Error" } }
+      ]
+    }
+  ]
+}

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/dns-server.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/dns-server.json
@@ -117,6 +117,22 @@
       "filters": [
         { "comparison": { "property": "Level", "value": "Error" } }
       ]
+    },
+    {
+      "id": "dns-zone-transfer-and-errors",
+      "name": "DNS zone transfer & server errors",
+      "purpose": "Color-coded DNS Server activity: zone transfer completed (6001, 6002), an inbound zone-transfer request to watch (6004), and server errors (plug-in 150, socket 408, AD integration 4015).",
+      "group": "DnsServer",
+      "channels": [ "DNS Server" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 8,
+      "version": 1,
+      "filters": [
+        { "color": "Green", "comparison": { "property": "Id", "matchMode": "Many", "values": [ "6001", "6002" ] } },
+        { "color": "Orange", "comparison": { "property": "Id", "value": "6004" } },
+        { "color": "Red", "comparison": { "property": "Id", "matchMode": "Many", "values": [ "150", "408", "4015" ] } }
+      ]
     }
   ]
 }

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/exchange.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/exchange.json
@@ -1,0 +1,119 @@
+{
+  "schemaVersion": 1,
+  "scenarios": [
+    {
+      "id": "exchange-transport-backpressure",
+      "name": "Exchange transport back-pressure & mail-flow",
+      "purpose": "Exchange transport resource pressure and mail-flow events (MSExchangeTransport 1009, 15004, 15006, 15007).",
+      "group": "Exchange",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 0,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "MSExchangeTransport" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1009", "15004", "15006", "15007" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "exchange-frontend-tls-certificate",
+      "name": "Exchange front-end TLS certificate missing",
+      "purpose": "Exchange Front End Transport could not find its configured TLS certificate, breaking STARTTLS mail flow (MSExchangeFrontEndTransport 12014).",
+      "group": "Exchange",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 1,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "MSExchangeFrontEndTransport" },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "12014" } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "exchange-store-mount-failures",
+      "name": "Exchange store / database mount failures",
+      "purpose": "Exchange information store and database mount failures (MSExchangeIS 9518, 9519, 9646).",
+      "group": "Exchange",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 2,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "MSExchangeIS" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "9518", "9519" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "exchange-dag-replication",
+      "name": "Exchange DAG replication health",
+      "purpose": "Exchange Database Availability Group replication health events (MSExchangeRepl 2153, 4074, 4099, 4113).",
+      "group": "Exchange",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 3,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "MSExchangeRepl" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "2153", "4074", "4099", "4113" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "exchange-adaccess-failures",
+      "name": "Exchange ADAccess (topology) failures",
+      "purpose": "Exchange Active Directory topology and access failures (MSExchange ADAccess 2080, 2102, 2114).",
+      "group": "Exchange",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 4,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "MSExchange ADAccess" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "2102", "2114" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "exchange-all-component-errors",
+      "name": "Exchange all-component errors",
+      "purpose": "Every error and critical event from any Exchange component (noisy catch-all).",
+      "group": "Exchange",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 5,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "operator": "Contains", "value": "MSExchange" },
+          "predicates": [
+            { "comparison": { "property": "Level", "matchMode": "Many", "values": [ "Error", "Critical" ] } }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/exchange.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/exchange.json
@@ -3,8 +3,8 @@
   "scenarios": [
     {
       "id": "exchange-transport-backpressure",
-      "name": "Exchange transport back-pressure & mail-flow",
-      "purpose": "Exchange transport resource pressure and mail-flow events (MSExchangeTransport 1009, 15004, 15006, 15007).",
+      "name": "Exchange transport back-pressure",
+      "purpose": "Color-coded Exchange transport resource pressure (Application; Source MSExchangeTransport): pressure increased (15004), rejecting message submissions (15006, 15007), and a receive connector rejecting connections at its limit (1009).",
       "group": "Exchange",
       "channels": [ "Application" ],
       "requiresAdmin": false,
@@ -12,12 +12,9 @@
       "order": 0,
       "version": 1,
       "filters": [
-        {
-          "comparison": { "property": "Source", "value": "MSExchangeTransport" },
-          "predicates": [
-            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1009", "15004", "15006", "15007" ] } }
-          ]
-        }
+        { "color": "Yellow", "comparison": { "property": "Source", "value": "MSExchangeTransport" }, "predicates": [ { "comparison": { "property": "Id", "value": "15004" } } ] },
+        { "color": "Red", "comparison": { "property": "Source", "value": "MSExchangeTransport" }, "predicates": [ { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "15006", "15007" ] } } ] },
+        { "color": "Orange", "comparison": { "property": "Source", "value": "MSExchangeTransport" }, "predicates": [ { "comparison": { "property": "Id", "value": "1009" } } ] }
       ]
     },
     {

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/file-print-and-storage.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/file-print-and-storage.json
@@ -243,6 +243,22 @@
       "filters": [
         { "comparison": { "property": "Level", "matchMode": "Many", "values": [ "Critical", "Error" ] } }
       ]
+    },
+    {
+      "id": "file-share-lifecycle",
+      "name": "File share lifecycle",
+      "purpose": "Color-coded network file-share changes (Security audit): share added (5142), share modified (5143), and share deleted (5144). Requires the File Share audit subcategory.",
+      "group": "FilePrintAndStorage",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 20,
+      "version": 1,
+      "filters": [
+        { "color": "Green", "comparison": { "property": "Id", "value": "5142" } },
+        { "color": "Blue", "comparison": { "property": "Id", "value": "5143" } },
+        { "color": "Red", "comparison": { "property": "Id", "value": "5144" } }
+      ]
     }
   ]
 }

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/file-print-and-storage.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/file-print-and-storage.json
@@ -1,0 +1,248 @@
+{
+  "schemaVersion": 1,
+  "scenarios": [
+    {
+      "id": "print-spooler-failures",
+      "name": "Print spooler & job failures",
+      "purpose": "Print spooler and print-job failures (PrintService 372, 808).",
+      "group": "FilePrintAndStorage",
+      "channels": [ "Microsoft-Windows-PrintService/Admin" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 0,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "372", "808" ] } }
+      ]
+    },
+    {
+      "id": "print-document-audit",
+      "name": "Print job audit (document printed)",
+      "purpose": "Document-printed audit events with user, printer, and document detail (PrintService 307).",
+      "group": "FilePrintAndStorage",
+      "channels": [ "Microsoft-Windows-PrintService/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 1,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "307" } }
+      ]
+    },
+    {
+      "id": "printer-share-changes",
+      "name": "Printer share created / removed",
+      "purpose": "Printer share creation and removal for print-server change auditing (PrintService 848, 849).",
+      "group": "FilePrintAndStorage",
+      "channels": [ "Microsoft-Windows-PrintService/Admin" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 2,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "848", "849" ] } }
+      ]
+    },
+    {
+      "id": "printer-driver-installation",
+      "name": "Printer driver installation",
+      "purpose": "A printer driver was added (PrintService 316); relevant to PrintNightmare-style abuse.",
+      "group": "FilePrintAndStorage",
+      "channels": [ "Microsoft-Windows-PrintService/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 3,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "316" } }
+      ]
+    },
+    {
+      "id": "fsrm-quota-file-screen",
+      "name": "FSRM quota & file-screen events",
+      "purpose": "File Server Resource Manager quota and file-screen activity (SrmSvc).",
+      "group": "FilePrintAndStorage",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 4,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Source", "value": "SrmSvc" } }
+      ]
+    },
+    {
+      "id": "windows-server-backup-failures",
+      "name": "Windows Server Backup failures",
+      "purpose": "Windows Server Backup job failures (Backup 8, 9, 19, 49, 517, 521, 561).",
+      "group": "FilePrintAndStorage",
+      "channels": [ "Microsoft-Windows-Backup" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 5,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "8", "9", "19", "49", "517", "521", "561" ] } }
+      ]
+    },
+    {
+      "id": "iscsi-connection-drops",
+      "name": "iSCSI connection drops & latency",
+      "purpose": "iSCSI initiator connection drops and latency events (iScsiPrt 7, 9, 20, 39, 129).",
+      "group": "FilePrintAndStorage",
+      "channels": [ "System" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 6,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "iScsiPrt" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "7", "9", "20", "39", "129" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "dfs-namespace-health",
+      "name": "DFS namespace health & referrals",
+      "purpose": "DFS Namespace service health and referral problems (DfsSvc).",
+      "group": "FilePrintAndStorage",
+      "channels": [ "System" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 7,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Source", "value": "DfsSvc" } }
+      ]
+    },
+    {
+      "id": "data-deduplication-failures",
+      "name": "Data deduplication failures",
+      "purpose": "Data Deduplication errors and warnings, including job and integrity failures.",
+      "group": "FilePrintAndStorage",
+      "channels": [ "Microsoft-Windows-Deduplication/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 8,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Level", "matchMode": "Many", "values": [ "Error", "Warning" ] } }
+      ]
+    },
+    {
+      "id": "smb1-protocol-negotiated",
+      "name": "SMB1 protocol negotiated",
+      "purpose": "A client negotiated the deprecated SMB1 protocol with this server (SMBServer 3000).",
+      "group": "FilePrintAndStorage",
+      "channels": [ "Microsoft-Windows-SMBServer/Operational" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 9,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "3000" } }
+      ]
+    },
+    {
+      "id": "smb-server-security-events",
+      "name": "SMB server security posture",
+      "purpose": "SMB server unencrypted-access rejection, preauth integrity failure, anonymous access denied, and SMB2/3-disabled events (1003, 1005, 1009, 1024).",
+      "group": "FilePrintAndStorage",
+      "channels": [ "Microsoft-Windows-SMBServer/Operational" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 10,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1003", "1005", "1009", "1024" ] } }
+      ]
+    },
+    {
+      "id": "smb-anonymous-access-denied",
+      "name": "SMB anonymous share access denied",
+      "purpose": "The server refused anonymous (null-session) access to a share (SMBServer 1007).",
+      "group": "FilePrintAndStorage",
+      "channels": [ "Microsoft-Windows-SMBServer/Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 11,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "1007" } }
+      ]
+    },
+    {
+      "id": "storage-replica-errors",
+      "name": "Storage Replica errors",
+      "purpose": "Storage Replica replication errors and warnings (StorageReplica Admin, including 4004 and 5014).",
+      "group": "FilePrintAndStorage",
+      "channels": [ "Microsoft-Windows-StorageReplica/Admin" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 12,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Level", "matchMode": "Many", "values": [ "Error", "Warning" ] } }
+      ]
+    },
+    {
+      "id": "file-share-changes-audit",
+      "name": "File share created / modified / deleted (audit)",
+      "purpose": "Network share lifecycle audit events (5142, 5143, 5144); requires File Share auditing.",
+      "group": "FilePrintAndStorage",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 13,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "5142", "5143", "5144" ] } }
+      ]
+    },
+    {
+      "id": "file-share-access-audit",
+      "name": "File share session access (audit)",
+      "purpose": "Network share first-access-per-session audit events (5140); requires File Share auditing.",
+      "group": "FilePrintAndStorage",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 14,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "5140" } }
+      ]
+    },
+    {
+      "id": "work-folders-server-errors",
+      "name": "Work Folders server sync errors",
+      "purpose": "Work Folders (SyncShare) server-side sync errors and warnings.",
+      "group": "FilePrintAndStorage",
+      "channels": [ "Microsoft-Windows-SyncShare/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 15,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Level", "matchMode": "Many", "values": [ "Error", "Warning" ] } }
+      ]
+    },
+    {
+      "id": "storage-migration-failures",
+      "name": "Storage Migration Service failures",
+      "purpose": "Storage Migration Service orchestrator errors during inventory, transfer, and cutover.",
+      "group": "FilePrintAndStorage",
+      "channels": [ "Microsoft-Windows-StorageMigrationService/Admin" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 16,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Level", "matchMode": "Many", "values": [ "Critical", "Error" ] } }
+      ]
+    }
+  ]
+}

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/network.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/network.json
@@ -1,0 +1,158 @@
+{
+  "schemaVersion": 1,
+  "scenarios": [
+    {
+      "id": "dns-resolution-timeouts",
+      "name": "DNS resolution timeouts",
+      "purpose": "DNS client resolution timeouts and failures (DNS-Client 1013, 1014, 1015).",
+      "group": "Network",
+      "channels": [ "Microsoft-Windows-DNS-Client/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 0,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1013", "1014", "1015" ] },
+          "predicates": [
+            { "comparison": { "property": "Level", "matchMode": "Many", "values": [ "Warning", "Error", "Critical" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "dns-dynamic-registration-failures",
+      "name": "DNS dynamic registration failures",
+      "purpose": "Failures registering this host's records in DNS (DNS-Client 8003, 8004, 8015, 8018, 8021, 8022, 8023).",
+      "group": "Network",
+      "channels": [ "Microsoft-Windows-DNS-Client/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 1,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Id", "matchMode": "Many", "values": [ "8003", "8004", "8015", "8018", "8021", "8022", "8023" ] }
+        }
+      ]
+    },
+    {
+      "id": "dhcp-lease-failures-apipa",
+      "name": "DHCP lease failures / APIPA",
+      "purpose": "DHCP client lease acquisition failures and APIPA fallback (Dhcp-Client 1000-1008).",
+      "group": "Network",
+      "channels": [ "Microsoft-Windows-Dhcp-Client/Admin" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 2,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1000", "1001", "1002", "1003", "1006", "1007", "1008" ] }
+        }
+      ]
+    },
+    {
+      "id": "duplicate-ip-address-conflict",
+      "name": "Duplicate IP / address conflict",
+      "purpose": "IP address conflicts reported by TCP/IP (Tcpip / NetBT 4198, 4199) or the DHCP client (1005).",
+      "group": "Network",
+      "channels": [ "System" ],
+      "optionalChannels": [ "Microsoft-Windows-Dhcp-Client/Admin" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 3,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "matchMode": "Many", "values": [ "Tcpip", "NetBT" ] },
+          "predicates": [
+            { "joinWithAny": false, "comparison": { "property": "Id", "matchMode": "Many", "values": [ "4198", "4199" ] } },
+            { "joinWithAny": true, "comparison": { "property": "Source", "value": "Microsoft-Windows-Dhcp-Client" } },
+            { "joinWithAny": false, "comparison": { "property": "Id", "value": "1005" } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "firewall-rule-policy-changes",
+      "name": "Firewall rule / policy changes",
+      "purpose": "Windows Firewall rule and policy add/modify/delete events for change auditing.",
+      "group": "Network",
+      "channels": [ "Microsoft-Windows-Windows Firewall With Advanced Security/Firewall" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 4,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Id", "matchMode": "Many", "values": [ "2002", "2003", "2004", "2005", "2006", "2052", "2071", "2073", "2082", "2083", "2097" ] }
+        }
+      ]
+    },
+    {
+      "id": "firewall-blocked-app-hints",
+      "name": "Firewall blocked-app hints",
+      "purpose": "Applications whose listening sockets were blocked by Windows Firewall (2011).",
+      "group": "Network",
+      "channels": [ "Microsoft-Windows-Windows Firewall With Advanced Security/Firewall" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 5,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Id", "value": "2011" }
+        }
+      ]
+    },
+    {
+      "id": "smb-client-connectivity-failures",
+      "name": "SMB client connectivity failures",
+      "purpose": "SMB client share-access and connectivity failures (SMBClient 30702, 30800, 30803-30816).",
+      "group": "Network",
+      "channels": [ "Microsoft-Windows-SMBClient/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 6,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Id", "matchMode": "Many", "values": [ "30702", "30800", "30803", "30804", "30805", "30807", "30816" ] }
+        }
+      ]
+    },
+    {
+      "id": "wifi-connect-disconnect-auth",
+      "name": "Wi-Fi connect / disconnect / auth",
+      "purpose": "Wireless association, disconnect, and authentication events (WLAN-AutoConfig).",
+      "group": "Network",
+      "channels": [ "Microsoft-Windows-WLAN-AutoConfig/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 7,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Id", "matchMode": "Many", "values": [ "8000", "8001", "8002", "8003", "11000", "11001", "11002", "12011", "12012", "12013" ] }
+        }
+      ]
+    },
+    {
+      "id": "network-location-profile-changes",
+      "name": "Network location / profile changes",
+      "purpose": "Network profile category changes between public, private, and domain (NetworkProfile 10000-10002).",
+      "group": "Network",
+      "channels": [ "Microsoft-Windows-NetworkProfile/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 8,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Id", "matchMode": "Many", "values": [ "10000", "10001", "10002" ] }
+        }
+      ]
+    }
+  ]
+}

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/nps-and-rras.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/nps-and-rras.json
@@ -76,6 +76,22 @@
           ]
         }
       ]
+    },
+    {
+      "id": "nps-radius-triage",
+      "name": "NPS / RADIUS access triage",
+      "purpose": "Color-coded Network Policy Server (RADIUS) access decisions: granted (6272, 6278), denied by policy (6273), and discarded requests (6274).",
+      "group": "NpsAndRras",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 0,
+      "order": 2,
+      "version": 1,
+      "filters": [
+        { "color": "Green", "comparison": { "property": "Id", "matchMode": "Many", "values": [ "6272", "6278" ] } },
+        { "color": "Red", "comparison": { "property": "Id", "value": "6273" } },
+        { "color": "Orange", "comparison": { "property": "Id", "value": "6274" } }
+      ]
     }
   ]
 }

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/nps-and-rras.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/nps-and-rras.json
@@ -1,0 +1,81 @@
+{
+  "schemaVersion": 1,
+  "scenarios": [
+    {
+      "id": "nps-radius-authentication",
+      "name": "NPS / RADIUS authentication",
+      "purpose": "Network Policy Server granted or denied network access (6272, 6273, 6278).",
+      "group": "NpsAndRras",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 0,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "6272", "6273", "6278" ] } }
+      ]
+    },
+    {
+      "id": "nps-radius-lockout",
+      "name": "NPS / RADIUS account lockout",
+      "purpose": "NPS locked an account after repeated failed authentications (6279); a brute-force signal.",
+      "group": "NpsAndRras",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 1,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "6279" } }
+      ]
+    },
+    {
+      "id": "nps-nap-quarantine",
+      "name": "NPS NAP quarantine / probation",
+      "purpose": "NPS placed a client in quarantine or probation after a health check (6276, 6277).",
+      "group": "NpsAndRras",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 2,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "6276", "6277" ] } }
+      ]
+    },
+    {
+      "id": "nps-requests-discarded",
+      "name": "NPS requests discarded",
+      "purpose": "NPS discarded an authentication or accounting request due to policy or configuration faults (6274, 6275).",
+      "group": "NpsAndRras",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 3,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "6274", "6275" ] } }
+      ]
+    },
+    {
+      "id": "vpn-rras-failures",
+      "name": "VPN & RRAS connectivity failures",
+      "purpose": "Routing and Remote Access and RAS errors and warnings (Rasman, RemoteAccess, RasServer).",
+      "group": "NpsAndRras",
+      "channels": [ "System" ],
+      "optionalChannels": [ "Microsoft-Windows-RemoteAccess-MgmtClient/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 4,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "matchMode": "Many", "values": [ "Rasman", "RemoteAccess", "Microsoft-Windows-RasServer" ] },
+          "predicates": [
+            { "comparison": { "property": "Level", "matchMode": "Many", "values": [ "Error", "Warning" ] } }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/office.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/office.json
@@ -1,0 +1,99 @@
+{
+  "schemaVersion": 1,
+  "scenarios": [
+    {
+      "id": "office-application-alerts",
+      "name": "Office application alerts (OAlerts)",
+      "purpose": "Microsoft Office application alert events such as save and recovery prompts (OAlerts 300).",
+      "group": "Office",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 0,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "matchMode": "Many", "values": [ "Microsoft Office 16 Alerts", "Microsoft Office 15 Alerts" ] },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "300" } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "office-crashes-hangs",
+      "name": "Office crashes / hangs",
+      "purpose": "Crashes and hangs of the core Office applications (Word, Excel, Outlook, PowerPoint).",
+      "group": "Office",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 1,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Description", "operator": "Contains", "value": "WINWORD.EXE" },
+          "predicates": [
+            { "joinWithAny": true, "comparison": { "property": "Description", "operator": "Contains", "value": "EXCEL.EXE" } },
+            { "joinWithAny": true, "comparison": { "property": "Description", "operator": "Contains", "value": "OUTLOOK.EXE" } },
+            { "joinWithAny": true, "comparison": { "property": "Description", "operator": "Contains", "value": "POWERPNT.EXE" } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "teams-crashes-hangs",
+      "name": "Microsoft Teams crashes / hangs",
+      "purpose": "Crashes and hangs of new and classic Microsoft Teams (ms-teams.exe, Teams.exe).",
+      "group": "Office",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 2,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Description", "operator": "Contains", "value": "Teams.exe" }
+        }
+      ]
+    },
+    {
+      "id": "onedrive-crashes",
+      "name": "OneDrive process crashes",
+      "purpose": "OneDrive client process crashes (OneDrive.exe).",
+      "group": "Office",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 3,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Application Error" },
+          "predicates": [
+            { "comparison": { "property": "Description", "operator": "Contains", "value": "OneDrive.exe" } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "edge-webview2-crashes",
+      "name": "Edge / WebView2 runtime crashes",
+      "purpose": "Microsoft Edge and WebView2 runtime crashes (msedge.exe, msedgewebview2.exe).",
+      "group": "Office",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 4,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Description", "operator": "Contains", "value": "msedge.exe" },
+          "predicates": [
+            { "joinWithAny": true, "comparison": { "property": "Description", "operator": "Contains", "value": "msedgewebview2.exe" } }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/security.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/security.json
@@ -176,6 +176,58 @@
           "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1102", "4719" ] }
         }
       ]
+    },
+    {
+      "id": "logon-activity-triage",
+      "name": "Logon activity triage",
+      "purpose": "Color-coded logon outcomes in one view: successful logon (4624), failed logon (4625), account lockout (4740), and explicit-credential / RunAs logon (4648). Requires the Logon and Account-Management audit subcategories.",
+      "group": "Security",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 0,
+      "order": 11,
+      "version": 1,
+      "filters": [
+        { "color": "Green", "comparison": { "property": "Id", "value": "4624" } },
+        { "color": "Red", "comparison": { "property": "Id", "value": "4625" } },
+        { "color": "Orange", "comparison": { "property": "Id", "value": "4740" } },
+        { "color": "Purple", "comparison": { "property": "Id", "value": "4648" } }
+      ]
+    },
+    {
+      "id": "account-compromise-timeline",
+      "name": "Account compromise timeline",
+      "purpose": "Reconstructs a takeover end-to-end, color-coded: failed logons / spray (4625), the successful breakthrough (4624), privilege escalation (4672), persistence via account and group changes (4720, 4722, 4724, 4728, 4732, 4756), and audit-log clear to cover tracks (1102).",
+      "group": "Security",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 12,
+      "version": 1,
+      "filters": [
+        { "color": "Red", "comparison": { "property": "Id", "value": "4625" } },
+        { "color": "Orange", "comparison": { "property": "Id", "value": "4624" } },
+        { "color": "Purple", "comparison": { "property": "Id", "value": "4672" } },
+        { "color": "Magenta", "comparison": { "property": "Id", "matchMode": "Many", "values": [ "4720", "4722", "4724", "4728", "4732", "4756" ] } },
+        { "color": "DarkRed", "comparison": { "property": "Id", "value": "1102" } }
+      ]
+    },
+    {
+      "id": "account-lockout-investigation",
+      "name": "Account lockout investigation",
+      "purpose": "The full lockout story in one view, color-coded: the failed logons that caused it (4625), the lockout (4740), the unlock (4767), and an admin password reset (4724).",
+      "group": "Security",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 13,
+      "version": 1,
+      "filters": [
+        { "color": "Red", "comparison": { "property": "Id", "value": "4625" } },
+        { "color": "Orange", "comparison": { "property": "Id", "value": "4740" } },
+        { "color": "Green", "comparison": { "property": "Id", "value": "4767" } },
+        { "color": "Purple", "comparison": { "property": "Id", "value": "4724" } }
+      ]
     }
   ]
 }

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/security.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/security.json
@@ -1,0 +1,181 @@
+{
+  "schemaVersion": 1,
+  "scenarios": [
+    {
+      "id": "failed-signins-brute-force",
+      "name": "Failed sign-ins / brute force",
+      "purpose": "Failed logon attempts that reveal brute-force, password-spray, or bad-credential activity (4625).",
+      "group": "Security",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 0,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Id", "value": "4625" }
+        }
+      ]
+    },
+    {
+      "id": "account-lockouts",
+      "name": "Account lockouts",
+      "purpose": "Accounts locked out after repeated failed logons (4740).",
+      "group": "Security",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 1,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Id", "value": "4740" }
+        }
+      ]
+    },
+    {
+      "id": "successful-signins",
+      "name": "Successful sign-ins",
+      "purpose": "Successful account logons for session and access auditing (4624).",
+      "group": "Security",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 2,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Id", "value": "4624" }
+        }
+      ]
+    },
+    {
+      "id": "explicit-credentials-runas",
+      "name": "Explicit credentials / RunAs",
+      "purpose": "Logons using explicit credentials such as RunAs (4648); useful for lateral-movement hunting.",
+      "group": "Security",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 3,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Id", "value": "4648" }
+        }
+      ]
+    },
+    {
+      "id": "special-privilege-logon",
+      "name": "Special-privilege logon",
+      "purpose": "Logons granted sensitive privileges, including administrative equivalents (4672).",
+      "group": "Security",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 4,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Id", "value": "4672" }
+        }
+      ]
+    },
+    {
+      "id": "account-management",
+      "name": "Account management",
+      "purpose": "User account create, enable, disable, delete, password-reset, and change events (4720-4781).",
+      "group": "Security",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 5,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Id", "matchMode": "Many", "values": [ "4720", "4722", "4723", "4724", "4725", "4726", "4738", "4781" ] }
+        }
+      ]
+    },
+    {
+      "id": "group-membership-changes",
+      "name": "Group membership changes",
+      "purpose": "Security-group member add and remove events (4728, 4729, 4732, 4733, 4756).",
+      "group": "Security",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 6,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Id", "matchMode": "Many", "values": [ "4728", "4729", "4732", "4733", "4756" ] }
+        }
+      ]
+    },
+    {
+      "id": "kerberos-ticket-activity",
+      "name": "Kerberos & ticket activity",
+      "purpose": "Kerberos TGT and service-ticket requests and failures (4768, 4769, 4771, 4772).",
+      "group": "Security",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 7,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Id", "matchMode": "Many", "values": [ "4768", "4769", "4771", "4772" ] }
+        }
+      ]
+    },
+    {
+      "id": "credential-validation-ntlm",
+      "name": "Credential validation (NTLM)",
+      "purpose": "NTLM credential validation events on the authenticating server (4776).",
+      "group": "Security",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 8,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Id", "value": "4776" }
+        }
+      ]
+    },
+    {
+      "id": "logoff-activity",
+      "name": "Logoff activity",
+      "purpose": "Account logoff and session-end events (4634, 4647).",
+      "group": "Security",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 9,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Id", "matchMode": "Many", "values": [ "4634", "4647" ] }
+        }
+      ]
+    },
+    {
+      "id": "audit-security-policy-changes",
+      "name": "Audit / security policy changes",
+      "purpose": "Audit-log clear (1102) and audit-policy change (4719) events; classic defense-evasion signals.",
+      "group": "Security",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 10,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1102", "4719" ] }
+        }
+      ]
+    }
+  ]
+}

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/sharepoint.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/sharepoint.json
@@ -1,0 +1,81 @@
+{
+  "schemaVersion": 1,
+  "scenarios": [
+    {
+      "id": "sharepoint-uls-timer-failures",
+      "name": "SharePoint critical ULS & timer-job failures",
+      "purpose": "SharePoint critical ULS and timer-job failures (5586, 6398).",
+      "group": "SharePoint",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 0,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "operator": "Contains", "value": "SharePoint" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "5586", "6398" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "sharepoint-search-crawl-failures",
+      "name": "SharePoint search / crawl failures",
+      "purpose": "SharePoint search and crawl administration failures (6482).",
+      "group": "SharePoint",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 1,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "operator": "Contains", "value": "SharePoint" },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "6482" } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "sharepoint-user-profile-sync-failure",
+      "name": "SharePoint User Profile sync failure",
+      "purpose": "SharePoint User Profile synchronization timer-job failure (5553).",
+      "group": "SharePoint",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 2,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "operator": "Contains", "value": "SharePoint" },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "5553" } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "sharepoint-claims-auth-failure",
+      "name": "SharePoint Security Token Service failure",
+      "purpose": "SharePoint Security Token Service could not activate, blocking claims authentication (8306).",
+      "group": "SharePoint",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 3,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "operator": "Contains", "value": "SharePoint" },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "8306" } }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/sql-server.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/sql-server.json
@@ -1,0 +1,277 @@
+{
+  "schemaVersion": 1,
+  "scenarios": [
+    {
+      "id": "sql-login-failures",
+      "name": "SQL login failures",
+      "purpose": "SQL Server failed-login events (18456); credential and access problems.",
+      "group": "SqlServer",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 0,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "operator": "Contains", "value": "MSSQL" },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "18456" } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "sql-fatal-engine-errors",
+      "name": "SQL high-severity / fatal engine errors",
+      "purpose": "Severe SQL Server engine errors including I/O and consistency failures (701, 823, 824, 825, 9001, 17883, 17884, 17887, 17888).",
+      "group": "SqlServer",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 1,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "operator": "Contains", "value": "MSSQL" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "701", "823", "824", "825", "9001", "17883", "17884", "17887", "17888" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "sql-page-checksum-failure",
+      "name": "SQL page checksum failure (storage corruption)",
+      "purpose": "A SQL data page changed between write and read, indicating storage-layer corruption (832).",
+      "group": "SqlServer",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 2,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "operator": "Contains", "value": "MSSQL" },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "832" } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "sql-deadlocks",
+      "name": "SQL deadlocks",
+      "purpose": "Transactions chosen as deadlock victims (1205); requires deadlock logging via trace flag 1222 or sp_altermessage 1205 WITH_LOG.",
+      "group": "SqlServer",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 3,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "operator": "Contains", "value": "MSSQL" },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "1205" } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "sql-filegroup-datafile-full",
+      "name": "SQL filegroup / data file full",
+      "purpose": "A filegroup or data file is full, blocking writes to user databases (1101, 1105).",
+      "group": "SqlServer",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 4,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "operator": "Contains", "value": "MSSQL" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1101", "1105" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "sql-transaction-log-full",
+      "name": "SQL transaction log full",
+      "purpose": "The transaction log is full, blocking all data modifications (9002).",
+      "group": "SqlServer",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 5,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "operator": "Contains", "value": "MSSQL" },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "9002" } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "sql-database-file-open-failure",
+      "name": "SQL database file open failure",
+      "purpose": "SQL Server could not open a database or log file at startup (17204, 17207); precedes RECOVERY_PENDING or SUSPECT.",
+      "group": "SqlServer",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 6,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "operator": "Contains", "value": "MSSQL" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "17204", "17207" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "sql-internal-assertion",
+      "name": "SQL internal assertion failure",
+      "purpose": "SQL Server internal assertion violations indicating possible corruption or engine bugs (3624, 17065, 17066, 17067).",
+      "group": "SqlServer",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 7,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "operator": "Contains", "value": "MSSQL" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "3624", "17065", "17066", "17067" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "sql-abnormal-termination",
+      "name": "SQL abnormal termination (crash)",
+      "purpose": "SQL Server process access violations and fatal-exception terminations (17308, 17311).",
+      "group": "SqlServer",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 8,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "operator": "Contains", "value": "MSSQL" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "17308", "17311" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "sql-backup-restore-failures",
+      "name": "SQL backup / restore failures",
+      "purpose": "SQL Server backup and restore failures, including VDI I/O errors (3041, 18204, 18210).",
+      "group": "SqlServer",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 9,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "operator": "Contains", "value": "MSSQL" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "3041", "18204", "18210" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "sql-alwayson-secondary-disrupted",
+      "name": "SQL Always On secondary disrupted",
+      "purpose": "An availability-group secondary entered RESTORING or SUSPECT state (35268, 35269).",
+      "group": "SqlServer",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 10,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "operator": "Contains", "value": "MSSQL" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "35268", "35269" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "sql-memory-paged-out",
+      "name": "SQL process memory paged out",
+      "purpose": "A significant part of the SQL Server process was paged out under memory pressure (17890).",
+      "group": "SqlServer",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 11,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "operator": "Contains", "value": "MSSQL" },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "17890" } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "sql-service-lifecycle",
+      "name": "SQL service start & shutdown",
+      "purpose": "SQL Server ready-for-connections and shutdown events for correlating outages (17126, 17147, 17148).",
+      "group": "SqlServer",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 12,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "operator": "Contains", "value": "MSSQL" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "17126", "17147", "17148" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "sql-agent-job-failures",
+      "name": "SQL Agent job failures",
+      "purpose": "SQL Server Agent job-step failures (SQLSERVERAGENT 208).",
+      "group": "SqlServer",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 13,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "operator": "Contains", "value": "SQLSERVERAGENT" },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "208" } }
+          ]
+        },
+        {
+          "comparison": { "property": "Source", "operator": "Contains", "value": "SQLAgent" },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "208" } }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/sql-server.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/sql-server.json
@@ -272,6 +272,40 @@
           ]
         }
       ]
+    },
+    {
+      "id": "sql-health-triage",
+      "name": "SQL Server health triage",
+      "purpose": "Color-coded SQL Server engine health (Application log; matches any instance via Source contains MSSQL): ready for connections (17126), shutdown (17147, 17148), login failure (18456), transaction-log-full and read-retry warnings (9002, 825), and severe I/O / consistency errors (823, 824).",
+      "group": "SqlServer",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 0,
+      "order": 10,
+      "version": 1,
+      "filters": [
+        { "color": "Green", "comparison": { "property": "Source", "operator": "Contains", "value": "MSSQL" }, "predicates": [ { "comparison": { "property": "Id", "value": "17126" } } ] },
+        { "color": "Blue", "comparison": { "property": "Source", "operator": "Contains", "value": "MSSQL" }, "predicates": [ { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "17147", "17148" ] } } ] },
+        { "color": "Orange", "comparison": { "property": "Source", "operator": "Contains", "value": "MSSQL" }, "predicates": [ { "comparison": { "property": "Id", "value": "18456" } } ] },
+        { "color": "Yellow", "comparison": { "property": "Source", "operator": "Contains", "value": "MSSQL" }, "predicates": [ { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "9002", "825" ] } } ] },
+        { "color": "DarkRed", "comparison": { "property": "Source", "operator": "Contains", "value": "MSSQL" }, "predicates": [ { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "823", "824" ] } } ] }
+      ]
+    },
+    {
+      "id": "sql-backup-restore-timeline",
+      "name": "SQL backup / restore timeline",
+      "purpose": "Color-coded SQL Server backup and restore activity (Application log; Source contains MSSQL): database and log backup success (18264, 18265), database restored (18267), and backup failure (3041).",
+      "group": "SqlServer",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 11,
+      "version": 1,
+      "filters": [
+        { "color": "Green", "comparison": { "property": "Source", "operator": "Contains", "value": "MSSQL" }, "predicates": [ { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "18264", "18265" ] } } ] },
+        { "color": "Blue", "comparison": { "property": "Source", "operator": "Contains", "value": "MSSQL" }, "predicates": [ { "comparison": { "property": "Id", "value": "18267" } } ] },
+        { "color": "Red", "comparison": { "property": "Source", "operator": "Contains", "value": "MSSQL" }, "predicates": [ { "comparison": { "property": "Id", "value": "3041" } } ] }
+      ]
     }
   ]
 }

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/storage.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/storage.json
@@ -104,7 +104,7 @@
     {
       "id": "vss-shadow-copy-backup-failures",
       "name": "VSS / shadow-copy / backup failures",
-      "purpose": "Volume Shadow Copy faults across the System log (Volsnap 25, 36) and the Application log (VSS 13, 8193, 12289).",
+      "purpose": "Volume Shadow Copy faults, color-coded: System-log Volsnap storage pressure (25, 36) versus Application-log VSS provider/backup failures (13, 8193, 12289).",
       "group": "Storage",
       "channels": [ "System", "Application" ],
       "requiresAdmin": false,
@@ -113,6 +113,7 @@
       "version": 1,
       "filters": [
         {
+          "color": "Orange",
           "comparison": { "property": "LogName", "value": "System" },
           "predicates": [
             { "joinWithAny": false, "comparison": { "property": "Source", "value": "Volsnap" } },
@@ -120,6 +121,7 @@
           ]
         },
         {
+          "color": "Red",
           "comparison": { "property": "LogName", "value": "Application" },
           "predicates": [
             { "joinWithAny": false, "comparison": { "property": "Source", "value": "VSS" } },

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/storage.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/storage.json
@@ -1,0 +1,151 @@
+{
+  "schemaVersion": 1,
+  "scenarios": [
+    {
+      "id": "disk-io-errors-bad-blocks",
+      "name": "Disk I/O errors / bad blocks",
+      "purpose": "Disk read/write errors and bad-block reports (disk 7, 11, 15, 51, 153).",
+      "group": "Storage",
+      "channels": [ "System" ],
+      "requiresAdmin": false,
+      "priority": 0,
+      "order": 0,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "disk" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "7", "11", "15", "51", "153" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ntfs-corruption-repair",
+      "name": "NTFS corruption / repair needed",
+      "purpose": "NTFS file-system corruption and self-heal events (Ntfs 55, 98, 130, 131, 137, 140).",
+      "group": "Storage",
+      "channels": [ "System" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 1,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Ntfs" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "55", "98", "130", "131", "137", "140" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "volume-manager-partition-signature",
+      "name": "Volume manager / partition signature",
+      "purpose": "Volume manager dump-write failures (volmgr 161) and partition-signature collisions (partmgr 58).",
+      "group": "Storage",
+      "channels": [ "System" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 2,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "volmgr" },
+          "predicates": [
+            { "joinWithAny": false, "comparison": { "property": "Id", "value": "161" } },
+            { "joinWithAny": true, "comparison": { "property": "Source", "value": "partmgr" } },
+            { "joinWithAny": false, "comparison": { "property": "Id", "value": "58" } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "storage-controller-driver-resets",
+      "name": "Storage controller / driver resets",
+      "purpose": "Storage adapter timeouts and resets (storahci, stornvme, iaStorA 11, 14, 129) and disk controller errors (153).",
+      "group": "Storage",
+      "channels": [ "System" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 3,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "storahci" },
+          "predicates": [
+            { "joinWithAny": false, "comparison": { "property": "Id", "matchMode": "Many", "values": [ "11", "14", "129" ] } },
+            { "joinWithAny": true, "comparison": { "property": "Source", "value": "stornvme" } },
+            { "joinWithAny": false, "comparison": { "property": "Id", "matchMode": "Many", "values": [ "11", "14", "129" ] } },
+            { "joinWithAny": true, "comparison": { "property": "Source", "value": "iaStorA" } },
+            { "joinWithAny": false, "comparison": { "property": "Id", "matchMode": "Many", "values": [ "11", "14", "129" ] } },
+            { "joinWithAny": true, "comparison": { "property": "Source", "value": "disk" } },
+            { "joinWithAny": false, "comparison": { "property": "Id", "value": "153" } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "bitlocker-recovery-tpm-issues",
+      "name": "BitLocker recovery / TPM issues",
+      "purpose": "BitLocker recovery-mode and TPM problems (BitLocker-API 514, 521, 525, 526, 532, 846, 851, 852).",
+      "group": "Storage",
+      "channels": [ "Microsoft-Windows-BitLocker/BitLocker Management" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 4,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Id", "matchMode": "Many", "values": [ "514", "521", "525", "526", "532", "846", "851", "852" ] }
+        }
+      ]
+    },
+    {
+      "id": "vss-shadow-copy-backup-failures",
+      "name": "VSS / shadow-copy / backup failures",
+      "purpose": "Volume Shadow Copy faults across the System log (Volsnap 25, 36) and the Application log (VSS 13, 8193, 12289).",
+      "group": "Storage",
+      "channels": [ "System", "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 5,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "LogName", "value": "System" },
+          "predicates": [
+            { "joinWithAny": false, "comparison": { "property": "Source", "value": "Volsnap" } },
+            { "joinWithAny": false, "comparison": { "property": "Id", "matchMode": "Many", "values": [ "25", "36" ] } }
+          ]
+        },
+        {
+          "comparison": { "property": "LogName", "value": "Application" },
+          "predicates": [
+            { "joinWithAny": false, "comparison": { "property": "Source", "value": "VSS" } },
+            { "joinWithAny": false, "comparison": { "property": "Id", "matchMode": "Many", "values": [ "13", "8193", "12289" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "chkdsk-boot-time-results",
+      "name": "Chkdsk boot-time results",
+      "purpose": "Boot-time disk-check results written by Wininit (1001).",
+      "group": "Storage",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 6,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Wininit" },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "1001" } }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/system-health.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/system-health.json
@@ -20,7 +20,7 @@
     {
       "id": "failed-services-at-boot",
       "name": "Failed services at boot",
-      "purpose": "Service Control Manager failures that block services from starting.",
+      "purpose": "Service start failures color-coded by type: failed to start (SCM 7000/7001/7023/7024), hung while starting (7022), and boot/system driver load failure (7026).",
       "group": "SystemHealth",
       "channels": [ "System" ],
       "requiresAdmin": false,
@@ -29,9 +29,24 @@
       "version": 1,
       "filters": [
         {
+          "color": "Red",
           "comparison": { "property": "Source", "value": "Service Control Manager" },
           "predicates": [
-            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "7000", "7001", "7022", "7023", "7024", "7026" ] } }
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "7000", "7001", "7023", "7024" ] } }
+          ]
+        },
+        {
+          "color": "Orange",
+          "comparison": { "property": "Source", "value": "Service Control Manager" },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "7022" } }
+          ]
+        },
+        {
+          "color": "DarkRed",
+          "comparison": { "property": "Source", "value": "Service Control Manager" },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "7026" } }
           ]
         }
       ]
@@ -39,7 +54,7 @@
     {
       "id": "crashing-services",
       "name": "Crashing services",
-      "purpose": "Services that terminated unexpectedly and their recovery actions (SCM 7031, 7034).",
+      "purpose": "Services that terminated unexpectedly: recoverable crash with a configured recovery action (SCM 7031) versus terminal failure after exhausting recovery (7034).",
       "group": "SystemHealth",
       "channels": [ "System" ],
       "requiresAdmin": false,
@@ -48,9 +63,17 @@
       "version": 1,
       "filters": [
         {
+          "color": "Red",
           "comparison": { "property": "Source", "value": "Service Control Manager" },
           "predicates": [
-            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "7031", "7034" ] } }
+            { "comparison": { "property": "Id", "value": "7031" } }
+          ]
+        },
+        {
+          "color": "DarkRed",
+          "comparison": { "property": "Source", "value": "Service Control Manager" },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "7034" } }
           ]
         }
       ]
@@ -137,8 +160,8 @@
     },
     {
       "id": "unexpected-restart-power-loss-bsod",
-      "name": "Unexpected restart / power loss / BSOD",
-      "purpose": "Dirty shutdowns: Kernel-Power 41, BugCheck 1001, and EventLog 6008.",
+      "name": "Unexpected restart / BSOD reconstruction",
+      "purpose": "Reconstructs an unexpected restart, color-coded: BSOD bugcheck report (WER-SystemErrorReporting / BugCheck 1001), kernel dirty transition (Kernel-Power 41), dirty previous shutdown (EventLog 6008), the shutdown reason (User32 1074), and the recovery boot (Kernel-General 12).",
       "group": "SystemHealth",
       "channels": [ "System" ],
       "requiresAdmin": false,
@@ -147,13 +170,38 @@
       "version": 1,
       "filters": [
         {
+          "color": "DarkRed",
+          "comparison": { "property": "Source", "matchMode": "Many", "values": [ "Microsoft-Windows-WER-SystemErrorReporting", "BugCheck" ] },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "1001" } }
+          ]
+        },
+        {
+          "color": "Yellow",
           "comparison": { "property": "Source", "value": "Microsoft-Windows-Kernel-Power" },
           "predicates": [
-            { "joinWithAny": false, "comparison": { "property": "Id", "value": "41" } },
-            { "joinWithAny": true, "comparison": { "property": "Source", "value": "BugCheck" } },
-            { "joinWithAny": false, "comparison": { "property": "Id", "value": "1001" } },
-            { "joinWithAny": true, "comparison": { "property": "Source", "value": "EventLog" } },
-            { "joinWithAny": false, "comparison": { "property": "Id", "value": "6008" } }
+            { "comparison": { "property": "Id", "value": "41" } }
+          ]
+        },
+        {
+          "color": "LightRed",
+          "comparison": { "property": "Source", "value": "EventLog" },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "6008" } }
+          ]
+        },
+        {
+          "color": "LightOrange",
+          "comparison": { "property": "Source", "value": "User32" },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "1074" } }
+          ]
+        },
+        {
+          "color": "Green",
+          "comparison": { "property": "Source", "value": "Microsoft-Windows-Kernel-General" },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "12" } }
           ]
         }
       ]
@@ -161,7 +209,7 @@
     {
       "id": "boot-shutdown-restart-timeline",
       "name": "Boot / shutdown / restart timeline",
-      "purpose": "Clean service start/stop (EventLog 6005/6006/6008), shutdown initiator (User32 1074), and kernel boot/shutdown (12/13).",
+      "purpose": "Color-coded boot/shutdown lifecycle: boot (Kernel-General 12 / EventLog 6005), clean shutdown (Kernel-General 13 / EventLog 6006), the shutdown reason (User32 1074), and a dirty previous shutdown (EventLog 6008).",
       "group": "SystemHealth",
       "channels": [ "System" ],
       "requiresAdmin": false,
@@ -170,13 +218,35 @@
       "version": 1,
       "filters": [
         {
+          "color": "Green",
+          "comparison": { "property": "Source", "value": "Microsoft-Windows-Kernel-General" },
+          "predicates": [
+            { "joinWithAny": false, "comparison": { "property": "Id", "value": "12" } },
+            { "joinWithAny": true, "comparison": { "property": "Source", "value": "EventLog" } },
+            { "joinWithAny": false, "comparison": { "property": "Id", "value": "6005" } }
+          ]
+        },
+        {
+          "color": "Blue",
+          "comparison": { "property": "Source", "value": "Microsoft-Windows-Kernel-General" },
+          "predicates": [
+            { "joinWithAny": false, "comparison": { "property": "Id", "value": "13" } },
+            { "joinWithAny": true, "comparison": { "property": "Source", "value": "EventLog" } },
+            { "joinWithAny": false, "comparison": { "property": "Id", "value": "6006" } }
+          ]
+        },
+        {
+          "color": "Teal",
+          "comparison": { "property": "Source", "value": "User32" },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "1074" } }
+          ]
+        },
+        {
+          "color": "Orange",
           "comparison": { "property": "Source", "value": "EventLog" },
           "predicates": [
-            { "joinWithAny": false, "comparison": { "property": "Id", "matchMode": "Many", "values": [ "6005", "6006", "6008" ] } },
-            { "joinWithAny": true, "comparison": { "property": "Source", "value": "User32" } },
-            { "joinWithAny": false, "comparison": { "property": "Id", "value": "1074" } },
-            { "joinWithAny": true, "comparison": { "property": "Source", "value": "Microsoft-Windows-Kernel-General" } },
-            { "joinWithAny": false, "comparison": { "property": "Id", "matchMode": "Many", "values": [ "12", "13" ] } }
+            { "comparison": { "property": "Id", "value": "6008" } }
           ]
         }
       ]
@@ -257,20 +327,45 @@
     },
     {
       "id": "out-of-memory-resource-exhaustion",
-      "name": "Out-of-memory / resource exhaustion",
-      "purpose": "Windows diagnosed a low virtual-memory condition (Resource-Exhaustion-Detector 2004).",
+      "name": "Resource exhaustion with crash fallout",
+      "purpose": "Correlates a low-memory diagnosis with the application failures around it, color-coded: OS low virtual-memory (System: Resource-Exhaustion-Detector 2004), app crash (Application: Application Error 1000), app hang (Application Hang 1002), and the WER report (Windows Error Reporting 1001).",
       "group": "SystemHealth",
-      "channels": [ "System" ],
-      "optionalChannels": [ "Microsoft-Windows-Resource-Exhaustion-Detector/Operational" ],
+      "channels": [ "System", "Application" ],
       "requiresAdmin": false,
       "priority": 1,
       "order": 13,
       "version": 1,
       "filters": [
         {
-          "comparison": { "property": "Source", "value": "Microsoft-Windows-Resource-Exhaustion-Detector" },
+          "color": "Yellow",
+          "comparison": { "property": "LogName", "value": "System" },
           "predicates": [
-            { "comparison": { "property": "Id", "value": "2004" } }
+            { "joinWithAny": false, "comparison": { "property": "Source", "value": "Microsoft-Windows-Resource-Exhaustion-Detector" } },
+            { "joinWithAny": false, "comparison": { "property": "Id", "value": "2004" } }
+          ]
+        },
+        {
+          "color": "DarkRed",
+          "comparison": { "property": "LogName", "value": "Application" },
+          "predicates": [
+            { "joinWithAny": false, "comparison": { "property": "Source", "value": "Application Error" } },
+            { "joinWithAny": false, "comparison": { "property": "Id", "value": "1000" } }
+          ]
+        },
+        {
+          "color": "Orange",
+          "comparison": { "property": "LogName", "value": "Application" },
+          "predicates": [
+            { "joinWithAny": false, "comparison": { "property": "Source", "value": "Application Hang" } },
+            { "joinWithAny": false, "comparison": { "property": "Id", "value": "1002" } }
+          ]
+        },
+        {
+          "color": "Purple",
+          "comparison": { "property": "LogName", "value": "Application" },
+          "predicates": [
+            { "joinWithAny": false, "comparison": { "property": "Source", "value": "Windows Error Reporting" } },
+            { "joinWithAny": false, "comparison": { "property": "Id", "value": "1001" } }
           ]
         }
       ]

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/system-health.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/system-health.json
@@ -6,7 +6,6 @@
       "name": "Recent Critical & Error Events",
       "purpose": "Surface the most severe System-log events first.",
       "group": "SystemHealth",
-      "tags": [ "system", "sysadmin", "failures" ],
       "channels": [ "System" ],
       "requiresAdmin": false,
       "priority": 0,
@@ -23,7 +22,6 @@
       "name": "Failed services at boot",
       "purpose": "Service Control Manager failures that block services from starting.",
       "group": "SystemHealth",
-      "tags": [ "system", "sysadmin", "failures" ],
       "channels": [ "System" ],
       "requiresAdmin": false,
       "priority": 0,
@@ -39,15 +37,33 @@
       ]
     },
     {
+      "id": "crashing-services",
+      "name": "Crashing services",
+      "purpose": "Services that terminated unexpectedly and their recovery actions (SCM 7031, 7034).",
+      "group": "SystemHealth",
+      "channels": [ "System" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 2,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Service Control Manager" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "7031", "7034" ] } }
+          ]
+        }
+      ]
+    },
+    {
       "id": "newly-installed-services",
       "name": "Newly installed services",
       "purpose": "A new service was installed (Service Control Manager event 7045); also a threat signal.",
       "group": "SystemHealth",
-      "tags": [ "system", "sysadmin", "audit" ],
       "channels": [ "System" ],
       "requiresAdmin": false,
-      "priority": 0,
-      "order": 2,
+      "priority": 1,
+      "order": 3,
       "version": 1,
       "filters": [
         {
@@ -59,15 +75,75 @@
       ]
     },
     {
+      "id": "boot-driver-failures",
+      "name": "Boot driver failures",
+      "purpose": "A boot-start driver failed to load (SCM 7026) or a device driver reported a problem (Kernel-PnP 219).",
+      "group": "SystemHealth",
+      "channels": [ "System" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 4,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Service Control Manager" },
+          "predicates": [
+            { "joinWithAny": false, "comparison": { "property": "Id", "value": "7026" } },
+            { "joinWithAny": true, "comparison": { "property": "Source", "value": "Microsoft-Windows-Kernel-PnP" } },
+            { "joinWithAny": false, "comparison": { "property": "Id", "value": "219" } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "device-pnp-install-problems",
+      "name": "Device / PnP install problems",
+      "purpose": "Plug and Play device and driver install failures (Kernel-PnP 219, 411).",
+      "group": "SystemHealth",
+      "channels": [ "System" ],
+      "optionalChannels": [ "Microsoft-Windows-Kernel-PnP/Configuration" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 5,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Microsoft-Windows-Kernel-PnP" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "219", "411" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "umdf-driver-failures",
+      "name": "UMDF driver failures",
+      "purpose": "User-mode driver framework reported a driver fault (10110, 10111).",
+      "group": "SystemHealth",
+      "channels": [ "System" ],
+      "optionalChannels": [ "Microsoft-Windows-DriverFrameworks-UserMode/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 6,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Microsoft-Windows-DriverFrameworks-UserMode" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "10110", "10111" ] } }
+          ]
+        }
+      ]
+    },
+    {
       "id": "unexpected-restart-power-loss-bsod",
       "name": "Unexpected restart / power loss / BSOD",
       "purpose": "Dirty shutdowns: Kernel-Power 41, BugCheck 1001, and EventLog 6008.",
       "group": "SystemHealth",
-      "tags": [ "system", "sysadmin", "failures" ],
       "channels": [ "System" ],
       "requiresAdmin": false,
       "priority": 0,
-      "order": 3,
+      "order": 7,
       "version": 1,
       "filters": [
         {
@@ -83,27 +159,156 @@
       ]
     },
     {
-      "id": "service-install-and-control-audit",
-      "name": "Service install & control audit",
-      "purpose": "Correlate service installs across the System log (7045) and the Security audit log (4697).",
+      "id": "boot-shutdown-restart-timeline",
+      "name": "Boot / shutdown / restart timeline",
+      "purpose": "Clean service start/stop (EventLog 6005/6006/6008), shutdown initiator (User32 1074), and kernel boot/shutdown (12/13).",
       "group": "SystemHealth",
-      "tags": [ "system", "security", "audit" ],
-      "channels": [ "System", "Security" ],
-      "requiresAdmin": true,
+      "channels": [ "System" ],
+      "requiresAdmin": false,
       "priority": 1,
-      "order": 4,
+      "order": 8,
       "version": 1,
       "filters": [
         {
-          "comparison": { "property": "LogName", "value": "System" },
+          "comparison": { "property": "Source", "value": "EventLog" },
           "predicates": [
-            { "joinWithAny": false, "comparison": { "property": "Id", "value": "7045" } }
+            { "joinWithAny": false, "comparison": { "property": "Id", "matchMode": "Many", "values": [ "6005", "6006", "6008" ] } },
+            { "joinWithAny": true, "comparison": { "property": "Source", "value": "User32" } },
+            { "joinWithAny": false, "comparison": { "property": "Id", "value": "1074" } },
+            { "joinWithAny": true, "comparison": { "property": "Source", "value": "Microsoft-Windows-Kernel-General" } },
+            { "joinWithAny": false, "comparison": { "property": "Id", "matchMode": "Many", "values": [ "12", "13" ] } }
           ]
-        },
+        }
+      ]
+    },
+    {
+      "id": "failed-fast-startup-boot-timeout",
+      "name": "Failed fast-startup / boot timeout",
+      "purpose": "Kernel-Boot reported a fast-startup or boot-sequence problem (16, 27, 29).",
+      "group": "SystemHealth",
+      "channels": [ "System" ],
+      "optionalChannels": [ "Microsoft-Windows-Kernel-Boot/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 9,
+      "version": 1,
+      "filters": [
         {
-          "comparison": { "property": "LogName", "value": "Security" },
+          "comparison": { "property": "Source", "value": "Microsoft-Windows-Kernel-Boot" },
           "predicates": [
-            { "joinWithAny": false, "comparison": { "property": "Id", "value": "4697" } }
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "16", "27", "29" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "slow-boot-shutdown-causes",
+      "name": "Slow boot / shutdown causes",
+      "purpose": "Diagnostics-Performance boot (100-103) and shutdown (200-203) degradation events.",
+      "group": "SystemHealth",
+      "channels": [ "Microsoft-Windows-Diagnostics-Performance/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 10,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Id", "matchMode": "Many", "values": [ "100", "101", "102", "103", "200", "201", "202", "203" ] }
+        }
+      ]
+    },
+    {
+      "id": "fatal-hardware-errors-whea",
+      "name": "Fatal hardware errors (WHEA)",
+      "purpose": "Windows Hardware Error Architecture reported a fatal hardware error (1, 18).",
+      "group": "SystemHealth",
+      "channels": [ "System" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 11,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Microsoft-Windows-WHEA-Logger" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1", "18" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "corrected-hardware-errors-whea",
+      "name": "Corrected hardware errors (WHEA)",
+      "purpose": "Windows Hardware Error Architecture corrected-error warnings (17, 19, 47).",
+      "group": "SystemHealth",
+      "channels": [ "System" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 12,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Microsoft-Windows-WHEA-Logger" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "17", "19", "47" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "out-of-memory-resource-exhaustion",
+      "name": "Out-of-memory / resource exhaustion",
+      "purpose": "Windows diagnosed a low virtual-memory condition (Resource-Exhaustion-Detector 2004).",
+      "group": "SystemHealth",
+      "channels": [ "System" ],
+      "optionalChannels": [ "Microsoft-Windows-Resource-Exhaustion-Detector/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 13,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Microsoft-Windows-Resource-Exhaustion-Detector" },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "2004" } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cpu-thermal-firmware-throttling",
+      "name": "CPU thermal / firmware throttling",
+      "purpose": "Processor performance limited by system firmware or thermal conditions (Kernel-Processor-Power 37).",
+      "group": "SystemHealth",
+      "channels": [ "System" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 14,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Microsoft-Windows-Kernel-Processor-Power" },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "37" } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "sleep-hibernate-resume-transitions",
+      "name": "Sleep / hibernate / resume transitions",
+      "purpose": "Power-state transitions for tracking sleep, hibernate, and resume (Kernel-Power 42, 107, 109).",
+      "group": "SystemHealth",
+      "channels": [ "System" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 15,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Microsoft-Windows-Kernel-Power" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "42", "107", "109" ] } }
           ]
         }
       ]

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/threats-and-incident-response.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/threats-and-incident-response.json
@@ -1,0 +1,546 @@
+{
+  "schemaVersion": 1,
+  "scenarios": [
+    {
+      "id": "new-service-installed-system",
+      "name": "New service installed (SCM)",
+      "purpose": "A new service was installed (Service Control Manager 7045); a common persistence signal.",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "System" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 0,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Source", "value": "Service Control Manager" }, "predicates": [ { "comparison": { "property": "Id", "value": "7045" } } ] }
+      ]
+    },
+    {
+      "id": "new-service-installed-audited",
+      "name": "New service installed (audited)",
+      "purpose": "Security-audited service installation (4697); requires the audit policy to be enabled.",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 1,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "4697" } }
+      ]
+    },
+    {
+      "id": "service-installation-combined",
+      "name": "Service installation (combined)",
+      "purpose": "Correlate service installs across the System log (7045) and the Security audit log (4697).",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "System", "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 2,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "LogName", "value": "System" }, "predicates": [ { "comparison": { "property": "Id", "value": "7045" } } ] },
+        { "comparison": { "property": "LogName", "value": "Security" }, "predicates": [ { "comparison": { "property": "Id", "value": "4697" } } ] }
+      ]
+    },
+    {
+      "id": "scheduled-task-created-audited",
+      "name": "Scheduled task created / changed (audited)",
+      "purpose": "Security-audited scheduled-task create, update, delete, enable, and disable (4698-4702).",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 3,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "4698", "4699", "4700", "4701", "4702" ] } }
+      ]
+    },
+    {
+      "id": "scheduled-task-lifecycle-operational",
+      "name": "Scheduled task lifecycle (operational)",
+      "purpose": "Task Scheduler registration, update, and delete events from the Operational log (106, 140, 141).",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Microsoft-Windows-TaskScheduler/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 4,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "106", "140", "141" ] } }
+      ]
+    },
+    {
+      "id": "scheduled-task-activity-combined",
+      "name": "Scheduled task activity (combined)",
+      "purpose": "Combine audited scheduled-task changes (Security 4698-4702) with operational task lifecycle (106, 140, 141).",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Security", "Microsoft-Windows-TaskScheduler/Operational" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 5,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "LogName", "value": "Security" }, "predicates": [ { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "4698", "4699", "4700", "4701", "4702" ] } } ] },
+        { "comparison": { "property": "LogName", "value": "Microsoft-Windows-TaskScheduler/Operational" }, "predicates": [ { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "106", "140", "141" ] } } ] }
+      ]
+    },
+    {
+      "id": "wmi-event-subscription-persistence",
+      "name": "WMI event-subscription persistence",
+      "purpose": "WMI permanent event subscriptions, a stealthy persistence mechanism (WMI-Activity 5859, 5860, 5861).",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Microsoft-Windows-WMI-Activity/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 6,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "5859", "5860", "5861" ] } }
+      ]
+    },
+    {
+      "id": "powershell-script-block-logging",
+      "name": "PowerShell script-block logging",
+      "purpose": "PowerShell script-block logging (4104); captures the actual script content executed.",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Microsoft-Windows-PowerShell/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 7,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "4104" } }
+      ]
+    },
+    {
+      "id": "suspicious-powershell-script-blocks",
+      "name": "Suspicious PowerShell script blocks",
+      "purpose": "Script-block events flagged at warning level, which PowerShell uses for suspicious content (4104).",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Microsoft-Windows-PowerShell/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 8,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "4104" }, "predicates": [ { "comparison": { "property": "Level", "value": "Warning" } } ] }
+      ]
+    },
+    {
+      "id": "powershell-module-pipeline-logging",
+      "name": "PowerShell module / pipeline logging",
+      "purpose": "PowerShell module load and pipeline execution logging (4103, 4105, 4106).",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Microsoft-Windows-PowerShell/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 9,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "4103", "4105", "4106" ] } }
+      ]
+    },
+    {
+      "id": "classic-powershell-engine",
+      "name": "Classic PowerShell engine / pipeline",
+      "purpose": "Classic Windows PowerShell engine and pipeline events (400, 403, 600, 800).",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Windows PowerShell" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 10,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "400", "403", "600", "800" ] } }
+      ]
+    },
+    {
+      "id": "powershell-all-activity-combined",
+      "name": "PowerShell all activity (combined)",
+      "purpose": "Combine modern script-block and module logging with the classic Windows PowerShell engine log.",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Microsoft-Windows-PowerShell/Operational", "Windows PowerShell" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 11,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "LogName", "value": "Microsoft-Windows-PowerShell/Operational" }, "predicates": [ { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "4103", "4104", "4105", "4106" ] } } ] },
+        { "comparison": { "property": "LogName", "value": "Windows PowerShell" }, "predicates": [ { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "400", "403", "600", "800" ] } } ] }
+      ]
+    },
+    {
+      "id": "process-creation-with-command-line",
+      "name": "Process creation with command line",
+      "purpose": "Audited process creation (4688); command-line capture requires the corresponding audit policy.",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 12,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "4688" } }
+      ]
+    },
+    {
+      "id": "suspicious-lolbin-execution",
+      "name": "Suspicious LOLBin execution",
+      "purpose": "Process-creation events whose command line names a commonly abused living-off-the-land binary.",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 13,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "Description", "operator": "Contains", "value": "rundll32" } } ] },
+        { "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "Description", "operator": "Contains", "value": "regsvr32" } } ] },
+        { "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "Description", "operator": "Contains", "value": "mshta" } } ] },
+        { "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "Description", "operator": "Contains", "value": "wmic" } } ] },
+        { "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "Description", "operator": "Contains", "value": "certutil" } } ] },
+        { "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "Description", "operator": "Contains", "value": "bitsadmin" } } ] },
+        { "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "Description", "operator": "Contains", "value": "msiexec" } } ] },
+        { "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "Description", "operator": "Contains", "value": "installutil" } } ] }
+      ]
+    },
+    {
+      "id": "encoded-hidden-powershell-cmdline",
+      "name": "Encoded / hidden PowerShell command line",
+      "purpose": "Process-creation events whose command line shows encoded or hidden PowerShell execution.",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 14,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "Description", "operator": "Contains", "value": "-enc" } } ] },
+        { "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "Description", "operator": "Contains", "value": "-EncodedCommand" } } ] },
+        { "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "Description", "operator": "Contains", "value": "FromBase64String" } } ] },
+        { "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "Description", "operator": "Contains", "value": "-w hidden" } } ] },
+        { "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "Description", "operator": "Contains", "value": "-nop" } } ] },
+        { "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "Description", "operator": "Contains", "value": "DownloadString" } } ] }
+      ]
+    },
+    {
+      "id": "sysmon-process-creation",
+      "name": "Sysmon process creation",
+      "purpose": "Sysmon process-create events with full parent and hash detail (1).",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Microsoft-Windows-Sysmon/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 15,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "1" } }
+      ]
+    },
+    {
+      "id": "sysmon-network-connection",
+      "name": "Sysmon network connection",
+      "purpose": "Sysmon network-connection events (3).",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Microsoft-Windows-Sysmon/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 16,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "3" } }
+      ]
+    },
+    {
+      "id": "sysmon-process-network-filecreate",
+      "name": "Sysmon process, network, file-create",
+      "purpose": "Sysmon process-create (1), network-connect (3), and file-create (11) for activity triage.",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Microsoft-Windows-Sysmon/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 17,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1", "3", "11" ] } }
+      ]
+    },
+    {
+      "id": "sysmon-process-injection",
+      "name": "Sysmon process injection",
+      "purpose": "Sysmon CreateRemoteThread (8) and ProcessAccess (10) events that signal injection.",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Microsoft-Windows-Sysmon/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 18,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "8", "10" ] } }
+      ]
+    },
+    {
+      "id": "sysmon-image-driver-load",
+      "name": "Sysmon image / driver load",
+      "purpose": "Sysmon image-load (7) and driver-load (6) events.",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Microsoft-Windows-Sysmon/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 19,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "6", "7" ] } }
+      ]
+    },
+    {
+      "id": "sysmon-registry-autostart",
+      "name": "Sysmon registry autostart",
+      "purpose": "Sysmon registry events covering autostart locations (12, 13, 14).",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Microsoft-Windows-Sysmon/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 20,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "12", "13", "14" ] } }
+      ]
+    },
+    {
+      "id": "sysmon-dns-query",
+      "name": "Sysmon DNS query",
+      "purpose": "Sysmon DNS-query events (22).",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Microsoft-Windows-Sysmon/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 21,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "22" } }
+      ]
+    },
+    {
+      "id": "sysmon-tamper-service-state",
+      "name": "Sysmon tamper / service state",
+      "purpose": "Sysmon service state-change (4), config-change (16), and tamper (25) events.",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Microsoft-Windows-Sysmon/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 22,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "4", "16", "25" ] } }
+      ]
+    },
+    {
+      "id": "defender-malware-detected",
+      "name": "Defender - malware detected",
+      "purpose": "Microsoft Defender Antivirus malware detections (1116, 1006, 1015).",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Microsoft-Windows-Windows Defender/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 23,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1116", "1006", "1015" ] } }
+      ]
+    },
+    {
+      "id": "defender-remediation-action-taken",
+      "name": "Defender - remediation / action taken",
+      "purpose": "Defender remediation actions such as quarantine, removal, and block (1117, 1007-1009, 1118, 1119).",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Microsoft-Windows-Windows Defender/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 24,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1117", "1007", "1008", "1009", "1118", "1119" ] } }
+      ]
+    },
+    {
+      "id": "defender-tampering-protection-disabled",
+      "name": "Defender - tampering / protection disabled",
+      "purpose": "Defender protection-state changes that may indicate tampering (5001, 5004, 5007, 5010, 5012).",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Microsoft-Windows-Windows Defender/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 25,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "5001", "5004", "5007", "5010", "5012" ] } }
+      ]
+    },
+    {
+      "id": "defender-asr-network-exploit",
+      "name": "Defender - ASR / network / exploit protection",
+      "purpose": "Attack-surface-reduction, network-protection, and exploit-protection events (1121, 1122, 1125, 1126).",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Microsoft-Windows-Windows Defender/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 26,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1121", "1122", "1125", "1126" ] } }
+      ]
+    },
+    {
+      "id": "security-audit-log-cleared",
+      "name": "Security audit log cleared or stopped",
+      "purpose": "The Security audit log was cleared (1102) or the event log service was shut down (1100); both can indicate anti-forensic tampering.",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 27,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1100", "1102" ] } }
+      ]
+    },
+    {
+      "id": "event-log-cleared-any",
+      "name": "Event log cleared (any log)",
+      "purpose": "Any event log was cleared (Eventlog 104).",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "System" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 28,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Source", "value": "Microsoft-Windows-Eventlog" }, "predicates": [ { "comparison": { "property": "Id", "value": "104" } } ] }
+      ]
+    },
+    {
+      "id": "log-cleared-anti-forensics-combined",
+      "name": "Log cleared / anti-forensics (combined)",
+      "purpose": "Correlate Security audit-log clear or service stop (1102, 1100) with any-log clears in the System log (104).",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Security", "System" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 29,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "LogName", "value": "Security" }, "predicates": [ { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1100", "1102" ] } } ] },
+        { "comparison": { "property": "LogName", "value": "System" }, "predicates": [ { "joinWithAny": false, "comparison": { "property": "Source", "value": "Microsoft-Windows-Eventlog" } }, { "joinWithAny": false, "comparison": { "property": "Id", "value": "104" } } ] }
+      ]
+    },
+    {
+      "id": "rdp-local-session",
+      "name": "RDP local session (logon / disconnect / reconnect)",
+      "purpose": "Terminal Services local session manager logon, disconnect, and reconnect events (21, 24, 25).",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Microsoft-Windows-TerminalServices-LocalSessionManager/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 30,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "21", "24", "25" ] } }
+      ]
+    },
+    {
+      "id": "rdp-inbound-authentication",
+      "name": "RDP inbound authentication",
+      "purpose": "Remote Connection Manager inbound RDP authentication events (1149).",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Microsoft-Windows-TerminalServices-RemoteConnectionManager/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 31,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "1149" } }
+      ]
+    },
+    {
+      "id": "rdp-activity-combined",
+      "name": "RDP activity (combined)",
+      "purpose": "Combine inbound RDP authentication (1149) with local session logon, disconnect, and reconnect (21, 24, 25).",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Microsoft-Windows-TerminalServices-RemoteConnectionManager/Operational", "Microsoft-Windows-TerminalServices-LocalSessionManager/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 32,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "LogName", "value": "Microsoft-Windows-TerminalServices-RemoteConnectionManager/Operational" }, "predicates": [ { "comparison": { "property": "Id", "value": "1149" } } ] },
+        { "comparison": { "property": "LogName", "value": "Microsoft-Windows-TerminalServices-LocalSessionManager/Operational" }, "predicates": [ { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "21", "24", "25" ] } } ] }
+      ]
+    },
+    {
+      "id": "winrm-remoting-activity",
+      "name": "WinRM remoting activity",
+      "purpose": "WinRM remote-management session and operation events (6, 91, 161, 168, 169).",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Microsoft-Windows-WinRM/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 33,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "6", "91", "161", "168", "169" ] } }
+      ]
+    },
+    {
+      "id": "wmi-remote-activity",
+      "name": "WMI remote / activity",
+      "purpose": "WMI activity and remote operation events (5857-5861).",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Microsoft-Windows-WMI-Activity/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 34,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "5857", "5858", "5859", "5860", "5861" ] } }
+      ]
+    },
+    {
+      "id": "remote-execution-lateral-movement-combined",
+      "name": "Remote execution / lateral movement (combined)",
+      "purpose": "Combine WinRM, PowerShell, WMI, and Task Scheduler operational logs for lateral-movement hunting.",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Microsoft-Windows-WinRM/Operational", "Microsoft-Windows-PowerShell/Operational", "Microsoft-Windows-WMI-Activity/Operational", "Microsoft-Windows-TaskScheduler/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 35,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "LogName", "value": "Microsoft-Windows-WinRM/Operational" }, "predicates": [ { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "6", "91", "161", "168", "169" ] } } ] },
+        { "comparison": { "property": "LogName", "value": "Microsoft-Windows-PowerShell/Operational" }, "predicates": [ { "comparison": { "property": "Id", "value": "4104" } } ] },
+        { "comparison": { "property": "LogName", "value": "Microsoft-Windows-WMI-Activity/Operational" }, "predicates": [ { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "5857", "5858", "5860", "5861" ] } } ] },
+        { "comparison": { "property": "LogName", "value": "Microsoft-Windows-TaskScheduler/Operational" }, "predicates": [ { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "106", "140", "141" ] } } ] }
+      ]
+    },
+    {
+      "id": "endpoint-ir-triage-persistence-evasion",
+      "name": "Endpoint IR triage - persistence & evasion",
+      "purpose": "Flagship cross-log triage: audited persistence and evasion (Security), service installs and log clears (System), task lifecycle (Task Scheduler), and script-block logging (PowerShell).",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Security", "System", "Microsoft-Windows-TaskScheduler/Operational", "Microsoft-Windows-PowerShell/Operational" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 36,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "LogName", "value": "Security" }, "predicates": [ { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "4697", "4698", "4699", "4702", "1102", "1100" ] } } ] },
+        { "comparison": { "property": "LogName", "value": "System" }, "predicates": [ { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "7045", "104" ] } } ] },
+        { "comparison": { "property": "LogName", "value": "Microsoft-Windows-TaskScheduler/Operational" }, "predicates": [ { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "106", "140", "141" ] } } ] },
+        { "comparison": { "property": "LogName", "value": "Microsoft-Windows-PowerShell/Operational" }, "predicates": [ { "comparison": { "property": "Id", "value": "4104" } } ] }
+      ]
+    }
+  ]
+}

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/updates-and-policy.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/updates-and-policy.json
@@ -29,8 +29,8 @@
     },
     {
       "id": "windows-update-diagnostics",
-      "name": "Windows Update failures",
-      "purpose": "Windows Update client installation and download errors and warnings.",
+      "name": "Windows Update outcome",
+      "purpose": "Windows Update client outcomes, color-coded: successful install (WindowsUpdateClient 19), warnings, and errors.",
       "group": "UpdatesAndPolicy",
       "channels": [ "System" ],
       "optionalChannels": [ "Microsoft-Windows-WindowsUpdateClient/Operational" ],
@@ -40,9 +40,24 @@
       "version": 1,
       "filters": [
         {
+          "color": "Green",
           "comparison": { "property": "Source", "value": "Microsoft-Windows-WindowsUpdateClient" },
           "predicates": [
-            { "comparison": { "property": "Level", "matchMode": "Many", "values": [ "Error", "Warning" ] } }
+            { "comparison": { "property": "Id", "value": "19" } }
+          ]
+        },
+        {
+          "color": "Yellow",
+          "comparison": { "property": "Source", "value": "Microsoft-Windows-WindowsUpdateClient" },
+          "predicates": [
+            { "comparison": { "property": "Level", "value": "Warning" } }
+          ]
+        },
+        {
+          "color": "Red",
+          "comparison": { "property": "Source", "value": "Microsoft-Windows-WindowsUpdateClient" },
+          "predicates": [
+            { "comparison": { "property": "Level", "value": "Error" } }
           ]
         }
       ]

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/updates-and-policy.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/updates-and-policy.json
@@ -1,0 +1,122 @@
+{
+  "schemaVersion": 1,
+  "scenarios": [
+    {
+      "id": "group-policy-processing-errors",
+      "name": "Group Policy processing errors",
+      "purpose": "Group Policy processing failures from the Operational log plus classic System-log errors (1058, 1085).",
+      "group": "UpdatesAndPolicy",
+      "channels": [ "Microsoft-Windows-GroupPolicy/Operational", "System" ],
+      "requiresAdmin": false,
+      "priority": 0,
+      "order": 0,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "LogName", "value": "Microsoft-Windows-GroupPolicy/Operational" },
+          "predicates": [
+            { "comparison": { "property": "Level", "matchMode": "Many", "values": [ "Error", "Warning" ] } }
+          ]
+        },
+        {
+          "comparison": { "property": "LogName", "value": "System" },
+          "predicates": [
+            { "joinWithAny": false, "comparison": { "property": "Source", "value": "Microsoft-Windows-GroupPolicy" } },
+            { "joinWithAny": false, "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1058", "1085" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "windows-update-diagnostics",
+      "name": "Windows Update failures",
+      "purpose": "Windows Update client installation and download errors and warnings.",
+      "group": "UpdatesAndPolicy",
+      "channels": [ "System" ],
+      "optionalChannels": [ "Microsoft-Windows-WindowsUpdateClient/Operational" ],
+      "requiresAdmin": false,
+      "priority": 0,
+      "order": 1,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Microsoft-Windows-WindowsUpdateClient" },
+          "predicates": [
+            { "comparison": { "property": "Level", "matchMode": "Many", "values": [ "Error", "Warning" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "windows-setup-servicing-errors",
+      "name": "Windows setup & servicing errors",
+      "purpose": "Component servicing and standalone-update-installer errors (Servicing, WUSA).",
+      "group": "UpdatesAndPolicy",
+      "channels": [ "Setup" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 2,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "matchMode": "Many", "values": [ "Microsoft-Windows-Servicing", "Microsoft-Windows-WUSA" ] },
+          "predicates": [
+            { "comparison": { "property": "Level", "matchMode": "Many", "values": [ "Error", "Warning" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "time-synchronization-failures",
+      "name": "Time synchronization failures",
+      "purpose": "Windows Time service synchronization problems (Time-Service / W32Time 29, 36, 50, 129, 131).",
+      "group": "UpdatesAndPolicy",
+      "channels": [ "System" ],
+      "optionalChannels": [ "Microsoft-Windows-Time-Service/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 3,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "matchMode": "Many", "values": [ "Microsoft-Windows-Time-Service", "W32Time" ] },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "29", "36", "50", "129", "131" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "app-compatibility-issues",
+      "name": "App compatibility issues",
+      "purpose": "Program Compatibility Assistant errors and warnings for apps that misbehave on this Windows build.",
+      "group": "UpdatesAndPolicy",
+      "channels": [ "Microsoft-Windows-Application-Experience/Program-Compatibility-Assistant" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 4,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Level", "matchMode": "Many", "values": [ "Error", "Warning" ] }
+        }
+      ]
+    },
+    {
+      "id": "certificate-lifecycle-events",
+      "name": "Certificate lifecycle events",
+      "purpose": "Certificate enrollment and renewal errors and warnings on this machine.",
+      "group": "UpdatesAndPolicy",
+      "channels": [ "Microsoft-Windows-CertificateServicesClient-Lifecycle-System/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 5,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Level", "matchMode": "Many", "values": [ "Error", "Warning" ] }
+        }
+      ]
+    }
+  ]
+}

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/virtualization-and-clustering.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/virtualization-and-clustering.json
@@ -61,8 +61,8 @@
     },
     {
       "id": "cluster-node-quarantine",
-      "name": "Cluster node quarantine",
-      "purpose": "A failover cluster node was quarantined after consecutive failures (FailoverClustering 1672, 1676).",
+      "name": "Cluster node distress",
+      "purpose": "Failover cluster node and resource distress, color-coded: node quarantined (1672, 1676), clustered resource/role failed (1069, 1205), CSV paused (5120), and node removed from membership (1135).",
       "group": "VirtualizationAndClustering",
       "channels": [ "System" ],
       "requiresAdmin": false,
@@ -71,9 +71,31 @@
       "version": 1,
       "filters": [
         {
+          "color": "Orange",
           "comparison": { "property": "Source", "value": "Microsoft-Windows-FailoverClustering" },
           "predicates": [
             { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1672", "1676" ] } }
+          ]
+        },
+        {
+          "color": "Yellow",
+          "comparison": { "property": "Source", "value": "Microsoft-Windows-FailoverClustering" },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "5120" } }
+          ]
+        },
+        {
+          "color": "Red",
+          "comparison": { "property": "Source", "value": "Microsoft-Windows-FailoverClustering" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1069", "1205" ] } }
+          ]
+        },
+        {
+          "color": "DarkRed",
+          "comparison": { "property": "Source", "value": "Microsoft-Windows-FailoverClustering" },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "1135" } }
           ]
         }
       ]

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/virtualization-and-clustering.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/virtualization-and-clustering.json
@@ -1,0 +1,205 @@
+{
+  "schemaVersion": 1,
+  "scenarios": [
+    {
+      "id": "hyperv-vm-health",
+      "name": "Hyper-V VM health",
+      "purpose": "Critical and error events across the Hyper-V VMMS, Worker, and Hypervisor admin logs.",
+      "group": "VirtualizationAndClustering",
+      "channels": [ "Microsoft-Windows-Hyper-V-VMMS/Admin", "Microsoft-Windows-Hyper-V-Worker/Admin", "Microsoft-Windows-Hyper-V-Hypervisor/Admin" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 0,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "LogName", "value": "Microsoft-Windows-Hyper-V-VMMS/Admin" }, "predicates": [ { "comparison": { "property": "Level", "matchMode": "Many", "values": [ "Critical", "Error" ] } } ] },
+        { "comparison": { "property": "LogName", "value": "Microsoft-Windows-Hyper-V-Worker/Admin" }, "predicates": [ { "comparison": { "property": "Level", "matchMode": "Many", "values": [ "Critical", "Error" ] } } ] },
+        { "comparison": { "property": "LogName", "value": "Microsoft-Windows-Hyper-V-Hypervisor/Admin" }, "predicates": [ { "comparison": { "property": "Level", "matchMode": "Many", "values": [ "Critical", "Error" ] } } ] }
+      ]
+    },
+    {
+      "id": "hyperv-live-migration-failures",
+      "name": "Hyper-V live migration failures",
+      "purpose": "Hyper-V live migration failures (VMMS 21502, 21026).",
+      "group": "VirtualizationAndClustering",
+      "channels": [ "Microsoft-Windows-Hyper-V-VMMS/Admin" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 1,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "21502", "21026" ] } }
+      ]
+    },
+    {
+      "id": "hyperv-replica-failures",
+      "name": "Hyper-V Replica failures",
+      "purpose": "Hyper-V Replica replication failures (VMMS 24004, 24026, 29202, 29206, 29210, 29220).",
+      "group": "VirtualizationAndClustering",
+      "channels": [ "Microsoft-Windows-Hyper-V-VMMS/Admin" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 2,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "24004", "24026", "29202", "29206", "29210" ] } }
+      ]
+    },
+    {
+      "id": "hyperv-vswitch-health",
+      "name": "Hyper-V virtual switch health",
+      "purpose": "Hyper-V virtual switch errors and warnings (VmSwitch 10, 15, 113).",
+      "group": "VirtualizationAndClustering",
+      "channels": [ "Microsoft-Windows-Hyper-V-VmSwitch/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 3,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "10", "15", "113" ] } }
+      ]
+    },
+    {
+      "id": "cluster-node-quarantine",
+      "name": "Cluster node quarantine",
+      "purpose": "A failover cluster node was quarantined after consecutive failures (FailoverClustering 1672, 1676).",
+      "group": "VirtualizationAndClustering",
+      "channels": [ "System" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 4,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Microsoft-Windows-FailoverClustering" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1672", "1676" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cluster-service-fatal",
+      "name": "Cluster service fatal errors",
+      "purpose": "Failover cluster service self-termination events (FailoverClustering 1000, 1001, 1006, 1073, 1080, 1092).",
+      "group": "VirtualizationAndClustering",
+      "channels": [ "System" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 5,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Microsoft-Windows-FailoverClustering" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1000", "1001", "1006", "1073", "1080", "1092" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cluster-network-partition",
+      "name": "Cluster network partition",
+      "purpose": "Failover cluster network interface and partition failures (FailoverClustering 1127, 1129, 1130, 1553, 1554).",
+      "group": "VirtualizationAndClustering",
+      "channels": [ "System" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 6,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Microsoft-Windows-FailoverClustering" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1127", "1129", "1130", "1553", "1554" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cluster-role-failover-exhausted",
+      "name": "Cluster role failover exhausted",
+      "purpose": "Clustered roles that exceeded their failover threshold and were left failed (FailoverClustering 1146, 1250, 1254, 1255).",
+      "group": "VirtualizationAndClustering",
+      "channels": [ "System" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 7,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Microsoft-Windows-FailoverClustering" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1146", "1250", "1254", "1255" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cluster-quorum-db-integrity",
+      "name": "Cluster quorum & database integrity",
+      "purpose": "Failover cluster quorum loss and database corruption events (FailoverClustering 1057, 1070, 1080, 1547, 1564, 1575).",
+      "group": "VirtualizationAndClustering",
+      "channels": [ "System" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 8,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Microsoft-Windows-FailoverClustering" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1057", "1070", "1080", "1547", "1564", "1575" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cluster-disk-resource-failures",
+      "name": "Cluster disk resource failures",
+      "purpose": "Clustered disk and storage resource failures (FailoverClustering 1034, 1035, 1037, 1038, 1069).",
+      "group": "VirtualizationAndClustering",
+      "channels": [ "System" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 9,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Microsoft-Windows-FailoverClustering" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1034", "1035", "1037", "1038", "1069" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "s2d-disk-volume-health",
+      "name": "Storage Spaces Direct disk & volume health",
+      "purpose": "Storage Spaces Direct physical disk and volume health transitions (StorageSpaces-Driver 311, 315, 316, 157, 163, 164).",
+      "group": "VirtualizationAndClustering",
+      "channels": [ "Microsoft-Windows-StorageSpaces-Driver/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 10,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "311", "315", "316" ] } }
+      ]
+    },
+    {
+      "id": "cluster-aware-updating-failures",
+      "name": "Cluster-Aware Updating failures",
+      "purpose": "Cluster-Aware Updating run failures, including node-drain and script errors.",
+      "group": "VirtualizationAndClustering",
+      "channels": [ "Microsoft-Windows-ClusterAwareUpdating/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 11,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Level", "matchMode": "Many", "values": [ "Critical", "Error", "Warning" ] } }
+      ]
+    }
+  ]
+}

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/web-and-iis.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/web-and-iis.json
@@ -1,0 +1,173 @@
+{
+  "schemaVersion": 1,
+  "scenarios": [
+    {
+      "id": "iis-app-pool-crashes",
+      "name": "App pool / WAS worker crashes & rapid-fail",
+      "purpose": "Windows Process Activation Service worker-process crashes and rapid-fail protection (WAS 5009, 5011, 5021, 5057, 5117, 5139, 5186).",
+      "group": "WebAndIis",
+      "channels": [ "System" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 0,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "value": "Microsoft-Windows-WAS" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "5009", "5011", "5021", "5057", "5186" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "w3wp-dotnet-crashes",
+      "name": "w3wp .NET runtime crashes",
+      "purpose": "IIS worker-process crashes from the .NET runtime and Application Error whose fault module is w3wp (1000, 1023, 1026).",
+      "group": "WebAndIis",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 1,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "matchMode": "Many", "values": [ ".NET Runtime", "Application Error" ] },
+          "predicates": [
+            { "joinWithAny": false, "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1000", "1023", "1026" ] } },
+            { "joinWithAny": false, "comparison": { "property": "Description", "operator": "Contains", "value": "w3wp" } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "httpsys-listener-ssl-errors",
+      "name": "HTTP.sys SSL configuration errors",
+      "purpose": "HTTP.sys SSL configuration errors for an endpoint (HTTP.sys event 15021).",
+      "group": "WebAndIis",
+      "channels": [ "System" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 2,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "matchMode": "Many", "values": [ "Microsoft-Windows-HttpEvent", "Http" ] },
+          "predicates": [
+            { "comparison": { "property": "Id", "value": "15021" } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "aspnet-unhandled-exceptions",
+      "name": "ASP.NET unhandled exceptions & restarts",
+      "purpose": "ASP.NET unhandled exceptions and worker restarts (1309, 1310, 1325).",
+      "group": "WebAndIis",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 3,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "operator": "Contains", "value": "ASP.NET" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "1309", "1310", "1325" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ancm-startup-failure",
+      "name": "ASP.NET Core (ANCM) startup failure",
+      "purpose": "ASP.NET Core Module failed to start an application (IIS AspNetCore Module V2 1010).",
+      "group": "WebAndIis",
+      "channels": [ "Application" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 4,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Source", "matchMode": "Many", "values": [ "IIS AspNetCore Module V2", "IIS AspNetCore Module" ] },
+          "predicates": [
+            { "comparison": { "property": "Level", "matchMode": "Many", "values": [ "Critical", "Error" ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "iis-native-module-install",
+      "name": "IIS native module install",
+      "purpose": "A native IIS module was registered (Configuration 29); a primary web-shell backdoor persistence signal.",
+      "group": "WebAndIis",
+      "channels": [ "Microsoft-Windows-IIS-Configuration/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 5,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Id", "value": "29" },
+          "predicates": [
+            { "comparison": { "property": "Description", "operator": "Contains", "value": "/system.webServer/modules/add" } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "iis-etw-logging-disabled",
+      "name": "IIS ETW logging disabled",
+      "purpose": "The ETW logging target was removed from IIS (Configuration 29); a defense-evasion tactic.",
+      "group": "WebAndIis",
+      "channels": [ "Microsoft-Windows-IIS-Configuration/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 6,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Id", "value": "29" },
+          "predicates": [
+            { "joinWithAny": false, "comparison": { "property": "Description", "operator": "Contains", "value": "@logTargetW3C" } },
+            { "joinWithAny": false, "comparison": { "property": "Description", "operator": "Contains", "value": "ETW" } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "iis-http-logging-disabled",
+      "name": "IIS HTTP logging disabled",
+      "purpose": "HTTP request logging was disabled for a site (Configuration 29); covers up attacker requests.",
+      "group": "WebAndIis",
+      "channels": [ "Microsoft-Windows-IIS-Configuration/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 7,
+      "version": 1,
+      "filters": [
+        {
+          "comparison": { "property": "Id", "value": "29" },
+          "predicates": [
+            { "comparison": { "property": "Description", "operator": "Contains", "value": "/system.webServer/httpLogging/@dontLog" } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "iis-configuration-changes",
+      "name": "IIS configuration changes & errors",
+      "purpose": "IIS configuration errors and warnings from the configuration operational log.",
+      "group": "WebAndIis",
+      "channels": [ "Microsoft-Windows-IIS-Configuration/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 8,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Level", "matchMode": "Many", "values": [ "Error", "Warning" ] } }
+      ]
+    }
+  ]
+}

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/web-and-iis.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/web-and-iis.json
@@ -3,8 +3,8 @@
   "scenarios": [
     {
       "id": "iis-app-pool-crashes",
-      "name": "App pool / WAS worker crashes & rapid-fail",
-      "purpose": "Windows Process Activation Service worker-process crashes and rapid-fail protection (WAS 5009, 5011, 5021, 5057, 5117, 5139, 5186).",
+      "name": "App pool / WAS worker lifecycle",
+      "purpose": "Windows Process Activation Service worker-process health, color-coded: worker crash / timeout (WAS 5009, 5011, 5012), app pool disabled by rapid-fail protection (5002, 5057), and identity / worker-process problems (5021, 5186).",
       "group": "WebAndIis",
       "channels": [ "System" ],
       "requiresAdmin": false,
@@ -13,9 +13,24 @@
       "version": 1,
       "filters": [
         {
+          "color": "Red",
           "comparison": { "property": "Source", "value": "Microsoft-Windows-WAS" },
           "predicates": [
-            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "5009", "5011", "5021", "5057", "5186" ] } }
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "5009", "5011", "5012" ] } }
+          ]
+        },
+        {
+          "color": "DarkRed",
+          "comparison": { "property": "Source", "value": "Microsoft-Windows-WAS" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "5002", "5057" ] } }
+          ]
+        },
+        {
+          "color": "Orange",
+          "comparison": { "property": "Source", "value": "Microsoft-Windows-WAS" },
+          "predicates": [
+            { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "5021", "5186" ] } }
           ]
         }
       ]

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/wins.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/wins.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": 1,
+  "scenarios": [
+    {
+      "id": "wins-registration-errors",
+      "name": "WINS name registration errors",
+      "purpose": "WINS service errors and warnings, including name registration and replication problems.",
+      "group": "Wins",
+      "channels": [ "WINS" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 0,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Level", "matchMode": "Many", "values": [ "Error", "Warning" ] } }
+      ]
+    }
+  ]
+}

--- a/src/EventLogExpert.Scenarios/Serialization/ScenarioCatalogLoader.cs
+++ b/src/EventLogExpert.Scenarios/Serialization/ScenarioCatalogLoader.cs
@@ -268,7 +268,6 @@ internal static partial class ScenarioCatalogLoader
                 Name = dto.Name!,
                 Purpose = dto.Purpose!,
                 Group = group,
-                Tags = [.. dto.Tags ?? []],
                 Channels = [.. dto.Channels!],
                 OptionalChannels = [.. dto.OptionalChannels ?? []],
                 Gating = gating,

--- a/src/EventLogExpert.Scenarios/Serialization/ScenarioCatalogLoader.cs
+++ b/src/EventLogExpert.Scenarios/Serialization/ScenarioCatalogLoader.cs
@@ -169,10 +169,11 @@ internal static partial class ScenarioCatalogLoader
                 }
             }
 
-            if (predicatesOk)
-            {
-                rows.Add(new ScenarioFilterRow(new BasicFilter(root, predicates.ToImmutable()), dto.IsExcluded));
-            }
+            if (!predicatesOk) { continue; }
+
+            var color = ParseEnum(dto.Color, rowContext, "color", required: false, errors, HighlightColor.None);
+
+            rows.Add(new ScenarioFilterRow(new BasicFilter(root, predicates.ToImmutable()), dto.IsExcluded ?? false, color));
         }
 
         return rows;
@@ -366,6 +367,11 @@ internal static partial class ScenarioCatalogLoader
 
         var isCombined = definition.Channels.Length > 1;
 
+        if (definition.Filters.Length == 1 && definition.Filters[0].Color != HighlightColor.None)
+        {
+            errors.Add($"{context}: single-row scenarios must not use highlight colors.");
+        }
+
         for (var i = 0; i < definition.Filters.Length; i++)
         {
             var row = definition.Filters[i];
@@ -382,6 +388,11 @@ internal static partial class ScenarioCatalogLoader
 
     private static void ValidateRow(ScenarioFilterRow row, string context, List<string> errors)
     {
+        if (row.IsExcluded && row.Color != HighlightColor.None)
+        {
+            errors.Add($"{context}: excluded rows cannot have a highlight color.");
+        }
+
         if (!BasicFilterFormatter.TryFormat(row.Filter, strictPredicates: true, out var text))
         {
             errors.Add($"{context}: filter did not format (a comparison or predicate is incomplete).");

--- a/src/EventLogExpert.Scenarios/Serialization/ScenarioDto.cs
+++ b/src/EventLogExpert.Scenarios/Serialization/ScenarioDto.cs
@@ -31,7 +31,5 @@ internal sealed class ScenarioDto
 
     public List<string>? SourceGates { get; set; }
 
-    public List<string>? Tags { get; set; }
-
     public int Version { get; set; }
 }

--- a/src/EventLogExpert.Scenarios/Serialization/ScenarioFilterRowDto.cs
+++ b/src/EventLogExpert.Scenarios/Serialization/ScenarioFilterRowDto.cs
@@ -5,9 +5,11 @@ namespace EventLogExpert.Scenarios.Serialization;
 
 internal sealed class ScenarioFilterRowDto
 {
+    public string? Color { get; set; }
+
     public ComparisonDto? Comparison { get; set; }
 
-    public bool IsExcluded { get; set; }
+    public bool? IsExcluded { get; set; }
 
     public List<PredicateDto>? Predicates { get; set; }
 }

--- a/src/EventLogExpert.Scenarios/Serialization/ScenarioJsonContext.cs
+++ b/src/EventLogExpert.Scenarios/Serialization/ScenarioJsonContext.cs
@@ -12,6 +12,8 @@ namespace EventLogExpert.Scenarios.Serialization;
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     PropertyNameCaseInsensitive = true,
     ReadCommentHandling = JsonCommentHandling.Skip,
-    AllowTrailingCommas = true)]
+    AllowTrailingCommas = true,
+    WriteIndented = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
 [JsonSerializable(typeof(ScenarioFileDto))]
 internal sealed partial class ScenarioJsonContext : JsonSerializerContext;

--- a/src/EventLogExpert.UI/FilterEditor/Rows/FilterRowActions.razor
+++ b/src/EventLogExpert.UI/FilterEditor/Rows/FilterRowActions.razor
@@ -1,6 +1,16 @@
 @if (Value is { } savedFilter)
 {
     <div class="filter-row-actions">
+        @if (ShowScenarioCopy)
+        {
+            <button aria-label="@($"Copy {DescribeFilter(savedFilter)} as scenario JSON")"
+                class="button icon-button"
+                @onclick="@(() => CopyScenarioJsonAsync(savedFilter))"
+                title="Copy as scenario JSON"
+                type="button">
+                <i aria-hidden="true" class="bi bi-filetype-json"></i>
+            </button>
+        }
         <button aria-label="@($"Edit {DescribeFilter(savedFilter)}")"
             class="button icon-button"
             @onclick="OnEdit"

--- a/src/EventLogExpert.UI/FilterEditor/Rows/FilterRowActions.razor.cs
+++ b/src/EventLogExpert.UI/FilterEditor/Rows/FilterRowActions.razor.cs
@@ -14,10 +14,8 @@ public sealed partial class FilterRowActions : ComponentBase
 
     private ElementReference _editButtonRef;
 
-    /// <summary>
-    ///     DOM id of the comparison-text element in <see cref="FilterRowHeader" />; chained into the Toggle's
-    ///     <c>aria-labelledby</c> so SR users hear the filter context plus the Enable purpose hint.
-    /// </summary>
+    [CascadingParameter] public ScenarioAuthoringRowContext? AuthoringContext { get; set; }
+
     [Parameter] public string? FilterLabelId { get; set; }
 
     [Parameter] public EventCallback OnEdit { get; set; }
@@ -33,8 +31,13 @@ public sealed partial class FilterRowActions : ComponentBase
             ? _enableToggleLabelId
             : $"{FilterLabelId} {_enableToggleLabelId}";
 
+    private bool ShowScenarioCopy => AuthoringContext is { Enabled: true };
+
     internal ValueTask FocusEditAsync() => ElementFocus.SafelyAsync(_editButtonRef);
 
     private static string DescribeFilter(SavedFilter filter) =>
         string.IsNullOrWhiteSpace(filter.ComparisonText) ? "filter" : $"filter '{filter.ComparisonText}'";
+
+    private Task CopyScenarioJsonAsync(SavedFilter savedFilter) =>
+        AuthoringContext?.CopyAsync(savedFilter) ?? Task.CompletedTask;
 }

--- a/src/EventLogExpert.UI/FilterEditor/ScenarioAuthoringRowContext.cs
+++ b/src/EventLogExpert.UI/FilterEditor/ScenarioAuthoringRowContext.cs
@@ -1,0 +1,22 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Persistence;
+
+namespace EventLogExpert.UI.FilterEditor;
+
+/// <summary>
+///     Cascaded capability that lets a filter row's action cluster export that single row as scenario-catalog JSON.
+///     It is provided once per container - the filter pane (active rows) and the filter-library modal (saved-group rows) -
+///     and only when scenario authoring is enabled, so the per-row button appears solely where a container opts in and is
+///     absent everywhere else. A developer authoring aid.
+/// </summary>
+/// <param name="Enabled">Whether the per-row "Copy as scenario JSON" button should render.</param>
+/// <param name="CopyAsync">
+///     Exports the supplied row as scenario JSON (copies to the clipboard) and reports the outcome to
+///     the user.
+/// </param>
+public sealed record ScenarioAuthoringRowContext(bool Enabled, Func<SavedFilter, Task> CopyAsync)
+{
+    public Func<SavedFilter, Task> CopyAsync { get; init; } = CopyAsync ?? throw new ArgumentNullException(nameof(CopyAsync));
+}

--- a/src/EventLogExpert.UI/FilterEditor/ScenarioClipboardExporter.cs
+++ b/src/EventLogExpert.UI/FilterEditor/ScenarioClipboardExporter.cs
@@ -1,0 +1,77 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.Alerts;
+using EventLogExpert.Runtime.Announcement;
+using EventLogExpert.Runtime.Common.Clipboard;
+using EventLogExpert.Scenarios.Catalog;
+
+namespace EventLogExpert.UI.FilterEditor;
+
+internal sealed class ScenarioClipboardExporter
+{
+    private const string ChannelsGuidance = "Fill in channels[] before adding to the catalog.";
+
+    private readonly IAlertDialogService _alertDialogService;
+    private readonly IAnnouncementService _announcementService;
+    private readonly IClipboardService _clipboardService;
+
+    public ScenarioClipboardExporter(
+        IAnnouncementService announcementService,
+        IAlertDialogService alertDialogService,
+        IClipboardService clipboardService)
+    {
+        ArgumentNullException.ThrowIfNull(announcementService);
+        ArgumentNullException.ThrowIfNull(alertDialogService);
+        ArgumentNullException.ThrowIfNull(clipboardService);
+
+        _announcementService = announcementService;
+        _alertDialogService = alertDialogService;
+        _clipboardService = clipboardService;
+    }
+
+    public async Task AnnounceAsync(string success, IReadOnlyList<string> warnings)
+    {
+        var message = warnings.Contains(ScenarioExporter.NoLiveChannelsWarning)
+            ? $"{success} {ChannelsGuidance}"
+            : success;
+
+        var substantive = SubstantiveWarnings(warnings);
+
+        if (substantive.Count == 0)
+        {
+            _announcementService.Announce(message);
+
+            return;
+        }
+
+        await _alertDialogService.ShowAlert(
+            "Scenario JSON exported with warnings",
+            message + Environment.NewLine + string.Join(Environment.NewLine, substantive),
+            "OK");
+    }
+
+    public async Task CopyAsync(ScenarioExportResult export, string success, string emptyNoun)
+    {
+        if (NotExportable(export, emptyNoun)) { return; }
+
+        await _clipboardService.CopyTextAsync(export.Json);
+        await AnnounceAsync(success, export.Warnings);
+    }
+
+    public bool NotExportable(ScenarioExportResult export, string emptyNoun)
+    {
+        if (export.EmittedRowCount > 0) { return false; }
+
+        var detail = SubstantiveWarnings(export.Warnings);
+
+        _announcementService.Announce(detail.Count > 0
+            ? $"Could not export {emptyNoun}: {string.Join(" ", detail)}"
+            : $"Could not export {emptyNoun}: only Basic filters can be exported as scenarios.");
+
+        return true;
+    }
+
+    private static IReadOnlyList<string> SubstantiveWarnings(IReadOnlyList<string> warnings) =>
+        [.. warnings.Where(warning => warning != ScenarioExporter.NoLiveChannelsWarning)];
+}

--- a/src/EventLogExpert.UI/FilterLibrary/FilterLibraryModal.razor
+++ b/src/EventLogExpert.UI/FilterLibrary/FilterLibraryModal.razor
@@ -27,128 +27,130 @@
         }
         else
         {
-            <SidebarTabs @bind-ActiveTab="_activeTab"
-                IsTabpanelFocusable="@IsTabpanelEmpty"
-                @ref="_sidebarTabsRef"
-                TablistAriaLabel="Filter library views"
-                Tabs="@CurrentTabLabels"
-                TTab="LibraryTab">
-                <TabContent Context="tab">
-                    @{
-                        var tagManagementPanelId = GetTagManagementPanelId(tab);
-                        var tagOverflowRegionId = GetTagOverflowRegionId(tab);
-                    }
-                    @if (AllLibraryTags.Count > 0)
-                    {
-                        <div aria-label="Filter by tag"
-                            class="library-tag-filter-bar"
-                            @onkeydown="HandleTagFilterBarKeyDown"
-                            role="group">
-                            <span class="library-tag-filter-bar-label">Tags:</span>
-                            <button aria-controls="@(_isTagManagementExpanded ? tagManagementPanelId : null)"
-                                aria-expanded="@(_isTagManagementExpanded ? "true" : "false")"
-                                aria-label="@(_isTagManagementExpanded ? "Hide tag management" : "Manage tags")"
-                                class="button icon-button library-tag-management-trigger"
-                                @onclick="ToggleTagManagement"
-                                title="Manage tags"
-                                type="button">
-                                <i aria-hidden="true" class="bi bi-gear"></i>
-                            </button>
-                            @{
-                                var visibleTags = AllLibraryTags.Take(TagFilterBarMaxVisible).ToList();
-                                var hiddenTagsCount = AllLibraryTags.Count - visibleTags.Count;
-                            }
-                            @foreach (var tag in visibleTags)
-                            {
-                                var isSelected = _selectedTagsByTab[tab].Contains(tag, StringComparer.OrdinalIgnoreCase);
-                                <button aria-pressed="@(isSelected ? "true" : "false")"
-                                    class="library-tag-filter-chip"
-                                    @onclick="@(() => ToggleTagFilter(tag))"
-                                    type="button">
-                                    @tag
-                                </button>
-                            }
-                            @if (hiddenTagsCount > 0)
-                            {
-                                <button aria-controls="@(_isTagOverflowExpanded ? tagOverflowRegionId : null)"
-                                    aria-expanded="@(_isTagOverflowExpanded ? "true" : "false")"
-                                    aria-label="@(_isTagOverflowExpanded ? "Hide additional tags" : $"Show {hiddenTagsCount} additional tags")"
-                                    class="library-tag-filter-chip-overflow"
-                                    @onclick="ToggleTagOverflowExpanded"
-                                    type="button">
-                                    @(_isTagOverflowExpanded ? "− less" : $"+{hiddenTagsCount} more")
-                                </button>
-                            }
-                            @if (_isTagOverflowExpanded && hiddenTagsCount > 0)
-                            {
-                                <div class="library-tag-filter-bar-overflow" id="@tagOverflowRegionId">
-                                    @foreach (var tag in AllLibraryTags.Skip(TagFilterBarMaxVisible))
-                                    {
-                                        var isOverflowSelected = _selectedTagsByTab[tab].Contains(tag, StringComparer.OrdinalIgnoreCase);
-                                        <button aria-pressed="@(isOverflowSelected ? "true" : "false")"
-                                            class="library-tag-filter-chip"
-                                            @onclick="@(() => ToggleTagFilter(tag))"
-                                            type="button">
-                                            @tag
-                                        </button>
-                                    }
-                                </div>
-                            }
-                        </div>
-
-                        @if (_isTagManagementExpanded)
-                        {
-                            <TagManagementPanel AllEntries="@FilterLibraryState.Value.Entries"
-                                AllLibraryTags="@AllLibraryTags"
-                                Id="@tagManagementPanelId"
-                                OnTagDeleted="HandleTagDeleted"
-                                OnTagRenamed="HandleTagRenamed" />
+            <CascadingValue IsFixed="true" Value="_authoringContext">
+                <SidebarTabs @bind-ActiveTab="_activeTab"
+                    IsTabpanelFocusable="@IsTabpanelEmpty"
+                    @ref="_sidebarTabsRef"
+                    TablistAriaLabel="Filter library views"
+                    Tabs="@CurrentTabLabels"
+                    TTab="LibraryTab">
+                    <TabContent Context="tab">
+                        @{
+                            var tagManagementPanelId = GetTagManagementPanelId(tab);
+                            var tagOverflowRegionId = GetTagOverflowRegionId(tab);
                         }
-                    }
-                    @switch (tab)
-                    {
-                        case LibraryTab.Saved:
-                            <LibrarySavedTabHeader AllLibraryTags="@AllLibraryTags"
-                                ExistingSavedFilters="@SavedFilterEntries" />
-
-                            @if (SavedEntries.Count == 0)
-                            {
-                                <p class="library-empty-state">@GetEmptyStateMessage(tab)</p>
-                            }
-                            else
-                            {
-                                @foreach (var entry in SavedEntries)
-                                {
-                                    @RenderEntryRow(tab, entry)
+                        @if (AllLibraryTags.Count > 0)
+                        {
+                            <div aria-label="Filter by tag"
+                                class="library-tag-filter-bar"
+                                @onkeydown="HandleTagFilterBarKeyDown"
+                                role="group">
+                                <span class="library-tag-filter-bar-label">Tags:</span>
+                                <button aria-controls="@(_isTagManagementExpanded ? tagManagementPanelId : null)"
+                                    aria-expanded="@(_isTagManagementExpanded ? "true" : "false")"
+                                    aria-label="@(_isTagManagementExpanded ? "Hide tag management" : "Manage tags")"
+                                    class="button icon-button library-tag-management-trigger"
+                                    @onclick="ToggleTagManagement"
+                                    title="Manage tags"
+                                    type="button">
+                                    <i aria-hidden="true" class="bi bi-gear"></i>
+                                </button>
+                                @{
+                                    var visibleTags = AllLibraryTags.Take(TagFilterBarMaxVisible).ToList();
+                                    var hiddenTagsCount = AllLibraryTags.Count - visibleTags.Count;
                                 }
-                            }
+                                @foreach (var tag in visibleTags)
+                                {
+                                    var isSelected = _selectedTagsByTab[tab].Contains(tag, StringComparer.OrdinalIgnoreCase);
+                                    <button aria-pressed="@(isSelected ? "true" : "false")"
+                                        class="library-tag-filter-chip"
+                                        @onclick="@(() => ToggleTagFilter(tag))"
+                                        type="button">
+                                        @tag
+                                    </button>
+                                }
+                                @if (hiddenTagsCount > 0)
+                                {
+                                    <button aria-controls="@(_isTagOverflowExpanded ? tagOverflowRegionId : null)"
+                                        aria-expanded="@(_isTagOverflowExpanded ? "true" : "false")"
+                                        aria-label="@(_isTagOverflowExpanded ? "Hide additional tags" : $"Show {hiddenTagsCount} additional tags")"
+                                        class="library-tag-filter-chip-overflow"
+                                        @onclick="ToggleTagOverflowExpanded"
+                                        type="button">
+                                        @(_isTagOverflowExpanded ? "− less" : $"+{hiddenTagsCount} more")
+                                    </button>
+                                }
+                                @if (_isTagOverflowExpanded && hiddenTagsCount > 0)
+                                {
+                                    <div class="library-tag-filter-bar-overflow" id="@tagOverflowRegionId">
+                                        @foreach (var tag in AllLibraryTags.Skip(TagFilterBarMaxVisible))
+                                        {
+                                            var isOverflowSelected = _selectedTagsByTab[tab].Contains(tag, StringComparer.OrdinalIgnoreCase);
+                                            <button aria-pressed="@(isOverflowSelected ? "true" : "false")"
+                                                class="library-tag-filter-chip"
+                                                @onclick="@(() => ToggleTagFilter(tag))"
+                                                type="button">
+                                                @tag
+                                            </button>
+                                        }
+                                    </div>
+                                }
+                            </div>
 
-                            break;
-                        case LibraryTab.Favorites:
-                            @if (FavoriteEntries.Count == 0)
+                            @if (_isTagManagementExpanded)
                             {
-                                <p class="library-empty-state">@GetEmptyStateMessage(tab)</p>
+                                <TagManagementPanel AllEntries="@FilterLibraryState.Value.Entries"
+                                    AllLibraryTags="@AllLibraryTags"
+                                    Id="@tagManagementPanelId"
+                                    OnTagDeleted="HandleTagDeleted"
+                                    OnTagRenamed="HandleTagRenamed" />
                             }
-                            else
-                            {
-                                @foreach (var entry in FavoriteEntries) { @RenderEntryRow(tab, entry) }
-                            }
+                        }
+                        @switch (tab)
+                        {
+                            case LibraryTab.Saved:
+                                <LibrarySavedTabHeader AllLibraryTags="@AllLibraryTags"
+                                    ExistingSavedFilters="@SavedFilterEntries" />
 
-                            break;
-                        case LibraryTab.PreviouslyUsed:
-                            @if (PreviouslyUsedEntries.Count == 0)
-                            {
-                                <p class="library-empty-state">@GetEmptyStateMessage(tab)</p>
-                            }
-                            else
-                            {
-                                @foreach (var entry in PreviouslyUsedEntries) { @RenderEntryRow(tab, entry) }
-                            }
+                                @if (SavedEntries.Count == 0)
+                                {
+                                    <p class="library-empty-state">@GetEmptyStateMessage(tab)</p>
+                                }
+                                else
+                                {
+                                    @foreach (var entry in SavedEntries)
+                                    {
+                                        @RenderEntryRow(tab, entry)
+                                    }
+                                }
 
-                            break;
-                    }
-                </TabContent>
-            </SidebarTabs>
+                                break;
+                            case LibraryTab.Favorites:
+                                @if (FavoriteEntries.Count == 0)
+                                {
+                                    <p class="library-empty-state">@GetEmptyStateMessage(tab)</p>
+                                }
+                                else
+                                {
+                                    @foreach (var entry in FavoriteEntries) { @RenderEntryRow(tab, entry) }
+                                }
+
+                                break;
+                            case LibraryTab.PreviouslyUsed:
+                                @if (PreviouslyUsedEntries.Count == 0)
+                                {
+                                    <p class="library-empty-state">@GetEmptyStateMessage(tab)</p>
+                                }
+                                else
+                                {
+                                    @foreach (var entry in PreviouslyUsedEntries) { @RenderEntryRow(tab, entry) }
+                                }
+
+                                break;
+                        }
+                    </TabContent>
+                </SidebarTabs>
+            </CascadingValue>
         }
     </ChildContent>
 </ModalChrome>
@@ -164,11 +166,13 @@
                 @key="entry.Id"
                 OnAddToFilterSet="@HandleAddToFilterSetAsync"
                 OnApply="@HandleApplyAsync"
+                OnCopyScenario="@OnCopyScenarioCallback"
                 OnDelete="@HandleDelete"
                 OnDisposed="@OnRowDisposed"
                 OnExportEntry="@HandleExportEntryAsync"
                 OnReplace="@HandleReplaceAsync"
                 OnRequestPendingFocus="@(id => HandleRequestPendingFocusAsync(tab, id))"
+                OnSaveScenario="@OnSaveScenarioCallback"
                 OnSaveToLibrary="@HandleSaveToLibrary"
                 OnToggleFavorite="@HandleToggleFavorite"
                 @ref="_rowRefs[(tab, entry.Id)]" />

--- a/src/EventLogExpert.UI/FilterLibrary/FilterLibraryModal.razor.cs
+++ b/src/EventLogExpert.UI/FilterLibrary/FilterLibraryModal.razor.cs
@@ -1,12 +1,16 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Filtering.Persistence;
 using EventLogExpert.Runtime.Alerts;
 using EventLogExpert.Runtime.Announcement;
+using EventLogExpert.Runtime.Common.Clipboard;
 using EventLogExpert.Runtime.Common.Files;
 using EventLogExpert.Runtime.FilterLibrary;
 using EventLogExpert.Runtime.Modal;
+using EventLogExpert.Runtime.Scenarios;
 using EventLogExpert.UI.Common;
+using EventLogExpert.UI.FilterEditor;
 using EventLogExpert.UI.Modal;
 using Fluxor;
 using Microsoft.AspNetCore.Components;
@@ -40,6 +44,8 @@ public sealed partial class FilterLibraryModal : ModalBase<bool>
     private readonly string _tagOverflowRegionId = ComponentId.NewUnique("tag-overflow").Value;
 
     private LibraryTab _activeTab = LibraryTab.Saved;
+    private ScenarioAuthoringRowContext? _authoringContext;
+    private ScenarioClipboardExporter _clipboardExporter = null!;
     private bool _isTagManagementExpanded;
     private bool _isTagOverflowExpanded;
     private bool _justClearedTags;
@@ -51,6 +57,8 @@ public sealed partial class FilterLibraryModal : ModalBase<bool>
     private SidebarTabs<LibraryTab>? _sidebarTabsRef;
 
     [Parameter] public LibraryTab? InitialTab { get; set; }
+
+    [Inject] private IAlertDialogService AlertDialogService { get; init; } = null!;
 
     private IReadOnlyList<LibraryEntryFilterSet> AllFilterSets =>
         [.. FilterLibraryState.Value.Entries
@@ -64,6 +72,8 @@ public sealed partial class FilterLibraryModal : ModalBase<bool>
             .OrderBy(t => t, StringComparer.OrdinalIgnoreCase)];
 
     [Inject] private IAnnouncementService AnnouncementService { get; init; } = null!;
+
+    [Inject] private IClipboardService ClipboardService { get; init; } = null!;
 
     private IReadOnlyList<(LibraryTab Tab, string Label)> CurrentTabLabels =>
     [
@@ -92,6 +102,14 @@ public sealed partial class FilterLibraryModal : ModalBase<bool>
     [Inject] private IFilterLibraryCommands FilterLibraryCommands { get; init; } = null!;
 
     [Inject] private IState<FilterLibraryState> FilterLibraryState { get; init; } = null!;
+
+    private EventCallback<LibraryEntryId> OnCopyScenarioCallback => ScenarioAuthoringOptions.Enabled
+        ? EventCallback.Factory.Create<LibraryEntryId>(this, HandleCopyScenarioAsync)
+        : default;
+
+    private EventCallback<LibraryEntryId> OnSaveScenarioCallback => ScenarioAuthoringOptions.Enabled
+        ? EventCallback.Factory.Create<LibraryEntryId>(this, HandleSaveScenarioAsync)
+        : default;
 
     private IReadOnlyList<LibraryEntry> PreviouslyUsedEntries
     {
@@ -123,6 +141,10 @@ public sealed partial class FilterLibraryModal : ModalBase<bool>
 
     private IReadOnlyList<LibraryEntrySavedFilter> SavedFilterEntries =>
         [.. FilterLibraryState.Value.Entries.OfType<LibraryEntrySavedFilter>()];
+
+    [Inject] private ScenarioAuthoringOptions ScenarioAuthoringOptions { get; init; } = null!;
+
+    [Inject] private IScenarioAuthoringService ScenarioAuthoringService { get; init; } = null!;
 
     internal static void ApplyImportPreflight(
         ImportPreflight preflight,
@@ -380,6 +402,12 @@ public sealed partial class FilterLibraryModal : ModalBase<bool>
         {
             FilterLibraryCommands.LoadLibrary();
         }
+
+        _clipboardExporter = new ScenarioClipboardExporter(AnnouncementService, AlertDialogService, ClipboardService);
+
+        _authoringContext = ScenarioAuthoringOptions.Enabled
+            ? new ScenarioAuthoringRowContext(Enabled: true, CopyLibraryRowAsync)
+            : null;
     }
 
     protected override Task<bool> OnRequestCloseAsync(ModalCloseRequest request)
@@ -403,6 +431,15 @@ public sealed partial class FilterLibraryModal : ModalBase<bool>
         var sanitized = new string(name.Select(c => invalid.Contains(c) ? '-' : c).ToArray());
         return sanitized.Length > 100 ? sanitized[..100] : sanitized;
     }
+
+    private Task CopyLibraryRowAsync(SavedFilter filter) =>
+        _clipboardExporter.CopyAsync(
+            ScenarioAuthoringService.ExportRows([filter], []),
+            "Filter copied to the clipboard as scenario JSON.",
+            "this filter");
+
+    private LibraryEntryFilterSet? FindFilterSet(LibraryEntryId entryId) =>
+        FilterLibraryState.Value.Entries.FirstOrDefault(e => e.Id.Equals(entryId)) as LibraryEntryFilterSet;
 
     private string GetEmptyStateMessage(LibraryTab tab)
     {
@@ -449,6 +486,16 @@ public sealed partial class FilterLibraryModal : ModalBase<bool>
         await CompleteAsync(true);
     }
 
+    private async Task HandleCopyScenarioAsync(LibraryEntryId entryId)
+    {
+        if (FindFilterSet(entryId) is not { } filterSet) { return; }
+
+        await _clipboardExporter.CopyAsync(
+            ScenarioAuthoringService.ExportRows([.. filterSet.Filters], []),
+            $"'{filterSet.Name}' copied to the clipboard as scenario JSON.",
+            "this filter set");
+    }
+
     private void HandleDelete(LibraryEntryId id) => FilterLibraryCommands.DeleteEntry(id);
 
     private async Task HandleExportEntryAsync(LibraryEntryId entryId)
@@ -491,6 +538,35 @@ public sealed partial class FilterLibraryModal : ModalBase<bool>
         RecordPendingFocusAfterRemoval(sourceTab, entryId);
 
         return Task.CompletedTask;
+    }
+
+    private async Task HandleSaveScenarioAsync(LibraryEntryId entryId)
+    {
+        if (FindFilterSet(entryId) is not { } filterSet) { return; }
+
+        var export = ScenarioAuthoringService.ExportRows([.. filterSet.Filters], []);
+
+        if (_clipboardExporter.NotExportable(export, "this filter set")) { return; }
+
+        var suggested = $"{SanitizeForFileName(filterSet.Name)}-scenario-{DateTimeOffset.Now:yyyyMMdd}.json";
+        var path = await FilePickerService.PickSaveAsync("Export scenario JSON", [".json"], suggestedFileName: suggested);
+
+        if (string.IsNullOrEmpty(path)) { return; }
+
+        try
+        {
+            await File.WriteAllTextAsync(path, export.Json);
+        }
+        catch (Exception ex) when (
+            ex is UnauthorizedAccessException or SecurityException or
+                PathTooLongException or DirectoryNotFoundException or IOException)
+        {
+            await ShowImportExportErrorAsync("Export failed", ex.Message);
+
+            return;
+        }
+
+        await _clipboardExporter.AnnounceAsync($"Scenario JSON saved to {path}.", export.Warnings);
     }
 
     private void HandleSaveToLibrary(LibraryEntryId id) => FilterLibraryCommands.SaveEntry(id);

--- a/src/EventLogExpert.UI/FilterLibrary/LibraryEntryRow.razor.cs
+++ b/src/EventLogExpert.UI/FilterLibrary/LibraryEntryRow.razor.cs
@@ -45,6 +45,8 @@ public sealed partial class LibraryEntryRow : ComponentBase, IAsyncDisposable
 
     [Parameter][EditorRequired] public EventCallback<LibraryEntryId> OnApply { get; set; }
 
+    [Parameter] public EventCallback<LibraryEntryId> OnCopyScenario { get; set; }
+
     [Parameter][EditorRequired] public EventCallback<LibraryEntryId> OnDelete { get; set; }
 
     [Parameter] public Action<(LibraryTab Tab, LibraryEntryId Id)>? OnDisposed { get; set; }
@@ -54,6 +56,8 @@ public sealed partial class LibraryEntryRow : ComponentBase, IAsyncDisposable
     [Parameter][EditorRequired] public EventCallback<LibraryEntryId> OnReplace { get; set; }
 
     [Parameter][EditorRequired] public EventCallback<LibraryEntryId> OnRequestPendingFocus { get; set; }
+
+    [Parameter] public EventCallback<LibraryEntryId> OnSaveScenario { get; set; }
 
     [Parameter][EditorRequired] public EventCallback<LibraryEntryId> OnSaveToLibrary { get; set; }
 
@@ -210,6 +214,16 @@ public sealed partial class LibraryEntryRow : ComponentBase, IAsyncDisposable
             items.Add(MenuItem.Item("Export...", OnExportEntryAsync));
         }
 
+        if (Entry is LibraryEntryFilterSet && OnCopyScenario.HasDelegate)
+        {
+            items.Add(MenuItem.Item("Copy as scenario JSON", OnCopyScenarioAsync));
+        }
+
+        if (Entry is LibraryEntryFilterSet && OnSaveScenario.HasDelegate)
+        {
+            items.Add(MenuItem.Item("Save as scenario JSON", OnSaveScenarioAsync));
+        }
+
         items.Add(MenuItem.Separator());
         items.Add(MenuItem.Item("Delete", OnDeleteAsync, isDanger: true));
 
@@ -232,6 +246,8 @@ public sealed partial class LibraryEntryRow : ComponentBase, IAsyncDisposable
     }
 
     private Task OnApplyAsync() => OnApply.InvokeAsync(Entry.Id);
+
+    private Task OnCopyScenarioAsync() => OnCopyScenario.InvokeAsync(Entry.Id);
 
     private async Task OnDeleteAsync()
     {
@@ -348,6 +364,8 @@ public sealed partial class LibraryEntryRow : ComponentBase, IAsyncDisposable
 
         await OnReplace.InvokeAsync(Entry.Id);
     }
+
+    private Task OnSaveScenarioAsync() => OnSaveScenario.InvokeAsync(Entry.Id);
 
     private async Task OnSaveToLibraryAsync()
     {

--- a/src/EventLogExpert.UI/FilterPane/FilterPane.razor
+++ b/src/EventLogExpert.UI/FilterPane/FilterPane.razor
@@ -80,6 +80,35 @@
                 <i class="bi bi-bookmarks"></i>
             </button>
 
+            @if (ScenarioAuthoringEnabled)
+            {
+                var hasEnabledFilters = HasEnabledFilters;
+
+                <button aria-describedby="@(hasEnabledFilters ? null : "scenario-export-empty-hint")"
+                    aria-label="Copy scenario JSON"
+                    class="button icon-button"
+                    disabled="@(!hasEnabledFilters)"
+                    @onclick="CopyScenarioJsonAsync"
+                    title="Copy current filter rows as scenario-catalog JSON"
+                    type="button">
+                    <i aria-hidden="true" class="bi bi-clipboard-data"></i>
+                </button>
+
+                <button aria-describedby="@(hasEnabledFilters ? null : "scenario-export-empty-hint")"
+                    aria-label="Save scenario JSON"
+                    class="button icon-button"
+                    disabled="@(!hasEnabledFilters)"
+                    @onclick="SaveScenarioJsonAsync"
+                    title="Save current filter rows as scenario-catalog JSON..."
+                    type="button">
+                    <i aria-hidden="true" class="bi bi-filetype-json"></i>
+                </button>
+
+                <span class="visually-hidden" id="scenario-export-empty-hint">
+                    Enable a filter before exporting as a scenario.
+                </span>
+            }
+
             <span class="visually-hidden" id="save-filters-empty-hint">
                 Add a filter before saving as a Filter Set.
             </span>
@@ -222,23 +251,25 @@
             </div>
         }
 
-        @foreach (var item in FilterPaneState.Value.Filters)
-        {
-            <FilterRow Id="@ComponentId.For(item.Id, ComponentIdScope.PaneFilter).Value"
-                @key="item.Id"
-                OnDisposed="@OnRowDisposed"
-                OnRemoved="HandleRemovedFilter"
-                @ref="_rowRefs[item.Id]"
-                Value="item" />
-        }
+        <CascadingValue IsFixed="true" Value="_authoringContext">
+            @foreach (var item in FilterPaneState.Value.Filters)
+            {
+                <FilterRow Id="@ComponentId.For(item.Id, ComponentIdScope.PaneFilter).Value"
+                    @key="item.Id"
+                    OnDisposed="@OnRowDisposed"
+                    OnRemoved="HandleRemovedFilter"
+                    @ref="_rowRefs[item.Id]"
+                    Value="item" />
+            }
 
-        @foreach (var draft in _pendingDrafts)
-        {
-            <FilterRow Id="@ComponentId.For(draft.Id, ComponentIdScope.PanePendingFilter).Value"
-                @key="draft.Id"
-                OnPendingDiscard="() => HandlePendingDiscard(draft)"
-                OnPendingSave="filter => HandlePendingSave(draft, filter)"
-                PendingDraft="draft" />
-        }
+            @foreach (var draft in _pendingDrafts)
+            {
+                <FilterRow Id="@ComponentId.For(draft.Id, ComponentIdScope.PanePendingFilter).Value"
+                    @key="draft.Id"
+                    OnPendingDiscard="() => HandlePendingDiscard(draft)"
+                    OnPendingSave="filter => HandlePendingSave(draft, filter)"
+                    PendingDraft="draft" />
+            }
+        </CascadingValue>
     </div>
 </div>

--- a/src/EventLogExpert.UI/FilterPane/FilterPane.razor.cs
+++ b/src/EventLogExpert.UI/FilterPane/FilterPane.razor.cs
@@ -1,20 +1,25 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Eventing.Common.Channels;
 using EventLogExpert.Eventing.Common.EventLogs;
 using EventLogExpert.Filtering.Drafts;
 using EventLogExpert.Filtering.Evaluation;
 using EventLogExpert.Filtering.Persistence;
 using EventLogExpert.Runtime.Alerts;
 using EventLogExpert.Runtime.Announcement;
+using EventLogExpert.Runtime.Common.Clipboard;
 using EventLogExpert.Runtime.Common.Display;
+using EventLogExpert.Runtime.Common.Files;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.Runtime.FilterLibrary;
 using EventLogExpert.Runtime.FilterPane;
 using EventLogExpert.Runtime.FilterProgress;
 using EventLogExpert.Runtime.Menu;
 using EventLogExpert.Runtime.Modal;
+using EventLogExpert.Runtime.Scenarios;
 using EventLogExpert.Runtime.Settings;
+using EventLogExpert.Scenarios.Catalog;
 using EventLogExpert.UI.Common.Interop;
 using EventLogExpert.UI.FilterEditor;
 using EventLogExpert.UI.Focus;
@@ -23,6 +28,7 @@ using Fluxor;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
+using System.Security;
 using FilterMode = EventLogExpert.Filtering.Evaluation.FilterMode;
 
 namespace EventLogExpert.UI.FilterPane;
@@ -40,7 +46,9 @@ public sealed partial class FilterPane
     private ElementReference _addFilterButtonRef;
     private ElementReference _addFilterChevronRef;
     private long _addFilterMenuId;
+    private ScenarioAuthoringRowContext? _authoringContext;
     private bool _canEditDate;
+    private ScenarioClipboardExporter _clipboardExporter = null!;
     private TimeZoneInfo _currentTimeZone = TimeZoneInfo.Utc;
     private bool _focusAddButtonAfterRemove;
     private FilterId? _focusTargetAfterRemove;
@@ -49,6 +57,8 @@ public sealed partial class FilterPane
 
     internal IReadOnlyList<string> AvailableFilterSetTags =>
         AvailableTagsForSets([.. FilterLibraryState.Value.Entries.OfType<LibraryEntryFilterSet>()]);
+
+    internal bool ScenarioAuthoringEnabled => ScenarioAuthoringOptions.Enabled;
 
     internal IReadOnlyList<LibraryEntryFilterSet> VisibleFilterSets =>
         FilterSetsByTags(
@@ -60,7 +70,11 @@ public sealed partial class FilterPane
 
     [Inject] private IAnnouncementService AnnouncementService { get; init; } = null!;
 
+    [Inject] private IClipboardService ClipboardService { get; init; } = null!;
+
     [Inject] private IState<EventLogState> EventLogState { get; init; } = null!;
+
+    [Inject] private IFilePickerService FilePickerService { get; init; } = null!;
 
     [Inject] private IFilterLibraryCommands FilterLibraryCommands { get; init; } = null!;
 
@@ -74,6 +88,8 @@ public sealed partial class FilterPane
 
     private bool HasClearableFilters =>
         IsDateFilterVisible || FilterPaneState.Value.Filters.IsEmpty is false || _pendingDrafts.Count > 0;
+
+    private bool HasEnabledFilters => FilterPaneState.Value.Filters.Any(filter => filter.IsEnabled);
 
     private bool HasFilters =>
         IsDateFilterVisible || IsFilterSetPickerVisible || FilterPaneState.Value.Filters.IsEmpty is false || _pendingDrafts.Count > 0;
@@ -104,6 +120,10 @@ public sealed partial class FilterPane
     private string MenuState => HasFilters ? _isFilterListVisible.ToString().ToLower() : "false";
 
     [Inject] private IModalCoordinator ModalCoordinator { get; init; } = null!;
+
+    [Inject] private ScenarioAuthoringOptions ScenarioAuthoringOptions { get; init; } = null!;
+
+    [Inject] private IScenarioAuthoringService ScenarioAuthoringService { get; init; } = null!;
 
     [Inject] private ISettingsService Settings { get; init; } = null!;
 
@@ -268,6 +288,12 @@ public sealed partial class FilterPane
         Settings.TimeZoneChanged += UpdateFilterDateTimeZone;
         MenuService.StateChanged += OnMenuServiceStateChanged;
 
+        _clipboardExporter = new ScenarioClipboardExporter(AnnouncementService, AlertDialogService, ClipboardService);
+
+        _authoringContext = ScenarioAuthoringOptions.Enabled
+            ? new ScenarioAuthoringRowContext(Enabled: true, CopyActiveRowAsync)
+            : null;
+
         base.OnInitialized();
     }
 
@@ -380,7 +406,29 @@ public sealed partial class FilterPane
         if (confirmed) { FilterPaneCommands.ClearAllFilters(); }
     }
 
+    private Task CopyActiveRowAsync(SavedFilter filter) =>
+        _clipboardExporter.CopyAsync(
+            ScenarioAuthoringService.ExportRows([filter], CurrentChannelNames()),
+            "Filter copied to the clipboard as scenario JSON.",
+            "this filter");
+
+    private Task CopyScenarioJsonAsync() =>
+        _clipboardExporter.CopyAsync(ExportCurrentRows(), "Scenario JSON copied to the clipboard.", "these filters");
+
+    private IReadOnlyList<string> CurrentChannelNames() =>
+    [
+        .. EventLogState.Value.ActiveLogs.Values
+            .Where(log => log.Type == LogPathType.Channel)
+            .Select(log => log.Name)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+    ];
+
     private void EditDateFilter() => _canEditDate = true;
+
+    private ScenarioExportResult ExportCurrentRows() =>
+        ScenarioAuthoringService.ExportRows(
+            [.. FilterPaneState.Value.Filters.Where(filter => filter.IsEnabled)],
+            CurrentChannelNames());
 
     private int GetActiveFilters()
     {
@@ -521,6 +569,31 @@ public sealed partial class FilterPane
     }
 
     private Task SaveFiltersAsFilterSetAsync() => !HasSavableFilters ? Task.CompletedTask : MenuActions.SaveFiltersAsFilterSetAsync();
+
+    private async Task SaveScenarioJsonAsync()
+    {
+        var export = ExportCurrentRows();
+
+        if (_clipboardExporter.NotExportable(export, "these filters")) { return; }
+
+        var path = await FilePickerService.PickSaveAsync("Export scenario JSON", [".json"], "scenario.json");
+
+        if (path is null) { return; }
+
+        try
+        {
+            await File.WriteAllTextAsync(path, export.Json);
+        }
+        catch (Exception exception)
+            when (exception is IOException or UnauthorizedAccessException or SecurityException)
+        {
+            await AlertDialogService.ShowAlert("Export failed", exception.Message, "OK");
+
+            return;
+        }
+
+        await _clipboardExporter.AnnounceAsync($"Scenario JSON saved to {path}.", export.Warnings);
+    }
 
     private void ToggleDateFilter() => FilterPaneCommands.ToggleFilterDate();
 

--- a/src/EventLogExpert/MauiProgram.cs
+++ b/src/EventLogExpert/MauiProgram.cs
@@ -8,6 +8,7 @@ using EventLogExpert.Runtime.Banner;
 using EventLogExpert.Runtime.Common.Files;
 using EventLogExpert.Runtime.FilterLibrary;
 using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.Runtime.Scenarios;
 using EventLogExpert.UI.Banner;
 using EventLogExpert.UI.Database;
 using Fluxor;
@@ -36,6 +37,14 @@ public static class MauiProgram
         {
             builder.Services.AddBlazorWebViewDeveloperTools();
         }
+
+#if DEBUG
+        const bool ScenarioAuthoringEnabled = true;
+#else
+        bool ScenarioAuthoringEnabled = Environment.GetCommandLineArgs()
+            .Contains("/EnableScenarioAuthoring", StringComparer.OrdinalIgnoreCase);
+#endif
+        builder.Services.AddSingleton(new ScenarioAuthoringOptions(ScenarioAuthoringEnabled));
 
         builder.Services.AddFluxor(options =>
         {

--- a/tests/Unit/EventLogExpert.Runtime.Tests/DependencyInjection/RuntimeServiceCollectionExtensionsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/DependencyInjection/RuntimeServiceCollectionExtensionsTests.cs
@@ -176,6 +176,7 @@ public sealed class RuntimeServiceCollectionExtensionsTests
     [InlineData(typeof(BuiltInScenarioRegistry))]
     [InlineData(typeof(IScenarioQueryService))]
     [InlineData(typeof(IScenarioLaunchService))]
+    [InlineData(typeof(IScenarioAuthoringService))]
     public async Task AddEventLogRuntime_ShouldResolveHostFacingAbstraction(Type serviceType)
     {
         // Arrange

--- a/tests/Unit/EventLogExpert.Scenarios.Tests/BuiltInCatalogValidationTests.cs
+++ b/tests/Unit/EventLogExpert.Scenarios.Tests/BuiltInCatalogValidationTests.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.Events;
 using EventLogExpert.Filtering.Basic;
 using EventLogExpert.Filtering.Common.Filtering;
 using EventLogExpert.Filtering.Evaluation;
@@ -57,6 +58,49 @@ public sealed class BuiltInCatalogValidationTests
                 row.Filter.Comparison.Property is EventProperty.LogName ||
                 row.Filter.Predicates.Any(predicate => predicate.Comparison.Property is EventProperty.LogName),
                 $"Combined scenario '{scenario.Id}' has a row that is not LogName-scoped.")));
+    }
+
+    [Fact]
+    public void DescriptionContains_MatchesRealisticEvent()
+    {
+        var officeSet = s_registry.BuildFilterSet(s_registry.Scenarios.Single(scenario => scenario.Id == "office-crashes-hangs"));
+        var wordCrash = new ResolvedEvent("Application", LogPathType.Channel)
+        {
+            LogName = "Application",
+            Source = "Application Error",
+            Id = 1000,
+            Description = "Faulting application name: WINWORD.EXE, version: 16.0.1, time stamp: 0x0"
+        };
+        Assert.Contains(officeSet, saved => saved.Compiled!.Predicate(wordCrash));
+
+        var lolbinSet = s_registry.BuildFilterSet(s_registry.Scenarios.Single(scenario => scenario.Id == "suspicious-lolbin-execution"));
+        var processCreate = new ResolvedEvent("Security", LogPathType.Channel)
+        {
+            LogName = "Security",
+            Source = "Microsoft-Windows-Security-Auditing",
+            Id = 4688,
+            Description = "A new process has been created. New Process Name: C:\\Windows\\System32\\rundll32.exe"
+        };
+        Assert.Contains(lolbinSet, saved => saved.Compiled!.Predicate(processCreate));
+    }
+
+    [Fact]
+    public void MultiSourceOrRow_MatchesEachOrTerm()
+    {
+        var scenario = s_registry.Scenarios.Single(scenario => scenario.Id == "storage-controller-driver-resets");
+        var saved = s_registry.BuildFilterSet(scenario).Single();
+        Assert.NotNull(saved.Compiled);
+
+        static ResolvedEvent Event(string source, int id) =>
+            new("System", LogPathType.Channel) { LogName = "System", Source = source, Id = id };
+
+        Assert.True(saved.Compiled!.Predicate(Event("storahci", 11)), "storahci term should match");
+        Assert.True(saved.Compiled!.Predicate(Event("stornvme", 14)), "stornvme term should match");
+        Assert.True(saved.Compiled!.Predicate(Event("iaStorA", 129)), "iaStorA term should match");
+        Assert.True(saved.Compiled!.Predicate(Event("disk", 153)), "disk term should match");
+        Assert.False(saved.Compiled!.Predicate(Event("disk", 11)), "disk with a non-matching id should not match");
+        Assert.False(saved.Compiled!.Predicate(Event("storahci", 999)), "storahci with a non-matching id should not match");
+        Assert.False(saved.Compiled!.Predicate(Event("Disk", 153)), "Source matching is case-sensitive (Ordinal): the real provider is 'disk', so 'Disk' must not match");
     }
 
     [Theory]

--- a/tests/Unit/EventLogExpert.Scenarios.Tests/BuiltInScenarioRegistryTests.cs
+++ b/tests/Unit/EventLogExpert.Scenarios.Tests/BuiltInScenarioRegistryTests.cs
@@ -4,12 +4,37 @@
 using EventLogExpert.Filtering.Basic;
 using EventLogExpert.Filtering.Common.Filtering;
 using EventLogExpert.Filtering.Evaluation;
+using EventLogExpert.Filtering.Persistence;
 using EventLogExpert.Scenarios.Catalog;
 
 namespace EventLogExpert.Scenarios.Tests;
 
 public sealed class BuiltInScenarioRegistryTests
 {
+    [Fact]
+    public void BuildFilterSet_AppliesRowColor()
+    {
+        var scenario = new ScenarioDefinition
+        {
+            Id = "c",
+            Name = "c",
+            Purpose = "p",
+            Group = ScenarioGroup.SystemHealth,
+            Channels = ["System"],
+            Filters =
+            [
+                new ScenarioFilterRow(Row("12"), Color: HighlightColor.Green),
+                new ScenarioFilterRow(Row("41"), Color: HighlightColor.Red)
+            ]
+        };
+
+        var registry = new BuiltInScenarioRegistry([new FakeSource(scenario)]);
+
+        var filterSet = registry.BuildFilterSet(registry.Scenarios[0]);
+
+        Assert.Equal([HighlightColor.Green, HighlightColor.Red], filterSet.Select(saved => saved.Color));
+    }
+
     [Fact]
     public void BuildFilterSet_ProducesOneCompiledBasicFilterPerRow()
     {
@@ -69,6 +94,17 @@ public sealed class BuiltInScenarioRegistryTests
             ]
         };
     }
+
+    private static BasicFilter Row(string id) =>
+        new(
+            new FilterComparison
+            {
+                Property = EventProperty.Id,
+                Operator = ComparisonOperator.Equals,
+                MatchMode = MatchMode.Single,
+                Value = id
+            },
+            []);
 
     private sealed class FakeSource(params ScenarioDefinition[] scenarios) : IScenarioSource
     {

--- a/tests/Unit/EventLogExpert.Scenarios.Tests/ScenarioCatalogLoaderTests.cs
+++ b/tests/Unit/EventLogExpert.Scenarios.Tests/ScenarioCatalogLoaderTests.cs
@@ -31,6 +31,21 @@ public sealed class ScenarioCatalogLoaderTests
         Assert.True(result.Errors.Count >= 3, $"Expected >= 3 errors, got: {string.Join("; ", result.Errors)}");
     }
 
+    [Fact]
+    public void Load_BadColorToken_IsError()
+    {
+        var result = Load(Wrap("""
+            { "id": "x", "name": "X", "purpose": "p", "group": "SystemHealth",
+              "channels": [ "System" ],
+              "filters": [
+                { "color": "NotAColor", "comparison": { "property": "Id", "value": "12" } },
+                { "comparison": { "property": "Id", "value": "41" } }
+              ] }
+            """));
+
+        Assert.Contains(result.Errors, error => error.Contains("color"));
+    }
+
     [Theory]
     [InlineData("\"property\": \"LogNam\"")]
     [InlineData("\"property\": \"Log Name\"")]
@@ -72,6 +87,22 @@ public sealed class ScenarioCatalogLoaderTests
             """));
 
         Assert.Contains(result.Errors, error => error.Contains(expected));
+    }
+
+    [Fact]
+    public void Load_ColoredMultiRowScenario_Succeeds()
+    {
+        var result = Load(Wrap("""
+            { "id": "x", "name": "X", "purpose": "p", "group": "SystemHealth",
+              "channels": [ "System" ],
+              "filters": [
+                { "color": "Green", "comparison": { "property": "Id", "value": "12" } },
+                { "color": "Red", "comparison": { "property": "Id", "value": "41" } }
+              ] }
+            """));
+
+        Assert.Empty(result.Errors);
+        Assert.Single(result.Scenarios);
     }
 
     [Fact]
@@ -118,6 +149,21 @@ public sealed class ScenarioCatalogLoaderTests
             """);
 
         Assert.Contains(result.Errors, error => error.Contains("duplicate id"));
+    }
+
+    [Fact]
+    public void Load_ExcludedRowWithColor_IsError()
+    {
+        var result = Load(Wrap("""
+            { "id": "x", "name": "X", "purpose": "p", "group": "SystemHealth",
+              "channels": [ "System" ],
+              "filters": [
+                { "color": "Red", "isExcluded": true, "comparison": { "property": "Id", "value": "12" } },
+                { "comparison": { "property": "Id", "value": "41" } }
+              ] }
+            """));
+
+        Assert.Contains(result.Errors, error => error.Contains("excluded rows cannot have a highlight color"));
     }
 
     [Fact]
@@ -201,6 +247,20 @@ public sealed class ScenarioCatalogLoaderTests
 
         Assert.Empty(result.Scenarios);
         Assert.Contains(result.Errors, error => error.Contains("scenario is null"));
+    }
+
+    [Fact]
+    public void Load_SingleRowWithColor_IsError()
+    {
+        var result = Load(Wrap("""
+            { "id": "x", "name": "X", "purpose": "p", "group": "SystemHealth",
+              "channels": [ "System" ],
+              "filters": [
+                { "color": "Green", "comparison": { "property": "Id", "value": "12" } }
+              ] }
+            """));
+
+        Assert.Contains(result.Errors, error => error.Contains("single-row scenarios must not use highlight colors"));
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Scenarios.Tests/ScenarioCatalogLoaderTests.cs
+++ b/tests/Unit/EventLogExpert.Scenarios.Tests/ScenarioCatalogLoaderTests.cs
@@ -130,43 +130,6 @@ public sealed class ScenarioCatalogLoaderTests
     }
 
     [Fact]
-    public void Load_NullScenarioElement_IsAggregatedError_NotThrow()
-    {
-        var result = Load("""
-            { "schemaVersion": 1, "scenarios": [ null ] }
-            """);
-
-        Assert.Empty(result.Scenarios);
-        Assert.Contains(result.Errors, error => error.Contains("scenario is null"));
-    }
-
-    [Fact]
-    public void Load_NullFilterRowElement_IsAggregatedError_NotThrow()
-    {
-        var result = Load(Wrap("""
-            { "id": "x", "name": "X", "purpose": "p", "group": "SystemHealth",
-              "channels": [ "System" ],
-              "filters": [ null ] }
-            """));
-
-        Assert.Empty(result.Scenarios);
-        Assert.Contains(result.Errors, error => error.Contains("filter row is null"));
-    }
-
-    [Fact]
-    public void Load_NullPredicateElement_IsAggregatedError_NotThrow()
-    {
-        var result = Load(Wrap("""
-            { "id": "x", "name": "X", "purpose": "p", "group": "SystemHealth",
-              "channels": [ "System" ],
-              "filters": [ { "comparison": { "property": "Id", "value": "1" }, "predicates": [ null ] } ] }
-            """));
-
-        Assert.Empty(result.Scenarios);
-        Assert.Contains(result.Errors, error => error.Contains("predicate is null"));
-    }
-
-    [Fact]
     public void Load_MinimalValidScenario_Succeeds()
     {
         var result = Load(Wrap("""
@@ -204,6 +167,43 @@ public sealed class ScenarioCatalogLoaderTests
     }
 
     [Fact]
+    public void Load_NullFilterRowElement_IsAggregatedError_NotThrow()
+    {
+        var result = Load(Wrap("""
+            { "id": "x", "name": "X", "purpose": "p", "group": "SystemHealth",
+              "channels": [ "System" ],
+              "filters": [ null ] }
+            """));
+
+        Assert.Empty(result.Scenarios);
+        Assert.Contains(result.Errors, error => error.Contains("filter row is null"));
+    }
+
+    [Fact]
+    public void Load_NullPredicateElement_IsAggregatedError_NotThrow()
+    {
+        var result = Load(Wrap("""
+            { "id": "x", "name": "X", "purpose": "p", "group": "SystemHealth",
+              "channels": [ "System" ],
+              "filters": [ { "comparison": { "property": "Id", "value": "1" }, "predicates": [ null ] } ] }
+            """));
+
+        Assert.Empty(result.Scenarios);
+        Assert.Contains(result.Errors, error => error.Contains("predicate is null"));
+    }
+
+    [Fact]
+    public void Load_NullScenarioElement_IsAggregatedError_NotThrow()
+    {
+        var result = Load("""
+            { "schemaVersion": 1, "scenarios": [ null ] }
+            """);
+
+        Assert.Empty(result.Scenarios);
+        Assert.Contains(result.Errors, error => error.Contains("scenario is null"));
+    }
+
+    [Fact]
     public void Load_SourceRegistrationGating_IsRejected()
     {
         var result = Load(Wrap("""
@@ -235,6 +235,19 @@ public sealed class ScenarioCatalogLoaderTests
 
         Assert.Empty(result.Scenarios);
         Assert.Contains(result.Errors, error => error.Contains("schemaVersion"));
+    }
+
+    [Fact]
+    public void TryLoad_BuiltInCatalog_HasNoValidationErrors()
+    {
+        var result = ScenarioCatalogLoader.TryLoad(typeof(ScenarioCatalogLoader).Assembly);
+
+        Assert.True(
+            result.Errors.IsEmpty,
+            $"Built-in catalog has validation errors:{Environment.NewLine}{string.Join(Environment.NewLine, result.Errors)}");
+        Assert.True(result.Scenarios.Count >= 16, $"Expected at least 16 built-in scenarios, found {result.Scenarios.Count}.");
+        Assert.Contains(result.Scenarios, scenario => scenario.Id == "recent-critical-and-error-events");
+        Assert.Contains(result.Scenarios, scenario => scenario.Id == "unexpected-restart-power-loss-bsod");
     }
 
     private static ScenarioCatalogLoadResult Load(string json) =>

--- a/tests/Unit/EventLogExpert.Scenarios.Tests/ScenarioExporterTests.cs
+++ b/tests/Unit/EventLogExpert.Scenarios.Tests/ScenarioExporterTests.cs
@@ -1,0 +1,144 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Basic;
+using EventLogExpert.Filtering.Common.Filtering;
+using EventLogExpert.Filtering.Evaluation;
+using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Scenarios.Catalog;
+using EventLogExpert.Scenarios.Serialization;
+using System.Text;
+
+namespace EventLogExpert.Scenarios.Tests;
+
+public sealed class ScenarioExporterTests
+{
+    [Fact]
+    public void Export_AdvancedExpressionResolvedToBasic_RoundTrips()
+    {
+        // A row whose BasicFilter was produced from raw expression text (the Advanced->Basic path the UI uses).
+        var basic = SavedFilter.TryCreate("Id == 1000 && Source == \"Application Error\"", mode: FilterMode.Basic)?.BasicFilter;
+        Assert.NotNull(basic);
+
+        ScenarioExportRow[] rows = [new(basic, false, HighlightColor.None), Row(HighlightColor.None, EventProperty.Id, "1001")];
+        var result = ScenarioExporter.Export(rows, Meta("Application"));
+
+        Assert.Empty(result.Warnings);
+        Assert.Empty(ScenarioCatalogLoader.TryLoad([("x.json", Encoding.UTF8.GetBytes(result.Json))]).Errors);
+    }
+
+    [Fact]
+    public void Export_ColorEmittedAsEnumName()
+    {
+        ScenarioExportRow[] rows = [Row(HighlightColor.DarkRed, EventProperty.Id, "1"), Row(HighlightColor.Green, EventProperty.Id, "2")];
+
+        var json = ScenarioExporter.Export(rows, Meta("System")).Json;
+
+        Assert.Contains("\"color\": \"DarkRed\"", json);
+        Assert.Contains("\"color\": \"Green\"", json);
+    }
+
+    [Fact]
+    public void Export_DerivesRequiresAdminForSecurityChannel()
+    {
+        var json = ScenarioExporter.Export([Row(HighlightColor.None, EventProperty.Id, "4624")], Meta("Security")).Json;
+
+        Assert.Contains("\"requiresAdmin\": true", json);
+    }
+
+    [Fact]
+    public void Export_EmittedRowCount_MatchesEmittedRows()
+    {
+        Assert.Equal(0, ScenarioExporter.Export([], Meta("System")).EmittedRowCount);
+        Assert.Equal(1, ScenarioExporter.Export([Row(HighlightColor.None, EventProperty.Id, "1")], Meta("System")).EmittedRowCount);
+
+        ScenarioExportRow[] two = [Row(HighlightColor.None, EventProperty.Id, "1"), Row(HighlightColor.None, EventProperty.Id, "2")];
+        Assert.Equal(2, ScenarioExporter.Export(two, Meta("System")).EmittedRowCount);
+    }
+
+    [Fact]
+    public void Export_Many_OmitsOperatorAndUsesValues()
+    {
+        var json = ScenarioExporter.Export([Row(HighlightColor.None, EventProperty.Id, "1", "2", "3")], Meta("System")).Json;
+
+        Assert.Contains("\"matchMode\": \"Many\"", json);
+        Assert.Contains("\"values\"", json);
+        Assert.DoesNotContain("\"operator\"", json);
+    }
+
+    [Fact]
+    public void Export_NoChannels_Warns()
+    {
+        var result = ScenarioExporter.Export(
+            [Row(HighlightColor.None, EventProperty.Id, "1")],
+            new ScenarioExportMetadata("id", "n", "p", ScenarioGroup.SystemHealth, []));
+
+        Assert.Contains(ScenarioExporter.NoLiveChannelsWarning, result.Warnings);
+    }
+
+    [Fact]
+    public void Export_NoRows_OmitsSelfValidationNoise()
+    {
+        var result = ScenarioExporter.Export([], Meta("System"));
+
+        Assert.Equal(0, result.EmittedRowCount);
+        Assert.DoesNotContain(result.Warnings, warning => warning.Contains("must declare at least one filter row"));
+    }
+
+    [Fact]
+    public void Export_RawShape_IsCamelCaseIndentedWithNoNullKeys()
+    {
+        var json = ScenarioExporter.Export([Row(HighlightColor.None, EventProperty.Source, "disk")], Meta("System")).Json;
+
+        Assert.Contains("\"schemaVersion\": 1", json);
+        Assert.Contains("\"property\": \"Source\"", json);
+        Assert.Contains("\"value\": \"disk\"", json);
+        Assert.Contains("\n", json);
+        Assert.DoesNotContain("null", json);
+        Assert.DoesNotContain("\"operator\"", json);
+        Assert.DoesNotContain("\"matchMode\"", json);
+        Assert.DoesNotContain("\"color\"", json);
+    }
+
+    [Fact]
+    public void Export_RoundTripsByteIdentical()
+    {
+        ScenarioExportRow[] rows =
+        [
+            Row(HighlightColor.Green, EventProperty.Source, "Microsoft-Windows-Kernel-General"),
+            Row(HighlightColor.Red, EventProperty.Id, "41", "6008")
+        ];
+
+        var first = ScenarioExporter.Export(rows, Meta("System"));
+        Assert.Empty(first.Warnings);
+
+        var loaded = ScenarioCatalogLoader.TryLoad([("x.json", Encoding.UTF8.GetBytes(first.Json))]);
+        Assert.Empty(loaded.Errors);
+
+        var reExported = ScenarioExporter.Export(
+            [.. loaded.Scenarios[0].Filters.Select(row => new ScenarioExportRow(row.Filter, row.IsExcluded, row.Color))],
+            Meta("System"));
+
+        Assert.Equal(first.Json, reExported.Json);
+    }
+
+    [Fact]
+    public void Export_SingleRowWithColor_SurfacesGuardrailWarning()
+    {
+        var result = ScenarioExporter.Export([Row(HighlightColor.Green, EventProperty.Id, "1")], Meta("System"));
+
+        Assert.Contains(result.Warnings, warning => warning.Contains("single-row"));
+    }
+
+    private static ScenarioExportMetadata Meta(params string[] channels) =>
+        new("test-scenario", "Test scenario", "A test.", ScenarioGroup.SystemHealth, channels);
+
+    private static ScenarioExportRow Row(HighlightColor color, EventProperty property, params string[] values)
+    {
+        FilterComparison comparison = values.Length == 1
+            ? new() { Property = property, Operator = ComparisonOperator.Equals, MatchMode = MatchMode.Single, Value = values[0] }
+            : new() { Property = property, Operator = ComparisonOperator.Equals, MatchMode = MatchMode.Many, Values = [.. values] };
+
+        return new ScenarioExportRow(new BasicFilter(comparison, []), false, color);
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterEditor/Rows/FilterRowActionsScenarioTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterEditor/Rows/FilterRowActionsScenarioTests.cs
@@ -1,0 +1,71 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using AngleSharp.Dom;
+using Bunit;
+using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.UI.FilterEditor;
+using EventLogExpert.UI.FilterEditor.Rows;
+using Microsoft.AspNetCore.Components.Web;
+
+namespace EventLogExpert.UI.Tests.FilterEditor.Rows;
+
+public sealed class FilterRowActionsScenarioTests : BunitContext
+{
+    [Fact]
+    public void AuthoringDisabled_RendersNoCopyButton()
+    {
+        var context = new ScenarioAuthoringRowContext(Enabled: false, _ => Task.CompletedTask);
+
+        var component = Render<FilterRowActions>(parameters => parameters
+            .Add(p => p.Value, MakeSavedFilter())
+            .AddCascadingValue(context));
+
+        Assert.Null(FindScenarioButton(component));
+    }
+
+    [Fact]
+    public async Task AuthoringEnabled_RendersCopyButton_AndClickInvokesCopyWithRowFilter()
+    {
+        var savedFilter = MakeSavedFilter();
+        SavedFilter? copied = null;
+        var context = new ScenarioAuthoringRowContext(Enabled: true, filter =>
+        {
+            copied = filter;
+
+            return Task.CompletedTask;
+        });
+
+        var component = Render<FilterRowActions>(parameters => parameters
+            .Add(p => p.Value, savedFilter)
+            .AddCascadingValue(context));
+
+        var button = FindScenarioButton(component);
+        Assert.NotNull(button);
+
+        await button!.ClickAsync(new MouseEventArgs());
+
+        Assert.Same(savedFilter, copied);
+    }
+
+    [Fact]
+    public void NoAuthoringContext_RendersNoCopyButton()
+    {
+        var component = Render<FilterRowActions>(parameters => parameters
+            .Add(p => p.Value, MakeSavedFilter()));
+
+        Assert.Null(FindScenarioButton(component));
+    }
+
+    private static IElement? FindScenarioButton(IRenderedComponent<FilterRowActions> component) =>
+        component.FindAll("button")
+            .FirstOrDefault(button => button.GetAttribute("aria-label")?.Contains("scenario JSON") == true);
+
+    private static SavedFilter MakeSavedFilter() =>
+        new()
+        {
+            ComparisonText = "Id == 1000",
+            Compiled = null,
+            IsEnabled = true,
+        };
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterEditor/ScenarioClipboardExporterTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterEditor/ScenarioClipboardExporterTests.cs
@@ -1,0 +1,99 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.Alerts;
+using EventLogExpert.Runtime.Announcement;
+using EventLogExpert.Runtime.Common.Clipboard;
+using EventLogExpert.Scenarios.Catalog;
+using EventLogExpert.UI.FilterEditor;
+using NSubstitute;
+using System.Collections.Immutable;
+
+namespace EventLogExpert.UI.Tests.FilterEditor;
+
+public sealed class ScenarioClipboardExporterTests
+{
+    private readonly IAlertDialogService _alertDialog = Substitute.For<IAlertDialogService>();
+    private readonly IAnnouncementService _announcements = Substitute.For<IAnnouncementService>();
+    private readonly IClipboardService _clipboard = Substitute.For<IClipboardService>();
+
+    [Fact]
+    public async Task AnnounceAsync_WhenChannelsEmpty_AppendsChannelsGuidance()
+    {
+        await CreateExporter().AnnounceAsync(
+            "Scenario JSON copied to the clipboard.",
+            [ScenarioExporter.NoLiveChannelsWarning]);
+
+        _announcements.Received(1).Announce(
+            "Scenario JSON copied to the clipboard. Fill in channels[] before adding to the catalog.");
+    }
+
+    [Fact]
+    public async Task AnnounceAsync_WhenSubstantiveWarnings_ShowsAlertNotAnnouncement()
+    {
+        await CreateExporter().AnnounceAsync("Saved.", ["single-row color guardrail"]);
+
+        await _alertDialog.Received(1).ShowAlert(
+            "Scenario JSON exported with warnings",
+            Arg.Is<string>(message => message.Contains("single-row color guardrail")),
+            "OK");
+        _announcements.DidNotReceive().Announce(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task CopyAsync_WhenExportable_CopiesJsonAndAnnounces()
+    {
+        var export = new ScenarioExportResult("{ }", ImmutableList<string>.Empty, EmittedRowCount: 1);
+
+        await CreateExporter().CopyAsync(export, "Copied.", "these filters");
+
+        await _clipboard.Received(1).CopyTextAsync("{ }");
+        _announcements.Received(1).Announce("Copied.");
+    }
+
+    [Fact]
+    public async Task CopyAsync_WhenNothingEmitted_DoesNotCopy()
+    {
+        var export = new ScenarioExportResult(string.Empty, ImmutableList<string>.Empty, EmittedRowCount: 0);
+
+        await CreateExporter().CopyAsync(export, "Copied.", "this filter");
+
+        await _clipboard.DidNotReceive().CopyTextAsync(Arg.Any<string>());
+        _announcements.Received(1)
+            .Announce("Could not export this filter: only Basic filters can be exported as scenarios.");
+    }
+
+    [Fact]
+    public void NotExportable_WhenNothingEmitted_AnnouncesAndReturnsTrue()
+    {
+        var export = new ScenarioExportResult(string.Empty, ImmutableList<string>.Empty, EmittedRowCount: 0);
+
+        Assert.True(CreateExporter().NotExportable(export, "these filters"));
+        _announcements.Received(1)
+            .Announce("Could not export these filters: only Basic filters can be exported as scenarios.");
+    }
+
+    [Fact]
+    public void NotExportable_WhenRowsEmitted_ReturnsFalseWithoutAnnouncing()
+    {
+        var export = new ScenarioExportResult("{}", ImmutableList<string>.Empty, EmittedRowCount: 2);
+
+        Assert.False(CreateExporter().NotExportable(export, "these filters"));
+        _announcements.DidNotReceive().Announce(Arg.Any<string>());
+    }
+
+    [Fact]
+    public void NotExportable_WhenRowsSkipped_SurfacesSkippedCount()
+    {
+        var export = new ScenarioExportResult(
+            string.Empty,
+            ["3 row(s) skipped: not expressible as a Basic filter."],
+            EmittedRowCount: 0);
+
+        Assert.True(CreateExporter().NotExportable(export, "these filters"));
+        _announcements.Received(1)
+            .Announce("Could not export these filters: 3 row(s) skipped: not expressible as a Basic filter.");
+    }
+
+    private ScenarioClipboardExporter CreateExporter() => new(_announcements, _alertDialog, _clipboard);
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterLibrary/FilterLibraryModalTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterLibrary/FilterLibraryModalTests.cs
@@ -5,10 +5,12 @@ using Bunit;
 using EventLogExpert.Filtering.Persistence;
 using EventLogExpert.Runtime.Alerts;
 using EventLogExpert.Runtime.Announcement;
+using EventLogExpert.Runtime.Common.Clipboard;
 using EventLogExpert.Runtime.Common.Files;
 using EventLogExpert.Runtime.FilterLibrary;
 using EventLogExpert.Runtime.FilterPane;
 using EventLogExpert.Runtime.Modal;
+using EventLogExpert.Runtime.Scenarios;
 using EventLogExpert.UI.FilterLibrary;
 using EventLogExpert.UI.Tests.TestUtils;
 using Fluxor;
@@ -50,6 +52,9 @@ public sealed class FilterLibraryModalTests : BunitContext
         Services.AddSingleton(paneState);
 
         Services.AddSingleton(Substitute.For<IAlertDialogService>());
+        Services.AddSingleton(Substitute.For<IScenarioAuthoringService>());
+        Services.AddSingleton(Substitute.For<IClipboardService>());
+        Services.AddSingleton(new ScenarioAuthoringOptions(false));
 
         Services.AddFluxor(options => options.ScanAssemblies(typeof(FilterLibraryModal).Assembly));
 

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterPane/FilterPaneTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterPane/FilterPaneTests.cs
@@ -5,17 +5,22 @@ using Bunit;
 using EventLogExpert.Filtering.Persistence;
 using EventLogExpert.Runtime.Alerts;
 using EventLogExpert.Runtime.Announcement;
+using EventLogExpert.Runtime.Common.Clipboard;
+using EventLogExpert.Runtime.Common.Files;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.Runtime.FilterLibrary;
 using EventLogExpert.Runtime.FilterPane;
 using EventLogExpert.Runtime.FilterProgress;
 using EventLogExpert.Runtime.Menu;
 using EventLogExpert.Runtime.Modal;
+using EventLogExpert.Runtime.Scenarios;
 using EventLogExpert.Runtime.Settings;
+using EventLogExpert.Scenarios.Catalog;
 using EventLogExpert.UI.FilterEditor;
 using EventLogExpert.UI.FilterPane;
 using EventLogExpert.UI.Tests.TestUtils;
 using Fluxor;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using System.Collections.Immutable;
@@ -45,6 +50,10 @@ public sealed class FilterPaneTests : BunitContext
         Services.AddSingleton(Substitute.For<IAlertDialogService>());
         Services.AddSingleton(Substitute.For<IModalCoordinator>());
         Services.AddSingleton(Substitute.For<IMenuActionService>());
+        Services.AddSingleton(Substitute.For<IScenarioAuthoringService>());
+        Services.AddSingleton(Substitute.For<IClipboardService>());
+        Services.AddSingleton(Substitute.For<IFilePickerService>());
+        Services.AddSingleton(new ScenarioAuthoringOptions(false));
 
         var paneState = _paneStateMock;
         paneState.Value.Returns(new FilterPaneState());
@@ -149,6 +158,56 @@ public sealed class FilterPaneTests : BunitContext
         var tags = UI.FilterPane.FilterPane.AvailableTagsForSets([a, b]);
 
         Assert.Equal(new[] { "alpha", "mid", "zebra" }, tags.ToArray());
+    }
+
+    [Fact]
+    public async Task CopyScenario_ExportsOnlyEnabledRows()
+    {
+        Services.AddSingleton(new ScenarioAuthoringOptions(true));
+        var authoring = Services.GetRequiredService<IScenarioAuthoringService>();
+        authoring.ExportRows(Arg.Any<IReadOnlyList<SavedFilter>>(), Arg.Any<IReadOnlyList<string>>())
+            .Returns(new ScenarioExportResult("{}", ImmutableList<string>.Empty, EmittedRowCount: 1));
+
+        var enabled = SavedFilter.TryCreate("Level == 4")! with { IsEnabled = true };
+        var disabled = SavedFilter.TryCreate("Level == 2")! with { IsEnabled = false };
+        SetLibraryState(new FilterLibraryState { IsLoaded = true, Entries = ImmutableList<LibraryEntry>.Empty });
+        SetPaneState(new FilterPaneState { Filters = [enabled, disabled] });
+
+        var component = Render<UI.FilterPane.FilterPane>();
+        var copyButton = component.FindAll("button")
+            .First(button => button.GetAttribute("aria-label") == "Copy scenario JSON");
+
+        await copyButton.ClickAsync(new MouseEventArgs());
+
+        authoring.Received(1).ExportRows(
+            Arg.Is<IReadOnlyList<SavedFilter>>(rows => rows.Count == 1 && rows[0].IsEnabled),
+            Arg.Any<IReadOnlyList<string>>());
+    }
+
+    [Fact]
+    public void EditButton_OnActiveFilterRow_EntersEditMode()
+    {
+        Services.AddSingleton(new ScenarioAuthoringOptions(true));
+        SetLibraryState(new FilterLibraryState { IsLoaded = true, Entries = ImmutableList<LibraryEntry>.Empty });
+        SetPaneState(new FilterPaneState { Filters = [SavedFilter.TryCreate("Level == 4")!] });
+
+        var component = Render<UI.FilterPane.FilterPane>();
+
+        // The per-row scenario-copy button must be present for this regression (it sits alongside Edit in the row).
+        Assert.Contains(
+            component.FindAll("button"),
+            b => b.GetAttribute("aria-label")?.Contains("scenario JSON") == true);
+
+        var editButton = component.FindAll("button")
+            .FirstOrDefault(b => b.GetAttribute("aria-label")?.StartsWith("Edit ", StringComparison.Ordinal) == true);
+        Assert.NotNull(editButton);
+
+        editButton!.Click();
+
+        // Entering edit mode replaces the saved-row actions (including the Edit button) with the edit panel.
+        Assert.DoesNotContain(
+            component.FindAll("button"),
+            b => b.GetAttribute("aria-label")?.StartsWith("Edit ", StringComparison.Ordinal) == true);
     }
 
     [Fact]
@@ -330,6 +389,33 @@ public sealed class FilterPaneTests : BunitContext
     }
 
     [Fact]
+    public void PerRowScenarioCopy_WhenAuthoringDisabled_RendersNoButton()
+    {
+        SetLibraryState(new FilterLibraryState { IsLoaded = true, Entries = ImmutableList<LibraryEntry>.Empty });
+        SetPaneState(new FilterPaneState { Filters = [SavedFilter.TryCreate("Level == 4")!] });
+
+        var component = Render<UI.FilterPane.FilterPane>();
+
+        Assert.DoesNotContain(
+            component.FindAll("button"),
+            button => button.GetAttribute("aria-label")?.Contains("scenario JSON") == true);
+    }
+
+    [Fact]
+    public void PerRowScenarioCopy_WhenAuthoringEnabled_RendersButtonOnFilterRow()
+    {
+        Services.AddSingleton(new ScenarioAuthoringOptions(true));
+        SetLibraryState(new FilterLibraryState { IsLoaded = true, Entries = ImmutableList<LibraryEntry>.Empty });
+        SetPaneState(new FilterPaneState { Filters = [SavedFilter.TryCreate("Level == 4")!] });
+
+        var component = Render<UI.FilterPane.FilterPane>();
+
+        Assert.Contains(
+            component.FindAll("button"),
+            button => button.GetAttribute("aria-label")?.Contains("scenario JSON") == true);
+    }
+
+    [Fact]
     public void PruneStaleFilterSetTags_RemovesTagsNoLongerAvailable()
     {
         var tagged = BuildFilterSet("Set", ["keep"]);
@@ -385,6 +471,45 @@ public sealed class FilterPaneTests : BunitContext
 
         Assert.True(component.Find("button[aria-label='Save as Filter Set']").HasAttribute("disabled"));
         Assert.True(component.Find("button[aria-label='Clear All Filters']").HasAttribute("disabled"));
+    }
+
+    [Fact]
+    public async Task SaveScenario_WhenFileWriteFails_ShowsExportFailedAlert()
+    {
+        Services.AddSingleton(new ScenarioAuthoringOptions(true));
+        Services.GetRequiredService<IScenarioAuthoringService>()
+            .ExportRows(Arg.Any<IReadOnlyList<SavedFilter>>(), Arg.Any<IReadOnlyList<string>>())
+            .Returns(new ScenarioExportResult("{}", ImmutableList<string>.Empty, EmittedRowCount: 1));
+
+        var missingDirectoryPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "scenario.json");
+        Services.GetRequiredService<IFilePickerService>()
+            .PickSaveAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<string?>())
+            .Returns(missingDirectoryPath);
+
+        var alertDialog = Services.GetRequiredService<IAlertDialogService>();
+        SetLibraryState(new FilterLibraryState { IsLoaded = true, Entries = ImmutableList<LibraryEntry>.Empty });
+        SetPaneState(new FilterPaneState { Filters = [SavedFilter.TryCreate("Level == 4")! with { IsEnabled = true }] });
+
+        var component = Render<UI.FilterPane.FilterPane>();
+        var saveButton = component.FindAll("button")
+            .First(button => button.GetAttribute("aria-label") == "Save scenario JSON");
+
+        await saveButton.ClickAsync(new MouseEventArgs());
+
+        await alertDialog.Received(1).ShowAlert("Export failed", Arg.Any<string>(), "OK");
+    }
+
+    [Fact]
+    public void ScenarioButtons_WhenAllRowsDisabled_AreDisabled()
+    {
+        Services.AddSingleton(new ScenarioAuthoringOptions(true));
+        SetLibraryState(new FilterLibraryState { IsLoaded = true, Entries = ImmutableList<LibraryEntry>.Empty });
+        SetPaneState(new FilterPaneState { Filters = [SavedFilter.TryCreate("Level == 4")! with { IsEnabled = false }] });
+
+        var component = Render<UI.FilterPane.FilterPane>();
+
+        Assert.True(component.Find("button[aria-label='Copy scenario JSON']").HasAttribute("disabled"));
+        Assert.True(component.Find("button[aria-label='Save scenario JSON']").HasAttribute("disabled"));
     }
 
     private static LibraryEntryFilterSet BuildFilterSet(string name, ImmutableList<string>? tags = null) =>


### PR DESCRIPTION
Builds on the scenario engine (#595) to add the user-facing scenario catalog plus authoring support.

## What this adds
- **Built-in scenario catalog** - 217 triage scenarios across 20 groups (system health, security, networking, server roles, Microsoft products, etc.), each a named filter set tied to one or more channels.
- **Per-row highlight colors** - the scenario format carries an optional highlight color per filter row, enabling color-coded multi-filter triage and timeline scenarios.
- **Dev-only scenario export** - an authoring aid that exports live Basic filter rows from the filter pane and filter library as scenario-catalog JSON (the inverse of the catalog loader). It self-validates the emitted JSON by reloading it and surfaces row-level warnings. Gated off in release builds (enabled in DEBUG, or via the `/EnableScenarioAuthoring` switch).

## Notes
- The export tool is developer-only and never appears in normal release builds.
- Adds unit tests across the Scenarios, Runtime, and UI projects.