### PR TITLE
Enable native ARM64 builds for the explorer shell extension

### DIFF
--- a/src/EventLogExpert.ExplorerExtensionNative/EventLogExpert.ExplorerExtensionNative.vcxproj
+++ b/src/EventLogExpert.ExplorerExtensionNative/EventLogExpert.ExplorerExtensionNative.vcxproj
@@ -21,6 +21,9 @@
   -->
   <Import Project="..\packages\Microsoft.Windows.SDK.CPP.10.0.26100.8249\build\native\Microsoft.Windows.SDK.cpp.props" Condition="Exists('..\packages\Microsoft.Windows.SDK.CPP.10.0.26100.8249\build\native\Microsoft.Windows.SDK.cpp.props')" />
   <Import Project="..\packages\Microsoft.Windows.SDK.CPP.x64.10.0.26100.8249\build\native\Microsoft.Windows.SDK.cpp.x64.props" Condition="Exists('..\packages\Microsoft.Windows.SDK.CPP.x64.10.0.26100.8249\build\native\Microsoft.Windows.SDK.cpp.x64.props')" />
+  <!-- arm64 import libs (only when targeting ARM64). The per-arch SDK.CPP package self-gates by $(Platform), so
+       importing it is inert off-target; the explicit ARM64 condition keeps the x64 import path byte-identical. -->
+  <Import Project="..\packages\Microsoft.Windows.SDK.CPP.arm64.10.0.26100.8249\build\native\Microsoft.Windows.SDK.cpp.arm64.props" Condition="Exists('..\packages\Microsoft.Windows.SDK.CPP.arm64.10.0.26100.8249\build\native\Microsoft.Windows.SDK.cpp.arm64.props') AND '$(Platform)'=='ARM64'" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -30,6 +33,14 @@
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
 
@@ -69,6 +80,23 @@
          load briefly from dllhost.exe and aren't a typical Spectre-sensitive surface. -->
   </PropertyGroup>
 
+  <!-- ARM64 mirrors x64 (settings are arch-agnostic). The only x64-only linker setting, CETCompat, is omitted from
+       Release|ARM64 below (CET is an Intel/x86-64 feature). -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings" />
   <ImportGroup Label="Shared" />
@@ -78,6 +106,12 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
 
   <PropertyGroup Label="UserMacros" />
 
@@ -85,6 +119,12 @@
     <IncludePath>$(IntDir)Generated Files;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <IncludePath>$(IntDir)Generated Files;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <IncludePath>$(IntDir)Generated Files;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <IncludePath>$(IntDir)Generated Files;$(IncludePath)</IncludePath>
   </PropertyGroup>
 
@@ -128,6 +168,48 @@
       <EnableUAC>false</EnableUAC>
       <ModuleDefinitionFile>Source.def</ModuleDefinitionFile>
       <CETCompat>true</CETCompat>
+    </Link>
+  </ItemDefinitionGroup>
+
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;EVENTLOGEXPERTEXPLOREREXTENSION_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+      <ModuleDefinitionFile>Source.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;EVENTLOGEXPERTEXPLOREREXTENSION_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+      <ModuleDefinitionFile>Source.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
 

--- a/src/EventLogExpert.ExplorerExtensionNative/packages.config
+++ b/src/EventLogExpert.ExplorerExtensionNative/packages.config
@@ -10,4 +10,5 @@
        See docs/Explorer-Context-Menu.md. -->
   <package id="Microsoft.Windows.SDK.CPP" version="10.0.26100.8249" targetFramework="native" />
   <package id="Microsoft.Windows.SDK.CPP.x64" version="10.0.26100.8249" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.arm64" version="10.0.26100.8249" targetFramework="native" />
 </packages>

--- a/src/EventLogExpert/EventLogExpert.csproj
+++ b/src/EventLogExpert/EventLogExpert.csproj
@@ -77,14 +77,14 @@
     </ItemGroup>
 
     <!--
-      Derive the native vcxproj Platform from the current .NET RuntimeIdentifier. Only x64 is
-      supported today — the vcxproj only declares Debug|x64/Release|x64 configurations. Other
-      RIDs (win-arm64, win-x86) require matching ProjectConfiguration entries in the vcxproj
-      first; the BuildExplorerExtensionNative target fails fast with a clear message rather
-      than producing a confusing MSB4126 from VS MSBuild.
+      Derive the native vcxproj Platform from the current .NET RuntimeIdentifier. x64 and arm64
+      are supported (the vcxproj declares Debug|x64/Release|x64 + Debug|ARM64/Release|ARM64). Other
+      RIDs (e.g. win-x86) have no matching ProjectConfiguration; the BuildExplorerExtensionNative
+      target then fails fast with a clear message rather than a confusing MSB4126 from VS MSBuild.
     -->
     <PropertyGroup>
-      <ExplorerExtensionNativePlatform Condition="'$(RuntimeIdentifier)' == '' OR $(RuntimeIdentifier.Contains('-x64'))">x64</ExplorerExtensionNativePlatform>
+      <ExplorerExtensionNativePlatform Condition="'$(RuntimeIdentifier)' != '' AND $(RuntimeIdentifier.Contains('-arm64'))">ARM64</ExplorerExtensionNativePlatform>
+      <ExplorerExtensionNativePlatform Condition="'$(ExplorerExtensionNativePlatform)' == '' AND ('$(RuntimeIdentifier)' == '' OR $(RuntimeIdentifier.Contains('-x64')))">x64</ExplorerExtensionNativePlatform>
     </PropertyGroup>
 
     <!--
@@ -124,10 +124,16 @@
         <_VswherePath>$(MSBuildProgramFiles32)\Microsoft Visual Studio\Installer\vswhere.exe</_VswherePath>
       </PropertyGroup>
       <Error Condition="'$(ExplorerExtensionNativePlatform)' == ''"
-             Text="EventLogExpert.ExplorerExtensionNative.vcxproj only declares x64 ProjectConfiguration entries. RuntimeIdentifier=$(RuntimeIdentifier) does not map to a supported native platform. Build for win-x64 OR add matching arm64/Win32 ProjectConfiguration + ItemDefinitionGroup blocks to the vcxproj." />
+             Text="EventLogExpert.ExplorerExtensionNative.vcxproj declares x64 and ARM64 ProjectConfiguration entries. RuntimeIdentifier=$(RuntimeIdentifier) does not map to a supported native platform (win-x64 or win-arm64). Build for win-x64/win-arm64 OR add matching ProjectConfiguration + ItemDefinitionGroup blocks (e.g. Win32) to the vcxproj." />
       <!-- Locate VS MSBuild requiring the VC toolset specifically — bare Microsoft.Component.MSBuild
            can match a Build Tools install without the C++ workload, which can't process vcxproj. -->
-      <Exec Command="&quot;$(_VswherePath)&quot; -latest -products * -requires Microsoft.Component.MSBuild Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -find MSBuild\Current\Bin\amd64\MSBuild.exe"
+      <PropertyGroup>
+        <!-- ARM64 cross-compile from an x64 host needs BOTH the x64 host toolset AND the arm64 target
+             toolset. x64 builds require only x86.x64, so x64-only dev/CI machines are unaffected. -->
+        <_ExplorerExtensionVcComponents>Microsoft.VisualStudio.Component.VC.Tools.x86.x64</_ExplorerExtensionVcComponents>
+        <_ExplorerExtensionVcComponents Condition="'$(ExplorerExtensionNativePlatform)' == 'ARM64'">Microsoft.VisualStudio.Component.VC.Tools.x86.x64 Microsoft.VisualStudio.Component.VC.Tools.ARM64</_ExplorerExtensionVcComponents>
+      </PropertyGroup>
+      <Exec Command="&quot;$(_VswherePath)&quot; -latest -products * -requires Microsoft.Component.MSBuild $(_ExplorerExtensionVcComponents) -find MSBuild\Current\Bin\amd64\MSBuild.exe"
             ConsoleToMSBuild="true"
             ContinueOnError="true">
         <Output TaskParameter="ConsoleOutput" PropertyName="VsMSBuildPath" />
@@ -138,7 +144,7 @@
         <VsMSBuildPath>$(VsMSBuildPath.Trim())</VsMSBuildPath>
       </PropertyGroup>
       <Error Condition="'$(VsMSBuildPath)' == '' OR !Exists('$(VsMSBuildPath)')"
-             Text="Could not locate Visual Studio MSBuild.exe with the C++ workload via vswhere ($(_VswherePath)). The native shell extension requires the Desktop Development with C++ workload (Microsoft.VisualStudio.Component.VC.Tools.x86.x64) AND the Windows 10/11 SDK. See docs/Explorer-Context-Menu.md for prereqs." />
+             Text="Could not locate Visual Studio MSBuild.exe with the required C++ workload components via vswhere ($(_VswherePath)). The native shell extension requires a VS install with $(_ExplorerExtensionVcComponents) AND the Windows 10/11 SDK. See docs/Explorer-Context-Menu.md for prereqs." />
       <Exec Command="where nuget.exe" ConsoleToMSBuild="true" ContinueOnError="true" IgnoreExitCode="true">
         <Output TaskParameter="ExitCode" PropertyName="_WhereNugetExitCode" />
         <Output TaskParameter="ConsoleOutput" PropertyName="_WhereNugetOutput" />


### PR DESCRIPTION
Adds native ARM64 build support for the C++/WinRT explorer shell extension, alongside the existing x64.

What:
- ExplorerExtensionNative.vcxproj: add Debug|ARM64 + Release|ARM64 configurations (mirroring x64; CETCompat, an Intel/x86-64-only linker setting, is omitted) and a platform-gated Microsoft.Windows.SDK.CPP.arm64 props import. Purely additive; the x64 configuration is byte-identical.
- packages.config: add Microsoft.Windows.SDK.CPP.arm64 10.0.26100.8249 (arm64 import libraries; same version as the base + x64 SDK packages).
- EventLogExpert.csproj: map win-arm64 to ARM64 for the native build, and require the per-architecture MSVC toolset via vswhere (x64 builds still require only the x64 tools; ARM64 builds require the x64 host tools plus the ARM64 cross tools).

Validation: dotnet publish -r win-arm64 -p:WindowsPackageType=MSIX succeeds on windows-2022; dumpbin reports AA64 machine (ARM64) on the produced DLL. The x64 build is unchanged.

Stacked on the -m:1 build-split branch; base retargets to main when that merges. Enables the native ARM64 build only; shipping ARM64 release artifacts is a follow-up.
