### PR TITLE
Fix the force-kill disposition race and harden the elevation connect harness

### DIFF
--- a/src/EventLogExpert.Runtime/DatabaseTools/Elevation/ElevatedDatabaseToolsRunner.cs
+++ b/src/EventLogExpert.Runtime/DatabaseTools/Elevation/ElevatedDatabaseToolsRunner.cs
@@ -248,7 +248,7 @@ internal sealed class ElevatedDatabaseToolsRunner : IElevatedDatabaseToolsRunner
         var graceCts = new CancellationTokenSource();
         killState.SetGraceTimer(graceCts);
 
-        _ = Task.Run(async () =>
+        var killTask = Task.Run(async () =>
         {
             try
             {
@@ -276,6 +276,8 @@ internal sealed class ElevatedDatabaseToolsRunner : IElevatedDatabaseToolsRunner
                 _traceLogger.Warning($"{ElevatedHelperTag} kill-timer task threw {ex.GetType().Name}: {ex.Message}");
             }
         });
+
+        killState.SetKillTask(killTask);
     }
 
     private void MirrorMessageToDebugLog(DatabaseToolsIpcMessage message)
@@ -493,6 +495,13 @@ internal sealed class ElevatedDatabaseToolsRunner : IElevatedDatabaseToolsRunner
             // Helper sent a terminal message (or pipe closed). Cancel the kill-timer so it doesn't fire on a clean finish.
             killState.CancelGraceTimer();
 
+            // Join the kill-timer so its disposition write happens-before the TranslateOutcome read.
+            try { await killState.KillTaskOrCompleted.WaitAsync(_exitGrace); }
+            catch (TimeoutException)
+            {
+                _traceLogger.Warning($"{ElevatedHelperTag} kill-timer did not settle within {_exitGrace.TotalSeconds:N0}s; proceeding with current disposition.");
+            }
+
             // 7) Wait for helper to exit (bounded by _exitGrace, then force-kill if it lingers and is killable).
             int exitCode;
             try
@@ -684,6 +693,7 @@ internal sealed class ElevatedDatabaseToolsRunner : IElevatedDatabaseToolsRunner
         private int _cancelRequested;
         private int _disposition;
         private CancellationTokenSource? _graceTimerCts;
+        private Task? _killTask;
 
         public KillDisposition Disposition => (KillDisposition)Volatile.Read(ref _disposition);
 
@@ -711,5 +721,9 @@ internal sealed class ElevatedDatabaseToolsRunner : IElevatedDatabaseToolsRunner
         public void MarkKillSucceeded() => Interlocked.Exchange(ref _disposition, (int)KillDisposition.Succeeded);
 
         public void SetGraceTimer(CancellationTokenSource cts) => Volatile.Write(ref _graceTimerCts, cts);
+
+        public void SetKillTask(Task task) => Volatile.Write(ref _killTask, task);
+
+        public Task KillTaskOrCompleted => Volatile.Read(ref _killTask) ?? Task.CompletedTask;
     }
 }

--- a/tests/Integration/EventLogExpert.ElevationHelper.IntegrationTests/TestUtils/TestElevatedHelperProcessHost.cs
+++ b/tests/Integration/EventLogExpert.ElevationHelper.IntegrationTests/TestUtils/TestElevatedHelperProcessHost.cs
@@ -7,15 +7,17 @@ using Microsoft.Win32.SafeHandles;
 using System.Diagnostics;
 using System.IO.Pipes;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace EventLogExpert.ElevationHelper.IntegrationTests.TestUtils;
 
 internal sealed class TestElevatedHelperProcessHost(ITraceLogger logger) : IElevatedHelperProcessHost
 {
     private const int MaxClientPidRejections = 32;
+    private const int MaxStderrChars = 4096;
     private const int PipeBufferSize = 65536;
 
-    private static readonly TimeSpan s_connectTimeout = TimeSpan.FromSeconds(15);
+    private static readonly TimeSpan s_connectTimeout = TimeSpan.FromSeconds(60);
 
     internal enum PidVerifyResult
     {
@@ -67,24 +69,72 @@ internal sealed class TestElevatedHelperProcessHost(ITraceLogger logger) : IElev
             helperProcess = Process.Start(psi) ?? throw new InvalidOperationException("Process.Start returned null without throwing.");
 
             var capturedPid = helperProcess.Id;
-            helperProcess.ErrorDataReceived += (_, e) => { if (e.Data is not null) { logger.Warning($"helper[{capturedPid}] stderr: {e.Data}"); } };
+            var stderrLock = new object();
+            var stderrBuffer = new StringBuilder();
+
+            helperProcess.ErrorDataReceived += (_, e) =>
+            {
+                if (e.Data is null) { return; }
+
+                logger.Warning($"helper[{capturedPid}] stderr: {e.Data}");
+
+                lock (stderrLock)
+                {
+                    var remaining = MaxStderrChars - stderrBuffer.Length;
+
+                    if (remaining <= 0) { return; }
+
+                    stderrBuffer.Append(e.Data.Length <= remaining ? e.Data : e.Data[..remaining]);
+
+                    if (stderrBuffer.Length < MaxStderrChars) { stderrBuffer.Append('\n'); }
+                }
+            };
             helperProcess.OutputDataReceived += (_, e) => { if (e.Data is not null) { logger.Information($"helper[{capturedPid}] stdout: {e.Data}"); } };
             helperProcess.BeginErrorReadLine();
             helperProcess.BeginOutputReadLine();
+
+            string SnapshotStderr() { lock (stderrLock) { return stderrBuffer.ToString(); } }
 
             logger.Information($"{nameof(TestElevatedHelperProcessHost)}: spawned helper PID {helperProcess.Id} (pipe={pipeName}, dotnet {helperDllPath})");
 
             using var connectCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             connectCts.CancelAfter(s_connectTimeout);
 
+            // Watch for early helper exit on its own source so a connect timeout cannot misreport it as an exit.
+            using var exitWatchCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+            var acceptTask = AcceptAndVerifyClientPidAsync(pipeServer, helperProcess.Id, logger, connectCts.Token);
+            var exitTask = WaitForExitOrCancelAsync(helperProcess, exitWatchCts.Token);
+
             try
             {
-                await AcceptAndVerifyClientPidAsync(pipeServer, helperProcess.Id, logger, connectCts.Token);
+                var winner = await Task.WhenAny(acceptTask, exitTask);
+
+                if (winner == exitTask && exitTask.Result && !acceptTask.IsCompletedSuccessfully)
+                {
+                    throw new InvalidOperationException(
+                        $"Elevated helper PID {helperProcess.Id} exited (exit code {helperProcess.ExitCode}) before connecting. stderr tail: {SnapshotStderr()}");
+                }
+
+                await acceptTask;
             }
-            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            catch (OperationCanceledException) when (connectCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
             {
+                if (helperProcess.HasExited)
+                {
+                    throw new InvalidOperationException(
+                        $"Elevated helper PID {helperProcess.Id} exited (exit code {helperProcess.ExitCode}) before connecting. stderr tail: {SnapshotStderr()}");
+                }
+
                 throw new TimeoutException(
-                    $"Elevated helper PID {helperProcess.Id} did not connect within {s_connectTimeout.TotalSeconds:N0}s.");
+                    $"Elevated helper PID {helperProcess.Id} did not connect within {s_connectTimeout.TotalSeconds:N0}s (helper still running). stderr tail: {SnapshotStderr()}");
+            }
+            finally
+            {
+                exitWatchCts.Cancel();
+                connectCts.Cancel();
+                await ObserveQuietly(acceptTask);
+                await ObserveQuietly(exitTask);
             }
 
             var handle = new TestElevatedHelperProcess(helperProcess, pipeServer, logger);
@@ -185,6 +235,12 @@ internal sealed class TestElevatedHelperProcessHost(ITraceLogger logger) : IElev
         return string.Join(' ', parts.Select(QuoteIfNeeded));
     }
 
+    private static async Task ObserveQuietly(Task task)
+    {
+        try { await task; }
+        catch { /* losing-race tasks throw on cleanup cancellation; observed and dropped */ }
+    }
+
     private static string QuoteIfNeeded(string arg)
     {
         if (string.IsNullOrEmpty(arg)) { return "\"\""; }
@@ -208,6 +264,20 @@ internal sealed class TestElevatedHelperProcessHost(ITraceLogger logger) : IElev
         }
 
         return testRuntimeConfig;
+    }
+
+    private static async Task<bool> WaitForExitOrCancelAsync(Process process, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await process.WaitForExitAsync(cancellationToken);
+
+            return true;
+        }
+        catch (OperationCanceledException)
+        {
+            return false;
+        }
     }
 
     private static class NativeMethods


### PR DESCRIPTION
## What

Fixes two intermittent CI test flakes in the elevation-helper area. Both are independent of the build/ARM64 work in #609 and are based on `main`.

### 1. Force-kill disposition race (#593) - also a production correctness bug

`ElevatedDatabaseToolsRunner` records the force-kill `KillDisposition` on a fire-and-forget kill-timer task: it calls `process.Kill()` and only then `MarkKillSucceeded()`. `Kill()` closes the helper pipe (the helper dies), which unblocks the runner's drain loop, so the main flow can reach `TranslateOutcome` and read `KillState.Disposition` *before* the timer task records it. When that read wins, the outcome is the generic `"Cancelled."` instead of the `"Cancelled (... force-killed). If you ran an Upgrade, a .bak of the original target may remain ... rename it to recover."` message.

That is the unit-test flake `RunAsync_WhenHelperKillSucceedsAfterCancel_ReportsForceKilled` (passes in isolation, fails under parallel contention), and the same ordering applies in production - a force-killed helper can lose the recovery hint.

**Fix:** the kill-timer task is captured in `KillState`; after `CancelGraceTimer()` and before the exit-wait, the runner awaits it (bounded by `_exitGrace`), so the disposition write happens-before the disposition read. The bound preserves the existing "runner never hangs" guarantee.

### 2. Elevation helper connect harness masks early exit

`TestElevatedHelperProcessHost.StartAsync` waited only for the pipe to connect (15s) and never observed early helper-process exit, so a crash / wrong deps / cold-Docker startup surfaced as an opaque `"did not connect within 15s"` after wasting the full window.

**Fix:** race the connect against a separate exit-watch source (so a connect timeout cannot be misreported as an exit); on early exit, throw a diagnosable error with the exit code and a bounded, lock-guarded stderr tail; raise the cold-start timeout to 60s; the `finally` cancels and observes both tasks so neither leaks.

## Why it matters

Flake 1 reds `build-and-test` intermittently and, in production, can drop the data-recovery hint after a force-kill. Flake 2 turns a fast, diagnosable helper-startup failure into a slow blind timeout (and would mask a real RID/arch regression if the build graph ever changes).

## Verification

- Build: 0 warnings / 0 errors (`Runtime.Tests` and `ElevationHelper.IntegrationTests`).
- Flake 1: `RunAsync_WhenHelperKillSucceedsAfterCancel...` + the unkillable sister test 15/15 green; full `Runtime.Tests` 1629/1629 x3.
- Flake 2: harness compiles; the integration suite itself is container-gated and runs in CI.

The local force-kill race is timing-dependent and did not reproduce locally before the fix; the diagnosis is grounded in source analysis and the existing #593 CI failures, and the fix makes the disposition read deterministic.

## Scope

Two files: `src/EventLogExpert.Runtime/.../ElevatedDatabaseToolsRunner.cs` (production) and `tests/Integration/.../TestUtils/TestElevatedHelperProcessHost.cs` (test harness). No public API change (the runner additions are on a private nested type).

Closes #593.
