### PR TITLE
Update package versions and mitigate CVE-2025-6965 (transitive SQLite)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,28 +1,40 @@
 <Project>
-    <PropertyGroup>
-        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    </PropertyGroup>
-    <ItemGroup>
-        <PackageVersion Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-        <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
-        <!-- Pinned to the version transitively resolved through Microsoft.Maui.Controls (per
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <!-- Required so the SQLitePCLRaw.lib.e_sqlite3 security override below can pin a
+         transitively-resolved package without adding a direct PackageReference. -->
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
+    <!-- Pinned to the version transitively resolved through Microsoft.Maui.Controls (per
              dotnet list package, include-transitive) so the ExplorerExtension companion exe and
              the MAUI head share a single Microsoft.WindowsAppSDK version. -->
-        <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.7.250909003" />
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
-        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-        <PackageVersion Include="System.CommandLine" Version="2.0.5" />
-        <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.5" />
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
-        <PackageVersion Include="Fluxor.Blazor.Web" Version="6.9.0" />
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-        <PackageVersion Include="NSubstitute" Version="5.3.0" />
-        <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
-        <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-        <PackageVersion Include="coverlet.collector" Version="8.0.1" />
-        <PackageVersion Include="xunit.v3.mtp-off" Version="3.2.2" />
-        <PackageVersion Include="bunit" Version="2.7.2" />
-    </ItemGroup>
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.9" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
+    <!-- TEMPORARY security override for CVE-2025-6965 (GHSA-2m69-gcr7-jv3q, High).
+         Microsoft.Data.Sqlite / Microsoft.EntityFrameworkCore.Sqlite 10.0.9 transitively pull
+         SQLitePCLRaw.bundle_e_sqlite3 2.1.11 -> SQLitePCLRaw.lib.e_sqlite3 2.1.11 (SQLite < 3.50.2).
+         There is no 2.1.x patch; lib.e_sqlite3 3.50.3 is a native-only package (no managed deps) that
+         satisfies the bundle's [2.1.11, ) range, so this swaps in the SQLite 3.50.3 binary while keeping
+         the SQLitePCLRaw 2.x managed core. Remove once Microsoft.Data.Sqlite ships the upstream fix
+         (dotnet/efcore PR 38402, milestone 11.0-preview6). Tracked by:
+         https://github.com/microsoft/EventLogExpert/issues/604 -->
+    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
+    <PackageVersion Include="Fluxor.Blazor.Web" Version="6.9.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="xunit.v3.mtp-off" Version="3.2.2" />
+    <PackageVersion Include="bunit" Version="2.7.2" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Updates centrally-managed package versions in `Directory.Packages.props` and adds a temporary
security override to clear the **CVE-2025-6965** advisory on the transitive native SQLite library.

## Package version bumps

| Package | From | To |
| --- | --- | --- |
| Microsoft.WindowsAppSDK | 1.7.250909003 | 2.2.0 |
| Microsoft.Extensions.DependencyInjection (+ Abstractions) | 10.0.5 | 10.0.9 |
| Microsoft.Extensions.Logging.Abstractions | 10.0.5 | 10.0.9 |
| System.CommandLine | 2.0.5 | 2.0.9 |
| Microsoft.Data.Sqlite | 10.0.5 | 10.0.9 |
| Microsoft.EntityFrameworkCore.Sqlite | 10.0.5 | 10.0.9 |
| Microsoft.NET.Test.Sdk | 18.4.0 | 18.6.0 |
| coverlet.collector | 8.0.1 | 10.0.1 |

## SQLite CVE-2025-6965 mitigation

`Microsoft.Data.Sqlite` / `Microsoft.EntityFrameworkCore.Sqlite` 10.0.9 still transitively resolve
`SQLitePCLRaw.bundle_e_sqlite3` 2.1.11 → `SQLitePCLRaw.lib.e_sqlite3` 2.1.11 (SQLite < 3.50.2), which is
flagged by [CVE-2025-6965 / GHSA-2m69-gcr7-jv3q](https://github.com/advisories/GHSA-2m69-gcr7-jv3q)
(High). There is no 2.1.x patch.

This pins **only the native** `SQLitePCLRaw.lib.e_sqlite3` to `3.50.3` via Central Package Management
transitive pinning (`CentralPackageTransitivePinningEnabled`). That package has no managed dependencies,
so the SQLitePCLRaw 2.x managed core (which `Microsoft.Data.Sqlite` 10.0.9 was built against) is
unchanged — only the bundled SQLite native binary moves to **3.50.3**.

Temporary workaround until `Microsoft.Data.Sqlite` ships the upstream fix
(dotnet/efcore [#38402](https://github.com/dotnet/efcore/pull/38402), milestone 11.0-preview6).
Removal is tracked by #604.

## Verification

- `dotnet nuget why` on all three SQLite-consuming projects (`Runtime`, `Provider.Database`,
  `Eventing.TestUtils`) now resolves `lib.e_sqlite3` → **3.50.3** (bundle stays 2.1.11).
- Forced `dotnet restore` on those projects: no NuGet version-conflict warnings.
- `EventLogExpert.Provider.Database` builds clean (0 warnings, 0 errors).
