### PR TITLE
Make the in-app updater select the multi-architecture bundle only

### DIFF
--- a/src/EventLogExpert.Runtime/Update/UpdateService.cs
+++ b/src/EventLogExpert.Runtime/Update/UpdateService.cs
@@ -8,6 +8,7 @@ using EventLogExpert.Runtime.Common.Versioning;
 using EventLogExpert.Runtime.Settings;
 using EventLogExpert.Runtime.Update.Deployment;
 using EventLogExpert.Runtime.Update.ReleaseNotes;
+using System.Runtime.InteropServices;
 
 namespace EventLogExpert.Runtime.Update;
 
@@ -158,11 +159,23 @@ internal sealed class UpdateService(
 
         try
         {
-            string downloadPath = latest.Value.Assets.First(x => x.Name.Contains(".msix")).Uri;
+            string? downloadPath = SelectUpdateDownloadUri(latest.Value.Assets);
 
             if (string.IsNullOrEmpty(downloadPath))
             {
-                traceLogger.Warning($"{nameof(CheckForUpdates)} Could not get asset download path.");
+                string availableAssets = latest.Value.Assets is null or { Count: 0 }
+                    ? "(none)"
+                    : string.Join(", ", latest.Value.Assets.Select(asset => string.IsNullOrEmpty(asset.Name) ? "(unnamed)" : asset.Name));
+
+                traceLogger.Warning($"{nameof(CheckForUpdates)} No update bundle (.msixbundle) was found in the " +
+                    $"latest release. OS architecture: {RuntimeInformation.OSArchitecture}. Available assets: {availableAssets}");
+
+                if (userInitiated)
+                {
+                    await alertDialogService.ShowAlert("Update Unavailable",
+                        "No compatible update package was found.",
+                        "OK");
+                }
 
                 return;
             }
@@ -215,5 +228,21 @@ internal sealed class UpdateService(
         var title = $"Release notes for v{versionProvider.CurrentVersion}";
 
         return new ReleaseNotesContent(title, markdown);
+    }
+
+    /// <summary>
+    ///     Selects the download URI of the multi-architecture app bundle (.msixbundle) from the release assets, or
+    ///     <see langword="null" /> when the release contains no bundle.
+    /// </summary>
+    internal static string? SelectUpdateDownloadUri(IReadOnlyList<GitHubReleaseAsset>? assets)
+    {
+        return assets?.Where(asset =>
+                asset.Name is not null &&
+                (asset.Name.StartsWith("EventLogExpert_", StringComparison.OrdinalIgnoreCase) ||
+                    asset.Name.StartsWith("EventLogExpert.", StringComparison.OrdinalIgnoreCase)) &&
+                asset.Name.EndsWith(".msixbundle", StringComparison.OrdinalIgnoreCase) &&
+                !string.IsNullOrWhiteSpace(asset.Uri))
+            .Select(asset => asset.Uri)
+            .FirstOrDefault();
     }
 }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/TestUtils/Constants/Constants.GitHubRelease.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/TestUtils/Constants/Constants.GitHubRelease.cs
@@ -7,14 +7,14 @@ public sealed partial class Constants
 {
     public const string AppInstalledVersion = "23.1.1.1";
 
-    public const string GitHubLatestName = "EventLogExpert_23.1.1.2_x64.msix";
+    public const string GitHubLatestName = "EventLogExpert_23.1.1.2.msixbundle";
     public const string GitHubLatestUri =
-        "https://github.com/microsoft/EventLogExpert/releases/download/v23.1.1.2/EventLogExpert_23.1.1.2_x64.msix";
+        "https://github.com/microsoft/EventLogExpert/releases/download/v23.1.1.2/EventLogExpert_23.1.1.2.msixbundle";
     public const string GitHubLatestVersion = "v23.1.1.2";
 
-    public const string GitHubPrereleaseName = "EventLogExpert_23.1.1.3_x64.msix";
+    public const string GitHubPrereleaseName = "EventLogExpert_23.1.1.3.msixbundle";
     public const string GitHubPrereleaseUri =
-        "https://github.com/microsoft/EventLogExpert/releases/download/v23.1.1.3/EventLogExpert_23.1.1.3_x64.msix";
+        "https://github.com/microsoft/EventLogExpert/releases/download/v23.1.1.3/EventLogExpert_23.1.1.3.msixbundle";
     public const string GitHubPrereleaseVersion = "v23.1.1.3";
 
     public const string GitHubReleaseNotes =

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Update/UpdateServiceAssetSelectionTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Update/UpdateServiceAssetSelectionTests.cs
@@ -1,0 +1,189 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.Update;
+
+namespace EventLogExpert.Runtime.Tests.Update;
+
+public sealed class UpdateServiceAssetSelectionTests
+{
+    private const string Arm64Name = "EventLogExpert_23.1.1.2_arm64.msix";
+    private const string Arm64Uri =
+        "https://github.com/microsoft/EventLogExpert/releases/download/v23.1.1.2/EventLogExpert_23.1.1.2_arm64.msix";
+
+    private const string BundleName = "EventLogExpert_23.1.1.2.msixbundle";
+    private const string BundleUri =
+        "https://github.com/microsoft/EventLogExpert/releases/download/v23.1.1.2/EventLogExpert_23.1.1.2.msixbundle";
+
+    private const string DotBundleName = "EventLogExpert.msixbundle";
+    private const string DotBundleUri =
+        "https://github.com/microsoft/EventLogExpert/releases/download/v23.1.1.2/EventLogExpert.msixbundle";
+
+    private const string RuntimeName = "Microsoft.WindowsAppRuntime.1.7.msix";
+    private const string RuntimeUri =
+        "https://github.com/microsoft/EventLogExpert/releases/download/v23.1.1.2/Microsoft.WindowsAppRuntime.1.7.msix";
+
+    private const string ToolsBundleName = "EventLogExpertTools_23.1.1.2.msixbundle";
+    private const string ToolsBundleUri =
+        "https://github.com/microsoft/EventLogExpert/releases/download/v23.1.1.2/EventLogExpertTools_23.1.1.2.msixbundle";
+
+    private const string X64Name = "EventLogExpert_23.1.1.2_x64.msix";
+    private const string X64Uri =
+        "https://github.com/microsoft/EventLogExpert/releases/download/v23.1.1.2/EventLogExpert_23.1.1.2_x64.msix";
+
+    [Fact]
+    public void SelectUpdateDownloadUri_BundleAmidFullReleaseAssetSet_ReturnsBundleUri()
+    {
+        List<GitHubReleaseAsset> assets =
+        [
+            Asset(BundleName, BundleUri),
+            Asset(X64Name, X64Uri),
+            Asset(Arm64Name, Arm64Uri),
+            Asset(RuntimeName, RuntimeUri)
+        ];
+
+        string? result = UpdateService.SelectUpdateDownloadUri(assets);
+
+        Assert.Equal(BundleUri, result);
+    }
+
+    [Fact]
+    public void SelectUpdateDownloadUri_BundleOnly_ReturnsBundleUri()
+    {
+        List<GitHubReleaseAsset> assets = [Asset(BundleName, BundleUri)];
+
+        string? result = UpdateService.SelectUpdateDownloadUri(assets);
+
+        Assert.Equal(BundleUri, result);
+    }
+
+    [Fact]
+    public void SelectUpdateDownloadUri_DifferentlyCasedBundleName_MatchesCaseInsensitively()
+    {
+        List<GitHubReleaseAsset> assets = [Asset("eventlogexpert_23.1.1.2.MSIXBUNDLE", BundleUri)];
+
+        string? result = UpdateService.SelectUpdateDownloadUri(assets);
+
+        Assert.Equal(BundleUri, result);
+    }
+
+    [Fact]
+    public void SelectUpdateDownloadUri_DotFormBundleName_ReturnsBundleUri()
+    {
+        List<GitHubReleaseAsset> assets =
+        [
+            Asset(DotBundleName, DotBundleUri),
+            Asset(X64Name, X64Uri),
+            Asset(Arm64Name, Arm64Uri)
+        ];
+
+        string? result = UpdateService.SelectUpdateDownloadUri(assets);
+
+        Assert.Equal(DotBundleUri, result);
+    }
+
+    [Fact]
+    public void SelectUpdateDownloadUri_EmptyAssets_ReturnsNull()
+    {
+        string? result = UpdateService.SelectUpdateDownloadUri([]);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void SelectUpdateDownloadUri_MalformedNullNameAssetWithValidBundle_ReturnsBundleUriWithoutThrowing()
+    {
+        List<GitHubReleaseAsset> assets =
+        [
+            new GitHubReleaseAsset { Name = null!, Uri = "https://malformed" },
+            Asset(BundleName, BundleUri)
+        ];
+
+        string? result = UpdateService.SelectUpdateDownloadUri(assets);
+
+        Assert.Equal(BundleUri, result);
+    }
+
+    [Fact]
+    public void SelectUpdateDownloadUri_NoBundleOnlyPerArchAndRuntime_ReturnsNull()
+    {
+        List<GitHubReleaseAsset> assets =
+        [
+            Asset(X64Name, X64Uri),
+            Asset(Arm64Name, Arm64Uri),
+            Asset(RuntimeName, RuntimeUri)
+        ];
+
+        string? result = UpdateService.SelectUpdateDownloadUri(assets);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void SelectUpdateDownloadUri_NullAssets_ReturnsNull()
+    {
+        string? result = UpdateService.SelectUpdateDownloadUri(null);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void SelectUpdateDownloadUri_RuntimeAssetOnly_ReturnsNull()
+    {
+        List<GitHubReleaseAsset> assets = [Asset(RuntimeName, RuntimeUri)];
+
+        string? result = UpdateService.SelectUpdateDownloadUri(assets);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void SelectUpdateDownloadUri_SiblingToolsBundleBeforeAppBundle_ReturnsAppBundleUri()
+    {
+        List<GitHubReleaseAsset> assets =
+        [
+            Asset(ToolsBundleName, ToolsBundleUri),
+            Asset(BundleName, BundleUri)
+        ];
+
+        string? result = UpdateService.SelectUpdateDownloadUri(assets);
+
+        Assert.Equal(BundleUri, result);
+    }
+
+    [Fact]
+    public void SelectUpdateDownloadUri_SiblingToolsBundleOnly_ReturnsNull()
+    {
+        List<GitHubReleaseAsset> assets = [Asset(ToolsBundleName, ToolsBundleUri)];
+
+        string? result = UpdateService.SelectUpdateDownloadUri(assets);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void SelectUpdateDownloadUri_WhitespaceUriBundleBeforeValidBundle_ReturnsValidBundleUri()
+    {
+        List<GitHubReleaseAsset> assets =
+        [
+            Asset(BundleName, "   "),
+            Asset(BundleName, BundleUri)
+        ];
+
+        string? result = UpdateService.SelectUpdateDownloadUri(assets);
+
+        Assert.Equal(BundleUri, result);
+    }
+
+    [Fact]
+    public void SelectUpdateDownloadUri_WhitespaceUriBundleOnly_ReturnsNull()
+    {
+        List<GitHubReleaseAsset> assets = [Asset(BundleName, "   ")];
+
+        string? result = UpdateService.SelectUpdateDownloadUri(assets);
+
+        Assert.Null(result);
+    }
+
+    private static GitHubReleaseAsset Asset(string name, string uri) => new() { Name = name, Uri = uri };
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Update/UpdateServiceTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Update/UpdateServiceTests.cs
@@ -362,6 +362,64 @@ public sealed class UpdateServiceTests
     }
 
     [Fact]
+    public async Task CheckForUpdates_NoCompatiblePackageAutoScan_ShouldStaySilentAndNotDeploy()
+    {
+        // Arrange
+        var mockCurrentVersionProvider = Substitute.For<ICurrentVersionProvider>();
+        mockCurrentVersionProvider.CurrentVersion.Returns(new Version(Constants.AppInstalledVersion));
+        mockCurrentVersionProvider.IsDevBuild.Returns(false);
+
+        var mockGitHubService = Substitute.For<IGitHubService>();
+        mockGitHubService.GetReleases().Returns(Task.FromResult(CreateRuntimeOnlyRelease()));
+
+        var mockDeploymentService = Substitute.For<IDeploymentService>();
+        var mockAlertDialogService = Substitute.For<IAlertDialogService>();
+
+        var updateService = CreateUpdateService(
+            mockCurrentVersionProvider,
+            gitHubService: mockGitHubService,
+            deploymentService: mockDeploymentService,
+            alertDialogService: mockAlertDialogService);
+
+        // Act
+        await updateService.CheckForUpdates(usePreRelease: false, userInitiated: false);
+
+        // Assert
+        await mockAlertDialogService.DidNotReceive().ShowAlert(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>());
+        mockDeploymentService.DidNotReceive().RestartNowAndUpdate(Arg.Any<string>(), Arg.Any<bool>());
+        mockDeploymentService.DidNotReceive().UpdateOnNextRestart(Arg.Any<string>(), Arg.Any<bool>());
+    }
+
+    [Fact]
+    public async Task CheckForUpdates_NoCompatiblePackageUserInitiated_ShouldAlertAndNotDeploy()
+    {
+        // Arrange
+        var mockCurrentVersionProvider = Substitute.For<ICurrentVersionProvider>();
+        mockCurrentVersionProvider.CurrentVersion.Returns(new Version(Constants.AppInstalledVersion));
+        mockCurrentVersionProvider.IsDevBuild.Returns(false);
+
+        var mockGitHubService = Substitute.For<IGitHubService>();
+        mockGitHubService.GetReleases().Returns(Task.FromResult(CreateRuntimeOnlyRelease()));
+
+        var mockDeploymentService = Substitute.For<IDeploymentService>();
+        var mockAlertDialogService = Substitute.For<IAlertDialogService>();
+
+        var updateService = CreateUpdateService(
+            mockCurrentVersionProvider,
+            gitHubService: mockGitHubService,
+            deploymentService: mockDeploymentService,
+            alertDialogService: mockAlertDialogService);
+
+        // Act
+        await updateService.CheckForUpdates(usePreRelease: false, userInitiated: true);
+
+        // Assert
+        await mockAlertDialogService.Received(1).ShowAlert("Update Unavailable", Arg.Any<string>(), "OK");
+        mockDeploymentService.DidNotReceive().RestartNowAndUpdate(Arg.Any<string>(), Arg.Any<bool>());
+        mockDeploymentService.DidNotReceive().UpdateOnNextRestart(Arg.Any<string>(), Arg.Any<bool>());
+    }
+
+    [Fact]
     public async Task CheckForUpdates_NoReleases_ShouldShowAlert()
     {
         // Arrange
@@ -661,41 +719,6 @@ public sealed class UpdateServiceTests
     }
 
     [Fact]
-    public async Task CheckForUpdates_WhenRunningPreReleaseAndChannelPreviouslyEnabledThenDisabled_ShouldPromptRollback()
-    {
-        // Arrange
-        var mockCurrentVersionProvider = Substitute.For<ICurrentVersionProvider>();
-        mockCurrentVersionProvider.CurrentVersion.Returns(new Version(Constants.GitHubPrereleaseVersion[1..]));
-        mockCurrentVersionProvider.IsDevBuild.Returns(false);
-
-        var mockGitHubService = Substitute.For<IGitHubService>();
-        mockGitHubService.GetReleases().Returns(Task.FromResult(GitHubUtils.CreateGitHubReleases()));
-
-        var mockAppTitleService = Substitute.For<IAppTitleService>();
-        var mockDeploymentService = Substitute.For<IDeploymentService>();
-
-        var mockSettings = Substitute.For<ISettingsService>();
-        mockSettings.IsPreReleaseEnabled.Returns(false);
-        mockSettings.HasEverEnabledPreRelease.Returns(true);
-
-        var updateService = CreateUpdateService(
-            mockCurrentVersionProvider,
-            appTitleService: mockAppTitleService,
-            gitHubService: mockGitHubService,
-            deploymentService: mockDeploymentService,
-            settings: mockSettings);
-
-        // Act
-        await updateService.CheckForUpdates(usePreRelease: false);
-
-        // Assert
-        mockAppTitleService.Received(1).SetIsPrerelease(true);
-        mockSettings.DidNotReceive().IsPreReleaseEnabled = Arg.Any<bool>();
-
-        mockDeploymentService.Received(1).UpdateOnNextRestart(Constants.GitHubLatestUri);
-    }
-
-    [Fact]
     public async Task CheckForUpdates_WhenRunningPreReleaseAndChannelNeverEnabled_ShouldEnableChannelAndSuppressRollbackPrompt()
     {
         // Arrange
@@ -734,6 +757,41 @@ public sealed class UpdateServiceTests
 
         mockDeploymentService.DidNotReceive().UpdateOnNextRestart(Arg.Any<string>(), Arg.Any<bool>());
         mockDeploymentService.DidNotReceive().RestartNowAndUpdate(Arg.Any<string>(), Arg.Any<bool>());
+    }
+
+    [Fact]
+    public async Task CheckForUpdates_WhenRunningPreReleaseAndChannelPreviouslyEnabledThenDisabled_ShouldPromptRollback()
+    {
+        // Arrange
+        var mockCurrentVersionProvider = Substitute.For<ICurrentVersionProvider>();
+        mockCurrentVersionProvider.CurrentVersion.Returns(new Version(Constants.GitHubPrereleaseVersion[1..]));
+        mockCurrentVersionProvider.IsDevBuild.Returns(false);
+
+        var mockGitHubService = Substitute.For<IGitHubService>();
+        mockGitHubService.GetReleases().Returns(Task.FromResult(GitHubUtils.CreateGitHubReleases()));
+
+        var mockAppTitleService = Substitute.For<IAppTitleService>();
+        var mockDeploymentService = Substitute.For<IDeploymentService>();
+
+        var mockSettings = Substitute.For<ISettingsService>();
+        mockSettings.IsPreReleaseEnabled.Returns(false);
+        mockSettings.HasEverEnabledPreRelease.Returns(true);
+
+        var updateService = CreateUpdateService(
+            mockCurrentVersionProvider,
+            appTitleService: mockAppTitleService,
+            gitHubService: mockGitHubService,
+            deploymentService: mockDeploymentService,
+            settings: mockSettings);
+
+        // Act
+        await updateService.CheckForUpdates(usePreRelease: false);
+
+        // Assert
+        mockAppTitleService.Received(1).SetIsPrerelease(true);
+        mockSettings.DidNotReceive().IsPreReleaseEnabled = Arg.Any<bool>();
+
+        mockDeploymentService.Received(1).UpdateOnNextRestart(Constants.GitHubLatestUri);
     }
 
     [Fact]
@@ -853,6 +911,27 @@ public sealed class UpdateServiceTests
         await mockAlertDialogService.DidNotReceive()
             .ShowAlert(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>());
     }
+
+    // A release newer than the installed version whose only asset is the WindowsAppRuntime dependency (no
+    // EventLogExpert package or bundle), so the bundle-only selector finds no compatible package.
+    private static IEnumerable<GitHubRelease> CreateRuntimeOnlyRelease() =>
+    [
+        new()
+        {
+            Version = "v23.1.1.2",
+            IsPreRelease = false,
+            ReleaseDate = DateTime.Now,
+            Assets =
+            [
+                new GitHubReleaseAsset
+                {
+                    Name = "Microsoft.WindowsAppRuntime.1.7.msix",
+                    Uri = "https://github.com/microsoft/EventLogExpert/releases/download/v23.1.1.2/Microsoft.WindowsAppRuntime.1.7.msix"
+                }
+            ],
+            RawChanges = string.Empty
+        }
+    ];
 
     private static UpdateService CreateUpdateService(
         ICurrentVersionProvider? currentVersionProvider = null,


### PR DESCRIPTION
## What

The in-app updater (`UpdateService.SelectUpdateDownloadUri`) now selects the multi-architecture app bundle
(`EventLogExpert_<version>.msixbundle`) only, instead of choosing a per-architecture `.msix`. The architecture
parameter is removed; Windows resolves the installable architecture from the bundle (and migrates an emulated
x64-on-arm64 install to native arm64). When a release has no bundle the selector returns `null`, which surfaces
a clean "No compatible update package was found." alert on a manual check and stays silent on a background
scan, never calling the deployment service.

## Why

Earlier iterations preferred a per-arch `.msix` so that update downloads and new-install bundle downloads
could be told apart in GitHub's per-asset counters. Microsoft's MSIX update rules make that split unworkable:
once a client is installed from a `.msixbundle`, every future update must also be a bundle (a bundle cannot be
updated by a standalone `.msix`). "Install via bundle, update via standalone msix" is therefore not a supported
combination for a single client, and a msix-first selector with a bundle fallback is a latent trap. Selecting
the bundle for every client is internally consistent (standalone to bundle is a supported one-way migration;
bundle to bundle thereafter) and lets the bundle handle architecture selection and the x64 to arm64 migration.

The deployment side already supports this: `PackageDeploymentService` uses `AddPackageByUriAsync` with
`ForceTargetAppShutdown` / `ForceUpdateFromAnyVersion` (and `DeferRegistrationWhenPackagesAreInUse` for the
restart path), and the package manifest declares the `packageManagement` capability.

## Tests

- `UpdateServiceAssetSelectionTests` rewritten to a 13-case bundle-only matrix: bundle amid the full release
  asset set, bundle-only, the underscore-less slip form (`EventLogExpert.msixbundle`), case-insensitive match,
  no-bundle to null, runtime-only to null, a sibling `EventLogExpertTools_*.msixbundle` that must NOT be
  selected (before the app bundle and alone), a whitespace-Uri bundle that must not shadow a valid one, a
  malformed null-name asset, and null / empty inputs.
- `CheckForUpdates` deploy-path and no-compatible (manual alert / background silent) tests continue to cover
  the end-to-end path; the shared test release constants are repointed to the bundle.
- Build: 0 warnings / 0 errors. Full `EventLogExpert.Runtime.Tests`: 1644 / 1644.

## Rollout dependency (do not ship ahead of the bundle)

This updater needs releases to actually contain a `.msixbundle`, which is produced by the separate ADO release
pipeline (dual-RID publish, `makeappx bundle`, `.appinstaller` MainBundle, dual-sign). A release without a
bundle would return `null` and stop updates for clients on this updater, so the rollout must be sequenced with
that pipeline work. Install-vs-update telemetry (which can no longer be derived from bundle-vs-msix download
counts) and the transition-release asset ordering for already-installed older clients are tracked as
release-phase items.

Stacked on #609 (base `jschick/embed-symbols-drop-m1`).
