### PR TITLE
Export filtered events to CSV and JSON

### DIFF
--- a/src/EventLogExpert.Runtime/Banner/BannerViewSelector.cs
+++ b/src/EventLogExpert.Runtime/Banner/BannerViewSelector.cs
@@ -12,6 +12,7 @@ public enum BannerView
     Error,
     Attention,
     UpgradeProgress,
+    ExportProgress,
     Info
 }
 
@@ -26,6 +27,7 @@ public static class BannerViewSelector
         bool attentionDismissed,
         bool attentionSuppressedByModalContext,
         BannerProgressEntry? backgroundProgress,
+        ExportProgressEntry? exportProgress,
         IReadOnlyList<BannerInfoEntry> infoBanners)
     {
         ArgumentNullException.ThrowIfNull(errorBanners);
@@ -41,9 +43,10 @@ public static class BannerViewSelector
             && !attentionDismissed
             && !attentionSuppressedByModalContext;
 
-        var items = new List<BannerCycleItem>(
+        List<BannerCycleItem> items = new(
             errorBanners.Count + (includeAttention ? 1 : 0)
-            + (backgroundProgress is not null ? 1 : 0) + infoBanners.Count);
+            + (backgroundProgress is not null ? 1 : 0)
+            + (exportProgress is not null ? 1 : 0) + infoBanners.Count);
 
         for (int i = 0; i < errorBanners.Count; i++)
         {
@@ -58,6 +61,11 @@ public static class BannerViewSelector
         if (backgroundProgress is not null)
         {
             items.Add(new BannerCycleItem(BannerView.UpgradeProgress, 0, null));
+        }
+
+        if (exportProgress is not null)
+        {
+            items.Add(new BannerCycleItem(BannerView.ExportProgress, 0, null));
         }
 
         for (int i = 0; i < infoBanners.Count; i++)

--- a/src/EventLogExpert.Runtime/Banner/ExportProgressBannerService.cs
+++ b/src/EventLogExpert.Runtime/Banner/ExportProgressBannerService.cs
@@ -1,0 +1,44 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Banner;
+
+internal sealed class ExportProgressBannerService : IExportProgressBannerService
+{
+    private readonly Lock _stateLock = new();
+
+    private ExportProgressEntry? _currentExport;
+
+    public event Action? StateChanged;
+
+    public ExportProgressEntry? CurrentExport
+    {
+        get { using (_stateLock.EnterScope()) { return _currentExport; } }
+    }
+
+    public void Begin(string message, Action cancel)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(message);
+        ArgumentNullException.ThrowIfNull(cancel);
+
+        using (_stateLock.EnterScope())
+        {
+            _currentExport = new ExportProgressEntry(message, cancel);
+        }
+
+        // Raised outside the lock so a subscriber re-reading CurrentExport cannot deadlock.
+        StateChanged?.Invoke();
+    }
+
+    public void End()
+    {
+        using (_stateLock.EnterScope())
+        {
+            if (_currentExport is null) { return; }
+
+            _currentExport = null;
+        }
+
+        StateChanged?.Invoke();
+    }
+}

--- a/src/EventLogExpert.Runtime/Banner/ExportProgressEntry.cs
+++ b/src/EventLogExpert.Runtime/Banner/ExportProgressEntry.cs
@@ -1,0 +1,10 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Banner;
+
+/// <summary>
+///     A single in-flight event export shown as an indeterminate progress banner. <paramref name="Cancel" /> requests
+///     cancellation of the underlying streaming write.
+/// </summary>
+public sealed record ExportProgressEntry(string Message, Action Cancel);

--- a/src/EventLogExpert.Runtime/Banner/IExportProgressBannerService.cs
+++ b/src/EventLogExpert.Runtime/Banner/IExportProgressBannerService.cs
@@ -1,0 +1,25 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Banner;
+
+/// <summary>
+///     Tracks the single in-flight event export so the banner cycle can surface an indeterminate, cancelable progress
+///     banner. This is deliberately separate from the database-coupled <c>BannerService</c> facets: export progress has no
+///     upgrade/database dependency.
+/// </summary>
+public interface IExportProgressBannerService
+{
+    event Action StateChanged;
+
+    ExportProgressEntry? CurrentExport { get; }
+
+    /// <summary>
+    ///     Marks an export as started. Replaces any existing entry; callers are expected to gate re-entry so only one
+    ///     export runs at a time.
+    /// </summary>
+    void Begin(string message, Action cancel);
+
+    /// <summary>Clears the current export entry. Idempotent when no export is in progress.</summary>
+    void End();
+}

--- a/src/EventLogExpert.Runtime/Common/Files/FileSaveFileTypes.cs
+++ b/src/EventLogExpert.Runtime/Common/Files/FileSaveFileTypes.cs
@@ -7,6 +7,10 @@ namespace EventLogExpert.Runtime.Common.Files;
 
 public static class FileSaveFileTypes
 {
+    public static readonly IReadOnlyDictionary<string, IReadOnlyList<string>> Csv =
+        ImmutableDictionary<string, IReadOnlyList<string>>.Empty
+            .Add("CSV", [".csv"]);
+
     public static readonly IReadOnlyDictionary<string, IReadOnlyList<string>> Json =
         ImmutableDictionary<string, IReadOnlyList<string>>.Empty
             .Add("JSON", [".json"]);

--- a/src/EventLogExpert.Runtime/Common/Files/IFileSaveService.cs
+++ b/src/EventLogExpert.Runtime/Common/Files/IFileSaveService.cs
@@ -1,45 +1,10 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
-using EventLogExpert.Runtime.Alerts;
-
 namespace EventLogExpert.Runtime.Common.Files;
 
 public interface IFileSaveService
 {
-    /// <summary>
-    ///     Opens a system "Save As" dialog and, only after the user confirms a destination, invokes
-    ///     <paramref name="writeContent" /> against a writable stream whose contents are then saved to the destination.
-    ///     Returns the saved path on success, or <c>null</c> if the user cancelled (in which case
-    ///     <paramref name="writeContent" /> is never invoked). Throws if the user picked a path but the write or completion
-    ///     failed, or if the host environment cannot present a save dialog (e.g., no MAUI window available); callers should
-    ///     handle failures via try/catch and surface them through <see cref="IAlertDialogService" />.
-    /// </summary>
-    /// <param name="suggestedFileName">Default filename shown in the dialog (e.g., "debug-log.log").</param>
-    /// <param name="fileTypes">
-    ///     Group label to extension list (e.g., "Log files" -> [".log", ".txt"]). Must contain at least
-    ///     one entry.
-    /// </param>
-    /// <param name="writeContent">
-    ///     Asynchronous writer invoked exactly once with a writable stream after the user confirms a
-    ///     destination. Implementations may stream directly to disk or buffer the entire output in memory before writing to
-    ///     the picked file (the MAUI implementation buffers so that a writer exception leaves the picked file untouched);
-    ///     callers should keep exports reasonably bounded to fit in memory. The stream is owned by the service and disposed
-    ///     once the writer completes; callers must not retain or dispose it.
-    /// </param>
-    Task<string?> SaveAsync(
-        string suggestedFileName,
-        IReadOnlyDictionary<string, IReadOnlyList<string>> fileTypes,
-        Func<Stream, Task> writeContent);
-
-    /// <summary>
-    ///     Like <see cref="SaveAsync" /> but streams <paramref name="writeContent" /> to disk without buffering the whole
-    ///     output in memory. When the picked file's folder is writable, the output is staged in a sibling temp file and
-    ///     committed with an atomic replace, so a failed or cancelled write leaves any existing file untouched. For
-    ///     provider-backed destinations whose folder is not directly accessible (e.g. some cloud locations), the commit falls
-    ///     back to a platform-mediated replace from a fully-staged temp copy; this is best-effort rather than guaranteed
-    ///     atomic, so a failure during the final replace may leave an existing file partially overwritten.
-    /// </summary>
     Task<string?> SaveStreamingAsync(
         string suggestedFileName,
         IReadOnlyDictionary<string, IReadOnlyList<string>> fileTypes,

--- a/src/EventLogExpert.Runtime/Common/Files/IFileSaveService.cs
+++ b/src/EventLogExpert.Runtime/Common/Files/IFileSaveService.cs
@@ -31,4 +31,18 @@ public interface IFileSaveService
         string suggestedFileName,
         IReadOnlyDictionary<string, IReadOnlyList<string>> fileTypes,
         Func<Stream, Task> writeContent);
+
+    /// <summary>
+    ///     Like <see cref="SaveAsync" /> but streams <paramref name="writeContent" /> to disk without buffering the whole
+    ///     output in memory. When the picked file's folder is writable, the output is staged in a sibling temp file and
+    ///     committed with an atomic replace, so a failed or cancelled write leaves any existing file untouched. For
+    ///     provider-backed destinations whose folder is not directly accessible (e.g. some cloud locations), the commit falls
+    ///     back to a platform-mediated replace from a fully-staged temp copy; this is best-effort rather than guaranteed
+    ///     atomic, so a failure during the final replace may leave an existing file partially overwritten.
+    /// </summary>
+    Task<string?> SaveStreamingAsync(
+        string suggestedFileName,
+        IReadOnlyDictionary<string, IReadOnlyList<string>> fileTypes,
+        Func<Stream, CancellationToken, Task> writeContent,
+        CancellationToken cancellationToken);
 }

--- a/src/EventLogExpert.Runtime/DependencyInjection/RuntimeServiceCollectionExtensions.cs
+++ b/src/EventLogExpert.Runtime/DependencyInjection/RuntimeServiceCollectionExtensions.cs
@@ -64,8 +64,11 @@ public static class RuntimeServiceCollectionExtensions
         services.AddSingleton<IDatabaseOperationCoordinator, DatabaseOperationCoordinator>();
     }
 
-    private static void AddExportServices(IServiceCollection services) =>
+    private static void AddExportServices(IServiceCollection services)
+    {
         services.AddSingleton<ITabularExportWriter, TabularExportWriter>();
+        services.AddSingleton<IEventTableExporter, EventTableExporter>();
+    }
 
     extension(IServiceCollection services)
     {

--- a/src/EventLogExpert.Runtime/DependencyInjection/RuntimeServiceCollectionExtensions.cs
+++ b/src/EventLogExpert.Runtime/DependencyInjection/RuntimeServiceCollectionExtensions.cs
@@ -15,6 +15,7 @@ using EventLogExpert.Runtime.DatabaseTools;
 using EventLogExpert.Runtime.DatabaseTools.Elevation;
 using EventLogExpert.Runtime.DebugLog;
 using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.Export;
 using EventLogExpert.Runtime.FilterLibrary;
 using EventLogExpert.Runtime.FilterPane;
 using EventLogExpert.Runtime.LogTable;
@@ -62,6 +63,9 @@ public static class RuntimeServiceCollectionExtensions
 
         services.AddSingleton<IDatabaseOperationCoordinator, DatabaseOperationCoordinator>();
     }
+
+    private static void AddExportServices(IServiceCollection services) =>
+        services.AddSingleton<ITabularExportWriter, TabularExportWriter>();
 
     extension(IServiceCollection services)
     {
@@ -130,6 +134,7 @@ public static class RuntimeServiceCollectionExtensions
             ArgumentNullException.ThrowIfNull(services);
 
             AddDatabaseServices(services);
+            AddExportServices(services);
 
             // Command facades.
             services.AddSingleton<IEventLogCommands, EventLogCommands>();

--- a/src/EventLogExpert.Runtime/DependencyInjection/RuntimeServiceCollectionExtensions.cs
+++ b/src/EventLogExpert.Runtime/DependencyInjection/RuntimeServiceCollectionExtensions.cs
@@ -171,6 +171,11 @@ public static class RuntimeServiceCollectionExtensions
             services.AddSingleton<IErrorBannerService>(static sp => sp.GetRequiredService<BannerService>());
             services.AddSingleton<IInfoBannerService>(static sp => sp.GetRequiredService<BannerService>());
 
+            // Export progress is a standalone banner facet with no database coupling, so it is a
+            // separate singleton from BannerService. The UI BannerCycleStateService consumes it as a
+            // 7th source; the head menu driver brackets a streaming export with Begin/End.
+            services.AddSingleton<IExportProgressBannerService, ExportProgressBannerService>();
+
             services.AddSingleton<IAnnouncementService, AnnouncementService>();
 
             services.AddSingleton<DebugLogService>();

--- a/src/EventLogExpert.Runtime/Export/CsvExportSink.cs
+++ b/src/EventLogExpert.Runtime/Export/CsvExportSink.cs
@@ -1,0 +1,95 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Buffers;
+using System.Text;
+
+namespace EventLogExpert.Runtime.Export;
+
+internal sealed class CsvExportSink(Stream destination, string[] headers) : ExportSink(headers.Length)
+{
+    private const char FieldSeparator = ',';
+    private const int WriterBufferSize = 16 * 1024;
+
+    private static readonly ReadOnlyMemory<char> s_byteOrderMark = "\uFEFF".AsMemory();
+    private static readonly SearchValues<char> s_charactersRequiringQuotes = SearchValues.Create(",\"\r\n");
+    private static readonly ReadOnlyMemory<char> s_rowTerminator = "\r\n".AsMemory();
+    private static readonly UTF8Encoding s_utf8NoBom = new(encoderShouldEmitUTF8Identifier: false);
+
+    private readonly StringBuilder _fieldBuilder = new();
+    private readonly string[] _headers = headers;
+    private readonly StreamWriter _writer = new(destination, s_utf8NoBom, WriterBufferSize, leaveOpen: true);
+
+    protected override async ValueTask CompleteCoreAsync(CancellationToken cancellationToken) =>
+        await _writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+    protected override ValueTask DisposeCoreAsync()
+    {
+        // CompleteCoreAsync is the single, cancellable flush, so disposal has nothing to do. Disposing the
+        // StreamWriter would force an uncancellable underlying-stream flush (and after an aborted export, a torn
+        // record). It wraps the caller-owned stream (leaveOpen) and holds only a managed char buffer with no
+        // finalizer, so it is safely abandoned for the GC.
+        return ValueTask.CompletedTask;
+    }
+
+    protected override ValueTask WriteHeaderCoreAsync(CancellationToken cancellationToken) =>
+        WriteRecordAsync(_headers, writeByteOrderMark: true, cancellationToken);
+
+    protected override ValueTask WriteRowCoreAsync(IReadOnlyList<string?> cells, CancellationToken cancellationToken) =>
+        WriteRecordAsync(cells, writeByteOrderMark: false, cancellationToken);
+
+    private static void AppendField(StringBuilder builder, string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return;
+        }
+
+        if (value.AsSpan().IndexOfAny(s_charactersRequiringQuotes) < 0)
+        {
+            builder.Append(value);
+            return;
+        }
+
+        builder.Append('"');
+
+        foreach (char character in value)
+        {
+            if (character == '"')
+            {
+                builder.Append('"');
+            }
+
+            builder.Append(character);
+        }
+
+        builder.Append('"');
+    }
+
+    private async ValueTask WriteRecordAsync(
+        IReadOnlyList<string?> fields, bool writeByteOrderMark, CancellationToken cancellationToken)
+    {
+        if (writeByteOrderMark)
+        {
+            // Emit the UTF-8 BOM here, not via the encoder, so a cancelled pre-header export writes no bytes at
+            // all; Excel needs the BOM to detect UTF-8.
+            await _writer.WriteAsync(s_byteOrderMark, cancellationToken).ConfigureAwait(false);
+        }
+
+        for (int i = 0; i < fields.Count; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            _fieldBuilder.Clear();
+
+            if (i > 0)
+            {
+                _fieldBuilder.Append(FieldSeparator);
+            }
+
+            AppendField(_fieldBuilder, fields[i]);
+            await _writer.WriteAsync(_fieldBuilder, cancellationToken).ConfigureAwait(false);
+        }
+
+        await _writer.WriteAsync(s_rowTerminator, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/EventLogExpert.Runtime/Export/EventTableExporter.cs
+++ b/src/EventLogExpert.Runtime/Export/EventTableExporter.cs
@@ -20,6 +20,7 @@ internal sealed class EventTableExporter(ITabularExportWriter writer) : IEventTa
         IReadOnlyList<ResolvedEvent> events,
         IReadOnlyList<ColumnName> columns,
         TimeZoneInfo timeZone,
+        bool includeDescription,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(destination);
@@ -27,18 +28,23 @@ internal sealed class EventTableExporter(ITabularExportWriter writer) : IEventTa
         ArgumentNullException.ThrowIfNull(columns);
         ArgumentNullException.ThrowIfNull(timeZone);
 
-        var headers = new string[columns.Count];
+        string[] headers = new string[columns.Count + (includeDescription ? 1 : 0)];
 
         for (int i = 0; i < columns.Count; i++)
         {
             headers[i] = EventTableColumnFormatter.GetColumnHeader(columns[i], timeZone);
         }
 
+        if (includeDescription)
+        {
+            headers[columns.Count] = EventTableColumnFormatter.DescriptionColumnHeader;
+        }
+
         await writer.WriteAsync(
                 destination,
                 format,
                 headers,
-                ProjectRows(events, columns, timeZone, format, cancellationToken),
+                ProjectRows(events, columns, timeZone, format, includeDescription, cancellationToken),
                 cancellationToken)
             .ConfigureAwait(false);
     }
@@ -51,6 +57,7 @@ internal sealed class EventTableExporter(ITabularExportWriter writer) : IEventTa
         IReadOnlyList<ColumnName> columns,
         TimeZoneInfo timeZone,
         ExportFormat format,
+        bool includeDescription,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         // The projection is synchronous over a materialized list; this await only satisfies the async-iterator
@@ -58,6 +65,7 @@ internal sealed class EventTableExporter(ITabularExportWriter writer) : IEventTa
         await Task.CompletedTask.ConfigureAwait(false);
 
         bool neutralizeCsvFormula = format == ExportFormat.Csv;
+        int cellCount = columns.Count + (includeDescription ? 1 : 0);
 
         // Enumerate, never index: events may be a CombinedEventView whose indexer is O(n) per access (it merge-walks
         // from a seek point), so indexed iteration would be O(n^2). foreach is the O(n) designed access path.
@@ -65,12 +73,19 @@ internal sealed class EventTableExporter(ITabularExportWriter writer) : IEventTa
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var cells = new string?[columns.Count];
+            string?[] cells = new string?[cellCount];
 
             for (int i = 0; i < columns.Count; i++)
             {
                 string cell = EventTableColumnFormatter.GetCellText(@event, columns[i], timeZone, IsoDateTimeFormat);
                 cells[i] = neutralizeCsvFormula ? NeutralizeCsvFormula(cell) : cell;
+            }
+
+            if (includeDescription)
+            {
+                cells[columns.Count] = neutralizeCsvFormula
+                    ? NeutralizeCsvFormula(@event.Description)
+                    : @event.Description;
             }
 
             yield return cells;

--- a/src/EventLogExpert.Runtime/Export/EventTableExporter.cs
+++ b/src/EventLogExpert.Runtime/Export/EventTableExporter.cs
@@ -10,9 +10,9 @@ namespace EventLogExpert.Runtime.Export;
 
 internal sealed class EventTableExporter(ITabularExportWriter writer) : IEventTableExporter
 {
-    private const string IsoDateTimeFormat = "yyyy-MM-dd HH:mm:ss";
+    private const string ExportDateTimeFormat = "yyyy-MM-dd HH:mm:ss";
 
-    private static readonly SearchValues<char> s_formulaInjectionTriggers = SearchValues.Create("=+-@\t\r");
+    private static readonly SearchValues<char> s_formulaInjectionTriggers = SearchValues.Create("=+-@");
 
     public async Task ExportAsync(
         Stream destination,
@@ -49,8 +49,25 @@ internal sealed class EventTableExporter(ITabularExportWriter writer) : IEventTa
             .ConfigureAwait(false);
     }
 
-    private static string NeutralizeCsvFormula(string value) =>
-        value.Length > 0 && s_formulaInjectionTriggers.Contains(value[0]) ? "'" + value : value;
+    private static string NeutralizeCsvFormula(string value)
+    {
+        if (value.Length == 0) { return value; }
+
+        // A leading TAB or CR is itself a CSV-injection vector; neutralize it directly (it is whitespace,
+        // so the scan below would otherwise skip past it).
+        if (value[0] is '\t' or '\r') { return "'" + value; }
+
+        // Spreadsheet apps trim leading whitespace before evaluating a cell, so a value like " =SUM(A1)"
+        // is still a formula. Neutralize when the first non-whitespace character is a formula trigger.
+        foreach (char character in value)
+        {
+            if (char.IsWhiteSpace(character)) { continue; }
+
+            return s_formulaInjectionTriggers.Contains(character) ? "'" + value : value;
+        }
+
+        return value;
+    }
 
     private static async IAsyncEnumerable<IReadOnlyList<string?>> ProjectRows(
         IReadOnlyList<ResolvedEvent> events,
@@ -77,7 +94,7 @@ internal sealed class EventTableExporter(ITabularExportWriter writer) : IEventTa
 
             for (int i = 0; i < columns.Count; i++)
             {
-                string cell = EventTableColumnFormatter.GetCellText(@event, columns[i], timeZone, IsoDateTimeFormat);
+                string cell = EventTableColumnFormatter.GetCellText(@event, columns[i], timeZone, ExportDateTimeFormat);
                 cells[i] = neutralizeCsvFormula ? NeutralizeCsvFormula(cell) : cell;
             }
 

--- a/src/EventLogExpert.Runtime/Export/EventTableExporter.cs
+++ b/src/EventLogExpert.Runtime/Export/EventTableExporter.cs
@@ -1,0 +1,79 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Runtime.LogTable;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+
+namespace EventLogExpert.Runtime.Export;
+
+internal sealed class EventTableExporter(ITabularExportWriter writer) : IEventTableExporter
+{
+    private const string IsoDateTimeFormat = "yyyy-MM-dd HH:mm:ss";
+
+    private static readonly SearchValues<char> s_formulaInjectionTriggers = SearchValues.Create("=+-@\t\r");
+
+    public async Task ExportAsync(
+        Stream destination,
+        ExportFormat format,
+        IReadOnlyList<ResolvedEvent> events,
+        IReadOnlyList<ColumnName> columns,
+        TimeZoneInfo timeZone,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(destination);
+        ArgumentNullException.ThrowIfNull(events);
+        ArgumentNullException.ThrowIfNull(columns);
+        ArgumentNullException.ThrowIfNull(timeZone);
+
+        var headers = new string[columns.Count];
+
+        for (int i = 0; i < columns.Count; i++)
+        {
+            headers[i] = EventTableColumnFormatter.GetColumnHeader(columns[i], timeZone);
+        }
+
+        await writer.WriteAsync(
+                destination,
+                format,
+                headers,
+                ProjectRows(events, columns, timeZone, format, cancellationToken),
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static string NeutralizeCsvFormula(string value) =>
+        value.Length > 0 && s_formulaInjectionTriggers.Contains(value[0]) ? "'" + value : value;
+
+    private static async IAsyncEnumerable<IReadOnlyList<string?>> ProjectRows(
+        IReadOnlyList<ResolvedEvent> events,
+        IReadOnlyList<ColumnName> columns,
+        TimeZoneInfo timeZone,
+        ExportFormat format,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        // The projection is synchronous over a materialized list; this await only satisfies the async-iterator
+        // contract (no per-row scheduling overhead). The sink applies backpressure on the write side.
+        await Task.CompletedTask.ConfigureAwait(false);
+
+        bool neutralizeCsvFormula = format == ExportFormat.Csv;
+
+        // Enumerate, never index: events may be a CombinedEventView whose indexer is O(n) per access (it merge-walks
+        // from a seek point), so indexed iteration would be O(n^2). foreach is the O(n) designed access path.
+        foreach (ResolvedEvent @event in events)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var cells = new string?[columns.Count];
+
+            for (int i = 0; i < columns.Count; i++)
+            {
+                string cell = EventTableColumnFormatter.GetCellText(@event, columns[i], timeZone, IsoDateTimeFormat);
+                cells[i] = neutralizeCsvFormula ? NeutralizeCsvFormula(cell) : cell;
+            }
+
+            yield return cells;
+        }
+    }
+}

--- a/src/EventLogExpert.Runtime/Export/ExportFormat.cs
+++ b/src/EventLogExpert.Runtime/Export/ExportFormat.cs
@@ -1,0 +1,10 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Export;
+
+internal enum ExportFormat
+{
+    Csv,
+    Json
+}

--- a/src/EventLogExpert.Runtime/Export/ExportFormat.cs
+++ b/src/EventLogExpert.Runtime/Export/ExportFormat.cs
@@ -3,7 +3,7 @@
 
 namespace EventLogExpert.Runtime.Export;
 
-internal enum ExportFormat
+public enum ExportFormat
 {
     Csv,
     Json

--- a/src/EventLogExpert.Runtime/Export/ExportSink.cs
+++ b/src/EventLogExpert.Runtime/Export/ExportSink.cs
@@ -1,0 +1,90 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Export;
+
+internal abstract class ExportSink(int columnCount) : IAsyncDisposable
+{
+    private bool _completed;
+    private bool _disposed;
+    private bool _headerWritten;
+
+    public async ValueTask CompleteAsync(CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (!_headerWritten)
+        {
+            throw new InvalidOperationException("The header row must be written before completing the export.");
+        }
+
+        if (_completed)
+        {
+            throw new InvalidOperationException("The export has already been completed.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await CompleteCoreAsync(cancellationToken).ConfigureAwait(false);
+        _completed = true;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        await DisposeCoreAsync().ConfigureAwait(false);
+        GC.SuppressFinalize(this);
+    }
+
+    public async ValueTask WriteHeaderAsync(CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (_headerWritten)
+        {
+            throw new InvalidOperationException("The header row has already been written.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await WriteHeaderCoreAsync(cancellationToken).ConfigureAwait(false);
+        _headerWritten = true;
+    }
+
+    public async ValueTask WriteRowAsync(IReadOnlyList<string?> cells, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(cells);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (!_headerWritten)
+        {
+            throw new InvalidOperationException("The header row must be written before any data row.");
+        }
+
+        if (_completed)
+        {
+            throw new InvalidOperationException("Cannot write a row after the export has been completed.");
+        }
+
+        if (cells.Count != columnCount)
+        {
+            throw new ArgumentException(
+                $"The row has {cells.Count} cells but {columnCount} columns were declared.", nameof(cells));
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        await WriteRowCoreAsync(cells, cancellationToken).ConfigureAwait(false);
+    }
+
+    protected abstract ValueTask CompleteCoreAsync(CancellationToken cancellationToken);
+
+    protected abstract ValueTask DisposeCoreAsync();
+
+    protected abstract ValueTask WriteHeaderCoreAsync(CancellationToken cancellationToken);
+
+    protected abstract ValueTask WriteRowCoreAsync(IReadOnlyList<string?> cells, CancellationToken cancellationToken);
+}

--- a/src/EventLogExpert.Runtime/Export/IEventTableExporter.cs
+++ b/src/EventLogExpert.Runtime/Export/IEventTableExporter.cs
@@ -14,5 +14,6 @@ public interface IEventTableExporter
         IReadOnlyList<ResolvedEvent> events,
         IReadOnlyList<ColumnName> columns,
         TimeZoneInfo timeZone,
+        bool includeDescription,
         CancellationToken cancellationToken);
 }

--- a/src/EventLogExpert.Runtime/Export/IEventTableExporter.cs
+++ b/src/EventLogExpert.Runtime/Export/IEventTableExporter.cs
@@ -1,0 +1,18 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Runtime.LogTable;
+
+namespace EventLogExpert.Runtime.Export;
+
+public interface IEventTableExporter
+{
+    Task ExportAsync(
+        Stream destination,
+        ExportFormat format,
+        IReadOnlyList<ResolvedEvent> events,
+        IReadOnlyList<ColumnName> columns,
+        TimeZoneInfo timeZone,
+        CancellationToken cancellationToken);
+}

--- a/src/EventLogExpert.Runtime/Export/ITabularExportWriter.cs
+++ b/src/EventLogExpert.Runtime/Export/ITabularExportWriter.cs
@@ -1,0 +1,14 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Export;
+
+internal interface ITabularExportWriter
+{
+    Task WriteAsync(
+        Stream destination,
+        ExportFormat format,
+        IReadOnlyList<string> headers,
+        IAsyncEnumerable<IReadOnlyList<string?>> rows,
+        CancellationToken cancellationToken);
+}

--- a/src/EventLogExpert.Runtime/Export/JsonExportSink.cs
+++ b/src/EventLogExpert.Runtime/Export/JsonExportSink.cs
@@ -1,0 +1,67 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Text.Json;
+
+namespace EventLogExpert.Runtime.Export;
+
+internal sealed class JsonExportSink(Stream destination, string[] headers) : ExportSink(headers.Length)
+{
+    private const int FlushThresholdBytes = 64 * 1024;
+
+    private static readonly JsonWriterOptions s_options = new() { Indented = true };
+
+    private readonly string[] _headers = headers;
+    private readonly Utf8JsonWriter _writer = new(destination, s_options);
+
+    protected override async ValueTask CompleteCoreAsync(CancellationToken cancellationToken)
+    {
+        _writer.WriteEndArray();
+        await _writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    protected override ValueTask DisposeCoreAsync()
+    {
+        // CompleteCoreAsync is the single, cancellable flush, so disposal has nothing to do. Disposing the
+        // Utf8JsonWriter would force an uncancellable underlying-stream flush (and after an aborted export, partial
+        // JSON). It wraps the caller-owned stream (leaveOpen) and holds only a managed byte buffer with no finalizer,
+        // so it is safely abandoned for the GC.
+        return ValueTask.CompletedTask;
+    }
+
+    protected override ValueTask WriteHeaderCoreAsync(CancellationToken cancellationToken)
+    {
+        _writer.WriteStartArray();
+
+        return ValueTask.CompletedTask;
+    }
+
+    protected override async ValueTask WriteRowCoreAsync(IReadOnlyList<string?> cells, CancellationToken cancellationToken)
+    {
+        _writer.WriteStartObject();
+
+        for (int i = 0; i < _headers.Length; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            string? cell = cells[i];
+
+            if (cell is null)
+            {
+                _writer.WriteNull(_headers[i]);
+            }
+            else
+            {
+                _writer.WriteString(_headers[i], cell);
+            }
+
+            // Utf8JsonWriter buffers in a pooled array until flushed; cap it per cell to stay bounded-memory.
+            if (_writer.BytesPending >= FlushThresholdBytes)
+            {
+                await _writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        _writer.WriteEndObject();
+    }
+}

--- a/src/EventLogExpert.Runtime/Export/TabularExportWriter.cs
+++ b/src/EventLogExpert.Runtime/Export/TabularExportWriter.cs
@@ -1,0 +1,70 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Export;
+
+internal sealed class TabularExportWriter : ITabularExportWriter
+{
+    public async Task WriteAsync(
+        Stream destination,
+        ExportFormat format,
+        IReadOnlyList<string> headers,
+        IAsyncEnumerable<IReadOnlyList<string?>> rows,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(destination);
+        ArgumentNullException.ThrowIfNull(headers);
+        ArgumentNullException.ThrowIfNull(rows);
+
+        string[] columnHeaders = ValidateAndCopyHeaders(headers);
+
+        await using ExportSink sink = CreateSink(format, destination, columnHeaders);
+
+        await sink.WriteHeaderAsync(cancellationToken).ConfigureAwait(false);
+
+        await foreach (IReadOnlyList<string?> row in rows.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            await sink.WriteRowAsync(row, cancellationToken).ConfigureAwait(false);
+        }
+
+        await sink.CompleteAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static ExportSink CreateSink(ExportFormat format, Stream destination, string[] columnHeaders) =>
+        format switch
+        {
+            ExportFormat.Csv => new CsvExportSink(destination, columnHeaders),
+            ExportFormat.Json => new JsonExportSink(destination, columnHeaders),
+            _ => throw new ArgumentOutOfRangeException(nameof(format), format, "Unsupported export format.")
+        };
+
+    private static string[] ValidateAndCopyHeaders(IReadOnlyList<string> headers)
+    {
+        if (headers.Count == 0)
+        {
+            throw new ArgumentException("At least one column header is required.", nameof(headers));
+        }
+
+        string[] columnHeaders = new string[headers.Count];
+        HashSet<string> seenHeaders = new(StringComparer.Ordinal);
+
+        for (int i = 0; i < headers.Count; i++)
+        {
+            string header = headers[i];
+
+            if (string.IsNullOrEmpty(header))
+            {
+                throw new ArgumentException($"The column header at index {i} is null or empty.", nameof(headers));
+            }
+
+            if (!seenHeaders.Add(header))
+            {
+                throw new ArgumentException($"Duplicate column header '{header}'.", nameof(headers));
+            }
+
+            columnHeaders[i] = header;
+        }
+
+        return columnHeaders;
+    }
+}

--- a/src/EventLogExpert.Runtime/LogTable/EventTableColumnFormatter.cs
+++ b/src/EventLogExpert.Runtime/LogTable/EventTableColumnFormatter.cs
@@ -9,11 +9,8 @@ namespace EventLogExpert.Runtime.LogTable;
 
 public static class EventTableColumnFormatter
 {
-    /// <param name="dateTimeFormat">
-    ///     When <c>null</c>, the DateAndTime cell uses the current culture's default formatting
-    ///     (on-screen display parity); when non-null, the format is applied with <see cref="CultureInfo.InvariantCulture" />
-    ///     (stable export).
-    /// </param>
+    public const string DescriptionColumnHeader = "Description";
+
     public static string GetCellText(
         ResolvedEvent @event, ColumnName column, TimeZoneInfo timeZone, string? dateTimeFormat = null) =>
         column switch

--- a/src/EventLogExpert.Runtime/LogTable/EventTableColumnFormatter.cs
+++ b/src/EventLogExpert.Runtime/LogTable/EventTableColumnFormatter.cs
@@ -1,0 +1,53 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Runtime.Common.Display;
+using System.Globalization;
+
+namespace EventLogExpert.Runtime.LogTable;
+
+public static class EventTableColumnFormatter
+{
+    /// <param name="dateTimeFormat">
+    ///     When <c>null</c>, the DateAndTime cell uses the current culture's default formatting
+    ///     (on-screen display parity); when non-null, the format is applied with <see cref="CultureInfo.InvariantCulture" />
+    ///     (stable export).
+    /// </param>
+    public static string GetCellText(
+        ResolvedEvent @event, ColumnName column, TimeZoneInfo timeZone, string? dateTimeFormat = null) =>
+        column switch
+        {
+            ColumnName.RecordId => @event.RecordId?.ToString() ?? string.Empty,
+            ColumnName.Level => @event.Level,
+            ColumnName.DateAndTime => FormatTimeCreated(@event.TimeCreated, timeZone, dateTimeFormat),
+            ColumnName.ActivityId => @event.ActivityId?.ToString() ?? string.Empty,
+            ColumnName.Log => GetLogShortName(@event.OwningLog),
+            ColumnName.ComputerName => @event.ComputerName,
+            ColumnName.Source => @event.Source,
+            ColumnName.EventId => @event.Id.ToString(),
+            ColumnName.TaskCategory => @event.TaskCategory,
+            ColumnName.Keywords => @event.KeywordsDisplayName,
+            ColumnName.ProcessId => @event.ProcessId?.ToString() ?? string.Empty,
+            ColumnName.ThreadId => @event.ThreadId?.ToString() ?? string.Empty,
+            ColumnName.User => @event.UserId?.ToString() ?? string.Empty,
+            _ => string.Empty
+        };
+
+    public static string GetColumnHeader(ColumnName column, TimeZoneInfo timeZone) =>
+        column == ColumnName.DateAndTime && !timeZone.Equals(TimeZoneInfo.Local)
+            ? $"Date and Time {timeZone.DisplayName.Split(' ').First()}"
+            : column.ToFullString();
+
+    private static string FormatTimeCreated(DateTime timeCreated, TimeZoneInfo timeZone, string? dateTimeFormat)
+    {
+        DateTime converted = timeCreated.ConvertTimeZone(timeZone);
+
+        return dateTimeFormat is null
+            ? converted.ToString()
+            : converted.ToString(dateTimeFormat, CultureInfo.InvariantCulture);
+    }
+
+    private static string GetLogShortName(string owningLog) =>
+        owningLog[(owningLog.LastIndexOf('\\') + 1)..];
+}

--- a/src/EventLogExpert.Runtime/LogTable/LogTableState.cs
+++ b/src/EventLogExpert.Runtime/LogTable/LogTableState.cs
@@ -61,11 +61,46 @@ public sealed record LogTableState
         ImmutableDictionary<EventLogId, SegmentedSortedList> perLog) =>
         new(perLog.Values, perLog.Values.First().Context);
 
-    public bool IsGroupCollapsed(string groupKey) =>
-        GroupsCollapsedByDefault ^ GroupCollapseOverrides.Contains(groupKey);
-
     public IReadOnlyList<ResolvedEvent> EventsForLog(EventLogId logId) =>
         PerLogEvents.TryGetValue(logId, out var list) ? list : [];
+
+    public IReadOnlyList<ResolvedEvent> GetActiveDisplayedEvents()
+    {
+        var activeTable = EventTables.FirstOrDefault(table => table.Id == ActiveEventLogId);
+
+        if (activeTable is null) { return []; }
+
+        return activeTable.IsCombined ? DisplayedEvents : EventsForLog(activeTable.Id);
+    }
+
+    public IReadOnlyList<ColumnName> GetOrderedEnabledColumns(ILogTableColumnDefaultsProvider columnDefaults)
+    {
+        ArgumentNullException.ThrowIfNull(columnDefaults);
+
+        var enabledColumns = Columns
+            .Where(column => column.Value)
+            .Select(column => column.Key)
+            .ToHashSet();
+
+        var order = ColumnOrder.IsEmpty ? columnDefaults.ColumnOrder : ColumnOrder;
+        var ordered = order.Where(enabledColumns.Contains).ToList();
+        var present = ordered.ToHashSet();
+
+        // Append any enabled column missing from the active order (e.g. enabled but absent from a persisted
+        // ColumnOrder) so it is never silently dropped from the table or an export.
+        foreach (var column in columnDefaults.ColumnOrder)
+        {
+            if (enabledColumns.Contains(column) && present.Add(column))
+            {
+                ordered.Add(column);
+            }
+        }
+
+        return ordered;
+    }
+
+    public bool IsGroupCollapsed(string groupKey) =>
+        GroupsCollapsedByDefault ^ GroupCollapseOverrides.Contains(groupKey);
 
     // Each call must carry a single log's events (one OwningLog).
     internal LogTableState WithLogEvents(EventLogId logId, params ResolvedEvent[] events)

--- a/src/EventLogExpert.Runtime/LogTable/LogTableState.cs
+++ b/src/EventLogExpert.Runtime/LogTable/LogTableState.cs
@@ -83,8 +83,19 @@ public sealed record LogTableState
             .ToHashSet();
 
         var order = ColumnOrder.IsEmpty ? columnDefaults.ColumnOrder : ColumnOrder;
-        var ordered = order.Where(enabledColumns.Contains).ToList();
-        var present = ordered.ToHashSet();
+
+        HashSet<ColumnName> present = [];
+        List<ColumnName> ordered = [];
+
+        // De-duplicate while preserving first occurrence: a persisted ColumnOrder may contain duplicates
+        // that would otherwise become duplicate export headers (rejected by TabularExportWriter).
+        foreach (var column in order)
+        {
+            if (enabledColumns.Contains(column) && present.Add(column))
+            {
+                ordered.Add(column);
+            }
+        }
 
         // Append any enabled column missing from the active order (e.g. enabled but absent from a persisted
         // ColumnOrder) so it is never silently dropped from the table or an export.

--- a/src/EventLogExpert.Runtime/Menu/IMenuActionService.cs
+++ b/src/EventLogExpert.Runtime/Menu/IMenuActionService.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Runtime.Common.Clipboard;
+using EventLogExpert.Runtime.Export;
 
 namespace EventLogExpert.Runtime.Menu;
 
@@ -14,6 +15,8 @@ public interface IMenuActionService
     Task CopySelectedAsync(EventCopyFormat? format);
 
     void Exit();
+
+    Task ExportEventsAsync(ExportFormat format);
 
     /// <summary>
     ///     Returns the names of every event log channel known to the host. Cached on first call; subsequent calls return

--- a/src/EventLogExpert.UI/Banner/BannerCycleStateService.cs
+++ b/src/EventLogExpert.UI/Banner/BannerCycleStateService.cs
@@ -13,6 +13,7 @@ public sealed class BannerCycleStateService : IBannerCycleStateService, IDisposa
     private readonly IAttentionBannerService _attention;
     private readonly ICriticalErrorService _critical;
     private readonly IErrorBannerService _errors;
+    private readonly IExportProgressBannerService _exportProgress;
     private readonly IInfoBannerService _infos;
     private readonly IModalCoordinator _modalCoordinator;
     private readonly IProgressBannerService _progress;
@@ -42,6 +43,7 @@ public sealed class BannerCycleStateService : IBannerCycleStateService, IDisposa
         IErrorBannerService errors,
         IInfoBannerService infos,
         IProgressBannerService progress,
+        IExportProgressBannerService exportProgress,
         ICriticalErrorService critical,
         IModalCoordinator modalCoordinator)
     {
@@ -49,6 +51,7 @@ public sealed class BannerCycleStateService : IBannerCycleStateService, IDisposa
         _errors = errors;
         _infos = infos;
         _progress = progress;
+        _exportProgress = exportProgress;
         _critical = critical;
         _modalCoordinator = modalCoordinator;
 
@@ -56,6 +59,7 @@ public sealed class BannerCycleStateService : IBannerCycleStateService, IDisposa
         _errors.StateChanged += OnFacetChanged;
         _infos.StateChanged += OnFacetChanged;
         _progress.StateChanged += OnFacetChanged;
+        _exportProgress.StateChanged += OnFacetChanged;
         _critical.StateChanged += OnFacetChanged;
         _modalCoordinator.StateChanged += OnFacetChanged;
 
@@ -95,6 +99,7 @@ public sealed class BannerCycleStateService : IBannerCycleStateService, IDisposa
         _errors.StateChanged -= OnFacetChanged;
         _infos.StateChanged -= OnFacetChanged;
         _progress.StateChanged -= OnFacetChanged;
+        _exportProgress.StateChanged -= OnFacetChanged;
         _critical.StateChanged -= OnFacetChanged;
         _modalCoordinator.StateChanged -= OnFacetChanged;
     }
@@ -185,6 +190,7 @@ public sealed class BannerCycleStateService : IBannerCycleStateService, IDisposa
         IReadOnlyList<ErrorBannerEntry> errors,
         IReadOnlyList<DatabaseEntry> attentionEntries,
         BannerProgressEntry? backgroundProgress,
+        ExportProgressEntry? exportProgress,
         IReadOnlyList<BannerInfoEntry> infos)
     {
         var result = new HashSet<(BannerView View, BannerId? EntryId)>();
@@ -196,6 +202,8 @@ public sealed class BannerCycleStateService : IBannerCycleStateService, IDisposa
         if (attentionEntries.Count > 0) { result.Add((BannerView.Attention, null)); }
 
         if (backgroundProgress is not null) { result.Add((BannerView.UpgradeProgress, null)); }
+
+        if (exportProgress is not null) { result.Add((BannerView.ExportProgress, null)); }
 
         foreach (var info in infos) { result.Add((BannerView.Info, info.Id)); }
 
@@ -212,10 +220,11 @@ public sealed class BannerCycleStateService : IBannerCycleStateService, IDisposa
     // BannerView enum is ordered for display, not priority — use this rank for comparisons.
     private static int PriorityRank(BannerView view) => view switch
     {
-        BannerView.Critical => 5,
-        BannerView.Error => 4,
-        BannerView.Attention => 3,
-        BannerView.UpgradeProgress => 2,
+        BannerView.Critical => 6,
+        BannerView.Error => 5,
+        BannerView.Attention => 4,
+        BannerView.UpgradeProgress => 3,
+        BannerView.ExportProgress => 2,
         BannerView.Info => 1,
         _ => 0
     };
@@ -254,6 +263,7 @@ public sealed class BannerCycleStateService : IBannerCycleStateService, IDisposa
         var attentionEntries = _attention.AttentionEntries;
         var attentionDismissed = _attention.AttentionDismissed;
         var backgroundProgress = _progress.BackgroundProgress;
+        var exportProgress = _exportProgress.CurrentExport;
         var infos = _infos.InfoBanners;
 
         IReadOnlyList<BannerCycleItem> items = BannerViewSelector.BuildCycle(
@@ -263,6 +273,7 @@ public sealed class BannerCycleStateService : IBannerCycleStateService, IDisposa
             attentionDismissed,
             attentionSuppressed,
             backgroundProgress,
+            exportProgress,
             infos);
 
         // Fingerprint is built from the UNFILTERED source — otherwise modal close would re-introduce
@@ -272,6 +283,7 @@ public sealed class BannerCycleStateService : IBannerCycleStateService, IDisposa
             errors,
             attentionEntries,
             backgroundProgress,
+            exportProgress,
             infos);
 
         BannerCycleItem? priorityOverride = ComputePriorityOverride(

--- a/src/EventLogExpert.UI/Banner/BannerHost.razor
+++ b/src/EventLogExpert.UI/Banner/BannerHost.razor
@@ -10,6 +10,7 @@
     IReadOnlyList<BannerInfoEntry> infos = InfoBannerService.InfoBanners;
     IReadOnlyList<DatabaseEntry> attentionEntries = AttentionBannerService.AttentionEntries;
     BannerProgressEntry? backgroundProgress = ProgressBannerService.BackgroundProgress;
+    ExportProgressEntry? exportProgress = ExportProgressBannerService.CurrentExport;
 
     bool showCyclePagination = items.Count > 1 && view != BannerView.Critical;
 
@@ -53,8 +54,13 @@
 
             break;
 
-        case BannerView.UpgradeProgress when backgroundProgress is { } progress:
-            <UpgradeProgressBanner CycleNav="cycleNav" Progress="progress" />
+        case BannerView.UpgradeProgress when backgroundProgress != null:
+            <UpgradeProgressBanner CycleNav="cycleNav" Progress="backgroundProgress" />
+
+            break;
+
+        case BannerView.ExportProgress when exportProgress != null:
+            <ExportProgressBanner CycleNav="cycleNav" Export="exportProgress" />
 
             break;
 

--- a/src/EventLogExpert.UI/Banner/BannerHost.razor.cs
+++ b/src/EventLogExpert.UI/Banner/BannerHost.razor.cs
@@ -18,6 +18,8 @@ public sealed partial class BannerHost : ComponentBase, IDisposable
 
     [Inject] private IErrorBannerService ErrorBannerService { get; init; } = null!;
 
+    [Inject] private IExportProgressBannerService ExportProgressBannerService { get; init; } = null!;
+
     [Inject] private IInfoBannerService InfoBannerService { get; init; } = null!;
 
     [Inject] private IProgressBannerService ProgressBannerService { get; init; } = null!;

--- a/src/EventLogExpert.UI/Banner/ExportProgressBanner.razor
+++ b/src/EventLogExpert.UI/Banner/ExportProgressBanner.razor
@@ -1,0 +1,13 @@
+<aside class="banner banner-export-progress" role="status">
+    <i aria-hidden="true" class="banner-spinner bi bi-arrow-repeat"></i>
+
+    <span class="banner-message">@Export.Message</span>
+
+    @CycleNav
+
+    <button class="banner-action button"
+        @onclick="() => OnCancelExportClickedAsync(Export)"
+        type="button">
+        Cancel
+    </button>
+</aside>

--- a/src/EventLogExpert.UI/Banner/ExportProgressBanner.razor.cs
+++ b/src/EventLogExpert.UI/Banner/ExportProgressBanner.razor.cs
@@ -1,0 +1,24 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.Banner;
+using Microsoft.AspNetCore.Components;
+
+namespace EventLogExpert.UI.Banner;
+
+public sealed partial class ExportProgressBanner : ComponentBase
+{
+    [Parameter] public RenderFragment? CycleNav { get; set; }
+
+    [Parameter] public ExportProgressEntry Export { get; set; } = null!;
+
+    [Inject] private ITraceLogger TraceLogger { get; init; } = null!;
+
+    private Task OnCancelExportClickedAsync(ExportProgressEntry entry) =>
+        BannerActionGuard.RunSafelyAsync(
+            () => { entry.Cancel(); return Task.CompletedTask; },
+            TraceLogger,
+            nameof(ExportProgressBanner),
+            nameof(OnCancelExportClickedAsync));
+}

--- a/src/EventLogExpert.UI/DatabaseTools/DatabaseToolsLogView.razor.cs
+++ b/src/EventLogExpert.UI/DatabaseTools/DatabaseToolsLogView.razor.cs
@@ -222,7 +222,7 @@ public sealed partial class DatabaseToolsLogView : IAsyncDisposable
 
         try
         {
-            await FileSaveService.SaveAsync(suggestedFileName, FileSaveFileTypes.Log, async stream =>
+            await FileSaveService.SaveStreamingAsync(suggestedFileName, FileSaveFileTypes.Log, async (stream, _) =>
             {
                 await using var writer = new StreamWriter(stream, leaveOpen: true);
 
@@ -232,7 +232,7 @@ public sealed partial class DatabaseToolsLogView : IAsyncDisposable
 
                     await writer.WriteAsync(snapshot[i]);
                 }
-            });
+            }, CancellationToken.None);
         }
         catch (Exception ex)
         {

--- a/src/EventLogExpert.UI/DebugLog/DebugLogModal.razor.cs
+++ b/src/EventLogExpert.UI/DebugLog/DebugLogModal.razor.cs
@@ -168,7 +168,7 @@ public sealed partial class DebugLogModal : ModalBase<bool>
 
         try
         {
-            await FileSaveService.SaveAsync(suggestedFileName, FileSaveFileTypes.Log, async stream =>
+            await FileSaveService.SaveStreamingAsync(suggestedFileName, FileSaveFileTypes.Log, async (stream, _) =>
             {
                 await using var writer = new StreamWriter(stream, leaveOpen: true);
 
@@ -178,7 +178,7 @@ public sealed partial class DebugLogModal : ModalBase<bool>
 
                     await writer.WriteAsync(snapshot[i]);
                 }
-            });
+            }, CancellationToken.None);
         }
         catch (Exception ex)
         {

--- a/src/EventLogExpert.UI/LogTable/LogTablePane.razor
+++ b/src/EventLogExpert.UI/LogTable/LogTablePane.razor
@@ -24,25 +24,11 @@
                     @oncontextmenu:preventDefault="true"
                     @oncontextmenu:stopPropagation="true"
                     role="gridcell">
-                    @switch (capturedColumn)
+                    @if (capturedColumn == ColumnName.Level)
                     {
-                        case ColumnName.RecordId: @evt.RecordId break;
-                        case ColumnName.Level:
-                            <span aria-hidden="true" class="@GetLevelClass(evt.Level)"></span>
-                            @evt.Level
-                            break;
-                        case ColumnName.DateAndTime: @evt.TimeCreated.ConvertTimeZone(_timeZoneSettings) break;
-                        case ColumnName.ActivityId: @evt.ActivityId break;
-                        case ColumnName.Log: @GetLogShortName(evt.OwningLog) break;
-                        case ColumnName.ComputerName: @evt.ComputerName break;
-                        case ColumnName.Source: @evt.Source break;
-                        case ColumnName.EventId: @evt.Id break;
-                        case ColumnName.TaskCategory: @evt.TaskCategory break;
-                        case ColumnName.Keywords: @evt.KeywordsDisplayName break;
-                        case ColumnName.ProcessId: @evt.ProcessId break;
-                        case ColumnName.ThreadId: @evt.ThreadId break;
-                        case ColumnName.User: @evt.UserId break;
+                        <span aria-hidden="true" class="@GetLevelClass(evt.Level)"></span>
                     }
+                    @EventTableColumnFormatter.GetCellText(evt, capturedColumn, _timeZoneSettings)
                 </td>
             }
 

--- a/src/EventLogExpert.UI/LogTable/LogTablePane.razor
+++ b/src/EventLogExpert.UI/LogTable/LogTablePane.razor
@@ -80,7 +80,7 @@
                 </th>
             }
 
-            <th aria-colindex="@(_enabledColumns.Length + 1)" class="description" role="columnheader">Description</th>
+            <th aria-colindex="@(_enabledColumns.Length + 1)" class="description" role="columnheader">@EventTableColumnFormatter.DescriptionColumnHeader</th>
         </tr>
         </thead>
         <tbody @oncontextmenu="InvokeContextMenu" @oncontextmenu:preventDefault="true" @oncontextmenu:stopPropagation="true">

--- a/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
@@ -270,9 +270,6 @@ public sealed partial class LogTablePane
             _ => string.Empty,
         };
 
-    private static string GetLogShortName(string owningLog) =>
-        owningLog[(owningLog.LastIndexOf('\\') + 1)..];
-
     private static ResolvedEvent? ResolveByKey(
         IReadOnlyList<ResolvedEvent> displayedEvents,
         ResolvedEvent? candidate) =>
@@ -459,9 +456,7 @@ public sealed partial class LogTablePane
     }
 
     private string GetDateColumnHeader() =>
-        Settings.TimeZoneInfo.Equals(TimeZoneInfo.Local) ?
-            "Date and Time" :
-            $"Date and Time {Settings.TimeZoneInfo.DisplayName.Split(" ").First()}";
+        EventTableColumnFormatter.GetColumnHeader(ColumnName.DateAndTime, Settings.TimeZoneInfo);
 
     private string GetGroupName() => _logTableState.GroupBy?.ToFullString() ?? string.Empty;
 
@@ -514,22 +509,8 @@ public sealed partial class LogTablePane
         return color;
     }
 
-    private ColumnName[] GetOrderedEnabledColumns()
-    {
-        var enabledSet = _logTableState.Columns
-            .Where(column => column.Value)
-            .Select(column => column.Key)
-            .ToHashSet();
-
-        if (_logTableState.ColumnOrder.IsEmpty)
-        {
-            return ColumnDefaults.ColumnOrder.Where(enabledSet.Contains).ToArray();
-        }
-
-        return _logTableState.ColumnOrder
-            .Where(enabledSet.Contains)
-            .ToArray();
-    }
+    private ColumnName[] GetOrderedEnabledColumns() =>
+        [.. _logTableState.GetOrderedEnabledColumns(ColumnDefaults)];
 
     private int GetRowIndex(ResolvedEvent evt)
     {

--- a/src/EventLogExpert.UI/Menu/MenuBar.razor.cs
+++ b/src/EventLogExpert.UI/Menu/MenuBar.razor.cs
@@ -5,6 +5,7 @@ using EventLogExpert.Eventing.Common.Channels;
 using EventLogExpert.Runtime.Common.Clipboard;
 using EventLogExpert.Runtime.Common.Versioning;
 using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.Export;
 using EventLogExpert.Runtime.FilterPane;
 using EventLogExpert.Runtime.LogTable;
 using EventLogExpert.Runtime.Menu;
@@ -128,6 +129,9 @@ public sealed partial class MenuBar
             MenuItem.SubMenu("Combine", BuildOpenSubMenu(true), hasActiveLogs),
             MenuItem.Separator(),
             MenuItem.Item("Close All", () => Actions.CloseAllLogsAsync(), isEnabled: hasActiveLogs),
+            MenuItem.Separator(),
+            MenuItem.Item("Export to CSV", () => Actions.ExportEventsAsync(ExportFormat.Csv), isEnabled: hasActiveLogs),
+            MenuItem.Item("Export to JSON", () => Actions.ExportEventsAsync(ExportFormat.Json), isEnabled: hasActiveLogs),
             MenuItem.Item("Exit", Actions.Exit),
         ];
     }

--- a/src/EventLogExpert.UI/wwwroot/Banner/banner.css
+++ b/src/EventLogExpert.UI/wwwroot/Banner/banner.css
@@ -44,6 +44,11 @@
     color: var(--text-on-statusbar);
 }
 
+.banner-export-progress {
+    background-color: var(--clr-statusbar);
+    color: var(--text-on-statusbar);
+}
+
 .banner-spinner {
     flex: 0 0 auto;
     animation: banner-spin 1.5s linear infinite;

--- a/src/EventLogExpert/Adapters/Clipboard/MauiClipboardService.cs
+++ b/src/EventLogExpert/Adapters/Clipboard/MauiClipboardService.cs
@@ -243,23 +243,7 @@ public sealed class MauiClipboardService : IClipboardService
     }
 
     private string GetColumnText(ColumnName column, ResolvedEvent @event) =>
-        column switch
-        {
-            ColumnName.Level => @event.Level,
-            ColumnName.DateAndTime => @event.TimeCreated.ConvertTimeZone(_settings.TimeZoneInfo).ToString(),
-            ColumnName.ActivityId => @event.ActivityId?.ToString() ?? string.Empty,
-            ColumnName.Log => GetLogShortName(@event.OwningLog),
-            ColumnName.ComputerName => @event.ComputerName,
-            ColumnName.Source => @event.Source,
-            ColumnName.EventId => @event.Id.ToString(),
-            ColumnName.TaskCategory => @event.TaskCategory,
-            ColumnName.Keywords => @event.KeywordsDisplayName,
-            ColumnName.ProcessId => @event.ProcessId?.ToString() ?? string.Empty,
-            ColumnName.ThreadId => @event.ThreadId?.ToString() ?? string.Empty,
-            ColumnName.User => @event.UserId?.ToString() ?? string.Empty,
-            ColumnName.RecordId => @event.RecordId?.ToString() ?? string.Empty,
-            _ => string.Empty
-        };
+        EventTableColumnFormatter.GetCellText(@event, column, _settings.TimeZoneInfo);
 
     private async Task<string> GetFormattedEvent(EventCopyFormat? format)
     {

--- a/src/EventLogExpert/Adapters/FileSave/MauiFileSaveService.cs
+++ b/src/EventLogExpert/Adapters/FileSave/MauiFileSaveService.cs
@@ -3,6 +3,7 @@
 
 using EventLogExpert.Platforms.Windows;
 using EventLogExpert.Runtime.Common.Files;
+using System.Runtime.InteropServices;
 using Windows.Storage;
 using Windows.Storage.Pickers;
 using Windows.Storage.Provider;
@@ -20,41 +21,15 @@ public sealed class MauiFileSaveService : IFileSaveService
         ArgumentNullException.ThrowIfNull(fileTypes);
         ArgumentNullException.ThrowIfNull(writeContent);
 
-        if (fileTypes.Count == 0)
-        {
-            throw new ArgumentException(
-                "At least one file-type choice must be supplied.", nameof(fileTypes));
-        }
+        var pickedFile = await PickSaveFileAsync(suggestedFileName, fileTypes);
 
-        var pickedFile = await MainThread.InvokeOnMainThreadAsync(async () =>
-        {
-            var picker = new FileSavePicker
-            {
-                SuggestedStartLocation = PickerLocationId.ComputerFolder,
-                SuggestedFileName = suggestedFileName
-            };
-
-            foreach ((string label, IReadOnlyList<string> extensions) in fileTypes)
-            {
-                picker.FileTypeChoices.Add(label, [.. extensions]);
-            }
-
-            PickerHostWindow.Initialize(picker);
-
-            return await picker.PickSaveFileAsync();
-        });
-
-        if (pickedFile is null)
-        {
-            return null;
-        }
+        if (pickedFile is null) { return null; }
 
         // Buffer first; picked file stays untouched if writeContent throws.
         using var buffer = new MemoryStream();
         await writeContent(buffer);
         buffer.Position = 0;
 
-        // Required for provider-backed destinations (e.g., OneDrive).
         CachedFileManager.DeferUpdates(pickedFile);
 
         FileUpdateStatus status;
@@ -71,7 +46,190 @@ public sealed class MauiFileSaveService : IFileSaveService
             status = await CachedFileManager.CompleteUpdatesAsync(pickedFile);
         }
 
-        return status is not (FileUpdateStatus.Complete or FileUpdateStatus.CompleteAndRenamed) ?
-            throw new IOException($"Save failed with status '{status}'.") : pickedFile.Path;
+        return ToResultPath(pickedFile, status);
+    }
+
+    public async Task<string?> SaveStreamingAsync(
+        string suggestedFileName,
+        IReadOnlyDictionary<string, IReadOnlyList<string>> fileTypes,
+        Func<Stream, CancellationToken, Task> writeContent,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(suggestedFileName);
+        ArgumentNullException.ThrowIfNull(fileTypes);
+        ArgumentNullException.ThrowIfNull(writeContent);
+
+        var pickedFile = await PickSaveFileAsync(suggestedFileName, fileTypes);
+
+        if (pickedFile is null) { return null; }
+
+        var parentFolder = await TryGetParentAsync(pickedFile);
+        var tempInParent = parentFolder is null
+            ? null
+            : await TryCreateTempFileAsync(parentFolder, pickedFile.Name);
+
+        // Primary path requires write access to the picked file's folder; otherwise fall back to a local temp + copy.
+        return tempInParent is not null
+            ? await SaveByReplacingAsync(pickedFile, tempInParent, writeContent, cancellationToken)
+            : await SaveByLocalTempCopyAsync(pickedFile, writeContent, cancellationToken);
+    }
+
+    private static async Task<StorageFile?> PickSaveFileAsync(
+        string suggestedFileName, IReadOnlyDictionary<string, IReadOnlyList<string>> fileTypes)
+    {
+        if (fileTypes.Count == 0)
+        {
+            throw new ArgumentException("At least one file-type choice must be supplied.", nameof(fileTypes));
+        }
+
+        return await MainThread.InvokeOnMainThreadAsync(async () =>
+        {
+            var picker = new FileSavePicker
+            {
+                SuggestedStartLocation = PickerLocationId.ComputerFolder,
+                SuggestedFileName = suggestedFileName
+            };
+
+            foreach ((string label, IReadOnlyList<string> extensions) in fileTypes)
+            {
+                picker.FileTypeChoices.Add(label, [.. extensions]);
+            }
+
+            PickerHostWindow.Initialize(picker);
+
+            return await picker.PickSaveFileAsync();
+        });
+    }
+
+    private static async Task<string?> SaveByLocalTempCopyAsync(
+        StorageFile pickedFile, Func<Stream, CancellationToken, Task> writeContent, CancellationToken cancellationToken)
+    {
+        string localTempPath = Path.Combine(Path.GetTempPath(), $"eventlogexpert-export-{Guid.NewGuid():N}.tmp");
+        bool deferred = false;
+        bool completed = false;
+        FileUpdateStatus status = FileUpdateStatus.Failed;
+
+        try
+        {
+            await using (var tempStream = File.Create(localTempPath))
+            {
+                await writeContent(tempStream, cancellationToken);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var localTempFile = await StorageFile.GetFileFromPathAsync(localTempPath);
+
+            CachedFileManager.DeferUpdates(pickedFile);
+            deferred = true;
+
+            // Final cancellation gate before the uncancellable commit: if cancelled here, the finally resolves the
+            // deferred-update contract and the picked file is left untouched (CopyAndReplaceAsync never runs).
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Replace the picked file from the fully-staged temp in a single platform-mediated operation rather than
+            // truncating then re-filling it ourselves, which would guarantee a zero-length window on any copy fault.
+            // This is best-effort rather than atomic on provider-backed destinations (see IFileSaveService docs).
+            await localTempFile.CopyAndReplaceAsync(pickedFile);
+
+            status = await CachedFileManager.CompleteUpdatesAsync(pickedFile);
+            completed = true;
+        }
+        finally
+        {
+            if (deferred && !completed)
+            {
+                try { await CachedFileManager.CompleteUpdatesAsync(pickedFile); }
+                catch (Exception) { /* best-effort: resolve the provider update contract on failure. */ }
+            }
+
+            try { File.Delete(localTempPath); }
+            catch (Exception) { /* best-effort: the local temp is a copy source, never the saved output. */ }
+        }
+
+        return ToResultPath(pickedFile, status);
+    }
+
+    private static async Task<string?> SaveByReplacingAsync(
+        StorageFile pickedFile,
+        StorageFile tempFile,
+        Func<Stream, CancellationToken, Task> writeContent,
+        CancellationToken cancellationToken)
+    {
+        bool deferred = false;
+        bool completed = false;
+        bool replaced = false;
+        FileUpdateStatus status = FileUpdateStatus.Failed;
+
+        try
+        {
+            CachedFileManager.DeferUpdates(pickedFile);
+            deferred = true;
+
+            await using (var tempStream = await tempFile.OpenStreamForWriteAsync())
+            {
+                tempStream.SetLength(0);
+                await writeContent(tempStream, cancellationToken);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Atomic commit: the picked file is replaced only after the write succeeds.
+            await tempFile.MoveAndReplaceAsync(pickedFile);
+            replaced = true;
+
+            status = await CachedFileManager.CompleteUpdatesAsync(pickedFile);
+            completed = true;
+        }
+        finally
+        {
+            if (deferred && !completed)
+            {
+                try { await CachedFileManager.CompleteUpdatesAsync(pickedFile); }
+                catch (Exception) { /* best-effort: resolve the provider update contract on failure. */ }
+            }
+
+            if (!replaced)
+            {
+                // After a successful replace the temp IS the saved output and must not be deleted.
+                try { await tempFile.DeleteAsync(); }
+                catch (Exception) { /* best-effort cleanup. */ }
+            }
+        }
+
+        return ToResultPath(pickedFile, status);
+    }
+
+    private static string ToResultPath(StorageFile pickedFile, FileUpdateStatus status) =>
+        status is FileUpdateStatus.Complete or FileUpdateStatus.CompleteAndRenamed
+            ? pickedFile.Path
+            : throw new IOException($"Save failed with status '{status}'.");
+
+    private static async Task<StorageFile?> TryCreateTempFileAsync(StorageFolder folder, string pickedName)
+    {
+        try
+        {
+            // The save picker may grant access only to the picked file, not its folder; fall back when creation is denied.
+            return await folder.CreateFileAsync($"{pickedName}.tmp", CreationCollisionOption.GenerateUniqueName);
+        }
+        catch (Exception exception) when (exception is UnauthorizedAccessException or COMException)
+        {
+            // The parent folder already resolved, so a creation failure here is an access/permission issue; fall back
+            // to the local-temp copy. Other (unexpected) exceptions propagate so a genuine fault is not masked by
+            // silently choosing the non-atomic path.
+            return null;
+        }
+    }
+
+    private static async Task<StorageFolder?> TryGetParentAsync(StorageFile file)
+    {
+        try
+        {
+            return await file.GetParentAsync();
+        }
+        catch (Exception)
+        {
+            return null;
+        }
     }
 }

--- a/src/EventLogExpert/Adapters/FileSave/MauiFileSaveService.cs
+++ b/src/EventLogExpert/Adapters/FileSave/MauiFileSaveService.cs
@@ -12,43 +12,6 @@ namespace EventLogExpert.Adapters.FileSave;
 
 public sealed class MauiFileSaveService : IFileSaveService
 {
-    public async Task<string?> SaveAsync(
-        string suggestedFileName,
-        IReadOnlyDictionary<string, IReadOnlyList<string>> fileTypes,
-        Func<Stream, Task> writeContent)
-    {
-        ArgumentNullException.ThrowIfNull(suggestedFileName);
-        ArgumentNullException.ThrowIfNull(fileTypes);
-        ArgumentNullException.ThrowIfNull(writeContent);
-
-        var pickedFile = await PickSaveFileAsync(suggestedFileName, fileTypes);
-
-        if (pickedFile is null) { return null; }
-
-        // Buffer first; picked file stays untouched if writeContent throws.
-        using var buffer = new MemoryStream();
-        await writeContent(buffer);
-        buffer.Position = 0;
-
-        CachedFileManager.DeferUpdates(pickedFile);
-
-        FileUpdateStatus status;
-
-        try
-        {
-            await using var fileStream = await pickedFile.OpenStreamForWriteAsync();
-            // OpenStreamForWriteAsync does not truncate; without this, larger files leave stale trailing bytes.
-            fileStream.SetLength(0);
-            await buffer.CopyToAsync(fileStream);
-        }
-        finally
-        {
-            status = await CachedFileManager.CompleteUpdatesAsync(pickedFile);
-        }
-
-        return ToResultPath(pickedFile, status);
-    }
-
     public async Task<string?> SaveStreamingAsync(
         string suggestedFileName,
         IReadOnlyDictionary<string, IReadOnlyList<string>> fileTypes,

--- a/src/EventLogExpert/Adapters/FileSave/MauiFileSaveService.cs
+++ b/src/EventLogExpert/Adapters/FileSave/MauiFileSaveService.cs
@@ -22,6 +22,8 @@ public sealed class MauiFileSaveService : IFileSaveService
         ArgumentNullException.ThrowIfNull(fileTypes);
         ArgumentNullException.ThrowIfNull(writeContent);
 
+        cancellationToken.ThrowIfCancellationRequested();
+
         var pickedFile = await PickSaveFileAsync(suggestedFileName, fileTypes);
 
         if (pickedFile is null) { return null; }

--- a/src/EventLogExpert/Adapters/Menu/MauiMenuActionService.cs
+++ b/src/EventLogExpert/Adapters/Menu/MauiMenuActionService.cs
@@ -190,16 +190,20 @@ public sealed class MauiMenuActionService(
             savedPath = await _fileSaveService.SaveStreamingAsync(
                 suggestedFileName,
                 fileTypes,
-                (stream, token) =>
+                async (stream, token) =>
                 {
                     // Begin only once the picker has returned a destination and the streaming write is
                     // starting; dismissing the picker never reaches here, so it stays silent. The finished
-                    // flag turns a late Cancel click (after End) into a clean no-op.
+                    // flag turns a late Cancel click into a clean no-op.
                     _exportProgress.Begin(
                         "Exporting events…", () => { if (!Volatile.Read(ref finished)) { cancellation.Cancel(); } });
 
-                    return _eventTableExporter.ExportAsync(
+                    await _eventTableExporter.ExportAsync(
                         stream, format, events, columns, timeZone, includeDescription: true, token);
+
+                    // The streaming write is done; stop honoring Cancel before SaveStreamingAsync runs its
+                    // post-write cancel gates, so a late Cancel can't abort an already-written export's commit.
+                    Volatile.Write(ref finished, true);
                 },
                 cancellation.Token);
         }

--- a/src/EventLogExpert/Adapters/Menu/MauiMenuActionService.cs
+++ b/src/EventLogExpert/Adapters/Menu/MauiMenuActionService.cs
@@ -5,6 +5,7 @@ using EventLogExpert.Eventing.Common.Channels;
 using EventLogExpert.Eventing.Readers;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Runtime.Alerts;
+using EventLogExpert.Runtime.Banner;
 using EventLogExpert.Runtime.Common.Clipboard;
 using EventLogExpert.Runtime.Common.Files;
 using EventLogExpert.Runtime.Common.Versioning;
@@ -55,6 +56,7 @@ public sealed class MauiMenuActionService(
     IState<LogTableState> logTableState,
     ILogTableColumnDefaultsProvider columnDefaults,
     IEventTableExporter eventTableExporter,
+    IExportProgressBannerService exportProgressBannerService,
     IFileSaveService fileSaveService) : IMenuActionService, IDisposable
 {
     private readonly IClipboardService _clipboardService = clipboardService;
@@ -65,6 +67,7 @@ public sealed class MauiMenuActionService(
     private readonly IEventLogCommands _eventLogCommands = eventLogCommands;
     private readonly IState<EventLogState> _eventLogState = eventLogState;
     private readonly IEventTableExporter _eventTableExporter = eventTableExporter;
+    private readonly IExportProgressBannerService _exportProgress = exportProgressBannerService;
     private readonly IFileSaveService _fileSaveService = fileSaveService;
     private readonly IFilterLibraryCommands _filterLibraryCommands = filterLibraryCommands;
     private readonly IFilterPaneCommands _filterPaneCommands = filterPaneCommands;
@@ -80,6 +83,7 @@ public sealed class MauiMenuActionService(
     private IReadOnlyList<string>? _cachedLogNames;
     private CancellationTokenSource _cancellationTokenSource = new();
     private bool _disposed;
+    private int _exportInFlight;
 
     public async Task CheckForUpdatesAsync()
     {
@@ -165,24 +169,74 @@ public sealed class MauiMenuActionService(
         string suggestedFileName =
             $"events-{DateTime.Now.ToString("yyyyMMdd-HHmmss", CultureInfo.InvariantCulture)}{extension}";
 
-        string? savedPath;
+        // Only one export may run at a time: the progress banner holds a single entry and the cancel
+        // affordance owns a single CTS, so a concurrent export would orphan the first cancellation.
+        if (Interlocked.CompareExchange(ref _exportInFlight, 1, 0) != 0)
+        {
+            await _dialogService.ShowAlert(
+                "Export events", "An export is already in progress.", "Ok", AlertPresentation.Banner);
+
+            return;
+        }
+
+        CancellationTokenSource cancellation = new();
+        bool finished = false;
+        string? savedPath = null;
+        Exception? failure = null;
+        bool canceled = false;
 
         try
         {
+            // The Cancel button captures this delegate; the finished flag turns a late click (after End
+            // tears the banner down) into a clean no-op instead of relying on a swallowed ObjectDisposedException.
+            _exportProgress.Begin(
+                "Exporting events…", () => { if (!Volatile.Read(ref finished)) { cancellation.Cancel(); } });
+
             savedPath = await _fileSaveService.SaveStreamingAsync(
                 suggestedFileName,
                 fileTypes,
                 (stream, token) => _eventTableExporter.ExportAsync(
                     stream, format, events, columns, timeZone, includeDescription: true, token),
-                // No user-facing cancel affordance exists for export yet; the pipeline threads a token end to end,
-                // so a cancel control can be wired here later without a signature change.
-                CancellationToken.None);
+                cancellation.Token);
+        }
+        catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+        {
+            canceled = true;
         }
         catch (Exception ex)
         {
-            _traceLogger.Error($"Failed to export events: {ex}");
+            failure = ex;
+        }
+        finally
+        {
+            Volatile.Write(ref finished, true);
 
-            await _dialogService.ShowAlert("Export failed", ex.Message, "Ok", AlertPresentation.Banner);
+            // End() raises StateChanged; isolate it so a throwing subscriber can never skip the CTS
+            // disposal or the in-flight reset, which would otherwise wedge every later export.
+            try
+            {
+                _exportProgress.End();
+            }
+            finally
+            {
+                cancellation.Dispose();
+                Interlocked.Exchange(ref _exportInFlight, 0);
+            }
+        }
+
+        if (canceled)
+        {
+            await _dialogService.ShowAlert(
+                "Export canceled", "The export was canceled.", "Ok", AlertPresentation.Banner);
+
+            return;
+        }
+
+        if (failure is not null)
+        {
+            _traceLogger.Error($"Failed to export events: {failure}");
+
+            await _dialogService.ShowAlert("Export failed", failure.Message, "Ok", AlertPresentation.Banner);
 
             return;
         }

--- a/src/EventLogExpert/Adapters/Menu/MauiMenuActionService.cs
+++ b/src/EventLogExpert/Adapters/Menu/MauiMenuActionService.cs
@@ -187,16 +187,20 @@ public sealed class MauiMenuActionService(
 
         try
         {
-            // The Cancel button captures this delegate; the finished flag turns a late click (after End
-            // tears the banner down) into a clean no-op instead of relying on a swallowed ObjectDisposedException.
-            _exportProgress.Begin(
-                "Exporting events…", () => { if (!Volatile.Read(ref finished)) { cancellation.Cancel(); } });
-
             savedPath = await _fileSaveService.SaveStreamingAsync(
                 suggestedFileName,
                 fileTypes,
-                (stream, token) => _eventTableExporter.ExportAsync(
-                    stream, format, events, columns, timeZone, includeDescription: true, token),
+                (stream, token) =>
+                {
+                    // Begin only once the picker has returned a destination and the streaming write is
+                    // starting; dismissing the picker never reaches here, so it stays silent. The finished
+                    // flag turns a late Cancel click (after End) into a clean no-op.
+                    _exportProgress.Begin(
+                        "Exporting events…", () => { if (!Volatile.Read(ref finished)) { cancellation.Cancel(); } });
+
+                    return _eventTableExporter.ExportAsync(
+                        stream, format, events, columns, timeZone, includeDescription: true, token);
+                },
                 cancellation.Token);
         }
         catch (OperationCanceledException) when (cancellation.IsCancellationRequested)

--- a/src/EventLogExpert/Adapters/Menu/MauiMenuActionService.cs
+++ b/src/EventLogExpert/Adapters/Menu/MauiMenuActionService.cs
@@ -165,12 +165,15 @@ public sealed class MauiMenuActionService(
         string suggestedFileName =
             $"events-{DateTime.Now.ToString("yyyyMMdd-HHmmss", CultureInfo.InvariantCulture)}{extension}";
 
+        string? savedPath;
+
         try
         {
-            await _fileSaveService.SaveStreamingAsync(
+            savedPath = await _fileSaveService.SaveStreamingAsync(
                 suggestedFileName,
                 fileTypes,
-                (stream, token) => _eventTableExporter.ExportAsync(stream, format, events, columns, timeZone, token),
+                (stream, token) => _eventTableExporter.ExportAsync(
+                    stream, format, events, columns, timeZone, includeDescription: true, token),
                 // No user-facing cancel affordance exists for export yet; the pipeline threads a token end to end,
                 // so a cancel control can be wired here later without a signature change.
                 CancellationToken.None);
@@ -180,6 +183,18 @@ public sealed class MauiMenuActionService(
             _traceLogger.Error($"Failed to export events: {ex}");
 
             await _dialogService.ShowAlert("Export failed", ex.Message, "Ok", AlertPresentation.Banner);
+
+            return;
+        }
+
+        // A null path means the user dismissed the save picker; only confirm an actual write.
+        if (savedPath is not null)
+        {
+            await _dialogService.ShowAlert(
+                "Export complete",
+                $"Exported {events.Count:N0} {(events.Count == 1 ? "event" : "events")} to {savedPath}.",
+                "Ok",
+                AlertPresentation.Banner);
         }
     }
 

--- a/src/EventLogExpert/Adapters/Menu/MauiMenuActionService.cs
+++ b/src/EventLogExpert/Adapters/Menu/MauiMenuActionService.cs
@@ -9,6 +9,7 @@ using EventLogExpert.Runtime.Common.Clipboard;
 using EventLogExpert.Runtime.Common.Files;
 using EventLogExpert.Runtime.Common.Versioning;
 using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.Export;
 using EventLogExpert.Runtime.FilterLibrary;
 using EventLogExpert.Runtime.FilterPane;
 using EventLogExpert.Runtime.LogTable;
@@ -23,6 +24,7 @@ using EventLogExpert.UI.Settings;
 using EventLogExpert.WindowsPlatform.Activation;
 using Fluxor;
 using System.Collections.Immutable;
+using System.Globalization;
 using Application = Microsoft.Maui.Controls.Application;
 using IDispatcher = Fluxor.IDispatcher;
 using MauiFilePicker = Microsoft.Maui.Storage.FilePicker;
@@ -49,19 +51,27 @@ public sealed class MauiMenuActionService(
     ICurrentVersionProvider currentVersionProvider,
     ITraceLogger traceLogger,
     IFolderPickerService folderPickerService,
-    IState<EventLogState> eventLogState) : IMenuActionService, IDisposable
+    IState<EventLogState> eventLogState,
+    IState<LogTableState> logTableState,
+    ILogTableColumnDefaultsProvider columnDefaults,
+    IEventTableExporter eventTableExporter,
+    IFileSaveService fileSaveService) : IMenuActionService, IDisposable
 {
     private readonly IClipboardService _clipboardService = clipboardService;
+    private readonly ILogTableColumnDefaultsProvider _columnDefaults = columnDefaults;
     private readonly ICurrentVersionProvider _currentVersionProvider = currentVersionProvider;
     private readonly IAlertDialogService _dialogService = dialogService;
     private readonly IDispatcher _dispatcher = dispatcher;
     private readonly IEventLogCommands _eventLogCommands = eventLogCommands;
     private readonly IState<EventLogState> _eventLogState = eventLogState;
+    private readonly IEventTableExporter _eventTableExporter = eventTableExporter;
+    private readonly IFileSaveService _fileSaveService = fileSaveService;
     private readonly IFilterLibraryCommands _filterLibraryCommands = filterLibraryCommands;
     private readonly IFilterPaneCommands _filterPaneCommands = filterPaneCommands;
     private readonly IFolderPickerService _folderPickerService = folderPickerService;
     private readonly SemaphoreSlim _logNamesLock = new(1, 1);
     private readonly ILogTableCommands _logTableCommands = logTableCommands;
+    private readonly IState<LogTableState> _logTableState = logTableState;
     private readonly IModalCoordinator _modalCoordinator = modalCoordinator;
     private readonly ISettingsService _settings = settings;
     private readonly ITraceLogger _traceLogger = traceLogger;
@@ -120,6 +130,56 @@ public sealed class MauiMenuActionService(
         if (current is not null && window is not null)
         {
             current.CloseWindow(window);
+        }
+    }
+
+    public async Task ExportEventsAsync(ExportFormat format)
+    {
+        var state = _logTableState.Value;
+        var events = state.GetActiveDisplayedEvents();
+
+        if (events.Count == 0)
+        {
+            await _dialogService.ShowAlert(
+                "Export events", "There are no events to export.", "Ok", AlertPresentation.Banner);
+
+            return;
+        }
+
+        // Snapshot everything the export needs before opening the picker, so a state change while the dialog is open
+        // cannot mutate the rows/columns/timezone being written.
+        var columns = state.GetOrderedEnabledColumns(_columnDefaults);
+
+        if (columns.Count == 0)
+        {
+            await _dialogService.ShowAlert(
+                "Export events", "There are no visible columns to export.", "Ok", AlertPresentation.Banner);
+
+            return;
+        }
+
+        var timeZone = _settings.TimeZoneInfo;
+        bool isCsv = format == ExportFormat.Csv;
+        var fileTypes = isCsv ? FileSaveFileTypes.Csv : FileSaveFileTypes.Json;
+        string extension = isCsv ? ".csv" : ".json";
+        string suggestedFileName =
+            $"events-{DateTime.Now.ToString("yyyyMMdd-HHmmss", CultureInfo.InvariantCulture)}{extension}";
+
+        try
+        {
+            await _fileSaveService.SaveStreamingAsync(
+                suggestedFileName,
+                fileTypes,
+                (stream, token) => _eventTableExporter.ExportAsync(stream, format, events, columns, timeZone, token),
+                // No user-facing cancel affordance exists for export yet; the pipeline threads a token end to end,
+                // so a cancel control can be wired here later without a signature change.
+                CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            _traceLogger.Error($"Failed to export events: {ex}");
+
+            await _dialogService.ShowAlert("Export failed", ex.Message, "Ok", AlertPresentation.Banner);
         }
     }
 

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Banner/BannerViewSelectorTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Banner/BannerViewSelectorTests.cs
@@ -22,6 +22,7 @@ public sealed class BannerViewSelectorTests
                 attentionDismissed: false,
                 attentionSuppressedByModalContext: false,
                 backgroundProgress: null,
+                exportProgress: null,
                 infoBanners: []);
 
         // Assert
@@ -46,6 +47,7 @@ public sealed class BannerViewSelectorTests
                 attentionDismissed: false,
                 attentionSuppressedByModalContext: false,
                 backgroundProgress: BuildProgress(),
+                exportProgress: null,
                 infoBanners: [i0, i1, i2]);
 
         // Assert
@@ -70,6 +72,7 @@ public sealed class BannerViewSelectorTests
                 attentionDismissed: true,
                 attentionSuppressedByModalContext: false,
                 backgroundProgress: null,
+                exportProgress: null,
                 infoBanners: []);
 
         // Assert
@@ -93,6 +96,7 @@ public sealed class BannerViewSelectorTests
                 attentionDismissed: dismissed,
                 attentionSuppressedByModalContext: suppressedByModalContext,
                 backgroundProgress: null,
+                exportProgress: null,
                 infoBanners: []);
 
         if (expectAttention)
@@ -117,6 +121,7 @@ public sealed class BannerViewSelectorTests
                 attentionDismissed: false,
                 attentionSuppressedByModalContext: false,
                 backgroundProgress: null,
+                exportProgress: null,
                 infoBanners: []);
 
         // Assert
@@ -134,6 +139,7 @@ public sealed class BannerViewSelectorTests
                 attentionDismissed: false,
                 attentionSuppressedByModalContext: false,
                 backgroundProgress: null,
+                exportProgress: null,
                 infoBanners: []));
     }
 
@@ -150,6 +156,7 @@ public sealed class BannerViewSelectorTests
                 attentionDismissed: false,
                 attentionSuppressedByModalContext: true,
                 backgroundProgress: BuildProgress(),
+                exportProgress: null,
                 infoBanners: [info]);
 
         Assert.Equal(3, result.Count);
@@ -168,6 +175,7 @@ public sealed class BannerViewSelectorTests
                 attentionDismissed: false,
                 attentionSuppressedByModalContext: true,
                 backgroundProgress: null,
+                exportProgress: null,
                 infoBanners: []);
 
         Assert.Empty(result);
@@ -184,6 +192,7 @@ public sealed class BannerViewSelectorTests
                 attentionDismissed: false,
                 attentionSuppressedByModalContext: false,
                 backgroundProgress: BuildProgress(),
+                exportProgress: null,
                 infoBanners: [BuildInfo()]);
 
         // Assert
@@ -204,6 +213,7 @@ public sealed class BannerViewSelectorTests
                 attentionDismissed: false,
                 attentionSuppressedByModalContext: false,
                 backgroundProgress: null,
+                exportProgress: null,
                 infoBanners: []));
     }
 
@@ -218,6 +228,7 @@ public sealed class BannerViewSelectorTests
                 attentionDismissed: false,
                 attentionSuppressedByModalContext: false,
                 backgroundProgress: null,
+                exportProgress: null,
                 infoBanners: null!));
     }
 
@@ -232,6 +243,7 @@ public sealed class BannerViewSelectorTests
                 attentionDismissed: false,
                 attentionSuppressedByModalContext: false,
                 backgroundProgress: null,
+                exportProgress: null,
                 infoBanners: []);
 
         // Assert
@@ -255,6 +267,7 @@ public sealed class BannerViewSelectorTests
                 attentionDismissed: false,
                 attentionSuppressedByModalContext: false,
                 backgroundProgress: null,
+                exportProgress: null,
                 infoBanners: []);
 
         // Assert
@@ -262,6 +275,25 @@ public sealed class BannerViewSelectorTests
         Assert.Equal(new BannerCycleItem(BannerView.Error, 0, e0.Id), result[0]);
         Assert.Equal(new BannerCycleItem(BannerView.Error, 1, e1.Id), result[1]);
         Assert.Equal(new BannerCycleItem(BannerView.Error, 2, e2.Id), result[2]);
+    }
+
+    [Fact]
+    public void BuildCycle_OnlyExportProgress_ReturnsSingleExportProgressItem()
+    {
+        // Act
+        IReadOnlyList<BannerCycleItem> result = BannerViewSelector
+            .BuildCycle(currentCritical: null,
+                errorBanners: [],
+                attentionEntries: [],
+                attentionDismissed: false,
+                attentionSuppressedByModalContext: false,
+                backgroundProgress: null,
+                exportProgress: BuildExportProgress(),
+                infoBanners: []);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal(new BannerCycleItem(BannerView.ExportProgress, 0, null), result[0]);
     }
 
     [Fact]
@@ -279,6 +311,7 @@ public sealed class BannerViewSelectorTests
                 attentionDismissed: false,
                 attentionSuppressedByModalContext: false,
                 backgroundProgress: null,
+                exportProgress: null,
                 infoBanners: [i0, i1]);
 
         // Assert
@@ -298,6 +331,7 @@ public sealed class BannerViewSelectorTests
                 attentionDismissed: false,
                 attentionSuppressedByModalContext: false,
                 backgroundProgress: BuildProgress(),
+                exportProgress: null,
                 infoBanners: []);
 
         // Assert
@@ -321,6 +355,7 @@ public sealed class BannerViewSelectorTests
                 attentionDismissed: false,
                 attentionSuppressedByModalContext: false,
                 backgroundProgress: null,
+                exportProgress: null,
                 infoBanners: []);
 
         IReadOnlyList<BannerCycleItem> after = BannerViewSelector
@@ -330,6 +365,7 @@ public sealed class BannerViewSelectorTests
                 attentionDismissed: false,
                 attentionSuppressedByModalContext: false,
                 backgroundProgress: null,
+                exportProgress: null,
                 infoBanners: []);
 
         // Assert
@@ -339,11 +375,38 @@ public sealed class BannerViewSelectorTests
         Assert.Equal(new BannerCycleItem(BannerView.Error, 1, e2.Id), after[1]);
     }
 
+    [Fact]
+    public void BuildCycle_UpgradeAndExportProgress_OrdersUpgradeBeforeExportBeforeInfos()
+    {
+        // Arrange
+        BannerInfoEntry info = BuildInfo();
+
+        // Act
+        IReadOnlyList<BannerCycleItem> result = BannerViewSelector
+            .BuildCycle(currentCritical: null,
+                errorBanners: [],
+                attentionEntries: [],
+                attentionDismissed: false,
+                attentionSuppressedByModalContext: false,
+                backgroundProgress: BuildProgress(),
+                exportProgress: BuildExportProgress(),
+                infoBanners: [info]);
+
+        // Assert
+        Assert.Equal(3, result.Count);
+        Assert.Equal(new BannerCycleItem(BannerView.UpgradeProgress, 0, null), result[0]);
+        Assert.Equal(new BannerCycleItem(BannerView.ExportProgress, 0, null), result[1]);
+        Assert.Equal(new BannerCycleItem(BannerView.Info, 0, info.Id), result[2]);
+    }
+
     private static DatabaseEntry BuildAttention(string fileName) =>
         new(fileName, $@"C:\dbs\{fileName}", IsEnabled: false, DatabaseStatus.UpgradeRequired);
 
     private static ErrorBannerEntry BuildError() =>
         new(BannerId.Create(), "Error Title", "Error Message", null, null, s_testTime);
+
+    private static ExportProgressEntry BuildExportProgress() =>
+        new("Exporting events…", () => { });
 
     private static BannerInfoEntry BuildInfo() =>
         new(BannerId.Create(), "Info Title", "Info Message", BannerSeverity.Info, s_testTime);

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Banner/ExportProgressBannerServiceTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Banner/ExportProgressBannerServiceTests.cs
@@ -1,0 +1,123 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.Banner;
+
+namespace EventLogExpert.Runtime.Tests.Banner;
+
+public sealed class ExportProgressBannerServiceTests
+{
+    [Fact]
+    public void Begin_EmptyMessage_Throws()
+    {
+        ExportProgressBannerService sut = new();
+
+        Assert.Throws<ArgumentException>(() => sut.Begin(string.Empty, () => { }));
+    }
+
+    [Fact]
+    public void Begin_NullCancel_Throws()
+    {
+        ExportProgressBannerService sut = new();
+
+        Assert.Throws<ArgumentNullException>(() => sut.Begin("Exporting events…", null!));
+    }
+
+    [Fact]
+    public void Begin_NullMessage_Throws()
+    {
+        ExportProgressBannerService sut = new();
+
+        Assert.Throws<ArgumentNullException>(() => sut.Begin(null!, () => { }));
+    }
+
+    [Fact]
+    public void Begin_RaisesStateChangedOnce()
+    {
+        ExportProgressBannerService sut = new();
+        int fires = 0;
+        sut.StateChanged += () => fires++;
+
+        sut.Begin("Exporting events…", () => { });
+
+        Assert.Equal(1, fires);
+    }
+
+    [Fact]
+    public void Begin_SetsCurrentExport()
+    {
+        ExportProgressBannerService sut = new();
+
+        sut.Begin("Exporting events…", () => { });
+
+        ExportProgressEntry? current = sut.CurrentExport;
+        Assert.NotNull(current);
+        Assert.Equal("Exporting events…", current.Message);
+    }
+
+    [Fact]
+    public void Begin_StateChangedHandler_ObservesCurrentExportAlreadySet()
+    {
+        // The entry is committed under the lock before StateChanged is raised, so a subscriber that
+        // reads CurrentExport during the callback sees the new value (and does not deadlock).
+        ExportProgressBannerService sut = new();
+        ExportProgressEntry? observed = null;
+        sut.StateChanged += () => observed = sut.CurrentExport;
+
+        sut.Begin("Exporting events…", () => { });
+
+        Assert.NotNull(observed);
+        Assert.Equal("Exporting events…", observed.Message);
+    }
+
+    [Fact]
+    public void CurrentExport_Cancel_InvokesProvidedDelegate()
+    {
+        ExportProgressBannerService sut = new();
+        bool canceled = false;
+        sut.Begin("Exporting events…", () => canceled = true);
+
+        ExportProgressEntry? current = sut.CurrentExport;
+        Assert.NotNull(current);
+        current.Cancel();
+
+        Assert.True(canceled);
+    }
+
+    [Fact]
+    public void End_ClearsCurrentExport()
+    {
+        ExportProgressBannerService sut = new();
+        sut.Begin("Exporting events…", () => { });
+
+        sut.End();
+
+        Assert.Null(sut.CurrentExport);
+    }
+
+    [Fact]
+    public void End_RaisesStateChanged()
+    {
+        ExportProgressBannerService sut = new();
+        sut.Begin("Exporting events…", () => { });
+        int fires = 0;
+        sut.StateChanged += () => fires++;
+
+        sut.End();
+
+        Assert.Equal(1, fires);
+    }
+
+    [Fact]
+    public void End_WhenNoExportInProgress_DoesNotRaiseStateChanged()
+    {
+        ExportProgressBannerService sut = new();
+        int fires = 0;
+        sut.StateChanged += () => fires++;
+
+        sut.End();
+
+        Assert.Equal(0, fires);
+        Assert.Null(sut.CurrentExport);
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Export/CountingRowSource.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Export/CountingRowSource.cs
@@ -1,0 +1,30 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Globalization;
+using System.Runtime.CompilerServices;
+
+namespace EventLogExpert.Runtime.Tests.Export;
+
+internal sealed class CountingRowSource(int rowCount)
+{
+    public Action<int>? AfterRowProduced { get; set; }
+
+    public int RowsProduced { get; private set; }
+
+    public async IAsyncEnumerable<IReadOnlyList<string?>> GetRowsAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        for (int i = 0; i < rowCount; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            RowsProduced++;
+
+            yield return [i.ToString(CultureInfo.InvariantCulture), $"value-{i}"];
+
+            AfterRowProduced?.Invoke(i);
+
+            await Task.Yield();
+        }
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Export/CsvExportSinkTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Export/CsvExportSinkTests.cs
@@ -1,0 +1,171 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.Export;
+
+namespace EventLogExpert.Runtime.Tests.Export;
+
+public sealed class CsvExportSinkTests
+{
+    [Fact]
+    public async Task Complete_BeforeHeader_Throws()
+    {
+        using MemoryStream stream = new();
+        await using CsvExportSink sink = new(stream, ["A"]);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await sink.CompleteAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task DisposeAsync_LeavesDestinationStreamOpen()
+    {
+        using MemoryStream stream = new();
+        CsvExportSink sink = new(stream, ["A"]);
+
+        await sink.WriteHeaderAsync(TestContext.Current.CancellationToken);
+        await sink.CompleteAsync(TestContext.Current.CancellationToken);
+        await sink.DisposeAsync();
+
+        Assert.True(stream.CanWrite);
+    }
+
+    [Fact]
+    public async Task EmptyStringCell_BecomesEmptyField()
+    {
+        byte[] bytes = await WriteCsvAsync(["A", "B"], ["", "x"]);
+
+        Assert.Equal("A,B\r\n,x\r\n", ExportTestHelpers.DecodeWithoutBom(bytes));
+    }
+
+    [Fact]
+    public async Task FieldThatIsOnlyADoubleQuote_IsQuotedAndDoubled()
+    {
+        byte[] bytes = await WriteCsvAsync(["X"], ["\""]);
+
+        Assert.Equal("X\r\n\"\"\"\"\r\n", ExportTestHelpers.DecodeWithoutBom(bytes));
+    }
+
+    [Fact]
+    public async Task FieldWithComma_IsQuoted()
+    {
+        byte[] bytes = await WriteCsvAsync(["A", "B"], ["a,b", "x"]);
+
+        Assert.Equal("A,B\r\n\"a,b\",x\r\n", ExportTestHelpers.DecodeWithoutBom(bytes));
+    }
+
+    [Fact]
+    public async Task FieldWithDoubleQuote_IsQuotedAndDoubled()
+    {
+        byte[] bytes = await WriteCsvAsync(["A", "B"], ["a\"b", "x"]);
+
+        Assert.Equal("A,B\r\n\"a\"\"b\",x\r\n", ExportTestHelpers.DecodeWithoutBom(bytes));
+    }
+
+    [Theory]
+    [InlineData("a\nb")]
+    [InlineData("a\rb")]
+    [InlineData("a\r\nb")]
+    public async Task FieldWithLineBreak_IsQuoted(string value)
+    {
+        byte[] bytes = await WriteCsvAsync(["X"], [value]);
+
+        Assert.Equal($"X\r\n\"{value}\"\r\n", ExportTestHelpers.DecodeWithoutBom(bytes));
+    }
+
+    [Fact]
+    public async Task Header_EmitsUtf8ByteOrderMark()
+    {
+        byte[] bytes = await WriteCsvAsync(["A", "B"], ["1", "2"]);
+
+        Assert.True(ExportTestHelpers.StartsWithUtf8Bom(bytes));
+    }
+
+    [Fact]
+    public async Task HeaderAndRow_AreCrlfTerminated()
+    {
+        byte[] bytes = await WriteCsvAsync(["Level", "Source"], ["Information", "Kernel"]);
+
+        Assert.Equal("Level,Source\r\nInformation,Kernel\r\n", ExportTestHelpers.DecodeWithoutBom(bytes));
+    }
+
+    [Fact]
+    public async Task HeaderOnly_WithNoRows_WritesHeaderLineOnly()
+    {
+        byte[] bytes = await WriteCsvAsync(["A", "B"]);
+
+        Assert.Equal("A,B\r\n", ExportTestHelpers.DecodeWithoutBom(bytes));
+    }
+
+    [Fact]
+    public async Task HeaderWithSpecialCharacters_IsQuoted()
+    {
+        byte[] bytes = await WriteCsvAsync(["a,b", "c"], ["1", "2"]);
+
+        Assert.Equal("\"a,b\",c\r\n1,2\r\n", ExportTestHelpers.DecodeWithoutBom(bytes));
+    }
+
+    [Fact]
+    public async Task LeadingAndTrailingWhitespace_IsPreservedWithoutQuoting()
+    {
+        byte[] bytes = await WriteCsvAsync(["A", "B"], [" a ", "x"]);
+
+        Assert.Equal("A,B\r\n a ,x\r\n", ExportTestHelpers.DecodeWithoutBom(bytes));
+    }
+
+    [Fact]
+    public async Task NullCell_BecomesEmptyField()
+    {
+        byte[] bytes = await WriteCsvAsync(["A", "B"], [null, "x"]);
+
+        Assert.Equal("A,B\r\n,x\r\n", ExportTestHelpers.DecodeWithoutBom(bytes));
+    }
+
+    [Fact]
+    public async Task UnicodeCharacters_RoundTripAsUtf8()
+    {
+        byte[] bytes = await WriteCsvAsync(["A", "B"], ["café 日本語", "x"]);
+
+        Assert.Equal("A,B\r\ncafé 日本語,x\r\n", ExportTestHelpers.DecodeWithoutBom(bytes));
+    }
+
+    [Fact]
+    public async Task WriteRow_BeforeHeader_Throws()
+    {
+        using MemoryStream stream = new();
+        await using CsvExportSink sink = new(stream, ["A"]);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await sink.WriteRowAsync(["x"], TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task WriteRow_WithWrongCellCount_Throws()
+    {
+        using MemoryStream stream = new();
+        await using CsvExportSink sink = new(stream, ["A", "B"]);
+        await sink.WriteHeaderAsync(TestContext.Current.CancellationToken);
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            async () => await sink.WriteRowAsync(["only-one"], TestContext.Current.CancellationToken));
+    }
+
+    private static async Task<byte[]> WriteCsvAsync(string[] headers, params IReadOnlyList<string?>[] rows)
+    {
+        using MemoryStream stream = new();
+
+        await using (CsvExportSink sink = new(stream, headers))
+        {
+            await sink.WriteHeaderAsync(TestContext.Current.CancellationToken);
+
+            foreach (IReadOnlyList<string?> row in rows)
+            {
+                await sink.WriteRowAsync(row, TestContext.Current.CancellationToken);
+            }
+
+            await sink.CompleteAsync(TestContext.Current.CancellationToken);
+        }
+
+        return stream.ToArray();
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Export/EventTableExporterTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Export/EventTableExporterTests.cs
@@ -20,6 +20,67 @@ public sealed class EventTableExporterTests
     ];
     private static readonly TimeZoneInfo s_utc = TimeZoneInfo.Utc;
 
+    [Fact]
+    public async Task ExportAsync_Csv_ExcludeDescription_OmitsColumn()
+    {
+        ResolvedEvent[] events = [new("Log", LogPathType.Channel) { Id = 1, Source = "Alpha", Description = "Ignored" }];
+
+        byte[] bytes = await ExportAsync(ExportFormat.Csv, events, s_columns, includeDescription: false);
+
+        Assert.Equal("Event ID,Source\r\n1,Alpha\r\n", ExportTestHelpers.DecodeWithoutBom(bytes));
+    }
+
+    [Fact]
+    public async Task ExportAsync_Csv_IncludeDescription_AppendsColumn()
+    {
+        ResolvedEvent[] events =
+        [
+            new("Log", LogPathType.Channel) { Id = 1, Source = "Alpha", Description = "First" },
+            new("Log", LogPathType.Channel) { Id = 2, Source = "Beta" }
+        ];
+
+        byte[] bytes = await ExportAsync(ExportFormat.Csv, events, s_columns, includeDescription: true);
+
+        Assert.Equal(
+            "Event ID,Source,Description\r\n1,Alpha,First\r\n2,Beta,\r\n",
+            ExportTestHelpers.DecodeWithoutBom(bytes));
+    }
+
+    [Fact]
+    public async Task ExportAsync_Csv_IncludeDescription_LargeDescriptionRoundTrips()
+    {
+        string largeDescription = new('x', 70_000);
+        ResolvedEvent[] events = [new("Log", LogPathType.Channel) { Id = 1, Description = largeDescription }];
+
+        byte[] bytes = await ExportAsync(ExportFormat.Csv, events, [ColumnName.EventId], includeDescription: true);
+
+        Assert.Equal(
+            $"Event ID,Description\r\n1,{largeDescription}\r\n",
+            ExportTestHelpers.DecodeWithoutBom(bytes));
+    }
+
+    [Theory]
+    [InlineData("plain", "Event ID,Description\r\n1,plain\r\n")]
+    [InlineData("=cmd", "Event ID,Description\r\n1,'=cmd\r\n")]
+    [InlineData("+cmd", "Event ID,Description\r\n1,'+cmd\r\n")]
+    [InlineData("-cmd", "Event ID,Description\r\n1,'-cmd\r\n")]
+    [InlineData("@cmd", "Event ID,Description\r\n1,'@cmd\r\n")]
+    [InlineData("\tcmd", "Event ID,Description\r\n1,'\tcmd\r\n")]
+    [InlineData("\rcmd", "Event ID,Description\r\n1,\"'\rcmd\"\r\n")]
+    [InlineData("a\"b", "Event ID,Description\r\n1,\"a\"\"b\"\r\n")]
+    [InlineData("a\nb", "Event ID,Description\r\n1,\"a\nb\"\r\n")]
+    [InlineData("a\rb", "Event ID,Description\r\n1,\"a\rb\"\r\n")]
+    [InlineData("a\r\nb", "Event ID,Description\r\n1,\"a\r\nb\"\r\n")]
+    [InlineData("=cmd\r\nx", "Event ID,Description\r\n1,\"'=cmd\r\nx\"\r\n")]
+    public async Task ExportAsync_Csv_IncludeDescription_NeutralizesAndQuotes(string description, string expectedCsv)
+    {
+        ResolvedEvent[] events = [new("Log", LogPathType.Channel) { Id = 1, Description = description }];
+
+        byte[] bytes = await ExportAsync(ExportFormat.Csv, events, [ColumnName.EventId], includeDescription: true);
+
+        Assert.Equal(expectedCsv, ExportTestHelpers.DecodeWithoutBom(bytes));
+    }
+
     [Theory]
     [InlineData("=SUM(A1)", "Source\r\n'=SUM(A1)\r\n")]
     [InlineData("+1+1", "Source\r\n'+1+1\r\n")]
@@ -58,6 +119,17 @@ public sealed class EventTableExporterTests
     }
 
     [Fact]
+    public async Task ExportAsync_Json_IncludeDescription_AppendsProperty()
+    {
+        ResolvedEvent[] events = [new("Log", LogPathType.Channel) { Id = 1, Source = "Alpha", Description = "=cmd" }];
+
+        byte[] bytes = await ExportAsync(ExportFormat.Json, events, [ColumnName.Source], includeDescription: true);
+
+        using JsonDocument document = JsonDocument.Parse(new ReadOnlyMemory<byte>(bytes));
+        Assert.Equal("=cmd", document.RootElement[0].GetProperty("Description").GetString());
+    }
+
+    [Fact]
     public async Task ExportAsync_Json_WritesArrayOfObjects()
     {
         byte[] bytes = await ExportAsync(ExportFormat.Json, s_events, s_columns);
@@ -77,12 +149,16 @@ public sealed class EventTableExporterTests
     }
 
     private static async Task<byte[]> ExportAsync(
-        ExportFormat format, IReadOnlyList<ResolvedEvent> events, IReadOnlyList<ColumnName> columns)
+        ExportFormat format,
+        IReadOnlyList<ResolvedEvent> events,
+        IReadOnlyList<ColumnName> columns,
+        bool includeDescription = false)
     {
-        var exporter = new EventTableExporter(new TabularExportWriter());
-        using var stream = new MemoryStream();
+        EventTableExporter exporter = new(new TabularExportWriter());
+        using MemoryStream stream = new();
 
-        await exporter.ExportAsync(stream, format, events, columns, s_utc, TestContext.Current.CancellationToken);
+        await exporter.ExportAsync(
+            stream, format, events, columns, s_utc, includeDescription, TestContext.Current.CancellationToken);
 
         return stream.ToArray();
     }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Export/EventTableExporterTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Export/EventTableExporterTests.cs
@@ -90,6 +90,12 @@ public sealed class EventTableExporterTests
     [InlineData("\rCarriage", "Source\r\n\"'\rCarriage\"\r\n")]
     [InlineData("Alpha", "Source\r\nAlpha\r\n")]
     [InlineData("a=b", "Source\r\na=b\r\n")]
+    [InlineData(" =SUM(A1)", "Source\r\n' =SUM(A1)\r\n")]
+    [InlineData(" +1", "Source\r\n' +1\r\n")]
+    [InlineData("  -2", "Source\r\n'  -2\r\n")]
+    [InlineData(" @cmd", "Source\r\n' @cmd\r\n")]
+    [InlineData("  hello", "Source\r\n  hello\r\n")]
+    [InlineData("   ", "Source\r\n   \r\n")]
     public async Task ExportAsync_Csv_NeutralizesLeadingFormulaTriggers(string sourceValue, string expectedCsv)
     {
         ResolvedEvent[] events = [new("Log", LogPathType.Channel) { Id = 1, Source = sourceValue }];

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Export/EventTableExporterTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Export/EventTableExporterTests.cs
@@ -1,0 +1,89 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Runtime.Export;
+using EventLogExpert.Runtime.LogTable;
+using System.Text.Json;
+
+namespace EventLogExpert.Runtime.Tests.Export;
+
+public sealed class EventTableExporterTests
+{
+    private static readonly ColumnName[] s_columns = [ColumnName.EventId, ColumnName.Source];
+
+    private static readonly ResolvedEvent[] s_events =
+    [
+        new("Log", LogPathType.Channel) { Id = 1, Source = "Alpha" },
+        new("Log", LogPathType.Channel) { Id = 2, Source = "Beta" }
+    ];
+    private static readonly TimeZoneInfo s_utc = TimeZoneInfo.Utc;
+
+    [Theory]
+    [InlineData("=SUM(A1)", "Source\r\n'=SUM(A1)\r\n")]
+    [InlineData("+1+1", "Source\r\n'+1+1\r\n")]
+    [InlineData("-2-2", "Source\r\n'-2-2\r\n")]
+    [InlineData("@cmd", "Source\r\n'@cmd\r\n")]
+    [InlineData("\tTabLed", "Source\r\n'\tTabLed\r\n")]
+    [InlineData("\rCarriage", "Source\r\n\"'\rCarriage\"\r\n")]
+    [InlineData("Alpha", "Source\r\nAlpha\r\n")]
+    [InlineData("a=b", "Source\r\na=b\r\n")]
+    public async Task ExportAsync_Csv_NeutralizesLeadingFormulaTriggers(string sourceValue, string expectedCsv)
+    {
+        ResolvedEvent[] events = [new("Log", LogPathType.Channel) { Id = 1, Source = sourceValue }];
+
+        byte[] bytes = await ExportAsync(ExportFormat.Csv, events, [ColumnName.Source]);
+
+        Assert.Equal(expectedCsv, ExportTestHelpers.DecodeWithoutBom(bytes));
+    }
+
+    [Fact]
+    public async Task ExportAsync_Csv_WritesHeaderAndRows()
+    {
+        byte[] bytes = await ExportAsync(ExportFormat.Csv, s_events, s_columns);
+
+        Assert.Equal("Event ID,Source\r\n1,Alpha\r\n2,Beta\r\n", ExportTestHelpers.DecodeWithoutBom(bytes));
+    }
+
+    [Fact]
+    public async Task ExportAsync_Json_DoesNotNeutralizeFormula()
+    {
+        ResolvedEvent[] events = [new("Log", LogPathType.Channel) { Id = 1, Source = "=SUM(A1)" }];
+
+        byte[] bytes = await ExportAsync(ExportFormat.Json, events, [ColumnName.Source]);
+
+        using JsonDocument document = JsonDocument.Parse(new ReadOnlyMemory<byte>(bytes));
+        Assert.Equal("=SUM(A1)", document.RootElement[0].GetProperty("Source").GetString());
+    }
+
+    [Fact]
+    public async Task ExportAsync_Json_WritesArrayOfObjects()
+    {
+        byte[] bytes = await ExportAsync(ExportFormat.Json, s_events, s_columns);
+
+        using JsonDocument document = JsonDocument.Parse(new ReadOnlyMemory<byte>(bytes));
+        Assert.Equal(2, document.RootElement.GetArrayLength());
+        Assert.Equal("1", document.RootElement[0].GetProperty("Event ID").GetString());
+        Assert.Equal("Beta", document.RootElement[1].GetProperty("Source").GetString());
+    }
+
+    [Fact]
+    public async Task ExportAsync_NoEvents_Csv_WritesHeaderOnly()
+    {
+        byte[] bytes = await ExportAsync(ExportFormat.Csv, [], s_columns);
+
+        Assert.Equal("Event ID,Source\r\n", ExportTestHelpers.DecodeWithoutBom(bytes));
+    }
+
+    private static async Task<byte[]> ExportAsync(
+        ExportFormat format, IReadOnlyList<ResolvedEvent> events, IReadOnlyList<ColumnName> columns)
+    {
+        var exporter = new EventTableExporter(new TabularExportWriter());
+        using var stream = new MemoryStream();
+
+        await exporter.ExportAsync(stream, format, events, columns, s_utc, TestContext.Current.CancellationToken);
+
+        return stream.ToArray();
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Export/ExportTestHelpers.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Export/ExportTestHelpers.cs
@@ -1,0 +1,43 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Globalization;
+using System.Text;
+
+namespace EventLogExpert.Runtime.Tests.Export;
+
+internal static class ExportTestHelpers
+{
+    public static string DecodeWithoutBom(byte[] bytes)
+    {
+        ReadOnlySpan<byte> span = bytes;
+        ReadOnlySpan<byte> bom = [0xEF, 0xBB, 0xBF];
+
+        if (span.StartsWith(bom))
+        {
+            span = span[bom.Length..];
+        }
+
+        return Encoding.UTF8.GetString(span);
+    }
+
+    public static IEnumerable<IReadOnlyList<string?>> GenerateRows(int count)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            yield return [i.ToString(CultureInfo.InvariantCulture), $"value-{i}"];
+        }
+    }
+
+    public static bool StartsWithUtf8Bom(byte[] bytes) =>
+        bytes is [0xEF, 0xBB, 0xBF, ..];
+
+    public static async IAsyncEnumerable<IReadOnlyList<string?>> ToAsync(IEnumerable<IReadOnlyList<string?>> rows)
+    {
+        foreach (IReadOnlyList<string?> row in rows)
+        {
+            yield return row;
+            await Task.Yield();
+        }
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Export/JsonExportSinkTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Export/JsonExportSinkTests.cs
@@ -1,0 +1,134 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.Export;
+using System.Text.Json;
+
+namespace EventLogExpert.Runtime.Tests.Export;
+
+public sealed class JsonExportSinkTests
+{
+    [Fact]
+    public async Task DoesNotEmitByteOrderMark()
+    {
+        byte[] bytes = await WriteJsonAsync(["A"], ["1"]);
+
+        Assert.False(ExportTestHelpers.StartsWithUtf8Bom(bytes));
+    }
+
+    [Fact]
+    public async Task EscapesSpecialCharacters_AndRoundTrips()
+    {
+        string value = "a\"b\\c\n\td";
+
+        byte[] bytes = await WriteJsonAsync(["X"], [value]);
+
+        using JsonDocument document = Parse(bytes);
+        Assert.Equal(value, document.RootElement[0].GetProperty("X").GetString());
+    }
+
+    [Fact]
+    public async Task NoRows_ProduceEmptyArray()
+    {
+        byte[] bytes = await WriteJsonAsync(["A", "B"]);
+
+        using JsonDocument document = Parse(bytes);
+        Assert.Equal(JsonValueKind.Array, document.RootElement.ValueKind);
+        Assert.Equal(0, document.RootElement.GetArrayLength());
+    }
+
+    [Fact]
+    public async Task NullCell_EmitsJsonNull()
+    {
+        byte[] bytes = await WriteJsonAsync(["A", "B"], [null, "x"]);
+
+        using JsonDocument document = Parse(bytes);
+        Assert.Equal(JsonValueKind.Null, document.RootElement[0].GetProperty("A").ValueKind);
+    }
+
+    [Fact]
+    public async Task Output_IsIndented()
+    {
+        byte[] bytes = await WriteJsonAsync(["A"], ["1"]);
+
+        Assert.Contains("\n", ExportTestHelpers.DecodeWithoutBom(bytes));
+    }
+
+    [Fact]
+    public async Task PreservesHeaderOrder_InEachObject()
+    {
+        byte[] bytes = await WriteJsonAsync(["Third", "First", "Second"], ["3", "1", "2"]);
+
+        using JsonDocument document = Parse(bytes);
+        string[] propertyNames = [.. document.RootElement[0].EnumerateObject().Select(property => property.Name)];
+        string[] expected = ["Third", "First", "Second"];
+
+        Assert.Equal(expected, propertyNames);
+    }
+
+    [Fact]
+    public async Task ProducesArrayOfObjects_WithHeaderProperties()
+    {
+        byte[] bytes = await WriteJsonAsync(["Id", "Source"], ["4624", "Security"]);
+
+        using JsonDocument document = Parse(bytes);
+        Assert.Equal(JsonValueKind.Array, document.RootElement.ValueKind);
+        Assert.Equal(1, document.RootElement.GetArrayLength());
+
+        JsonElement row = document.RootElement[0];
+        Assert.Equal("4624", row.GetProperty("Id").GetString());
+        Assert.Equal("Security", row.GetProperty("Source").GetString());
+    }
+
+    [Fact]
+    public async Task UnicodeValue_RoundTrips()
+    {
+        string value = "café 日本語";
+
+        byte[] bytes = await WriteJsonAsync(["X"], [value]);
+
+        using JsonDocument document = Parse(bytes);
+        Assert.Equal(value, document.RootElement[0].GetProperty("X").GetString());
+    }
+
+    [Fact]
+    public async Task Values_AreEmittedAsStrings()
+    {
+        byte[] bytes = await WriteJsonAsync(["Id"], ["4624"]);
+
+        using JsonDocument document = Parse(bytes);
+        Assert.Equal(JsonValueKind.String, document.RootElement[0].GetProperty("Id").ValueKind);
+    }
+
+    [Fact]
+    public async Task WriteRow_WithWrongCellCount_Throws()
+    {
+        using MemoryStream stream = new();
+        await using JsonExportSink sink = new(stream, ["A", "B"]);
+        await sink.WriteHeaderAsync(TestContext.Current.CancellationToken);
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            async () => await sink.WriteRowAsync(["only-one"], TestContext.Current.CancellationToken));
+    }
+
+    private static JsonDocument Parse(byte[] utf8Json) => JsonDocument.Parse(new ReadOnlyMemory<byte>(utf8Json));
+
+    private static async Task<byte[]> WriteJsonAsync(string[] headers, params IReadOnlyList<string?>[] rows)
+    {
+        using MemoryStream stream = new();
+
+        await using (JsonExportSink sink = new(stream, headers))
+        {
+            await sink.WriteHeaderAsync(TestContext.Current.CancellationToken);
+
+            foreach (IReadOnlyList<string?> row in rows)
+            {
+                await sink.WriteRowAsync(row, TestContext.Current.CancellationToken);
+            }
+
+            await sink.CompleteAsync(TestContext.Current.CancellationToken);
+        }
+
+        return stream.ToArray();
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Export/RecordingStream.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Export/RecordingStream.cs
@@ -1,0 +1,74 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Tests.Export;
+
+internal sealed class RecordingStream : Stream
+{
+    public override bool CanRead => false;
+
+    public override bool CanSeek => false;
+
+    public override bool CanWrite => true;
+
+    public override long Length => TotalBytesWritten;
+
+    public int MaxSingleWriteBytes { get; private set; }
+
+    public override long Position
+    {
+        get => TotalBytesWritten;
+        set => throw new NotSupportedException();
+    }
+
+    public long TotalBytesWritten { get; private set; }
+
+    public bool WasDisposed { get; private set; }
+
+    public int WriteCallCount { get; private set; }
+
+    public override void Flush() { }
+
+    public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    public override void Write(byte[] buffer, int offset, int count) => Record(count);
+
+    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Record(count);
+
+        return Task.CompletedTask;
+    }
+
+    public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Record(buffer.Length);
+
+        return ValueTask.CompletedTask;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        WasDisposed = true;
+        base.Dispose(disposing);
+    }
+
+    private void Record(int count)
+    {
+        WriteCallCount++;
+        TotalBytesWritten += count;
+
+        if (count > MaxSingleWriteBytes)
+        {
+            MaxSingleWriteBytes = count;
+        }
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Export/TabularExportWriterTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Export/TabularExportWriterTests.cs
@@ -1,0 +1,211 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.Export;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+
+namespace EventLogExpert.Runtime.Tests.Export;
+
+public sealed class TabularExportWriterTests
+{
+    [Fact]
+    [SuppressMessage("Usage", "xUnit1051", Justification = "Test exercises cancellation with a test-controlled token.")]
+    public async Task Cancellation_StopsEnumerationEarly_AndLeavesStreamOpen()
+    {
+        using CancellationTokenSource cancellation = new();
+        RecordingStream stream = new();
+        CountingRowSource source = new(rowCount: 100)
+        {
+            AfterRowProduced = index =>
+            {
+                if (index == 2)
+                {
+                    cancellation.Cancel();
+                }
+            }
+        };
+        TabularExportWriter writer = new();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            async () => await writer.WriteAsync(
+                stream, ExportFormat.Csv, ["A", "B"], source.GetRowsAsync(), cancellation.Token));
+
+        Assert.True(source.RowsProduced <= 4);
+        Assert.False(stream.WasDisposed);
+    }
+
+    [Fact]
+    public async Task ConcurrentExports_ToSeparateStreams_DoNotShareState()
+    {
+        TabularExportWriter writer = new();
+        using MemoryStream first = new();
+        using MemoryStream second = new();
+
+        Task firstExport = writer.WriteAsync(
+            first, ExportFormat.Csv, ["A"], ExportTestHelpers.ToAsync([["first"]]), TestContext.Current.CancellationToken);
+        Task secondExport = writer.WriteAsync(
+            second, ExportFormat.Csv, ["B"], ExportTestHelpers.ToAsync([["second"]]), TestContext.Current.CancellationToken);
+
+        await Task.WhenAll(firstExport, secondExport);
+
+        Assert.Equal("A\r\nfirst\r\n", ExportTestHelpers.DecodeWithoutBom(first.ToArray()));
+        Assert.Equal("B\r\nsecond\r\n", ExportTestHelpers.DecodeWithoutBom(second.ToArray()));
+    }
+
+    [Fact]
+    public async Task DuplicateHeaders_Throws()
+    {
+        using MemoryStream stream = new();
+        TabularExportWriter writer = new();
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            async () => await writer.WriteAsync(
+                stream, ExportFormat.Csv, ["A", "A"], ExportTestHelpers.ToAsync([]), TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task EmptyHeaders_Throws()
+    {
+        using MemoryStream stream = new();
+        TabularExportWriter writer = new();
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            async () => await writer.WriteAsync(
+                stream, ExportFormat.Csv, [], ExportTestHelpers.ToAsync([]), TestContext.Current.CancellationToken));
+    }
+
+    [Theory]
+    [InlineData("A", null)]
+    [InlineData("A", "")]
+    public async Task HeaderWithNullOrEmptyElement_Throws(string first, string? second)
+    {
+        using MemoryStream stream = new();
+        TabularExportWriter writer = new();
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            async () => await writer.WriteAsync(
+                stream, ExportFormat.Csv, [first, second!], ExportTestHelpers.ToAsync([]), TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task LargeCsvInput_StreamsIncrementally_WithoutBufferingWholeOutput() =>
+        await AssertStreamsIncrementally(ExportFormat.Csv);
+
+    [Fact]
+    public async Task LargeJsonInput_StreamsIncrementally_WithoutBufferingWholeOutput() =>
+        await AssertStreamsIncrementally(ExportFormat.Json);
+
+    [Fact]
+    public async Task NullDestination_Throws()
+    {
+        TabularExportWriter writer = new();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await writer.WriteAsync(
+                null!, ExportFormat.Csv, ["A"], ExportTestHelpers.ToAsync([]), TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task NullRows_Throws()
+    {
+        using MemoryStream stream = new();
+        TabularExportWriter writer = new();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await writer.WriteAsync(stream, ExportFormat.Csv, ["A"], null!, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    [SuppressMessage("Usage", "xUnit1051", Justification = "Test exercises a pre-cancelled token.")]
+    public async Task PreCanceledToken_WritesNoBytes()
+    {
+        RecordingStream stream = new();
+        TabularExportWriter writer = new();
+        using CancellationTokenSource cancellation = new();
+        await cancellation.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            async () => await writer.WriteAsync(
+                stream, ExportFormat.Csv, ["A"], ExportTestHelpers.ToAsync([["1"]]), cancellation.Token));
+
+        Assert.Equal(0, stream.TotalBytesWritten);
+    }
+
+    [Fact]
+    public async Task RowWithWrongCellCount_Throws()
+    {
+        using MemoryStream stream = new();
+        TabularExportWriter writer = new();
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            async () => await writer.WriteAsync(
+                stream, ExportFormat.Csv, ["A", "B"],
+                ExportTestHelpers.ToAsync([["only-one"]]), TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task SuccessfulExport_LeavesDestinationStreamOpen()
+    {
+        RecordingStream stream = new();
+        TabularExportWriter writer = new();
+
+        await writer.WriteAsync(
+            stream, ExportFormat.Csv, ["A"], ExportTestHelpers.ToAsync([["1"]]), TestContext.Current.CancellationToken);
+
+        Assert.False(stream.WasDisposed);
+    }
+
+    [Fact]
+    public async Task UnsupportedFormat_Throws()
+    {
+        using MemoryStream stream = new();
+        TabularExportWriter writer = new();
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+            async () => await writer.WriteAsync(
+                stream, (ExportFormat)999, ["A"], ExportTestHelpers.ToAsync([]), TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task WritesCsv_EndToEnd()
+    {
+        using MemoryStream stream = new();
+        TabularExportWriter writer = new();
+
+        await writer.WriteAsync(
+            stream, ExportFormat.Csv, ["A", "B"],
+            ExportTestHelpers.ToAsync([["1", "2"], ["3", "4"]]), TestContext.Current.CancellationToken);
+
+        Assert.Equal("A,B\r\n1,2\r\n3,4\r\n", ExportTestHelpers.DecodeWithoutBom(stream.ToArray()));
+    }
+
+    [Fact]
+    public async Task WritesJson_EndToEnd()
+    {
+        using MemoryStream stream = new();
+        TabularExportWriter writer = new();
+
+        await writer.WriteAsync(
+            stream, ExportFormat.Json, ["A", "B"],
+            ExportTestHelpers.ToAsync([["1", "2"], ["3", "4"]]), TestContext.Current.CancellationToken);
+
+        using JsonDocument document = JsonDocument.Parse(new ReadOnlyMemory<byte>(stream.ToArray()));
+        Assert.Equal(2, document.RootElement.GetArrayLength());
+        Assert.Equal("1", document.RootElement[0].GetProperty("A").GetString());
+        Assert.Equal("4", document.RootElement[1].GetProperty("B").GetString());
+    }
+
+    private static async Task AssertStreamsIncrementally(ExportFormat format)
+    {
+        RecordingStream stream = new();
+        TabularExportWriter writer = new();
+
+        await writer.WriteAsync(
+            stream, format, ["A", "B"],
+            ExportTestHelpers.ToAsync(ExportTestHelpers.GenerateRows(20_000)), TestContext.Current.CancellationToken);
+
+        Assert.True(stream.WriteCallCount > 1);
+        Assert.True(stream.MaxSingleWriteBytes < 256 * 1024);
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/EventTableColumnFormatterTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/EventTableColumnFormatterTests.cs
@@ -63,7 +63,7 @@ public sealed class EventTableColumnFormatterTests
     }
 
     [Fact]
-    public void GetCellText_MissingNullableValues_ReturnEmpty()
+    public void GetCellText_MissingNullableValues_ReturnsEmpty()
     {
         var bare = new ResolvedEvent("Log", LogPathType.Channel);
 

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/EventTableColumnFormatterTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/EventTableColumnFormatterTests.cs
@@ -1,0 +1,104 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Runtime.LogTable;
+using System.Security.Principal;
+
+namespace EventLogExpert.Runtime.Tests.LogTable;
+
+public sealed class EventTableColumnFormatterTests
+{
+    private static readonly ResolvedEvent s_event = new("Server\\Security.evtx", LogPathType.File)
+    {
+        RecordId = 42,
+        Level = "Information",
+        TimeCreated = new DateTime(2026, 6, 18, 6, 57, 20, DateTimeKind.Utc),
+        Id = 4624,
+        Source = "Microsoft-Windows-Security-Auditing",
+        TaskCategory = "Logon",
+        ComputerName = "DC01",
+        ProcessId = 1234,
+        ThreadId = 56,
+        Keywords = ["Audit Success"],
+        UserId = new SecurityIdentifier("S-1-5-18")
+    };
+    private static readonly TimeZoneInfo s_plusTwo =
+        TimeZoneInfo.CreateCustomTimeZone("UnitTest+2", TimeSpan.FromHours(2), "UnitTest+2", "UnitTest+2");
+
+    [Fact]
+    public void GetCellText_DateAndTime_WithFormat_UsesInvariantIsoInTimeZone()
+    {
+        string actual = EventTableColumnFormatter.GetCellText(
+            s_event, ColumnName.DateAndTime, s_plusTwo, "yyyy-MM-dd HH:mm:ss");
+
+        Assert.Equal("2026-06-18 08:57:20", actual);
+    }
+
+    [Fact]
+    public void GetCellText_DateAndTime_WithoutFormat_MatchesDisplayToString()
+    {
+        string expected = TimeZoneInfo.ConvertTimeFromUtc(s_event.TimeCreated, s_plusTwo).ToString();
+
+        Assert.Equal(expected, EventTableColumnFormatter.GetCellText(s_event, ColumnName.DateAndTime, s_plusTwo));
+    }
+
+    [Fact]
+    public void GetCellText_EventId_ReturnsId()
+    {
+        Assert.Equal("4624", EventTableColumnFormatter.GetCellText(s_event, ColumnName.EventId, s_plusTwo));
+    }
+
+    [Fact]
+    public void GetCellText_Keywords_ReturnsDisplayName()
+    {
+        Assert.Equal("Audit Success", EventTableColumnFormatter.GetCellText(s_event, ColumnName.Keywords, s_plusTwo));
+    }
+
+    [Fact]
+    public void GetCellText_Log_ReturnsLeafAfterLastBackslash()
+    {
+        Assert.Equal("Security.evtx", EventTableColumnFormatter.GetCellText(s_event, ColumnName.Log, s_plusTwo));
+    }
+
+    [Fact]
+    public void GetCellText_MissingNullableValues_ReturnEmpty()
+    {
+        var bare = new ResolvedEvent("Log", LogPathType.Channel);
+
+        Assert.Equal(string.Empty, EventTableColumnFormatter.GetCellText(bare, ColumnName.RecordId, s_plusTwo));
+        Assert.Equal(string.Empty, EventTableColumnFormatter.GetCellText(bare, ColumnName.User, s_plusTwo));
+        Assert.Equal(string.Empty, EventTableColumnFormatter.GetCellText(bare, ColumnName.ActivityId, s_plusTwo));
+        Assert.Equal(string.Empty, EventTableColumnFormatter.GetCellText(bare, ColumnName.ProcessId, s_plusTwo));
+    }
+
+    [Fact]
+    public void GetCellText_User_ReturnsSidValue()
+    {
+        Assert.Equal("S-1-5-18", EventTableColumnFormatter.GetCellText(s_event, ColumnName.User, s_plusTwo));
+    }
+
+    [Fact]
+    public void GetColumnHeader_DateAndTime_Local_IsPlainLabel()
+    {
+        Assert.Equal(
+            "Date and Time", EventTableColumnFormatter.GetColumnHeader(ColumnName.DateAndTime, TimeZoneInfo.Local));
+    }
+
+    [Fact]
+    public void GetColumnHeader_DateAndTime_NonLocal_IncludesTimeZoneToken()
+    {
+        string header = EventTableColumnFormatter.GetColumnHeader(ColumnName.DateAndTime, s_plusTwo);
+
+        Assert.StartsWith("Date and Time ", header);
+        Assert.NotEqual("Date and Time", header);
+    }
+
+    [Fact]
+    public void GetColumnHeader_OtherColumn_UsesEnumMemberDisplayName()
+    {
+        Assert.Equal("Event ID", EventTableColumnFormatter.GetColumnHeader(ColumnName.EventId, s_plusTwo));
+        Assert.Equal("Record ID", EventTableColumnFormatter.GetColumnHeader(ColumnName.RecordId, s_plusTwo));
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/LogTableStateExportTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/LogTableStateExportTests.cs
@@ -1,0 +1,54 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.LogTable;
+using System.Collections.Immutable;
+
+namespace EventLogExpert.Runtime.Tests.LogTable;
+
+public sealed class LogTableStateExportTests
+{
+    [Fact]
+    public void GetActiveDisplayedEvents_NoActiveTable_ReturnsEmpty()
+    {
+        var state = new LogTableState();
+
+        Assert.Empty(state.GetActiveDisplayedEvents());
+    }
+
+    [Fact]
+    public void GetOrderedEnabledColumns_AppendsEnabledColumnsMissingFromOrder()
+    {
+        var state = new LogTableState
+        {
+            Columns = ImmutableDictionary<ColumnName, bool>.Empty
+                .Add(ColumnName.Source, true)
+                .Add(ColumnName.EventId, true),
+            ColumnOrder = [ColumnName.Source]
+        };
+
+        var ordered = state.GetOrderedEnabledColumns(new ColumnDefaults());
+
+        Assert.Equal(ColumnName.Source, ordered[0]);
+        Assert.Contains(ColumnName.EventId, ordered);
+        Assert.Equal(2, ordered.Count);
+    }
+
+    [Fact]
+    public void GetOrderedEnabledColumns_FiltersToEnabled_InColumnOrder()
+    {
+        var state = new LogTableState
+        {
+            Columns = ImmutableDictionary<ColumnName, bool>.Empty
+                .Add(ColumnName.Source, true)
+                .Add(ColumnName.EventId, true)
+                .Add(ColumnName.Level, false),
+            ColumnOrder = [ColumnName.EventId, ColumnName.Source, ColumnName.Level]
+        };
+
+        var ordered = state.GetOrderedEnabledColumns(new ColumnDefaults());
+
+        ColumnName[] expected = [ColumnName.EventId, ColumnName.Source];
+        Assert.Equal(expected, ordered);
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/LogTableStateExportTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/LogTableStateExportTests.cs
@@ -35,6 +35,25 @@ public sealed class LogTableStateExportTests
     }
 
     [Fact]
+    public void GetOrderedEnabledColumns_DuplicateOrderAndMissingEnabledColumn_DeduplicatesThenAppends()
+    {
+        var state = new LogTableState
+        {
+            Columns = ImmutableDictionary<ColumnName, bool>.Empty
+                .Add(ColumnName.Source, true)
+                .Add(ColumnName.EventId, true),
+            ColumnOrder = [ColumnName.Source, ColumnName.Source]
+        };
+
+        var ordered = state.GetOrderedEnabledColumns(new ColumnDefaults());
+
+        // Source deduplicated to one entry; EventId (enabled, absent from the order) appended from defaults.
+        Assert.Equal(ColumnName.Source, ordered[0]);
+        Assert.Contains(ColumnName.EventId, ordered);
+        Assert.Equal(2, ordered.Count);
+    }
+
+    [Fact]
     public void GetOrderedEnabledColumns_FiltersToEnabled_InColumnOrder()
     {
         var state = new LogTableState
@@ -49,6 +68,23 @@ public sealed class LogTableStateExportTests
         var ordered = state.GetOrderedEnabledColumns(new ColumnDefaults());
 
         ColumnName[] expected = [ColumnName.EventId, ColumnName.Source];
+        Assert.Equal(expected, ordered);
+    }
+
+    [Fact]
+    public void GetOrderedEnabledColumns_WithDuplicatesInColumnOrder_DeduplicatesPreservingFirstOccurrence()
+    {
+        var state = new LogTableState
+        {
+            Columns = ImmutableDictionary<ColumnName, bool>.Empty
+                .Add(ColumnName.Source, true)
+                .Add(ColumnName.EventId, true),
+            ColumnOrder = [ColumnName.Source, ColumnName.EventId, ColumnName.Source]
+        };
+
+        var ordered = state.GetOrderedEnabledColumns(new ColumnDefaults());
+
+        ColumnName[] expected = [ColumnName.Source, ColumnName.EventId];
         Assert.Equal(expected, ordered);
     }
 }

--- a/tests/Unit/EventLogExpert.UI.Tests/Banner/BannerCycleStateServiceTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Banner/BannerCycleStateServiceTests.cs
@@ -16,6 +16,7 @@ public sealed class BannerCycleStateServiceTests
     private readonly IAttentionBannerService _attention = Substitute.For<IAttentionBannerService>();
     private readonly ICriticalErrorService _critical = Substitute.For<ICriticalErrorService>();
     private readonly IErrorBannerService _errors = Substitute.For<IErrorBannerService>();
+    private readonly IExportProgressBannerService _exportProgress = Substitute.For<IExportProgressBannerService>();
     private readonly IInfoBannerService _infos = Substitute.For<IInfoBannerService>();
     private readonly IModalCoordinator _modalCoordinator = Substitute.For<IModalCoordinator>();
     private readonly IProgressBannerService _progress = Substitute.For<IProgressBannerService>();
@@ -28,6 +29,7 @@ public sealed class BannerCycleStateServiceTests
         _attention.AttentionEntries.Returns([]);
         _attention.AttentionDismissed.Returns(false);
         _progress.BackgroundProgress.Returns((BannerProgressEntry?)null);
+        _exportProgress.CurrentExport.Returns((ExportProgressEntry?)null);
         _modalCoordinator.ActiveSession.Returns((ModalSession?)null);
     }
 
@@ -68,10 +70,46 @@ public sealed class BannerCycleStateServiceTests
         _attention.StateChanged += Raise.Event<Action>();
         _infos.StateChanged += Raise.Event<Action>();
         _progress.StateChanged += Raise.Event<Action>();
+        _exportProgress.StateChanged += Raise.Event<Action>();
         _critical.StateChanged += Raise.Event<Action>();
         _modalCoordinator.StateChanged += Raise.Event<Action>();
 
         Assert.Equal(0, stateChangedFires);
+    }
+
+    [Fact]
+    public void ExportProgress_Present_AddsExportProgressItemToCycle()
+    {
+        _exportProgress.CurrentExport.Returns(MakeExport());
+
+        var service = CreateService();
+
+        Assert.Single(service.Items);
+        Assert.Equal(BannerView.ExportProgress, service.SelectedItem?.View);
+    }
+
+    [Fact]
+    public void ExportProgress_PriorityStolenSelection_NotClearedByUnrelatedRebuild()
+    {
+        BannerInfoEntry info0 = MakeInfo();
+        BannerInfoEntry info1 = MakeInfo();
+        _infos.InfoBanners.Returns([info0, info1]);
+        var service = CreateService();
+
+        // Two infos give a navigable cycle; select the second so it becomes the user-preferred item.
+        service.MoveNext();
+        Assert.Equal(info1.Id, service.SelectedItem?.EntryId);
+
+        // Export arrives and outranks Info, so it priority-steals the selection.
+        _exportProgress.CurrentExport.Returns(MakeExport());
+        _exportProgress.StateChanged += Raise.Event<Action>();
+        Assert.Equal(BannerView.ExportProgress, service.SelectedItem?.View);
+
+        // An unrelated rebuild must keep the priority-stolen export selected: export is still in the
+        // source fingerprint, so it is neither re-stolen nor cleared back to the user-preferred info.
+        _infos.InfoBanners.Returns([info0, info1, MakeInfo()]);
+        _infos.StateChanged += Raise.Event<Action>();
+        Assert.Equal(BannerView.ExportProgress, service.SelectedItem?.View);
     }
 
     [Fact]
@@ -548,6 +586,8 @@ public sealed class BannerCycleStateServiceTests
     private static ErrorBannerEntry MakeError() =>
         new(BannerId.Create(), "Title", "msg", null, null, DateTime.UtcNow);
 
+    private static ExportProgressEntry MakeExport() => new("Exporting events…", () => { });
+
     private static BannerInfoEntry MakeInfo() =>
         new(BannerId.Create(), "Title", "msg", BannerSeverity.Info, DateTime.UtcNow);
 
@@ -563,5 +603,5 @@ public sealed class BannerCycleStateServiceTests
             () => { });
 
     private BannerCycleStateService CreateService() =>
-        new(_attention, _errors, _infos, _progress, _critical, _modalCoordinator);
+        new(_attention, _errors, _infos, _progress, _exportProgress, _critical, _modalCoordinator);
 }

--- a/tests/Unit/EventLogExpert.UI.Tests/Banner/BannerHostTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Banner/BannerHostTests.cs
@@ -26,6 +26,7 @@ public sealed class BannerHostTests : BunitContext
     private readonly IClipboardService _clipboardService = Substitute.For<IClipboardService>();
     private readonly ICriticalErrorService _criticalErrorService;
     private readonly IErrorBannerService _errorBannerService;
+    private readonly IExportProgressBannerService _exportProgressBannerService;
     private readonly IInfoBannerService _infoBannerService;
     private readonly IMenuActionService _menuActionService = Substitute.For<IMenuActionService>();
     private readonly IModalCoordinator _modalCoordinator = Substitute.For<IModalCoordinator>();
@@ -34,7 +35,7 @@ public sealed class BannerHostTests : BunitContext
 
     public BannerHostTests()
     {
-        Services.AddBannerSubstitutes(out _attentionBannerService, out _progressBannerService, out _criticalErrorService, out _errorBannerService, out _infoBannerService);
+        Services.AddBannerSubstitutes(out _attentionBannerService, out _progressBannerService, out _exportProgressBannerService, out _criticalErrorService, out _errorBannerService, out _infoBannerService);
         Services.AddSingleton<IBannerCycleStateService, BannerCycleStateService>();
 
         _criticalErrorService.CurrentCritical.Returns((Exception?)null);
@@ -43,6 +44,7 @@ public sealed class BannerHostTests : BunitContext
         _attentionBannerService.AttentionEntries.Returns([]);
         _attentionBannerService.AttentionDismissed.Returns(false);
         _progressBannerService.BackgroundProgress.Returns((BannerProgressEntry?)null);
+        _exportProgressBannerService.CurrentExport.Returns((ExportProgressEntry?)null);
         _modalCoordinator.ActiveSession.Returns((ModalSession?)null);
 
         Services.AddSingleton(_applicationRestartService);
@@ -242,6 +244,32 @@ public sealed class BannerHostTests : BunitContext
         // because the old (Error, 1) tuple matched e2's new (Error, 1) position.
         Assert.Contains("Second: second message", component.Find("aside.banner-error").TextContent);
         Assert.DoesNotContain("Third", component.Find("aside.banner-error").TextContent);
+    }
+
+    [Fact]
+    public async Task BannerHost_ExportCancelClicked_InvokesCancelDelegate()
+    {
+        bool canceled = false;
+        _exportProgressBannerService.CurrentExport.Returns(
+            new ExportProgressEntry("Exporting events…", () => canceled = true));
+
+        var component = Render<BannerHost>();
+        await component.Find("aside.banner-export-progress button.banner-action").ClickAsync(new MouseEventArgs());
+
+        Assert.True(canceled);
+    }
+
+    [Fact]
+    public void BannerHost_ExportInProgress_RendersExportProgressBannerWithMessage()
+    {
+        _exportProgressBannerService.CurrentExport.Returns(
+            new ExportProgressEntry("Exporting events…", () => { }));
+
+        var component = Render<BannerHost>();
+
+        var banner = component.Find("aside.banner-export-progress");
+        Assert.Contains("Exporting events…", banner.TextContent);
+        Assert.Single(component.FindAll("aside.banner-export-progress button.banner-action"));
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.UI.Tests/DebugLog/DebugLogModalTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/DebugLog/DebugLogModalTests.cs
@@ -404,7 +404,7 @@ public sealed class DebugLogModalTests : BunitContext
     }
 
     [Fact]
-    public async Task DebugLogModal_ExportClick_CallsSaveAsyncWithEnvironmentNewLineJoinedDisplayed()
+    public async Task DebugLogModal_ExportClick_CallsSaveStreamingAsyncWithEnvironmentNewLineJoinedDisplayed()
     {
         // Arrange
         var lines = new[]
@@ -415,12 +415,13 @@ public sealed class DebugLogModalTests : BunitContext
 
         _fileLogger.LoadAsync(Arg.Any<CancellationToken>()).Returns(DebugLogUtils.ToAsyncEnumerable(lines));
 
-        Func<Stream, Task>? capturedWriter = null;
+        Func<Stream, CancellationToken, Task>? capturedWriter = null;
 
-        _fileSaveService.SaveAsync(
+        _fileSaveService.SaveStreamingAsync(
                 Arg.Any<string>(),
                 Arg.Any<IReadOnlyDictionary<string, IReadOnlyList<string>>>(),
-                Arg.Do<Func<Stream, Task>>(writer => capturedWriter = writer))
+                Arg.Do<Func<Stream, CancellationToken, Task>>(writer => capturedWriter = writer),
+                Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<string?>("C:\\debug-log.log"));
 
         var component = Render<DebugLogModal>();
@@ -434,10 +435,11 @@ public sealed class DebugLogModalTests : BunitContext
         await component.Find("button:contains('Export')").ClickAsync(new MouseEventArgs());
 
         // Assert
-        await _fileSaveService.Received(1).SaveAsync(
+        await _fileSaveService.Received(1).SaveStreamingAsync(
             Arg.Is<string>(name => name.StartsWith("debug-log-") && name.EndsWith(".log")),
             FileSaveFileTypes.Log,
-            Arg.Any<Func<Stream, Task>>());
+            Arg.Any<Func<Stream, CancellationToken, Task>>(),
+            Arg.Any<CancellationToken>());
 
         Assert.NotNull(capturedWriter);
         Assert.Equal(expectedContent, await InvokeWriterAndDecodeAsync(capturedWriter));
@@ -456,12 +458,13 @@ public sealed class DebugLogModalTests : BunitContext
 
         _fileLogger.LoadAsync(Arg.Any<CancellationToken>()).Returns(DebugLogUtils.ToAsyncEnumerable(lines));
 
-        Func<Stream, Task>? capturedWriter = null;
+        Func<Stream, CancellationToken, Task>? capturedWriter = null;
 
-        _fileSaveService.SaveAsync(
+        _fileSaveService.SaveStreamingAsync(
                 Arg.Any<string>(),
                 Arg.Any<IReadOnlyDictionary<string, IReadOnlyList<string>>>(),
-                Arg.Do<Func<Stream, Task>>(writer => capturedWriter = writer))
+                Arg.Do<Func<Stream, CancellationToken, Task>>(writer => capturedWriter = writer),
+                Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<string?>("C:\\debug-log.log"));
 
         var component = Render<DebugLogModal>();
@@ -474,10 +477,11 @@ public sealed class DebugLogModalTests : BunitContext
         await component.Find("button:contains('Export')").ClickAsync(new MouseEventArgs());
 
         // Assert
-        await _fileSaveService.Received(1).SaveAsync(
+        await _fileSaveService.Received(1).SaveStreamingAsync(
             Arg.Any<string>(),
             FileSaveFileTypes.Log,
-            Arg.Any<Func<Stream, Task>>());
+            Arg.Any<Func<Stream, CancellationToken, Task>>(),
+            Arg.Any<CancellationToken>());
 
         Assert.NotNull(capturedWriter);
         Assert.Equal(lines[1], await InvokeWriterAndDecodeAsync(capturedWriter));
@@ -490,10 +494,11 @@ public sealed class DebugLogModalTests : BunitContext
         var lines = new[] { DebugLogUtils.BuildLine(LogLevel.Information, Constants.DebugLogTestMessage) };
 
         _fileLogger.LoadAsync(Arg.Any<CancellationToken>()).Returns(DebugLogUtils.ToAsyncEnumerable(lines));
-        _fileSaveService.SaveAsync(
+        _fileSaveService.SaveStreamingAsync(
                 Arg.Any<string>(),
                 Arg.Any<IReadOnlyDictionary<string, IReadOnlyList<string>>>(),
-                Arg.Any<Func<Stream, Task>>())
+                Arg.Any<Func<Stream, CancellationToken, Task>>(),
+                Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<string?>(null));
 
         var component = Render<DebugLogModal>();
@@ -516,10 +521,11 @@ public sealed class DebugLogModalTests : BunitContext
         var lines = new[] { DebugLogUtils.BuildLine(LogLevel.Information, Constants.DebugLogTestMessage) };
 
         _fileLogger.LoadAsync(Arg.Any<CancellationToken>()).Returns(DebugLogUtils.ToAsyncEnumerable(lines));
-        _fileSaveService.SaveAsync(
+        _fileSaveService.SaveStreamingAsync(
                 Arg.Any<string>(),
                 Arg.Any<IReadOnlyDictionary<string, IReadOnlyList<string>>>(),
-                Arg.Any<Func<Stream, Task>>())
+                Arg.Any<Func<Stream, CancellationToken, Task>>(),
+                Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("disk full"));
 
         var component = Render<DebugLogModal>();
@@ -996,11 +1002,11 @@ public sealed class DebugLogModalTests : BunitContext
         }
     }
 
-    private static async Task<string> InvokeWriterAndDecodeAsync(Func<Stream, Task> writer)
+    private static async Task<string> InvokeWriterAndDecodeAsync(Func<Stream, CancellationToken, Task> writer)
     {
         using var stream = new MemoryStream();
 
-        await writer(stream);
+        await writer(stream, CancellationToken.None);
 
         return Encoding.UTF8.GetString(stream.ToArray());
     }

--- a/tests/Unit/EventLogExpert.UI.Tests/TestUtils/BannerHostDependenciesExtensions.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/TestUtils/BannerHostDependenciesExtensions.cs
@@ -36,6 +36,10 @@ internal static class BannerHostDependenciesExtensions
             progress.BackgroundProgress.Returns((BannerProgressEntry?)null);
             services.AddSingleton(progress);
 
+            var exportProgress = Substitute.For<IExportProgressBannerService>();
+            exportProgress.CurrentExport.Returns((ExportProgressEntry?)null);
+            services.AddSingleton(exportProgress);
+
             var modalCoordinator = Substitute.For<IModalCoordinator>();
             modalCoordinator.ActiveSession.Returns((ModalSession?)null);
             services.AddSingleton(modalCoordinator);

--- a/tests/Unit/EventLogExpert.UI.Tests/TestUtils/BannerSubstituteExtensions.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/TestUtils/BannerSubstituteExtensions.cs
@@ -8,7 +8,7 @@ using NSubstitute;
 namespace EventLogExpert.UI.Tests.TestUtils;
 
 /// <summary>
-///     Test helper that creates substitutes for all 5 banner facets and registers them in a single call. Intended for
+///     Test helper that creates substitutes for all 6 banner facets and registers them in a single call. Intended for
 ///     tests (e.g. <c>BannerHostTests</c>) that exercise multiple facets together. Tests that only touch one or two facets
 ///     should use direct <c>Substitute.For&lt;IXyzBannerService&gt;()</c> to keep per-test facet usage visible at the call
 ///     site.
@@ -19,18 +19,21 @@ internal static class BannerSubstituteExtensions
         this IServiceCollection services,
         out IAttentionBannerService attention,
         out IProgressBannerService progress,
+        out IExportProgressBannerService exportProgress,
         out ICriticalErrorService critical,
         out IErrorBannerService error,
         out IInfoBannerService info)
     {
         attention = Substitute.For<IAttentionBannerService>();
         progress = Substitute.For<IProgressBannerService>();
+        exportProgress = Substitute.For<IExportProgressBannerService>();
         critical = Substitute.For<ICriticalErrorService>();
         error = Substitute.For<IErrorBannerService>();
         info = Substitute.For<IInfoBannerService>();
 
         services.AddSingleton(attention);
         services.AddSingleton(progress);
+        services.AddSingleton(exportProgress);
         services.AddSingleton(critical);
         services.AddSingleton(error);
         services.AddSingleton(info);


### PR DESCRIPTION
## Summary

Adds the ability to export the current filtered event view to CSV or JSON from the menu, with a non-blocking, cancelable progress banner and a completion notification.

Delivered in four increments:

1. **Bounded-memory streaming export sink** - streams rows directly to the destination stream without buffering the full result set; backpressure-safe.
2. **Filtered view to CSV/JSON export** - exports the active tab's filtered events, respecting the active filter and the visible/ordered columns; sortable date-time (yyyy-MM-dd HH:mm:ss) timestamps; CSV formula-injection neutralization; atomic same-folder replace with a best-effort provider-backed fallback; empty-events and empty-columns guards.
3. **Description column + completion notification** - includes the always-on Description column (previously omitted because it is not a toggleable column) and shows an "Export complete" banner with the exported row count and path.
4. **Cancelable progress banner** - an indeterminate spinner banner during the streaming write with a Cancel button. Explicit cancel shows "Export canceled" and the partial file is cleaned up; dismissing the save picker stays silent; a re-entry guard prevents overlapping exports.

## Testing

- Runtime unit tests: 1474 pass
- UI unit tests: 841 pass
- MAUI head builds with 0 warnings (TreatWarningsAsErrors)

## On-device verification (head-only StorageFile path, not unit-testable here)

- [x] Spinner "Exporting events..." shows during the streaming write
- [x] Cancel during streaming: "Export canceled" and the partial file is removed
- [x] Cancel right as it finishes: "Export complete" (the late-cancel-during-commit is a no-op)
- [x] Save picker dismissed: no banner (silent)
- [x] Second export while one is running: "An export is already in progress."
- [x] Successful save: "Export complete" with correct count + full path
- [x] Exported CSV/JSON contains a populated trailing Description column
