### PR TITLE
Redesign alert and prompt dialogs as consistent fixed-width popups

### DIFF
--- a/src/EventLogExpert.Runtime/Alerts/AlertDialogService.cs
+++ b/src/EventLogExpert.Runtime/Alerts/AlertDialogService.cs
@@ -75,6 +75,7 @@ public sealed class AlertDialogService(
                     ["Title"] = title,
                     ["Message"] = message,
                     ["InitialValue"] = initialValue ?? string.Empty,
+                    ["Validate"] = validate,
                 });
             }
 

--- a/src/EventLogExpert.UI/Alerts/AlertModal.razor
+++ b/src/EventLogExpert.UI/Alerts/AlertModal.razor
@@ -5,12 +5,14 @@
     CancelLabel="@CancelLabel"
     Footer="@(string.IsNullOrEmpty(AcceptLabel) ? FooterPreset.Dismiss : FooterPreset.AcceptCancel)"
     InlineAlert="@CurrentInlineAlert"
+    MaxWidth="min(34rem, calc(100vw - 2rem))"
+    MinWidth="min(34rem, calc(100vw - 2rem))"
     OnAccept="HandleAcceptClickedAsync"
     OnCancel="HandleCancelClickedAsync"
     OnDialogClosedByUser="HandleDialogClosedByUserAsync"
     OnInlineAlertResolved="HandleInlineAlertResolvedAsync"
-    Title="@Title"
-    @ref="ChromeRef">
+    @ref="ChromeRef"
+    Title="@Title">
     <ChildContent>
         <p class="alert-modal-message">@Message</p>
     </ChildContent>

--- a/src/EventLogExpert.UI/Alerts/AlertModal.razor.css
+++ b/src/EventLogExpert.UI/Alerts/AlertModal.razor.css
@@ -3,4 +3,5 @@
 
     line-height: 1.4;
     white-space: pre-wrap;
+    overflow-wrap: anywhere;
 }

--- a/src/EventLogExpert.UI/Alerts/PromptModal.razor
+++ b/src/EventLogExpert.UI/Alerts/PromptModal.razor
@@ -5,6 +5,8 @@
     CancelLabel="Cancel"
     Footer="FooterPreset.AcceptCancel"
     InlineAlert="@CurrentInlineAlert"
+    MaxWidth="min(34rem, calc(100vw - 2rem))"
+    MinWidth="min(34rem, calc(100vw - 2rem))"
     OnAccept="HandleAcceptClickedAsync"
     OnCancel="OnCancelAsync"
     OnDialogClosedByUser="HandleDialogClosedByUserAsync"
@@ -12,13 +14,12 @@
     @ref="ChromeRef"
     Title="@Title">
     <ChildContent>
-        <p class="alert-modal-message" id="@_messageId">@Message</p>
-        <hr class="alert-modal-divider" />
-        <input aria-labelledby="@_messageId"
-            @bind="_value"
-            @bind:event="oninput"
-            class="alert-modal-input"
-            @ref="_inputRef"
-            type="text" />
+        <label class="prompt-modal-label" for="@_inputId">@Message</label>
+        <TextInput CssClass="input dialog-input"
+            Id="@_inputId"
+            @ref="_input"
+            UpdateOnInput="true"
+            Value="@_value"
+            ValueChanged="HandleValueChanged" />
     </ChildContent>
 </ModalChrome>

--- a/src/EventLogExpert.UI/Alerts/PromptModal.razor
+++ b/src/EventLogExpert.UI/Alerts/PromptModal.razor
@@ -1,6 +1,7 @@
 @inherits ModalBase<string>
 
-<ModalChrome AcceptLabel="OK"
+<ModalChrome AcceptDisabled="@(ValidationError is not null)"
+    AcceptLabel="OK"
     AriaLabel="@AriaLabelText"
     CancelLabel="Cancel"
     Footer="FooterPreset.AcceptCancel"
@@ -15,11 +16,22 @@
     Title="@Title">
     <ChildContent>
         <label class="prompt-modal-label" for="@_inputId">@Message</label>
-        <TextInput CssClass="input dialog-input"
+        <TextInput AriaDescribedBy="@(ValidationError is not null ? _errorId : null)"
+            AriaInvalid="@(ValidationError is not null)"
+            CssClass="input dialog-input"
             Id="@_inputId"
             @ref="_input"
             UpdateOnInput="true"
             Value="@_value"
             ValueChanged="HandleValueChanged" />
+
+        @if (ValidationError is not null)
+        {
+            <p aria-live="polite"
+                class="prompt-modal-validation-error"
+                id="@_errorId">
+                @ValidationError
+            </p>
+        }
     </ChildContent>
 </ModalChrome>

--- a/src/EventLogExpert.UI/Alerts/PromptModal.razor.cs
+++ b/src/EventLogExpert.UI/Alerts/PromptModal.razor.cs
@@ -15,6 +15,7 @@ namespace EventLogExpert.UI.Alerts;
 /// </summary>
 public sealed partial class PromptModal : ModalBase<string>
 {
+    private readonly string _errorId = ComponentId.NewUnique("prompt-modal-validation").Value;
     private readonly string _inputId = ComponentId.NewUnique("prompt-modal-input").Value;
 
     private bool _focusOnNextRender = true;
@@ -27,7 +28,11 @@ public sealed partial class PromptModal : ModalBase<string>
 
     [Parameter] public string Title { get; set; } = string.Empty;
 
+    [Parameter] public Func<string, string?>? Validate { get; set; }
+
     private string AriaLabelText => string.IsNullOrEmpty(Title) ? "Prompt" : Title;
+
+    private string? ValidationError => Validate?.Invoke(_value);
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -56,7 +61,8 @@ public sealed partial class PromptModal : ModalBase<string>
         base.OnInitialized();
     }
 
-    private Task HandleAcceptClickedAsync() => CompleteAsync(_value);
+    private Task HandleAcceptClickedAsync() =>
+        ValidationError is not null ? Task.CompletedTask : CompleteAsync(_value);
 
     private void HandleValueChanged(string value) => _value = value;
 }

--- a/src/EventLogExpert.UI/Alerts/PromptModal.razor.cs
+++ b/src/EventLogExpert.UI/Alerts/PromptModal.razor.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.UI.Common;
+using EventLogExpert.UI.Inputs;
 using EventLogExpert.UI.Modal;
 using Microsoft.AspNetCore.Components;
 
@@ -14,10 +15,10 @@ namespace EventLogExpert.UI.Alerts;
 /// </summary>
 public sealed partial class PromptModal : ModalBase<string>
 {
-    private readonly string _messageId = ComponentId.NewUnique("prompt-modal-message").Value;
+    private readonly string _inputId = ComponentId.NewUnique("prompt-modal-input").Value;
 
     private bool _focusOnNextRender = true;
-    private ElementReference _inputRef;
+    private TextInput? _input;
     private string _value = string.Empty;
 
     [Parameter] public string InitialValue { get; set; } = string.Empty;
@@ -30,13 +31,13 @@ public sealed partial class PromptModal : ModalBase<string>
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (_focusOnNextRender && CurrentInlineAlert is null)
+        if (_focusOnNextRender && _input is not null && CurrentInlineAlert is null)
         {
             _focusOnNextRender = false;
 
             try
             {
-                await _inputRef.FocusAsync(true);
+                await _input.FocusAsync(true);
             }
             catch
             {
@@ -56,4 +57,6 @@ public sealed partial class PromptModal : ModalBase<string>
     }
 
     private Task HandleAcceptClickedAsync() => CompleteAsync(_value);
+
+    private void HandleValueChanged(string value) => _value = value;
 }

--- a/src/EventLogExpert.UI/Alerts/PromptModal.razor.css
+++ b/src/EventLogExpert.UI/Alerts/PromptModal.razor.css
@@ -1,22 +1,8 @@
-.alert-modal-message {
-    margin: 0 0 .5rem 0;
+.prompt-modal-label {
+    display: block;
+    margin-bottom: .5rem;
 
     line-height: 1.4;
     white-space: pre-wrap;
-}
-
-.alert-modal-divider {
-    margin: .5rem 0;
-    border: 0;
-    border-top: 1px solid var(--clr-statusbar);
-}
-
-.alert-modal-input {
-    width: 100%;
-    padding: .25rem .5rem;
-
-    color: var(--text-primary);
-    background-color: var(--background-dark);
-    border: 1px solid var(--clr-statusbar);
-    border-radius: .2rem;
+    overflow-wrap: anywhere;
 }

--- a/src/EventLogExpert.UI/Alerts/PromptModal.razor.css
+++ b/src/EventLogExpert.UI/Alerts/PromptModal.razor.css
@@ -6,3 +6,15 @@
     white-space: pre-wrap;
     overflow-wrap: anywhere;
 }
+
+.prompt-modal-validation-error {
+    margin-top: .25rem;
+    margin-bottom: 0;
+    padding: .25rem .375rem;
+
+    overflow-wrap: anywhere;
+    color: var(--text-error);
+    background: color-mix(in srgb, var(--clr-red) 8%, transparent);
+    border-radius: .2rem;
+    font-size: .85rem;
+}

--- a/src/EventLogExpert.UI/Inputs/TextInput.razor
+++ b/src/EventLogExpert.UI/Inputs/TextInput.razor
@@ -1,9 +1,12 @@
 @inherits InputComponent<string>
 
 <input aria-describedby="@AriaDescribedBy"
+    aria-invalid="@(AriaInvalid ? "true" : null)"
     aria-label="@EffectiveAriaLabel"
     aria-labelledby="@AriaLabelledBy"
+    @attributes="_valueChangeBinding"
     class="@CssClass"
-    @onchange="UpdateValue"
+    id="@Id"
+    @ref="_element"
     type="text"
     value="@Value" />

--- a/src/EventLogExpert.UI/Inputs/TextInput.razor.cs
+++ b/src/EventLogExpert.UI/Inputs/TextInput.razor.cs
@@ -7,6 +7,32 @@ namespace EventLogExpert.UI.Inputs;
 
 public partial class TextInput : InputComponent<string>
 {
+    private ElementReference _element;
+    private Dictionary<string, object> _valueChangeBinding = [];
+
+    [Parameter] public bool AriaInvalid { get; set; }
+
+    [Parameter] public string? Id { get; set; }
+
+    [Parameter] public bool UpdateOnInput { get; set; }
+
+    internal ValueTask FocusAsync(bool preventScroll = false) => _element.FocusAsync(preventScroll);
+
+    protected override void OnParametersSet()
+    {
+        string eventName = UpdateOnInput ? "oninput" : "onchange";
+
+        if (!_valueChangeBinding.ContainsKey(eventName))
+        {
+            _valueChangeBinding = new Dictionary<string, object>
+            {
+                [eventName] = EventCallback.Factory.Create<ChangeEventArgs>(this, UpdateValue),
+            };
+        }
+
+        base.OnParametersSet();
+    }
+
     private async Task UpdateValue(ChangeEventArgs args)
     {
         Value = args.Value?.ToString() ?? string.Empty;

--- a/src/EventLogExpert.UI/Modal/ModalChrome.razor
+++ b/src/EventLogExpert.UI/Modal/ModalChrome.razor
@@ -18,7 +18,7 @@
         @if (!string.IsNullOrEmpty(Title))
         {
             <header class="dialog-header" inert="@HasInlineAlert">
-                <h2 class="dialog-title" id="@_titleId">@Title</h2>
+                <h2 class="dialog-title" id="@_titleId" title="@Title">@Title</h2>
 
                 @if (ShowCloseButton)
                 {
@@ -143,21 +143,21 @@
             role="alertdialog">
             @if (!string.IsNullOrEmpty(InlineAlert.Title))
             {
-                <h3 class="inline-alert-title" id="@_inlineAlertTitleId">@InlineAlert.Title</h3>
+                <h3 class="inline-alert-title" id="@_inlineAlertTitleId" title="@InlineAlert.Title">@InlineAlert.Title</h3>
             }
 
             <p class="inline-alert-message" id="@_inlineAlertMessageId">@InlineAlert.Message</p>
 
             @if (InlineAlert.IsPrompt)
             {
-                <input aria-describedby="@(ValidationError is not null ? _inlineAlertValidationErrorId : null)"
-                    aria-invalid="@(ValidationError is not null ? "true" : null)"
-                    aria-label="@(string.IsNullOrEmpty(InlineAlert.Title) ? InlineAlert.Message : InlineAlert.Title)"
-                    @bind="_inlineAlertPromptValue"
-                    @bind:event="oninput"
-                    class="inline-alert-input"
-                    @ref="_inlineAlertInputRef"
-                    type="text" />
+                <TextInput AriaDescribedBy="@(ValidationError is not null ? _inlineAlertValidationErrorId : null)"
+                    AriaInvalid="@(ValidationError is not null)"
+                    AriaLabel="@(string.IsNullOrEmpty(InlineAlert.Title) ? InlineAlert.Message : InlineAlert.Title)"
+                    CssClass="input dialog-input"
+                    @ref="_inlineAlertInput"
+                    UpdateOnInput="true"
+                    Value="@_inlineAlertPromptValue"
+                    ValueChanged="HandleInlineAlertPromptValueChanged" />
 
                 @if (ValidationError is not null)
                 {

--- a/src/EventLogExpert.UI/Modal/ModalChrome.razor
+++ b/src/EventLogExpert.UI/Modal/ModalChrome.razor
@@ -112,7 +112,7 @@
                 case FooterPreset.AcceptCancel:
                     <button autofocus
                         class="button button-green"
-                        disabled="@(HasInlineAlert || FooterDisabled)"
+                        disabled="@(HasInlineAlert || FooterDisabled || AcceptDisabled)"
                         @onclick="HandleAcceptAsync"
                         type="button">
                         @AcceptLabel
@@ -152,7 +152,7 @@
             {
                 <TextInput AriaDescribedBy="@(ValidationError is not null ? _inlineAlertValidationErrorId : null)"
                     AriaInvalid="@(ValidationError is not null)"
-                    AriaLabel="@(string.IsNullOrEmpty(InlineAlert.Title) ? InlineAlert.Message : InlineAlert.Title)"
+                    AriaLabelledBy="@_inlineAlertMessageId"
                     CssClass="input dialog-input"
                     @ref="_inlineAlertInput"
                     UpdateOnInput="true"

--- a/src/EventLogExpert.UI/Modal/ModalChrome.razor.cs
+++ b/src/EventLogExpert.UI/Modal/ModalChrome.razor.cs
@@ -5,6 +5,7 @@ using EventLogExpert.Runtime.Alerts;
 using EventLogExpert.UI.Banner;
 using EventLogExpert.UI.Common;
 using EventLogExpert.UI.Common.Interop;
+using EventLogExpert.UI.Inputs;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 
@@ -21,7 +22,7 @@ public sealed partial class ModalChrome : ComponentBase, IAsyncDisposable
     private ElementReference _inlineAlertAcceptButtonRef;
     private ElementReference _inlineAlertCancelButtonRef;
     private InlineAlertRequest? _inlineAlertInitializedFor;
-    private ElementReference _inlineAlertInputRef;
+    private TextInput? _inlineAlertInput;
     private string _inlineAlertPromptValue = string.Empty;
     private bool _isClosed;
     private bool _isClosingByCancel;
@@ -215,7 +216,10 @@ public sealed partial class ModalChrome : ComponentBase, IAsyncDisposable
         {
             if (InlineAlert.IsPrompt)
             {
-                await _inlineAlertInputRef.FocusAsync(true);
+                if (_inlineAlertInput is not null)
+                {
+                    await _inlineAlertInput.FocusAsync(true);
+                }
 
                 return;
             }
@@ -291,6 +295,8 @@ public sealed partial class ModalChrome : ComponentBase, IAsyncDisposable
 
     private Task HandleInlineAlertCancelAsync() =>
         OnInlineAlertResolved.InvokeAsync(new InlineAlertResult(false, null));
+
+    private void HandleInlineAlertPromptValueChanged(string value) => _inlineAlertPromptValue = value;
 
     private Task HandleSaveAsync() => OnSave.InvokeAsync();
 

--- a/src/EventLogExpert.UI/Modal/ModalChrome.razor.cs
+++ b/src/EventLogExpert.UI/Modal/ModalChrome.razor.cs
@@ -32,6 +32,8 @@ public sealed partial class ModalChrome : ComponentBase, IAsyncDisposable
     private string? _validationCacheError;
     private string? _validationCacheValue;
 
+    [Parameter] public bool AcceptDisabled { get; set; }
+
     [Parameter] public string AcceptLabel { get; set; } = "OK";
 
     [Parameter] public string? AriaLabel { get; set; }

--- a/src/EventLogExpert.UI/Modal/ModalChrome.razor.css
+++ b/src/EventLogExpert.UI/Modal/ModalChrome.razor.css
@@ -37,8 +37,12 @@ dialog:not(:modal) {
 }
 
 .dialog-title {
+    min-width: 0;
     margin: 0;
+    overflow: hidden;
 
+    white-space: nowrap;
+    text-overflow: ellipsis;
     font-size: 1.1rem;
     color: var(--clr-lightblue);
 }
@@ -66,6 +70,11 @@ dialog[data-body-layout="flex"]:not([style*="--modal-height"]) .dialog-body {
     min-height: min(60vh, 24rem);
 }
 
+dialog[data-body-layout="content"] .dialog-body {
+    max-height: calc(100vh - 10rem);
+    overflow: hidden auto;
+}
+
 .inline-alert-overlay {
     position: absolute;
     inset: 0;
@@ -84,8 +93,8 @@ dialog[data-body-layout="flex"]:not([style*="--modal-height"]) .dialog-body {
     display: flex;
     flex-direction: column;
     gap: .85rem;
-    min-width: 22rem;
-    max-width: min(40rem, calc(100vw - 2rem));
+    width: min(34rem, calc(100vw - 2rem));
+    max-height: calc(100vh - 2rem);
     padding: 1.25rem 1.5rem;
 
     color: var(--clr-lightblue);
@@ -96,29 +105,24 @@ dialog[data-body-layout="flex"]:not([style*="--modal-height"]) .dialog-body {
 }
 
 .inline-alert-title {
+    min-width: 0;
     margin: 0;
+    overflow: hidden;
 
+    white-space: nowrap;
+    text-overflow: ellipsis;
     font-size: 1.05rem;
     color: var(--clr-lightblue);
 }
 
 .inline-alert-message {
+    min-height: 0;
     margin: 0;
+    overflow-y: auto;
 
     line-height: 1.5;
     white-space: pre-wrap;
     overflow-wrap: anywhere;
-}
-
-.inline-alert-input {
-    width: 100%;
-    padding: .25rem .5rem;
-
-    color: var(--text-primary);
-    background-color: var(--background-dark);
-    border: 1px solid var(--clr-statusbar);
-    border-radius: .2rem;
-    font-family: inherit;
 }
 
 .inline-alert-validation-error {
@@ -126,6 +130,7 @@ dialog[data-body-layout="flex"]:not([style*="--modal-height"]) .dialog-body {
     margin-bottom: 0;
     padding: .25rem .375rem;
 
+    overflow-wrap: anywhere;
     color: var(--text-error);
     background: color-mix(in srgb, var(--clr-red) 8%, transparent);
     border-radius: .2rem;

--- a/src/EventLogExpert.UI/wwwroot/app.css
+++ b/src/EventLogExpert.UI/wwwroot/app.css
@@ -273,6 +273,17 @@ a { color: var(--clr-lightblue); }
 
 input[type="text"].input { padding: 0; }
 
+.input.dialog-input {
+    width: 100%;
+    margin: 0;
+    text-align: left;
+    font-family: inherit;
+    cursor: text;
+    user-select: text;
+}
+
+input[type="text"].input.dialog-input { padding: .25rem 0; }
+
 .input.filter-dropdown { width: 120px; }
 
 .input.filter-mode-dropdown { width: 90px; }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Alerts/AlertDialogServiceTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Alerts/AlertDialogServiceTests.cs
@@ -102,6 +102,29 @@ public sealed class ModalAlertDialogServiceTests
     }
 
     [Fact]
+    public async Task DisplayPrompt_WhenNoActiveHost_ShouldForwardValidatorToStandalonePrompt()
+    {
+        var coordinator = Substitute.For<IModalCoordinator>();
+        coordinator.TryGetInlineAlertHost(out Arg.Any<IInlineAlertHost?>()).Returns(false);
+
+        IReadOnlyDictionary<string, object?>? capturedPrompt = null;
+        Func<string, string?> validate = value => string.IsNullOrWhiteSpace(value) ? "Required." : null;
+
+        var sut = new AlertDialogService(
+            coordinator,
+            PassthroughMainThread(),
+            Substitute.For<IErrorBannerService>(),
+            Substitute.For<IInfoBannerService>(),
+            _ => Task.FromResult(false),
+            parameters => { capturedPrompt = parameters; return Task.FromResult("user-typed"); });
+
+        await sut.DisplayPrompt("Rename", "Enter new name", "old-value", validate);
+
+        Assert.NotNull(capturedPrompt);
+        Assert.Same(validate, capturedPrompt!["Validate"]);
+    }
+
+    [Fact]
     public async Task ShowAlert_ShouldMarshalThroughMainThreadService()
     {
         // Arrange — capture that MainThread invocation happens before the routing decision runs.

--- a/tests/Unit/EventLogExpert.UI.Tests/Alerts/AlertModalTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Alerts/AlertModalTests.cs
@@ -1,0 +1,43 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using EventLogExpert.Runtime.Modal;
+using EventLogExpert.UI.Alerts;
+using EventLogExpert.UI.Tests.TestUtils;
+using Fluxor;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace EventLogExpert.UI.Tests.Alerts;
+
+public sealed class AlertModalTests : BunitContext
+{
+    public AlertModalTests()
+    {
+        Services.AddBannerHostDependencies();
+        Services.AddMenuMocks();
+
+        var modalService = Substitute.For<IModalService>();
+        modalService.ActiveModalId.Returns(new ModalId(1L));
+        Services.AddSingleton(modalService);
+        Services.AddSingleton(Substitute.For<IModalCoordinator>());
+
+        Services.AddFluxor(options => options.ScanAssemblies(typeof(AlertModal).Assembly));
+
+        JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    [Fact]
+    public void Render_DialogUsesFixedWindowsStyleWidth()
+    {
+        var component = Render<AlertModal>(parameters => parameters
+            .Add(p => p.Title, "Alert")
+            .Add(p => p.Message, "Something happened."));
+
+        var style = component.Find("dialog").GetAttribute("style");
+
+        Assert.Contains("--modal-min-width: min(34rem, calc(100vw - 2rem));", style);
+        Assert.Contains("--modal-max-width: min(34rem, calc(100vw - 2rem));", style);
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/Alerts/PromptModalTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Alerts/PromptModalTests.cs
@@ -43,6 +43,17 @@ public sealed class PromptModalTests : BunitContext
     }
 
     [Fact]
+    public void NoValidator_ShowsNoErrorAndEnablesOk()
+    {
+        var component = Render<PromptModal>(parameters => parameters
+            .Add(p => p.Title, "Rename")
+            .Add(p => p.Message, "New name:"));
+
+        Assert.Empty(component.FindAll(".prompt-modal-validation-error"));
+        Assert.False(component.FindAll(".footer-group button")[0].HasAttribute("disabled"));
+    }
+
+    [Fact]
     public void Render_DialogUsesFixedWindowsStyleWidth()
     {
         var component = Render<PromptModal>(parameters => parameters
@@ -79,5 +90,77 @@ public sealed class PromptModalTests : BunitContext
 
         Assert.Equal("Enter a value", label.TextContent);
         Assert.Equal(input.GetAttribute("id"), label.GetAttribute("for"));
+    }
+
+    [Fact]
+    public void Validation_AcceptingInvalidValue_DoesNotComplete()
+    {
+        Func<string, string?> validate = value =>
+            string.IsNullOrWhiteSpace(value) ? "Name is required." : null;
+
+        var component = Render<PromptModal>(parameters => parameters
+            .Add(p => p.Title, "Rename")
+            .Add(p => p.Message, "New name:")
+            .Add(p => p.Validate, validate));
+
+        component.FindAll(".footer-group button")[0].Click();
+
+        _modalService.DidNotReceive().Complete(Arg.Any<ModalId>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public void Validation_InvalidInput_SetsAriaInvalidAndDescribesError()
+    {
+        Func<string, string?> validate = value =>
+            string.IsNullOrWhiteSpace(value) ? "Name is required." : null;
+
+        var component = Render<PromptModal>(parameters => parameters
+            .Add(p => p.Title, "Rename")
+            .Add(p => p.Message, "New name:")
+            .Add(p => p.Validate, validate));
+
+        var input = component.Find("input[type='text']");
+        var error = component.Find(".prompt-modal-validation-error");
+
+        Assert.Equal("true", input.GetAttribute("aria-invalid"));
+        Assert.Equal(error.Id, input.GetAttribute("aria-describedby"));
+    }
+
+    [Fact]
+    public void Validation_InvalidValue_ShowsError_DisablesOk_KeepsCancelEnabled()
+    {
+        Func<string, string?> validate = value =>
+            string.IsNullOrWhiteSpace(value) ? "Name is required." : null;
+
+        var component = Render<PromptModal>(parameters => parameters
+            .Add(p => p.Title, "Rename")
+            .Add(p => p.Message, "New name:")
+            .Add(p => p.Validate, validate));
+
+        var buttons = component.FindAll(".footer-group button");
+
+        Assert.Equal("Name is required.", component.Find(".prompt-modal-validation-error").TextContent.Trim());
+        Assert.True(buttons[0].HasAttribute("disabled"));
+        Assert.False(buttons[1].HasAttribute("disabled"));
+    }
+
+    [Fact]
+    public void Validation_TypingValidValue_ClearsErrorAndCompletesOnAccept()
+    {
+        Func<string, string?> validate = value =>
+            string.IsNullOrWhiteSpace(value) ? "Name is required." : null;
+
+        var component = Render<PromptModal>(parameters => parameters
+            .Add(p => p.Title, "Rename")
+            .Add(p => p.Message, "New name:")
+            .Add(p => p.Validate, validate));
+
+        component.Find("input").Input("valid name");
+
+        Assert.Empty(component.FindAll(".prompt-modal-validation-error"));
+
+        component.FindAll(".footer-group button")[0].Click();
+
+        _modalService.Received(1).Complete(Arg.Any<ModalId>(), "valid name");
     }
 }

--- a/tests/Unit/EventLogExpert.UI.Tests/Alerts/PromptModalTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Alerts/PromptModalTests.cs
@@ -13,14 +13,15 @@ namespace EventLogExpert.UI.Tests.Alerts;
 
 public sealed class PromptModalTests : BunitContext
 {
+    private readonly IModalService _modalService = Substitute.For<IModalService>();
+
     public PromptModalTests()
     {
         Services.AddBannerHostDependencies();
         Services.AddMenuMocks();
 
-        var modalService = Substitute.For<IModalService>();
-        modalService.ActiveModalId.Returns(new ModalId(1L));
-        Services.AddSingleton(modalService);
+        _modalService.ActiveModalId.Returns(new ModalId(1L));
+        Services.AddSingleton(_modalService);
         Services.AddSingleton(Substitute.For<IModalCoordinator>());
 
         Services.AddFluxor(options => options.ScanAssemblies(typeof(PromptModal).Assembly));
@@ -29,13 +30,54 @@ public sealed class PromptModalTests : BunitContext
     }
 
     [Fact]
-    public void Render_AlwaysRendersDividerBetweenMessageAndInput()
+    public void Accepting_CompletesWithValueTypedIntoInput()
+    {
+        var component = Render<PromptModal>(parameters => parameters
+            .Add(p => p.Title, "Rename")
+            .Add(p => p.Message, "New name:"));
+
+        component.Find("input").Input("renamed value");
+        component.Find(".footer-group .button-green").Click();
+
+        _modalService.Received(1).Complete(Arg.Any<ModalId>(), "renamed value");
+    }
+
+    [Fact]
+    public void Render_DialogUsesFixedWindowsStyleWidth()
     {
         var component = Render<PromptModal>(parameters => parameters
             .Add(p => p.Title, "Prompt")
             .Add(p => p.Message, "Enter a value"));
 
-        var divider = component.Find(".alert-modal-divider");
-        Assert.Equal("HR", divider.NodeName);
+        var style = component.Find("dialog").GetAttribute("style");
+
+        Assert.Contains("--modal-min-width: min(34rem, calc(100vw - 2rem));", style);
+        Assert.Contains("--modal-max-width: min(34rem, calc(100vw - 2rem));", style);
+    }
+
+    [Fact]
+    public void Render_InputUsesSharedDialogInputStyle()
+    {
+        var component = Render<PromptModal>(parameters => parameters
+            .Add(p => p.Title, "Prompt")
+            .Add(p => p.Message, "Enter a value"));
+
+        var input = component.Find("input[type='text']");
+
+        Assert.Contains("dialog-input", input.GetAttribute("class")!.Split(' '));
+    }
+
+    [Fact]
+    public void Render_MessageRendersAsLabelForTheInput()
+    {
+        var component = Render<PromptModal>(parameters => parameters
+            .Add(p => p.Title, "Prompt")
+            .Add(p => p.Message, "Enter a value"));
+
+        var label = component.Find("label");
+        var input = component.Find("input");
+
+        Assert.Equal("Enter a value", label.TextContent);
+        Assert.Equal(input.GetAttribute("id"), label.GetAttribute("for"));
     }
 }

--- a/tests/Unit/EventLogExpert.UI.Tests/Inputs/TextInputTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Inputs/TextInputTests.cs
@@ -9,6 +9,20 @@ namespace EventLogExpert.UI.Tests.Inputs;
 public sealed class TextInputTests : BunitContext
 {
     [Fact]
+    public void Default_RaisesValueChangedOnChangeEvent()
+    {
+        string? captured = null;
+
+        var component = Render<TextInput>(parameters => parameters
+            .Add(p => p.Value, string.Empty)
+            .Add(p => p.ValueChanged, value => { captured = value; }));
+
+        component.Find("input").Change("committed");
+
+        Assert.Equal("committed", captured);
+    }
+
+    [Fact]
     public void Render_AriaDescribedBy_AppliedToInput()
     {
         var component = Render<TextInput>(parameters => parameters
@@ -17,6 +31,28 @@ public sealed class TextInputTests : BunitContext
 
         var input = component.Find("input[type='text']");
         Assert.Equal("help-text-id", input.GetAttribute("aria-describedby"));
+    }
+
+    [Fact]
+    public void Render_AriaInvalidFalse_OmitsAttribute()
+    {
+        var component = Render<TextInput>(parameters => parameters
+            .Add(p => p.Value, string.Empty)
+            .Add(p => p.AriaInvalid, false));
+
+        var input = component.Find("input[type='text']");
+        Assert.False(input.HasAttribute("aria-invalid"));
+    }
+
+    [Fact]
+    public void Render_AriaInvalidTrue_AppliedToInput()
+    {
+        var component = Render<TextInput>(parameters => parameters
+            .Add(p => p.Value, string.Empty)
+            .Add(p => p.AriaInvalid, true));
+
+        var input = component.Find("input[type='text']");
+        Assert.Equal("true", input.GetAttribute("aria-invalid"));
     }
 
     [Fact]
@@ -52,5 +88,31 @@ public sealed class TextInputTests : BunitContext
         var input = component.Find("input[type='text']");
         Assert.False(input.HasAttribute("aria-label"));
         Assert.Equal("external-label-id", input.GetAttribute("aria-labelledby"));
+    }
+
+    [Fact]
+    public void Render_Id_AppliedToInput()
+    {
+        var component = Render<TextInput>(parameters => parameters
+            .Add(p => p.Value, string.Empty)
+            .Add(p => p.Id, "prompt-input-id"));
+
+        var input = component.Find("input[type='text']");
+        Assert.Equal("prompt-input-id", input.GetAttribute("id"));
+    }
+
+    [Fact]
+    public void UpdateOnInput_RaisesValueChangedOnInputEvent()
+    {
+        string? captured = null;
+
+        var component = Render<TextInput>(parameters => parameters
+            .Add(p => p.Value, string.Empty)
+            .Add(p => p.UpdateOnInput, true)
+            .Add(p => p.ValueChanged, value => { captured = value; }));
+
+        component.Find("input").Input("live");
+
+        Assert.Equal("live", captured);
     }
 }

--- a/tests/Unit/EventLogExpert.UI.Tests/Modal/ModalChromeValidateAsyncTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Modal/ModalChromeValidateAsyncTests.cs
@@ -112,7 +112,7 @@ public sealed class ModalChromeValidateAsyncTests : BunitContext
             .Add(x => x.InlineAlert, alert)
             .AddChildContent("<p>body</p>"));
 
-        var input = component.Find("input.inline-alert-input");
+        var input = component.Find("input.dialog-input");
         Assert.Equal("true", input.GetAttribute("aria-invalid"));
         var describedBy = input.GetAttribute("aria-describedby");
         Assert.False(string.IsNullOrEmpty(describedBy));
@@ -185,7 +185,7 @@ public sealed class ModalChromeValidateAsyncTests : BunitContext
             .Add(x => x.InlineAlert, alert)
             .AddChildContent("<p>body</p>"));
 
-        var input = component.Find("input.inline-alert-input");
+        var input = component.Find("input.dialog-input");
         Assert.False(input.HasAttribute("aria-invalid"));
         Assert.False(input.HasAttribute("aria-describedby"));
     }

--- a/tests/Unit/EventLogExpert.UI.Tests/Modal/ModalChromeValidateAsyncTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Modal/ModalChromeValidateAsyncTests.cs
@@ -46,6 +46,28 @@ public sealed class ModalChromeValidateAsyncTests : BunitContext
     }
 
     [Fact]
+    public void Prompt_InputLabelledByMessage()
+    {
+        var alert = new InlineAlertRequest(
+            Title: "Rename",
+            Message: "New name:",
+            AcceptLabel: "OK",
+            CancelLabel: "Cancel",
+            IsPrompt: true,
+            PromptInitialValue: "current");
+
+        var component = Render<ModalChrome>(p => p
+            .Add(x => x.InlineAlert, alert)
+            .AddChildContent("<p>body</p>"));
+
+        var input = component.Find("input.dialog-input");
+        var message = component.Find(".inline-alert-message");
+
+        Assert.Equal(message.Id, input.GetAttribute("aria-labelledby"));
+        Assert.False(input.HasAttribute("aria-label"));
+    }
+
+    [Fact]
     public void Prompt_ValidationErrorId_StableAcrossRenders()
     {
         var alert = new InlineAlertRequest(


### PR DESCRIPTION
## Summary
Redesigns the alert/prompt dialog system so all popups present as consistent, fixed-width dialogs and share the app's input component.

## Changes
- Standalone `AlertModal` / `PromptModal` now render at a fixed 34rem width (viewport-clamped via `min(34rem, calc(100vw - 2rem))`) instead of sizing to content.
- `PromptModal` uses the shared `TextInput` component (was a raw `<input>`), with the message as a `<label for>` and the underline `.input dialog-input` style.
- Titles never wrap: `.dialog-title` and `.inline-alert-title` truncate with an ellipsis (`nowrap` + `text-overflow: ellipsis` + `min-width: 0`) and expose the full text via a `title` tooltip.
- Inline alerts (shown inside an open modal) now match the standalone dialogs: same fixed width, never-wrap title, and a capped height with the message scrolling so action buttons stay visible.
- `TextInput` gains opt-in `Id`, `AriaInvalid`, and `UpdateOnInput` parameters plus an internal `FocusAsync`, enabling the prompt/inline-alert reuse with live validation.
- Long-token safety: messages, labels, and validation errors wrap with `overflow-wrap: anywhere`.

## Tests
- New `AlertModalTests`; expanded `PromptModalTests`, `TextInputTests`, `ModalChromeValidateAsyncTests`.
- All EventLogExpert.UI tests pass (905).