### PR TITLE
Migrate bespoke buttons to ChromelessButton (button follow-ups)

### DIFF
--- a/src/EventLogExpert.UI/Dashboard/EmptyStateDashboard.razor
+++ b/src/EventLogExpert.UI/Dashboard/EmptyStateDashboard.razor
@@ -18,43 +18,43 @@
                     <Button Disabled="@_isBusy" OnClick="ClearFilter">Clear filter</Button>
                 </div>
             }
-            <button class="empty-dashboard__utility" disabled="@_isBusy" @onclick="OpenDatabaseToolsAsync" type="button">
-                <i aria-hidden="true" class="bi bi-database-gear"></i><span>Manage databases...</span>
-            </button>
+            <ChromelessButton CssClass="empty-dashboard__utility" Disabled="@_isBusy" IconClass="bi bi-database-gear" OnClick="OpenDatabaseToolsAsync">
+                <span>Manage databases...</span>
+            </ChromelessButton>
         </div>
     </header>
 
     <section aria-labelledby="empty-dashboard-quickstart-heading" class="empty-dashboard__section">
         <h2 class="empty-dashboard__heading" id="empty-dashboard-quickstart-heading">Quick Launch</h2>
         <div class="empty-dashboard__launchbar">
-            <button aria-label="Open Application + System (live)" class="empty-dashboard__launch empty-dashboard__launch--primary" disabled="@_isBusy" @onclick="OpenApplicationAndSystemAsync" type="button">
-                <i aria-hidden="true" class="bi bi-collection"></i><span>Application + System (live)</span>
-            </button>
-            <button aria-label="Open Application (live)" class="empty-dashboard__launch" disabled="@_isBusy" @onclick="OpenApplicationAsync" type="button">
-                <i aria-hidden="true" class="bi bi-window"></i><span>Application (live)</span>
-            </button>
-            <button aria-label="Open System (live)" class="empty-dashboard__launch" disabled="@_isBusy" @onclick="OpenSystemAsync" type="button">
-                <i aria-hidden="true" class="bi bi-pc-display"></i><span>System (live)</span>
-            </button>
+            <ChromelessButton aria-label="Open Application + System (live)" CssClass="empty-dashboard__launch empty-dashboard__launch--primary" Disabled="@_isBusy" IconClass="bi bi-collection" OnClick="OpenApplicationAndSystemAsync">
+                <span>Application + System (live)</span>
+            </ChromelessButton>
+            <ChromelessButton aria-label="Open Application (live)" CssClass="empty-dashboard__launch" Disabled="@_isBusy" IconClass="bi bi-window" OnClick="OpenApplicationAsync">
+                <span>Application (live)</span>
+            </ChromelessButton>
+            <ChromelessButton aria-label="Open System (live)" CssClass="empty-dashboard__launch" Disabled="@_isBusy" IconClass="bi bi-pc-display" OnClick="OpenSystemAsync">
+                <span>System (live)</span>
+            </ChromelessButton>
             @if (Version.IsAdmin)
             {
-                <button aria-label="Open Security (live)" class="empty-dashboard__launch" disabled="@_isBusy" @onclick="OpenSecurityAsync" type="button">
-                    <i aria-hidden="true" class="bi bi-shield-lock"></i><span>Security (live)</span>
-                </button>
+                <ChromelessButton aria-label="Open Security (live)" CssClass="empty-dashboard__launch" Disabled="@_isBusy" IconClass="bi bi-shield-lock" OnClick="OpenSecurityAsync">
+                    <span>Security (live)</span>
+                </ChromelessButton>
             }
             else
             {
-                <button aria-describedby="@ElevationReasonId" aria-disabled="true" aria-label="Open Security (live)" class="empty-dashboard__launch empty-dashboard__launch--disabled" type="button">
-                    <i aria-hidden="true" class="bi bi-shield-lock"></i><span>Security (live)</span>
-                </button>
+                <ChromelessButton aria-describedby="@ElevationReasonId" aria-disabled="true" aria-label="Open Security (live)" CssClass="empty-dashboard__launch empty-dashboard__launch--disabled" IconClass="bi bi-shield-lock">
+                    <span>Security (live)</span>
+                </ChromelessButton>
             }
             <span aria-hidden="true" class="empty-dashboard__launch-divider"></span>
-            <button aria-label="Open Log file..." class="empty-dashboard__launch" disabled="@_isBusy" @onclick="OpenFileAsync" type="button">
-                <i aria-hidden="true" class="bi bi-file-earmark-text"></i><span>Log file...</span>
-            </button>
-            <button aria-label="Open Folder..." class="empty-dashboard__launch" disabled="@_isBusy" @onclick="OpenFolderAsync" type="button">
-                <i aria-hidden="true" class="bi bi-folder2-open"></i><span>Folder...</span>
-            </button>
+            <ChromelessButton aria-label="Open Log file..." CssClass="empty-dashboard__launch" Disabled="@_isBusy" IconClass="bi bi-file-earmark-text" OnClick="OpenFileAsync">
+                <span>Log file...</span>
+            </ChromelessButton>
+            <ChromelessButton aria-label="Open Folder..." CssClass="empty-dashboard__launch" Disabled="@_isBusy" IconClass="bi bi-folder2-open" OnClick="OpenFolderAsync">
+                <span>Folder...</span>
+            </ChromelessButton>
         </div>
     </section>
 

--- a/src/EventLogExpert.UI/Dashboard/EmptyStateDashboard.razor.css
+++ b/src/EventLogExpert.UI/Dashboard/EmptyStateDashboard.razor.css
@@ -72,7 +72,7 @@
     gap: 0.75rem;
 }
 
-.empty-dashboard__utility {
+.empty-dashboard__masthead-actions ::deep .empty-dashboard__utility {
     display: inline-flex;
     align-items: center;
     gap: 0.4rem;
@@ -86,22 +86,22 @@
     transition: border-color 0.15s ease, color 0.15s ease, background-color 0.15s ease;
 }
 
-.empty-dashboard__utility > .bi {
+.empty-dashboard__masthead-actions ::deep .empty-dashboard__utility > .bi {
     color: var(--clr-lightblue);
 }
 
-.empty-dashboard__utility:hover:not(:disabled) {
+.empty-dashboard__masthead-actions ::deep .empty-dashboard__utility:hover:not(:disabled) {
     border-color: var(--clr-lightblue);
     color: var(--text-primary);
     background-color: var(--background-darkgray);
 }
 
-.empty-dashboard__utility:focus-visible {
+.empty-dashboard__masthead-actions ::deep .empty-dashboard__utility:focus-visible {
     outline: 2px solid var(--clr-lightblue);
     outline-offset: 2px;
 }
 
-.empty-dashboard__utility:disabled {
+.empty-dashboard__masthead-actions ::deep .empty-dashboard__utility:disabled {
     color: var(--clr-placeholder);
     cursor: default;
 }
@@ -144,7 +144,7 @@
     gap: 0.5rem;
 }
 
-.empty-dashboard__launch {
+.empty-dashboard__launchbar ::deep .empty-dashboard__launch {
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
@@ -158,16 +158,16 @@
     transition: border-color 0.15s ease, background-color 0.15s ease;
 }
 
-.empty-dashboard__launch > .bi {
+.empty-dashboard__launchbar ::deep .empty-dashboard__launch > .bi {
     color: var(--clr-lightblue);
 }
 
-.empty-dashboard__launch:hover:not(:disabled):not(.empty-dashboard__launch--disabled):not(.empty-dashboard__launch--primary) {
+.empty-dashboard__launchbar ::deep .empty-dashboard__launch:hover:not(:disabled):not(.empty-dashboard__launch--disabled):not(.empty-dashboard__launch--primary) {
     border-color: var(--clr-lightblue);
     background-color: var(--background-darkgray);
 }
 
-.empty-dashboard__launch--primary {
+.empty-dashboard__launchbar ::deep .empty-dashboard__launch--primary {
     flex-shrink: 0;
     border-color: var(--clr-lightblue);
     background-color: var(--clr-lightblue);
@@ -175,25 +175,25 @@
     font-weight: 600;
 }
 
-.empty-dashboard__launch--primary > .bi {
+.empty-dashboard__launchbar ::deep .empty-dashboard__launch--primary > .bi {
     color: var(--accent-on-fill);
 }
 
-.empty-dashboard__launch--primary:hover:not(:disabled) {
+.empty-dashboard__launchbar ::deep .empty-dashboard__launch--primary:hover:not(:disabled) {
     box-shadow: var(--shadow-menu);
 }
 
-.empty-dashboard__launch:disabled,
-.empty-dashboard__launch--disabled {
+.empty-dashboard__launchbar ::deep .empty-dashboard__launch:disabled,
+.empty-dashboard__launchbar ::deep .empty-dashboard__launch--disabled {
     color: var(--clr-placeholder);
     cursor: default;
 }
 
-.empty-dashboard__launch--disabled > .bi {
+.empty-dashboard__launchbar ::deep .empty-dashboard__launch--disabled > .bi {
     color: var(--clr-placeholder);
 }
 
-.empty-dashboard__launch:focus-visible {
+.empty-dashboard__launchbar ::deep .empty-dashboard__launch:focus-visible {
     outline: 2px solid var(--clr-lightblue);
     outline-offset: 2px;
 }

--- a/src/EventLogExpert.UI/Dashboard/ScenarioDetail.razor
+++ b/src/EventLogExpert.UI/Dashboard/ScenarioDetail.razor
@@ -42,13 +42,11 @@
         }
     </div>
     <div class="scenario-detail__actions">
-        <button aria-label="@(IsFavored ? $"Remove {Scenario.Name} from favorites" : $"Add {Scenario.Name} to favorites")"
+        <ChromelessButton aria-label="@(IsFavored ? $"Remove {Scenario.Name} from favorites" : $"Add {Scenario.Name} to favorites")"
             aria-pressed="@(IsFavored ? "true" : "false")"
-            class="scenario-detail__star"
-            @onclick="OnToggleFavorite"
-            type="button">
-            <i aria-hidden="true" class="bi @(IsFavored ? "bi-star-fill" : "bi-star")"></i>
-        </button>
+            CssClass="scenario-detail__star"
+            IconClass="@(IsFavored ? "bi bi-star-fill" : "bi bi-star")"
+            OnClick="OnToggleFavorite" />
         <ChromelessButton aria-describedby="@(IsDisabled ? ElevationReasonId : null)"
             aria-disabled="@(IsDisabled ? "true" : "false")"
             CssClass="scenario-detail__launch"

--- a/src/EventLogExpert.UI/Dashboard/ScenarioDetail.razor
+++ b/src/EventLogExpert.UI/Dashboard/ScenarioDetail.razor
@@ -49,13 +49,13 @@
             type="button">
             <i aria-hidden="true" class="bi @(IsFavored ? "bi-star-fill" : "bi-star")"></i>
         </button>
-        <button aria-describedby="@(IsDisabled ? ElevationReasonId : null)"
+        <ChromelessButton aria-describedby="@(IsDisabled ? ElevationReasonId : null)"
             aria-disabled="@(IsDisabled ? "true" : "false")"
-            class="scenario-detail__launch"
-            disabled="@IsBusy"
-            @onclick="LaunchAsync"
-            type="button">
-            <i aria-hidden="true" class="bi bi-play-fill"></i><span>Launch</span>
-        </button>
+            CssClass="scenario-detail__launch"
+            Disabled="@IsBusy"
+            IconClass="bi bi-play-fill"
+            OnClick="LaunchAsync">
+            <span>Launch</span>
+        </ChromelessButton>
     </div>
 </div>

--- a/src/EventLogExpert.UI/Dashboard/ScenarioDetail.razor.css
+++ b/src/EventLogExpert.UI/Dashboard/ScenarioDetail.razor.css
@@ -116,7 +116,7 @@
     margin-top: 0.75rem;
 }
 
-.scenario-detail__star {
+.scenario-detail__actions ::deep .scenario-detail__star {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -131,15 +131,15 @@
     transition: color 0.15s ease, border-color 0.15s ease;
 }
 
-.scenario-detail__star[aria-pressed="true"] {
+.scenario-detail__actions ::deep .scenario-detail__star[aria-pressed="true"] {
     color: var(--clr-yellow);
 }
 
-.scenario-detail__star[aria-pressed="false"]:hover {
+.scenario-detail__actions ::deep .scenario-detail__star[aria-pressed="false"]:hover {
     border-color: var(--clr-lightblue);
 }
 
-.scenario-detail__star:focus-visible {
+.scenario-detail__actions ::deep .scenario-detail__star:focus-visible {
     outline: 2px solid var(--clr-lightblue);
     outline-offset: 2px;
 }

--- a/src/EventLogExpert.UI/Dashboard/ScenarioDetail.razor.css
+++ b/src/EventLogExpert.UI/Dashboard/ScenarioDetail.razor.css
@@ -144,7 +144,7 @@
     outline-offset: 2px;
 }
 
-.scenario-detail__launch {
+.scenario-detail__actions ::deep .scenario-detail__launch {
     display: inline-flex;
     align-items: center;
     gap: 0.4rem;
@@ -158,27 +158,27 @@
     cursor: pointer;
 }
 
-.scenario-detail__launch > .bi {
+.scenario-detail__actions ::deep .scenario-detail__launch > .bi {
     color: var(--accent-on-fill);
 }
 
-.scenario-detail__launch:hover:not(:disabled):not([aria-disabled="true"]) {
+.scenario-detail__actions ::deep .scenario-detail__launch:hover:not(:disabled):not([aria-disabled="true"]) {
     box-shadow: var(--shadow-menu);
 }
 
-.scenario-detail__launch:focus-visible {
+.scenario-detail__actions ::deep .scenario-detail__launch:focus-visible {
     outline: 2px solid var(--clr-lightblue);
     outline-offset: 2px;
 }
 
-.scenario-detail__launch:disabled,
-.scenario-detail__launch[aria-disabled="true"] {
+.scenario-detail__actions ::deep .scenario-detail__launch:disabled,
+.scenario-detail__actions ::deep .scenario-detail__launch[aria-disabled="true"] {
     border-color: var(--border-divider);
     background-color: var(--surface-inset);
     color: var(--text-secondary);
     cursor: default;
 }
 
-.scenario-detail__launch[aria-disabled="true"] > .bi {
+.scenario-detail__actions ::deep .scenario-detail__launch[aria-disabled="true"] > .bi {
     color: var(--text-secondary);
 }

--- a/src/EventLogExpert.UI/Database/DatabaseEntryRow.razor
+++ b/src/EventLogExpert.UI/Database/DatabaseEntryRow.razor
@@ -77,10 +77,7 @@
                         CssClass="db-entry-upgrade-btn"
                         Disabled="@IsUpgradeBlocked"
                         IconClass="bi bi-arrow-up-circle"
-                        OnClick="@(async () =>
-                                 {
-                                     if (!IsUpgradeBlocked) { await OnUpgrade.InvokeAsync(); }
-                                 })">
+                        OnClick="@(() => OnUpgrade.InvokeAsync())">
                         Upgrade
                     </Button>
 
@@ -91,10 +88,7 @@
                         CssClass="db-entry-upgrade-btn"
                         Disabled="@IsUpgradeBlocked"
                         IconClass="bi bi-arrow-clockwise"
-                        OnClick="@(async () =>
-                                 {
-                                     if (!IsUpgradeBlocked) { await OnUpgrade.InvokeAsync(); }
-                                 })">
+                        OnClick="@(() => OnUpgrade.InvokeAsync())">
                         Retry Upgrade
                     </DangerButton>
 

--- a/src/EventLogExpert.UI/Database/DatabaseEntryRow.razor
+++ b/src/EventLogExpert.UI/Database/DatabaseEntryRow.razor
@@ -11,7 +11,7 @@
 
     <div class="db-entry-row-content">
         <div class="db-entry-info">
-            <button class="db-entry-name" id="@_nameButtonId" @ref="_nameButtonRef" type="button">@Entry.FileName</button>
+            <ChromelessButton CssClass="db-entry-name" id="@_nameButtonId" @ref="_nameButton">@Entry.FileName</ChromelessButton>
             @if (ShouldShowBadge)
             {
                 <span class="db-entry-badge" data-badge="@BadgeKind">@BadgeLabel</span>

--- a/src/EventLogExpert.UI/Database/DatabaseEntryRow.razor.cs
+++ b/src/EventLogExpert.UI/Database/DatabaseEntryRow.razor.cs
@@ -8,6 +8,7 @@ using EventLogExpert.Runtime.Database.Upgrade;
 using EventLogExpert.Runtime.Menu;
 using EventLogExpert.UI.Common;
 using EventLogExpert.UI.Focus;
+using EventLogExpert.UI.Inputs;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 
@@ -21,7 +22,7 @@ public sealed partial class DatabaseEntryRow : ComponentBase
     private readonly string _nameButtonId = ComponentId.NewUnique("db-row-name").Value;
     private readonly string _pendingStatusId = ComponentId.NewUnique("db-row-pending").Value;
 
-    private ElementReference _nameButtonRef;
+    private ChromelessButton? _nameButton;
     private bool _shouldFocusNameAfterRender;
 
     private enum ActionKind
@@ -110,7 +111,10 @@ public sealed partial class DatabaseEntryRow : ComponentBase
 
     [Inject] private ITraceLogger TraceLogger { get; init; } = null!;
 
-    public ValueTask FocusNameAsync() => ElementFocus.SafelyAsync(_nameButtonRef, preventScroll: true);
+    public ValueTask FocusNameAsync() =>
+        _nameButton is { } button ?
+            ElementFocus.SafelyAsync(button.Element, preventScroll: true) :
+            ValueTask.CompletedTask;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {

--- a/src/EventLogExpert.UI/Database/DatabaseEntryRow.razor.css
+++ b/src/EventLogExpert.UI/Database/DatabaseEntryRow.razor.css
@@ -42,7 +42,7 @@
     min-width: 0;
 }
 
-.db-entry-name {
+.db-entry-row ::deep .db-entry-name {
     flex: 1 1 auto;
     min-width: 0;
 

--- a/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor
+++ b/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor
@@ -4,7 +4,7 @@
     @if (IsClassificationPending)
     {
         <div class="manage-status-banner manage-status-banner--info" role="status">
-            <i aria-hidden="true" class="bi bi-arrow-repeat manage-status-banner__spinner loader-spin"></i>
+            <i aria-hidden="true" class="bi bi-arrow-repeat loader-spin manage-status-banner__spinner"></i>
             <span class="manage-status-banner__message">Classifying databases&hellip;</span>
         </div>
     }
@@ -36,15 +36,13 @@
     {
         <div class="manage-databases-selection-header">
             <div class="manage-databases-master-checkbox">
-                <button aria-checked="@MasterCheckboxAriaChecked"
+                <ChromelessButton aria-checked="@MasterCheckboxAriaChecked"
                     aria-label="@MasterCheckboxAriaLabel"
-                    class="manage-databases-master-btn"
-                    @onclick="OnMasterCheckboxClickAsync"
-                    @ref="_masterCheckboxRef"
-                    role="checkbox"
-                    type="button">
-                    <i aria-hidden="true" class="bi @MasterCheckboxIconClass"></i>
-                </button>
+                    CssClass="manage-databases-master-btn"
+                    IconClass="@($"bi {MasterCheckboxIconClass}")"
+                    OnClick="OnMasterCheckboxClickAsync"
+                    @ref="_masterCheckbox"
+                    role="checkbox" />
             </div>
             <span class="manage-databases-selection-count">
                 @_selectedForBulk.Count of @DatabaseService.Entries.Count selected

--- a/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.cs
+++ b/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.cs
@@ -37,7 +37,7 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
     private Button? _importButton;
     private ImmutableHashSet<string> _initialActiveSnapshot = ImmutableHashSet<string>.Empty;
     private bool _isSelectionModeActive;
-    private ElementReference _masterCheckboxRef;
+    private ChromelessButton? _masterCheckbox;
     private bool _restorationOccurred;
     private bool _schemaUpgradeOccurred;
     private Button? _selectButton;
@@ -557,7 +557,7 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
 
         if (_selectedForBulk.Count > 0)
         {
-            await ElementFocus.SafelyAsync(_masterCheckboxRef, preventScroll: true);
+            await FocusRestoreAsync(_masterCheckbox);
 
             return;
         }
@@ -858,7 +858,7 @@ public sealed partial class ManageDatabasesTab : ComponentBase, IAsyncDisposable
             SelectAll();
         }
 
-        await ElementFocus.SafelyAsync(_masterCheckboxRef, preventScroll: true);
+        await FocusRestoreAsync(_masterCheckbox);
     }
 
     private async Task OnSaveClickAsync()

--- a/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.css
+++ b/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.css
@@ -35,7 +35,7 @@
     animation: manage-databases-selection-header-fade-in 200ms ease-out;
 }
 
-.manage-databases-master-btn {
+.manage-databases-tab ::deep .manage-databases-master-btn {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -59,7 +59,7 @@
     overflow: hidden;
 }
 
-.manage-databases-master-btn:focus-visible {
+.manage-databases-tab ::deep .manage-databases-master-btn:focus-visible {
     outline: 2px solid var(--clr-lightblue);
     outline-offset: 2px;
     border-radius: 2px;

--- a/src/EventLogExpert.UI/DetailsPane/DetailsPane.razor
+++ b/src/EventLogExpert.UI/DetailsPane/DetailsPane.razor
@@ -1,22 +1,19 @@
 @inherits FluxorComponent
 
-<div class="details-pane" data-toggle="@IsVisible" hidden="@(_selectedEvent is null)" @ref="_detailsPaneRootRef">
+<div class="details-pane" data-toggle="@IsVisible" hidden="@(_selectedEvent is null)">
     <div class="details-resizer"></div>
 
-    <div aria-expanded="@_isVisible.ToString().ToLower()"
+    <ChromelessButton aria-expanded="@_isVisible.ToString().ToLower()"
         aria-label="@(_isVisible ? "Details Expanded" : "Details Collapsed")"
-        class="flex-space-between"
+        CssClass="flex-space-between"
         id="details-header"
-        @onclick="ToggleMenu"
-        @onkeydown="HandleKeyDown"
-        role="button"
-        tabindex="0">
-        <div>Details</div>
+        OnClick="ToggleMenu">
+        <span>Details</span>
 
         <span class="menu-toggle" data-rotate="@IsVisible">
             <i class="bi bi-caret-up"></i>
         </span>
-    </div>
+    </ChromelessButton>
 
     @if (_selectedEvent is not null)
     {
@@ -39,18 +36,15 @@
 
         <hr />
 
-        <div aria-expanded="@_isXmlVisible.ToString().ToLower()"
+        <ChromelessButton aria-expanded="@_isXmlVisible.ToString().ToLower()"
             aria-label="@(_isXmlVisible ? "XML Expanded" : "XML Collapsed")"
-            class="details-row-xml flex-space-between"
-            @onclick="ToggleXml"
-            @onkeydown="HandleKeyDownXml"
-            role="button"
-            tabindex="0">
-            <div>XML</div>
+            CssClass="details-row-xml flex-space-between"
+            OnClick="ToggleXml">
+            <span>XML</span>
             <span class="menu-toggle" data-rotate="@_isXmlVisible.ToString().ToLower()">
                 <i class="bi bi-caret-up"></i>
             </span>
-        </div>
+        </ChromelessButton>
 
         <p class="details-xml" data-toggle="@_isXmlVisible.ToString().ToLower()">
             @if (_resolvedXml is null)

--- a/src/EventLogExpert.UI/DetailsPane/DetailsPane.razor.cs
+++ b/src/EventLogExpert.UI/DetailsPane/DetailsPane.razor.cs
@@ -10,7 +10,6 @@ using EventLogExpert.Runtime.Settings;
 using EventLogExpert.UI.Common.Interop;
 using Fluxor;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
 using System.Xml;
 using System.Xml.Linq;
@@ -20,7 +19,6 @@ namespace EventLogExpert.UI.DetailsPane;
 public sealed partial class DetailsPane
 {
     private IJSObjectReference? _detailsPaneModule;
-    private ElementReference _detailsPaneRootRef;
     private DotNetObjectReference<DetailsPane>? _dotNetRef;
     private bool _hasOpened;
     private bool _isVisible;
@@ -31,7 +29,6 @@ public sealed partial class DetailsPane
     ///     failure); any other value is the rendered XML.
     /// </summary>
     private string? _resolvedXml;
-    private IJSObjectReference? _scrollSuppressorModule;
     private ResolvedEvent? _selectedEvent;
     /// <summary>Cancels any in-flight XML resolution when the selection changes again before completion.</summary>
     private CancellationTokenSource? _xmlResolveCts;
@@ -73,12 +70,7 @@ public sealed partial class DetailsPane
                 _detailsPaneModule,
                 static module => module.InvokeVoidAsync("disposeDetailsPaneResizer"));
 
-            await JsModuleInterop.DisposeModuleSafelyAsync(
-                _scrollSuppressorModule,
-                module => module.InvokeVoidAsync("release", _detailsPaneRootRef));
-
             _detailsPaneModule = null;
-            _scrollSuppressorModule = null;
 
             _dotNetRef?.Dispose();
         }
@@ -100,20 +92,6 @@ public sealed partial class DetailsPane
                 "enableDetailsPaneResizer",
                 _dotNetRef,
                 PreferencesProvider.DetailsPaneHeightPreference);
-
-            try
-            {
-                _scrollSuppressorModule = await JSRuntime.InvokeAsync<IJSObjectReference>(
-                    "import",
-                    "./_content/EventLogExpert.UI/Common/keyboardScrollSuppressor.js");
-
-                await _scrollSuppressorModule.InvokeVoidAsync(
-                    "suppress",
-                    _detailsPaneRootRef,
-                    new[] { new { selector = "#details-header, .details-row-xml", keys = new[] { "Enter", " " } } });
-            }
-            catch (JSDisconnectedException) { }
-            catch (JSException) { }
         }
 
         await base.OnAfterRenderAsync(firstRender);
@@ -150,26 +128,6 @@ public sealed partial class DetailsPane
             TraceLogger.Trace($"DetailsPane: failed to parse XML for display, falling back to raw text: {ex.Message}");
 
             return _resolvedXml;
-        }
-    }
-
-    private void HandleKeyDown(KeyboardEventArgs e)
-    {
-        if (e.Repeat) { return; }
-
-        if (e.Key is "Enter" or " ")
-        {
-            ToggleMenu();
-        }
-    }
-
-    private void HandleKeyDownXml(KeyboardEventArgs e)
-    {
-        if (e.Repeat) { return; }
-
-        if (e.Key is "Enter" or " ")
-        {
-            ToggleXml();
         }
     }
 

--- a/src/EventLogExpert.UI/DetailsPane/DetailsPane.razor.css
+++ b/src/EventLogExpert.UI/DetailsPane/DetailsPane.razor.css
@@ -14,10 +14,10 @@
     &[data-toggle="false"] {
         height: auto;
         min-height: 0;
-
-        & > :not(#details-header) { display: none; }
     }
 }
+
+.details-pane[data-toggle="false"] ::deep > :not(#details-header) { display: none; }
 
 .details-resizer {
     height: 10px;
@@ -33,7 +33,14 @@
     cursor: n-resize;
 }
 
-#details-header {
+.details-pane ::deep #details-header {
+    appearance: none;
+    background: none;
+    border: 0;
+    padding: 0;
+    color: inherit;
+    font: inherit;
+    text-align: left;
     user-select: none;
     cursor: pointer;
 }
@@ -52,7 +59,14 @@
     white-space: pre-wrap;
 }
 
-.details-row-xml {
+.details-pane ::deep .details-row-xml {
+    appearance: none;
+    background: none;
+    border: 0;
+    padding: 0;
+    color: inherit;
+    font: inherit;
+    text-align: left;
     user-select: none;
     cursor: pointer;
 }

--- a/src/EventLogExpert.UI/FilterEditor/Editing/FilterPredicateEditor.razor
+++ b/src/EventLogExpert.UI/FilterEditor/Editing/FilterPredicateEditor.razor
@@ -1,15 +1,14 @@
 @if (IsEditing)
 {
     <div class="filter-predicate-editing">
-        <button aria-label="@(Value.JoinWithAny ? "Joining with OR; click to switch to AND" : "Joining with AND; click to switch to OR")"
-            class="filter-predicate-and-or"
+        <ChromelessButton aria-label="@(Value.JoinWithAny ? "Joining with OR; click to switch to AND" : "Joining with AND; click to switch to OR")"
+            CssClass="filter-predicate-and-or"
             data-mode="@(Value.JoinWithAny ? "or" : "and")"
-            @onclick="OnAndOrClick"
-            @ref="_editorFirstInputRef"
-            title="@(Value.JoinWithAny ? "OR" : "AND")"
-            type="button">
+            OnClick="OnAndOrClick"
+            @ref="_editorFirstInput"
+            title="@(Value.JoinWithAny ? "OR" : "AND")">
             @(Value.JoinWithAny ? "OR" : "AND")
-        </button>
+        </ChromelessButton>
 
         <FilterComparisonEditor Comparison="Value.Comparison"
             Id="@ComponentId.For(Value.Id, ComponentIdScope.Predicate).Value"
@@ -32,22 +31,19 @@
 else
 {
     <div class="filter-predicate">
-        <button aria-label="@($"Edit predicate: {SummaryText}")"
-            class="filter-predicate-edit"
-            @onclick="OnEditChip"
-            @ref="_chipEditButtonRef"
-            title="Edit predicate"
-            type="button">
+        <ChromelessButton aria-label="@($"Edit predicate: {SummaryText}")"
+            CssClass="filter-predicate-edit"
+            OnClick="OnEditChip"
+            @ref="_chipEditButton"
+            title="Edit predicate">
             <span class="filter-predicate-joiner">@JoinerLabel</span>
             <span class="filter-predicate-summary">@SummaryText</span>
-        </button>
+        </ChromelessButton>
 
-        <button aria-label="@($"Remove predicate: {SummaryText}")"
-            class="filter-predicate-remove"
-            @onclick="OnRemoveChip"
-            title="Remove predicate"
-            type="button">
-            <i aria-hidden="true" class="bi bi-x-circle"></i>
-        </button>
+        <ChromelessButton aria-label="@($"Remove predicate: {SummaryText}")"
+            CssClass="filter-predicate-remove"
+            IconClass="bi bi-x-circle"
+            OnClick="OnRemoveChip"
+            title="Remove predicate" />
     </div>
 }

--- a/src/EventLogExpert.UI/FilterEditor/Editing/FilterPredicateEditor.razor.cs
+++ b/src/EventLogExpert.UI/FilterEditor/Editing/FilterPredicateEditor.razor.cs
@@ -4,6 +4,7 @@
 using EventLogExpert.Filtering.Common.Filtering;
 using EventLogExpert.Filtering.Drafts;
 using EventLogExpert.UI.Focus;
+using EventLogExpert.UI.Inputs;
 using Microsoft.AspNetCore.Components;
 
 namespace EventLogExpert.UI.FilterEditor.Editing;
@@ -15,8 +16,8 @@ namespace EventLogExpert.UI.FilterEditor.Editing;
 /// </summary>
 public sealed partial class FilterPredicateEditor : ComponentBase
 {
-    private ElementReference _chipEditButtonRef;
-    private ElementReference _editorFirstInputRef;
+    private ChromelessButton? _chipEditButton;
+    private ChromelessButton? _editorFirstInput;
 
     [Parameter] public bool IsEditing { get; set; }
 
@@ -61,9 +62,11 @@ public sealed partial class FilterPredicateEditor : ComponentBase
         }
     }
 
-    internal ValueTask FocusChipEditButtonAsync() => ElementFocus.SafelyAsync(_chipEditButtonRef);
+    internal ValueTask FocusChipEditButtonAsync() =>
+        _chipEditButton is { } button ? ElementFocus.SafelyAsync(button.Element) : ValueTask.CompletedTask;
 
-    internal ValueTask FocusEditorFirstInputAsync() => ElementFocus.SafelyAsync(_editorFirstInputRef);
+    internal ValueTask FocusEditorFirstInputAsync() =>
+        _editorFirstInput is { } button ? ElementFocus.SafelyAsync(button.Element) : ValueTask.CompletedTask;
 
     /// <summary>
     ///     AND/OR joiner click handler. Toggles <see cref="FilterPredicateDraft.JoinWithAny" /> and bubbles the change up

--- a/src/EventLogExpert.UI/FilterEditor/Editing/FilterPredicateEditor.razor.css
+++ b/src/EventLogExpert.UI/FilterEditor/Editing/FilterPredicateEditor.razor.css
@@ -7,13 +7,13 @@
     min-height: 24px;
 }
 
-.filter-predicate:hover .filter-predicate-edit,
-.filter-predicate:hover .filter-predicate-remove {
+.filter-predicate:hover ::deep .filter-predicate-edit,
+.filter-predicate:hover ::deep .filter-predicate-remove {
     border-color: var(--clr-lightblue);
 }
 
-.filter-predicate-edit,
-.filter-predicate-remove {
+.filter-predicate ::deep .filter-predicate-edit,
+.filter-predicate ::deep .filter-predicate-remove {
     display: inline-flex;
     align-items: center;
 
@@ -29,7 +29,7 @@
     transition: color 0.1s ease-in-out, background-color 0.1s ease-in-out, border-color 0.1s ease-in-out;
 }
 
-.filter-predicate-edit {
+.filter-predicate ::deep .filter-predicate-edit {
     gap: 0.25rem;
     padding: 2px 6px 2px 12px;
     border-right: none;
@@ -56,7 +56,7 @@
     text-overflow: ellipsis;
 }
 
-.filter-predicate-remove {
+.filter-predicate ::deep .filter-predicate-remove {
     min-width: 32px;
     padding: 2px 12px 2px 8px;
 
@@ -67,19 +67,19 @@
     border-bottom-right-radius: 999px;
 }
 
-.filter-predicate-remove .bi {
+.filter-predicate ::deep .filter-predicate-remove .bi {
     font-size: 0.9rem;
     line-height: 1;
 }
 
-.filter-predicate-remove:hover {
+.filter-predicate ::deep .filter-predicate-remove:hover {
     color: var(--clr-on-status-fill);
     background: var(--clr-red);
     border-color: var(--clr-red) !important;
 }
 
-.filter-predicate-edit:focus-visible,
-.filter-predicate-remove:focus-visible {
+.filter-predicate ::deep .filter-predicate-edit:focus-visible,
+.filter-predicate ::deep .filter-predicate-remove:focus-visible {
     outline: 2px solid var(--toggle-accent);
     outline-offset: -2px;
 }
@@ -88,10 +88,10 @@
     .filter-predicate {
         border: 1px solid ButtonText;
     }
-    .filter-predicate-remove {
+    .filter-predicate ::deep .filter-predicate-remove {
         border-left: 1px solid ButtonText;
     }
-    .filter-predicate-remove:hover {
+    .filter-predicate ::deep .filter-predicate-remove:hover {
         background: Highlight;
         color: HighlightText;
     }
@@ -112,7 +112,7 @@
 }
 
 /* AND/OR toggle in editing mode \u2014 neutral pill matching the chip aesthetic. */
-.filter-predicate-and-or {
+.filter-predicate-editing ::deep .filter-predicate-and-or {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -136,23 +136,23 @@
     transition: color 0.1s ease-in-out, border-color 0.1s ease-in-out;
 }
 
-.filter-predicate-and-or[data-mode="or"] {
+.filter-predicate-editing ::deep .filter-predicate-and-or[data-mode="or"] {
     color: var(--clr-lightblue);
     border-color: var(--clr-lightblue);
 }
 
-.filter-predicate-and-or:hover {
+.filter-predicate-editing ::deep .filter-predicate-and-or:hover {
     color: var(--clr-lightblue);
     border-color: var(--clr-lightblue);
 }
 
-.filter-predicate-and-or:focus-visible {
+.filter-predicate-editing ::deep .filter-predicate-and-or:focus-visible {
     outline: 2px solid var(--toggle-accent);
     outline-offset: 2px;
 }
 
 @media (forced-colors: active) {
-    .filter-predicate-and-or[data-mode="or"] {
+    .filter-predicate-editing ::deep .filter-predicate-and-or[data-mode="or"] {
         color: Highlight;
         border-color: Highlight;
     }

--- a/src/EventLogExpert.UI/FilterLibrary/FilterLibraryModal.razor
+++ b/src/EventLogExpert.UI/FilterLibrary/FilterLibraryModal.razor
@@ -61,23 +61,22 @@
                                 @foreach (var tag in visibleTags)
                                 {
                                     var isSelected = _selectedTagsByTab[tab].Contains(tag, StringComparer.OrdinalIgnoreCase);
-                                    <button aria-pressed="@(isSelected ? "true" : "false")"
-                                        class="library-tag-filter-chip"
-                                        @onclick="@(() => ToggleTagFilter(tag))"
-                                        type="button">
+
+                                    <ChromelessButton aria-pressed="@(isSelected ? "true" : "false")"
+                                        CssClass="library-tag-filter-chip"
+                                        OnClick="@(() => ToggleTagFilter(tag))">
                                         @tag
-                                    </button>
+                                    </ChromelessButton>
                                 }
                                 @if (hiddenTagsCount > 0)
                                 {
-                                    <button aria-controls="@(_isTagOverflowExpanded ? tagOverflowRegionId : null)"
+                                    <ChromelessButton aria-controls="@(_isTagOverflowExpanded ? tagOverflowRegionId : null)"
                                         aria-expanded="@(_isTagOverflowExpanded ? "true" : "false")"
                                         aria-label="@(_isTagOverflowExpanded ? "Hide additional tags" : $"Show {hiddenTagsCount} additional tags")"
-                                        class="library-tag-filter-chip-overflow"
-                                        @onclick="ToggleTagOverflowExpanded"
-                                        type="button">
-                                        @(_isTagOverflowExpanded ? "− less" : $"+{hiddenTagsCount} more")
-                                    </button>
+                                        CssClass="library-tag-filter-chip-overflow"
+                                        OnClick="ToggleTagOverflowExpanded">
+                                        @(_isTagOverflowExpanded ? "- less" : $"+{hiddenTagsCount} more")
+                                    </ChromelessButton>
                                 }
                                 @if (_isTagOverflowExpanded && hiddenTagsCount > 0)
                                 {
@@ -85,12 +84,12 @@
                                         @foreach (var tag in AllLibraryTags.Skip(TagFilterBarMaxVisible))
                                         {
                                             var isOverflowSelected = _selectedTagsByTab[tab].Contains(tag, StringComparer.OrdinalIgnoreCase);
-                                            <button aria-pressed="@(isOverflowSelected ? "true" : "false")"
-                                                class="library-tag-filter-chip"
-                                                @onclick="@(() => ToggleTagFilter(tag))"
-                                                type="button">
+
+                                            <ChromelessButton aria-pressed="@(isOverflowSelected ? "true" : "false")"
+                                                CssClass="library-tag-filter-chip"
+                                                OnClick="@(() => ToggleTagFilter(tag))">
                                                 @tag
-                                            </button>
+                                            </ChromelessButton>
                                         }
                                     </div>
                                 }

--- a/src/EventLogExpert.UI/FilterLibrary/FilterLibraryModal.razor.css
+++ b/src/EventLogExpert.UI/FilterLibrary/FilterLibraryModal.razor.css
@@ -32,7 +32,7 @@
     line-height: 1;
 }
 
-.library-tag-filter-chip {
+.library-tag-filter-bar ::deep .library-tag-filter-chip {
     padding: 0 .375rem;
     color: var(--text-primary);
     background: transparent;
@@ -43,25 +43,25 @@
     cursor: pointer;
 }
 
-.library-tag-filter-chip:hover {
+.library-tag-filter-bar ::deep .library-tag-filter-chip:hover {
     border-color: var(--clr-statusbar);
 }
 
-.library-tag-filter-chip[aria-pressed="true"] {
+.library-tag-filter-bar ::deep .library-tag-filter-chip[aria-pressed="true"] {
     background: var(--clr-statusbar);
     color: var(--clr-white);
     border-color: var(--clr-statusbar);
 }
 
-.library-tag-filter-chip[aria-pressed="true"]:hover,
-.library-tag-filter-chip[aria-pressed="true"]:focus-visible {
+.library-tag-filter-bar ::deep .library-tag-filter-chip[aria-pressed="true"]:hover,
+.library-tag-filter-bar ::deep .library-tag-filter-chip[aria-pressed="true"]:focus-visible {
     background: var(--clr-statusbar);
     color: var(--clr-white);
     border-color: var(--clr-statusbar);
     filter: brightness(0.95);
 }
 
-.library-tag-filter-chip-overflow {
+.library-tag-filter-bar ::deep .library-tag-filter-chip-overflow {
     padding: 0 .375rem;
     font-size: .75rem;
     color: var(--text-secondary);

--- a/src/EventLogExpert.UI/FilterLibrary/LibraryEntryRow.razor
+++ b/src/EventLogExpert.UI/FilterLibrary/LibraryEntryRow.razor
@@ -49,13 +49,11 @@
                             var tag = Entry.Tags[i];
                             <span class="library-entry-tag-chip" role="listitem">
                                 <span class="library-entry-tag-chip-label">@tag</span>
-                                <button aria-label="@($"Remove tag {tag}")"
-                                    class="library-entry-tag-chip-remove"
-                                    @onclick="@(() => OnRemoveTagAsync(tag))"
-                                    @onclick:stopPropagation="true"
-                                    type="button">
-                                    <i aria-hidden="true" class="bi bi-x"></i>
-                                </button>
+                                <ChromelessButton aria-label="@($"Remove tag {tag}")"
+                                    CssClass="library-entry-tag-chip-remove"
+                                    IconClass="bi bi-x"
+                                    OnClick="@(() => OnRemoveTagAsync(tag))"
+                                    StopPropagation="true" />
                             </span>
                         }
                     </div>

--- a/src/EventLogExpert.UI/FilterLibrary/LibraryEntryRow.razor.css
+++ b/src/EventLogExpert.UI/FilterLibrary/LibraryEntryRow.razor.css
@@ -100,7 +100,7 @@
     margin-right: .125rem;
 }
 
-.library-entry-tag-chip-remove {
+.library-entry-tag-chip ::deep .library-entry-tag-chip-remove {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -118,20 +118,20 @@
     transition: width 120ms ease, opacity 120ms ease, background 120ms ease, color 120ms ease;
 }
 
-.library-entry-tag-chip:hover .library-entry-tag-chip-remove,
-.library-entry-tag-chip:focus-within .library-entry-tag-chip-remove {
+.library-entry-tag-chip:hover ::deep .library-entry-tag-chip-remove,
+.library-entry-tag-chip:focus-within ::deep .library-entry-tag-chip-remove {
     width: 16px;
     opacity: 0.6;
     margin-left: 2px;
 }
 
-.library-entry-tag-chip-remove:hover {
+.library-entry-tag-chip ::deep .library-entry-tag-chip-remove:hover {
     opacity: 1;
     color: var(--clr-red);
     background: color-mix(in srgb, var(--clr-red) 14%, transparent);
 }
 
-.library-entry-tag-chip-remove:focus-visible {
+.library-entry-tag-chip ::deep .library-entry-tag-chip-remove:focus-visible {
     opacity: 1;
     outline: 2px solid var(--clr-statusbar);
     outline-offset: 1px;

--- a/src/EventLogExpert.UI/Inputs/ButtonBase.cs
+++ b/src/EventLogExpert.UI/Inputs/ButtonBase.cs
@@ -24,15 +24,15 @@ public abstract class ButtonBase : ComponentBase
 
     [Parameter] public string? IconClass { get; set; }
 
-    [Parameter] public bool IconOnly { get; set; }
-
     [Parameter] public EventCallback<MouseEventArgs> OnClick { get; set; }
+
+    [Parameter] public bool StopPropagation { get; set; }
 
     [Parameter] public string? Type { get; set; } = "button";
 
-    protected abstract string? VariantClass { get; }
-
     public ValueTask FocusAsync(bool preventScroll = false) => _element.FocusAsync(preventScroll);
+
+    protected abstract string BuildCssClass();
 
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
@@ -44,38 +44,40 @@ public abstract class ButtonBase : ComponentBase
         }
 
         builder.AddAttribute(2, "type", string.IsNullOrWhiteSpace(Type) ? "button" : Type);
-        builder.AddAttribute(3, "class", BuildCssClass());
+
+        var cssClass = BuildCssClass();
+
+        if (!string.IsNullOrWhiteSpace(cssClass))
+        {
+            builder.AddAttribute(3, "class", cssClass);
+        }
+
         builder.AddAttribute(4, "disabled", Disabled);
-        builder.AddAttribute(5, "onclick", OnClick);
-        builder.AddElementReferenceCapture(6, capturedRef => _element = capturedRef);
+        builder.AddAttribute(5, "onclick", EventCallback.Factory.Create<MouseEventArgs>(this, HandleClickAsync));
+
+        if (StopPropagation)
+        {
+            builder.AddEventStopPropagationAttribute(6, "onclick", true);
+        }
+
+        builder.AddElementReferenceCapture(7, capturedRef => _element = capturedRef);
 
         if (!string.IsNullOrWhiteSpace(IconClass))
         {
-            builder.OpenElement(7, "i");
-            builder.AddAttribute(8, "aria-hidden", "true");
-            builder.AddAttribute(9, "class", IconClass);
+            builder.OpenElement(8, "i");
+            builder.AddAttribute(9, "aria-hidden", "true");
+            builder.AddAttribute(10, "class", IconClass);
             builder.CloseElement();
 
             if (ChildContent is not null)
             {
-                builder.AddContent(10, " ");
+                builder.AddContent(11, " ");
             }
         }
 
-        builder.AddContent(11, ChildContent);
+        builder.AddContent(12, ChildContent);
         builder.CloseElement();
     }
 
-    private string BuildCssClass()
-    {
-        var classes = new List<string>(4) { "button" };
-
-        if (!string.IsNullOrWhiteSpace(VariantClass)) { classes.Add(VariantClass); }
-
-        if (IconOnly) { classes.Add("icon-button"); }
-
-        if (!string.IsNullOrWhiteSpace(CssClass)) { classes.Add(CssClass); }
-
-        return string.Join(' ', classes);
-    }
+    private Task HandleClickAsync(MouseEventArgs args) => Disabled ? Task.CompletedTask : OnClick.InvokeAsync(args);
 }

--- a/src/EventLogExpert.UI/Inputs/ButtonBase.cs
+++ b/src/EventLogExpert.UI/Inputs/ButtonBase.cs
@@ -59,7 +59,11 @@ public abstract class ButtonBase : ComponentBase
         }
 
         builder.AddAttribute(4, "disabled", Disabled);
-        builder.AddAttribute(5, "onclick", EventCallback.Factory.Create<MouseEventArgs>(this, HandleClickAsync));
+
+        if (OnClick.HasDelegate || StopPropagation)
+        {
+            builder.AddAttribute(5, "onclick", EventCallback.Factory.Create<MouseEventArgs>(this, HandleClickAsync));
+        }
 
         if (StopPropagation)
         {
@@ -76,7 +80,11 @@ public abstract class ButtonBase : ComponentBase
             builder.AddEventStopPropagationAttribute(8, "onkeydown", true);
         }
 
-        builder.AddAttribute(9, "onmouseenter", OnMouseEnter);
+        if (OnMouseEnter.HasDelegate)
+        {
+            builder.AddAttribute(9, "onmouseenter", OnMouseEnter);
+        }
+
         builder.AddElementReferenceCapture(10, capturedRef => _element = capturedRef);
 
         if (!string.IsNullOrWhiteSpace(IconClass))

--- a/src/EventLogExpert.UI/Inputs/ButtonBase.cs
+++ b/src/EventLogExpert.UI/Inputs/ButtonBase.cs
@@ -26,6 +26,12 @@ public abstract class ButtonBase : ComponentBase
 
     [Parameter] public EventCallback<MouseEventArgs> OnClick { get; set; }
 
+    [Parameter] public EventCallback<KeyboardEventArgs> OnKeyDown { get; set; }
+
+    [Parameter] public EventCallback<MouseEventArgs> OnMouseEnter { get; set; }
+
+    [Parameter] public bool StopKeyDownPropagation { get; set; }
+
     [Parameter] public bool StopPropagation { get; set; }
 
     [Parameter] public string? Type { get; set; } = "button";
@@ -60,24 +66,37 @@ public abstract class ButtonBase : ComponentBase
             builder.AddEventStopPropagationAttribute(6, "onclick", true);
         }
 
-        builder.AddElementReferenceCapture(7, capturedRef => _element = capturedRef);
+        if (OnKeyDown.HasDelegate)
+        {
+            builder.AddAttribute(7, "onkeydown", EventCallback.Factory.Create<KeyboardEventArgs>(this, HandleKeyDownAsync));
+        }
+
+        if (StopKeyDownPropagation)
+        {
+            builder.AddEventStopPropagationAttribute(8, "onkeydown", true);
+        }
+
+        builder.AddAttribute(9, "onmouseenter", OnMouseEnter);
+        builder.AddElementReferenceCapture(10, capturedRef => _element = capturedRef);
 
         if (!string.IsNullOrWhiteSpace(IconClass))
         {
-            builder.OpenElement(8, "i");
-            builder.AddAttribute(9, "aria-hidden", "true");
-            builder.AddAttribute(10, "class", IconClass);
+            builder.OpenElement(11, "i");
+            builder.AddAttribute(12, "aria-hidden", "true");
+            builder.AddAttribute(13, "class", IconClass);
             builder.CloseElement();
 
             if (ChildContent is not null)
             {
-                builder.AddContent(11, " ");
+                builder.AddContent(14, " ");
             }
         }
 
-        builder.AddContent(12, ChildContent);
+        builder.AddContent(15, ChildContent);
         builder.CloseElement();
     }
 
     private Task HandleClickAsync(MouseEventArgs args) => Disabled ? Task.CompletedTask : OnClick.InvokeAsync(args);
+
+    private Task HandleKeyDownAsync(KeyboardEventArgs args) => Disabled ? Task.CompletedTask : OnKeyDown.InvokeAsync(args);
 }

--- a/src/EventLogExpert.UI/Inputs/ButtonBase.cs
+++ b/src/EventLogExpert.UI/Inputs/ButtonBase.cs
@@ -70,7 +70,7 @@ public abstract class ButtonBase : ComponentBase
             builder.AddEventStopPropagationAttribute(6, "onclick", true);
         }
 
-        if (OnKeyDown.HasDelegate)
+        if (OnKeyDown.HasDelegate || StopKeyDownPropagation)
         {
             builder.AddAttribute(7, "onkeydown", EventCallback.Factory.Create<KeyboardEventArgs>(this, HandleKeyDownAsync));
         }

--- a/src/EventLogExpert.UI/Inputs/ChromelessButton.cs
+++ b/src/EventLogExpert.UI/Inputs/ChromelessButton.cs
@@ -3,7 +3,7 @@
 
 namespace EventLogExpert.UI.Inputs;
 
-public sealed class Button : StyledButtonBase
+public sealed class ChromelessButton : ButtonBase
 {
-    protected override string? VariantClass => null;
+    protected override string BuildCssClass() => CssClass;
 }

--- a/src/EventLogExpert.UI/Inputs/DangerButton.cs
+++ b/src/EventLogExpert.UI/Inputs/DangerButton.cs
@@ -3,7 +3,7 @@
 
 namespace EventLogExpert.UI.Inputs;
 
-public sealed class DangerButton : ButtonBase
+public sealed class DangerButton : StyledButtonBase
 {
     protected override string VariantClass => "button-red";
 }

--- a/src/EventLogExpert.UI/Inputs/PrimaryButton.cs
+++ b/src/EventLogExpert.UI/Inputs/PrimaryButton.cs
@@ -3,7 +3,7 @@
 
 namespace EventLogExpert.UI.Inputs;
 
-public sealed class PrimaryButton : ButtonBase
+public sealed class PrimaryButton : StyledButtonBase
 {
     protected override string VariantClass => "button-green";
 }

--- a/src/EventLogExpert.UI/Inputs/StyledButtonBase.cs
+++ b/src/EventLogExpert.UI/Inputs/StyledButtonBase.cs
@@ -1,0 +1,26 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Components;
+
+namespace EventLogExpert.UI.Inputs;
+
+public abstract class StyledButtonBase : ButtonBase
+{
+    [Parameter] public bool IconOnly { get; set; }
+
+    protected abstract string? VariantClass { get; }
+
+    protected override string BuildCssClass()
+    {
+        var classes = new List<string>(4) { "button" };
+
+        if (!string.IsNullOrWhiteSpace(VariantClass)) { classes.Add(VariantClass); }
+
+        if (IconOnly) { classes.Add("icon-button"); }
+
+        if (!string.IsNullOrWhiteSpace(CssClass)) { classes.Add(CssClass); }
+
+        return string.Join(' ', classes);
+    }
+}

--- a/src/EventLogExpert.UI/Inputs/TagPicker.razor
+++ b/src/EventLogExpert.UI/Inputs/TagPicker.razor
@@ -7,12 +7,10 @@
 
             <span class="tag-picker-chip" role="listitem">
                 <span class="tag-picker-chip-label">@tag</span>
-                <button aria-label="@($"Remove {tag}")"
-                    class="tag-picker-chip-remove"
-                    @onclick="() => RemoveTagAsync(index)"
-                    type="button">
-                    <i aria-hidden="true" class="bi bi-x"></i>
-                </button>
+                <ChromelessButton aria-label="@($"Remove {tag}")"
+                    CssClass="tag-picker-chip-remove"
+                    IconClass="bi bi-x"
+                    OnClick="@(() => RemoveTagAsync(index))" />
             </span>
         }
 

--- a/src/EventLogExpert.UI/Inputs/TagPicker.razor.css
+++ b/src/EventLogExpert.UI/Inputs/TagPicker.razor.css
@@ -36,7 +36,7 @@
     white-space: nowrap;
 }
 
-.tag-picker-chip-remove {
+.tag-picker-chip ::deep .tag-picker-chip-remove {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -50,7 +50,7 @@
     line-height: 1;
 }
 
-.tag-picker-chip-remove:hover {
+.tag-picker-chip ::deep .tag-picker-chip-remove:hover {
     color: var(--clr-red);
 }
 

--- a/src/EventLogExpert.UI/Inputs/WarningButton.cs
+++ b/src/EventLogExpert.UI/Inputs/WarningButton.cs
@@ -3,7 +3,7 @@
 
 namespace EventLogExpert.UI.Inputs;
 
-public sealed class WarningButton : ButtonBase
+public sealed class WarningButton : StyledButtonBase
 {
     protected override string VariantClass => "button-yellow";
 }

--- a/src/EventLogExpert.UI/LogTable/LogTablePane.razor
+++ b/src/EventLogExpert.UI/LogTable/LogTablePane.razor
@@ -73,9 +73,12 @@
                     }
                     @if (_logTableState.OrderBy == columnHeader)
                     {
-                        <span class="menu-toggle" data-rotate="@_logTableState.IsDescending.ToString().ToLower()" @onclick="ToggleSorting">
-                            <i class="bi bi-caret-up"></i>
-                        </span>
+                        <ChromelessButton aria-label="Toggle sort direction"
+                            CssClass="menu-toggle"
+                            data-rotate="@_logTableState.IsDescending.ToString().ToLower()"
+                            IconClass="bi bi-caret-up"
+                            OnClick="ToggleSorting"
+                            StopKeyDownPropagation="true" />
                     }
                 </th>
             }

--- a/src/EventLogExpert.UI/LogTable/LogTablePane.razor.css
+++ b/src/EventLogExpert.UI/LogTable/LogTablePane.razor.css
@@ -23,11 +23,11 @@ th {
     background-color: var(--background-darkgray);
     cursor: default;
     user-select: none;
+}
 
-    & > span {
-        position: absolute;
-        right: 5px;
-    }
+th ::deep .menu-toggle {
+    position: absolute;
+    right: 5px;
 }
 
 th, td {
@@ -95,7 +95,7 @@ tr {
    forced-color-adjust: none below is LOAD-BEARING: per css-color-adjust-1
    §3.1, box-shadow computes to none in forced-colors mode whenever
    forced-color-adjust is auto, regardless of color value. Removing it
-   silently erases the inset stripe — the very non-color cue this rule
+   silently erases the inset stripe - the very non-color cue this rule
    exists to provide. */
 @media (forced-colors: active) {
     .table-row[data-highlight] {

--- a/src/EventLogExpert.UI/Menu/MenuBar.razor
+++ b/src/EventLogExpert.UI/Menu/MenuBar.razor
@@ -8,19 +8,18 @@
         bool isActive = IsActive(bar);
         bool isFocused = capturedIndex == _focusedBarIndex;
 
-        <button aria-expanded="@isActive.ToString().ToLowerInvariant()"
+        <ChromelessButton aria-expanded="@isActive.ToString().ToLowerInvariant()"
             aria-haspopup="menu"
-            class="@($"menu-bar-item{(isActive ? " active" : string.Empty)}")"
+            CssClass="@($"menu-bar-item{(isActive ? " active" : string.Empty)}")"
             @key="bar.Label"
-            @onclick="async _ => await OnBarClick(bar, capturedIndex)"
-            @onclick:stopPropagation
-            @onkeydown="async args => await OnBarKeyDown(args, capturedIndex)"
-            @onmouseenter="async _ => await OnBarHover(bar, capturedIndex)"
+            OnClick="@(async _ => await OnBarClick(bar, capturedIndex))"
+            OnKeyDown="@(async args => await OnBarKeyDown(args, capturedIndex))"
+            OnMouseEnter="@(async _ => await OnBarHover(bar, capturedIndex))"
             @ref="_barElements[capturedIndex]"
             role="menuitem"
-            tabindex="@(isFocused ? 0 : -1)"
-            type="button">
+            StopPropagation="true"
+            tabindex="@(isFocused ? 0 : -1)">
             @bar.Label
-        </button>
+        </ChromelessButton>
     }
 </nav>

--- a/src/EventLogExpert.UI/Menu/MenuBar.razor.cs
+++ b/src/EventLogExpert.UI/Menu/MenuBar.razor.cs
@@ -28,7 +28,7 @@ public sealed partial class MenuBar
 
     private readonly List<TopLevel> _bars = [];
 
-    private ChromelessButton[] _barElements = [];
+    private ChromelessButton?[] _barElements = [];
     private int _focusedBarIndex;
     private IJSObjectReference? _menuAnchorModule;
     private ElementReference _menuBarRootRef;
@@ -122,7 +122,7 @@ public sealed partial class MenuBar
         MenuService.NavigateBarRequested += OnNavigateBarRequested;
 
         _bars.AddRange(BuildTopLevel());
-        _barElements = new ChromelessButton[_bars.Count];
+        _barElements = new ChromelessButton?[_bars.Count];
 
         _ = PrewarmOtherLogNamesAsync();
 

--- a/src/EventLogExpert.UI/Menu/MenuBar.razor.cs
+++ b/src/EventLogExpert.UI/Menu/MenuBar.razor.cs
@@ -13,6 +13,7 @@ using EventLogExpert.Runtime.Menu;
 using EventLogExpert.Runtime.Settings;
 using EventLogExpert.UI.Common;
 using EventLogExpert.UI.Common.Interop;
+using EventLogExpert.UI.Inputs;
 using Fluxor;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
@@ -27,7 +28,7 @@ public sealed partial class MenuBar
 
     private readonly List<TopLevel> _bars = [];
 
-    private ElementReference[] _barElements = [];
+    private ChromelessButton[] _barElements = [];
     private int _focusedBarIndex;
     private IJSObjectReference? _menuAnchorModule;
     private ElementReference _menuBarRootRef;
@@ -121,7 +122,7 @@ public sealed partial class MenuBar
         MenuService.NavigateBarRequested += OnNavigateBarRequested;
 
         _bars.AddRange(BuildTopLevel());
-        _barElements = new ElementReference[_bars.Count];
+        _barElements = new ChromelessButton[_bars.Count];
 
         _ = PrewarmOtherLogNamesAsync();
 
@@ -349,7 +350,9 @@ public sealed partial class MenuBar
 
         StateHasChanged();
 
-        try { await _barElements[index].FocusAsync(); }
+        if (_barElements[index] is not { } barButton) { return; }
+
+        try { await barButton.FocusAsync(); }
         catch { /* element may not be in the DOM yet */ }
     }
 
@@ -437,9 +440,11 @@ public sealed partial class MenuBar
         _menuAnchorModule ??= await JSRuntime.InvokeAsync<IJSObjectReference>(
             "import", "./_content/EventLogExpert.UI/Menu/MenuAnchor.js");
 
+        if (_barElements[index] is not { } barButton) { return; }
+
         var rect = await _menuAnchorModule.InvokeAsync<MenuAnchorRect>(
             "getMenuElementRect",
-            _barElements[index]);
+            barButton.Element);
 
         if (requestId != Volatile.Read(ref _openRequestId)) { return; }
 

--- a/src/EventLogExpert.UI/Menu/MenuBar.razor.css
+++ b/src/EventLogExpert.UI/Menu/MenuBar.razor.css
@@ -7,7 +7,7 @@
     flex: 0 0 auto;
 }
 
-.menu-bar-item {
+.menu-bar ::deep .menu-bar-item {
     display: inline-flex;
     align-items: center;
     padding: 0 12px;
@@ -17,17 +17,17 @@
     font-size: 0.9rem;
     cursor: default;
     outline: none;
+}
 
-    &:hover,
-    &.active {
-        background-color: var(--menu-hover-overlay);
-        color: var(--text-on-statusbar);
-    }
+.menu-bar ::deep .menu-bar-item:hover,
+.menu-bar ::deep .menu-bar-item.active {
+    background-color: var(--menu-hover-overlay);
+    color: var(--text-on-statusbar);
+}
 
-    &:focus-visible {
-        background-color: var(--menu-hover-overlay);
-        color: var(--text-on-statusbar);
-        outline: 2px solid var(--clr-lightblue);
-        outline-offset: -2px;
-    }
+.menu-bar ::deep .menu-bar-item:focus-visible {
+    background-color: var(--menu-hover-overlay);
+    color: var(--text-on-statusbar);
+    outline: 2px solid var(--clr-lightblue);
+    outline-offset: -2px;
 }

--- a/src/EventLogExpert.UI/Modal/SidebarTabs.razor
+++ b/src/EventLogExpert.UI/Modal/SidebarTabs.razor
@@ -8,19 +8,18 @@
         role="tablist">
         @foreach (var (tab, label) in Tabs)
         {
-            <button aria-controls="@($"sidebar-tabpanel-{TablistId}-{tab}")"
+            <ChromelessButton aria-controls="@($"sidebar-tabpanel-{TablistId}-{tab}")"
                 aria-selected="@(tab.Equals(ActiveTab) ? "true" : "false")"
-                class="@(tab.Equals(ActiveTab) ? "tab active" : "tab")"
+                CssClass="@(tab.Equals(ActiveTab) ? "tab active" : "tab")"
                 id="@($"sidebar-tab-{TablistId}-{tab}")"
                 @key="tab"
-                @onclick="() => SetActiveTabAsync(tab)"
-                @onkeydown="e => OnTabKeyDownAsync(e, tab)"
+                OnClick="@(() => SetActiveTabAsync(tab))"
+                OnKeyDown="@(e => OnTabKeyDownAsync(e, tab))"
                 @ref="_tabButtonRefs[tab]"
                 role="tab"
-                tabindex="@(tab.Equals(ActiveTab) ? "0" : "-1")"
-                type="button">
+                tabindex="@(tab.Equals(ActiveTab) ? "0" : "-1")">
                 <span class="sidebar-tabs-tab-label">@label</span>
-            </button>
+            </ChromelessButton>
         }
     </div>
 

--- a/src/EventLogExpert.UI/Modal/SidebarTabs.razor.cs
+++ b/src/EventLogExpert.UI/Modal/SidebarTabs.razor.cs
@@ -13,7 +13,7 @@ namespace EventLogExpert.UI.Modal;
 public sealed partial class SidebarTabs<TTab> : ComponentBase, IAsyncDisposable
     where TTab : struct, Enum
 {
-    private readonly Dictionary<TTab, ChromelessButton> _tabButtonRefs = new();
+    private readonly Dictionary<TTab, ChromelessButton?> _tabButtonRefs = new();
     private readonly string _tablistId = ComponentId.NewUnique().Value;
 
     private TTab? _pendingFocusTab;
@@ -49,7 +49,7 @@ public sealed partial class SidebarTabs<TTab> : ComponentBase, IAsyncDisposable
 
     public async ValueTask<bool> FocusActiveTabAsync()
     {
-        if (!_tabButtonRefs.TryGetValue(ActiveTab, out var tabButton)) { return false; }
+        if (!_tabButtonRefs.TryGetValue(ActiveTab, out var tabButton) || tabButton is null) { return false; }
 
         try
         {
@@ -79,7 +79,7 @@ public sealed partial class SidebarTabs<TTab> : ComponentBase, IAsyncDisposable
             catch (JSException) { }
         }
 
-        if (_pendingFocusTab is { } tab && _tabButtonRefs.TryGetValue(tab, out var tabButton))
+        if (_pendingFocusTab is { } tab && _tabButtonRefs.TryGetValue(tab, out var tabButton) && tabButton is not null)
         {
             _pendingFocusTab = null;
 

--- a/src/EventLogExpert.UI/Modal/SidebarTabs.razor.cs
+++ b/src/EventLogExpert.UI/Modal/SidebarTabs.razor.cs
@@ -3,6 +3,7 @@
 
 using EventLogExpert.UI.Common;
 using EventLogExpert.UI.Common.Interop;
+using EventLogExpert.UI.Inputs;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
@@ -12,7 +13,7 @@ namespace EventLogExpert.UI.Modal;
 public sealed partial class SidebarTabs<TTab> : ComponentBase, IAsyncDisposable
     where TTab : struct, Enum
 {
-    private readonly Dictionary<TTab, ElementReference> _tabButtonRefs = new();
+    private readonly Dictionary<TTab, ChromelessButton> _tabButtonRefs = new();
     private readonly string _tablistId = ComponentId.NewUnique().Value;
 
     private TTab? _pendingFocusTab;
@@ -48,11 +49,11 @@ public sealed partial class SidebarTabs<TTab> : ComponentBase, IAsyncDisposable
 
     public async ValueTask<bool> FocusActiveTabAsync()
     {
-        if (!_tabButtonRefs.TryGetValue(ActiveTab, out var elementRef)) { return false; }
+        if (!_tabButtonRefs.TryGetValue(ActiveTab, out var tabButton)) { return false; }
 
         try
         {
-            await elementRef.FocusAsync();
+            await tabButton.FocusAsync();
 
             return true;
         }
@@ -78,12 +79,12 @@ public sealed partial class SidebarTabs<TTab> : ComponentBase, IAsyncDisposable
             catch (JSException) { }
         }
 
-        if (_pendingFocusTab is { } tab && _tabButtonRefs.TryGetValue(tab, out var elementRef))
+        if (_pendingFocusTab is { } tab && _tabButtonRefs.TryGetValue(tab, out var tabButton))
         {
             _pendingFocusTab = null;
 
-            try { await elementRef.FocusAsync(); }
-            catch { }
+            try { await tabButton.FocusAsync(); }
+            catch { /* Ignore focus errors */ }
         }
 
         await base.OnAfterRenderAsync(firstRender);

--- a/src/EventLogExpert.UI/Modal/SidebarTabs.razor.css
+++ b/src/EventLogExpert.UI/Modal/SidebarTabs.razor.css
@@ -14,7 +14,7 @@
     padding: 8px 4px 8px 0;
 }
 
-.sidebar-tabs-list .tab {
+.sidebar-tabs-list ::deep .tab {
     text-align: left;
     padding: 8px 12px;
     background: transparent;
@@ -26,22 +26,22 @@
     font: inherit;
 }
 
-.sidebar-tabs-list .tab:hover {
+.sidebar-tabs-list ::deep .tab:hover {
     background: var(--background-darkgray);
 }
 
-.sidebar-tabs-list .tab.active {
+.sidebar-tabs-list ::deep .tab.active {
     background: transparent;
     border-left-color: var(--clr-lightblue);
     color: var(--clr-lightblue);
     font-weight: 600;
 }
 
-.sidebar-tabs-list .tab.active:hover {
+.sidebar-tabs-list ::deep .tab.active:hover {
     background: var(--background-darkgray);
 }
 
-.sidebar-tabs-list .tab:focus-visible {
+.sidebar-tabs-list ::deep .tab:focus-visible {
     outline: 2px solid var(--clr-lightblue);
     outline-offset: -2px;
 }

--- a/src/EventLogExpert.UI/wwwroot/app.css
+++ b/src/EventLogExpert.UI/wwwroot/app.css
@@ -332,6 +332,12 @@ input[type="text"].input.dialog-input { padding: .25rem 0; }
 }
 
 .menu-toggle {
+    appearance: none;
+    background: none;
+    border: 0;
+    padding: 0;
+    color: inherit;
+    font: inherit;
     cursor: pointer;
     display: inline-flex;
     align-items: center;
@@ -344,6 +350,8 @@ input[type="text"].input.dialog-input { padding: .25rem 0; }
         display: flex;
         align-items: center;
         justify-content: center;
+        width: 1em;
+        height: 1em;
         line-height: 1;
         vertical-align: 0;
     }

--- a/tests/Unit/EventLogExpert.UI.Tests/Inputs/ButtonTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Inputs/ButtonTests.cs
@@ -36,6 +36,19 @@ public sealed class ButtonTests : BunitContext
     }
 
     [Fact]
+    public async Task Click_WhenDisabled_DoesNotInvokeOnClick()
+    {
+        bool invoked = false;
+        var component = Render<Button>(parameters => parameters
+            .Add(p => p.Disabled, true)
+            .Add(p => p.OnClick, () => invoked = true));
+
+        await component.Find("button").ClickAsync(new MouseEventArgs());
+
+        Assert.False(invoked);
+    }
+
+    [Fact]
     public void Render_AdditionalAttributes_SplattedToButton()
     {
         var component = Render<Button>(parameters => parameters

--- a/tests/Unit/EventLogExpert.UI.Tests/Inputs/ButtonTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Inputs/ButtonTests.cs
@@ -49,6 +49,43 @@ public sealed class ButtonTests : BunitContext
     }
 
     [Fact]
+    public async Task KeyDown_InvokesOnKeyDown()
+    {
+        bool invoked = false;
+        var component = Render<Button>(parameters => parameters
+            .Add(p => p.OnKeyDown, () => invoked = true));
+
+        await component.Find("button").KeyDownAsync(new KeyboardEventArgs());
+
+        Assert.True(invoked);
+    }
+
+    [Fact]
+    public async Task KeyDown_WhenDisabled_DoesNotInvokeOnKeyDown()
+    {
+        bool invoked = false;
+        var component = Render<Button>(parameters => parameters
+            .Add(p => p.Disabled, true)
+            .Add(p => p.OnKeyDown, () => invoked = true));
+
+        await component.Find("button").KeyDownAsync(new KeyboardEventArgs());
+
+        Assert.False(invoked);
+    }
+
+    [Fact]
+    public async Task MouseEnter_InvokesOnMouseEnter()
+    {
+        bool invoked = false;
+        var component = Render<Button>(parameters => parameters
+            .Add(p => p.OnMouseEnter, () => invoked = true));
+
+        await component.Find("button").MouseEnterAsync(new MouseEventArgs());
+
+        Assert.True(invoked);
+    }
+
+    [Fact]
     public void Render_AdditionalAttributes_SplattedToButton()
     {
         var component = Render<Button>(parameters => parameters

--- a/tests/Unit/EventLogExpert.UI.Tests/Inputs/ChromelessButtonTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Inputs/ChromelessButtonTests.cs
@@ -1,0 +1,30 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using EventLogExpert.UI.Inputs;
+
+namespace EventLogExpert.UI.Tests.Inputs;
+
+public sealed class ChromelessButtonTests : BunitContext
+{
+    [Fact]
+    public void Render_EmptyCssClass_OmitsClassAttribute()
+    {
+        var component = Render<ChromelessButton>();
+
+        var button = component.Find("button");
+        Assert.False(button.HasAttribute("class"));
+    }
+
+    [Fact]
+    public void Render_WithCssClass_RendersCssClassWithoutButtonChrome()
+    {
+        var component = Render<ChromelessButton>(parameters => parameters
+            .Add(p => p.CssClass, "empty-dashboard__launch"));
+
+        var button = component.Find("button");
+        Assert.Contains("empty-dashboard__launch", button.ClassList);
+        Assert.DoesNotContain("button", button.ClassList);
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneSelectionTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneSelectionTests.cs
@@ -185,11 +185,11 @@ public sealed class LogTablePaneSelectionTests : BunitContext
 
         var sortedHeader = cut.Find("th[data-column='Source']");
         Assert.Equal("descending", sortedHeader.GetAttribute("aria-sort"));
-        Assert.NotNull(sortedHeader.QuerySelector("span.menu-toggle"));
+        Assert.NotNull(sortedHeader.QuerySelector(".menu-toggle"));
 
         var unsortedHeader = cut.Find("th[data-column='Level']");
         Assert.Equal("none", unsortedHeader.GetAttribute("aria-sort"));
-        Assert.Null(unsortedHeader.QuerySelector("span.menu-toggle"));
+        Assert.Null(unsortedHeader.QuerySelector(".menu-toggle"));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Follow-up to the reusable Button component PR (#602). Eliminates the remaining duplicated raw `<button>` boilerplate (type, aria-hidden icon, onclick, focus, disabled handling) by routing bespoke buttons through a new chrome-less component, and centralizes interaction behavior in `ButtonBase` so it can be updated in one place.

Stacked on `jschick/button-component` (#602); retarget to `main` and rebase after #602 merges.

## Components

- `ChromelessButton`: a "bring-your-own-styling" `<button>` over the shared `ButtonBase` render core (no `.button` chrome), for bespoke buttons that carry their own scoped CSS.
- `StyledButtonBase`: the chromed base for `Button`/`PrimaryButton`/`DangerButton`/`WarningButton` (split out of `ButtonBase`).

## ButtonBase behavior centralization

- Centralized disabled-guard: `onclick` is gated so a disabled button never invokes `OnClick` (browser and programmatic), making per-call-site `if (!IsXBlocked)` guards redundant.
- `StopPropagation` and `StopKeyDownPropagation` params (event-modifier centralization).
- `OnKeyDown` (Disabled-guarded, wired only when set) and `OnMouseEnter`, needed for the roving-tabindex widgets.
- Empty-`class` guard.

## CSS isolation

Bespoke button styles live in scoped `*.razor.css`, which does not reach elements rendered inside a child component. Every migrated button's scoped rules were re-anchored with `::deep` on an authored wrapper (the repo's existing convention); `ChildContent` spans authored in the parent keep their scope and are left alone. All rewrites verified against the generated `*.rz.scp.css` artifacts.

## Migrated

EmptyStateDashboard x8, TagPicker, ScenarioDetail (launch and star), LibraryEntryRow remove-tag, FilterPredicateEditor x3, DatabaseEntryRow name, ManageDatabasesTab tri-state checkbox, FilterLibraryModal x3, DetailsPane x2 (now native keyboard-accessible buttons), LogTablePane sort (now keyboard-accessible), MenuBar, SidebarTabs.

## Notes for review

- Chevron-centering (`app.css .menu-toggle`) and the FilterPane collapse caret are worth a visual check.
- DetailsPane header/XML toggles now use native `<button>` activation (holding Enter repeat-toggles, standard native behavior).

## Gates

Build 0/0, UI tests 989/989, no banned dashes, all `::deep` verified in generated artifacts.