### PR TITLE
Exempt loading spinners from the reduced-motion animation reset

### DIFF
--- a/src/EventLogExpert.UI/Banner/ExportProgressBanner.razor
+++ b/src/EventLogExpert.UI/Banner/ExportProgressBanner.razor
@@ -1,5 +1,5 @@
 <aside class="banner banner-export-progress" role="status">
-    <i aria-hidden="true" class="banner-spinner bi bi-arrow-repeat"></i>
+    <i aria-hidden="true" class="banner-spinner bi bi-arrow-repeat loader-spin"></i>
 
     <span class="banner-message">@Export.Message</span>
 

--- a/src/EventLogExpert.UI/Banner/UpgradeProgressBanner.razor
+++ b/src/EventLogExpert.UI/Banner/UpgradeProgressBanner.razor
@@ -1,5 +1,5 @@
 <aside class="banner banner-upgrade-progress" role="status">
-    <i aria-hidden="true" class="banner-spinner bi bi-arrow-repeat"></i>
+    <i aria-hidden="true" class="banner-spinner bi bi-arrow-repeat loader-spin"></i>
 
     @if (string.IsNullOrEmpty(Progress.CurrentEntryName))
     {

--- a/src/EventLogExpert.UI/Database/DatabaseEntryRow.razor
+++ b/src/EventLogExpert.UI/Database/DatabaseEntryRow.razor
@@ -50,7 +50,7 @@
 
                         <span class="db-entry-upgrading">
                             <span class="db-entry-upgrading-status" role="status">
-                                <i aria-hidden="true" class="bi bi-arrow-repeat db-entry-spinner"></i>
+                                <i aria-hidden="true" class="bi bi-arrow-repeat db-entry-spinner loader-spin"></i>
                                 <span class="db-entry-upgrading-text" @key="verb">@displayText</span>
                                 @if (hasFile)
                                 {
@@ -65,7 +65,7 @@
                     else
                     {
                         <span class="db-entry-upgrading" role="status">
-                            <i aria-hidden="true" class="bi bi-arrow-repeat db-entry-spinner"></i>
+                            <i aria-hidden="true" class="bi bi-arrow-repeat db-entry-spinner loader-spin"></i>
                             <span>Upgrading&hellip;</span>
                         </span>
                     }

--- a/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor
+++ b/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor
@@ -4,7 +4,7 @@
     @if (IsClassificationPending)
     {
         <div class="manage-status-banner manage-status-banner--info" role="status">
-            <i aria-hidden="true" class="bi bi-arrow-repeat manage-status-banner__spinner"></i>
+            <i aria-hidden="true" class="bi bi-arrow-repeat manage-status-banner__spinner loader-spin"></i>
             <span class="manage-status-banner__message">Classifying databases&hellip;</span>
         </div>
     }

--- a/src/EventLogExpert.UI/FilterPane/FilterPane.razor
+++ b/src/EventLogExpert.UI/FilterPane/FilterPane.razor
@@ -52,7 +52,7 @@
     @if (FilterProgressState.Value.IsLoading)
     {
         <span class="filter-header-status">
-            [<i aria-label="Loading" class="spinner-border" role="status"></i> Applying Filters]
+            [<i aria-label="Loading" class="spinner-border loader-spin" role="status"></i> Applying Filters]
         </span>
     }
     else if (HasFilters && GetActiveFilters() > 0)

--- a/src/EventLogExpert.UI/LogTable/LogTabBar.razor
+++ b/src/EventLogExpert.UI/LogTable/LogTabBar.razor
@@ -12,7 +12,7 @@
                     tabindex="@(table.IsLoading ? -1 : 0)">
                     @if (table.IsLoading)
                     {
-                        <i aria-label="Loading" class="spinner-border" role="status"></i>
+                        <i aria-label="Loading" class="spinner-border loader-spin" role="status"></i>
                         @:&nbsp;
                     }
                     @GetTabName(table)

--- a/src/EventLogExpert.UI/wwwroot/app.css
+++ b/src/EventLogExpert.UI/wwwroot/app.css
@@ -141,7 +141,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-    *, *::before, *::after {
+    *:not(.loader-spin), *::before, *::after {
         animation-duration: 0.001ms !important;
         animation-iteration-count: 1 !important;
         transition-duration: 0.001ms !important;


### PR DESCRIPTION
## What
Loading spinners (DB upgrade/classify status, filter-apply, log-tab loading, export/upgrade progress banners) were frozen — not animating.

## Root cause
The blanket reduced-motion reset in `EventLogExpert.UI/wwwroot/app.css`:

```css
@media (prefers-reduced-motion: reduce) {
    *, *::before, *::after {
        animation-duration: 0.001ms !important;
        animation-iteration-count: 1 !important;
        ...
    }
}
```

disabled **all** animations — including functional loading spinners — whenever the OS reports reduced motion (Windows "Animation effects" off). Confirmed empirically in Edge (the same Chromium engine as the app's WebView2).

## Fix
Added a `loader-spin` utility class to the 7 spinner elements and excluded it from the reset (`*` to `*:not(.loader-spin)`). Functional loaders keep animating — a recognized WCAG exception for essential, state-conveying animation — while decorative animations remain disabled. Each spinner already carries `role="status"` / `aria-label` / `aria-hidden` as appropriate.

## Verification
- Empirically proven in Edge: under `prefers-reduced-motion: reduce`, a `loader-spin` element keeps spinning (1.5s) while a decorative animation stops.
- Build 0 warnings / 0 errors; UI test suite 921/921.
- 6-model pre-merge review panel: unanimous READY.

## Note
Stacked on #602 (base `jschick/button-component`). Will be retargeted to `main` after #602 merges.
