### PR TITLE
Add in-app scenario picker and date-range quick-pick to the filter pane

### DIFF
--- a/src/EventLogExpert.Eventing/Common/Events/ResolvedEvent.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/ResolvedEvent.cs
@@ -24,7 +24,7 @@ public sealed record ResolvedEvent(
 
     public string Level { get; init; } = string.Empty;
 
-    // This is the log name from the event reader
+    // The event's Channel system property (e.g. "Security"), populated for .evtx files as the original channel, not the file path.
     public string LogName { get; init; } = string.Empty;
 
     public int? ProcessId { get; init; }

--- a/src/EventLogExpert.Runtime/DependencyInjection/RuntimeServiceCollectionExtensions.cs
+++ b/src/EventLogExpert.Runtime/DependencyInjection/RuntimeServiceCollectionExtensions.cs
@@ -193,6 +193,7 @@ public static class RuntimeServiceCollectionExtensions
             services.AddSingleton<IChannelPresenceProbe, ChannelPresenceProbe>();
             services.AddSingleton<IScenarioQueryService, ScenarioQueryService>();
             services.AddSingleton<IScenarioLaunchService, ScenarioLaunchService>();
+            services.AddSingleton<IScenarioApplyService, ScenarioApplyService>();
             services.AddSingleton<IScenarioAuthoringService, ScenarioAuthoringService>();
 
             return services;

--- a/src/EventLogExpert.Runtime/Scenarios/IScenarioApplyService.cs
+++ b/src/EventLogExpert.Runtime/Scenarios/IScenarioApplyService.cs
@@ -1,0 +1,16 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Scenarios.Catalog;
+
+namespace EventLogExpert.Runtime.Scenarios;
+
+/// <summary>Applies a built-in scenario's filter rows to the pane in-app, without opening any log.</summary>
+public interface IScenarioApplyService
+{
+    /// <summary>
+    ///     Merges (append) or, when <paramref name="replace" /> is true, replaces the pane's filter rows with the
+    ///     scenario's rows.
+    /// </summary>
+    void ApplyInApp(ScenarioDefinition scenario, bool replace);
+}

--- a/src/EventLogExpert.Runtime/Scenarios/ScenarioApplyService.cs
+++ b/src/EventLogExpert.Runtime/Scenarios/ScenarioApplyService.cs
@@ -1,0 +1,27 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.FilterPane;
+using EventLogExpert.Scenarios.Catalog;
+using Fluxor;
+
+namespace EventLogExpert.Runtime.Scenarios;
+
+internal sealed class ScenarioApplyService(BuiltInScenarioRegistry registry, IDispatcher dispatcher) : IScenarioApplyService
+{
+    public void ApplyInApp(ScenarioDefinition scenario, bool replace)
+    {
+        ArgumentNullException.ThrowIfNull(scenario);
+
+        var filters = registry.BuildFilterSet(scenario);
+
+        if (replace)
+        {
+            dispatcher.Dispatch(new ReplaceFiltersAction(filters));
+
+            return;
+        }
+
+        dispatcher.Dispatch(new MergeFiltersAction(filters));
+    }
+}

--- a/src/EventLogExpert.Scenarios/Catalog/ScenarioGroupDisplay.cs
+++ b/src/EventLogExpert.Scenarios/Catalog/ScenarioGroupDisplay.cs
@@ -1,0 +1,32 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Scenarios.Catalog;
+
+public static class ScenarioGroupDisplay
+{
+    public static string DisplayName(this ScenarioGroup group) => group switch
+    {
+        ScenarioGroup.SystemHealth => "System Health",
+        ScenarioGroup.Applications => "Applications",
+        ScenarioGroup.Security => "Security",
+        ScenarioGroup.ThreatsAndIncidentResponse => "Threats and Incident Response",
+        ScenarioGroup.Network => "Network",
+        ScenarioGroup.Storage => "Storage",
+        ScenarioGroup.UpdatesAndPolicy => "Updates and Policy",
+        ScenarioGroup.ActiveDirectory => "Active Directory",
+        ScenarioGroup.DnsServer => "DNS Server",
+        ScenarioGroup.DhcpServer => "DHCP Server",
+        ScenarioGroup.NpsAndRras => "NPS and RRAS",
+        ScenarioGroup.Wins => "WINS",
+        ScenarioGroup.WebAndIis => "Web and IIS",
+        ScenarioGroup.VirtualizationAndClustering => "Virtualization and Clustering",
+        ScenarioGroup.FilePrintAndStorage => "File, Print, and Storage",
+        ScenarioGroup.SqlServer => "SQL Server",
+        ScenarioGroup.Exchange => "Exchange",
+        ScenarioGroup.SharePoint => "SharePoint",
+        ScenarioGroup.DefenderForEndpoint => "Defender for Endpoint",
+        ScenarioGroup.Office => "Office",
+        _ => group.ToString()
+    };
+}

--- a/src/EventLogExpert.UI/FilterPane/FilterPane.razor
+++ b/src/EventLogExpert.UI/FilterPane/FilterPane.razor
@@ -1,275 +1,345 @@
+@using EventLogExpert.Scenarios.Catalog
 @inherits FluxorComponent
 
 <div class="filter-pane">
-    <div class="filter-header">
-        <div class="filter-header-actions">
-            <div class="split-button">
-                <button class="button split-button-primary"
-                    @onclick="AddBasicFilter"
-                    @ref="_addFilterButtonRef"
-                    title="Add Basic filter (use chevron for Advanced or Recent)"
-                    type="button">
-                    <i aria-hidden="true" class="bi bi-plus-circle"></i> Add Filter
-                </button>
-                <button aria-controls="menu-host-popup"
-                    aria-expanded="@(IsAddFilterMenuOpen ? "true" : "false")"
-                    aria-haspopup="menu"
-                    aria-label="Choose filter mode"
-                    class="button split-button-chevron"
-                    @onclick="OpenAddFilterMenuAsync"
-                    @onkeydown="HandleAddFilterChevronKeyDownAsync"
-                    @ref="_addFilterChevronRef"
-                    type="button">
-                    <i class="bi bi-caret-down-fill"></i>
-                </button>
-            </div>
-
-            <button class="button" @onclick="AddExclusion">
-                <i class="bi bi-plus-circle"></i> Add Exclusion
+<div class="filter-header">
+    <div class="filter-header-actions">
+        <div class="split-button">
+            <button class="button split-button-primary"
+                @onclick="AddBasicFilter"
+                @ref="_addFilterButtonRef"
+                title="Add Basic filter (use chevron for Advanced or Recent)"
+                type="button">
+                <i aria-hidden="true" class="bi bi-plus-circle"></i> Add Filter
             </button>
-
-            @if (!IsDateFilterVisible)
-            {
-                <button class="button" @onclick="AddDateFilter">
-                    <i class="bi bi-plus-circle"></i> Add Date Filter
-                </button>
-            }
-
-            <button class="button" @onclick="OpenFilterSetPicker">
-                <i class="bi bi-plus-circle"></i> Apply Filter Set
+            <button aria-controls="menu-host-popup"
+                aria-expanded="@(IsAddFilterMenuOpen ? "true" : "false")"
+                aria-haspopup="menu"
+                aria-label="Choose filter mode"
+                class="button split-button-chevron"
+                @onclick="OpenAddFilterMenuAsync"
+                @onkeydown="HandleAddFilterChevronKeyDownAsync"
+                @ref="_addFilterChevronRef"
+                type="button">
+                <i class="bi bi-caret-down-fill"></i>
             </button>
         </div>
 
-        @if (FilterProgressState.Value.IsLoading)
+        <button class="button" @onclick="AddExclusion">
+            <i class="bi bi-plus-circle"></i> Add Exclusion
+        </button>
+
+        @if (!IsDateFilterVisible)
         {
-            <span class="filter-header-status">
-                [<i aria-label="Loading" class="spinner-border" role="status"></i> Applying Filters]
-            </span>
+            <button class="button" @onclick="AddDateFilter">
+                <i class="bi bi-plus-circle"></i> Add Date Filter
+            </button>
         }
-        else if (HasFilters && GetActiveFilters() > 0)
+
+        <button class="button" @onclick="OpenFilterSetPicker">
+            <i class="bi bi-plus-circle"></i> Apply Filter Set
+        </button>
+
+        @if (EventLogState.Value.ActiveLogs.Count > 0)
         {
-            <span class="filter-header-status">[Active Filters: @GetActiveFilters()]</span>
+            <button aria-controls="scenario-picker"
+                aria-expanded="@(IsScenarioPickerVisible ? "true" : "false")"
+                aria-haspopup="true"
+                class="button"
+                @onclick="OpenScenarioPicker"
+                type="button">
+                <i class="bi bi-plus-circle"></i> Apply Scenario
+            </button>
         }
-
-        <div class="filter-header-secondary">
-            <button aria-describedby="@(HasSavableFilters ? null : "save-filters-empty-hint")"
-                aria-label="Save as Filter Set"
-                class="button icon-button"
-                disabled="@(!HasSavableFilters)"
-                @onclick="SaveFiltersAsFilterSetAsync"
-                title="@(HasSavableFilters ? "Save as Filter Set..." : "No filters to save")"
-                type="button">
-                <i class="bi bi-bookmark-plus"></i>
-            </button>
-
-            <button aria-describedby="@(HasClearableFilters ? null : "clear-filters-empty-hint")"
-                aria-label="Clear All Filters"
-                class="button icon-button"
-                disabled="@(!HasClearableFilters)"
-                @onclick="ClearAllFiltersAsync"
-                title="@(HasClearableFilters ? "Clear All Filters..." : "No filters to clear")"
-                type="button">
-                <i class="bi bi-trash"></i>
-            </button>
-
-            <button aria-label="Open Filter Library"
-                class="button icon-button"
-                @onclick="OpenFilterLibraryAsync"
-                title="Open Filter Library"
-                type="button">
-                <i class="bi bi-bookmarks"></i>
-            </button>
-
-            @if (ScenarioAuthoringEnabled)
-            {
-                var hasEnabledFilters = HasEnabledFilters;
-
-                <button aria-describedby="@(hasEnabledFilters ? null : "scenario-export-empty-hint")"
-                    aria-label="Copy scenario JSON"
-                    class="button icon-button"
-                    disabled="@(!hasEnabledFilters)"
-                    @onclick="CopyScenarioJsonAsync"
-                    title="Copy current filter rows as scenario-catalog JSON"
-                    type="button">
-                    <i aria-hidden="true" class="bi bi-clipboard-data"></i>
-                </button>
-
-                <button aria-describedby="@(hasEnabledFilters ? null : "scenario-export-empty-hint")"
-                    aria-label="Save scenario JSON"
-                    class="button icon-button"
-                    disabled="@(!hasEnabledFilters)"
-                    @onclick="SaveScenarioJsonAsync"
-                    title="Save current filter rows as scenario-catalog JSON..."
-                    type="button">
-                    <i aria-hidden="true" class="bi bi-filetype-json"></i>
-                </button>
-
-                <span class="visually-hidden" id="scenario-export-empty-hint">
-                    Enable a filter before exporting as a scenario.
-                </span>
-            }
-
-            <span class="visually-hidden" id="save-filters-empty-hint">
-                Add a filter before saving as a Filter Set.
-            </span>
-            <span class="visually-hidden" id="clear-filters-empty-hint">
-                There are no filters to clear.
-            </span>
-
-            @if (HasFilters || FilterProgressState.Value.IsLoading)
-            {
-                <span aria-label="@(_isFilterListVisible ? "Filters Expanded" : "Filters Collapsed")"
-                    class="menu-toggle"
-                    data-rotate="@MenuState"
-                    @onclick="ToggleMenu"
-                    @onkeydown="HandleKeyDown"
-                    role="button"
-                    tabindex="0">
-                    <i class="bi bi-caret-up"></i>
-                </span>
-            }
-        </div>
     </div>
 
-    <div class="filter-set" data-toggle="@MenuState">
-        @if (IsDateFilterVisible)
+    @if (FilterProgressState.Value.IsLoading)
+    {
+        <span class="filter-header-status">
+            [<i aria-label="Loading" class="spinner-border" role="status"></i> Applying Filters]
+        </span>
+    }
+    else if (HasFilters && GetActiveFilters() > 0)
+    {
+        <span class="filter-header-status">[Active Filters: @GetActiveFilters()]</span>
+    }
+
+    <div class="filter-header-secondary">
+        <button aria-describedby="@(HasSavableFilters ? null : "save-filters-empty-hint")"
+            aria-label="Save as Filter Set"
+            class="button icon-button"
+            disabled="@(!HasSavableFilters)"
+            @onclick="SaveFiltersAsFilterSetAsync"
+            title="@(HasSavableFilters ? "Save as Filter Set..." : "No filters to save")"
+            type="button">
+            <i class="bi bi-bookmark-plus"></i>
+        </button>
+
+        <button aria-describedby="@(HasClearableFilters ? null : "clear-filters-empty-hint")"
+            aria-label="Clear All Filters"
+            class="button icon-button"
+            disabled="@(!HasClearableFilters)"
+            @onclick="ClearAllFiltersAsync"
+            title="@(HasClearableFilters ? "Clear All Filters..." : "No filters to clear")"
+            type="button">
+            <i class="bi bi-trash"></i>
+        </button>
+
+        <button aria-label="Open Filter Library"
+            class="button icon-button"
+            @onclick="OpenFilterLibraryAsync"
+            title="Open Filter Library"
+            type="button">
+            <i class="bi bi-bookmarks"></i>
+        </button>
+
+        @if (ScenarioAuthoringEnabled)
         {
-            <EditForm class="filter-form flex-row" Model="_model">
+            var hasEnabledFilters = HasEnabledFilters;
+
+            <button aria-describedby="@(hasEnabledFilters ? null : "scenario-export-empty-hint")"
+                aria-label="Copy scenario JSON"
+                class="button icon-button"
+                disabled="@(!hasEnabledFilters)"
+                @onclick="CopyScenarioJsonAsync"
+                title="Copy current filter rows as scenario-catalog JSON"
+                type="button">
+                <i aria-hidden="true" class="bi bi-clipboard-data"></i>
+            </button>
+
+            <button aria-describedby="@(hasEnabledFilters ? null : "scenario-export-empty-hint")"
+                aria-label="Save scenario JSON"
+                class="button icon-button"
+                disabled="@(!hasEnabledFilters)"
+                @onclick="SaveScenarioJsonAsync"
+                title="Save current filter rows as scenario-catalog JSON..."
+                type="button">
+                <i aria-hidden="true" class="bi bi-filetype-json"></i>
+            </button>
+
+            <span class="visually-hidden" id="scenario-export-empty-hint">
+                Enable a filter before exporting as a scenario.
+            </span>
+        }
+
+        <span class="visually-hidden" id="save-filters-empty-hint">
+            Add a filter before saving as a Filter Set.
+        </span>
+        <span class="visually-hidden" id="clear-filters-empty-hint">
+            There are no filters to clear.
+        </span>
+
+        @if (HasFilters || FilterProgressState.Value.IsLoading)
+        {
+            <span aria-label="@(_isFilterListVisible ? "Filters Expanded" : "Filters Collapsed")"
+                class="menu-toggle"
+                data-rotate="@MenuState"
+                @onclick="ToggleMenu"
+                @onkeydown="HandleKeyDown"
+                role="button"
+                tabindex="0">
+                <i class="bi bi-caret-up"></i>
+            </span>
+        }
+    </div>
+</div>
+
+<div class="filter-set" data-toggle="@MenuState">
+    @if (IsDateFilterVisible)
+    {
+        <EditForm class="filter-form flex-row" Model="_model">
+            <span>
+                After:
+                <InputDate aria-label="After" @bind-Value="_model.After" class="filter-datetime input" disabled="@(!_canEditDate)" Type="InputDateType.DateTimeLocal" />
+            </span>
+            <span>
+                Before:
+                <InputDate aria-label="Before" @bind-Value="_model.Before" class="filter-datetime input" disabled="@(!_canEditDate)" Type="InputDateType.DateTimeLocal" />
+            </span>
+
+            @if (_canEditDate)
+            {
                 <span>
-                    After:
-                    <InputDate aria-label="After" @bind-Value="_model.After" class="filter-datetime input" disabled="@(!_canEditDate)" Type="InputDateType.DateTimeLocal" />
-                </span>
-                <span>
-                    Before:
-                    <InputDate aria-label="Before" @bind-Value="_model.Before" class="filter-datetime input" disabled="@(!_canEditDate)" Type="InputDateType.DateTimeLocal" />
+                    Quick range:
+                    <DateRangeQuickPick AriaLabel="Quick date range" CssClass="input filter-datetime" OnRangeSelected="SetQuickDateRange" />
                 </span>
 
-                @if (_canEditDate)
+                <button class="button button-green" @onclick="ApplyDateFilter" type="button">
+                    <i class="bi bi-check-circle"></i> Apply
+                </button>
+
+                <button class="button button-red" @onclick="RemoveDateFilter" type="button">
+                    <i class="bi bi-dash-circle"></i> Remove
+                </button>
+            }
+            else
+            {
+                <button class="button" @onclick="EditDateFilter" type="button">
+                    <i class="bi bi-funnel"></i> Edit
+                </button>
+
+                <button class="button button-red" @onclick="RemoveDateFilter" type="button">
+                    <i class="bi bi-dash-circle"></i> Remove
+                </button>
+
+                @if (FilterPaneState.Value.FilteredDateRange?.IsEnabled is true)
                 {
-                    <button class="button button-green" @onclick="ApplyDateFilter">
-                        <i class="bi bi-check-circle"></i> Apply
-                    </button>
-
-                    <button class="button button-red" @onclick="RemoveDateFilter" type="button">
-                        <i class="bi bi-dash-circle"></i> Remove
+                    <button class="button button-red" @onclick="ToggleDateFilter" type="button">
+                        <i class="bi bi-dash-circle"></i> Disable
                     </button>
                 }
                 else
                 {
-                    <button class="button" @onclick="EditDateFilter">
-                        <i class="bi bi-funnel"></i> Edit
+                    <button class="button button-green" @onclick="ToggleDateFilter" type="button">
+                        <i class="bi bi-plus-circle"></i> Enable
                     </button>
-
-                    <button class="button button-red" @onclick="RemoveDateFilter" type="button">
-                        <i class="bi bi-dash-circle"></i> Remove
-                    </button>
-
-                    @if (FilterPaneState.Value.FilteredDateRange?.IsEnabled is true)
-                    {
-                        <button class="button button-red" @onclick="ToggleDateFilter">
-                            <i class="bi bi-dash-circle"></i> Disable
-                        </button>
-                    }
-                    else
-                    {
-                        <button class="button button-green" @onclick="ToggleDateFilter">
-                            <i class="bi bi-plus-circle"></i> Enable
-                        </button>
-                    }
                 }
-            </EditForm>
-        }
+            }
+        </EditForm>
+    }
 
-        @if (IsFilterSetPickerVisible)
-        {
-            <div class="filter-form flex-row">
-                @if (HasFilterSets)
+    @if (IsFilterSetPickerVisible)
+    {
+        <div class="filter-form flex-row">
+            @if (HasFilterSets)
+            {
+                @if (AvailableFilterSetTags is { Count: > 0 } setTags)
                 {
-                    @if (AvailableFilterSetTags is { Count: > 0 } setTags)
-                    {
-                        <span>
-                            Tags:
-                            <ValueSelect AriaLabel="Narrow filter sets by tag"
-                                CssClass="input filter-multiselect-dropdown"
-                                EmptyText="All tags"
-                                IsMultiSelect="true"
-                                T="string"
-                                Values="_filterSetTags"
-                                ValuesChanged="OnFilterSetTagsChanged">
-                                <ValueSelectItem ClearItem T="string">All tags</ValueSelectItem>
-                                @foreach (var tag in setTags)
-                                {
-                                    <ValueSelectItem T="string" Value="@tag">@tag</ValueSelectItem>
-                                }
-                            </ValueSelect>
-                        </span>
-                    }
-
                     <span>
-                        Filter Set:
-                        <ValueSelect AriaLabel="Filter Set"
-                            CssClass="input filter-set-dropdown"
-                            T="LibraryEntryId"
-                            ToStringFunc="@(GetFilterSetName)"
-                            Value="SelectedFilterSetId"
-                            ValueChanged="id => SelectedFilterSetId = id">
-                            @foreach (var filterSet in VisibleFilterSets)
+                        Tags:
+                        <ValueSelect AriaLabel="Narrow filter sets by tag"
+                            CssClass="input filter-multiselect-dropdown"
+                            EmptyText="All tags"
+                            IsMultiSelect="true"
+                            T="string"
+                            Values="_filterSetTags"
+                            ValuesChanged="OnFilterSetTagsChanged">
+                            <ValueSelectItem ClearItem T="string">All tags</ValueSelectItem>
+                            @foreach (var tag in setTags)
                             {
-                                <ValueSelectItem T="LibraryEntryId" Value="filterSet.Id">
-                                    <span class="filter-set-option-row" title="@FormatFilterSetLabel(filterSet)">
-                                        <span class="filter-set-option-name">@filterSet.Name</span>
-                                        <span class="filter-set-option-meta">(@FormatFilterSetDetail(filterSet))</span>
-                                    </span>
-                                </ValueSelectItem>
+                                <ValueSelectItem T="string" Value="@tag">@tag</ValueSelectItem>
                             }
                         </ValueSelect>
                     </span>
-
-                    <button class="button button-green" disabled="@(SelectedFilterSetId == default)" @onclick="ApplyFilterSetSelection">
-                        <i class="bi bi-check-circle"></i> Apply
-                    </button>
-                }
-                else
-                {
-                    <span class="filter-empty-state">
-                        @if (HasSavableFilters)
-                        {
-                            @:No saved filter sets yet — use <strong>Save as Filter Set</strong> on the right
-                            @:to create one from the current pane.
-                        }
-                        else
-                        {
-                            @:No saved filter sets yet. Add and apply filters first, then use
-                            @:<strong>Save as Filter Set</strong> on the right to create one.
-                        }
-                    </span>
                 }
 
-                <button class="button button-red" @onclick="CancelFilterSetPicker" type="button">
-                    <i class="bi bi-dash-circle"></i> Cancel
+                <span>
+                    Filter Set:
+                    <ValueSelect AriaLabel="Filter Set"
+                        CssClass="input filter-set-dropdown"
+                        T="LibraryEntryId"
+                        ToStringFunc="@(GetFilterSetName)"
+                        Value="SelectedFilterSetId"
+                        ValueChanged="id => SelectedFilterSetId = id">
+                        @foreach (var filterSet in VisibleFilterSets)
+                        {
+                            <ValueSelectItem T="LibraryEntryId" Value="filterSet.Id">
+                                <span class="filter-set-option-row" title="@FormatFilterSetLabel(filterSet)">
+                                    <span class="filter-set-option-name">@filterSet.Name</span>
+                                    <span class="filter-set-option-meta">(@FormatFilterSetDetail(filterSet))</span>
+                                </span>
+                            </ValueSelectItem>
+                        }
+                    </ValueSelect>
+                </span>
+
+                <button class="button button-green" disabled="@(SelectedFilterSetId == default)" @onclick="ApplyFilterSetSelection">
+                    <i class="bi bi-check-circle"></i> Apply
                 </button>
-            </div>
+
+                <button aria-label="Replace filters with selected filter set"
+                    class="button"
+                    disabled="@(SelectedFilterSetId == default)"
+                    @onclick="ReplaceFilterSetSelection"
+                    type="button">
+                    <i class="bi bi-arrow-repeat"></i> Replace
+                </button>
+            }
+            else
+            {
+                <span class="filter-empty-state">
+                    @if (HasSavableFilters)
+                    {
+                        @:No saved filter sets yet - use <strong>Save as Filter Set</strong> on the right
+                        @:to create one from the current pane.
+                    }
+                    else
+                    {
+                        @:No saved filter sets yet. Add and apply filters first, then use
+                        @:<strong>Save as Filter Set</strong> on the right to create one.
+                    }
+                </span>
+            }
+
+            <button class="button button-red" @onclick="CancelFilterSetPicker" type="button">
+                <i class="bi bi-dash-circle"></i> Cancel
+            </button>
+        </div>
+    }
+
+    @if (IsScenarioPickerVisible)
+    {
+        <div class="filter-form flex-row" id="scenario-picker">
+            @if (ScenarioMatchGroups.Count > 0)
+            {
+                @foreach (var group in ScenarioMatchGroups)
+                {
+                    <div class="scenario-picker-group">
+                        <span class="scenario-picker-group-header">@group.Key.DisplayName()</span>
+
+                        @foreach (var scenario in group)
+                        {
+                            <span class="scenario-picker-row" title="@scenario.Purpose">
+                                <span class="scenario-picker-name">@scenario.Name</span>
+
+                                <button aria-label="@($"Apply scenario {scenario.Name}")"
+                                    class="button button-green"
+                                    @onclick="() => ApplyScenario(scenario, false)"
+                                    type="button">
+                                    <i class="bi bi-check-circle"></i> Apply
+                                </button>
+
+                                <button aria-label="@($"Replace filters with scenario {scenario.Name}")"
+                                    class="button"
+                                    @onclick="() => ApplyScenario(scenario, true)"
+                                    type="button">
+                                    <i class="bi bi-arrow-repeat"></i> Replace
+                                </button>
+                            </span>
+                        }
+                    </div>
+                }
+            }
+            else
+            {
+                <span class="filter-empty-state" role="status">No scenarios match the loaded logs.</span>
+            }
+
+            <button class="button button-red" @onclick="CancelScenarioPicker" type="button">
+                <i class="bi bi-dash-circle"></i> Cancel
+            </button>
+        </div>
+    }
+
+    <CascadingValue IsFixed="true" Value="_authoringContext">
+        @foreach (var item in FilterPaneState.Value.Filters)
+        {
+            <FilterRow Id="@ComponentId.For(item.Id, ComponentIdScope.PaneFilter).Value"
+                @key="item.Id"
+                OnDisposed="@OnRowDisposed"
+                OnRemoved="HandleRemovedFilter"
+                @ref="_rowRefs[item.Id]"
+                Value="item" />
         }
 
-        <CascadingValue IsFixed="true" Value="_authoringContext">
-            @foreach (var item in FilterPaneState.Value.Filters)
-            {
-                <FilterRow Id="@ComponentId.For(item.Id, ComponentIdScope.PaneFilter).Value"
-                    @key="item.Id"
-                    OnDisposed="@OnRowDisposed"
-                    OnRemoved="HandleRemovedFilter"
-                    @ref="_rowRefs[item.Id]"
-                    Value="item" />
-            }
-
-            @foreach (var draft in _pendingDrafts)
-            {
-                <FilterRow Id="@ComponentId.For(draft.Id, ComponentIdScope.PanePendingFilter).Value"
-                    @key="draft.Id"
-                    OnPendingDiscard="() => HandlePendingDiscard(draft)"
-                    OnPendingSave="filter => HandlePendingSave(draft, filter)"
-                    PendingDraft="draft" />
-            }
-        </CascadingValue>
-    </div>
+        @foreach (var draft in _pendingDrafts)
+        {
+            <FilterRow Id="@ComponentId.For(draft.Id, ComponentIdScope.PanePendingFilter).Value"
+                @key="draft.Id"
+                OnPendingDiscard="() => HandlePendingDiscard(draft)"
+                OnPendingSave="filter => HandlePendingSave(draft, filter)"
+                PendingDraft="draft" />
+        }
+    </CascadingValue>
+</div>
 </div>

--- a/src/EventLogExpert.UI/FilterPane/FilterPane.razor.cs
+++ b/src/EventLogExpert.UI/FilterPane/FilterPane.razor.cs
@@ -28,6 +28,7 @@ using Fluxor;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
+using System.Collections.Immutable;
 using System.Security;
 using FilterMode = EventLogExpert.Filtering.Evaluation.FilterMode;
 
@@ -36,6 +37,7 @@ namespace EventLogExpert.UI.FilterPane;
 public sealed partial class FilterPane
 {
     internal bool IsFilterSetPickerVisible;
+    internal bool IsScenarioPickerVisible;
     internal LibraryEntryId SelectedFilterSetId;
 
     private readonly List<string> _filterSetTags = [];
@@ -54,6 +56,8 @@ public sealed partial class FilterPane
     private FilterId? _focusTargetAfterRemove;
     private bool _isFilterListVisible;
     private IJSObjectReference? _menuAnchorModule;
+    private IReadOnlyList<IGrouping<ScenarioGroup, ScenarioDefinition>> _scenarioMatchGroups = [];
+    private ImmutableDictionary<string, EventLogData>? _scenarioMatchSource;
 
     internal IReadOnlyList<string> AvailableFilterSetTags =>
         AvailableTagsForSets([.. FilterLibraryState.Value.Entries.OfType<LibraryEntryFilterSet>()]);
@@ -92,7 +96,7 @@ public sealed partial class FilterPane
     private bool HasEnabledFilters => FilterPaneState.Value.Filters.Any(filter => filter.IsEnabled);
 
     private bool HasFilters =>
-        IsDateFilterVisible || IsFilterSetPickerVisible || FilterPaneState.Value.Filters.IsEmpty is false || _pendingDrafts.Count > 0;
+        IsDateFilterVisible || IsFilterSetPickerVisible || IsScenarioPickerVisible || FilterPaneState.Value.Filters.IsEmpty is false || _pendingDrafts.Count > 0;
 
     private bool HasFilterSets =>
         FilterLibraryState.Value.IsLoaded
@@ -121,9 +125,37 @@ public sealed partial class FilterPane
 
     [Inject] private IModalCoordinator ModalCoordinator { get; init; } = null!;
 
+    [Inject] private IScenarioApplyService ScenarioApplyService { get; init; } = null!;
+
     [Inject] private ScenarioAuthoringOptions ScenarioAuthoringOptions { get; init; } = null!;
 
     [Inject] private IScenarioAuthoringService ScenarioAuthoringService { get; init; } = null!;
+
+    private IReadOnlyList<IGrouping<ScenarioGroup, ScenarioDefinition>> ScenarioMatchGroups
+    {
+        get
+        {
+            var activeLogs = EventLogState.Value.ActiveLogs;
+
+            if (ReferenceEquals(activeLogs, _scenarioMatchSource))
+            {
+                return _scenarioMatchGroups;
+            }
+
+            _scenarioMatchSource = activeLogs;
+            _scenarioMatchGroups =
+            [
+                .. ScenarioQueryService
+                        .GetInAppScenarios(LoadedLogNames(activeLogs))
+                        .GroupBy(scenario => scenario.Group)
+                        .OrderBy(group => group.Key)
+            ];
+
+            return _scenarioMatchGroups;
+        }
+    }
+
+    [Inject] private IScenarioQueryService ScenarioQueryService { get; init; } = null!;
 
     [Inject] private ISettingsService Settings { get; init; } = null!;
 
@@ -148,35 +180,17 @@ public sealed partial class FilterPane
         ];
     }
 
+    internal static IReadOnlyList<string> LoadedLogNames(ImmutableDictionary<string, EventLogData> activeLogs) =>
+    [
+        .. activeLogs.Values
+            .SelectMany(LogNamesFor)
+            .Where(name => !string.IsNullOrEmpty(name))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+    ];
+
     internal void ApplyFilterSetSelection()
     {
-        if (FilterLibraryState.Value.LoadError)
-        {
-            AnnouncementService.Announce(FilterPaneAnnouncements.LoadFailedRetryViaModal);
-            CancelFilterSetPicker();
-
-            return;
-        }
-
-        if (!FilterLibraryState.Value.IsLoaded)
-        {
-            AnnouncementService.Announce(FilterPaneAnnouncements.LoadingTryAgain);
-            CancelFilterSetPicker();
-
-            return;
-        }
-
-        var filterSets = FilterLibraryState.Value.Entries.OfType<LibraryEntryFilterSet>().ToList();
-
-        if (!filterSets.Any(p => p.Id.Equals(SelectedFilterSetId)))
-        {
-            AnnouncementService.Announce(FilterPaneAnnouncements.SelectedFilterSetMissing);
-            SelectedFilterSetId = filterSets
-                .OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase)
-                .FirstOrDefault()?.Id ?? default;
-
-            return;
-        }
+        if (!TryResolveSelectedFilterSet()) { return; }
 
         FilterLibraryCommands.ApplyEntry(SelectedFilterSetId);
         CancelFilterSetPicker();
@@ -192,6 +206,8 @@ public sealed partial class FilterPane
             isEnabled: HasRecentFilters,
             disabledReason: GetRecentDisabledReason()),
     ];
+
+    internal void EditDateFilter() => _canEditDate = true;
 
     internal string? GetRecentDisabledReason()
     {
@@ -231,6 +247,57 @@ public sealed partial class FilterPane
                 .First().Id
             : default;
         _isFilterListVisible = true;
+    }
+
+    internal void OpenScenarioPicker()
+    {
+        if (IsScenarioPickerVisible) { return; }
+
+        IsScenarioPickerVisible = true;
+        _isFilterListVisible = true;
+    }
+
+    internal void ReplaceFilterSetSelection()
+    {
+        if (!TryResolveSelectedFilterSet()) { return; }
+
+        FilterLibraryCommands.ReplaceWithEntry(SelectedFilterSetId);
+        CancelFilterSetPicker();
+    }
+
+    internal void SetQuickDateRange(DateFilter dateFilter) => UpdateFilterDate(dateFilter);
+
+    internal bool TryResolveSelectedFilterSet()
+    {
+        if (FilterLibraryState.Value.LoadError)
+        {
+            AnnouncementService.Announce(FilterPaneAnnouncements.LoadFailedRetryViaModal);
+            CancelFilterSetPicker();
+
+            return false;
+        }
+
+        if (!FilterLibraryState.Value.IsLoaded)
+        {
+            AnnouncementService.Announce(FilterPaneAnnouncements.LoadingTryAgain);
+            CancelFilterSetPicker();
+
+            return false;
+        }
+
+        var filterSets = FilterLibraryState.Value.Entries.OfType<LibraryEntryFilterSet>().ToList();
+
+        if (filterSets.Any(p => p.Id.Equals(SelectedFilterSetId)))
+        {
+            return true;
+        }
+
+        AnnouncementService.Announce(FilterPaneAnnouncements.SelectedFilterSetMissing);
+        SelectedFilterSetId = filterSets
+            .OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault()?.Id ?? default;
+
+        return false;
     }
 
     protected override async ValueTask DisposeAsyncCore(bool disposing)
@@ -276,6 +343,7 @@ public sealed partial class FilterPane
             _canEditDate = false;
             _pendingDrafts.Clear();
             IsFilterSetPickerVisible = false;
+            CancelScenarioPicker();
             SelectedFilterSetId = default;
             _filterSetTags.Clear();
         });
@@ -311,6 +379,11 @@ public sealed partial class FilterPane
 
     private static string FormatFilterSetLabel(LibraryEntryFilterSet set) =>
         $"{set.Name} ({FormatFilterSetDetail(set)})";
+
+    private static IEnumerable<string> LogNamesFor(EventLogData log) =>
+        log.Type == LogPathType.Channel
+            ? [log.Name]
+            : log.Events.Select(resolvedEvent => resolvedEvent.LogName).Distinct();
 
     private void AddAdvancedFilter()
     {
@@ -379,11 +452,24 @@ public sealed partial class FilterPane
         _canEditDate = false;
     }
 
+    private void ApplyScenario(ScenarioDefinition scenario, bool replace)
+    {
+        ScenarioApplyService.ApplyInApp(scenario, replace);
+        CancelScenarioPicker();
+    }
+
     private void CancelFilterSetPicker()
     {
         IsFilterSetPickerVisible = false;
         SelectedFilterSetId = default;
         _filterSetTags.Clear();
+    }
+
+    private void CancelScenarioPicker()
+    {
+        IsScenarioPickerVisible = false;
+        _scenarioMatchSource = null;
+        _scenarioMatchGroups = [];
     }
 
     private async Task ClearAllFiltersAsync()
@@ -422,8 +508,6 @@ public sealed partial class FilterPane
             .Select(log => log.Name)
             .Distinct(StringComparer.OrdinalIgnoreCase)
     ];
-
-    private void EditDateFilter() => _canEditDate = true;
 
     private ScenarioExportResult ExportCurrentRows() =>
         ScenarioAuthoringService.ExportRows(

--- a/src/EventLogExpert.UI/FilterPane/FilterPane.razor.css
+++ b/src/EventLogExpert.UI/FilterPane/FilterPane.razor.css
@@ -100,3 +100,30 @@
     min-width: 0;
 }
 
+.scenario-picker-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    min-width: 0;
+}
+
+.scenario-picker-group-header {
+    font-weight: 600;
+    opacity: 0.85;
+}
+
+.scenario-picker-row {
+    display: flex;
+    align-items: baseline;
+    gap: 0.375rem;
+    min-width: 0;
+}
+
+.scenario-picker-name {
+    flex: 0 1 auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+}
+

--- a/src/EventLogExpert.UI/Inputs/DateRangeQuickPick.razor
+++ b/src/EventLogExpert.UI/Inputs/DateRangeQuickPick.razor
@@ -1,0 +1,13 @@
+@inherits ComponentBase
+
+<ValueSelect AriaLabel="@AriaLabel"
+    CssClass="@CssClass"
+    T="string"
+    ToStringFunc="@PresetLabel"
+    Value="_selectedKey"
+    ValueChanged="OnPresetSelectedAsync">
+    @foreach (var preset in s_presets)
+    {
+        <ValueSelectItem T="string" Value="@preset.Key">@preset.Label</ValueSelectItem>
+    }
+</ValueSelect>

--- a/src/EventLogExpert.UI/Inputs/DateRangeQuickPick.razor.cs
+++ b/src/EventLogExpert.UI/Inputs/DateRangeQuickPick.razor.cs
@@ -1,0 +1,52 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Evaluation;
+using Microsoft.AspNetCore.Components;
+
+namespace EventLogExpert.UI.Inputs;
+
+public sealed partial class DateRangeQuickPick : ComponentBase
+{
+    private static readonly IReadOnlyList<DateRangePreset> s_presets =
+    [
+        new("7d", "Last 7 days", now => now.AddDays(-7)),
+        new("14d", "Last 14 days", now => now.AddDays(-14)),
+        new("1mo", "Last 1 month", now => now.AddMonths(-1)),
+        new("3mo", "Last 3 months", now => now.AddMonths(-3)),
+        new("6mo", "Last 6 months", now => now.AddMonths(-6)),
+        new("1yr", "Last 1 year", now => now.AddYears(-1)),
+        new("2yr", "Last 2 years", now => now.AddYears(-2)),
+    ];
+
+    private string _selectedKey = string.Empty;
+
+    [Parameter] public string AriaLabel { get; set; } = "Quick date range";
+
+    [Parameter] public string CssClass { get; set; } = string.Empty;
+
+    [Parameter] public Func<DateTime> NowUtc { get; set; } = () => DateTime.UtcNow;
+
+    [Parameter] public EventCallback<DateFilter> OnRangeSelected { get; set; }
+
+    [Parameter] public string PlaceholderText { get; set; } = "Quick range...";
+
+    private async Task OnPresetSelectedAsync(string key)
+    {
+        _selectedKey = key;
+
+        var preset = s_presets.FirstOrDefault(candidate => candidate.Key == key);
+
+        if (preset is null) { return; }
+
+        var now = NowUtc();
+        var dateFilter = new DateFilter { After = preset.ComputeAfter(now), Before = now };
+
+        await OnRangeSelected.InvokeAsync(dateFilter);
+    }
+
+    private string PresetLabel(string? key) =>
+        s_presets.FirstOrDefault(preset => preset.Key == key)?.Label ?? PlaceholderText;
+
+    private sealed record DateRangePreset(string Key, string Label, Func<DateTime, DateTime> ComputeAfter);
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/DependencyInjection/RuntimeServiceCollectionExtensionsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/DependencyInjection/RuntimeServiceCollectionExtensionsTests.cs
@@ -175,6 +175,7 @@ public sealed class RuntimeServiceCollectionExtensionsTests
     // Built-in scenarios.
     [InlineData(typeof(BuiltInScenarioRegistry))]
     [InlineData(typeof(IScenarioQueryService))]
+    [InlineData(typeof(IScenarioApplyService))]
     [InlineData(typeof(IScenarioLaunchService))]
     [InlineData(typeof(IScenarioAuthoringService))]
     public async Task AddEventLogRuntime_ShouldResolveHostFacingAbstraction(Type serviceType)

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/ScenarioApplyServiceTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/ScenarioApplyServiceTests.cs
@@ -1,0 +1,107 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.FilterPane;
+using EventLogExpert.Runtime.Scenarios;
+using Fluxor;
+using NSubstitute;
+using FilterPaneReducers = EventLogExpert.Runtime.FilterPane.Reducers;
+
+namespace EventLogExpert.Runtime.Tests.Scenarios;
+
+public sealed class ScenarioApplyServiceTests
+{
+    [Fact]
+    public void ApplyInApp_Merge_DispatchesMergeFiltersWithBuiltRows()
+    {
+        var scenario = ScenarioTestData.Single("a", "System", 1000);
+        var registry = ScenarioTestData.Registry(scenario);
+        var dispatcher = Substitute.For<IDispatcher>();
+        var service = new ScenarioApplyService(registry, dispatcher);
+
+        var expected = registry.BuildFilterSet(scenario);
+
+        service.ApplyInApp(scenario, replace: false);
+
+        dispatcher.Received(1).Dispatch(Arg.Is<MergeFiltersAction>(action =>
+            action.Filters.Count == expected.Count
+            && action.Filters[0].ComparisonText == expected[0].ComparisonText));
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<ReplaceFiltersAction>());
+    }
+
+    [Fact]
+    public void ApplyInApp_Merge_ThroughReducer_IsIdempotent()
+    {
+        var scenario = ScenarioTestData.Single("a", "System", 1000);
+        var registry = ScenarioTestData.Registry(scenario);
+        var dispatcher = Substitute.For<IDispatcher>();
+        var service = new ScenarioApplyService(registry, dispatcher);
+
+        MergeFiltersAction? captured = null;
+        dispatcher.When(target => target.Dispatch(Arg.Any<MergeFiltersAction>()))
+            .Do(call => captured = (MergeFiltersAction)call[0]);
+
+        service.ApplyInApp(scenario, replace: false);
+
+        Assert.NotNull(captured);
+
+        var afterFirst = FilterPaneReducers.ReduceMergeFilters(new FilterPaneState(), captured);
+        var afterSecond = FilterPaneReducers.ReduceMergeFilters(afterFirst, captured);
+
+        Assert.Single(afterFirst.Filters);
+        Assert.Equal(afterFirst.Filters.Count, afterSecond.Filters.Count);
+    }
+
+    [Fact]
+    public void ApplyInApp_NullScenario_Throws()
+    {
+        var registry = ScenarioTestData.Registry(ScenarioTestData.Single("a", "System", 1000));
+        var service = new ScenarioApplyService(registry, Substitute.For<IDispatcher>());
+
+        Assert.Throws<ArgumentNullException>(() => service.ApplyInApp(null!, replace: false));
+    }
+
+    [Fact]
+    public void ApplyInApp_Replace_DispatchesReplaceFilters()
+    {
+        var scenario = ScenarioTestData.Single("a", "System", 1000);
+        var registry = ScenarioTestData.Registry(scenario);
+        var dispatcher = Substitute.For<IDispatcher>();
+        var service = new ScenarioApplyService(registry, dispatcher);
+
+        var expected = registry.BuildFilterSet(scenario);
+
+        service.ApplyInApp(scenario, replace: true);
+
+        dispatcher.Received(1).Dispatch(Arg.Is<ReplaceFiltersAction>(action =>
+            action.Filters.Count == expected.Count
+            && action.Filters[0].ComparisonText == expected[0].ComparisonText));
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<MergeFiltersAction>());
+    }
+
+    [Fact]
+    public void ApplyInApp_Replace_ThroughReducer_SwapsRows()
+    {
+        var scenario = ScenarioTestData.Single("a", "System", 1000);
+        var registry = ScenarioTestData.Registry(scenario);
+        var dispatcher = Substitute.For<IDispatcher>();
+        var service = new ScenarioApplyService(registry, dispatcher);
+
+        ReplaceFiltersAction? captured = null;
+        dispatcher.When(target => target.Dispatch(Arg.Any<ReplaceFiltersAction>()))
+            .Do(call => captured = (ReplaceFiltersAction)call[0]);
+
+        var seeded = FilterPaneReducers.ReduceMergeFilters(
+            new FilterPaneState(),
+            new MergeFiltersAction(registry.BuildFilterSet(ScenarioTestData.Single("b", "System", 2000))));
+
+        service.ApplyInApp(scenario, replace: true);
+
+        Assert.NotNull(captured);
+
+        var replaced = FilterPaneReducers.ReduceReplaceFilters(seeded, captured);
+
+        Assert.Single(replaced.Filters);
+        Assert.Equal("Id == 1000", replaced.Filters[0].ComparisonText);
+    }
+}

--- a/tests/Unit/EventLogExpert.Scenarios.Tests/ScenarioGroupDisplayTests.cs
+++ b/tests/Unit/EventLogExpert.Scenarios.Tests/ScenarioGroupDisplayTests.cs
@@ -1,0 +1,42 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Scenarios.Catalog;
+
+namespace EventLogExpert.Scenarios.Tests;
+
+public sealed class ScenarioGroupDisplayTests
+{
+    public static IEnumerable<object[]> GroupNames() =>
+    [
+        [ScenarioGroup.SystemHealth, "System Health"],
+        [ScenarioGroup.Applications, "Applications"],
+        [ScenarioGroup.Security, "Security"],
+        [ScenarioGroup.ThreatsAndIncidentResponse, "Threats and Incident Response"],
+        [ScenarioGroup.Network, "Network"],
+        [ScenarioGroup.Storage, "Storage"],
+        [ScenarioGroup.UpdatesAndPolicy, "Updates and Policy"],
+        [ScenarioGroup.ActiveDirectory, "Active Directory"],
+        [ScenarioGroup.DnsServer, "DNS Server"],
+        [ScenarioGroup.DhcpServer, "DHCP Server"],
+        [ScenarioGroup.NpsAndRras, "NPS and RRAS"],
+        [ScenarioGroup.Wins, "WINS"],
+        [ScenarioGroup.WebAndIis, "Web and IIS"],
+        [ScenarioGroup.VirtualizationAndClustering, "Virtualization and Clustering"],
+        [ScenarioGroup.FilePrintAndStorage, "File, Print, and Storage"],
+        [ScenarioGroup.SqlServer, "SQL Server"],
+        [ScenarioGroup.Exchange, "Exchange"],
+        [ScenarioGroup.SharePoint, "SharePoint"],
+        [ScenarioGroup.DefenderForEndpoint, "Defender for Endpoint"],
+        [ScenarioGroup.Office, "Office"],
+    ];
+
+    [Fact]
+    public void DisplayName_CoversEveryGroup() =>
+        Assert.Equal(Enum.GetValues<ScenarioGroup>().Length, GroupNames().Count());
+
+    [Theory]
+    [MemberData(nameof(GroupNames))]
+    public void DisplayName_ReturnsCuratedName(ScenarioGroup group, string expected) =>
+        Assert.Equal(expected, group.DisplayName());
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterPane/FilterPaneTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterPane/FilterPaneTests.cs
@@ -1,7 +1,12 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using AngleSharp.Dom;
 using Bunit;
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Filtering.Evaluation;
 using EventLogExpert.Filtering.Persistence;
 using EventLogExpert.Runtime.Alerts;
 using EventLogExpert.Runtime.Announcement;
@@ -31,10 +36,13 @@ namespace EventLogExpert.UI.Tests.FilterPane;
 public sealed class FilterPaneTests : BunitContext
 {
     private readonly IAnnouncementService _announcements = Substitute.For<IAnnouncementService>();
+    private readonly IState<EventLogState> _eventLogStateMock = Substitute.For<IState<EventLogState>>();
     private readonly IFilterLibraryCommands _filterLibraryCommands = Substitute.For<IFilterLibraryCommands>();
     private readonly IFilterPaneCommands _filterPaneCommands = Substitute.For<IFilterPaneCommands>();
     private readonly IState<FilterLibraryState> _libraryStateMock = Substitute.For<IState<FilterLibraryState>>();
     private readonly IState<FilterPaneState> _paneStateMock = Substitute.For<IState<FilterPaneState>>();
+    private readonly IScenarioApplyService _scenarioApply = Substitute.For<IScenarioApplyService>();
+    private readonly IScenarioQueryService _scenarioQuery = Substitute.For<IScenarioQueryService>();
     private readonly ISettingsService _settings = Substitute.For<ISettingsService>();
 
     public FilterPaneTests()
@@ -53,6 +61,8 @@ public sealed class FilterPaneTests : BunitContext
         Services.AddSingleton(Substitute.For<IScenarioAuthoringService>());
         Services.AddSingleton(Substitute.For<IClipboardService>());
         Services.AddSingleton(Substitute.For<IFilePickerService>());
+        Services.AddSingleton(_scenarioApply);
+        Services.AddSingleton(_scenarioQuery);
         Services.AddSingleton(new ScenarioAuthoringOptions(false));
 
         var paneState = _paneStateMock;
@@ -63,9 +73,8 @@ public sealed class FilterPaneTests : BunitContext
         progressState.Value.Returns(new FilterProgressState());
         Services.AddSingleton(progressState);
 
-        var eventLogState = Substitute.For<IState<EventLogState>>();
-        eventLogState.Value.Returns(new EventLogState());
-        Services.AddSingleton(eventLogState);
+        _eventLogStateMock.Value.Returns(new EventLogState());
+        Services.AddSingleton(_eventLogStateMock);
 
         _settings.TimeZoneInfo.Returns(TimeZoneInfo.Utc);
 
@@ -150,6 +159,31 @@ public sealed class FilterPaneTests : BunitContext
     }
 
     [Fact]
+    public void ApplyScenarioButton_WhenLogsLoaded_IsShownWithPopupAttributes()
+    {
+        SetLibraryState(new FilterLibraryState { IsLoaded = true, Entries = ImmutableList<LibraryEntry>.Empty });
+        SetEventLogState(EventLogStateWithChannel("System"));
+
+        var component = Render<UI.FilterPane.FilterPane>();
+        var button = FindApplyScenarioButton(component);
+
+        Assert.NotNull(button);
+        Assert.Equal("true", button!.GetAttribute("aria-haspopup"));
+        Assert.Equal("false", button.GetAttribute("aria-expanded"));
+        Assert.Equal("scenario-picker", button.GetAttribute("aria-controls"));
+    }
+
+    [Fact]
+    public void ApplyScenarioButton_WhenNoLogsLoaded_IsHidden()
+    {
+        SetLibraryState(new FilterLibraryState { IsLoaded = true, Entries = ImmutableList<LibraryEntry>.Empty });
+
+        var component = Render<UI.FilterPane.FilterPane>();
+
+        Assert.Null(FindApplyScenarioButton(component));
+    }
+
+    [Fact]
     public void AvailableTagsForSets_ReturnsDistinctSortedUnion()
     {
         var a = BuildFilterSet("A", ["zebra", "alpha"]);
@@ -208,6 +242,29 @@ public sealed class FilterPaneTests : BunitContext
         Assert.DoesNotContain(
             component.FindAll("button"),
             b => b.GetAttribute("aria-label")?.StartsWith("Edit ", StringComparison.Ordinal) == true);
+    }
+
+    [Fact]
+    public void FilterSetReplaceButton_DisabledGatingMirrorsSelection()
+    {
+        var filterSet = BuildFilterSet("Picked");
+        SetLibraryState(new FilterLibraryState
+        {
+            IsLoaded = true,
+            Entries = ImmutableList.Create<LibraryEntry>(filterSet),
+        });
+        var component = Render<UI.FilterPane.FilterPane>();
+
+        component.Instance.OpenFilterSetPicker();
+        component.Render();
+
+        var replace = component.Find("button[aria-label='Replace filters with selected filter set']");
+        Assert.False(replace.HasAttribute("disabled"));
+
+        component.Instance.SelectedFilterSetId = default;
+        component.Render();
+
+        Assert.True(component.Find("button[aria-label='Replace filters with selected filter set']").HasAttribute("disabled"));
     }
 
     [Fact]
@@ -315,6 +372,30 @@ public sealed class FilterPaneTests : BunitContext
     }
 
     [Fact]
+    public void LoadedLogNames_CombinesChannelNamesAndFileEventLogNames_DistinctOrdinalIgnoreCase()
+    {
+        var channel = new EventLogData("System", LogPathType.Channel, []);
+        var file = new EventLogData(
+            "Forwarded.evtx",
+            LogPathType.File,
+            [
+                new ResolvedEvent("Forwarded.evtx", LogPathType.File) { LogName = "Security" },
+                new ResolvedEvent("Forwarded.evtx", LogPathType.File) { LogName = "security" },
+                new ResolvedEvent("Forwarded.evtx", LogPathType.File) { LogName = string.Empty },
+                new ResolvedEvent("Forwarded.evtx", LogPathType.File) { LogName = "Application" },
+            ]);
+        var logs = ImmutableDictionary<string, EventLogData>.Empty.Add("a", channel).Add("b", file);
+
+        var names = UI.FilterPane.FilterPane.LoadedLogNames(logs);
+
+        Assert.Equal(3, names.Count);
+        Assert.Contains("System", names);
+        Assert.Contains("Security", names);
+        Assert.Contains("Application", names);
+        Assert.DoesNotContain(string.Empty, names);
+    }
+
+    [Fact]
     public void OnRowDisposed_RemovesMatchingRowRef()
     {
         var pane = new UI.FilterPane.FilterPane();
@@ -386,6 +467,69 @@ public sealed class FilterPaneTests : BunitContext
         component.Instance.OpenFilterSetPicker();
 
         _announcements.Received(1).Announce(FilterPaneAnnouncements.LoadingTryAgain);
+    }
+
+    [Fact]
+    public async Task OpenScenarioPicker_FileLog_SurfacesScenariosFromEventLogName()
+    {
+        var fileLog = new EventLogData(
+            "Forwarded.evtx",
+            LogPathType.File,
+            [new ResolvedEvent("Forwarded.evtx", LogPathType.File) { LogName = "Security" }]);
+        SetLibraryState(new FilterLibraryState { IsLoaded = true, Entries = ImmutableList<LibraryEntry>.Empty });
+        SetEventLogState(new EventLogState
+        {
+            ActiveLogs = ImmutableDictionary<string, EventLogData>.Empty.Add("file", fileLog),
+        });
+
+        IReadOnlyCollection<string>? capturedNames = null;
+        _scenarioQuery.GetInAppScenarios(Arg.Do<IReadOnlyCollection<string>>(names => capturedNames = names))
+            .Returns([Scenario("sec", ScenarioGroup.Security)]);
+
+        var component = Render<UI.FilterPane.FilterPane>();
+        await FindApplyScenarioButton(component)!.ClickAsync(new MouseEventArgs());
+
+        Assert.NotNull(capturedNames);
+        Assert.Contains("Security", capturedNames!);
+        Assert.NotNull(component.Find("button[aria-label='Apply scenario sec']"));
+    }
+
+    [Fact]
+    public async Task OpenScenarioPicker_GroupsInDeclarationOrderAndExpandsButton()
+    {
+        SetLibraryState(new FilterLibraryState { IsLoaded = true, Entries = ImmutableList<LibraryEntry>.Empty });
+        SetEventLogState(EventLogStateWithChannel("System"));
+        _scenarioQuery.GetInAppScenarios(Arg.Any<IReadOnlyCollection<string>>())
+            .Returns(
+            [
+                Scenario("alpha", ScenarioGroup.Security),
+                Scenario("bravo", ScenarioGroup.SystemHealth),
+                Scenario("charlie", ScenarioGroup.Security),
+            ]);
+
+        var component = Render<UI.FilterPane.FilterPane>();
+        await FindApplyScenarioButton(component)!.ClickAsync(new MouseEventArgs());
+
+        var headers = component.FindAll(".scenario-picker-group-header").Select(header => header.TextContent).ToArray();
+        Assert.Equal([ScenarioGroup.SystemHealth.DisplayName(), ScenarioGroup.Security.DisplayName()], headers);
+        Assert.Equal("true", FindApplyScenarioButton(component)!.GetAttribute("aria-expanded"));
+
+        Assert.NotNull(component.Find("button[aria-label='Apply scenario alpha']"));
+        Assert.NotNull(component.Find("button[aria-label='Apply scenario charlie']"));
+    }
+
+    [Fact]
+    public async Task OpenScenarioPicker_WhenNoMatches_ShowsEmptyStateStatus()
+    {
+        SetLibraryState(new FilterLibraryState { IsLoaded = true, Entries = ImmutableList<LibraryEntry>.Empty });
+        SetEventLogState(EventLogStateWithChannel("System"));
+        _scenarioQuery.GetInAppScenarios(Arg.Any<IReadOnlyCollection<string>>()).Returns([]);
+
+        var component = Render<UI.FilterPane.FilterPane>();
+        await FindApplyScenarioButton(component)!.ClickAsync(new MouseEventArgs());
+
+        var status = component.Find("[role='status']");
+        Assert.Equal("No scenarios match the loaded logs.", status.TextContent);
     }
 
     [Fact]
@@ -465,6 +609,61 @@ public sealed class FilterPaneTests : BunitContext
     }
 
     [Fact]
+    public void ReplaceFilterSetSelection_WhenLoadError_AnnouncesAndDoesNotReplace()
+    {
+        var filterSet = BuildFilterSet("AnyName");
+        SetLibraryState(new FilterLibraryState
+        {
+            IsLoaded = true,
+            LoadError = true,
+            Entries = ImmutableList<LibraryEntry>.Empty,
+        });
+        var component = Render<UI.FilterPane.FilterPane>();
+        component.Instance.SelectedFilterSetId = filterSet.Id;
+
+        component.Instance.ReplaceFilterSetSelection();
+
+        _announcements.Received(1).Announce(FilterPaneAnnouncements.LoadFailedRetryViaModal);
+        _filterLibraryCommands.DidNotReceiveWithAnyArgs().ReplaceWithEntry(default);
+    }
+
+    [Fact]
+    public void ReplaceFilterSetSelection_WhenStillLoading_AnnouncesAndDoesNotReplace()
+    {
+        var filterSet = BuildFilterSet("AnyName");
+        SetLibraryState(new FilterLibraryState
+        {
+            IsLoaded = false,
+            Entries = ImmutableList<LibraryEntry>.Empty,
+        });
+        var component = Render<UI.FilterPane.FilterPane>();
+        component.Instance.SelectedFilterSetId = filterSet.Id;
+
+        component.Instance.ReplaceFilterSetSelection();
+
+        _announcements.Received(1).Announce(FilterPaneAnnouncements.LoadingTryAgain);
+        _filterLibraryCommands.DidNotReceiveWithAnyArgs().ReplaceWithEntry(default);
+    }
+
+    [Fact]
+    public void ReplaceFilterSetSelection_WhenSuccess_ReplacesAndDoesNotAnnounce()
+    {
+        var filterSet = BuildFilterSet("Picked");
+        SetLibraryState(new FilterLibraryState
+        {
+            IsLoaded = true,
+            Entries = ImmutableList.Create<LibraryEntry>(filterSet),
+        });
+        var component = Render<UI.FilterPane.FilterPane>();
+        component.Instance.SelectedFilterSetId = filterSet.Id;
+
+        component.Instance.ReplaceFilterSetSelection();
+
+        _filterLibraryCommands.Received(1).ReplaceWithEntry(filterSet.Id);
+        _announcements.DidNotReceiveWithAnyArgs().Announce(null!);
+    }
+
+    [Fact]
     public void SaveAndClearButtons_WhenNoFilters_AreDisabled()
     {
         var component = Render<UI.FilterPane.FilterPane>();
@@ -500,6 +699,23 @@ public sealed class FilterPaneTests : BunitContext
     }
 
     [Fact]
+    public async Task ScenarioApplyButton_InvokesApplyInAppMergeAndClosesPicker()
+    {
+        var scenario = Scenario("sys", ScenarioGroup.SystemHealth);
+        SetLibraryState(new FilterLibraryState { IsLoaded = true, Entries = ImmutableList<LibraryEntry>.Empty });
+        SetEventLogState(EventLogStateWithChannel("System"));
+        _scenarioQuery.GetInAppScenarios(Arg.Any<IReadOnlyCollection<string>>()).Returns([scenario]);
+
+        var component = Render<UI.FilterPane.FilterPane>();
+        await FindApplyScenarioButton(component)!.ClickAsync(new MouseEventArgs());
+
+        await component.Find("button[aria-label='Apply scenario sys']").ClickAsync(new MouseEventArgs());
+
+        _scenarioApply.Received(1).ApplyInApp(scenario, false);
+        Assert.False(component.Instance.IsScenarioPickerVisible);
+    }
+
+    [Fact]
     public void ScenarioButtons_WhenAllRowsDisabled_AreDisabled()
     {
         Services.AddSingleton(new ScenarioAuthoringOptions(true));
@@ -510,6 +726,41 @@ public sealed class FilterPaneTests : BunitContext
 
         Assert.True(component.Find("button[aria-label='Copy scenario JSON']").HasAttribute("disabled"));
         Assert.True(component.Find("button[aria-label='Save scenario JSON']").HasAttribute("disabled"));
+    }
+
+    [Fact]
+    public async Task ScenarioReplaceButton_InvokesApplyInAppReplace()
+    {
+        var scenario = Scenario("sys", ScenarioGroup.SystemHealth);
+        SetLibraryState(new FilterLibraryState { IsLoaded = true, Entries = ImmutableList<LibraryEntry>.Empty });
+        SetEventLogState(EventLogStateWithChannel("System"));
+        _scenarioQuery.GetInAppScenarios(Arg.Any<IReadOnlyCollection<string>>()).Returns([scenario]);
+
+        var component = Render<UI.FilterPane.FilterPane>();
+        await FindApplyScenarioButton(component)!.ClickAsync(new MouseEventArgs());
+
+        await component.Find("button[aria-label='Replace filters with scenario sys']").ClickAsync(new MouseEventArgs());
+
+        _scenarioApply.Received(1).ApplyInApp(scenario, true);
+    }
+
+    [Fact]
+    public void SetQuickDateRange_PopulatesEditFieldsWithoutApplyingFilter()
+    {
+        var component = Render<UI.FilterPane.FilterPane>();
+        component.Instance.EditDateFilter();
+        component.Render();
+
+        component.Instance.SetQuickDateRange(new DateFilter
+        {
+            After = new DateTime(2024, 6, 8, 12, 0, 0, DateTimeKind.Utc),
+            Before = new DateTime(2024, 6, 15, 12, 0, 0, DateTimeKind.Utc)
+        });
+        component.Render();
+
+        Assert.Contains("2024-06-08", component.Find("input[aria-label='After']").GetAttribute("value"));
+        Assert.Contains("2024-06-15", component.Find("input[aria-label='Before']").GetAttribute("value"));
+        _filterPaneCommands.DidNotReceiveWithAnyArgs().SetFilterDateRange(default);
     }
 
     private static LibraryEntryFilterSet BuildFilterSet(string name, ImmutableList<string>? tags = null) =>
@@ -535,6 +786,29 @@ public sealed class FilterPaneTests : BunitContext
             LastUsedUtc = isFavorite ? null : lastUsed,
         };
     }
+
+    private static EventLogState EventLogStateWithChannel(string channelName) =>
+        new()
+        {
+            ActiveLogs = ImmutableDictionary<string, EventLogData>.Empty
+                .Add(channelName, new EventLogData(channelName, LogPathType.Channel, [])),
+        };
+
+    private static IElement? FindApplyScenarioButton(IRenderedComponent<UI.FilterPane.FilterPane> component) =>
+        component.FindAll("button").FirstOrDefault(button => button.TextContent.Contains("Apply Scenario"));
+
+    private static ScenarioDefinition Scenario(string id, ScenarioGroup group) =>
+        new()
+        {
+            Id = id,
+            Name = id,
+            Purpose = $"Purpose {id}",
+            Group = group,
+            Channels = ["System"],
+            Filters = [],
+        };
+
+    private void SetEventLogState(EventLogState state) => _eventLogStateMock.Value.Returns(state);
 
     private void SetLibraryState(FilterLibraryState state) => _libraryStateMock.Value.Returns(state);
 

--- a/tests/Unit/EventLogExpert.UI.Tests/Inputs/DateRangeQuickPickTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Inputs/DateRangeQuickPickTests.cs
@@ -1,0 +1,123 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using EventLogExpert.Filtering.Evaluation;
+using EventLogExpert.UI.Inputs;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+
+namespace EventLogExpert.UI.Tests.Inputs;
+
+public sealed class DateRangeQuickPickTests : BunitContext
+{
+    private static readonly DateTime s_leapNow = new(2024, 2, 29, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime s_standardNow = new(2024, 6, 15, 12, 0, 0, DateTimeKind.Utc);
+
+    public DateRangeQuickPickTests() => JSInterop.Mode = JSRuntimeMode.Loose;
+
+    public static IEnumerable<object[]> PresetCases() =>
+    [
+        [s_standardNow, "Last 7 days", new DateTime(2024, 6, 8, 12, 0, 0, DateTimeKind.Utc)],
+        [s_standardNow, "Last 14 days", new DateTime(2024, 6, 1, 12, 0, 0, DateTimeKind.Utc)],
+        [s_standardNow, "Last 1 month", new DateTime(2024, 5, 15, 12, 0, 0, DateTimeKind.Utc)],
+        [s_standardNow, "Last 3 months", new DateTime(2024, 3, 15, 12, 0, 0, DateTimeKind.Utc)],
+        [s_standardNow, "Last 6 months", new DateTime(2023, 12, 15, 12, 0, 0, DateTimeKind.Utc)],
+        [s_standardNow, "Last 1 year", new DateTime(2023, 6, 15, 12, 0, 0, DateTimeKind.Utc)],
+        [s_standardNow, "Last 2 years", new DateTime(2022, 6, 15, 12, 0, 0, DateTimeKind.Utc)],
+
+        // Leap-day source: AddMonths/AddYears clamp to the nearest valid day.
+        [s_leapNow, "Last 1 month", new DateTime(2024, 1, 29, 12, 0, 0, DateTimeKind.Utc)],
+        [s_leapNow, "Last 6 months", new DateTime(2023, 8, 29, 12, 0, 0, DateTimeKind.Utc)],
+        [s_leapNow, "Last 1 year", new DateTime(2023, 2, 28, 12, 0, 0, DateTimeKind.Utc)],
+    ];
+
+    [Fact]
+    public async Task ArrowDown_NavigatesToSuccessivePresets()
+    {
+        var captured = new List<DateFilter>();
+        var component = Render<DateRangeQuickPick>(parameters => parameters
+            .Add(p => p.NowUtc, () => s_standardNow)
+            .Add(p => p.OnRangeSelected, EventCallback.Factory.Create<DateFilter>(this, captured.Add)));
+
+        var dropdown = component.Find(".dropdown-input");
+        await dropdown.KeyDownAsync(new KeyboardEventArgs { Code = "ArrowDown" });
+        await dropdown.KeyDownAsync(new KeyboardEventArgs { Code = "ArrowDown" });
+
+        Assert.Equal(2, captured.Count);
+        Assert.Equal(new DateTime(2024, 6, 8, 12, 0, 0, DateTimeKind.Utc), captured[0].After);
+        Assert.Equal(new DateTime(2024, 6, 1, 12, 0, 0, DateTimeKind.Utc), captured[1].After);
+    }
+
+    [Fact]
+    public void Render_AppliesAriaLabel()
+    {
+        var component = Render<DateRangeQuickPick>(parameters => parameters
+            .Add(p => p.AriaLabel, "Quick date range"));
+
+        Assert.Equal("Quick date range", component.Find("input[role='combobox']").GetAttribute("aria-label"));
+    }
+
+    [Fact]
+    public void Render_ShowsPlaceholderAndSevenPresetOptions()
+    {
+        var component = Render<DateRangeQuickPick>();
+
+        Assert.Equal("Quick range...", component.Find("input[role='combobox']").GetAttribute("value"));
+        Assert.Equal(7, component.FindAll("[role='option']").Count);
+    }
+
+    [Theory]
+    [MemberData(nameof(PresetCases))]
+    public async Task Selecting_Preset_EmitsExpectedUtcWindow(DateTime now, string label, DateTime expectedAfter)
+    {
+        DateFilter? captured = null;
+        var component = Render<DateRangeQuickPick>(parameters => parameters
+            .Add(p => p.NowUtc, () => now)
+            .Add(p => p.OnRangeSelected, EventCallback.Factory.Create<DateFilter>(this, filter => captured = filter)));
+
+        await SelectPreset(component, label);
+
+        Assert.NotNull(captured);
+        Assert.Equal(expectedAfter, captured!.After);
+        Assert.Equal(now, captured.Before);
+        Assert.Equal(DateTimeKind.Utc, captured.After!.Value.Kind);
+        Assert.Equal(DateTimeKind.Utc, captured.Before!.Value.Kind);
+        Assert.True(captured.IsEnabled);
+    }
+
+    [Fact]
+    public async Task Selecting_Preset_ShowsSelectedLabel()
+    {
+        var component = Render<DateRangeQuickPick>(parameters => parameters
+            .Add(p => p.NowUtc, () => s_standardNow)
+            .Add(p => p.OnRangeSelected, EventCallback.Factory.Create<DateFilter>(this, _ => { })));
+
+        await SelectPreset(component, "Last 7 days");
+
+        Assert.Equal("Last 7 days", component.Find("input[role='combobox']").GetAttribute("value"));
+    }
+
+    [Fact]
+    public async Task Selecting_PresetsInSequence_EmitsEachSelection()
+    {
+        var captured = new List<DateFilter>();
+        var component = Render<DateRangeQuickPick>(parameters => parameters
+            .Add(p => p.NowUtc, () => s_standardNow)
+            .Add(p => p.OnRangeSelected, EventCallback.Factory.Create<DateFilter>(this, captured.Add)));
+
+        await SelectPreset(component, "Last 7 days");
+        await SelectPreset(component, "Last 1 month");
+
+        Assert.Equal(2, captured.Count);
+        Assert.Equal(new DateTime(2024, 6, 8, 12, 0, 0, DateTimeKind.Utc), captured[0].After);
+        Assert.Equal(new DateTime(2024, 5, 15, 12, 0, 0, DateTimeKind.Utc), captured[1].After);
+    }
+
+    private static async Task SelectPreset(IRenderedComponent<DateRangeQuickPick> component, string label)
+    {
+        var option = component.FindAll("[role='option']").Single(item => item.TextContent.Trim() == label);
+
+        await option.MouseDownAsync(new MouseEventArgs());
+    }
+}


### PR DESCRIPTION
## Summary
Surfaces the built-in scenario catalog directly in the filter pane and adds date-range ergonomics, so users can apply curated event-log scenarios and relative time windows without leaving the pane.

## Changes
- In-app scenario picker: an "Apply Scenario" control opens a grouped list of built-in scenarios matching the loaded logs (live channels and opened .evtx files, matched by event channel name). Each scenario offers Apply (merge) or Replace; group headers use curated display names.
- Filter-set Replace: the saved-filter-set picker gains a Replace button alongside Apply.
- Date-range quick-pick: a reusable dropdown (last 7 days through 2 years) that fills the After/Before fields in UTC. Selecting a preset populates the date editor and waits for the explicit Apply (no auto-apply); it uses the app's ValueSelect for visual and keyboard consistency.

## Notes
- New IScenarioApplyService applies scenario filter rows in-app without opening a log.
- The scenario match scan runs only while the picker is open, memoized by the active-logs reference, and released when the picker closes.

## Testing
- Build clean (0 warnings / 0 errors).
- Unit tests pass: Scenarios 524, Runtime 1369, UI 837. New coverage for scenario apply/replace, group-display completeness, the date quick-pick (UTC / leap-day / keyboard navigation), and the populate-without-applying behavior.
