### PR TITLE
Add an empty-state scenario dashboard with favorites and master-detail browser

### DIFF
--- a/src/EventLogExpert.Runtime/DependencyInjection/RuntimeServiceCollectionExtensions.cs
+++ b/src/EventLogExpert.Runtime/DependencyInjection/RuntimeServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ using EventLogExpert.Runtime.LogTable;
 using EventLogExpert.Runtime.Menu;
 using EventLogExpert.Runtime.Modal;
 using EventLogExpert.Runtime.Scenarios;
+using EventLogExpert.Runtime.Scenarios.Favorites;
 using EventLogExpert.Runtime.Settings;
 using EventLogExpert.Runtime.Update;
 using EventLogExpert.Runtime.Update.Deployment;
@@ -126,6 +127,11 @@ public static class RuntimeServiceCollectionExtensions
         ///             implementation.
         ///         </item>
         ///         <item>
+        ///             <c>IScenarioFavoriteStore</c> - the scenario favorites effects depend on it. Register the default
+        ///             SQLite-backed store via <c>services.AddScenarioFavoriteSqliteStore(<i>dbPath</i>)</c>, or supply a custom
+        ///             implementation.
+        ///         </item>
+        ///         <item>
         ///             <c>IMenuActionService</c> - the scenario launch service depends on it to open a scenario's channels. The
         ///             host registers the concrete implementation (e.g., <c>MauiMenuActionService</c>).
         ///         </item>
@@ -144,6 +150,7 @@ public static class RuntimeServiceCollectionExtensions
             services.AddSingleton<IFilterLibraryCommands, FilterLibraryCommands>();
             services.AddSingleton<IFilterPaneCommands, FilterPaneCommands>();
             services.AddSingleton<ILogTableCommands, LogTableCommands>();
+            services.AddSingleton<IScenarioFavoriteCommands, ScenarioFavoriteCommands>();
 
             // Shared coordination state for EventLog effects classes.
             services.AddSingleton<LogCloseCoordinator>();

--- a/src/EventLogExpert.Runtime/FilterPane/Effects.cs
+++ b/src/EventLogExpert.Runtime/FilterPane/Effects.cs
@@ -71,6 +71,13 @@ internal sealed class Effects
         return Task.CompletedTask;
     }
 
+    [EffectMethod(typeof(RestoreFilterPaneStateAction))]
+    public Task HandleRestoreFilterPaneState(IDispatcher dispatcher)
+    {
+        UpdateEventTableFilters(_filterPaneState.Value, dispatcher);
+        return Task.CompletedTask;
+    }
+
     [EffectMethod]
     public Task HandleSetFilter(SetFilterAction action, IDispatcher dispatcher)
     {

--- a/src/EventLogExpert.Runtime/FilterPane/Reducers.cs
+++ b/src/EventLogExpert.Runtime/FilterPane/Reducers.cs
@@ -63,6 +63,10 @@ internal sealed class Reducers
     }
 
     [ReducerMethod]
+    public static FilterPaneState ReduceRestoreFilterPaneState(FilterPaneState state, RestoreFilterPaneStateAction action) =>
+        action.State;
+
+    [ReducerMethod]
     public static FilterPaneState ReduceSetFilter(FilterPaneState state, SetFilterAction action)
     {
         // Upsert: replace-by-Id (preserving position) or append.

--- a/src/EventLogExpert.Runtime/FilterPane/RestoreFilterPaneStateAction.cs
+++ b/src/EventLogExpert.Runtime/FilterPane/RestoreFilterPaneStateAction.cs
@@ -1,0 +1,6 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.FilterPane;
+
+internal sealed record RestoreFilterPaneStateAction(FilterPaneState State);

--- a/src/EventLogExpert.Runtime/Scenarios/Favorites/Effects.cs
+++ b/src/EventLogExpert.Runtime/Scenarios/Favorites/Effects.cs
@@ -1,0 +1,78 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.Announcement;
+using Fluxor;
+using System.Collections.Immutable;
+
+namespace EventLogExpert.Runtime.Scenarios.Favorites;
+
+internal sealed class Effects(
+    IScenarioFavoriteStore store,
+    IState<ScenarioFavoritesState> state,
+    IAnnouncementService announcementService,
+    ITraceLogger logger)
+{
+    private readonly SemaphoreSlim _writeGate = new(initialCount: 1, maxCount: 1);
+
+    [EffectMethod(typeof(LoadScenarioFavoritesAction))]
+    public async Task HandleLoadScenarioFavorites(IDispatcher dispatcher)
+    {
+        if (state.Value.IsLoaded) { return; }
+
+        await _writeGate.WaitAsync().ConfigureAwait(false);
+
+        try
+        {
+            if (state.Value.IsLoaded) { return; }
+
+            var ids = await store.LoadAllAsync().ConfigureAwait(false);
+            dispatcher.Dispatch(new LoadScenarioFavoritesSuccessAction(ids.ToImmutableHashSet(StringComparer.Ordinal)));
+        }
+        catch (Exception ex)
+        {
+            logger.Warning($"ScenarioFavorites load failed. {ex.Message}");
+        }
+        finally
+        {
+            _writeGate.Release();
+        }
+    }
+
+    [EffectMethod]
+    public async Task HandleSetScenarioFavorite(SetScenarioFavoriteAction action, IDispatcher dispatcher)
+    {
+        if (state.Value.FavoriteScenarioIds.Contains(action.ScenarioId) == action.IsFavorite) { return; }
+
+        await _writeGate.WaitAsync().ConfigureAwait(false);
+
+        try
+        {
+            if (state.Value.FavoriteScenarioIds.Contains(action.ScenarioId) == action.IsFavorite) { return; }
+
+            if (action.IsFavorite)
+            {
+                await store.AddAsync(action.ScenarioId).ConfigureAwait(false);
+            }
+            else
+            {
+                await store.DeleteAsync(action.ScenarioId).ConfigureAwait(false);
+            }
+
+            announcementService.Announce(action.IsFavorite
+                ? $"Added {action.ScenarioName} to favorites"
+                : $"Removed {action.ScenarioName} from favorites");
+
+            dispatcher.Dispatch(new SetScenarioFavoriteSuccessAction(action.ScenarioId, action.ScenarioName, action.IsFavorite));
+        }
+        catch (Exception ex)
+        {
+            logger.Warning($"ScenarioFavorites set failed for {action.ScenarioId}. {ex.Message}");
+        }
+        finally
+        {
+            _writeGate.Release();
+        }
+    }
+}

--- a/src/EventLogExpert.Runtime/Scenarios/Favorites/IScenarioFavoriteCommands.cs
+++ b/src/EventLogExpert.Runtime/Scenarios/Favorites/IScenarioFavoriteCommands.cs
@@ -1,0 +1,11 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Scenarios.Favorites;
+
+public interface IScenarioFavoriteCommands
+{
+    void Load();
+
+    void SetFavorite(string scenarioId, string scenarioName, bool isFavorite);
+}

--- a/src/EventLogExpert.Runtime/Scenarios/Favorites/IScenarioFavoriteStore.cs
+++ b/src/EventLogExpert.Runtime/Scenarios/Favorites/IScenarioFavoriteStore.cs
@@ -1,0 +1,13 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Scenarios.Favorites;
+
+internal interface IScenarioFavoriteStore
+{
+    Task AddAsync(string scenarioId, CancellationToken cancellationToken = default);
+
+    Task DeleteAsync(string scenarioId, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<string>> LoadAllAsync(CancellationToken cancellationToken = default);
+}

--- a/src/EventLogExpert.Runtime/Scenarios/Favorites/LoadScenarioFavoritesAction.cs
+++ b/src/EventLogExpert.Runtime/Scenarios/Favorites/LoadScenarioFavoritesAction.cs
@@ -1,0 +1,6 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Scenarios.Favorites;
+
+internal sealed record LoadScenarioFavoritesAction;

--- a/src/EventLogExpert.Runtime/Scenarios/Favorites/LoadScenarioFavoritesSuccessAction.cs
+++ b/src/EventLogExpert.Runtime/Scenarios/Favorites/LoadScenarioFavoritesSuccessAction.cs
@@ -1,0 +1,8 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Collections.Immutable;
+
+namespace EventLogExpert.Runtime.Scenarios.Favorites;
+
+internal sealed record LoadScenarioFavoritesSuccessAction(ImmutableHashSet<string> FavoriteScenarioIds);

--- a/src/EventLogExpert.Runtime/Scenarios/Favorites/Reducers.cs
+++ b/src/EventLogExpert.Runtime/Scenarios/Favorites/Reducers.cs
@@ -1,0 +1,26 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Fluxor;
+
+namespace EventLogExpert.Runtime.Scenarios.Favorites;
+
+internal sealed class Reducers
+{
+    [ReducerMethod]
+    public static ScenarioFavoritesState ReduceLoadScenarioFavoritesSuccess(
+        ScenarioFavoritesState state,
+        LoadScenarioFavoritesSuccessAction action) =>
+        state with { FavoriteScenarioIds = action.FavoriteScenarioIds, IsLoaded = true };
+
+    [ReducerMethod]
+    public static ScenarioFavoritesState ReduceSetScenarioFavoriteSuccess(
+        ScenarioFavoritesState state,
+        SetScenarioFavoriteSuccessAction action) =>
+        state with
+        {
+            FavoriteScenarioIds = action.IsFavorite
+                ? state.FavoriteScenarioIds.Add(action.ScenarioId)
+                : state.FavoriteScenarioIds.Remove(action.ScenarioId),
+        };
+}

--- a/src/EventLogExpert.Runtime/Scenarios/Favorites/ScenarioFavoriteCommands.cs
+++ b/src/EventLogExpert.Runtime/Scenarios/Favorites/ScenarioFavoriteCommands.cs
@@ -1,0 +1,14 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Fluxor;
+
+namespace EventLogExpert.Runtime.Scenarios.Favorites;
+
+internal sealed class ScenarioFavoriteCommands(IDispatcher dispatcher) : IScenarioFavoriteCommands
+{
+    public void Load() => dispatcher.Dispatch(new LoadScenarioFavoritesAction());
+
+    public void SetFavorite(string scenarioId, string scenarioName, bool isFavorite) =>
+        dispatcher.Dispatch(new SetScenarioFavoriteAction(scenarioId, scenarioName, isFavorite));
+}

--- a/src/EventLogExpert.Runtime/Scenarios/Favorites/ScenarioFavoriteServiceCollectionExtensions.cs
+++ b/src/EventLogExpert.Runtime/Scenarios/Favorites/ScenarioFavoriteServiceCollectionExtensions.cs
@@ -1,0 +1,22 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EventLogExpert.Runtime.Scenarios.Favorites;
+
+public static class ScenarioFavoriteServiceCollectionExtensions
+{
+    extension(IServiceCollection services)
+    {
+        public IServiceCollection AddScenarioFavoriteSqliteStore(string dbPath)
+        {
+            ArgumentNullException.ThrowIfNull(services);
+            ArgumentException.ThrowIfNullOrWhiteSpace(dbPath);
+
+            services.AddSingleton<IScenarioFavoriteStore>(_ => new ScenarioFavoriteSqliteStore(dbPath));
+
+            return services;
+        }
+    }
+}

--- a/src/EventLogExpert.Runtime/Scenarios/Favorites/ScenarioFavoriteSqliteStore.cs
+++ b/src/EventLogExpert.Runtime/Scenarios/Favorites/ScenarioFavoriteSqliteStore.cs
@@ -1,0 +1,113 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Microsoft.Data.Sqlite;
+using System.Globalization;
+
+namespace EventLogExpert.Runtime.Scenarios.Favorites;
+
+internal sealed class ScenarioFavoriteSqliteStore : IScenarioFavoriteStore
+{
+    private const string CreateTableSql = """
+                                          CREATE TABLE IF NOT EXISTS favorite_scenarios (
+                                              scenario_id TEXT PRIMARY KEY,
+                                              created_utc TEXT NOT NULL
+                                          );
+                                          """;
+
+    private const string DeleteSql = "DELETE FROM favorite_scenarios WHERE scenario_id = $id;";
+
+    private const string InsertOrIgnoreSql = """
+                                             INSERT OR IGNORE INTO favorite_scenarios (scenario_id, created_utc)
+                                             VALUES ($id, $created);
+                                             """;
+
+    private const string LoadAllSql = "SELECT scenario_id FROM favorite_scenarios ORDER BY created_utc;";
+
+    private readonly string _connectionString;
+    private readonly string _dbPath;
+
+    public ScenarioFavoriteSqliteStore(string dbPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(dbPath);
+
+        _dbPath = dbPath;
+        _connectionString = new SqliteConnectionStringBuilder { DataSource = dbPath }.ToString();
+    }
+
+    public async Task AddAsync(string scenarioId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(scenarioId);
+
+        await using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = InsertOrIgnoreSql;
+        cmd.Parameters.AddWithValue("$id", scenarioId);
+        cmd.Parameters.AddWithValue("$created", DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture));
+        await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task DeleteAsync(string scenarioId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(scenarioId);
+
+        await using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = DeleteSql;
+        cmd.Parameters.AddWithValue("$id", scenarioId);
+        await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<string>> LoadAllAsync(CancellationToken cancellationToken = default)
+    {
+        await using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = LoadAllSql;
+
+        var ids = new List<string>();
+        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            ids.Add(reader.GetString(0));
+        }
+
+        return ids;
+    }
+
+    private async Task<SqliteConnection> OpenConnectionAsync(CancellationToken cancellationToken)
+    {
+        var dir = Path.GetDirectoryName(_dbPath);
+
+        if (!string.IsNullOrEmpty(dir)) { Directory.CreateDirectory(dir); }
+
+        SqliteConnection? connection = null;
+
+        try
+        {
+            connection = new SqliteConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            await using (var pragmaCmd = connection.CreateCommand())
+            {
+                pragmaCmd.CommandText = "PRAGMA busy_timeout=5000;";
+                await pragmaCmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            await using (var schemaCmd = connection.CreateCommand())
+            {
+                schemaCmd.CommandText = CreateTableSql;
+                await schemaCmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            var result = connection;
+            connection = null;
+
+            return result;
+        }
+        finally
+        {
+            if (connection is not null) { await connection.DisposeAsync().ConfigureAwait(false); }
+        }
+    }
+}

--- a/src/EventLogExpert.Runtime/Scenarios/Favorites/ScenarioFavoritesState.cs
+++ b/src/EventLogExpert.Runtime/Scenarios/Favorites/ScenarioFavoritesState.cs
@@ -1,0 +1,15 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Fluxor;
+using System.Collections.Immutable;
+
+namespace EventLogExpert.Runtime.Scenarios.Favorites;
+
+[FeatureState]
+public sealed record ScenarioFavoritesState
+{
+    public ImmutableHashSet<string> FavoriteScenarioIds { get; init; } = [];
+
+    public bool IsLoaded { get; init; }
+}

--- a/src/EventLogExpert.Runtime/Scenarios/Favorites/SetScenarioFavoriteAction.cs
+++ b/src/EventLogExpert.Runtime/Scenarios/Favorites/SetScenarioFavoriteAction.cs
@@ -1,0 +1,6 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Scenarios.Favorites;
+
+internal sealed record SetScenarioFavoriteAction(string ScenarioId, string ScenarioName, bool IsFavorite);

--- a/src/EventLogExpert.Runtime/Scenarios/Favorites/SetScenarioFavoriteSuccessAction.cs
+++ b/src/EventLogExpert.Runtime/Scenarios/Favorites/SetScenarioFavoriteSuccessAction.cs
@@ -1,0 +1,6 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Scenarios.Favorites;
+
+internal sealed record SetScenarioFavoriteSuccessAction(string ScenarioId, string ScenarioName, bool IsFavorite);

--- a/src/EventLogExpert.Runtime/Scenarios/ScenarioLaunchService.cs
+++ b/src/EventLogExpert.Runtime/Scenarios/ScenarioLaunchService.cs
@@ -13,9 +13,11 @@ namespace EventLogExpert.Runtime.Scenarios;
 internal sealed class ScenarioLaunchService(
     BuiltInScenarioRegistry registry,
     IMenuActionService menuActionService,
+    IState<FilterPaneState> filterPaneState,
     IDispatcher dispatcher) : IScenarioLaunchService
 {
     private readonly IDispatcher _dispatcher = dispatcher;
+    private readonly IState<FilterPaneState> _filterPaneState = filterPaneState;
     private readonly IMenuActionService _menuActionService = menuActionService;
     private readonly BuiltInScenarioRegistry _registry = registry;
 
@@ -25,6 +27,8 @@ internal sealed class ScenarioLaunchService(
         bool combineLog = false)
     {
         ArgumentNullException.ThrowIfNull(scenario);
+
+        var priorFilterState = _filterPaneState.Value;
 
         var filters = _registry.BuildFilterSet(scenario);
 
@@ -36,6 +40,7 @@ internal sealed class ScenarioLaunchService(
         if (result.Opened == 0 && !combineLog)
         {
             _dispatcher.Dispatch(new CloseAllLogsAction());
+            _dispatcher.Dispatch(new RestoreFilterPaneStateAction(priorFilterState));
         }
 
         return new ScenarioLaunchResult(result.Opened, result.Empty, result.Failed);

--- a/src/EventLogExpert.UI/Dashboard/EmptyStateDashboard.razor
+++ b/src/EventLogExpert.UI/Dashboard/EmptyStateDashboard.razor
@@ -1,0 +1,89 @@
+@inherits FluxorComponent
+
+<section aria-labelledby="empty-dashboard-title" class="empty-dashboard" role="region">
+    <header class="empty-dashboard__masthead">
+        <div class="empty-dashboard__brand">
+            <span aria-hidden="true" class="empty-dashboard__brand-mark"><i class="bi bi-journal-text"></i></span>
+            <div>
+                <h1 class="empty-dashboard__title" id="empty-dashboard-title">EventLogExpert</h1>
+                <p class="empty-dashboard__lead">Open a log to get started, or jump straight into a common investigation.</p>
+            </div>
+        </div>
+        <div class="empty-dashboard__masthead-actions">
+            @if (FilterApplied.Value)
+            {
+                <div class="empty-dashboard__chip" role="status">
+                    <i aria-hidden="true" class="bi bi-funnel"></i>
+                    <span class="empty-dashboard__chip-text">A filter is still applied and will affect your next open.</span>
+                    <button class="button" disabled="@_isBusy" @onclick="ClearFilter" type="button">Clear filter</button>
+                </div>
+            }
+            <button class="empty-dashboard__utility" disabled="@_isBusy" @onclick="OpenDatabaseToolsAsync" type="button">
+                <i aria-hidden="true" class="bi bi-database-gear"></i><span>Manage databases...</span>
+            </button>
+        </div>
+    </header>
+
+    <section aria-labelledby="empty-dashboard-quickstart-heading" class="empty-dashboard__section">
+        <h2 class="empty-dashboard__heading" id="empty-dashboard-quickstart-heading">Quick Launch</h2>
+        <div class="empty-dashboard__launchbar">
+            <button aria-label="Open Application + System (live)" class="empty-dashboard__launch empty-dashboard__launch--primary" disabled="@_isBusy" @onclick="OpenApplicationAndSystemAsync" type="button">
+                <i aria-hidden="true" class="bi bi-collection"></i><span>Application + System (live)</span>
+            </button>
+            <button aria-label="Open Application (live)" class="empty-dashboard__launch" disabled="@_isBusy" @onclick="OpenApplicationAsync" type="button">
+                <i aria-hidden="true" class="bi bi-window"></i><span>Application (live)</span>
+            </button>
+            <button aria-label="Open System (live)" class="empty-dashboard__launch" disabled="@_isBusy" @onclick="OpenSystemAsync" type="button">
+                <i aria-hidden="true" class="bi bi-pc-display"></i><span>System (live)</span>
+            </button>
+            @if (Version.IsAdmin)
+            {
+                <button aria-label="Open Security (live)" class="empty-dashboard__launch" disabled="@_isBusy" @onclick="OpenSecurityAsync" type="button">
+                    <i aria-hidden="true" class="bi bi-shield-lock"></i><span>Security (live)</span>
+                </button>
+            }
+            else
+            {
+                <button aria-describedby="@ElevationReasonId" aria-disabled="true" aria-label="Open Security (live)" class="empty-dashboard__launch empty-dashboard__launch--disabled" type="button">
+                    <i aria-hidden="true" class="bi bi-shield-lock"></i><span>Security (live)</span>
+                </button>
+            }
+            <span aria-hidden="true" class="empty-dashboard__launch-divider"></span>
+            <button aria-label="Open Log file..." class="empty-dashboard__launch" disabled="@_isBusy" @onclick="OpenFileAsync" type="button">
+                <i aria-hidden="true" class="bi bi-file-earmark-text"></i><span>Log file...</span>
+            </button>
+            <button aria-label="Open Folder..." class="empty-dashboard__launch" disabled="@_isBusy" @onclick="OpenFolderAsync" type="button">
+                <i aria-hidden="true" class="bi bi-folder2-open"></i><span>Folder...</span>
+            </button>
+        </div>
+    </section>
+
+    <div class="empty-dashboard__catalog">
+        @if (_splashScenarios is null)
+        {
+            <p class="empty-dashboard__loading">Loading scenarios...</p>
+        }
+        else if (_categories.Count == 0)
+        {
+            <p class="empty-dashboard__empty" role="status">No scenarios are available for this machine.</p>
+        }
+        else
+        {
+            <SidebarTabs @bind-ActiveTab="_activeCategory" @ref="_sidebarTabs" TablistAriaLabel="Scenario categories" Tabs="_tabs" TTab="SplashCategory">
+                <TabContent Context="category">
+                    <ScenarioBrowserPanel ElevationReasonId="@ElevationReasonId"
+                        IsBusy="_isBusy"
+                        IsFavored="IsFavored"
+                        IsScenarioDisabled="IsScenarioDisabled"
+                        OnLaunch="LaunchScenarioAsync"
+                        OnSelect="scenario => Select(category, scenario)"
+                        OnToggleFavorite="ToggleFavorite"
+                        Scenarios="ScenariosFor(category)"
+                        Selected="_selectedByCategory.GetValueOrDefault(category)" />
+                </TabContent>
+            </SidebarTabs>
+        }
+    </div>
+
+    <span class="empty-dashboard__sr-only" id="@ElevationReasonId">Requires running as administrator.</span>
+</section>

--- a/src/EventLogExpert.UI/Dashboard/EmptyStateDashboard.razor.cs
+++ b/src/EventLogExpert.UI/Dashboard/EmptyStateDashboard.razor.cs
@@ -1,0 +1,304 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Runtime.Announcement;
+using EventLogExpert.Runtime.Common.Versioning;
+using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.FilterPane;
+using EventLogExpert.Runtime.Menu;
+using EventLogExpert.Runtime.Scenarios;
+using EventLogExpert.Runtime.Scenarios.Favorites;
+using EventLogExpert.Scenarios.Catalog;
+using EventLogExpert.UI.Modal;
+using Fluxor;
+using Fluxor.Blazor.Web.Components;
+using Microsoft.AspNetCore.Components;
+using System.Collections.Immutable;
+
+namespace EventLogExpert.UI.Dashboard;
+
+public sealed partial class EmptyStateDashboard : FluxorComponent
+{
+    private const string ElevationReasonId = "empty-dashboard-elevation-reason";
+
+    internal static readonly ImmutableArray<string> StarterScenarioIds =
+    [
+        "recent-critical-and-error-events",
+        "unexpected-restart-power-loss-bsod",
+        "failed-services-at-boot",
+        "disk-io-errors-bad-blocks",
+        "application-crashes",
+        "application-hangs",
+        "dotnet-unhandled-exceptions",
+        "windows-update-diagnostics",
+        "group-policy-processing-errors"
+    ];
+
+    private readonly Dictionary<SplashCategory, ScenarioDefinition?> _selectedByCategory = new();
+
+    private SplashCategory _activeCategory;
+    private List<(SplashCategory Category, string Label, IReadOnlyList<ScenarioDefinition> Scenarios)> _categories = [];
+    private bool _isBusy;
+    private bool _pendingTabFocus;
+    private SidebarTabs<SplashCategory>? _sidebarTabs;
+    private IReadOnlyList<ScenarioDefinition>? _splashScenarios;
+    private IReadOnlyList<(SplashCategory Tab, string Label)> _tabs = [];
+
+    [Inject] private IMenuActionService Actions { get; init; } = null!;
+
+    [Inject] private IAnnouncementService Announcer { get; init; } = null!;
+
+    [Inject] private IScenarioFavoriteCommands FavoriteCommands { get; init; } = null!;
+
+    [Inject] private IStateSelection<ScenarioFavoritesState, ImmutableHashSet<string>> Favorites { get; init; } = null!;
+
+    [Inject] private IStateSelection<EventLogState, bool> FilterApplied { get; init; } = null!;
+
+    [Inject] private IFilterPaneCommands FilterCommands { get; init; } = null!;
+
+    [Inject] private IState<ScenarioFavoritesState> ScenarioFavorites { get; init; } = null!;
+
+    [Inject] private IScenarioLaunchService ScenarioLaunch { get; init; } = null!;
+
+    [Inject] private IScenarioQueryService ScenarioQuery { get; init; } = null!;
+
+    [Inject] private ICurrentVersionProvider Version { get; init; } = null!;
+
+    internal static string ScenarioIcon(ScenarioGroup group) => group switch
+    {
+        ScenarioGroup.SystemHealth => "bi-heart-pulse",
+        ScenarioGroup.Applications => "bi-window-stack",
+        ScenarioGroup.Security => "bi-shield-lock",
+        ScenarioGroup.ThreatsAndIncidentResponse => "bi-shield-exclamation",
+        ScenarioGroup.Network => "bi-diagram-3",
+        ScenarioGroup.Storage => "bi-hdd-stack",
+        ScenarioGroup.UpdatesAndPolicy => "bi-arrow-repeat",
+        ScenarioGroup.ActiveDirectory => "bi-diagram-2",
+        ScenarioGroup.DnsServer => "bi-signpost-split",
+        ScenarioGroup.DhcpServer => "bi-ethernet",
+        ScenarioGroup.NpsAndRras => "bi-shield-check",
+        ScenarioGroup.Wins => "bi-hdd-network",
+        ScenarioGroup.WebAndIis => "bi-globe2",
+        ScenarioGroup.VirtualizationAndClustering => "bi-hdd-rack",
+        ScenarioGroup.FilePrintAndStorage => "bi-printer",
+        ScenarioGroup.SqlServer => "bi-database",
+        ScenarioGroup.Exchange => "bi-envelope",
+        ScenarioGroup.SharePoint => "bi-folder-symlink",
+        ScenarioGroup.DefenderForEndpoint => "bi-shield-shaded",
+        ScenarioGroup.Office => "bi-file-earmark-richtext",
+        _ => "bi-search"
+    };
+
+    protected override async ValueTask DisposeAsyncCore(bool disposing)
+    {
+        if (disposing)
+        {
+            Favorites.SelectedValueChanged -= OnFavoritesChanged;
+        }
+
+        await base.DisposeAsyncCore(disposing);
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (_pendingTabFocus && _sidebarTabs is not null)
+        {
+            _pendingTabFocus = false;
+
+            await _sidebarTabs.FocusActiveTabAsync();
+        }
+
+        await base.OnAfterRenderAsync(firstRender);
+    }
+
+    protected override void OnInitialized()
+    {
+        FilterApplied.Select(state => state.AppliedFilter.IsFilteringEnabled);
+        Favorites.Select(state => state.FavoriteScenarioIds);
+        Favorites.SelectedValueChanged += OnFavoritesChanged;
+        FavoriteCommands.Load();
+        base.OnInitialized();
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        _splashScenarios = await Task.Run(ScenarioQuery.GetSplashScenarios);
+        RebuildCategories();
+
+        if (_categories.Count > 0 && !_categories.Any(category => category.Category.Equals(_activeCategory)))
+        {
+            _activeCategory = _categories[0].Category;
+        }
+
+        await base.OnInitializedAsync();
+    }
+
+    private static string DescribeLaunch(ScenarioDefinition scenario, ScenarioLaunchResult result)
+    {
+        if (result.Opened == 0)
+        {
+            return $"No channels could be opened for {scenario.Name}.";
+        }
+
+        return result.Failed > 0
+            ? $"Opened {scenario.Name}; {result.Failed} {(result.Failed == 1 ? "channel" : "channels")} unavailable."
+            : $"Opened {scenario.Name}.";
+    }
+
+    private void ClearFilter() => FilterCommands.ClearAllFilters();
+
+    private IEnumerable<ScenarioDefinition> FavoriteScenarios() =>
+        _splashScenarios is null
+            ? []
+            : _splashScenarios
+                .Where(IsFavored)
+                .OrderBy(scenario => scenario.Priority)
+                .ThenBy(scenario => scenario.Order);
+
+    private bool IsFavored(ScenarioDefinition scenario) =>
+        ScenarioFavorites.Value.FavoriteScenarioIds.Contains(scenario.Id);
+
+    private bool IsScenarioDisabled(ScenarioDefinition scenario) => scenario.RequiresAdmin && !Version.IsAdmin;
+
+    private Task LaunchScenarioAsync(ScenarioDefinition scenario) =>
+        RunGuardedAsync(async () =>
+        {
+            var result = await ScenarioLaunch.LaunchAsync(scenario, null);
+            Announcer.Announce(DescribeLaunch(scenario, result));
+        });
+
+    private async void OnFavoritesChanged(object? _, ImmutableHashSet<string> __)
+    {
+        try
+        {
+            await InvokeAsync(() =>
+            {
+                RebuildCategories();
+                ReconcileActiveTab();
+                StateHasChanged();
+            });
+        }
+        catch (ObjectDisposedException) { }
+        catch (OperationCanceledException) { }
+    }
+
+    private Task OpenApplicationAndSystemAsync() =>
+        RunGuardedAsync(() => Actions.OpenLiveLogsAsync([LogChannelNames.ApplicationLog, LogChannelNames.SystemLog], false));
+
+    private Task OpenApplicationAsync() => RunGuardedAsync(() => Actions.OpenLiveLogAsync(LogChannelNames.ApplicationLog, false));
+
+    private Task OpenDatabaseToolsAsync() => RunGuardedAsync(() => Actions.OpenDatabaseToolsAsync());
+
+    private Task OpenFileAsync() => RunGuardedAsync(() => Actions.OpenFileAsync(false));
+
+    private Task OpenFolderAsync() => RunGuardedAsync(() => Actions.OpenFolderAsync(false));
+
+    private Task OpenSecurityAsync() => RunGuardedAsync(() => Actions.OpenLiveLogAsync(LogChannelNames.SecurityLog, false));
+
+    private Task OpenSystemAsync() => RunGuardedAsync(() => Actions.OpenLiveLogAsync(LogChannelNames.SystemLog, false));
+
+    private void RebuildCategories()
+    {
+        List<(SplashCategory Category, string Label, IReadOnlyList<ScenarioDefinition> Scenarios)> categories = [];
+
+        if (_splashScenarios is not null)
+        {
+            List<ScenarioDefinition> favorites = [.. FavoriteScenarios()];
+
+            if (favorites.Count > 0) { categories.Add((SplashCategory.Favorites, "Favorites", favorites)); }
+
+            List<ScenarioDefinition> recommended = [.. StarterScenarios()];
+
+            if (recommended.Count > 0) { categories.Add((SplashCategory.Recommended, "Recommended", recommended)); }
+
+            foreach (ScenarioGroup group in Enum.GetValues<ScenarioGroup>())
+            {
+                if (SplashCategoryMapping.ToSplashCategory(group) is not { } category) { continue; }
+
+                List<ScenarioDefinition> groupScenarios =
+                [
+                    .. _splashScenarios
+                        .Where(scenario => scenario.Group == group)
+                        .OrderBy(scenario => scenario.Priority)
+                        .ThenBy(scenario => scenario.Order)
+                ];
+
+                if (groupScenarios.Count == 0) { continue; }
+
+                categories.Add((category, group.DisplayName(), groupScenarios));
+            }
+        }
+
+        _categories = categories;
+        _tabs = [.. categories.Select(category => (category.Category, category.Label))];
+
+        HashSet<SplashCategory> present = [.. categories.Select(category => category.Category)];
+
+        foreach (SplashCategory stale in _selectedByCategory.Keys.Where(key => !present.Contains(key)).ToList())
+        {
+            _selectedByCategory.Remove(stale);
+        }
+
+        foreach ((SplashCategory category, _, IReadOnlyList<ScenarioDefinition> scenarios) in categories)
+        {
+            ScenarioDefinition? current = _selectedByCategory.GetValueOrDefault(category);
+
+            bool stillPresent = current is not null &&
+                scenarios.Any(scenario => string.Equals(scenario.Id, current.Id, StringComparison.Ordinal));
+
+            if (!stillPresent)
+            {
+                _selectedByCategory[category] = scenarios.Count > 0 ? scenarios[0] : null;
+            }
+        }
+    }
+
+    private void ReconcileActiveTab()
+    {
+        if (_categories.Count == 0) { return; }
+
+        if (_categories.Any(category => category.Category.Equals(_activeCategory))) { return; }
+
+        _activeCategory = _categories[0].Category;
+        _pendingTabFocus = true;
+    }
+
+    private async Task RunGuardedAsync(Func<Task> action)
+    {
+        if (_isBusy) { return; }
+
+        _isBusy = true;
+
+        try { await action(); }
+        finally { _isBusy = false; }
+    }
+
+    private IReadOnlyList<ScenarioDefinition> ScenariosFor(SplashCategory category)
+    {
+        foreach ((SplashCategory current, _, IReadOnlyList<ScenarioDefinition> scenarios) in _categories)
+        {
+            if (current.Equals(category)) { return scenarios; }
+        }
+
+        return [];
+    }
+
+    private void Select(SplashCategory category, ScenarioDefinition scenario) =>
+        _selectedByCategory[category] = scenario;
+
+    private IEnumerable<ScenarioDefinition> StarterScenarios()
+    {
+        if (_splashScenarios is null) { yield break; }
+
+        foreach (var id in StarterScenarioIds)
+        {
+            var match = _splashScenarios.FirstOrDefault(scenario => scenario.Id == id);
+
+            if (match is not null) { yield return match; }
+        }
+    }
+
+    private void ToggleFavorite(ScenarioDefinition scenario) =>
+        FavoriteCommands.SetFavorite(scenario.Id, scenario.Name, !IsFavored(scenario));
+}

--- a/src/EventLogExpert.UI/Dashboard/EmptyStateDashboard.razor.css
+++ b/src/EventLogExpert.UI/Dashboard/EmptyStateDashboard.razor.css
@@ -1,0 +1,267 @@
+.empty-dashboard {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 0;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.empty-dashboard__masthead {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1.25rem 2rem;
+    border-bottom: 1px solid var(--border-divider);
+    background-color: var(--background-dark);
+}
+
+.empty-dashboard__brand {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.empty-dashboard__brand-mark {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 8px;
+    background-color: color-mix(in srgb, var(--clr-lightblue) 14%, transparent);
+    color: var(--clr-lightblue);
+    font-size: 1.25rem;
+}
+
+.empty-dashboard__title {
+    margin: 0;
+    font-size: 1.6rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.empty-dashboard__lead {
+    margin: 0.15rem 0 0;
+    color: var(--text-secondary);
+}
+
+.empty-dashboard__chip {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 0.75rem;
+    border-left: 3px solid var(--clr-yellow);
+    border-radius: 4px;
+    background-color: var(--surface-inset);
+}
+
+.empty-dashboard__chip > .bi {
+    color: var(--clr-yellow);
+}
+
+.empty-dashboard__chip-text {
+    color: var(--text-primary);
+}
+
+.empty-dashboard__masthead-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.empty-dashboard__utility {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    min-height: var(--control-height);
+    padding: 0.35rem 0.75rem;
+    border: 1px solid var(--border-divider);
+    border-radius: 6px;
+    background-color: transparent;
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: border-color 0.15s ease, color 0.15s ease, background-color 0.15s ease;
+}
+
+.empty-dashboard__utility > .bi {
+    color: var(--clr-lightblue);
+}
+
+.empty-dashboard__utility:hover:not(:disabled) {
+    border-color: var(--clr-lightblue);
+    color: var(--text-primary);
+    background-color: var(--background-darkgray);
+}
+
+.empty-dashboard__utility:focus-visible {
+    outline: 2px solid var(--clr-lightblue);
+    outline-offset: 2px;
+}
+
+.empty-dashboard__utility:disabled {
+    color: var(--clr-placeholder);
+    cursor: default;
+}
+
+.empty-dashboard__section {
+    margin-top: 1.25rem;
+    padding-inline: 2rem;
+}
+
+.empty-dashboard__heading {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin: 0 0 0.75rem;
+    font-size: 0.95rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    color: var(--text-secondary);
+}
+
+.empty-dashboard__heading::before {
+    content: "";
+    flex-shrink: 0;
+    width: 3px;
+    height: 1em;
+    border-radius: 2px;
+    background-color: color-mix(in srgb, var(--clr-lightblue) 40%, transparent);
+}
+
+.empty-dashboard__heading:focus-visible {
+    outline: 2px solid var(--clr-lightblue);
+    outline-offset: 2px;
+    border-radius: 2px;
+}
+
+.empty-dashboard__launchbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.empty-dashboard__launch {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    min-height: var(--control-height);
+    padding: 0.4rem 0.85rem;
+    border: 1px solid var(--border-divider);
+    border-radius: 6px;
+    background-color: transparent;
+    color: var(--text-primary);
+    cursor: pointer;
+    transition: border-color 0.15s ease, background-color 0.15s ease;
+}
+
+.empty-dashboard__launch > .bi {
+    color: var(--clr-lightblue);
+}
+
+.empty-dashboard__launch:hover:not(:disabled):not(.empty-dashboard__launch--disabled):not(.empty-dashboard__launch--primary) {
+    border-color: var(--clr-lightblue);
+    background-color: var(--background-darkgray);
+}
+
+.empty-dashboard__launch--primary {
+    flex-shrink: 0;
+    border-color: var(--clr-lightblue);
+    background-color: var(--clr-lightblue);
+    color: var(--accent-on-fill);
+    font-weight: 600;
+}
+
+.empty-dashboard__launch--primary > .bi {
+    color: var(--accent-on-fill);
+}
+
+.empty-dashboard__launch--primary:hover:not(:disabled) {
+    box-shadow: var(--shadow-menu);
+}
+
+.empty-dashboard__launch:disabled,
+.empty-dashboard__launch--disabled {
+    color: var(--clr-placeholder);
+    cursor: default;
+}
+
+.empty-dashboard__launch--disabled > .bi {
+    color: var(--clr-placeholder);
+}
+
+.empty-dashboard__launch:focus-visible {
+    outline: 2px solid var(--clr-lightblue);
+    outline-offset: 2px;
+}
+
+.empty-dashboard__launch-divider {
+    align-self: stretch;
+    width: 1px;
+    margin: 0.1rem 0.25rem;
+    background-color: var(--border-divider);
+}
+
+.empty-dashboard__catalog {
+    flex: 1 1 0;
+    min-height: 0;
+    padding: 1.25rem 2rem 2rem;
+    overflow: hidden;
+    container-type: inline-size;
+}
+
+.empty-dashboard__catalog ::deep .sidebar-tabs {
+    height: 100%;
+    gap: 0;
+}
+
+.empty-dashboard__catalog ::deep .sidebar-tabs-list {
+    flex: 0 0 13rem;
+    min-height: 0;
+    overflow-x: hidden;
+    overflow-y: auto;
+    padding-right: 0;
+    border-right: 1px solid var(--border-divider);
+    scrollbar-gutter: stable;
+}
+
+.empty-dashboard__catalog ::deep .sidebar-tabs-list .tab {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+    min-height: var(--control-height);
+}
+
+.empty-dashboard__catalog ::deep .sidebar-tabs-list .tab .sidebar-tabs-tab-label {
+    display: -webkit-box;
+    min-width: 0;
+    max-width: 100%;
+    overflow: hidden;
+    line-height: 1.25;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+}
+
+.empty-dashboard__loading {
+    color: var(--text-secondary);
+    font-style: italic;
+}
+
+.empty-dashboard__empty {
+    margin: 0;
+    color: var(--text-secondary);
+}
+
+.empty-dashboard__sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    border: 0;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+}

--- a/src/EventLogExpert.UI/Dashboard/ScenarioBrowserPanel.razor
+++ b/src/EventLogExpert.UI/Dashboard/ScenarioBrowserPanel.razor
@@ -1,0 +1,41 @@
+<div class="scenario-browser" @ref="_scenarioBrowserRootRef">
+    @if (Scenarios.Count == 0)
+    {
+        <p class="scenario-browser__empty" role="status">No scenarios available in this category.</p>
+    }
+    else
+    {
+        <ul aria-label="Scenarios" class="scenario-browser__list" @onkeydown="OnListKeyDownAsync" role="listbox">
+            @foreach (var scenario in Scenarios)
+            {
+                <li aria-describedby="@(IsScenarioDisabled(scenario) ? ElevationReasonId : null)"
+                    aria-disabled="@(IsScenarioDisabled(scenario) ? "true" : "false")"
+                    aria-selected="@(IsSelected(scenario) ? "true" : "false")"
+                    class="@OptionClass(scenario)"
+                    @onclick="() => OnSelect.InvokeAsync(scenario)"
+                    @ref="_optionRefs[scenario.Id]"
+                    role="option"
+                    tabindex="@(IsSelected(scenario) ? "0" : "-1")"
+                    title="@scenario.Purpose">
+                    <span aria-hidden="true" class="scenario-browser__option-icon"><i class="bi @EmptyStateDashboard.ScenarioIcon(scenario.Group)"></i></span>
+                    <span class="scenario-browser__option-body">
+                        <span class="scenario-browser__option-name">@scenario.Name</span>
+                    </span>
+                </li>
+            }
+        </ul>
+
+        <div class="scenario-browser__detail">
+            @if (Selected is not null)
+            {
+                <ScenarioDetail ElevationReasonId="@ElevationReasonId"
+                    IsBusy="IsBusy"
+                    IsDisabled="IsScenarioDisabled(Selected)"
+                    IsFavored="IsFavored(Selected)"
+                    OnLaunch="() => OnLaunch.InvokeAsync(Selected)"
+                    OnToggleFavorite="() => OnToggleFavorite.InvokeAsync(Selected)"
+                    Scenario="Selected" />
+            }
+        </div>
+    }
+</div>

--- a/src/EventLogExpert.UI/Dashboard/ScenarioBrowserPanel.razor.cs
+++ b/src/EventLogExpert.UI/Dashboard/ScenarioBrowserPanel.razor.cs
@@ -1,0 +1,125 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Scenarios.Catalog;
+using EventLogExpert.UI.Common.Interop;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.JSInterop;
+
+namespace EventLogExpert.UI.Dashboard;
+
+public sealed partial class ScenarioBrowserPanel : IAsyncDisposable
+{
+    private readonly Dictionary<string, ElementReference> _optionRefs = new();
+
+    private string? _pendingFocusId;
+    private ElementReference _scenarioBrowserRootRef;
+    private IJSObjectReference? _scrollSuppressorModule;
+
+    [Parameter][EditorRequired] public string ElevationReasonId { get; set; } = string.Empty;
+
+    [Parameter] public bool IsBusy { get; set; }
+
+    [Parameter][EditorRequired] public Func<ScenarioDefinition, bool> IsFavored { get; set; } = static _ => false;
+
+    [Parameter][EditorRequired] public Func<ScenarioDefinition, bool> IsScenarioDisabled { get; set; } = static _ => false;
+
+    [Parameter] public EventCallback<ScenarioDefinition> OnLaunch { get; set; }
+
+    [Parameter] public EventCallback<ScenarioDefinition> OnSelect { get; set; }
+
+    [Parameter] public EventCallback<ScenarioDefinition> OnToggleFavorite { get; set; }
+
+    [Parameter][EditorRequired] public IReadOnlyList<ScenarioDefinition> Scenarios { get; set; } = [];
+
+    [Parameter] public ScenarioDefinition? Selected { get; set; }
+
+    [Inject] private IJSRuntime JSRuntime { get; init; } = null!;
+
+    public async ValueTask DisposeAsync()
+    {
+        await JsModuleInterop.DisposeModuleSafelyAsync(
+            _scrollSuppressorModule,
+            module => module.InvokeVoidAsync("release", _scenarioBrowserRootRef));
+
+        _scrollSuppressorModule = null;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            try
+            {
+                _scrollSuppressorModule = await JSRuntime.InvokeAsync<IJSObjectReference>(
+                    "import",
+                    "./_content/EventLogExpert.UI/Common/keyboardScrollSuppressor.js");
+
+                await _scrollSuppressorModule.InvokeVoidAsync(
+                    "suppress",
+                    _scenarioBrowserRootRef,
+                    new[] { new { selector = "[role='listbox']", keys = new[] { "ArrowUp", "ArrowDown", "Home", "End" } } });
+            }
+            catch (JSDisconnectedException) { }
+            catch (JSException) { }
+        }
+
+        if (_pendingFocusId is { } id && _optionRefs.TryGetValue(id, out var elementRef))
+        {
+            _pendingFocusId = null;
+
+            try { await elementRef.FocusAsync(); }
+            catch { }
+        }
+
+        await base.OnAfterRenderAsync(firstRender);
+    }
+
+    private int IndexOf(ScenarioDefinition scenario)
+    {
+        for (int index = 0; index < Scenarios.Count; index++)
+        {
+            if (string.Equals(Scenarios[index].Id, scenario.Id, StringComparison.Ordinal)) { return index; }
+        }
+
+        return -1;
+    }
+
+    private bool IsSelected(ScenarioDefinition scenario) =>
+        Selected is not null && string.Equals(Selected.Id, scenario.Id, StringComparison.Ordinal);
+
+    private async Task OnListKeyDownAsync(KeyboardEventArgs e)
+    {
+        if (Scenarios.Count == 0) { return; }
+
+        int current = Selected is null ? -1 : IndexOf(Selected);
+
+        int target = e.Key switch
+        {
+            "ArrowDown" => current < 0 ? 0 : Math.Min(current + 1, Scenarios.Count - 1),
+            "ArrowUp" => current <= 0 ? 0 : current - 1,
+            "Home" => 0,
+            "End" => Scenarios.Count - 1,
+            _ => -1,
+        };
+
+        if (target < 0) { return; }
+
+        ScenarioDefinition scenario = Scenarios[target];
+        _pendingFocusId = scenario.Id;
+
+        await OnSelect.InvokeAsync(scenario);
+    }
+
+    private string OptionClass(ScenarioDefinition scenario)
+    {
+        string classes = "scenario-browser__option";
+
+        if (IsSelected(scenario)) { classes += " scenario-browser__option--selected"; }
+
+        if (IsScenarioDisabled(scenario)) { classes += " scenario-browser__option--disabled"; }
+
+        return classes;
+    }
+}

--- a/src/EventLogExpert.UI/Dashboard/ScenarioBrowserPanel.razor.css
+++ b/src/EventLogExpert.UI/Dashboard/ScenarioBrowserPanel.razor.css
@@ -1,0 +1,114 @@
+.scenario-browser {
+    display: flex;
+    flex: 1 1 0;
+    gap: 1rem;
+    min-height: 0;
+    padding: 0.5rem 0 0.5rem 0.5rem;
+}
+
+.scenario-browser__list {
+    flex: 0 0 18rem;
+    min-width: 0;
+    min-height: 0;
+    margin: 0;
+    padding: 0;
+    overflow-y: auto;
+    list-style: none;
+}
+
+.scenario-browser__option {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    align-items: center;
+    gap: 0.75rem;
+    min-height: calc(var(--control-height) + 0.5rem);
+    padding: 0.5rem 0.85rem;
+    border-bottom: 1px solid var(--border-divider);
+    border-left: 3px solid transparent;
+    cursor: pointer;
+}
+
+.scenario-browser__option:last-child {
+    border-bottom: 0;
+}
+
+.scenario-browser__option:hover {
+    background-color: var(--background-darkgray);
+}
+
+.scenario-browser__option--selected {
+    border-left-color: var(--clr-lightblue);
+    background-color: var(--background-darkgray);
+}
+
+.scenario-browser__option--disabled {
+    cursor: default;
+}
+
+.scenario-browser__option--disabled .scenario-browser__option-icon,
+.scenario-browser__option--disabled .scenario-browser__option-body {
+    opacity: 0.55;
+}
+
+.scenario-browser__option:focus-visible {
+    outline: 2px solid var(--clr-lightblue);
+    outline-offset: -2px;
+}
+
+.scenario-browser__option-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--control-height);
+    height: var(--control-height);
+    border-radius: 6px;
+    background-color: color-mix(in srgb, var(--clr-lightblue) 14%, transparent);
+    color: var(--clr-lightblue);
+    font-size: 1.1rem;
+}
+
+.scenario-browser__option-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    min-width: 0;
+}
+
+.scenario-browser__option-name {
+    display: -webkit-box;
+    overflow: hidden;
+    font-weight: 600;
+    line-height: 1.25;
+    color: var(--toggle-accent);
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+}
+
+.scenario-browser__detail {
+    flex: 1 1 0;
+    min-width: 0;
+    min-height: 0;
+    overflow-y: auto;
+}
+
+.scenario-browser__empty {
+    margin: 0;
+    padding: 1rem;
+    color: var(--text-secondary);
+    font-style: italic;
+}
+
+@container (max-width: 960px) {
+    .scenario-browser {
+        flex-direction: column;
+    }
+
+    .scenario-browser__list {
+        flex: 0 0 auto;
+        max-height: 45%;
+    }
+
+    .scenario-browser__detail {
+        flex: 1 1 0;
+    }
+}

--- a/src/EventLogExpert.UI/Dashboard/ScenarioDetail.razor
+++ b/src/EventLogExpert.UI/Dashboard/ScenarioDetail.razor
@@ -1,0 +1,61 @@
+@using EventLogExpert.Scenarios.Catalog
+<div aria-labelledby="@_nameId" class="scenario-detail" role="region">
+    <p class="scenario-detail__eyebrow">
+        <i aria-hidden="true" class="bi @EmptyStateDashboard.ScenarioIcon(Scenario.Group)"></i>
+        <span>@Scenario.Group.DisplayName()</span>
+    </p>
+    <h3 class="scenario-detail__name" id="@_nameId">@Scenario.Name</h3>
+    <p class="scenario-detail__purpose">@Scenario.Purpose</p>
+    <div class="scenario-detail__facts">
+        <div class="scenario-detail__fact">
+            <span class="scenario-detail__fact-label">Logs</span>
+            <span class="scenario-detail__fact-value">@string.Join(", ", Scenario.Channels)</span>
+            @if (!Scenario.OptionalChannels.IsDefaultOrEmpty)
+            {
+                <span class="scenario-detail__fact-muted">Also if present: @string.Join(", ", Scenario.OptionalChannels)</span>
+            }
+        </div>
+        @if (Scenario.RequiresAdmin)
+        {
+            <div class="scenario-detail__fact">
+                <span class="scenario-detail__admin-badge">
+                    <i aria-hidden="true" class="bi bi-shield-lock"></i>
+                    <span>Requires administrator</span>
+                </span>
+            </div>
+        }
+        @if (FilterLines.Count > 0)
+        {
+            <div class="scenario-detail__fact">
+                <span class="scenario-detail__fact-label">Filters</span>
+                @foreach (var line in FilterLines)
+                {
+                    <span class="scenario-detail__filter">
+                        @if (line.Color is not HighlightColor.None)
+                        {
+                            <span aria-hidden="true" class="scenario-detail__swatch" data-highlight="@line.Color.ToCssName()"></span>
+                        }
+                        <span class="scenario-detail__fact-value">@line.Text</span>
+                    </span>
+                }
+            </div>
+        }
+    </div>
+    <div class="scenario-detail__actions">
+        <button aria-label="@(IsFavored ? $"Remove {Scenario.Name} from favorites" : $"Add {Scenario.Name} to favorites")"
+            aria-pressed="@(IsFavored ? "true" : "false")"
+            class="scenario-detail__star"
+            @onclick="OnToggleFavorite"
+            type="button">
+            <i aria-hidden="true" class="bi @(IsFavored ? "bi-star-fill" : "bi-star")"></i>
+        </button>
+        <button aria-describedby="@(IsDisabled ? ElevationReasonId : null)"
+            aria-disabled="@(IsDisabled ? "true" : "false")"
+            class="scenario-detail__launch"
+            disabled="@IsBusy"
+            @onclick="LaunchAsync"
+            type="button">
+            <i aria-hidden="true" class="bi bi-play-fill"></i><span>Launch</span>
+        </button>
+    </div>
+</div>

--- a/src/EventLogExpert.UI/Dashboard/ScenarioDetail.razor.cs
+++ b/src/EventLogExpert.UI/Dashboard/ScenarioDetail.razor.cs
@@ -1,0 +1,57 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Basic;
+using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Scenarios.Catalog;
+using EventLogExpert.UI.Common;
+using Microsoft.AspNetCore.Components;
+
+namespace EventLogExpert.UI.Dashboard;
+
+public sealed partial class ScenarioDetail
+{
+    private readonly string _nameId = ComponentId.NewUnique().Value;
+
+    [Parameter][EditorRequired] public string ElevationReasonId { get; set; } = string.Empty;
+
+    [Parameter] public bool IsBusy { get; set; }
+
+    [Parameter] public bool IsDisabled { get; set; }
+
+    [Parameter] public bool IsFavored { get; set; }
+
+    [Parameter] public EventCallback OnLaunch { get; set; }
+
+    [Parameter] public EventCallback OnToggleFavorite { get; set; }
+
+    [Parameter][EditorRequired] public ScenarioDefinition Scenario { get; set; } = null!;
+
+    private IReadOnlyList<FilterLine> FilterLines
+    {
+        get
+        {
+            if (Scenario.Filters.IsDefaultOrEmpty) { return []; }
+
+            List<FilterLine> lines = [];
+
+            foreach (var row in Scenario.Filters)
+            {
+                if (!BasicFilterFormatter.TryFormat(row.Filter, out var text)) { continue; }
+
+                lines.Add(new FilterLine(row.IsExcluded ? $"Exclude {text}" : text, row.Color));
+            }
+
+            return lines;
+        }
+    }
+
+    private async Task LaunchAsync()
+    {
+        if (IsDisabled) { return; }
+
+        await OnLaunch.InvokeAsync();
+    }
+
+    private readonly record struct FilterLine(string Text, HighlightColor Color);
+}

--- a/src/EventLogExpert.UI/Dashboard/ScenarioDetail.razor.css
+++ b/src/EventLogExpert.UI/Dashboard/ScenarioDetail.razor.css
@@ -1,0 +1,184 @@
+.scenario-detail {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    min-height: 100%;
+    padding: 1.25rem;
+    border: 1px solid var(--border-divider);
+    border-radius: 6px;
+    background-color: var(--background-darkgray);
+    box-shadow: var(--shadow-menu);
+}
+
+.scenario-detail__eyebrow {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin: 0;
+    font-size: 0.85rem;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    color: var(--text-secondary);
+}
+
+.scenario-detail__eyebrow > .bi {
+    color: var(--clr-lightblue);
+}
+
+.scenario-detail__name {
+    margin: 0;
+    font-size: 1.2rem;
+    font-weight: 600;
+    color: var(--toggle-accent);
+}
+
+.scenario-detail__purpose {
+    margin: 0;
+    line-height: 1.4;
+    color: var(--text-secondary);
+}
+
+.scenario-detail__facts {
+    display: flex;
+    flex-direction: column;
+    margin: 0.25rem 0;
+    border: 1px solid var(--border-divider);
+    border-radius: 6px;
+    background-color: var(--surface-inset);
+}
+
+.scenario-detail__fact {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    padding: 0.65rem 0.85rem;
+    border-bottom: 1px solid var(--border-divider);
+}
+
+.scenario-detail__fact:last-child {
+    border-bottom: 0;
+}
+
+.scenario-detail__fact-label {
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    color: var(--text-secondary);
+}
+
+.scenario-detail__fact-value {
+    line-height: 1.35;
+    color: var(--text-secondary);
+}
+
+.scenario-detail__fact-muted {
+    font-size: 0.85rem;
+    color: color-mix(in srgb, var(--text-secondary) 78%, transparent);
+}
+
+.scenario-detail__admin-badge {
+    display: inline-flex;
+    align-items: center;
+    align-self: flex-start;
+    gap: 0.4rem;
+    padding: 0.25rem 0.65rem;
+    border: 1px solid var(--border-divider);
+    border-radius: 999px;
+    background-color: transparent;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
+.scenario-detail__admin-badge > .bi {
+    color: var(--clr-yellow);
+}
+
+.scenario-detail__filter {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+}
+
+.scenario-detail__swatch {
+    flex: 0 0 auto;
+    width: 0.85rem;
+    height: 0.85rem;
+    border: 1px solid var(--border-divider);
+    border-radius: 3px;
+    background-color: var(--hl-bg);
+}
+
+.scenario-detail__actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 0.75rem;
+}
+
+.scenario-detail__star {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--control-height);
+    height: var(--control-height);
+    padding: 0;
+    border: 1px solid var(--border-divider);
+    border-radius: 6px;
+    background-color: transparent;
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.scenario-detail__star[aria-pressed="true"] {
+    color: var(--clr-yellow);
+}
+
+.scenario-detail__star[aria-pressed="false"]:hover {
+    border-color: var(--clr-lightblue);
+}
+
+.scenario-detail__star:focus-visible {
+    outline: 2px solid var(--clr-lightblue);
+    outline-offset: 2px;
+}
+
+.scenario-detail__launch {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    min-height: var(--control-height);
+    padding: 0.4rem 1rem;
+    border: 1px solid var(--clr-lightblue);
+    border-radius: 6px;
+    background-color: var(--clr-lightblue);
+    color: var(--accent-on-fill);
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.scenario-detail__launch > .bi {
+    color: var(--accent-on-fill);
+}
+
+.scenario-detail__launch:hover:not(:disabled):not([aria-disabled="true"]) {
+    box-shadow: var(--shadow-menu);
+}
+
+.scenario-detail__launch:focus-visible {
+    outline: 2px solid var(--clr-lightblue);
+    outline-offset: 2px;
+}
+
+.scenario-detail__launch:disabled,
+.scenario-detail__launch[aria-disabled="true"] {
+    border-color: var(--border-divider);
+    background-color: var(--surface-inset);
+    color: var(--text-secondary);
+    cursor: default;
+}
+
+.scenario-detail__launch[aria-disabled="true"] > .bi {
+    color: var(--text-secondary);
+}

--- a/src/EventLogExpert.UI/Dashboard/SplashCategory.cs
+++ b/src/EventLogExpert.UI/Dashboard/SplashCategory.cs
@@ -1,0 +1,60 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Scenarios.Catalog;
+
+namespace EventLogExpert.UI.Dashboard;
+
+internal enum SplashCategory
+{
+    Favorites,
+    Recommended,
+    SystemHealth,
+    Applications,
+    Security,
+    ThreatsAndIncidentResponse,
+    Network,
+    Storage,
+    UpdatesAndPolicy,
+    ActiveDirectory,
+    DnsServer,
+    DhcpServer,
+    NpsAndRras,
+    Wins,
+    WebAndIis,
+    VirtualizationAndClustering,
+    FilePrintAndStorage,
+    SqlServer,
+    Exchange,
+    SharePoint,
+    DefenderForEndpoint,
+    Office,
+}
+
+internal static class SplashCategoryMapping
+{
+    public static SplashCategory? ToSplashCategory(ScenarioGroup group) => group switch
+    {
+        ScenarioGroup.SystemHealth => SplashCategory.SystemHealth,
+        ScenarioGroup.Applications => SplashCategory.Applications,
+        ScenarioGroup.Security => SplashCategory.Security,
+        ScenarioGroup.ThreatsAndIncidentResponse => SplashCategory.ThreatsAndIncidentResponse,
+        ScenarioGroup.Network => SplashCategory.Network,
+        ScenarioGroup.Storage => SplashCategory.Storage,
+        ScenarioGroup.UpdatesAndPolicy => SplashCategory.UpdatesAndPolicy,
+        ScenarioGroup.ActiveDirectory => SplashCategory.ActiveDirectory,
+        ScenarioGroup.DnsServer => SplashCategory.DnsServer,
+        ScenarioGroup.DhcpServer => SplashCategory.DhcpServer,
+        ScenarioGroup.NpsAndRras => SplashCategory.NpsAndRras,
+        ScenarioGroup.Wins => SplashCategory.Wins,
+        ScenarioGroup.WebAndIis => SplashCategory.WebAndIis,
+        ScenarioGroup.VirtualizationAndClustering => SplashCategory.VirtualizationAndClustering,
+        ScenarioGroup.FilePrintAndStorage => SplashCategory.FilePrintAndStorage,
+        ScenarioGroup.SqlServer => SplashCategory.SqlServer,
+        ScenarioGroup.Exchange => SplashCategory.Exchange,
+        ScenarioGroup.SharePoint => SplashCategory.SharePoint,
+        ScenarioGroup.DefenderForEndpoint => SplashCategory.DefenderForEndpoint,
+        ScenarioGroup.Office => SplashCategory.Office,
+        _ => null,
+    };
+}

--- a/src/EventLogExpert.UI/DetailsPane/DetailsPane.razor
+++ b/src/EventLogExpert.UI/DetailsPane/DetailsPane.razor
@@ -1,6 +1,6 @@
 @inherits FluxorComponent
 
-<div class="details-pane" data-toggle="@IsVisible" hidden="@(_selectedEvent is null)">
+<div class="details-pane" data-toggle="@IsVisible" hidden="@(_selectedEvent is null)" @ref="_detailsPaneRootRef">
     <div class="details-resizer"></div>
 
     <div aria-expanded="@_isVisible.ToString().ToLower()"

--- a/src/EventLogExpert.UI/DetailsPane/DetailsPane.razor.cs
+++ b/src/EventLogExpert.UI/DetailsPane/DetailsPane.razor.cs
@@ -20,6 +20,7 @@ namespace EventLogExpert.UI.DetailsPane;
 public sealed partial class DetailsPane
 {
     private IJSObjectReference? _detailsPaneModule;
+    private ElementReference _detailsPaneRootRef;
     private DotNetObjectReference<DetailsPane>? _dotNetRef;
     private bool _hasOpened;
     private bool _isVisible;
@@ -30,6 +31,7 @@ public sealed partial class DetailsPane
     ///     failure); any other value is the rendered XML.
     /// </summary>
     private string? _resolvedXml;
+    private IJSObjectReference? _scrollSuppressorModule;
     private ResolvedEvent? _selectedEvent;
     /// <summary>Cancels any in-flight XML resolution when the selection changes again before completion.</summary>
     private CancellationTokenSource? _xmlResolveCts;
@@ -71,7 +73,12 @@ public sealed partial class DetailsPane
                 _detailsPaneModule,
                 static module => module.InvokeVoidAsync("disposeDetailsPaneResizer"));
 
+            await JsModuleInterop.DisposeModuleSafelyAsync(
+                _scrollSuppressorModule,
+                module => module.InvokeVoidAsync("release", _detailsPaneRootRef));
+
             _detailsPaneModule = null;
+            _scrollSuppressorModule = null;
 
             _dotNetRef?.Dispose();
         }
@@ -93,6 +100,20 @@ public sealed partial class DetailsPane
                 "enableDetailsPaneResizer",
                 _dotNetRef,
                 PreferencesProvider.DetailsPaneHeightPreference);
+
+            try
+            {
+                _scrollSuppressorModule = await JSRuntime.InvokeAsync<IJSObjectReference>(
+                    "import",
+                    "./_content/EventLogExpert.UI/Common/keyboardScrollSuppressor.js");
+
+                await _scrollSuppressorModule.InvokeVoidAsync(
+                    "suppress",
+                    _detailsPaneRootRef,
+                    new[] { new { selector = "#details-header, .details-row-xml", keys = new[] { "Enter", " " } } });
+            }
+            catch (JSDisconnectedException) { }
+            catch (JSException) { }
         }
 
         await base.OnAfterRenderAsync(firstRender);

--- a/src/EventLogExpert.UI/FilterPane/FilterPane.razor
+++ b/src/EventLogExpert.UI/FilterPane/FilterPane.razor
@@ -1,7 +1,7 @@
 @using EventLogExpert.Scenarios.Catalog
 @inherits FluxorComponent
 
-<div class="filter-pane">
+<div class="filter-pane" @ref="_filterPaneRootRef">
 <div class="filter-header">
     <div class="filter-header-actions">
         <div class="split-button">
@@ -25,18 +25,18 @@
             </button>
         </div>
 
-        <button class="button" @onclick="AddExclusion">
+        <button class="button" @onclick="AddExclusion" type="button">
             <i class="bi bi-plus-circle"></i> Add Exclusion
         </button>
 
         @if (!IsDateFilterVisible)
         {
-            <button class="button" @onclick="AddDateFilter">
+            <button class="button" @onclick="AddDateFilter" type="button">
                 <i class="bi bi-plus-circle"></i> Add Date Filter
             </button>
         }
 
-        <button class="button" @onclick="OpenFilterSetPicker">
+        <button class="button" @onclick="OpenFilterSetPicker" type="button">
             <i class="bi bi-plus-circle"></i> Apply Filter Set
         </button>
 
@@ -44,7 +44,6 @@
         {
             <button aria-controls="scenario-picker"
                 aria-expanded="@(IsScenarioPickerVisible ? "true" : "false")"
-                aria-haspopup="true"
                 class="button"
                 @onclick="OpenScenarioPicker"
                 type="button">
@@ -243,7 +242,7 @@
                     </ValueSelect>
                 </span>
 
-                <button class="button button-green" disabled="@(SelectedFilterSetId == default)" @onclick="ApplyFilterSetSelection">
+                <button class="button button-green" disabled="@(SelectedFilterSetId == default)" @onclick="ApplyFilterSetSelection" type="button">
                     <i class="bi bi-check-circle"></i> Apply
                 </button>
 
@@ -280,35 +279,56 @@
     @if (IsScenarioPickerVisible)
     {
         <div class="filter-form flex-row" id="scenario-picker">
-            @if (ScenarioMatchGroups.Count > 0)
+            @if (ScenarioMatches.Count > 0)
             {
-                @foreach (var group in ScenarioMatchGroups)
+                @if (ScenarioMatchGroups.Count > 1)
                 {
-                    <div class="scenario-picker-group">
-                        <span class="scenario-picker-group-header">@group.Key.DisplayName()</span>
-
-                        @foreach (var scenario in group)
-                        {
-                            <span class="scenario-picker-row" title="@scenario.Purpose">
-                                <span class="scenario-picker-name">@scenario.Name</span>
-
-                                <button aria-label="@($"Apply scenario {scenario.Name}")"
-                                    class="button button-green"
-                                    @onclick="() => ApplyScenario(scenario, false)"
-                                    type="button">
-                                    <i class="bi bi-check-circle"></i> Apply
-                                </button>
-
-                                <button aria-label="@($"Replace filters with scenario {scenario.Name}")"
-                                    class="button"
-                                    @onclick="() => ApplyScenario(scenario, true)"
-                                    type="button">
-                                    <i class="bi bi-arrow-repeat"></i> Replace
-                                </button>
-                            </span>
-                        }
-                    </div>
+                    <span>
+                        Category:
+                        <ValueSelect AriaLabel="Category"
+                            CssClass="input scenario-category-dropdown"
+                            T="ScenarioGroup?"
+                            ToStringFunc="@(group => group?.DisplayName() ?? string.Empty)"
+                            Value="EffectiveScenarioGroup"
+                            ValueChanged="OnScenarioGroupChanged">
+                            @foreach (var match in ScenarioMatchGroups)
+                            {
+                                <ValueSelectItem T="ScenarioGroup?" Value="match.Key">@match.Key.DisplayName()</ValueSelectItem>
+                            }
+                        </ValueSelect>
+                    </span>
                 }
+
+                <span>
+                    Scenario:
+                    <ValueSelect AriaLabel="Scenario"
+                        CssClass="input scenario-item-dropdown"
+                        T="string"
+                        ToStringFunc="@(GetScenarioName)"
+                        Value="ResolvedScenario?.Id"
+                        ValueChanged="id => SelectedScenarioId = id">
+                        @foreach (var scenario in VisibleScenarioMatches)
+                        {
+                            <ValueSelectItem T="string" Value="scenario.Id">
+                                <span class="filter-set-option-row" title="@($"{scenario.Group.DisplayName()} - {scenario.Purpose}")">
+                                    <span class="filter-set-option-name">@scenario.Name</span>
+                                </span>
+                            </ValueSelectItem>
+                        }
+                    </ValueSelect>
+                </span>
+
+                <button class="button button-green" disabled="@(ResolvedScenario is null)" @onclick="ApplyScenarioSelection" type="button">
+                    <i class="bi bi-check-circle"></i> Apply
+                </button>
+
+                <button aria-label="Replace filters with selected scenario"
+                    class="button"
+                    disabled="@(ResolvedScenario is null)"
+                    @onclick="ReplaceScenarioSelection"
+                    type="button">
+                    <i class="bi bi-arrow-repeat"></i> Replace
+                </button>
             }
             else
             {

--- a/src/EventLogExpert.UI/FilterPane/FilterPane.razor.cs
+++ b/src/EventLogExpert.UI/FilterPane/FilterPane.razor.cs
@@ -39,6 +39,8 @@ public sealed partial class FilterPane
     internal bool IsFilterSetPickerVisible;
     internal bool IsScenarioPickerVisible;
     internal LibraryEntryId SelectedFilterSetId;
+    internal ScenarioGroup? SelectedScenarioGroup;
+    internal string? SelectedScenarioId;
 
     private readonly List<string> _filterSetTags = [];
     private readonly DateFilter _model = new();
@@ -52,12 +54,14 @@ public sealed partial class FilterPane
     private bool _canEditDate;
     private ScenarioClipboardExporter _clipboardExporter = null!;
     private TimeZoneInfo _currentTimeZone = TimeZoneInfo.Utc;
+    private ElementReference _filterPaneRootRef;
     private bool _focusAddButtonAfterRemove;
     private FilterId? _focusTargetAfterRemove;
     private bool _isFilterListVisible;
     private IJSObjectReference? _menuAnchorModule;
     private IReadOnlyList<IGrouping<ScenarioGroup, ScenarioDefinition>> _scenarioMatchGroups = [];
     private ImmutableDictionary<string, EventLogData>? _scenarioMatchSource;
+    private IJSObjectReference? _scrollSuppressorModule;
 
     internal IReadOnlyList<string> AvailableFilterSetTags =>
         AvailableTagsForSets([.. FilterLibraryState.Value.Entries.OfType<LibraryEntryFilterSet>()]);
@@ -75,6 +79,11 @@ public sealed partial class FilterPane
     [Inject] private IAnnouncementService AnnouncementService { get; init; } = null!;
 
     [Inject] private IClipboardService ClipboardService { get; init; } = null!;
+
+    private ScenarioGroup? EffectiveScenarioGroup =>
+        SelectedScenarioGroup is { } group && ScenarioMatchGroups.Any(match => match.Key == group)
+            ? group
+            : ScenarioMatchGroups.FirstOrDefault()?.Key;
 
     [Inject] private IState<EventLogState> EventLogState { get; init; } = null!;
 
@@ -125,11 +134,17 @@ public sealed partial class FilterPane
 
     [Inject] private IModalCoordinator ModalCoordinator { get; init; } = null!;
 
+    private ScenarioDefinition? ResolvedScenario =>
+        VisibleScenarioMatches.FirstOrDefault(match => match.Id == SelectedScenarioId)
+            ?? VisibleScenarioMatches.FirstOrDefault();
+
     [Inject] private IScenarioApplyService ScenarioApplyService { get; init; } = null!;
 
     [Inject] private ScenarioAuthoringOptions ScenarioAuthoringOptions { get; init; } = null!;
 
     [Inject] private IScenarioAuthoringService ScenarioAuthoringService { get; init; } = null!;
+
+    private IReadOnlyList<ScenarioDefinition> ScenarioMatches => [.. ScenarioMatchGroups.SelectMany(group => group)];
 
     private IReadOnlyList<IGrouping<ScenarioGroup, ScenarioDefinition>> ScenarioMatchGroups
     {
@@ -158,6 +173,11 @@ public sealed partial class FilterPane
     [Inject] private IScenarioQueryService ScenarioQueryService { get; init; } = null!;
 
     [Inject] private ISettingsService Settings { get; init; } = null!;
+
+    private IReadOnlyList<ScenarioDefinition> VisibleScenarioMatches =>
+        EffectiveScenarioGroup is { } group
+            ? [.. ScenarioMatchGroups.First(match => match.Key == group)]
+            : [];
 
     internal static IReadOnlyList<string> AvailableTagsForSets(IReadOnlyList<LibraryEntryFilterSet> sets) =>
         [.. sets.SelectMany(s => s.Tags).Distinct(StringComparer.OrdinalIgnoreCase).OrderBy(t => t, StringComparer.OrdinalIgnoreCase)];
@@ -196,6 +216,17 @@ public sealed partial class FilterPane
         CancelFilterSetPicker();
     }
 
+    internal void ApplyScenarioSelection()
+    {
+        if (ResolvedScenario is not { } scenario)
+        {
+            AnnouncementService.Announce(FilterPaneAnnouncements.SelectedScenarioMissing);
+            return;
+        }
+
+        ApplyScenario(scenario, replace: false);
+    }
+
     internal IReadOnlyList<MenuItem> BuildAddFilterMenu() =>
     [
         MenuItem.Item("Basic", AddBasicFilterFromMenu),
@@ -218,6 +249,12 @@ public sealed partial class FilterPane
         return !FilterLibraryState.Value.IsLoaded ?
             FilterPaneAnnouncements.LoadingTryAgain :
             FilterPaneAnnouncements.RecentNoneAvailable;
+    }
+
+    internal void OnScenarioGroupChanged(ScenarioGroup? group)
+    {
+        SelectedScenarioGroup = group;
+        SelectedScenarioId = VisibleScenarioMatches.FirstOrDefault()?.Id;
     }
 
     internal void OpenFilterSetPicker()
@@ -254,6 +291,8 @@ public sealed partial class FilterPane
         if (IsScenarioPickerVisible) { return; }
 
         IsScenarioPickerVisible = true;
+        SelectedScenarioGroup = ScenarioMatchGroups.FirstOrDefault()?.Key;
+        SelectedScenarioId = VisibleScenarioMatches.FirstOrDefault()?.Id;
         _isFilterListVisible = true;
     }
 
@@ -263,6 +302,17 @@ public sealed partial class FilterPane
 
         FilterLibraryCommands.ReplaceWithEntry(SelectedFilterSetId);
         CancelFilterSetPicker();
+    }
+
+    internal void ReplaceScenarioSelection()
+    {
+        if (ResolvedScenario is not { } scenario)
+        {
+            AnnouncementService.Announce(FilterPaneAnnouncements.SelectedScenarioMissing);
+            return;
+        }
+
+        ApplyScenario(scenario, replace: true);
     }
 
     internal void SetQuickDateRange(DateFilter dateFilter) => UpdateFilterDate(dateFilter);
@@ -307,9 +357,14 @@ public sealed partial class FilterPane
             Settings.TimeZoneChanged -= UpdateFilterDateTimeZone;
             MenuService.StateChanged -= OnMenuServiceStateChanged;
 
+            await JsModuleInterop.DisposeModuleSafelyAsync(
+                _scrollSuppressorModule,
+                module => module.InvokeVoidAsync("release", _filterPaneRootRef));
+
             await JsModuleInterop.DisposeModuleSafelyAsync(_menuAnchorModule);
 
             _menuAnchorModule = null;
+            _scrollSuppressorModule = null;
         }
 
         await base.DisposeAsyncCore(disposing);
@@ -317,6 +372,27 @@ public sealed partial class FilterPane
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        if (firstRender)
+        {
+            try
+            {
+                _scrollSuppressorModule = await JSRuntime.InvokeAsync<IJSObjectReference>(
+                    "import",
+                    "./_content/EventLogExpert.UI/Common/keyboardScrollSuppressor.js");
+
+                await _scrollSuppressorModule.InvokeVoidAsync(
+                    "suppress",
+                    _filterPaneRootRef,
+                    new[]
+                    {
+                        new { selector = ".split-button-chevron", keys = new[] { "ArrowUp", "ArrowDown" } },
+                        new { selector = ".menu-toggle", keys = new[] { "Enter", " " } }
+                    });
+            }
+            catch (JSDisconnectedException) { }
+            catch (JSException) { }
+        }
+
         PruneStaleRowRefs();
         PruneStaleFilterSetTags();
 
@@ -468,6 +544,8 @@ public sealed partial class FilterPane
     private void CancelScenarioPicker()
     {
         IsScenarioPickerVisible = false;
+        SelectedScenarioGroup = null;
+        SelectedScenarioId = null;
         _scenarioMatchSource = null;
         _scenarioMatchGroups = [];
     }
@@ -529,6 +607,13 @@ public sealed partial class FilterPane
         var set = FilterLibraryState.Value.Entries.OfType<LibraryEntryFilterSet>().FirstOrDefault(p => p.Id.Equals(id));
 
         return set is null ? string.Empty : FormatFilterSetLabel(set);
+    }
+
+    private string GetScenarioName(string? id)
+    {
+        var scenario = ScenarioMatches.FirstOrDefault(match => match.Id == id);
+
+        return scenario is null ? string.Empty : scenario.Name;
     }
 
     private async Task HandleAddFilterChevronKeyDownAsync(KeyboardEventArgs e)

--- a/src/EventLogExpert.UI/FilterPane/FilterPane.razor.css
+++ b/src/EventLogExpert.UI/FilterPane/FilterPane.razor.css
@@ -100,30 +100,3 @@
     min-width: 0;
 }
 
-.scenario-picker-group {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-    min-width: 0;
-}
-
-.scenario-picker-group-header {
-    font-weight: 600;
-    opacity: 0.85;
-}
-
-.scenario-picker-row {
-    display: flex;
-    align-items: baseline;
-    gap: 0.375rem;
-    min-width: 0;
-}
-
-.scenario-picker-name {
-    flex: 0 1 auto;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    min-width: 0;
-}
-

--- a/src/EventLogExpert.UI/FilterPane/FilterPaneAnnouncements.cs
+++ b/src/EventLogExpert.UI/FilterPane/FilterPaneAnnouncements.cs
@@ -9,7 +9,9 @@ internal static class FilterPaneAnnouncements
 
     public const string LoadingTryAgain = "Filter library is still loading. Please try again.";
 
-    public const string RecentNoneAvailable = "No recent filters yet — apply a Basic or Advanced filter to populate.";
+    public const string RecentNoneAvailable = "No recent filters yet - apply a Basic or Advanced filter to populate.";
 
     public const string SelectedFilterSetMissing = "Selected filter set no longer exists.";
+
+    public const string SelectedScenarioMissing = "Selected scenario no longer matches the loaded logs.";
 }

--- a/src/EventLogExpert.UI/Layout/MainContent.razor
+++ b/src/EventLogExpert.UI/Layout/MainContent.razor
@@ -1,0 +1,12 @@
+@inherits FluxorComponent
+
+@if (HasActiveLogs.Value)
+{
+    <FilterPane />
+    <LogTablePane />
+    <DetailsPane />
+}
+else
+{
+    <EmptyStateDashboard />
+}

--- a/src/EventLogExpert.UI/Layout/MainContent.razor.cs
+++ b/src/EventLogExpert.UI/Layout/MainContent.razor.cs
@@ -1,0 +1,21 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.EventLog;
+using Fluxor;
+using Fluxor.Blazor.Web.Components;
+using Microsoft.AspNetCore.Components;
+
+namespace EventLogExpert.UI.Layout;
+
+public sealed partial class MainContent : FluxorComponent
+{
+    [Inject]
+    private IStateSelection<EventLogState, bool> HasActiveLogs { get; init; } = null!;
+
+    protected override void OnInitialized()
+    {
+        HasActiveLogs.Select(state => !state.ActiveLogs.IsEmpty);
+        base.OnInitialized();
+    }
+}

--- a/src/EventLogExpert.UI/Layout/MainLayout.razor
+++ b/src/EventLogExpert.UI/Layout/MainLayout.razor
@@ -9,9 +9,7 @@
     <MenuBar />
 
     <main class="page-content" id="main-content" tabindex="-1">
-        <FilterPane />
-        <LogTablePane />
-        <DetailsPane />
+        <MainContent />
     </main>
 
     <footer>

--- a/src/EventLogExpert.UI/LogTable/LogTabBar.razor
+++ b/src/EventLogExpert.UI/LogTable/LogTabBar.razor
@@ -1,6 +1,6 @@
 @inherits FluxorComponent
 
-<div class="log-tab-bar" hidden="@(LogTableState.Value.EventTables.Count <= 1)">
+<div class="log-tab-bar" hidden="@(LogTableState.Value.EventTables.Count <= 1)" @ref="_logTabBarRootRef">
     <div class="tab-row">
         @foreach (var table in _sortedTabs)
         {

--- a/src/EventLogExpert.UI/LogTable/LogTabBar.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/LogTabBar.razor.cs
@@ -15,7 +15,9 @@ namespace EventLogExpert.UI.LogTable;
 public sealed partial class LogTabBar
 {
     private IJSObjectReference? _logTabBarModule;
+    private ElementReference _logTabBarRootRef;
     private LogTableState _logTableState = null!;
+    private IJSObjectReference? _scrollSuppressorModule;
     private List<LogView> _sortedTabs = [];
 
     [Inject] private IEventLogCommands EventLogCommands { get; init; } = null!;
@@ -30,9 +32,14 @@ public sealed partial class LogTabBar
     {
         if (disposing)
         {
+            await JsModuleInterop.DisposeModuleSafelyAsync(
+                _scrollSuppressorModule,
+                module => module.InvokeVoidAsync("release", _logTabBarRootRef));
+
             await JsModuleInterop.DisposeModuleSafelyAsync(_logTabBarModule);
 
             _logTabBarModule = null;
+            _scrollSuppressorModule = null;
         }
 
         await base.DisposeAsyncCore(disposing);
@@ -49,6 +56,15 @@ public sealed partial class LogTabBar
                     "./_content/EventLogExpert.UI/LogTable/LogTabBar.razor.js");
 
                 await _logTabBarModule.InvokeVoidAsync("registerLogTabBarEvents");
+
+                _scrollSuppressorModule = await JSRuntime.InvokeAsync<IJSObjectReference>(
+                    "import",
+                    "./_content/EventLogExpert.UI/Common/keyboardScrollSuppressor.js");
+
+                await _scrollSuppressorModule.InvokeVoidAsync(
+                    "suppress",
+                    _logTabBarRootRef,
+                    new[] { new { selector = "[role='button']", keys = new[] { "Enter", " " } } });
             }
             catch (JSDisconnectedException) { }
             catch (JSException) { }

--- a/src/EventLogExpert.UI/Menu/MenuBar.razor
+++ b/src/EventLogExpert.UI/Menu/MenuBar.razor
@@ -1,6 +1,6 @@
 @inherits FluxorComponent
 
-<nav aria-label="Main menu" aria-orientation="horizontal" class="menu-bar" role="menubar">
+<nav aria-label="Main menu" aria-orientation="horizontal" class="menu-bar" @ref="_menuBarRootRef" role="menubar">
     @for (int index = 0; index < _bars.Count; index++)
     {
         var bar = _bars[index];

--- a/src/EventLogExpert.UI/Menu/MenuBar.razor.cs
+++ b/src/EventLogExpert.UI/Menu/MenuBar.razor.cs
@@ -28,7 +28,9 @@ public sealed partial class MenuBar
     private ElementReference[] _barElements = [];
     private int _focusedBarIndex;
     private IJSObjectReference? _menuAnchorModule;
+    private ElementReference _menuBarRootRef;
     private long _openRequestId;
+    private IJSObjectReference? _scrollSuppressorModule;
 
     [Inject] private IMenuActionService Actions { get; init; } = null!;
 
@@ -67,12 +69,39 @@ public sealed partial class MenuBar
             MenuService.StateChanged -= OnMenuServiceStateChanged;
             MenuService.NavigateBarRequested -= OnNavigateBarRequested;
 
+            await JsModuleInterop.DisposeModuleSafelyAsync(
+                _scrollSuppressorModule,
+                module => module.InvokeVoidAsync("release", _menuBarRootRef));
+
             await JsModuleInterop.DisposeModuleSafelyAsync(_menuAnchorModule);
 
             _menuAnchorModule = null;
+            _scrollSuppressorModule = null;
         }
 
         await base.DisposeAsyncCore(disposing);
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            try
+            {
+                _scrollSuppressorModule = await JSRuntime.InvokeAsync<IJSObjectReference>(
+                    "import",
+                    "./_content/EventLogExpert.UI/Common/keyboardScrollSuppressor.js");
+
+                await _scrollSuppressorModule.InvokeVoidAsync(
+                    "suppress",
+                    _menuBarRootRef,
+                    new[] { new { selector = "[role='menuitem']", keys = new[] { "ArrowRight", "ArrowLeft", "Home", "End", "ArrowDown", "ArrowUp" } } });
+            }
+            catch (JSDisconnectedException) { }
+            catch (JSException) { }
+        }
+
+        await base.OnAfterRenderAsync(firstRender);
     }
 
     protected override void OnInitialized()

--- a/src/EventLogExpert.UI/Modal/SidebarTabs.razor
+++ b/src/EventLogExpert.UI/Modal/SidebarTabs.razor
@@ -12,13 +12,14 @@
                 aria-selected="@(tab.Equals(ActiveTab) ? "true" : "false")"
                 class="@(tab.Equals(ActiveTab) ? "tab active" : "tab")"
                 id="@($"sidebar-tab-{TablistId}-{tab}")"
+                @key="tab"
                 @onclick="() => SetActiveTabAsync(tab)"
                 @onkeydown="e => OnTabKeyDownAsync(e, tab)"
                 @ref="_tabButtonRefs[tab]"
                 role="tab"
                 tabindex="@(tab.Equals(ActiveTab) ? "0" : "-1")"
                 type="button">
-                @label
+                <span class="sidebar-tabs-tab-label">@label</span>
             </button>
         }
     </div>
@@ -29,6 +30,7 @@
             <div aria-labelledby="@($"sidebar-tab-{TablistId}-{tab}")"
                 class="@(tab.Equals(ActiveTab) ? "sidebar-tabs-tabpanel active" : "sidebar-tabs-tabpanel")"
                 id="@($"sidebar-tabpanel-{TablistId}-{tab}")"
+                @key="tab"
                 role="tabpanel"
                 style="@(tab.Equals(ActiveTab) ? "" : "display: none")"
                 tabindex="@(tab.Equals(ActiveTab) && (IsTabpanelFocusable?.Invoke(tab) ?? false) ? "0" : null)">

--- a/src/EventLogExpert.UI/_Imports.razor
+++ b/src/EventLogExpert.UI/_Imports.razor
@@ -26,6 +26,7 @@
 @using EventLogExpert.UI.Announcement
 @using EventLogExpert.UI.Banner
 @using EventLogExpert.UI.Common
+@using EventLogExpert.UI.Dashboard
 @using EventLogExpert.UI.Database
 @using EventLogExpert.UI.DetailsPane
 @using EventLogExpert.UI.FilterEditor

--- a/src/EventLogExpert.UI/wwwroot/Common/keyboardScrollSuppressor.js
+++ b/src/EventLogExpert.UI/wwwroot/Common/keyboardScrollSuppressor.js
@@ -1,0 +1,42 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+const handlers = new WeakMap();
+
+export function suppress(container, rules) {
+    if (!container) { return; }
+
+    release(container);
+
+    const compiled = rules.map(rule => ({ selector: rule.selector, keys: new Set(rule.keys) }));
+
+    const onKeyDown = (event) => {
+        if (!(event.target instanceof Element)) { return; }
+
+        for (const rule of compiled) {
+            if (!rule.keys.has(event.key)) { continue; }
+
+            const match = event.target.closest(rule.selector);
+
+            if (match && container.contains(match)) {
+                event.preventDefault();
+
+                return;
+            }
+        }
+    };
+
+    container.addEventListener("keydown", onKeyDown);
+    handlers.set(container, onKeyDown);
+}
+
+export function release(container) {
+    if (!container) { return; }
+
+    const onKeyDown = handlers.get(container);
+
+    if (onKeyDown) {
+        container.removeEventListener("keydown", onKeyDown);
+        handlers.delete(container);
+    }
+}

--- a/src/EventLogExpert.UI/wwwroot/app.css
+++ b/src/EventLogExpert.UI/wwwroot/app.css
@@ -287,13 +287,15 @@ input[type="text"].input { padding: 0; }
     max-width: 100%;
 }
 
-.input.filter-multiselect-dropdown {
+.input.filter-multiselect-dropdown,
+.input.scenario-category-dropdown {
     flex: 1 1 auto;
     min-width: 240px;
     max-width: 420px;
 }
 
-.input.filter-set-dropdown { width: 600px; }
+.input.filter-set-dropdown,
+.input.scenario-item-dropdown { width: 600px; }
 
 .input.filter-value-dropdown,
 .input.filter-description {

--- a/src/EventLogExpert/MauiProgram.cs
+++ b/src/EventLogExpert/MauiProgram.cs
@@ -9,6 +9,7 @@ using EventLogExpert.Runtime.Common.Files;
 using EventLogExpert.Runtime.FilterLibrary;
 using EventLogExpert.Runtime.LogTable;
 using EventLogExpert.Runtime.Scenarios;
+using EventLogExpert.Runtime.Scenarios.Favorites;
 using EventLogExpert.UI.Banner;
 using EventLogExpert.UI.Database;
 using Fluxor;
@@ -76,8 +77,9 @@ public static class MauiProgram
         builder.Services.AddTransient<IEventResolver, EventResolver>();
 
         // FilterLibrary persistence
-        builder.Services.AddFilterLibrarySqliteStore(
-            Path.Combine(FileSystem.AppDataDirectory, "filter-library.db"));
+        var appDbPath = Path.Combine(FileSystem.AppDataDirectory, "filter-library.db");
+        builder.Services.AddFilterLibrarySqliteStore(appDbPath);
+        builder.Services.AddScenarioFavoriteSqliteStore(appDbPath);
 
         builder.Services.AddFilterLibraryExport();
 

--- a/src/EventLogExpert/wwwroot/css/app.css
+++ b/src/EventLogExpert/wwwroot/css/app.css
@@ -1,5 +1,5 @@
 @import url('open-iconic/font/css/open-iconic-bootstrap.min.css');
-@import url("https://cdn.jsdelivr.net/npm/bootstrap-icons@1.9.1/font/bootstrap-icons.css");
+@import url("https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.css");
 
 #blazor-error-ui {
     background: lightyellow;

--- a/tests/Integration/EventLogExpert.Runtime.IntegrationTests/Scenarios/ScenarioFavoriteSqliteStoreTests.cs
+++ b/tests/Integration/EventLogExpert.Runtime.IntegrationTests/Scenarios/ScenarioFavoriteSqliteStoreTests.cs
@@ -1,0 +1,108 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.FilterLibrary;
+using EventLogExpert.Runtime.Scenarios.Favorites;
+using Microsoft.Data.Sqlite;
+using NSubstitute;
+
+namespace EventLogExpert.Runtime.IntegrationTests.Scenarios;
+
+public sealed class ScenarioFavoriteSqliteStoreTests : IDisposable
+{
+    private readonly List<string> _tempDatabases = [];
+
+    [Fact]
+    public async Task Add_PersistsAndIsLoadable()
+    {
+        var dbPath = CreateTempDatabasePath();
+        ScenarioFavoriteSqliteStore store = new(dbPath);
+
+        await store.AddAsync("application-crashes", TestContext.Current.CancellationToken);
+        var result = await store.LoadAllAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(["application-crashes"], result);
+    }
+
+    [Fact]
+    public async Task Add_SameScenarioTwice_IsIdempotent()
+    {
+        var dbPath = CreateTempDatabasePath();
+        ScenarioFavoriteSqliteStore store = new(dbPath);
+
+        await store.AddAsync("application-crashes", TestContext.Current.CancellationToken);
+        await store.AddAsync("application-crashes", TestContext.Current.CancellationToken);
+        var result = await store.LoadAllAsync(TestContext.Current.CancellationToken);
+
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task Delete_RemovesOnlyTheNamedScenario()
+    {
+        var dbPath = CreateTempDatabasePath();
+        ScenarioFavoriteSqliteStore store = new(dbPath);
+        await store.AddAsync("application-crashes", TestContext.Current.CancellationToken);
+        await store.AddAsync("failed-services-at-boot", TestContext.Current.CancellationToken);
+
+        await store.DeleteAsync("application-crashes", TestContext.Current.CancellationToken);
+        var result = await store.LoadAllAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(["failed-services-at-boot"], result);
+    }
+
+    public void Dispose()
+    {
+        SqliteConnection.ClearAllPools();
+
+        foreach (var path in _tempDatabases)
+        {
+            try
+            {
+                if (File.Exists(path)) { File.Delete(path); }
+            }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+        }
+    }
+
+    [Fact]
+    public async Task LoadAll_OnFreshDatabase_ReturnsEmpty()
+    {
+        var dbPath = CreateTempDatabasePath();
+        ScenarioFavoriteSqliteStore store = new(dbPath);
+
+        var result = await store.LoadAllAsync(TestContext.Current.CancellationToken);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task SharesDatabaseFileWithFilterLibrary_WithoutInterference()
+    {
+        var dbPath = CreateTempDatabasePath();
+        ScenarioFavoriteSqliteStore favorites = new(dbPath);
+        FilterLibrarySqliteStore library = new(dbPath, Substitute.For<ITraceLogger>());
+        var filter = SavedFilter.TryCreate("Level == 4");
+        Assert.NotNull(filter);
+        LibraryEntrySavedFilter entry = new() { Name = "Shared", CreatedUtc = DateTimeOffset.UtcNow, Filter = filter };
+
+        await library.AddAsync(entry, TestContext.Current.CancellationToken);
+        await favorites.AddAsync("application-crashes", TestContext.Current.CancellationToken);
+
+        var favoriteIds = await favorites.LoadAllAsync(TestContext.Current.CancellationToken);
+        var entries = await library.LoadAllAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(["application-crashes"], favoriteIds);
+        Assert.Equal("Shared", Assert.Single(entries).Name);
+    }
+
+    private string CreateTempDatabasePath()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"ScenarioFavoriteSqliteStoreTests_{Guid.NewGuid()}.db");
+        _tempDatabases.Add(path);
+        return path;
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/DependencyInjection/RuntimeServiceCollectionExtensionsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/DependencyInjection/RuntimeServiceCollectionExtensionsTests.cs
@@ -24,6 +24,7 @@ using EventLogExpert.Runtime.LogTable;
 using EventLogExpert.Runtime.Menu;
 using EventLogExpert.Runtime.Modal;
 using EventLogExpert.Runtime.Scenarios;
+using EventLogExpert.Runtime.Scenarios.Favorites;
 using EventLogExpert.Runtime.Settings;
 using EventLogExpert.Runtime.Update;
 using EventLogExpert.Runtime.Update.Deployment;
@@ -143,6 +144,7 @@ public sealed class RuntimeServiceCollectionExtensionsTests
     [InlineData(typeof(IFilterLibraryCommands))]
     [InlineData(typeof(IFilterPaneCommands))]
     [InlineData(typeof(ILogTableCommands))]
+    [InlineData(typeof(IScenarioFavoriteCommands))]
     // UI capabilities.
     [InlineData(typeof(IHighlightSelector))]
     [InlineData(typeof(ILogTableColumnDefaultsProvider))]
@@ -199,6 +201,7 @@ public sealed class RuntimeServiceCollectionExtensionsTests
         services.AddSingleton(Substitute.For<IWindowsIdentityProvider>());
         services.AddSingleton(Substitute.For<IFilePickerService>());
         services.AddSingleton(Substitute.For<IState<EventLogState>>());
+        services.AddSingleton(Substitute.For<IState<FilterPaneState>>());
         services.AddSingleton(Substitute.For<IStateSelection<EventLogState, bool>>());
         services.AddSingleton(new FileLocationOptions(Path.Combine(Path.GetTempPath(), "EventLogExpertTests")));
         services.AddSingleton<HttpClient>();
@@ -218,6 +221,24 @@ public sealed class RuntimeServiceCollectionExtensionsTests
         Assert.NotNull(resolved);
     }
 
+    [Fact]
+    public async Task BothSqliteStores_ShareOneDatabasePath_ResolveIndependently()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"EventLogExpertDualStore_{Guid.NewGuid()}.db");
+        var services = new ServiceCollection();
+        services.AddSingleton(Substitute.For<ITraceLogger>());
+        services.AddFilterLibrarySqliteStore(dbPath);
+        services.AddScenarioFavoriteSqliteStore(dbPath);
+
+        await using var provider = services.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateScopes = true, ValidateOnBuild = true });
+
+        await using var scope = provider.CreateAsyncScope();
+
+        Assert.NotNull(scope.ServiceProvider.GetService<IFilterLibraryStore>());
+        Assert.NotNull(scope.ServiceProvider.GetService<IScenarioFavoriteStore>());
+    }
+
     private static void RegisterHostDependencies(IServiceCollection services)
     {
         services.AddSingleton(Substitute.For<IDispatcher>());
@@ -231,6 +252,7 @@ public sealed class RuntimeServiceCollectionExtensionsTests
         services.AddSingleton(Substitute.For<IWindowsIdentityProvider>());
         services.AddSingleton(Substitute.For<IFilePickerService>());
         services.AddSingleton(Substitute.For<IState<EventLogState>>());
+        services.AddSingleton(Substitute.For<IState<FilterPaneState>>());
         services.AddSingleton(Substitute.For<IStateSelection<EventLogState, bool>>());
         services.AddSingleton(new FileLocationOptions(Path.Combine(Path.GetTempPath(), "EventLogExpertTests")));
         services.AddSingleton<HttpClient>();

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterPane/RestoreFilterPaneStateTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterPane/RestoreFilterPaneStateTests.cs
@@ -1,0 +1,68 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Evaluation;
+using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Filtering.TestUtils;
+using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.FilterPane;
+using Fluxor;
+using NSubstitute;
+using System.Collections.Immutable;
+using Effects = EventLogExpert.Runtime.FilterPane.Effects;
+using Reducers = EventLogExpert.Runtime.FilterPane.Reducers;
+
+namespace EventLogExpert.Runtime.Tests.FilterPane;
+
+public sealed class RestoreFilterPaneStateTests
+{
+    [Fact]
+    public async Task HandleRestoreFilterPaneState_DispatchesUpdateEventTableFilters()
+    {
+        var (effects, dispatcher) = CreateEffects(isEnabled: true, filters: [FilterBuilder.CreateTestFilter(isEnabled: true)]);
+
+        await effects.HandleRestoreFilterPaneState(dispatcher);
+
+        dispatcher.Received(1).Dispatch(Arg.Any<ApplyFilterAction>());
+    }
+
+    [Fact]
+    public void ReduceRestoreFilterPaneState_PreservesDisabledRowsAndDateVerbatim()
+    {
+        var disabledRow = FilterBuilder.CreateTestFilter(isEnabled: false);
+        var captured = new FilterPaneState
+        {
+            IsEnabled = false,
+            Filters = [disabledRow],
+            FilteredDateRange = new DateFilter
+            {
+                After = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                Before = new DateTime(2024, 1, 31, 0, 0, 0, DateTimeKind.Utc),
+                IsEnabled = false
+            }
+        };
+
+        var result = Reducers.ReduceRestoreFilterPaneState(new FilterPaneState(), new RestoreFilterPaneStateAction(captured));
+
+        Assert.Equal(disabledRow.Id, result.Filters[0].Id);
+        Assert.False(result.Filters[0].IsEnabled);
+        Assert.False(result.FilteredDateRange!.IsEnabled);
+        Assert.False(result.IsEnabled);
+    }
+
+    private static (Effects Effects, IDispatcher Dispatcher) CreateEffects(bool isEnabled, ImmutableList<SavedFilter> filters)
+    {
+        var filterPaneState = Substitute.For<IState<FilterPaneState>>();
+        filterPaneState.Value.Returns(new FilterPaneState { IsEnabled = isEnabled, Filters = filters });
+
+        var appliedFilter = Substitute.For<IStateSelection<EventLogState, Filter>>();
+        appliedFilter.Value.Returns(new Filter(null, []));
+
+        var eventDateRange = Substitute.For<IStateSelection<EventLogState, (DateTime After, DateTime Before)?>>();
+        eventDateRange.Value.Returns(((DateTime, DateTime)?)null);
+
+        var effects = new Effects(appliedFilter, eventDateRange, filterPaneState);
+
+        return (effects, Substitute.For<IDispatcher>());
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/Favorites/EffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/Favorites/EffectsTests.cs
@@ -1,0 +1,117 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.Announcement;
+using EventLogExpert.Runtime.Scenarios.Favorites;
+using Fluxor;
+using NSubstitute;
+
+namespace EventLogExpert.Runtime.Tests.Scenarios.Favorites;
+
+public sealed class EffectsTests
+{
+    private readonly IAnnouncementService _announcer = Substitute.For<IAnnouncementService>();
+    private readonly IDispatcher _dispatcher = Substitute.For<IDispatcher>();
+    private readonly ITraceLogger _logger = Substitute.For<ITraceLogger>();
+    private readonly IState<ScenarioFavoritesState> _state = Substitute.For<IState<ScenarioFavoritesState>>();
+    private readonly IScenarioFavoriteStore _store = Substitute.For<IScenarioFavoriteStore>();
+
+    [Fact]
+    public async Task HandleLoadScenarioFavorites_LoadFailure_DoesNotDispatchSuccess()
+    {
+        _state.Value.Returns(new ScenarioFavoritesState());
+        _store.LoadAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<IReadOnlyList<string>>(new IOException("boom")));
+        var sut = new Effects(_store, _state, _announcer, _logger);
+
+        await sut.HandleLoadScenarioFavorites(_dispatcher);
+
+        _dispatcher.DidNotReceive().Dispatch(Arg.Any<LoadScenarioFavoritesSuccessAction>());
+    }
+
+    [Fact]
+    public async Task HandleLoadScenarioFavorites_Success_DispatchesLoadedIds()
+    {
+        _state.Value.Returns(new ScenarioFavoritesState());
+        _store.LoadAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<string>>(["application-crashes", "failed-services-at-boot"]));
+        var sut = new Effects(_store, _state, _announcer, _logger);
+
+        await sut.HandleLoadScenarioFavorites(_dispatcher);
+
+        _dispatcher.Received(1).Dispatch(Arg.Is<LoadScenarioFavoritesSuccessAction>(action =>
+            action.FavoriteScenarioIds.Contains("application-crashes") &&
+            action.FavoriteScenarioIds.Contains("failed-services-at-boot")));
+    }
+
+    [Fact]
+    public async Task HandleLoadScenarioFavorites_WhenAlreadyLoaded_DoesNotReadStore()
+    {
+        _state.Value.Returns(new ScenarioFavoritesState { IsLoaded = true });
+        var sut = new Effects(_store, _state, _announcer, _logger);
+
+        await sut.HandleLoadScenarioFavorites(_dispatcher);
+
+        await _store.DidNotReceive().LoadAllAsync(Arg.Any<CancellationToken>());
+        _dispatcher.DidNotReceive().Dispatch(Arg.Any<LoadScenarioFavoritesSuccessAction>());
+    }
+
+    [Fact]
+    public async Task HandleSetScenarioFavorite_Favorite_PersistsAnnouncesAndDispatches()
+    {
+        _state.Value.Returns(new ScenarioFavoritesState());
+        var sut = new Effects(_store, _state, _announcer, _logger);
+
+        await sut.HandleSetScenarioFavorite(
+            new SetScenarioFavoriteAction("application-crashes", "Application crashes", IsFavorite: true), _dispatcher);
+
+        await _store.Received(1).AddAsync("application-crashes", Arg.Any<CancellationToken>());
+        _announcer.Received(1).Announce("Added Application crashes to favorites");
+        _dispatcher.Received(1).Dispatch(Arg.Is<SetScenarioFavoriteSuccessAction>(action =>
+            action.ScenarioId == "application-crashes" && action.IsFavorite));
+    }
+
+    [Fact]
+    public async Task HandleSetScenarioFavorite_NoOpWhenAlreadyInDesiredState()
+    {
+        _state.Value.Returns(new ScenarioFavoritesState { FavoriteScenarioIds = ["application-crashes"] });
+        var sut = new Effects(_store, _state, _announcer, _logger);
+
+        await sut.HandleSetScenarioFavorite(
+            new SetScenarioFavoriteAction("application-crashes", "Application crashes", IsFavorite: true), _dispatcher);
+
+        await _store.DidNotReceive().AddAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        _announcer.DidNotReceive().Announce(Arg.Any<string>());
+        _dispatcher.DidNotReceive().Dispatch(Arg.Any<SetScenarioFavoriteSuccessAction>());
+    }
+
+    [Fact]
+    public async Task HandleSetScenarioFavorite_PersistFailure_NoAnnounceNoSuccess()
+    {
+        _state.Value.Returns(new ScenarioFavoritesState());
+        _store.AddAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(new IOException("boom")));
+        var sut = new Effects(_store, _state, _announcer, _logger);
+
+        await sut.HandleSetScenarioFavorite(
+            new SetScenarioFavoriteAction("application-crashes", "Application crashes", IsFavorite: true), _dispatcher);
+
+        _announcer.DidNotReceive().Announce(Arg.Any<string>());
+        _dispatcher.DidNotReceive().Dispatch(Arg.Any<SetScenarioFavoriteSuccessAction>());
+    }
+
+    [Fact]
+    public async Task HandleSetScenarioFavorite_Unfavorite_DeletesAndAnnounces()
+    {
+        _state.Value.Returns(new ScenarioFavoritesState { FavoriteScenarioIds = ["application-crashes"] });
+        var sut = new Effects(_store, _state, _announcer, _logger);
+
+        await sut.HandleSetScenarioFavorite(
+            new SetScenarioFavoriteAction("application-crashes", "Application crashes", IsFavorite: false), _dispatcher);
+
+        await _store.Received(1).DeleteAsync("application-crashes", Arg.Any<CancellationToken>());
+        _announcer.Received(1).Announce("Removed Application crashes from favorites");
+        _dispatcher.Received(1).Dispatch(Arg.Is<SetScenarioFavoriteSuccessAction>(action => !action.IsFavorite));
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/Favorites/ReducersTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/Favorites/ReducersTests.cs
@@ -1,0 +1,52 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.Scenarios.Favorites;
+using System.Collections.Immutable;
+
+namespace EventLogExpert.Runtime.Tests.Scenarios.Favorites;
+
+public sealed class ReducersTests
+{
+    [Fact]
+    public void ReduceLoadScenarioFavoritesSuccess_ReplacesSetAndMarksLoaded()
+    {
+        var state = new ScenarioFavoritesState();
+        var ids = ImmutableHashSet.Create("application-crashes", "failed-services-at-boot");
+
+        var result = Reducers.ReduceLoadScenarioFavoritesSuccess(state, new LoadScenarioFavoritesSuccessAction(ids));
+
+        Assert.Equal(ids, result.FavoriteScenarioIds);
+        Assert.True(result.IsLoaded);
+    }
+
+    [Fact]
+    public void ReduceSetScenarioFavoriteSuccess_Favorite_AddsId()
+    {
+        var state = new ScenarioFavoritesState { IsLoaded = true };
+
+        var result = Reducers.ReduceSetScenarioFavoriteSuccess(
+            state,
+            new SetScenarioFavoriteSuccessAction("application-crashes", "Application crashes", IsFavorite: true));
+
+        Assert.Contains("application-crashes", result.FavoriteScenarioIds);
+        Assert.True(result.IsLoaded);
+    }
+
+    [Fact]
+    public void ReduceSetScenarioFavoriteSuccess_Unfavorite_RemovesId()
+    {
+        var state = new ScenarioFavoritesState
+        {
+            FavoriteScenarioIds = ImmutableHashSet.Create("application-crashes", "failed-services-at-boot"),
+            IsLoaded = true,
+        };
+
+        var result = Reducers.ReduceSetScenarioFavoriteSuccess(
+            state,
+            new SetScenarioFavoriteSuccessAction("application-crashes", "Application crashes", IsFavorite: false));
+
+        Assert.DoesNotContain("application-crashes", result.FavoriteScenarioIds);
+        Assert.Contains("failed-services-at-boot", result.FavoriteScenarioIds);
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/Favorites/ScenarioFavoriteCommandsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/Favorites/ScenarioFavoriteCommandsTests.cs
@@ -1,0 +1,48 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.Scenarios.Favorites;
+using Fluxor;
+using NSubstitute;
+
+namespace EventLogExpert.Runtime.Tests.Scenarios.Favorites;
+
+public sealed class ScenarioFavoriteCommandsTests
+{
+    [Fact]
+    public void Load_DispatchesLoadAction()
+    {
+        var dispatcher = Substitute.For<IDispatcher>();
+        var sut = new ScenarioFavoriteCommands(dispatcher);
+
+        sut.Load();
+
+        dispatcher.Received(1).Dispatch(Arg.Any<LoadScenarioFavoritesAction>());
+    }
+
+    [Fact]
+    public void SetFavorite_Favorite_DispatchesActionWithArguments()
+    {
+        var dispatcher = Substitute.For<IDispatcher>();
+        var sut = new ScenarioFavoriteCommands(dispatcher);
+
+        sut.SetFavorite("application-crashes", "Application crashes", isFavorite: true);
+
+        dispatcher.Received(1).Dispatch(Arg.Is<SetScenarioFavoriteAction>(action =>
+            action.ScenarioId == "application-crashes" &&
+            action.ScenarioName == "Application crashes" &&
+            action.IsFavorite));
+    }
+
+    [Fact]
+    public void SetFavorite_Unfavorite_DispatchesActionWithFalse()
+    {
+        var dispatcher = Substitute.For<IDispatcher>();
+        var sut = new ScenarioFavoriteCommands(dispatcher);
+
+        sut.SetFavorite("application-crashes", "Application crashes", isFavorite: false);
+
+        dispatcher.Received(1).Dispatch(Arg.Is<SetScenarioFavoriteAction>(action =>
+            action.ScenarioId == "application-crashes" && !action.IsFavorite));
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/ScenarioLaunchServiceTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/ScenarioLaunchServiceTests.cs
@@ -1,6 +1,7 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Filtering.TestUtils;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.Runtime.FilterPane;
 using EventLogExpert.Runtime.Menu;
@@ -62,6 +63,16 @@ public sealed class ScenarioLaunchServiceTests
     }
 
     [Fact]
+    public async Task LaunchAsync_SomethingOpened_DoesNotRestoreFilters()
+    {
+        var (service, dispatcher, _, scenario) = Create(new OpenLogsBatchResult(1, 0, 0, 0, []));
+
+        await service.LaunchAsync(scenario, dateWindow: null);
+
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<RestoreFilterPaneStateAction>());
+    }
+
+    [Fact]
     public async Task LaunchAsync_ZeroOpenButCombining_DoesNotDispatchCloseAll()
     {
         var (service, dispatcher, _, scenario) = Create(new OpenLogsBatchResult(0, 0, 1, 0, []));
@@ -69,6 +80,30 @@ public sealed class ScenarioLaunchServiceTests
         await service.LaunchAsync(scenario, dateWindow: null, combineLog: true);
 
         dispatcher.DidNotReceive().Dispatch(Arg.Any<CloseAllLogsAction>());
+    }
+
+    [Fact]
+    public async Task LaunchAsync_ZeroOpenButCombining_DoesNotRestoreFilters()
+    {
+        var (service, dispatcher, _, scenario) = Create(new OpenLogsBatchResult(0, 0, 1, 0, []));
+
+        await service.LaunchAsync(scenario, dateWindow: null, combineLog: true);
+
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<RestoreFilterPaneStateAction>());
+    }
+
+    [Fact]
+    public async Task LaunchAsync_ZeroOpenFreshView_ClosesLogsBeforeRestoringFilters()
+    {
+        var (service, dispatcher, _, scenario) = Create(new OpenLogsBatchResult(0, 1, 0, 0, ["System"]));
+
+        await service.LaunchAsync(scenario, dateWindow: null);
+
+        Received.InOrder(() =>
+        {
+            dispatcher.Dispatch(Arg.Any<CloseAllLogsAction>());
+            dispatcher.Dispatch(Arg.Any<RestoreFilterPaneStateAction>());
+        });
     }
 
     [Fact]
@@ -81,6 +116,34 @@ public sealed class ScenarioLaunchServiceTests
         dispatcher.Received(1).Dispatch(Arg.Any<CloseAllLogsAction>());
     }
 
+    [Fact]
+    public async Task LaunchAsync_ZeroOpenFreshView_RestoresFilterStateCapturedBeforeApply()
+    {
+        var scenario = ScenarioTestData.Single("a", "System", 1000);
+        var registry = ScenarioTestData.Registry(scenario);
+
+        var menu = Substitute.For<IMenuActionService>();
+        menu.OpenLiveLogsAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<bool>())
+            .Returns(new OpenLogsBatchResult(0, 1, 0, 0, ["System"]));
+
+        var priorState = new FilterPaneState { Filters = [FilterBuilder.CreateTestFilter(isEnabled: false)] };
+        var afterApplyState = new FilterPaneState { Filters = [FilterBuilder.CreateTestFilter(isEnabled: true)] };
+
+        var filterPaneState = Substitute.For<IState<FilterPaneState>>();
+        filterPaneState.Value.Returns(priorState);
+
+        var dispatcher = Substitute.For<IDispatcher>();
+        dispatcher.When(d => d.Dispatch(Arg.Any<ReplaceFiltersAction>()))
+            .Do(_ => filterPaneState.Value.Returns(afterApplyState));
+
+        var service = new ScenarioLaunchService(registry, menu, filterPaneState, dispatcher);
+
+        await service.LaunchAsync(scenario, dateWindow: null);
+
+        dispatcher.Received(1)
+            .Dispatch(Arg.Is<RestoreFilterPaneStateAction>(action => ReferenceEquals(action.State, priorState)));
+    }
+
     private static (IScenarioLaunchService Service, IDispatcher Dispatcher, IMenuActionService Menu, ScenarioDefinition Scenario)
         Create(OpenLogsBatchResult openResult)
     {
@@ -90,8 +153,11 @@ public sealed class ScenarioLaunchServiceTests
         var menu = Substitute.For<IMenuActionService>();
         menu.OpenLiveLogsAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<bool>()).Returns(openResult);
 
+        var filterPaneState = Substitute.For<IState<FilterPaneState>>();
+        filterPaneState.Value.Returns(new FilterPaneState());
+
         var dispatcher = Substitute.For<IDispatcher>();
-        var service = new ScenarioLaunchService(registry, menu, dispatcher);
+        var service = new ScenarioLaunchService(registry, menu, filterPaneState, dispatcher);
 
         return (service, dispatcher, menu, scenario);
     }

--- a/tests/Unit/EventLogExpert.UI.Tests/Dashboard/EmptyStateDashboardTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Dashboard/EmptyStateDashboardTests.cs
@@ -1,0 +1,410 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using AngleSharp.Dom;
+using Bunit;
+using EventLogExpert.Filtering.Evaluation;
+using EventLogExpert.Runtime.Announcement;
+using EventLogExpert.Runtime.Common.Versioning;
+using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.FilterPane;
+using EventLogExpert.Runtime.Menu;
+using EventLogExpert.Runtime.Scenarios;
+using EventLogExpert.Runtime.Scenarios.Favorites;
+using EventLogExpert.Scenarios.Catalog;
+using EventLogExpert.UI.Dashboard;
+using Fluxor;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using System.Collections.Immutable;
+
+namespace EventLogExpert.UI.Tests.Dashboard;
+
+public sealed class EmptyStateDashboardTests : BunitContext
+{
+    private const string ActiveDetailLaunch = ".sidebar-tabs-tabpanel.active .scenario-detail__launch";
+    private const string ActiveDetailName = ".sidebar-tabs-tabpanel.active .scenario-detail__name";
+    private const string ActiveDetailStar = ".sidebar-tabs-tabpanel.active .scenario-detail__star";
+    private const string ActiveOption = ".sidebar-tabs-tabpanel.active [role='option']";
+
+    private readonly IMenuActionService _actions = Substitute.For<IMenuActionService>();
+    private readonly IAnnouncementService _announcer = Substitute.For<IAnnouncementService>();
+    private readonly IScenarioFavoriteCommands _favoriteCommands = Substitute.For<IScenarioFavoriteCommands>();
+    private readonly IState<ScenarioFavoritesState> _favorites = Substitute.For<IState<ScenarioFavoritesState>>();
+    private readonly IStateSelection<ScenarioFavoritesState, ImmutableHashSet<string>> _favoritesSelection =
+        Substitute.For<IStateSelection<ScenarioFavoritesState, ImmutableHashSet<string>>>();
+
+    private readonly IStateSelection<EventLogState, bool> _filterApplied = Substitute.For<IStateSelection<EventLogState, bool>>();
+    private readonly IFilterPaneCommands _filterCommands = Substitute.For<IFilterPaneCommands>();
+    private readonly IScenarioLaunchService _scenarioLaunch = Substitute.For<IScenarioLaunchService>();
+    private readonly IScenarioQueryService _scenarioQuery = Substitute.For<IScenarioQueryService>();
+    private readonly ICurrentVersionProvider _version = Substitute.For<ICurrentVersionProvider>();
+
+    public EmptyStateDashboardTests()
+    {
+        _scenarioLaunch.LaunchAsync(Arg.Any<ScenarioDefinition>(), Arg.Any<DateFilter?>(), Arg.Any<bool>())
+            .Returns(new ScenarioLaunchResult(1, 0, 0));
+        _scenarioQuery.GetSplashScenarios().Returns([]);
+        _favorites.Value.Returns(new ScenarioFavoritesState());
+        _favoritesSelection.Value.Returns(ImmutableHashSet<string>.Empty);
+
+        Services.AddSingleton(_actions);
+        Services.AddSingleton(_announcer);
+        Services.AddSingleton(_favoriteCommands);
+        Services.AddSingleton(_favorites);
+        Services.AddSingleton(_favoritesSelection);
+        Services.AddSingleton(_filterApplied);
+        Services.AddSingleton(_filterCommands);
+        Services.AddSingleton(_scenarioLaunch);
+        Services.AddSingleton(_scenarioQuery);
+        Services.AddSingleton(_version);
+        Services.AddFluxor(options => options.ScanAssemblies(typeof(EmptyStateDashboard).Assembly));
+        JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    [Fact]
+    public void Catalog_WhenNoCategories_ShowsEmptyState()
+    {
+        var cut = Render<EmptyStateDashboard>();
+
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".empty-dashboard__empty")));
+        Assert.Empty(cut.FindAll(".sidebar-tabs"));
+    }
+
+    [Fact]
+    public void Catalog_WhenScenariosLoading_ShowsLoading()
+    {
+        using var gate = new ManualResetEventSlim(false);
+        _scenarioQuery.GetSplashScenarios().Returns(_ => { gate.Wait(); return []; });
+
+        var cut = Render<EmptyStateDashboard>();
+
+        Assert.NotEmpty(cut.FindAll(".empty-dashboard__loading"));
+
+        gate.Set();
+    }
+
+    [Fact]
+    public void Chip_WhenFilterApplied_ClearInvokesClearAllFilters()
+    {
+        _filterApplied.Value.Returns(true);
+
+        var cut = Render<EmptyStateDashboard>();
+        cut.Find(".empty-dashboard__chip button").Click();
+
+        cut.WaitForAssertion(() => _filterCommands.Received(1).ClearAllFilters());
+    }
+
+    [Fact]
+    public void Chip_WhenNoFilterApplied_NotRendered()
+    {
+        _filterApplied.Value.Returns(false);
+
+        var cut = Render<EmptyStateDashboard>();
+
+        Assert.Empty(cut.FindAll(".empty-dashboard__chip"));
+    }
+
+    [Fact]
+    public void DetailLaunch_InvokesScenarioLaunchAndAnnounces()
+    {
+        _scenarioQuery.GetSplashScenarios().Returns([Scenario("application-crashes", "Application crashes")]);
+
+        var cut = Render<EmptyStateDashboard>();
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(ActiveDetailLaunch)));
+
+        cut.Find(ActiveDetailLaunch).Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            _scenarioLaunch.Received(1)
+                .LaunchAsync(Arg.Is<ScenarioDefinition>(scenario => scenario.Id == "application-crashes"), null);
+            _announcer.Received(1).Announce(Arg.Any<string>());
+        });
+    }
+
+    [Fact]
+    public void DetailLaunch_WhenLaunchOpensNothing_AnnouncesFailure()
+    {
+        _scenarioLaunch.LaunchAsync(Arg.Any<ScenarioDefinition>(), Arg.Any<DateFilter?>(), Arg.Any<bool>())
+            .Returns(new ScenarioLaunchResult(0, 1, 0));
+        _scenarioQuery.GetSplashScenarios().Returns([Scenario("application-crashes", "Application crashes")]);
+
+        var cut = Render<EmptyStateDashboard>();
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(ActiveDetailLaunch)));
+
+        cut.Find(ActiveDetailLaunch).Click();
+
+        cut.WaitForAssertion(() =>
+            _announcer.Received(1).Announce(Arg.Is<string>(message => message.Contains("No channels"))));
+    }
+
+    [Fact]
+    public void DetailStar_TogglesFavorite()
+    {
+        _scenarioQuery.GetSplashScenarios().Returns([Scenario("application-crashes", "Application crashes")]);
+
+        var cut = Render<EmptyStateDashboard>();
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(ActiveDetailStar)));
+
+        cut.Find(ActiveDetailStar).Click();
+
+        cut.WaitForAssertion(() =>
+            _favoriteCommands.Received(1).SetFavorite("application-crashes", "Application crashes", true));
+    }
+
+    [Fact]
+    public void Favorites_LoadDispatchedOnFirstRender()
+    {
+        var cut = Render<EmptyStateDashboard>();
+
+        cut.WaitForAssertion(() => _favoriteCommands.Received(1).Load());
+    }
+
+    [Fact]
+    public void Favoriting_ReactivelyAddsFavoritesTab()
+    {
+        _scenarioQuery.GetSplashScenarios().Returns([Scenario("application-crashes", "Application crashes")]);
+
+        var cut = Render<EmptyStateDashboard>();
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll("[role='tab']")));
+        Assert.DoesNotContain("Favorites", TabLabels(cut));
+
+        _favorites.Value.Returns(new ScenarioFavoritesState { FavoriteScenarioIds = ["application-crashes"] });
+        RaiseFavoritesChanged(cut, "application-crashes");
+
+        cut.WaitForAssertion(() => Assert.Contains("Favorites", TabLabels(cut)));
+    }
+
+    [Fact]
+    public void ManageDatabases_IsInMastheadAndInvokesOpen()
+    {
+        var cut = Render<EmptyStateDashboard>();
+
+        cut.Find(".empty-dashboard__utility").Click();
+
+        cut.WaitForAssertion(() => _actions.Received(1).OpenDatabaseToolsAsync());
+        Assert.DoesNotContain(
+            cut.FindAll(".empty-dashboard__launchbar button"),
+            button => button.TextContent.Contains("Manage databases"));
+    }
+
+    [Fact]
+    public void Masthead_UsesJournalBrandIcon()
+    {
+        var cut = Render<EmptyStateDashboard>();
+
+        Assert.NotEmpty(cut.FindAll(".empty-dashboard__brand-mark .bi-journal-text"));
+    }
+
+    [Fact]
+    public void QuickLaunch_OpenApplicationAndSystem_InvokesCombineOpen()
+    {
+        var cut = Render<EmptyStateDashboard>();
+
+        FindLaunch(cut, "Open Application + System (live)").Click();
+
+        cut.WaitForAssertion(() => _actions.Received(1).OpenLiveLogsAsync(
+            Arg.Is<IEnumerable<string>>(channels => channels.SequenceEqual(new[] { "Application", "System" })),
+            false));
+    }
+
+    [Fact]
+    public void QuickLaunch_OpenFile_InvokesOpenFile()
+    {
+        var cut = Render<EmptyStateDashboard>();
+
+        FindLaunch(cut, "Open Log file...").Click();
+
+        cut.WaitForAssertion(() => _actions.Received(1).OpenFileAsync(false));
+    }
+
+    [Fact]
+    public void QuickLaunch_VisibleLabelsDropOpenButAriaLabelKeepsIt()
+    {
+        var cut = Render<EmptyStateDashboard>();
+
+        var primary = FindLaunch(cut, "Open Application + System (live)");
+
+        Assert.Equal("Application + System (live)", primary.TextContent.Trim());
+        Assert.Equal("Open Application + System (live)", primary.GetAttribute("aria-label"));
+        Assert.DoesNotContain("Open", primary.TextContent);
+    }
+
+    [Fact]
+    public void QuickLaunch_WhileBusy_DisablesOtherButtons()
+    {
+        var gate = new TaskCompletionSource();
+        _actions.OpenFileAsync(false).Returns(gate.Task);
+
+        var cut = Render<EmptyStateDashboard>();
+        FindLaunch(cut, "Open Log file...").Click();
+
+        cut.WaitForAssertion(() => Assert.True(FindLaunch(cut, "Open Application (live)").HasAttribute("disabled")));
+
+        gate.SetResult();
+    }
+
+    [Fact]
+    public void Security_WhenAdmin_InvokesOpen()
+    {
+        _version.IsAdmin.Returns(true);
+
+        var cut = Render<EmptyStateDashboard>();
+        FindLaunch(cut, "Open Security (live)").Click();
+
+        cut.WaitForAssertion(() => _actions.Received(1).OpenLiveLogAsync("Security", false));
+    }
+
+    [Fact]
+    public void Security_WhenNotAdmin_IsAriaDisabledWithReason()
+    {
+        _version.IsAdmin.Returns(false);
+
+        var cut = Render<EmptyStateDashboard>();
+        var security = FindLaunch(cut, "Open Security (live)");
+        var reasonId = security.GetAttribute("aria-describedby");
+
+        Assert.Equal("true", security.GetAttribute("aria-disabled"));
+        Assert.False(string.IsNullOrEmpty(reasonId));
+        Assert.Contains("administrator", cut.Find($"#{reasonId}").TextContent, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SelectingCategory_ShowsThatCategorysScenarios()
+    {
+        _scenarioQuery.GetSplashScenarios().Returns(
+        [
+            Scenario("application-crashes", "Application crashes", group: ScenarioGroup.SystemHealth),
+            Scenario("sql-health-triage", "SQL Server health triage", group: ScenarioGroup.SqlServer)
+        ]);
+
+        var cut = Render<EmptyStateDashboard>();
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll("[role='tab']")));
+
+        cut.FindAll("[role='tab']").First(tab => tab.TextContent.Contains("SQL Server")).Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            var names = ActiveOptionNames(cut);
+            Assert.Equal(["SQL Server health triage"], names);
+        });
+    }
+
+    [Fact]
+    public void SelectingScenario_UpdatesDetail()
+    {
+        _scenarioQuery.GetSplashScenarios().Returns(
+        [
+            Scenario("crash-a", "Crash A", group: ScenarioGroup.SqlServer, order: 0),
+            Scenario("crash-b", "Crash B", group: ScenarioGroup.SqlServer, order: 1)
+        ]);
+
+        var cut = Render<EmptyStateDashboard>();
+        cut.WaitForAssertion(() => Assert.Equal("Crash A", cut.Find(ActiveDetailName).TextContent));
+
+        cut.FindAll(ActiveOption).First(option => option.TextContent.Contains("Crash B")).Click();
+
+        cut.WaitForAssertion(() => Assert.Equal("Crash B", cut.Find(ActiveDetailName).TextContent));
+    }
+
+    [Fact]
+    public void StarterScenarioIds_AllResolveInBuiltInCatalog()
+    {
+        var registry = new BuiltInScenarioRegistry([new BuiltInScenarioSource()]);
+        var catalogIds = registry.Scenarios.Select(scenario => scenario.Id).ToHashSet(StringComparer.Ordinal);
+
+        Assert.All(EmptyStateDashboard.StarterScenarioIds, id => Assert.Contains(id, catalogIds));
+    }
+
+    [Fact]
+    public void Tablist_FavoritesAbsentWhenNoneFavorited()
+    {
+        _scenarioQuery.GetSplashScenarios().Returns([Scenario("application-crashes", "Application crashes")]);
+
+        var cut = Render<EmptyStateDashboard>();
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll("[role='tab']")));
+
+        Assert.DoesNotContain("Favorites", TabLabels(cut));
+    }
+
+    [Fact]
+    public void Tablist_ListsFavoritesRecommendedAndGroupsInOrder()
+    {
+        _favorites.Value.Returns(new ScenarioFavoritesState { FavoriteScenarioIds = ["application-crashes"] });
+        _scenarioQuery.GetSplashScenarios().Returns(
+        [
+            Scenario("application-crashes", "Application crashes", group: ScenarioGroup.SystemHealth),
+            Scenario("sql-health-triage", "SQL Server health triage", group: ScenarioGroup.SqlServer)
+        ]);
+
+        var cut = Render<EmptyStateDashboard>();
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll("[role='tab']")));
+
+        Assert.Equal(
+            ["Favorites", "Recommended", "System Health", "SQL Server"],
+            TabLabels(cut));
+    }
+
+    [Fact]
+    public void ToSplashCategory_MapsAllScenarioGroups()
+    {
+        Assert.All(
+            Enum.GetValues<ScenarioGroup>(),
+            group => Assert.NotNull(SplashCategoryMapping.ToSplashCategory(group)));
+    }
+
+    [Fact]
+    public void Unfavoriting_LastFavorite_RemovesTabAndReconcilesActive()
+    {
+        _favorites.Value.Returns(new ScenarioFavoritesState { FavoriteScenarioIds = ["application-crashes"] });
+        _scenarioQuery.GetSplashScenarios().Returns([Scenario("application-crashes", "Application crashes")]);
+
+        var cut = Render<EmptyStateDashboard>();
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Favorites", TabLabels(cut));
+            Assert.Equal("Favorites", cut.Find("[role='tab'][aria-selected='true']").TextContent.Trim());
+        });
+
+        _favorites.Value.Returns(new ScenarioFavoritesState());
+        RaiseFavoritesChanged(cut);
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.DoesNotContain("Favorites", TabLabels(cut));
+            Assert.Equal("Recommended", cut.Find("[role='tab'][aria-selected='true']").TextContent.Trim());
+        });
+    }
+
+    private static IReadOnlyList<string> ActiveOptionNames(IRenderedComponent<EmptyStateDashboard> cut) =>
+        cut.FindAll(".sidebar-tabs-tabpanel.active .scenario-browser__option-name").Select(node => node.TextContent).ToList();
+
+    private static IElement FindLaunch(IRenderedComponent<EmptyStateDashboard> cut, string ariaLabel) =>
+        cut.FindAll(".empty-dashboard__launch").First(button => button.GetAttribute("aria-label") == ariaLabel);
+
+    private static ScenarioDefinition Scenario(
+        string id,
+        string name,
+        bool requiresAdmin = false,
+        ScenarioGroup group = ScenarioGroup.SystemHealth,
+        int order = 0) =>
+        new()
+        {
+            Id = id,
+            Name = name,
+            Purpose = "Purpose",
+            Group = group,
+            Channels = ["System"],
+            RequiresAdmin = requiresAdmin,
+            Filters = [],
+            Order = order
+        };
+
+    private static IReadOnlyList<string> TabLabels(IRenderedComponent<EmptyStateDashboard> cut) =>
+        cut.FindAll("[role='tab']").Select(tab => tab.TextContent.Trim()).ToList();
+
+    private void RaiseFavoritesChanged(IRenderedComponent<EmptyStateDashboard> cut, params string[] favoriteIds) =>
+        cut.InvokeAsync(() => _favoritesSelection.SelectedValueChanged +=
+            Raise.Event<EventHandler<ImmutableHashSet<string>>>(this, favoriteIds.ToImmutableHashSet()));
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/Dashboard/ScenarioBrowserPanelTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Dashboard/ScenarioBrowserPanelTests.cs
@@ -1,0 +1,136 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using EventLogExpert.Scenarios.Catalog;
+using EventLogExpert.UI.Dashboard;
+using Microsoft.AspNetCore.Components.Web;
+
+namespace EventLogExpert.UI.Tests.Dashboard;
+
+public sealed class ScenarioBrowserPanelTests : BunitContext
+{
+    public ScenarioBrowserPanelTests() => JSInterop.Mode = JSRuntimeMode.Loose;
+
+    [Fact]
+    public void Click_SelectsOption()
+    {
+        var scenarios = new[] { Scenario("first", "First"), Scenario("second", "Second") };
+        ScenarioDefinition? selected = null;
+
+        var cut = Render<ScenarioBrowserPanel>(parameters => parameters
+            .Add(panel => panel.Scenarios, scenarios)
+            .Add(panel => panel.Selected, scenarios[0])
+            .Add(panel => panel.ElevationReasonId, "reason")
+            .Add(panel => panel.IsFavored, _ => false)
+            .Add(panel => panel.IsScenarioDisabled, _ => false)
+            .Add(panel => panel.OnSelect, scenario => selected = scenario));
+
+        cut.FindAll("[role='option']").First(option => option.TextContent.Contains("Second")).Click();
+
+        cut.WaitForAssertion(() => Assert.Equal("second", selected?.Id));
+    }
+
+    [Fact]
+    public void DisabledOption_IsSelectableButDoesNotLaunch()
+    {
+        var disabled = Scenario("locked", "Locked", requiresAdmin: true);
+        bool launched = false;
+
+        var cut = Render<ScenarioBrowserPanel>(parameters => parameters
+            .Add(panel => panel.Scenarios, [disabled])
+            .Add(panel => panel.Selected, disabled)
+            .Add(panel => panel.ElevationReasonId, "reason")
+            .Add(panel => panel.IsFavored, _ => false)
+            .Add(panel => panel.IsScenarioDisabled, _ => true)
+            .Add(panel => panel.OnLaunch, _ => launched = true));
+
+        Assert.Equal("true", cut.Find("[role='option']").GetAttribute("aria-disabled"));
+
+        cut.Find(".scenario-detail__launch").Click();
+
+        Assert.False(launched);
+    }
+
+    [Fact]
+    public void EmptyList_ShowsEmptyState()
+    {
+        var cut = Render<ScenarioBrowserPanel>(parameters => parameters
+            .Add(panel => panel.Scenarios, [])
+            .Add(panel => panel.ElevationReasonId, "reason")
+            .Add(panel => panel.IsFavored, _ => false)
+            .Add(panel => panel.IsScenarioDisabled, _ => false));
+
+        Assert.NotEmpty(cut.FindAll(".scenario-browser__empty"));
+        Assert.Empty(cut.FindAll(".scenario-detail"));
+    }
+
+    [Fact]
+    public void Option_RendersNameOnly_WithPurposeInTitle()
+    {
+        var scenarios = new[] { Scenario("first", "First") };
+
+        var cut = Render<ScenarioBrowserPanel>(parameters => parameters
+            .Add(panel => panel.Scenarios, scenarios)
+            .Add(panel => panel.Selected, scenarios[0])
+            .Add(panel => panel.ElevationReasonId, "reason")
+            .Add(panel => panel.IsFavored, _ => false)
+            .Add(panel => panel.IsScenarioDisabled, _ => false));
+
+        var option = cut.Find("[role='option']");
+
+        Assert.Equal("First", option.QuerySelector(".scenario-browser__option-name")!.TextContent);
+        Assert.Empty(option.QuerySelectorAll(".scenario-browser__option-purpose"));
+        Assert.Equal("Purpose", option.GetAttribute("title"));
+    }
+
+    [Fact]
+    public void SelectionFollowsFocus_ArrowDown_SelectsNextScenario()
+    {
+        var scenarios = new[] { Scenario("first", "First"), Scenario("second", "Second") };
+        ScenarioDefinition? selected = null;
+
+        var cut = Render<ScenarioBrowserPanel>(parameters => parameters
+            .Add(panel => panel.Scenarios, scenarios)
+            .Add(panel => panel.Selected, scenarios[0])
+            .Add(panel => panel.ElevationReasonId, "reason")
+            .Add(panel => panel.IsFavored, _ => false)
+            .Add(panel => panel.IsScenarioDisabled, _ => false)
+            .Add(panel => panel.OnSelect, scenario => selected = scenario));
+
+        cut.Find(".scenario-browser__list").KeyDown(new KeyboardEventArgs { Key = "ArrowDown" });
+
+        cut.WaitForAssertion(() => Assert.Equal("second", selected?.Id));
+    }
+
+    [Fact]
+    public void SelectionStateless_SelectedParamDrivesDetail()
+    {
+        var scenarios = new[] { Scenario("first", "First"), Scenario("second", "Second") };
+
+        var cut = Render<ScenarioBrowserPanel>(parameters => parameters
+            .Add(panel => panel.Scenarios, scenarios)
+            .Add(panel => panel.Selected, scenarios[1])
+            .Add(panel => panel.ElevationReasonId, "reason")
+            .Add(panel => panel.IsFavored, _ => false)
+            .Add(panel => panel.IsScenarioDisabled, _ => false));
+
+        Assert.Equal("Second", cut.Find(".scenario-detail__name").TextContent);
+
+        cut.Render(parameters => parameters.Add(panel => panel.Selected, scenarios[0]));
+
+        Assert.Equal("First", cut.Find(".scenario-detail__name").TextContent);
+    }
+
+    private static ScenarioDefinition Scenario(string id, string name, bool requiresAdmin = false) =>
+        new()
+        {
+            Id = id,
+            Name = name,
+            Purpose = "Purpose",
+            Group = ScenarioGroup.SystemHealth,
+            Channels = ["System"],
+            RequiresAdmin = requiresAdmin,
+            Filters = []
+        };
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/Dashboard/ScenarioDetailTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Dashboard/ScenarioDetailTests.cs
@@ -1,0 +1,260 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using EventLogExpert.Filtering.Basic;
+using EventLogExpert.Filtering.Common.Filtering;
+using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Scenarios.Catalog;
+using EventLogExpert.UI.Dashboard;
+
+namespace EventLogExpert.UI.Tests.Dashboard;
+
+public sealed class ScenarioDetailTests : BunitContext
+{
+    public ScenarioDetailTests() => JSInterop.Mode = JSRuntimeMode.Loose;
+
+    [Fact]
+    public void AdminBadge_WhenNotRequiresAdmin_IsAbsent()
+    {
+        var cut = Render<ScenarioDetail>(parameters => parameters
+            .Add(detail => detail.Scenario, Scenario("application-crashes", "Application crashes"))
+            .Add(detail => detail.ElevationReasonId, "reason"));
+
+        Assert.Empty(cut.FindAll(".scenario-detail__admin-badge"));
+    }
+
+    [Fact]
+    public void AdminBadge_WhenRequiresAdmin_IsRendered()
+    {
+        var cut = Render<ScenarioDetail>(parameters => parameters
+            .Add(detail => detail.Scenario, Scenario("application-crashes", "Application crashes") with
+            {
+                RequiresAdmin = true
+            })
+            .Add(detail => detail.ElevationReasonId, "reason"));
+
+        var badge = cut.Find(".scenario-detail__admin-badge");
+
+        Assert.Contains("Requires administrator", badge.TextContent);
+        Assert.NotEmpty(cut.FindAll(".scenario-detail__admin-badge .bi-shield-lock"));
+    }
+
+    [Fact]
+    public void Facts_ShowsRequiredChannels()
+    {
+        var cut = Render<ScenarioDetail>(parameters => parameters
+            .Add(detail => detail.Scenario, Scenario("application-crashes", "Application crashes") with
+            {
+                Channels = ["Application", "System"]
+            })
+            .Add(detail => detail.ElevationReasonId, "reason"));
+
+        var values = cut.FindAll(".scenario-detail__fact-value");
+
+        Assert.Contains(values, value => value.TextContent == "Application, System");
+    }
+
+    [Fact]
+    public void Facts_WhenNoOptionalChannels_OmitsAlsoIfPresentLine()
+    {
+        var cut = Render<ScenarioDetail>(parameters => parameters
+            .Add(detail => detail.Scenario, Scenario("application-crashes", "Application crashes"))
+            .Add(detail => detail.ElevationReasonId, "reason"));
+
+        Assert.Empty(cut.FindAll(".scenario-detail__fact-muted"));
+    }
+
+    [Fact]
+    public void Facts_WhenOptionalChannelsPresent_ShowsAlsoIfPresentLine()
+    {
+        var cut = Render<ScenarioDetail>(parameters => parameters
+            .Add(detail => detail.Scenario, Scenario("application-crashes", "Application crashes") with
+            {
+                Channels = ["Application"],
+                OptionalChannels = ["Setup", "Security"]
+            })
+            .Add(detail => detail.ElevationReasonId, "reason"));
+
+        Assert.Equal(
+            "Also if present: Setup, Security",
+            cut.Find(".scenario-detail__fact-muted").TextContent);
+    }
+
+    [Fact]
+    public void Filters_RenderOneFormattedLinePerRow()
+    {
+        var cut = Render<ScenarioDetail>(parameters => parameters
+            .Add(detail => detail.Scenario, Scenario("application-crashes", "Application crashes") with
+            {
+                Filters =
+                [
+                    new ScenarioFilterRow(EqualsFilter(EventProperty.Id, "100")),
+                    new ScenarioFilterRow(EqualsFilter(EventProperty.Level, "Error"))
+                ]
+            })
+            .Add(detail => detail.ElevationReasonId, "reason"));
+
+        var lines = cut.FindAll(".scenario-detail__filter");
+
+        Assert.Equal(2, lines.Count);
+        Assert.Equal("Id == 100", lines[0].TextContent.Trim());
+        Assert.Equal("Level == \"Error\"", lines[1].TextContent.Trim());
+    }
+
+    [Fact]
+    public void Filters_WhenColorSet_RendersSwatchWithDataHighlight()
+    {
+        var cut = Render<ScenarioDetail>(parameters => parameters
+            .Add(detail => detail.Scenario, Scenario("application-crashes", "Application crashes") with
+            {
+                Filters = [new ScenarioFilterRow(EqualsFilter(EventProperty.Id, "100"), Color: HighlightColor.Red)]
+            })
+            .Add(detail => detail.ElevationReasonId, "reason"));
+
+        Assert.Equal("red", cut.Find(".scenario-detail__swatch").GetAttribute("data-highlight"));
+    }
+
+    [Fact]
+    public void Filters_WhenEmpty_OmitsFiltersSection()
+    {
+        var cut = Render<ScenarioDetail>(parameters => parameters
+            .Add(detail => detail.Scenario, Scenario("application-crashes", "Application crashes"))
+            .Add(detail => detail.ElevationReasonId, "reason"));
+
+        Assert.Empty(cut.FindAll(".scenario-detail__filter"));
+        Assert.DoesNotContain(
+            cut.FindAll(".scenario-detail__fact-label"),
+            label => label.TextContent == "Filters");
+    }
+
+    [Fact]
+    public void Filters_WhenExcluded_PrefixesExclude()
+    {
+        var cut = Render<ScenarioDetail>(parameters => parameters
+            .Add(detail => detail.Scenario, Scenario("application-crashes", "Application crashes") with
+            {
+                Filters = [new ScenarioFilterRow(EqualsFilter(EventProperty.Id, "100"), IsExcluded: true)]
+            })
+            .Add(detail => detail.ElevationReasonId, "reason"));
+
+        Assert.Equal("Exclude Id == 100", cut.Find(".scenario-detail__filter").TextContent.Trim());
+    }
+
+    [Fact]
+    public void Filters_WhenTryFormatFails_RowIsSkipped()
+    {
+        var cut = Render<ScenarioDetail>(parameters => parameters
+            .Add(detail => detail.Scenario, Scenario("application-crashes", "Application crashes") with
+            {
+                Filters =
+                [
+                    new ScenarioFilterRow(EqualsFilter(EventProperty.Level, "   ")),
+                    new ScenarioFilterRow(EqualsFilter(EventProperty.Id, "100"))
+                ]
+            })
+            .Add(detail => detail.ElevationReasonId, "reason"));
+
+        var lines = cut.FindAll(".scenario-detail__filter");
+
+        Assert.Single(lines);
+        Assert.Equal("Id == 100", lines[0].TextContent.Trim());
+    }
+
+    [Fact]
+    public void Launch_WhenDisabled_IsGuardedAndDescribed()
+    {
+        bool launched = false;
+
+        var cut = Render<ScenarioDetail>(parameters => parameters
+            .Add(detail => detail.Scenario, Scenario("application-crashes", "Application crashes"))
+            .Add(detail => detail.ElevationReasonId, "reason")
+            .Add(detail => detail.IsDisabled, true)
+            .Add(detail => detail.OnLaunch, () => launched = true));
+
+        var launch = cut.Find(".scenario-detail__launch");
+
+        Assert.Equal("true", launch.GetAttribute("aria-disabled"));
+        Assert.Equal("reason", launch.GetAttribute("aria-describedby"));
+
+        launch.Click();
+
+        Assert.False(launched);
+    }
+
+    [Fact]
+    public void Launch_WhenEnabled_InvokesLaunch()
+    {
+        bool launched = false;
+
+        var cut = Render<ScenarioDetail>(parameters => parameters
+            .Add(detail => detail.Scenario, Scenario("application-crashes", "Application crashes"))
+            .Add(detail => detail.ElevationReasonId, "reason")
+            .Add(detail => detail.OnLaunch, () => launched = true));
+
+        cut.Find(".scenario-detail__launch").Click();
+
+        Assert.True(launched);
+    }
+
+    [Fact]
+    public void RendersNamePurposeAndEyebrow()
+    {
+        var cut = Render<ScenarioDetail>(parameters => parameters
+            .Add(detail => detail.Scenario, Scenario("application-crashes", "Application crashes"))
+            .Add(detail => detail.ElevationReasonId, "reason"));
+
+        Assert.Equal("Application crashes", cut.Find(".scenario-detail__name").TextContent);
+        Assert.Equal("Purpose", cut.Find(".scenario-detail__purpose").TextContent);
+        Assert.Contains("System Health", cut.Find(".scenario-detail__eyebrow").TextContent);
+    }
+
+    [Fact]
+    public void Star_Click_InvokesToggleFavorite()
+    {
+        bool toggled = false;
+
+        var cut = Render<ScenarioDetail>(parameters => parameters
+            .Add(detail => detail.Scenario, Scenario("application-crashes", "Application crashes"))
+            .Add(detail => detail.ElevationReasonId, "reason")
+            .Add(detail => detail.OnToggleFavorite, () => toggled = true));
+
+        cut.Find(".scenario-detail__star").Click();
+
+        Assert.True(toggled);
+    }
+
+    [Fact]
+    public void Star_WhenFavored_IsPressedWithFilledIcon()
+    {
+        var cut = Render<ScenarioDetail>(parameters => parameters
+            .Add(detail => detail.Scenario, Scenario("application-crashes", "Application crashes"))
+            .Add(detail => detail.ElevationReasonId, "reason")
+            .Add(detail => detail.IsFavored, true));
+
+        Assert.Equal("true", cut.Find(".scenario-detail__star").GetAttribute("aria-pressed"));
+        Assert.NotEmpty(cut.FindAll(".scenario-detail__star .bi-star-fill"));
+    }
+
+    private static BasicFilter EqualsFilter(EventProperty property, string value) =>
+        new(
+            new FilterComparison
+            {
+                Property = property,
+                Operator = ComparisonOperator.Equals,
+                MatchMode = MatchMode.Single,
+                Value = value
+            },
+            []);
+
+    private static ScenarioDefinition Scenario(string id, string name) =>
+        new()
+        {
+            Id = id,
+            Name = name,
+            Purpose = "Purpose",
+            Group = ScenarioGroup.SystemHealth,
+            Channels = ["System"],
+            Filters = []
+        };
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterPane/FilterPaneTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterPane/FilterPaneTests.cs
@@ -159,7 +159,7 @@ public sealed class FilterPaneTests : BunitContext
     }
 
     [Fact]
-    public void ApplyScenarioButton_WhenLogsLoaded_IsShownWithPopupAttributes()
+    public void ApplyScenarioButton_WhenLogsLoaded_IsShownAsExpander()
     {
         SetLibraryState(new FilterLibraryState { IsLoaded = true, Entries = ImmutableList<LibraryEntry>.Empty });
         SetEventLogState(EventLogStateWithChannel("System"));
@@ -168,7 +168,7 @@ public sealed class FilterPaneTests : BunitContext
         var button = FindApplyScenarioButton(component);
 
         Assert.NotNull(button);
-        Assert.Equal("true", button!.GetAttribute("aria-haspopup"));
+        Assert.Null(button!.GetAttribute("aria-haspopup"));
         Assert.Equal("false", button.GetAttribute("aria-expanded"));
         Assert.Equal("scenario-picker", button.GetAttribute("aria-controls"));
     }
@@ -184,6 +184,57 @@ public sealed class FilterPaneTests : BunitContext
     }
 
     [Fact]
+    public void ApplyScenarioSelection_AfterCategoryChange_AppliesScenarioFromNewCategory()
+    {
+        var sys = Scenario("sys", ScenarioGroup.SystemHealth);
+        var sec = Scenario("sec", ScenarioGroup.Security);
+        SetLibraryState(new FilterLibraryState { IsLoaded = true, Entries = ImmutableList<LibraryEntry>.Empty });
+        SetEventLogState(EventLogStateWithChannel("System"));
+        _scenarioQuery.GetInAppScenarios(Arg.Any<IReadOnlyCollection<string>>()).Returns([sys, sec]);
+
+        var component = Render<UI.FilterPane.FilterPane>();
+        component.Instance.OpenScenarioPicker();
+        component.Instance.OnScenarioGroupChanged(ScenarioGroup.Security);
+
+        component.Instance.ApplyScenarioSelection();
+
+        _scenarioApply.Received(1).ApplyInApp(sec, false);
+    }
+
+    [Fact]
+    public void ApplyScenarioSelection_WhenNoMatches_AnnouncesAndDoesNotApply()
+    {
+        SetLibraryState(new FilterLibraryState { IsLoaded = true, Entries = ImmutableList<LibraryEntry>.Empty });
+        SetEventLogState(EventLogStateWithChannel("System"));
+        _scenarioQuery.GetInAppScenarios(Arg.Any<IReadOnlyCollection<string>>()).Returns([]);
+
+        var component = Render<UI.FilterPane.FilterPane>();
+        component.Instance.OpenScenarioPicker();
+
+        component.Instance.ApplyScenarioSelection();
+
+        _announcements.Received(1).Announce(FilterPaneAnnouncements.SelectedScenarioMissing);
+        _scenarioApply.DidNotReceiveWithAnyArgs().ApplyInApp(null!, false);
+    }
+
+    [Fact]
+    public void ApplyScenarioSelection_WhenSelectionStale_AppliesFirstVisibleScenario()
+    {
+        var match = Scenario("sys", ScenarioGroup.SystemHealth);
+        SetLibraryState(new FilterLibraryState { IsLoaded = true, Entries = ImmutableList<LibraryEntry>.Empty });
+        SetEventLogState(EventLogStateWithChannel("System"));
+        _scenarioQuery.GetInAppScenarios(Arg.Any<IReadOnlyCollection<string>>()).Returns([match]);
+
+        var component = Render<UI.FilterPane.FilterPane>();
+        component.Instance.OpenScenarioPicker();
+        component.Instance.SelectedScenarioId = "no-such-scenario";
+
+        component.Instance.ApplyScenarioSelection();
+
+        _scenarioApply.Received(1).ApplyInApp(match, false);
+    }
+
+    [Fact]
     public void AvailableTagsForSets_ReturnsDistinctSortedUnion()
     {
         var a = BuildFilterSet("A", ["zebra", "alpha"]);
@@ -192,6 +243,25 @@ public sealed class FilterPaneTests : BunitContext
         var tags = UI.FilterPane.FilterPane.AvailableTagsForSets([a, b]);
 
         Assert.Equal(new[] { "alpha", "mid", "zebra" }, tags.ToArray());
+    }
+
+    [Fact]
+    public async Task CancelScenarioPicker_ResetsSelectedScenarioId()
+    {
+        var scenario = Scenario("sys", ScenarioGroup.SystemHealth);
+        SetLibraryState(new FilterLibraryState { IsLoaded = true, Entries = ImmutableList<LibraryEntry>.Empty });
+        SetEventLogState(EventLogStateWithChannel("System"));
+        _scenarioQuery.GetInAppScenarios(Arg.Any<IReadOnlyCollection<string>>()).Returns([scenario]);
+
+        var component = Render<UI.FilterPane.FilterPane>();
+        await FindApplyScenarioButton(component)!.ClickAsync(new MouseEventArgs());
+        Assert.Equal(scenario.Id, component.Instance.SelectedScenarioId);
+
+        await component.Find("#scenario-picker button.button-red").ClickAsync(new MouseEventArgs());
+
+        Assert.False(component.Instance.IsScenarioPickerVisible);
+        Assert.Null(component.Instance.SelectedScenarioGroup);
+        Assert.Null(component.Instance.SelectedScenarioId);
     }
 
     [Fact]
@@ -414,6 +484,25 @@ public sealed class FilterPaneTests : BunitContext
     }
 
     [Fact]
+    public void OnScenarioGroupChanged_ResetsScenarioToFirstOfNewCategory()
+    {
+        var sys = Scenario("sys", ScenarioGroup.SystemHealth);
+        var sec1 = Scenario("sec1", ScenarioGroup.Security);
+        var sec2 = Scenario("sec2", ScenarioGroup.Security);
+        SetLibraryState(new FilterLibraryState { IsLoaded = true, Entries = ImmutableList<LibraryEntry>.Empty });
+        SetEventLogState(EventLogStateWithChannel("System"));
+        _scenarioQuery.GetInAppScenarios(Arg.Any<IReadOnlyCollection<string>>()).Returns([sys, sec1, sec2]);
+
+        var component = Render<UI.FilterPane.FilterPane>();
+        component.Instance.OpenScenarioPicker();
+
+        component.Instance.OnScenarioGroupChanged(ScenarioGroup.Security);
+
+        Assert.Equal(ScenarioGroup.Security, component.Instance.SelectedScenarioGroup);
+        Assert.Equal("sec1", component.Instance.SelectedScenarioId);
+    }
+
+    [Fact]
     public void OpenFilterSetPicker_PreSelectsFirstFilterSetCaseInsensitive()
     {
         var filterSetZ = BuildFilterSet("ZebraGroup");
@@ -491,11 +580,11 @@ public sealed class FilterPaneTests : BunitContext
 
         Assert.NotNull(capturedNames);
         Assert.Contains("Security", capturedNames!);
-        Assert.NotNull(component.Find("button[aria-label='Apply scenario sec']"));
+        Assert.Contains(component.FindAll(".filter-set-option-name"), option => option.TextContent == "sec");
     }
 
     [Fact]
-    public async Task OpenScenarioPicker_GroupsInDeclarationOrderAndExpandsButton()
+    public async Task OpenScenarioPicker_ListsFirstCategoryScenariosInDeclarationOrder()
     {
         SetLibraryState(new FilterLibraryState { IsLoaded = true, Entries = ImmutableList<LibraryEntry>.Empty });
         SetEventLogState(EventLogStateWithChannel("System"));
@@ -510,12 +599,53 @@ public sealed class FilterPaneTests : BunitContext
         var component = Render<UI.FilterPane.FilterPane>();
         await FindApplyScenarioButton(component)!.ClickAsync(new MouseEventArgs());
 
-        var headers = component.FindAll(".scenario-picker-group-header").Select(header => header.TextContent).ToArray();
-        Assert.Equal([ScenarioGroup.SystemHealth.DisplayName(), ScenarioGroup.Security.DisplayName()], headers);
+        var optionNames = component.FindAll(".filter-set-option-name").Select(option => option.TextContent).ToArray();
+        Assert.Equal(["bravo"], optionNames);
         Assert.Equal("true", FindApplyScenarioButton(component)!.GetAttribute("aria-expanded"));
+    }
 
-        Assert.NotNull(component.Find("button[aria-label='Apply scenario alpha']"));
-        Assert.NotNull(component.Find("button[aria-label='Apply scenario charlie']"));
+    [Fact]
+    public async Task OpenScenarioPicker_MultipleCategories_RendersCategoryDropdown()
+    {
+        SetLibraryState(new FilterLibraryState { IsLoaded = true, Entries = ImmutableList<LibraryEntry>.Empty });
+        SetEventLogState(EventLogStateWithChannel("System"));
+        _scenarioQuery.GetInAppScenarios(Arg.Any<IReadOnlyCollection<string>>())
+            .Returns([Scenario("sys", ScenarioGroup.SystemHealth), Scenario("sec", ScenarioGroup.Security)]);
+
+        var component = Render<UI.FilterPane.FilterPane>();
+        await FindApplyScenarioButton(component)!.ClickAsync(new MouseEventArgs());
+
+        Assert.Contains("Category:", component.Find("#scenario-picker").TextContent);
+    }
+
+    [Fact]
+    public void OpenScenarioPicker_PreselectsFirstMatch()
+    {
+        var first = Scenario("first", ScenarioGroup.SystemHealth);
+        SetLibraryState(new FilterLibraryState { IsLoaded = true, Entries = ImmutableList<LibraryEntry>.Empty });
+        SetEventLogState(EventLogStateWithChannel("System"));
+        _scenarioQuery.GetInAppScenarios(Arg.Any<IReadOnlyCollection<string>>())
+            .Returns([first, Scenario("second", ScenarioGroup.SystemHealth)]);
+
+        var component = Render<UI.FilterPane.FilterPane>();
+        component.Instance.OpenScenarioPicker();
+
+        Assert.Equal(ScenarioGroup.SystemHealth, component.Instance.SelectedScenarioGroup);
+        Assert.Equal(first.Id, component.Instance.SelectedScenarioId);
+    }
+
+    [Fact]
+    public async Task OpenScenarioPicker_SingleCategory_OmitsCategoryDropdown()
+    {
+        SetLibraryState(new FilterLibraryState { IsLoaded = true, Entries = ImmutableList<LibraryEntry>.Empty });
+        SetEventLogState(EventLogStateWithChannel("System"));
+        _scenarioQuery.GetInAppScenarios(Arg.Any<IReadOnlyCollection<string>>())
+            .Returns([Scenario("one", ScenarioGroup.SystemHealth), Scenario("two", ScenarioGroup.SystemHealth)]);
+
+        var component = Render<UI.FilterPane.FilterPane>();
+        await FindApplyScenarioButton(component)!.ClickAsync(new MouseEventArgs());
+
+        Assert.DoesNotContain("Category:", component.Find("#scenario-picker").TextContent);
     }
 
     [Fact]
@@ -699,7 +829,7 @@ public sealed class FilterPaneTests : BunitContext
     }
 
     [Fact]
-    public async Task ScenarioApplyButton_InvokesApplyInAppMergeAndClosesPicker()
+    public void ScenarioApplySelection_InvokesApplyInAppMergeAndClosesPicker()
     {
         var scenario = Scenario("sys", ScenarioGroup.SystemHealth);
         SetLibraryState(new FilterLibraryState { IsLoaded = true, Entries = ImmutableList<LibraryEntry>.Empty });
@@ -707,9 +837,8 @@ public sealed class FilterPaneTests : BunitContext
         _scenarioQuery.GetInAppScenarios(Arg.Any<IReadOnlyCollection<string>>()).Returns([scenario]);
 
         var component = Render<UI.FilterPane.FilterPane>();
-        await FindApplyScenarioButton(component)!.ClickAsync(new MouseEventArgs());
-
-        await component.Find("button[aria-label='Apply scenario sys']").ClickAsync(new MouseEventArgs());
+        component.Instance.OpenScenarioPicker();
+        component.Instance.ApplyScenarioSelection();
 
         _scenarioApply.Received(1).ApplyInApp(scenario, false);
         Assert.False(component.Instance.IsScenarioPickerVisible);
@@ -729,7 +858,7 @@ public sealed class FilterPaneTests : BunitContext
     }
 
     [Fact]
-    public async Task ScenarioReplaceButton_InvokesApplyInAppReplace()
+    public void ScenarioReplaceSelection_InvokesApplyInAppReplace()
     {
         var scenario = Scenario("sys", ScenarioGroup.SystemHealth);
         SetLibraryState(new FilterLibraryState { IsLoaded = true, Entries = ImmutableList<LibraryEntry>.Empty });
@@ -737,9 +866,8 @@ public sealed class FilterPaneTests : BunitContext
         _scenarioQuery.GetInAppScenarios(Arg.Any<IReadOnlyCollection<string>>()).Returns([scenario]);
 
         var component = Render<UI.FilterPane.FilterPane>();
-        await FindApplyScenarioButton(component)!.ClickAsync(new MouseEventArgs());
-
-        await component.Find("button[aria-label='Replace filters with scenario sys']").ClickAsync(new MouseEventArgs());
+        component.Instance.OpenScenarioPicker();
+        component.Instance.ReplaceScenarioSelection();
 
         _scenarioApply.Received(1).ApplyInApp(scenario, true);
     }
@@ -760,7 +888,7 @@ public sealed class FilterPaneTests : BunitContext
 
         Assert.Contains("2024-06-08", component.Find("input[aria-label='After']").GetAttribute("value"));
         Assert.Contains("2024-06-15", component.Find("input[aria-label='Before']").GetAttribute("value"));
-        _filterPaneCommands.DidNotReceiveWithAnyArgs().SetFilterDateRange(default);
+        _filterPaneCommands.DidNotReceiveWithAnyArgs().SetFilterDateRange(null);
     }
 
     private static LibraryEntryFilterSet BuildFilterSet(string name, ImmutableList<string>? tags = null) =>

--- a/tests/Unit/EventLogExpert.UI.Tests/Layout/MainContentTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Layout/MainContentTests.cs
@@ -1,0 +1,56 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using Bunit.TestDoubles;
+using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.UI.Dashboard;
+using EventLogExpert.UI.Layout;
+using EventLogExpert.UI.LogTable;
+using Fluxor;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using DetailsPaneComponent = EventLogExpert.UI.DetailsPane.DetailsPane;
+using FilterPaneComponent = EventLogExpert.UI.FilterPane.FilterPane;
+
+namespace EventLogExpert.UI.Tests.Layout;
+
+public sealed class MainContentTests : BunitContext
+{
+    private readonly IStateSelection<EventLogState, bool> _hasActiveLogs =
+        Substitute.For<IStateSelection<EventLogState, bool>>();
+
+    public MainContentTests()
+    {
+        Services.AddSingleton(_hasActiveLogs);
+        Services.AddFluxor(options => options.ScanAssemblies(typeof(MainContent).Assembly));
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        ComponentFactories.AddStub<FilterPaneComponent>();
+        ComponentFactories.AddStub<LogTablePane>();
+        ComponentFactories.AddStub<DetailsPaneComponent>();
+        ComponentFactories.AddStub<EmptyStateDashboard>();
+    }
+
+    [Fact]
+    public void Render_WhenLogsActive_RendersPanesNotDashboard()
+    {
+        _hasActiveLogs.Value.Returns(true);
+
+        var cut = Render<MainContent>();
+
+        Assert.NotEmpty(cut.FindComponents<Stub<FilterPaneComponent>>());
+        Assert.Empty(cut.FindComponents<Stub<EmptyStateDashboard>>());
+    }
+
+    [Fact]
+    public void Render_WhenNoActiveLogs_RendersDashboardNotPanes()
+    {
+        _hasActiveLogs.Value.Returns(false);
+
+        var cut = Render<MainContent>();
+
+        Assert.NotEmpty(cut.FindComponents<Stub<EmptyStateDashboard>>());
+        Assert.Empty(cut.FindComponents<Stub<FilterPaneComponent>>());
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/TestParallelization.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/TestParallelization.cs
@@ -1,0 +1,4 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
## Summary

Adds an empty-state scenario dashboard shown whenever no log is open (including after all logs are closed), plus the supporting scenario-favorites and filter-pane infrastructure.

- **Empty-state scenario dashboard** (`EmptyStateDashboard`): a master-detail scenario browser - a category sidebar (vertical tabs), a scenario list, and a detail pane showing the scenario's logs/filters with a Launch action. Quick-launch buttons cover live Application/System/Security logs and file/folder open.
- **Scenario favorites**: star any scenario; favorites persist in a new `favorite_scenarios` table in the shared app SQLite database (Fluxor state/effects/reducers behind `IScenarioFavoriteStore`). A pinned Favorites tab surfaces them.
- **FilterPane "Apply Scenario" picker**: when logs are open, apply a built-in scenario's filters via a Category + Scenario two-dropdown row that mirrors the "Apply Filter Set" row (the Category dropdown collapses when only one category matches).
- **Scenario launch + filter-pane state restore**: launching a scenario opens its channels and applies its filters; if the channels fail to open, the prior filter-pane state is restored.
- **Keyboard-scroll accessibility fix** (from PR review): the new scenario listbox handled Arrow/Home/End without preventing the browser's default page scroll. A shared JS module (`wwwroot/Common/keyboardScrollSuppressor.js`) now synchronously suppresses the page scroll for those nav keys, matching the existing `SidebarTabs`/`LogTablePane` JS approach. The same fix was applied to the sibling nav surfaces that had the identical pre-existing scroll bug: FilterPane (add-filter chevron + filter-list toggle), DetailsPane (the two role=button toggles), LogTabBar (tabs), and MenuBar (menu items). `type="button"` was also added to the FilterPane buttons that were missing it.
- Bootstrap Icons upgraded to 1.13.

## Testing

- Unit tests: Runtime 1495 passing, UI 896 passing. Coverage spans the favorites store/effects/reducers/commands, the dashboard, the scenario browser/detail, the FilterPane picker, layout, and scenario-launch/filter-restore.
- Favorites SQLite persistence is covered by an integration test (runs in the container CI).
- EventLogExpert.UI and the MAUI app build clean.

## Follow-ups (non-blocking)

- Retry / user-visible path for the best-effort favorites load.
- Relocate the favorites SQLite test out of the container-gated integration assembly so it runs in the local/unit loop.
- Favorites store failure-path tests (locked / unwritable / corrupt DB).
- Convert the shared `ValueSelect` dropdown to the synchronous JS scroll-suppressor so its dropdowns (including the FilterPane pickers) lose the one-keystroke Blazor preventDefault lag. Deferred because `ValueSelect` is used app-wide.

Closes #587