### PR TITLE
Version-aware provider resolution with source-recency provenance

### DIFF
--- a/src/EventLogExpert.DatabaseTools/Common/Operations/OperationBase.cs
+++ b/src/EventLogExpert.DatabaseTools/Common/Operations/OperationBase.cs
@@ -83,13 +83,14 @@ internal abstract class OperationBase
     }
 
     /// <summary>
-    ///     Yields <see cref="ProviderDetails" /> for each local provider, applying the optional regex filter and skip set
-    ///     before metadata is resolved.
+    ///     Yields <see cref="ProviderDetails" /> for each local provider, applying the optional regex filter and
+    ///     name-level <paramref name="excludeProviderNames" /> exclude set before metadata is resolved. Local providers are
+    ///     live, so their identity is always <c>(name, "")</c>; a name-level exclude is therefore exact here.
     /// </summary>
     protected static async IAsyncEnumerable<ProviderDetails> LoadLocalProvidersAsync(
         ITraceLogger logger,
         Regex? regex,
-        IReadOnlySet<string>? skipProviderNames = null,
+        IReadOnlySet<string>? excludeProviderNames = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         // Local-provider resolution is synchronous (registry/metadata reads). This wrapper exposes it as an
@@ -101,7 +102,7 @@ internal abstract class OperationBase
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (skipProviderNames is not null && skipProviderNames.Contains(providerName)) { continue; }
+            if (excludeProviderNames is not null && excludeProviderNames.Contains(providerName)) { continue; }
 
             yield return new EventMessageProvider(providerName, logger: logger).LoadProviderDetails();
         }

--- a/src/EventLogExpert.DatabaseTools/Common/Operations/ProviderSource.cs
+++ b/src/EventLogExpert.DatabaseTools/Common/Operations/ProviderSource.cs
@@ -57,6 +57,7 @@ internal static class ProviderSource
 
         return identities
             .OrderBy(identity => identity.ProviderName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(identity => identity.ProviderName, StringComparer.Ordinal)
             .ThenBy(identity => identity.VersionKey, StringComparer.Ordinal)
             .ToList();
     }

--- a/src/EventLogExpert.DatabaseTools/Common/Operations/ProviderSource.cs
+++ b/src/EventLogExpert.DatabaseTools/Common/Operations/ProviderSource.cs
@@ -32,6 +32,36 @@ internal static class ProviderSource
     private const string EvtxExtension = ".evtx";
 
     /// <summary>
+    ///     Returns the distinct provider identities (name + content <see cref="ProviderDetails.VersionKey" />) available
+    ///     from <paramref name="path" />, applying an optional <paramref name="regex" /> to filter by name. Live providers
+    ///     discovered from an .evtx source contribute <c>(name, "")</c> because event records expose only the name. Does not
+    ///     load full provider details.
+    /// </summary>
+    public static async Task<IReadOnlyList<ProviderIdentity>> LoadProviderIdentitiesAsync(
+        string path,
+        ITraceLogger logger,
+        Regex? regex = null,
+        CancellationToken cancellationToken = default)
+    {
+        var identities = new HashSet<ProviderIdentity>();
+
+        foreach (var file in EnumerateSourceFiles(path, logger))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            foreach (var identity in await LoadIdentitiesFromFileAsync(file, logger, cancellationToken))
+            {
+                if (regex is null || regex.IsMatch(identity.ProviderName)) { identities.Add(identity); }
+            }
+        }
+
+        return identities
+            .OrderBy(identity => identity.ProviderName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(identity => identity.VersionKey, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    /// <summary>
     ///     Returns the distinct provider names available from <paramref name="path" />, applying an optional
     ///     <paramref name="regex" /> to filter names. Case sensitivity follows the caller's <see cref="RegexOptions" />. Does
     ///     not load full provider details.
@@ -57,14 +87,21 @@ internal static class ProviderSource
         return regex is null ? names.ToList() : names.Where(n => regex.IsMatch(n)).ToList();
     }
 
+    /// <summary>
+    ///     Streams full <see cref="ProviderDetails" /> from <paramref name="path" />, skipping providers two ways:
+    ///     <paramref name="excludeProviderNames" /> drops EVERY version of a named provider (a user / name-level exclude),
+    ///     while <paramref name="skipIdentities" /> drops only specific <c>(name, version)</c> identities (e.g. versions
+    ///     already present in a merge/diff target). A provider is skipped if either set matches.
+    /// </summary>
     public static IAsyncEnumerable<ProviderDetails> LoadProvidersAsync(
         string path,
         ITraceLogger logger,
         Regex? regex = null,
-        IReadOnlySet<string>? skipProviderNames = null,
+        IReadOnlySet<string>? excludeProviderNames = null,
+        IReadOnlySet<ProviderIdentity>? skipIdentities = null,
         IReadOnlyList<string>? preDiscoveredProviderNames = null,
         CancellationToken cancellationToken = default) =>
-        LoadProvidersIteratorAsync(path, logger, regex, skipProviderNames, preDiscoveredProviderNames, cancellationToken);
+        LoadProvidersIteratorAsync(path, logger, regex, excludeProviderNames, skipIdentities, preDiscoveredProviderNames, cancellationToken);
 
     /// <summary>Validates that <paramref name="path" /> exists and has a recognized form.</summary>
     public static bool TryValidate(string path, ITraceLogger logger)
@@ -207,7 +244,8 @@ internal static class ProviderSource
         string file,
         ITraceLogger logger,
         Regex? regex,
-        IReadOnlySet<string>? skipProviderNames,
+        IReadOnlySet<string>? excludeProviderNames,
+        IReadOnlySet<ProviderIdentity>? skipIdentities,
         HashSet<ProviderIdentity> seen,
         CancellationToken cancellationToken)
     {
@@ -235,7 +273,9 @@ internal static class ProviderSource
 
                     if (regex is not null && !regex.IsMatch(identity.ProviderName)) { return false; }
 
-                    return skipProviderNames is null || !skipProviderNames.Contains(identity.ProviderName);
+                    if (excludeProviderNames is not null && excludeProviderNames.Contains(identity.ProviderName)) { return false; }
+
+                    return skipIdentities is null || !skipIdentities.Contains(identity);
                 })
                 .ToList();
 
@@ -271,6 +311,7 @@ internal static class ProviderSource
                 var rows = await context.ProviderDetails
                     .Where(p => chunk.Contains(p.ProviderName))
                     .OrderBy(p => p.ProviderName)
+                    .ThenBy(p => p.VersionKey)
                     .ToListAsync(cancellationToken);
 
                 loaded.AddRange(rows.Where(row => wantedIdentities.Contains(ProviderIdentity.Of(row))));
@@ -288,6 +329,49 @@ internal static class ProviderSource
 
             return [];
         }
+    }
+
+    private static async Task<IReadOnlyList<ProviderIdentity>> LoadIdentitiesFromFileAsync(
+        string file,
+        ITraceLogger logger,
+        CancellationToken cancellationToken)
+    {
+        var ext = Path.GetExtension(file);
+
+        if (string.Equals(ext, DbExtension, StringComparison.OrdinalIgnoreCase))
+        {
+            try
+            {
+                await using var providerContext = new ProviderDbContext(file, true, false, logger);
+
+                if (!IsSourceSchemaCurrent(providerContext, file, logger)) { return []; }
+
+                var pairs = await providerContext.ProviderDetails
+                    .AsNoTracking()
+                    .Select(p => new { p.ProviderName, p.VersionKey })
+                    .ToListAsync(cancellationToken);
+
+                return pairs.Select(p => new ProviderIdentity(p.ProviderName, p.VersionKey)).ToList();
+            }
+            catch (DbException ex)
+            {
+                logger.Warning($"Skipping invalid database file '{file}': {ex.Message}");
+
+                return [];
+            }
+        }
+
+        if (string.Equals(ext, EvtxExtension, StringComparison.OrdinalIgnoreCase))
+        {
+            // Live providers from an exported log expose only a name (no content version), so their identity is (name, empty).
+            return MtaProviderSource.DiscoverProviderNames(file, logger)
+                .Select(name => new ProviderIdentity(name, string.Empty))
+                .ToList();
+        }
+
+        logger.Warning($"Skipping unsupported source file: {file}");
+
+        return [];
     }
 
     private static async Task<IReadOnlyList<string>> LoadNamesFromFileAsync(string file, ITraceLogger logger, CancellationToken cancellationToken)
@@ -325,7 +409,8 @@ internal static class ProviderSource
         string path,
         ITraceLogger logger,
         Regex? regex,
-        IReadOnlySet<string>? skipProviderNames,
+        IReadOnlySet<string>? excludeProviderNames,
+        IReadOnlySet<ProviderIdentity>? skipIdentities,
         IReadOnlyList<string>? preDiscoveredProviderNames,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
@@ -349,7 +434,7 @@ internal static class ProviderSource
             {
                 // Materialize the full per-file result before yielding so a mid-read DbException yields nothing for
                 // this file and does not corrupt the cross-file `seen` set. C# also forbids `yield` inside try/catch.
-                var loaded = await LoadDbDetailsAsync(file, logger, regex, skipProviderNames, seen, cancellationToken);
+                var loaded = await LoadDbDetailsAsync(file, logger, regex, excludeProviderNames, skipIdentities, seen, cancellationToken);
 
                 foreach (var details in loaded) { yield return details; }
             }
@@ -357,7 +442,7 @@ internal static class ProviderSource
             {
                 var hint = canUsePreDiscovered ? preDiscoveredProviderNames : null;
 
-                foreach (var details in MtaProviderSource.LoadProviders(file, logger, regex, skipProviderNames, seen, hint))
+                foreach (var details in MtaProviderSource.LoadProviders(file, logger, regex, excludeProviderNames, skipIdentities, seen, hint))
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/EventLogExpert.DatabaseTools/Common/Operations/ProviderSource.cs
+++ b/src/EventLogExpert.DatabaseTools/Common/Operations/ProviderSource.cs
@@ -208,7 +208,7 @@ internal static class ProviderSource
         ITraceLogger logger,
         Regex? regex,
         IReadOnlySet<string>? skipProviderNames,
-        HashSet<string> seen,
+        HashSet<ProviderIdentity> seen,
         CancellationToken cancellationToken)
     {
         try
@@ -219,25 +219,45 @@ internal static class ProviderSource
 
             context.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
 
-            // Filter by name without mutating `seen` so that a subsequent catch does not
-            // permanently mark these names as loaded when they were never successfully read.
-            var allNames = await context.ProviderDetails.Select(p => p.ProviderName).ToListAsync(cancellationToken);
-            var namesToLoad = allNames
-                .Where(name =>
+            // Project (name, version) identities and filter without mutating `seen`, so a subsequent catch does not
+            // permanently mark these identities as loaded when they were never successfully read. Dedup is
+            // version-aware: an identity already loaded from an earlier source file is skipped, but a different
+            // version of the same provider name is not.
+            var allIdentities = await context.ProviderDetails
+                .Select(p => new { p.ProviderName, p.VersionKey })
+                .ToListAsync(cancellationToken);
+
+            var identitiesToLoad = allIdentities
+                .Select(p => new ProviderIdentity(p.ProviderName, p.VersionKey))
+                .Where(identity =>
                 {
-                    if (seen.Contains(name)) { return false; }
+                    if (seen.Contains(identity)) { return false; }
 
-                    if (regex is not null && !regex.IsMatch(name)) { return false; }
+                    if (regex is not null && !regex.IsMatch(identity.ProviderName)) { return false; }
 
-                    return skipProviderNames is null || !skipProviderNames.Contains(name);
+                    return skipProviderNames is null || !skipProviderNames.Contains(identity.ProviderName);
                 })
-                .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
                 .ToList();
 
-            if (namesToLoad.Count == 0) { return []; }
+            if (identitiesToLoad.Count == 0) { return []; }
 
-            // Chunk the IN-clause to stay below SQLite's parameter limit (default 999).
-            var loaded = new List<ProviderDetails>(namesToLoad.Count);
+            var wantedIdentities = identitiesToLoad.ToHashSet();
+
+            // Reload full rows by NAME (SQLite cannot translate a composite-tuple IN clause), chunking to stay below
+            // SQLite's parameter limit (default 999). Derive the names from the identity LIST (not the HashSet) and
+            // de-duplicate them ORDINALLY: ProviderIdentity equality and SQLite's NOCASE collation differ on non-ASCII
+            // case (NOCASE folds only ASCII, OrdinalIgnoreCase folds all of Unicode), so two names differing solely by
+            // non-ASCII case are distinct rows that must both reach the IN clause - collapsing them via the HashSet or
+            // an OrdinalIgnoreCase Distinct would drop one. The reload by name can pull versions we did not ask for, so
+            // post-filter the materialized rows back down to the wanted identities. Today VersionKey is always empty,
+            // making the post-filter a no-op; it becomes load-bearing once content hashing lets versions coexist.
+            var namesToLoad = identitiesToLoad
+                .Select(identity => identity.ProviderName)
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            var loaded = new List<ProviderDetails>(identitiesToLoad.Count);
 
             for (var offset = 0; offset < namesToLoad.Count; offset += MaxInClauseParameters)
             {
@@ -248,15 +268,17 @@ internal static class ProviderSource
                     .Take(MaxInClauseParameters)
                     .ToList();
 
-                loaded.AddRange(await context.ProviderDetails
+                var rows = await context.ProviderDetails
                     .Where(p => chunk.Contains(p.ProviderName))
                     .OrderBy(p => p.ProviderName)
-                    .ToListAsync(cancellationToken));
+                    .ToListAsync(cancellationToken);
+
+                loaded.AddRange(rows.Where(row => wantedIdentities.Contains(ProviderIdentity.Of(row))));
             }
 
             // Mark as seen only after a successful load so a catch for a corrupt file does
-            // not prevent the same provider names from being loaded from a later source file.
-            foreach (var name in namesToLoad) { seen.Add(name); }
+            // not prevent the same identities from being loaded from a later source file.
+            foreach (var identity in identitiesToLoad) { seen.Add(identity); }
 
             return loaded;
         }
@@ -307,7 +329,7 @@ internal static class ProviderSource
         IReadOnlyList<string>? preDiscoveredProviderNames,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var seen = new HashSet<ProviderIdentity>();
         var files = EnumerateSourceFiles(path, logger).ToList();
 
         // preDiscoveredProviderNames optimization only applies for single-file .evtx sources. For folders and .db

--- a/src/EventLogExpert.DatabaseTools/Common/Operations/ProviderSource.cs
+++ b/src/EventLogExpert.DatabaseTools/Common/Operations/ProviderSource.cs
@@ -241,6 +241,8 @@ internal static class ProviderSource
 
             for (var offset = 0; offset < namesToLoad.Count; offset += MaxInClauseParameters)
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 var chunk = namesToLoad
                     .Skip(offset)
                     .Take(MaxInClauseParameters)

--- a/src/EventLogExpert.DatabaseTools/CreateDatabase/CreateDatabaseOperation.cs
+++ b/src/EventLogExpert.DatabaseTools/CreateDatabase/CreateDatabaseOperation.cs
@@ -43,7 +43,7 @@ internal sealed class CreateDatabaseOperation(CreateDatabaseRequest request) : O
             return DatabaseToolsOutcome.Failed;
         }
 
-        HashSet<string> skipProviderNames = new(StringComparer.OrdinalIgnoreCase);
+        HashSet<string> excludeProviderNames = new(StringComparer.OrdinalIgnoreCase);
 
         if (!string.IsNullOrWhiteSpace(request.SkipProvidersInFile))
         {
@@ -54,10 +54,10 @@ internal sealed class CreateDatabaseOperation(CreateDatabaseRequest request) : O
 
             foreach (var name in await ProviderSource.LoadProviderNamesAsync(request.SkipProvidersInFile, logger, cancellationToken: cancellationToken))
             {
-                skipProviderNames.Add(name);
+                excludeProviderNames.Add(name);
             }
 
-            logger.Information($"Found {skipProviderNames.Count} providers in {request.SkipProvidersInFile}. These will not be included in the new database.");
+            logger.Information($"Found {excludeProviderNames.Count} providers in {request.SkipProvidersInFile}. These will not be included in the new database.");
         }
 
         // Defensive recompile if input has Regex.InfiniteMatchTimeout (otherwise catch below is dead).
@@ -75,8 +75,8 @@ internal sealed class CreateDatabaseOperation(CreateDatabaseRequest request) : O
         try
         {
             IAsyncEnumerable<ProviderDetails> providersToAdd = request.SourcePath is null
-                ? LoadLocalProvidersAsync(logger, filterRegex, skipProviderNames, cancellationToken)
-                : ProviderSource.LoadProvidersAsync(request.SourcePath, logger, filterRegex, skipProviderNames, cancellationToken: cancellationToken);
+                ? LoadLocalProvidersAsync(logger, filterRegex, excludeProviderNames, cancellationToken)
+                : ProviderSource.LoadProvidersAsync(request.SourcePath, logger, filterRegex, excludeProviderNames, cancellationToken: cancellationToken);
 
             await foreach (var details in providersToAdd.WithCancellation(cancellationToken))
             {

--- a/src/EventLogExpert.DatabaseTools/CreateDatabase/CreateDatabaseOperation.cs
+++ b/src/EventLogExpert.DatabaseTools/CreateDatabase/CreateDatabaseOperation.cs
@@ -5,6 +5,7 @@ using EventLogExpert.DatabaseTools.Common.Operations;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Provider.Resolution;
 using EventLogExpert.ProviderDatabase.Context;
+using EventLogExpert.ProviderDatabase.Hashing;
 using System.Text.RegularExpressions;
 
 namespace EventLogExpert.DatabaseTools.CreateDatabase;
@@ -67,6 +68,11 @@ internal sealed class CreateDatabaseOperation(CreateDatabaseRequest request) : O
         var headerLogged = false;
         var pendingForHeader = new List<ProviderDetails>(BatchSize);
 
+        // Collapse identical content arriving under different source keys (e.g. an unstamped legacy row plus an
+        // already-hashed row in a multi-file source): both re-hash to the same VersionKey, so the second would
+        // otherwise collide on the composite primary key. Track stamped identities and skip duplicates first-wins.
+        var stampedIdentities = new HashSet<ProviderIdentity>();
+
         // Defer creating the DbContext (and therefore the .db file on disk) until we have
         // at least one provider to persist. This prevents leaving an empty database behind
         // when no provider details could be resolved.
@@ -81,6 +87,13 @@ internal sealed class CreateDatabaseOperation(CreateDatabaseRequest request) : O
             await foreach (var details in providersToAdd.WithCancellation(cancellationToken))
             {
                 cancellationToken.ThrowIfCancellationRequested();
+
+                // Stamp the content hash so distinct versions of a provider name coexist under the composite key and
+                // identical providers (across machines / OS builds) collapse to one row. Idempotent for an
+                // already-hashed source; computes the key for freshly-resolved (live) providers.
+                details.VersionKey = VersionKeyCalculator.Compute(details);
+
+                if (!stampedIdentities.Add(ProviderIdentity.Of(details))) { continue; }
 
                 if (!headerLogged)
                 {

--- a/src/EventLogExpert.DatabaseTools/CreateDatabase/CreateDatabaseOperation.cs
+++ b/src/EventLogExpert.DatabaseTools/CreateDatabase/CreateDatabaseOperation.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.DatabaseTools.Common.Operations;
+using EventLogExpert.Eventing.PublisherMetadata;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Provider.Resolution;
 using EventLogExpert.ProviderDatabase.Context;
@@ -84,6 +85,8 @@ internal sealed class CreateDatabaseOperation(CreateDatabaseRequest request) : O
                 ? LoadLocalProvidersAsync(logger, filterRegex, excludeProviderNames, cancellationToken)
                 : ProviderSource.LoadProvidersAsync(request.SourcePath, logger, filterRegex, excludeProviderNames, cancellationToken: cancellationToken);
 
+            var hostOsProvenance = request.SourcePath is null ? HostOsProvenance.Read(logger) : null;
+
             await foreach (var details in providersToAdd.WithCancellation(cancellationToken))
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -94,6 +97,14 @@ internal sealed class CreateDatabaseOperation(CreateDatabaseRequest request) : O
                 details.VersionKey = VersionKeyCalculator.Compute(details);
 
                 if (!stampedIdentities.Add(ProviderIdentity.Of(details))) { continue; }
+
+                if (hostOsProvenance is not null)
+                {
+                    details.SourceOsBuild = hostOsProvenance.Build;
+                    details.SourceOsRevision = hostOsProvenance.Revision;
+                    details.SourceOsEdition = hostOsProvenance.Edition;
+                    details.SourceOsDisplayVersion = hostOsProvenance.DisplayVersion;
+                }
 
                 if (!headerLogged)
                 {

--- a/src/EventLogExpert.DatabaseTools/DiffDatabase/DiffDatabaseOperation.cs
+++ b/src/EventLogExpert.DatabaseTools/DiffDatabase/DiffDatabaseOperation.cs
@@ -42,14 +42,13 @@ internal sealed class DiffDatabaseOperation(DiffDatabaseRequest request) : Opera
             return DatabaseToolsOutcome.Failed;
         }
 
-        var firstProviderNames = new HashSet<string>(
-            await ProviderSource.LoadProviderNamesAsync(request.FirstSourcePath, logger, cancellationToken: cancellationToken),
-            StringComparer.OrdinalIgnoreCase);
+        var firstIdentities = (await ProviderSource.LoadProviderIdentitiesAsync(
+            request.FirstSourcePath, logger, cancellationToken: cancellationToken)).ToHashSet();
 
         var providersCopied = new List<ProviderDetails>();
 
         logger.Information(
-            $"Skipping up to {firstProviderNames.Count} provider name(s) from the second source that also appear in the first source.");
+            $"Skipping up to {firstIdentities.Count} provider version(s) from the second source that also appear in the first source.");
 
         ProviderDbContext? newDbContext = null;
 
@@ -58,7 +57,7 @@ internal sealed class DiffDatabaseOperation(DiffDatabaseRequest request) : Opera
             await foreach (var details in ProviderSource.LoadProvidersAsync(request.SecondSourcePath,
                 logger,
                 regex: null,
-                skipProviderNames: firstProviderNames,
+                skipIdentities: firstIdentities,
                 cancellationToken: cancellationToken))
             {
                 cancellationToken.ThrowIfCancellationRequested();

--- a/src/EventLogExpert.DatabaseTools/MergeDatabase/MergeDatabaseOperation.cs
+++ b/src/EventLogExpert.DatabaseTools/MergeDatabase/MergeDatabaseOperation.cs
@@ -37,16 +37,20 @@ internal sealed class MergeDatabaseOperation(MergeDatabaseRequest request) : Ope
             return DatabaseToolsOutcome.Failed;
         }
 
-        var sourceNames = new HashSet<string>(
-            await ProviderSource.LoadProviderNamesAsync(request.SourcePath, logger, cancellationToken: cancellationToken),
-            StringComparer.OrdinalIgnoreCase);
+        var sourceIdentities = (await ProviderSource.LoadProviderIdentitiesAsync(
+            request.SourcePath, logger, cancellationToken: cancellationToken)).ToHashSet();
 
-        if (sourceNames.Count == 0)
+        if (sourceIdentities.Count == 0)
         {
             logger.Warning($"No providers were discovered in the source.");
 
             return DatabaseToolsOutcome.Succeeded;
         }
+
+        var sourceNames = sourceIdentities
+            .Select(identity => identity.ProviderName)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
 
         DatabaseSchemaState targetState;
 
@@ -80,72 +84,80 @@ internal sealed class MergeDatabaseOperation(MergeDatabaseRequest request) : Ope
         {
             await using var targetContext = new ProviderDbContext(request.TargetDatabasePath, false, logger);
 
-            var sourceNamesList = sourceNames.ToList();
-            var targetMatchingNames = new List<string>();
+            // Find which of the source's identities already exist in the target. Query target rows by NAME (SQLite
+            // cannot translate a composite-tuple IN), project KEYS only (no blob columns), then narrow to the exact
+            // (name, version) identities the source carries. Versions of a matched name that the source does NOT carry
+            // are intentionally left untouched.
+            var identitiesAlreadyInTarget = new HashSet<ProviderIdentity>();
 
-            for (var offset = 0; offset < sourceNamesList.Count; offset += ProviderSource.MaxInClauseParameters)
+            for (var offset = 0; offset < sourceNames.Count; offset += ProviderSource.MaxInClauseParameters)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var chunk = sourceNamesList
+                var chunk = sourceNames
                     .Skip(offset)
                     .Take(ProviderSource.MaxInClauseParameters)
                     .ToList();
 
-                targetMatchingNames.AddRange(
-                    await targetContext.ProviderDetails
-                        .AsNoTracking()
-                        .Where(p => chunk.Contains(p.ProviderName))
-                        .Select(p => p.ProviderName)
-                        .ToListAsync(cancellationToken));
-            }
+                var targetKeys = await targetContext.ProviderDetails
+                    .AsNoTracking()
+                    .Where(p => chunk.Contains(p.ProviderName))
+                    .Select(p => new { p.ProviderName, p.VersionKey })
+                    .ToListAsync(cancellationToken);
 
-            var providerNamesInTarget = new HashSet<string>(targetMatchingNames, StringComparer.OrdinalIgnoreCase);
+                foreach (var key in targetKeys)
+                {
+                    var identity = new ProviderIdentity(key.ProviderName, key.VersionKey);
+
+                    if (sourceIdentities.Contains(identity)) { identitiesAlreadyInTarget.Add(identity); }
+                }
+            }
 
             // Wrap the destructive phase (overwrite delete + provider copy) in a transaction so a cancel mid-flight
             // does not leave the target with permanently-missing providers. The non-overwrite path is also wrapped
             // so partial copies don't persist on failure - re-running merge produces the intended end state regardless.
             await using var transaction = await targetContext.Database.BeginTransactionAsync(cancellationToken);
 
-            if (targetMatchingNames.Count > 0)
+            if (identitiesAlreadyInTarget.Count > 0)
             {
-                logger.Information($"The target database contains {targetMatchingNames.Count} provider row(s) matching {providerNamesInTarget.Count} provider name(s) in the source.");
+                logger.Information($"The target database already contains {identitiesAlreadyInTarget.Count} of the source's provider version(s).");
 
                 if (request.Overwrite)
                 {
-                    logger.Information($"Removing these providers from the target database...");
+                    logger.Information($"Removing these provider version(s) from the target database...");
 
-                    var removed = 0;
-
-                    for (var offset = 0; offset < targetMatchingNames.Count; offset += ProviderSource.MaxInClauseParameters)
+                    // Delete only the colliding (name, version) identities by composite primary key via stub entities,
+                    // so the copy below re-inserts them from the source while any OTHER versions of those names already
+                    // in the target survive. Stub deletion deletes by key without materializing the (large) blob rows.
+                    foreach (var identity in identitiesAlreadyInTarget)
                     {
-                        cancellationToken.ThrowIfCancellationRequested();
-
-                        var chunk = targetMatchingNames
-                            .Skip(offset)
-                            .Take(ProviderSource.MaxInClauseParameters)
-                            .ToList();
-
-                        removed += await targetContext.ProviderDetails
-                            .Where(p => chunk.Contains(p.ProviderName))
-                            .ExecuteDeleteAsync(cancellationToken);
+                        targetContext.Entry(new ProviderDetails { ProviderName = identity.ProviderName, VersionKey = identity.VersionKey })
+                            .State = EntityState.Deleted;
                     }
 
-                    logger.Information($"Removal of {removed} provider row(s) completed.");
+                    await targetContext.SaveChangesAsync(cancellationToken);
+                    targetContext.ChangeTracker.Clear();
+
+                    logger.Information($"Removal of {identitiesAlreadyInTarget.Count} provider version(s) completed.");
                 }
                 else
                 {
-                    logger.Information($"These providers will not be copied from the source.");
+                    logger.Information($"These provider version(s) will not be copied from the source.");
                 }
             }
 
             logger.Information($"Copying providers from the source...");
 
-            var skipForLoad = request.Overwrite ? null : providerNamesInTarget;
+            var skipForLoad = request.Overwrite ? null : identitiesAlreadyInTarget;
 
-            var expectedCopiedNames = skipForLoad is null
-                ? sourceNames.ToList()
-                : sourceNames.Where(n => !skipForLoad.Contains(n)).ToList();
+            var expectedCopiedIdentities = skipForLoad is null
+                ? sourceIdentities
+                : sourceIdentities.Where(identity => !skipForLoad.Contains(identity)).ToHashSet();
+
+            var expectedCopiedNames = expectedCopiedIdentities
+                .Select(identity => identity.ProviderName)
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
 
             logger.Information($"");
             LogProviderDetailHeader(logger, expectedCopiedNames);
@@ -157,8 +169,8 @@ internal sealed class MergeDatabaseOperation(MergeDatabaseRequest request) : Ope
                 request.SourcePath,
                 logger,
                 regex: null,
-                skipProviderNames: skipForLoad,
-                preDiscoveredProviderNames: sourceNamesList,
+                skipIdentities: skipForLoad,
+                preDiscoveredProviderNames: sourceNames,
                 cancellationToken: cancellationToken))
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -166,7 +178,7 @@ internal sealed class MergeDatabaseOperation(MergeDatabaseRequest request) : Ope
                 targetContext.ProviderDetails.Add(provider);
                 pendingBatch.Add(provider);
 
-                progress?.Report(new DatabaseToolsProgress(copiedCount + pendingBatch.Count, expectedCopiedNames.Count, provider.ProviderName));
+                progress?.Report(new DatabaseToolsProgress(copiedCount + pendingBatch.Count, expectedCopiedIdentities.Count, provider.ProviderName));
 
                 if (pendingBatch.Count < BatchSize) { continue; }
 

--- a/src/EventLogExpert.DatabaseTools/MergeDatabase/MergeDatabaseOperation.cs
+++ b/src/EventLogExpert.DatabaseTools/MergeDatabase/MergeDatabaseOperation.cs
@@ -146,7 +146,7 @@ internal sealed class MergeDatabaseOperation(MergeDatabaseRequest request) : Ope
                 }
             }
 
-            logger.Information($"Copying providers from the source...");
+            logger.Information($"Copying provider versions from the source...");
 
             var skipForLoad = request.Overwrite ? null : identitiesAlreadyInTarget;
 
@@ -195,7 +195,7 @@ internal sealed class MergeDatabaseOperation(MergeDatabaseRequest request) : Ope
             await transaction.CommitAsync(cancellationToken);
 
             logger.Information($"");
-            logger.Information($"Copied {copiedCount} provider(s).");
+            logger.Information($"Copied {copiedCount} provider version(s).");
 
             return DatabaseToolsOutcome.Succeeded;
         }

--- a/src/EventLogExpert.DatabaseTools/MergeDatabase/MergeDatabaseOperation.cs
+++ b/src/EventLogExpert.DatabaseTools/MergeDatabase/MergeDatabaseOperation.cs
@@ -25,7 +25,8 @@ internal sealed class MergeDatabaseOperation(MergeDatabaseRequest request) : Ope
         IProgress<DatabaseToolsProgress>? progress,
         CancellationToken cancellationToken)
     {
-        if (!ProviderSource.TryValidate(request.SourcePath, logger))
+        if (!ProviderSource.TryValidate(request.SourcePath, logger) ||
+            !await ProviderSource.ValidateSourceSchemasAsync(request.SourcePath, logger, cancellationToken))
         {
             return DatabaseToolsOutcome.Failed;
         }

--- a/src/EventLogExpert.Eventing/PublisherMetadata/EventMessageProvider.cs
+++ b/src/EventLogExpert.Eventing/PublisherMetadata/EventMessageProvider.cs
@@ -5,6 +5,7 @@ using EventLogExpert.Eventing.Interop;
 using EventLogExpert.Eventing.Readers;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Provider.Resolution;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace EventLogExpert.Eventing.PublisherMetadata;
@@ -230,11 +231,20 @@ public sealed class EventMessageProvider(
 
         var legacyProviderFiles = _registryProvider.GetMessageFilesForLegacyProvider(_providerName);
 
-        if (!TrySetLazyMessages(provider, legacyProviderFiles))
+        var messageFilePaths = new List<string>();
+
+        if (TrySetLazyMessages(provider, legacyProviderFiles))
         {
-            if (!string.IsNullOrEmpty(providerMetadata?.MessageFilePath) &&
-                TrySetLazyMessages(provider, [providerMetadata.MessageFilePath]))
+            messageFilePaths.AddRange(legacyProviderFiles);
+        }
+        else
+        {
+            var modernMessageFilePath = providerMetadata?.MessageFilePath;
+
+            if (!string.IsNullOrEmpty(modernMessageFilePath) &&
+                TrySetLazyMessages(provider, [modernMessageFilePath]))
             {
+                messageFilePaths.Add(modernMessageFilePath);
                 _logger?.Debug(
                     $"No legacy messages loaded for provider {_providerName}. Using message file from modern provider.");
             }
@@ -250,6 +260,10 @@ public sealed class EventMessageProvider(
         {
             _logger?.Debug($"Parameter file for provider {_providerName} produced no messages.");
         }
+
+        // Record the newest message-DLL file version as the per-provider recency signal (captured at db-create).
+        // FileVersionInfo I/O runs once per provider here, never per event.
+        SetMessageFileVersion(provider, messageFilePaths);
 
         if (provider.IsEmpty)
         {
@@ -331,6 +345,24 @@ public sealed class EventMessageProvider(
         }
 
         return entries.Count > 0 ? new ValueMapDefinition(rawMap.IsBitMap, entries) : null;
+    }
+
+    // Stamps the provider with the newest 4-part numeric file version across its resolved message DLLs - the
+    // per-provider recency signal. Uses FileVersionInfo NUMERIC parts, not the FileVersion string: inbox DLLs carry
+    // a trailing " (WinBuild.160101.0800)" that Version.Parse rejects, which would null the ordinal for nearly every
+    // OS provider. Leaves MessageFileVersion null when no candidate file yields a version.
+    private void SetMessageFileVersion(ProviderDetails provider, IReadOnlyList<string> messageFilePaths)
+    {
+        Version? newest = null;
+
+        foreach (var path in messageFilePaths)
+        {
+            var version = TryReadFileVersion(path);
+
+            if (version is not null && (newest is null || version > newest)) { newest = version; }
+        }
+
+        if (newest is not null) { provider.MessageFileVersion = newest.ToString(); }
     }
 
     private void TryFallbackToOwningPublisher(ProviderDetails target, HashSet<string>? visited)
@@ -478,6 +510,24 @@ public sealed class EventMessageProvider(
             {
                 Marshal.FreeHGlobal(buffer);
             }
+        }
+    }
+
+    private Version? TryReadFileVersion(string path)
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(path) || !File.Exists(path)) { return null; }
+
+            var info = FileVersionInfo.GetVersionInfo(path);
+
+            return new Version(info.FileMajorPart, info.FileMinorPart, info.FileBuildPart, info.FilePrivatePart);
+        }
+        catch (Exception ex)
+        {
+            _logger?.Debug($"Failed to read file version for {path} (provider {_providerName}). Exception:\n{ex}");
+
+            return null;
         }
     }
 

--- a/src/EventLogExpert.Eventing/PublisherMetadata/HostOsProvenance.cs
+++ b/src/EventLogExpert.Eventing/PublisherMetadata/HostOsProvenance.cs
@@ -1,0 +1,54 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Logging.Abstractions;
+using Microsoft.Win32;
+
+namespace EventLogExpert.Eventing.PublisherMetadata;
+
+/// <summary>
+///     Provenance of the host OS a provider database is built from, read once per db-create from the local
+///     <c>HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion</c> hive. Recorded per provider row so resolution can prefer
+///     the newest source (the recency tiebreak) without relying on the database file name. All fields are null when the
+///     hive cannot be read; resolution degrades gracefully to completeness + load order.
+/// </summary>
+public sealed record HostOsProvenance(int? Build, int? Revision, string? Edition, string? DisplayVersion)
+{
+    public static HostOsProvenance Empty { get; } = new(null, null, null, null);
+
+    public static HostOsProvenance Read(ITraceLogger? logger = null)
+    {
+        try
+        {
+            // Open an owned base key (do NOT use Registry.LocalMachine - that's a shared static), matching
+            // RegistryProvider so concurrent instances dispose independently.
+            using var hklm = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Default);
+
+            using var currentVersion = hklm.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion");
+
+            if (currentVersion is null)
+            {
+                logger?.Debug($"{nameof(HostOsProvenance)}: CurrentVersion key not found; provenance unavailable.");
+
+                return Empty;
+            }
+
+            // CurrentBuildNumber is a REG_SZ; UBR is a DWORD; EditionID / DisplayVersion are REG_SZ.
+            var build = int.TryParse(currentVersion.GetValue("CurrentBuildNumber") as string, out var parsedBuild)
+                ? parsedBuild
+                : (int?)null;
+
+            var revision = currentVersion.GetValue("UBR") is int rawRevision ? rawRevision : (int?)null;
+            var edition = currentVersion.GetValue("EditionID") as string;
+            var displayVersion = currentVersion.GetValue("DisplayVersion") as string;
+
+            return new HostOsProvenance(build, revision, edition, displayVersion);
+        }
+        catch (Exception ex)
+        {
+            logger?.Debug($"{nameof(HostOsProvenance)}: failed to read host OS provenance. Exception:\n{ex}");
+
+            return Empty;
+        }
+    }
+}

--- a/src/EventLogExpert.Eventing/PublisherMetadata/MtaProviderSource.cs
+++ b/src/EventLogExpert.Eventing/PublisherMetadata/MtaProviderSource.cs
@@ -83,10 +83,11 @@ public static class MtaProviderSource
         string evtxPath,
         ITraceLogger logger,
         Regex? regex = null,
-        IReadOnlySet<string>? skipProviderNames = null,
+        IReadOnlySet<string>? excludeProviderNames = null,
+        IReadOnlySet<ProviderIdentity>? skipIdentities = null,
         HashSet<ProviderIdentity>? seen = null,
         IReadOnlyList<string>? preDiscoveredProviderNames = null) =>
-        LoadProvidersCore(evtxPath, logger, regex, skipProviderNames, seen, preDiscoveredProviderNames);
+        LoadProvidersCore(evtxPath, logger, regex, excludeProviderNames, skipIdentities, seen, preDiscoveredProviderNames);
 
     private static IReadOnlyList<string> DiscoverProviderNamesCore(
         string evtxPath,
@@ -156,7 +157,8 @@ public static class MtaProviderSource
         string evtxPath,
         ITraceLogger logger,
         Regex? regex,
-        IReadOnlySet<string>? skipProviderNames,
+        IReadOnlySet<string>? excludeProviderNames,
+        IReadOnlySet<ProviderIdentity>? skipIdentities,
         HashSet<ProviderIdentity>? seen,
         IReadOnlyList<string>? preDiscoveredProviderNames = null)
     {
@@ -181,7 +183,9 @@ public static class MtaProviderSource
             // provider, distinct from an offline content-hashed version (a later phase).
             var identity = new ProviderIdentity(providerName, string.Empty);
 
-            if (skipProviderNames is not null && skipProviderNames.Contains(providerName)) { continue; }
+            if (excludeProviderNames is not null && excludeProviderNames.Contains(providerName)) { continue; }
+
+            if (skipIdentities is not null && skipIdentities.Contains(identity)) { continue; }
 
             if (seen is not null && seen.Contains(identity)) { continue; }
 

--- a/src/EventLogExpert.Eventing/PublisherMetadata/MtaProviderSource.cs
+++ b/src/EventLogExpert.Eventing/PublisherMetadata/MtaProviderSource.cs
@@ -84,7 +84,7 @@ public static class MtaProviderSource
         ITraceLogger logger,
         Regex? regex = null,
         IReadOnlySet<string>? skipProviderNames = null,
-        HashSet<string>? seen = null,
+        HashSet<ProviderIdentity>? seen = null,
         IReadOnlyList<string>? preDiscoveredProviderNames = null) =>
         LoadProvidersCore(evtxPath, logger, regex, skipProviderNames, seen, preDiscoveredProviderNames);
 
@@ -157,7 +157,7 @@ public static class MtaProviderSource
         ITraceLogger logger,
         Regex? regex,
         IReadOnlySet<string>? skipProviderNames,
-        HashSet<string>? seen,
+        HashSet<ProviderIdentity>? seen,
         IReadOnlyList<string>? preDiscoveredProviderNames = null)
     {
         // Honor the pre-discovered hint when supplied; otherwise re-scan the evtx file. The hint must already
@@ -176,9 +176,14 @@ public static class MtaProviderSource
 
         foreach (var providerName in providerNames)
         {
+            // Live providers expose only a name (events carry no content version), so their identity is always
+            // (name, empty). The empty VersionKey is meaningful rather than a placeholder: it marks a live/online
+            // provider, distinct from an offline content-hashed version (a later phase).
+            var identity = new ProviderIdentity(providerName, string.Empty);
+
             if (skipProviderNames is not null && skipProviderNames.Contains(providerName)) { continue; }
 
-            if (seen is not null && seen.Contains(providerName)) { continue; }
+            if (seen is not null && seen.Contains(identity)) { continue; }
 
             var details = new EventMessageProvider(providerName, mtaFiles, logger).LoadProviderDetails();
 
@@ -191,7 +196,7 @@ public static class MtaProviderSource
 
             // Mark as seen only after confirming the provider has data, so that an empty/missing
             // provider from one .evtx does not block loading it from a later source file.
-            seen?.Add(providerName);
+            seen?.Add(identity);
 
             yield return details;
         }

--- a/src/EventLogExpert.Eventing/Resolvers/EventResolver.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/EventResolver.cs
@@ -279,21 +279,28 @@ public sealed class EventResolver : EventResolverBase, IEventResolver
         {
             ObjectDisposedException.ThrowIf(IsDisposed, this);
 
+            List<ProviderDetails>? candidates = null;
+
             foreach (var lookup in lookups)
             {
-                var details = lookup.FindProvider(providerName);
-
-                if (details is null) { continue; }
-
-                Logger?.Debug($"Resolved {providerName} from database {lookup.Name}.");
-                ProviderDetails.TryAdd(providerName, details);
-                _providerFromNonLocal.TryAdd(providerName, true);
-
-                return true;
+                foreach (var details in lookup.FindAllProviderVersions(providerName))
+                {
+                    (candidates ??= []).Add(details);
+                }
             }
-        }
 
-        return false;
+            if (candidates is null) { return false; }
+
+            var resolved = ProviderVersionSelector.SelectMostComplete(candidates);
+
+            if (resolved is null) { return false; }
+
+            Logger?.Debug($"Resolved {providerName} from {candidates.Count} database version(s).");
+            ProviderDetails.TryAdd(providerName, resolved);
+            _providerFromNonLocal.TryAdd(providerName, true);
+
+            return true;
+        }
     }
 
     private bool TryResolveFromMta(string providerName, ImmutableArray<string> metadataPaths)

--- a/src/EventLogExpert.Eventing/Resolvers/EventResolver.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/EventResolver.cs
@@ -295,7 +295,13 @@ public sealed class EventResolver : EventResolverBase, IEventResolver
 
             if (resolved is null) { return false; }
 
-            Logger?.Debug($"Resolved {providerName} from {candidates.Count} database version(s).");
+            // Recency picks the newest AVAILABLE source, not the source OS of the event being resolved: an EVTX
+            // record carries no OS/build signal, so this is a global preference, not a per-event match.
+            Logger?.Debug(
+                $"Resolved {providerName} from {candidates.Count} database version(s); winning source build " +
+                $"{resolved.SourceOsBuild?.ToString() ?? "?"}.{resolved.SourceOsRevision?.ToString() ?? "?"} " +
+                $"{resolved.SourceOsEdition ?? "?"} {resolved.SourceOsDisplayVersion ?? "?"}, message file version " +
+                $"{resolved.MessageFileVersion ?? "?"}.");
             ProviderDetails.TryAdd(providerName, resolved);
             _providerFromNonLocal.TryAdd(providerName, true);
 

--- a/src/EventLogExpert.Provider.Database/Context/ProviderDbContext.cs
+++ b/src/EventLogExpert.Provider.Database/Context/ProviderDbContext.cs
@@ -81,7 +81,7 @@ public sealed class ProviderDbContext : DbContext, IProviderDetailsLookup
                 userVersion = Convert.ToInt32(versionCommand.ExecuteScalar());
             }
 
-            if (userVersion == DatabaseSchemaVersion.Current)
+            if (userVersion == DatabaseSchemaVersion.Current && IsCanonicalShape(connection))
             {
                 // Stamped canonical database - current shape, no rebuild. Skip the structural probe.
                 return LogResult(new DatabaseSchemaState(DatabaseSchemaVersion.Current));
@@ -340,8 +340,9 @@ public sealed class ProviderDbContext : DbContext, IProviderDetailsLookup
     private static bool IsType(string? actual, string expected) =>
         string.Equals(actual?.Trim(), expected, StringComparison.OrdinalIgnoreCase);
 
-    private static ProviderDetails ReadCompressedRow(IDataReader reader, string providerName) =>
-        new()
+    private static ProviderDetails ReadCompressedRow(IDataReader reader, string providerName)
+    {
+        var details = new ProviderDetails
         {
             ProviderName = providerName,
             Messages = CompressedJsonValueConverter<List<MessageModel>>.ConvertFromCompressedJson((byte[])reader["Messages"]),
@@ -354,6 +355,38 @@ public sealed class ProviderDbContext : DbContext, IProviderDetailsLookup
             VersionKey = TryReadVersionKey(reader),
             ResolvedFromOwningPublisher = TryReadResolvedFromOwningPublisher(reader, providerName)
         };
+
+        ReadProvenanceInto(reader, details);
+
+        return details;
+    }
+
+    private static void ReadProvenanceInto(IDataReader reader, ProviderDetails details)
+    {
+        for (var i = 0; i < reader.FieldCount; i++)
+        {
+            if (reader.IsDBNull(i)) { continue; }
+
+            switch (reader.GetName(i))
+            {
+                case nameof(Provider.Resolution.ProviderDetails.SourceOsBuild):
+                    details.SourceOsBuild = Convert.ToInt32(reader.GetValue(i));
+                    break;
+                case nameof(Provider.Resolution.ProviderDetails.SourceOsRevision):
+                    details.SourceOsRevision = Convert.ToInt32(reader.GetValue(i));
+                    break;
+                case nameof(Provider.Resolution.ProviderDetails.SourceOsEdition):
+                    details.SourceOsEdition = reader.GetString(i);
+                    break;
+                case nameof(Provider.Resolution.ProviderDetails.SourceOsDisplayVersion):
+                    details.SourceOsDisplayVersion = reader.GetString(i);
+                    break;
+                case nameof(Provider.Resolution.ProviderDetails.MessageFileVersion):
+                    details.MessageFileVersion = reader.GetString(i);
+                    break;
+            }
+        }
+    }
 
     private static bool TryDetectPrimaryKeyNoCaseCollation(DbConnection connection)
     {
@@ -462,6 +495,54 @@ public sealed class ProviderDbContext : DbContext, IProviderDetailsLookup
         }
 
         return string.Empty;
+    }
+
+#if DEBUG
+    private bool ActualColumnsMatchModel(DbConnection connection)
+    {
+        var actualColumns = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        using (var command = connection.CreateCommand())
+        {
+            command.CommandText = "PRAGMA table_info(\"ProviderDetails\")";
+
+            using var reader = command.ExecuteReader();
+
+            while (reader.Read())
+            {
+                var columnName = reader["name"]?.ToString();
+
+                if (!string.IsNullOrEmpty(columnName)) { actualColumns.Add(columnName); }
+            }
+        }
+
+        var entityType = Model.FindEntityType(typeof(ProviderDetails));
+
+        if (entityType is null) { return true; }
+
+        var modelColumns = entityType.GetProperties().Select(property => property.GetColumnName());
+
+        return actualColumns.SetEquals(modelColumns);
+    }
+#endif
+
+    // In RELEASE this compiles to `return true`, so detection is byte-identical to a plain user_version==Current
+    // short-circuit - no behavior change for shipped builds, no per-event cost (it runs only when a database opens).
+    // In DEBUG it additionally verifies the physical column set still matches the current EF model, so a developer
+    // database stamped with the current version but built from an earlier model shape rebuilds itself in place
+    // instead of requiring a manual delete. The expected set is derived from the model, so this self-heals EVERY
+    // future within-stamp column add/rename, not just the provenance columns. Type-only changes still require a
+    // DatabaseSchemaVersion bump (the must-bump invariant) - name-set equivalence deliberately ignores affinity to
+    // avoid SQLite type-string false positives.
+    private bool IsCanonicalShape(DbConnection connection)
+    {
+#if DEBUG
+        return ActualColumnsMatchModel(connection);
+#else
+        _ = connection;
+
+        return true;
+#endif
     }
 
     private void StampCanonicalUserVersion()

--- a/src/EventLogExpert.Provider.Database/Context/ProviderDbContext.cs
+++ b/src/EventLogExpert.Provider.Database/Context/ProviderDbContext.cs
@@ -55,6 +55,14 @@ public sealed class ProviderDbContext : DbContext, IProviderDetailsLookup
 
     private string Path { get; }
 
+    // Ordered by VersionKey so the consolidated winner's true ties (same description length) break deterministically on
+    // a stable per-database order rather than SQLite's unspecified row order.
+    public IReadOnlyList<ProviderDetails> FindAllProviderVersions(string providerName) =>
+        ProviderDetails
+            .Where(p => p.ProviderName == providerName)
+            .OrderBy(p => p.VersionKey)
+            .ToList();
+
     public ProviderDetails? FindProvider(string providerName) =>
         ProviderDetails.FirstOrDefault(p => p.ProviderName == providerName);
 

--- a/src/EventLogExpert.Provider.Database/Context/ProviderDbContext.cs
+++ b/src/EventLogExpert.Provider.Database/Context/ProviderDbContext.cs
@@ -8,6 +8,7 @@ using EventLogExpert.Provider.Schema;
 using EventLogExpert.ProviderDatabase.Maintenance;
 using EventLogExpert.ProviderDatabase.Serialization;
 using Microsoft.EntityFrameworkCore;
+using System.Collections.ObjectModel;
 using System.Data;
 using System.Data.Common;
 
@@ -37,9 +38,14 @@ public sealed class ProviderDbContext : DbContext, IProviderDetailsLookup
             ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
         }
 
-        if (ensureCreated)
+        if (!ensureCreated) { return; }
+
+        // EnsureCreated builds the ProviderDetails table from the current (canonical) model only when the database did
+        // not already exist. Stamp the canonical user_version on a freshly-created writable database so it is recognized
+        // as current; an existing database is left untouched here (a stale one is rebuilt by the upgrade path, not in place).
+        if (Database.EnsureCreated() && !readOnly)
         {
-            Database.EnsureCreated();
+            StampCanonicalUserVersion();
         }
     }
 
@@ -59,15 +65,39 @@ public sealed class ProviderDbContext : DbContext, IProviderDetailsLookup
 
         try
         {
+            int userVersion;
+
+            using (var versionCommand = connection.CreateCommand())
+            {
+                versionCommand.CommandText = "PRAGMA user_version";
+                userVersion = Convert.ToInt32(versionCommand.ExecuteScalar());
+            }
+
+            if (userVersion == DatabaseSchemaVersion.Current)
+            {
+                // Stamped canonical database - current shape, no rebuild. Skip the structural probe.
+                return LogResult(new DatabaseSchemaState(DatabaseSchemaVersion.Current));
+            }
+
+            if (userVersion > DatabaseSchemaVersion.Current)
+            {
+                // Stamped by a newer build than this one understands; never rebuild/downgrade it.
+                return LogResult(new DatabaseSchemaState(DatabaseSchemaVersion.Unknown) { NeedsUpgrade = true });
+            }
+
+            // userVersion below Current (0 for every database created before the stamp existed; also any sub-current
+            // stamp): classify structurally below (to distinguish v1/v2-unsupported and Unknown from rebuildable v3/v4),
+            // then flag for rebuild unconditionally - an unstamped/stale database is never canonical even when its columns
+            // already match the current shape (and a future Current bump correctly rebuilds old stamped databases).
             string? messagesType = null;
             string? eventsType = null;
             string? keywordsType = null;
             string? opcodesType = null;
             string? tasksType = null;
             string? parametersType = null;
-            var hasAnyColumn = false;
-            var hasParametersColumn = false;
-            var hasResolvedColumn = false;
+            bool hasAnyColumn = false;
+            bool hasParametersColumn = false;
+            bool hasResolvedColumn = false;
 
             using (var command = connection.CreateCommand())
             {
@@ -156,12 +186,15 @@ public sealed class ProviderDbContext : DbContext, IProviderDetailsLookup
                 }
             }
 
-            var state = new DatabaseSchemaState(currentVersion);
+            return LogResult(new DatabaseSchemaState(currentVersion) { NeedsUpgrade = true });
 
-            _logger?.Debug(
-                $"{nameof(ProviderDbContext)}.{nameof(IsUpgradeNeeded)}() for database {Path}. currentVersion: {currentVersion} needsUpgrade: {state.NeedsUpgrade}");
+            DatabaseSchemaState LogResult(DatabaseSchemaState result)
+            {
+                _logger?.Debug(
+                    $"{nameof(ProviderDbContext)}.{nameof(IsUpgradeNeeded)}() for database {Path}. currentVersion: {result.CurrentVersion} needsUpgrade: {result.NeedsUpgrade}");
 
-            return state;
+                return result;
+            }
         }
         finally
         {
@@ -246,6 +279,10 @@ public sealed class ProviderDbContext : DbContext, IProviderDetailsLookup
         size = new FileInfo(Path).Length;
 
         _logger?.Information($"ProviderDbContext upgrade completed. Size: {size} Path: {Path}");
+
+        // The rebuild produced the current model's shape (EnsureCreated above). Stamp the canonical user_version so the
+        // database is recognized as current on the next open.
+        StampCanonicalUserVersion();
     }
 
     protected override void OnConfiguring(DbContextOptionsBuilder options) =>
@@ -253,8 +290,11 @@ public sealed class ProviderDbContext : DbContext, IProviderDetailsLookup
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
+        // INVARIANT: any change to the persisted ProviderDetails model (columns, key, or converters) MUST bump
+        // DatabaseSchemaVersion.Current. Detection trusts the stored user_version stamp over the column shape, so a model
+        // change without a version bump would let a stamped-but-old-shape database read as canonical and crash EF.
         modelBuilder.Entity<ProviderDetails>()
-            .HasKey(e => e.ProviderName);
+            .HasKey(e => new { e.ProviderName, e.VersionKey });
 
         modelBuilder.Entity<ProviderDetails>()
             .Property(e => e.ProviderName)
@@ -284,9 +324,9 @@ public sealed class ProviderDbContext : DbContext, IProviderDetailsLookup
             .Property(e => e.Tasks)
             .HasConversion<CompressedJsonValueConverter<IDictionary<int, string>>>();
 
-        // Maps are recovered at runtime from the provider's WEVT_TEMPLATE resource and are not persisted to the cache.
         modelBuilder.Entity<ProviderDetails>()
-            .Ignore(e => e.Maps);
+            .Property(e => e.Maps)
+            .HasConversion<CompressedJsonValueConverter<IReadOnlyDictionary<string, ValueMapDefinition>>>();
     }
 
     private static bool IsType(string? actual, string expected) =>
@@ -302,6 +342,8 @@ public sealed class ProviderDbContext : DbContext, IProviderDetailsLookup
             Keywords = CompressedJsonValueConverter<Dictionary<long, string>>.ConvertFromCompressedJson((byte[])reader["Keywords"]),
             Opcodes = CompressedJsonValueConverter<Dictionary<int, string>>.ConvertFromCompressedJson((byte[])reader["Opcodes"]),
             Tasks = CompressedJsonValueConverter<Dictionary<int, string>>.ConvertFromCompressedJson((byte[])reader["Tasks"]),
+            Maps = TryReadMaps(reader),
+            VersionKey = TryReadVersionKey(reader),
             ResolvedFromOwningPublisher = TryReadResolvedFromOwningPublisher(reader, providerName)
         };
 
@@ -355,6 +397,29 @@ public sealed class ProviderDbContext : DbContext, IProviderDetailsLookup
         return false;
     }
 
+    private static IReadOnlyDictionary<string, ValueMapDefinition> TryReadMaps(IDataReader reader)
+    {
+        for (var i = 0; i < reader.FieldCount; i++)
+        {
+            if (!string.Equals(reader.GetName(i),
+                nameof(Provider.Resolution.ProviderDetails.Maps),
+                StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (reader.IsDBNull(i))
+            {
+                break;
+            }
+
+            return CompressedJsonValueConverter<IReadOnlyDictionary<string, ValueMapDefinition>>
+                .ConvertFromCompressedJson((byte[])reader.GetValue(i));
+        }
+
+        return ReadOnlyDictionary<string, ValueMapDefinition>.Empty;
+    }
+
     private static string? TryReadResolvedFromOwningPublisher(IDataReader reader, string providerName)
     {
         for (var i = 0; i < reader.FieldCount; i++)
@@ -372,5 +437,40 @@ public sealed class ProviderDbContext : DbContext, IProviderDetailsLookup
         _ = providerName;
 
         return null;
+    }
+
+    private static string TryReadVersionKey(IDataReader reader)
+    {
+        for (var i = 0; i < reader.FieldCount; i++)
+        {
+            if (!string.Equals(reader.GetName(i),
+                nameof(Provider.Resolution.ProviderDetails.VersionKey),
+                StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            return reader.IsDBNull(i) ? string.Empty : reader.GetString(i);
+        }
+
+        return string.Empty;
+    }
+
+    private void StampCanonicalUserVersion()
+    {
+        var connection = Database.GetDbConnection();
+        Database.OpenConnection();
+
+        try
+        {
+            using var command = connection.CreateCommand();
+            // PRAGMA user_version does not accept parameters; the value is a compile-time constant integer.
+            command.CommandText = $"PRAGMA user_version = {DatabaseSchemaVersion.Current}";
+            command.ExecuteNonQuery();
+        }
+        finally
+        {
+            Database.CloseConnection();
+        }
     }
 }

--- a/src/EventLogExpert.Provider.Database/Context/ProviderDbContext.cs
+++ b/src/EventLogExpert.Provider.Database/Context/ProviderDbContext.cs
@@ -298,9 +298,13 @@ public sealed class ProviderDbContext : DbContext, IProviderDetailsLookup
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        // INVARIANT: any change to the persisted ProviderDetails model (columns, key, or converters) MUST bump
-        // DatabaseSchemaVersion.Current. Detection trusts the stored user_version stamp over the column shape, so a model
-        // change without a version bump would let a stamped-but-old-shape database read as canonical and crash EF.
+        // INVARIANT: once a build that stamps the canonical user_version has shipped, any change to the persisted
+        // ProviderDetails model (columns, key, or converters) MUST bump DatabaseSchemaVersion.Current - detection
+        // trusts the stored stamp over the column shape, so a model change without a bump would let a stamped
+        // old-shape database read as canonical and crash EF. During the prerelease window (no stamped build has
+        // shipped yet) the v4 shape is still being finalized in place WITHOUT bumping: every real database is
+        // unstamped (user_version=0) and rebuilds through the upgrade path, and the dev-only (DEBUG) shape self-heal
+        // (see IsCanonicalShape) rebuilds stamped developer databases whose columns no longer match the model.
         modelBuilder.Entity<ProviderDetails>()
             .HasKey(e => new { e.ProviderName, e.VersionKey });
 

--- a/src/EventLogExpert.Provider.Database/Hashing/ProviderContentCanonicalizer.cs
+++ b/src/EventLogExpert.Provider.Database/Hashing/ProviderContentCanonicalizer.cs
@@ -1,0 +1,227 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Provider.Resolution;
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Text;
+
+namespace EventLogExpert.ProviderDatabase.Hashing;
+
+/// <summary>
+///     Produces a canonical, deterministic, culture-invariant byte serialization of a <see cref="ProviderDetails" />
+///     rendering payload - the input to the content hash that becomes its <see cref="ProviderDetails.VersionKey" />. The
+///     encoding is a hand-written length-prefixed BINARY format (NOT JSON) so the bytes are stable across .NET versions
+///     and machines: two providers that render identically hash identically and collapse to one database row, while
+///     genuinely different payloads coexist. The provider NAME and the VersionKey itself are excluded (the name is the
+///     identity key; the VersionKey is the output).
+/// </summary>
+/// <remarks>
+///     Normalization is aligned with <c>ProviderDetailsMerger</c>'s equivalence so the hash and the merge agree on
+///     what makes two providers "the same version": dictionary entries are emitted sorted by key (dictionary enumeration
+///     order is unspecified); event keyword lists are sorted AND de-duplicated (the merger compares them as a set); event,
+///     message, and parameter entries are encoded to self-delimiting blobs that are sorted ordinally with exact duplicates
+///     dropped (manifest list order is not a stability contract); ValueMap entries keep their ORIGINAL order (bitmap
+///     decoding is order-dependent, so order is content). Strings are preserved EXACTLY - no Unicode or whitespace
+///     normalization - so the hash stays injective over the persisted bytes; the database's fail-hard rule requires that
+///     identical hashes imply identical content.
+/// </remarks>
+internal static class ProviderContentCanonicalizer
+{
+    /// <summary>
+    ///     Bumping this re-keys every provider on purpose (e.g. after a canonicalization fix). Pair it with the
+    ///     <c>vk1:</c> tag in <see cref="VersionKeyCalculator" /> so providers hashed under different schemes never silently
+    ///     share a key.
+    /// </summary>
+    private const byte SchemeVersion = 1;
+
+    public static byte[] Canonicalize(ProviderDetails provider)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+
+        WriteByte(buffer, SchemeVersion);
+
+        // The merger treats a null and an empty ResolvedFromOwningPublisher as the same "no owner" (IsNullOrEmpty), so
+        // normalize them to one value here - otherwise null vs "" would split two otherwise-identical providers.
+        WriteString(buffer, string.IsNullOrEmpty(provider.ResolvedFromOwningPublisher) ? null : provider.ResolvedFromOwningPublisher);
+        WriteSortedBlobs(buffer, provider.Events, EncodeEvent);
+        WriteSortedBlobs(buffer, provider.Messages, EncodeMessage);
+        WriteSortedBlobs(buffer, provider.Parameters, EncodeMessage);
+        WriteInt64Dictionary(buffer, provider.Keywords);
+        WriteInt32Dictionary(buffer, provider.Opcodes);
+        WriteInt32Dictionary(buffer, provider.Tasks);
+        WriteMaps(buffer, provider.Maps);
+
+        return buffer.WrittenSpan.ToArray();
+    }
+
+    private static byte[] EncodeEvent(EventModel model)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+
+        WriteInt64(buffer, model.Id);
+        WriteByte(buffer, model.Version);
+        WriteInt32(buffer, model.Level);
+        WriteInt32(buffer, model.Opcode);
+        WriteInt32(buffer, model.Task);
+
+        // The merger treats keywords as a SET (KeywordsEqual -> HashSet.SetEquals), so sort + de-duplicate to match:
+        // [1, 1, 2] and [2, 1] must hash identically.
+        var keywords = model.Keywords.Distinct().Order().ToArray();
+        WriteInt32(buffer, keywords.Length);
+
+        foreach (var keyword in keywords) { WriteInt64(buffer, keyword); }
+
+        WriteString(buffer, model.Template);
+        WriteString(buffer, model.Description);
+        WriteString(buffer, model.LogName);
+
+        return buffer.WrittenSpan.ToArray();
+    }
+
+    private static byte[] EncodeMessage(MessageModel model)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+
+        WriteUInt16(buffer, (ushort)model.ShortId);
+        WriteInt64(buffer, model.RawId);
+
+        // MessageModel.ProviderName is intentionally omitted: it mirrors the owning provider's name (excluded from the
+        // hash) and the merger's message equivalence ignores it, so hashing it would re-inject the provider name and
+        // stop two recordings of the same provider whose name differs only by case from collapsing to one row.
+        WriteString(buffer, model.LogLink);
+        WriteString(buffer, model.Tag);
+        WriteString(buffer, model.Template);
+        WriteString(buffer, model.Text);
+
+        return buffer.WrittenSpan.ToArray();
+    }
+
+    private static void WriteByte(ArrayBufferWriter<byte> buffer, byte value)
+    {
+        var span = buffer.GetSpan(1);
+        span[0] = value;
+        buffer.Advance(1);
+    }
+
+    private static void WriteInt32(ArrayBufferWriter<byte> buffer, int value)
+    {
+        BinaryPrimitives.WriteInt32LittleEndian(buffer.GetSpan(sizeof(int)), value);
+        buffer.Advance(sizeof(int));
+    }
+
+    private static void WriteInt32Dictionary(ArrayBufferWriter<byte> buffer, IDictionary<int, string> dictionary)
+    {
+        var keys = dictionary.Keys.Order().ToArray();
+        WriteInt32(buffer, keys.Length);
+
+        foreach (var key in keys)
+        {
+            WriteInt32(buffer, key);
+            WriteString(buffer, dictionary[key]);
+        }
+    }
+
+    private static void WriteInt64(ArrayBufferWriter<byte> buffer, long value)
+    {
+        BinaryPrimitives.WriteInt64LittleEndian(buffer.GetSpan(sizeof(long)), value);
+        buffer.Advance(sizeof(long));
+    }
+
+    private static void WriteInt64Dictionary(ArrayBufferWriter<byte> buffer, IDictionary<long, string> dictionary)
+    {
+        var keys = dictionary.Keys.Order().ToArray();
+        WriteInt32(buffer, keys.Length);
+
+        foreach (var key in keys)
+        {
+            WriteInt64(buffer, key);
+            WriteString(buffer, dictionary[key]);
+        }
+    }
+
+    private static void WriteMaps(ArrayBufferWriter<byte> buffer, IReadOnlyDictionary<string, ValueMapDefinition> maps)
+    {
+        var keys = maps.Keys.OrderBy(key => key, StringComparer.Ordinal).ToArray();
+        WriteInt32(buffer, keys.Length);
+
+        foreach (var key in keys)
+        {
+            var map = maps[key];
+
+            WriteString(buffer, key);
+            WriteByte(buffer, map.IsBitMap ? (byte)1 : (byte)0);
+
+            // ValueMap entry order is SEMANTIC (TryDecodeBitMap iterates in order; the merger compares via
+            // SequenceEqual), so preserve it - do NOT sort.
+            WriteInt32(buffer, map.Entries.Count);
+
+            foreach (var entry in map.Entries)
+            {
+                WriteUInt32(buffer, entry.Value);
+                WriteString(buffer, entry.Name);
+            }
+        }
+    }
+
+    private static void WriteSortedBlobs<T>(ArrayBufferWriter<byte> buffer, IReadOnlyList<T> items, Func<T, byte[]> encode)
+    {
+        // Encode each item to a self-delimiting blob, then order the blobs ordinally and drop exact duplicates so the
+        // hash is independent of the source list order and of duplicate rows.
+        var blobs = new List<byte[]>(items.Count);
+
+        foreach (var item in items) { blobs.Add(encode(item)); }
+
+        blobs.Sort(static (left, right) => left.AsSpan().SequenceCompareTo(right));
+
+        var distinctCount = 0;
+
+        for (var index = 0; index < blobs.Count; index++)
+        {
+            if (index > 0 && blobs[index].AsSpan().SequenceEqual(blobs[index - 1])) { continue; }
+
+            distinctCount++;
+        }
+
+        WriteInt32(buffer, distinctCount);
+
+        for (var index = 0; index < blobs.Count; index++)
+        {
+            if (index > 0 && blobs[index].AsSpan().SequenceEqual(blobs[index - 1])) { continue; }
+
+            buffer.Write(blobs[index]);
+        }
+    }
+
+    private static void WriteString(ArrayBufferWriter<byte> buffer, string? value)
+    {
+        if (value is null)
+        {
+            // A null string is distinct from an empty one (-1 length marker), so the encoding stays injective across
+            // the nullable string fields (Template/Description/LogName/LogLink/Tag).
+            WriteInt32(buffer, -1);
+
+            return;
+        }
+
+        var byteCount = Encoding.UTF8.GetByteCount(value);
+        WriteInt32(buffer, byteCount);
+
+        if (byteCount == 0) { return; }
+
+        Encoding.UTF8.GetBytes(value, buffer.GetSpan(byteCount));
+        buffer.Advance(byteCount);
+    }
+
+    private static void WriteUInt16(ArrayBufferWriter<byte> buffer, ushort value)
+    {
+        BinaryPrimitives.WriteUInt16LittleEndian(buffer.GetSpan(sizeof(ushort)), value);
+        buffer.Advance(sizeof(ushort));
+    }
+
+    private static void WriteUInt32(ArrayBufferWriter<byte> buffer, uint value)
+    {
+        BinaryPrimitives.WriteUInt32LittleEndian(buffer.GetSpan(sizeof(uint)), value);
+        buffer.Advance(sizeof(uint));
+    }
+}

--- a/src/EventLogExpert.Provider.Database/Hashing/VersionKeyCalculator.cs
+++ b/src/EventLogExpert.Provider.Database/Hashing/VersionKeyCalculator.cs
@@ -11,9 +11,9 @@ namespace EventLogExpert.ProviderDatabase.Hashing;
 ///     Computes a provider's content <see cref="ProviderDetails.VersionKey" />: a hash of its canonical rendering
 ///     payload (<see cref="ProviderContentCanonicalizer" />). Two providers with identical payloads - across machines or
 ///     OS builds - get the same key and collapse to one database row; genuinely different payloads get different keys and
-///     coexist as separate versions of the same provider name. Stamped at build ingress (<c>CreateDatabaseOperation</c> /
-///     <c>MergeDatabaseOperation</c> / <c>DiffDatabaseOperation</c>) before the row is persisted, so the composite
-///     <c>(ProviderName, VersionKey)</c> primary key can hold distinct versions of one name.
+///     coexist as separate versions of the same provider name. Stamped when a provider is first ingested from a live scan
+///     (<c>CreateDatabaseOperation</c>); the merge and diff operations copy already-stamped rows unchanged. The composite
+///     <c>(ProviderName, VersionKey)</c> primary key can therefore hold distinct versions of one name.
 /// </summary>
 public static class VersionKeyCalculator
 {
@@ -39,7 +39,7 @@ public static class VersionKeyCalculator
     /// </summary>
     private static string ToBase32Lower(ReadOnlySpan<byte> data)
     {
-        const string alphabet = "abcdefghijklmnopqrstuvwxyz234567";
+        const string Alphabet = "abcdefghijklmnopqrstuvwxyz234567";
 
         var output = new StringBuilder((data.Length * 8 + 4) / 5);
         var accumulator = 0;
@@ -53,7 +53,7 @@ public static class VersionKeyCalculator
             while (bitsBuffered >= 5)
             {
                 bitsBuffered -= 5;
-                output.Append(alphabet[(accumulator >> bitsBuffered) & 0x1F]);
+                output.Append(Alphabet[(accumulator >> bitsBuffered) & 0x1F]);
             }
 
             accumulator &= (1 << bitsBuffered) - 1;
@@ -61,7 +61,7 @@ public static class VersionKeyCalculator
 
         if (bitsBuffered > 0)
         {
-            output.Append(alphabet[(accumulator << (5 - bitsBuffered)) & 0x1F]);
+            output.Append(Alphabet[(accumulator << (5 - bitsBuffered)) & 0x1F]);
         }
 
         return output.ToString();

--- a/src/EventLogExpert.Provider.Database/Hashing/VersionKeyCalculator.cs
+++ b/src/EventLogExpert.Provider.Database/Hashing/VersionKeyCalculator.cs
@@ -1,0 +1,69 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Provider.Resolution;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace EventLogExpert.ProviderDatabase.Hashing;
+
+/// <summary>
+///     Computes a provider's content <see cref="ProviderDetails.VersionKey" />: a hash of its canonical rendering
+///     payload (<see cref="ProviderContentCanonicalizer" />). Two providers with identical payloads - across machines or
+///     OS builds - get the same key and collapse to one database row; genuinely different payloads get different keys and
+///     coexist as separate versions of the same provider name. Stamped at build ingress (<c>CreateDatabaseOperation</c> /
+///     <c>MergeDatabaseOperation</c> / <c>DiffDatabaseOperation</c>) before the row is persisted, so the composite
+///     <c>(ProviderName, VersionKey)</c> primary key can hold distinct versions of one name.
+/// </summary>
+public static class VersionKeyCalculator
+{
+    /// <summary>
+    ///     Scheme tag prefixing every computed key. It versions the WHOLE keying scheme (canonicalization + hash +
+    ///     encoding); a future change that must re-key providers bumps this to <c>vk2:</c> so old and new keys never silently
+    ///     collide. An empty <see cref="ProviderDetails.VersionKey" /> means "not yet stamped" (legacy / pre-hash rows), never
+    ///     a real identity.
+    /// </summary>
+    public const string SchemePrefix = "vk1:";
+
+    public static string Compute(ProviderDetails provider)
+    {
+        var canonical = ProviderContentCanonicalizer.Canonicalize(provider);
+        var hash = SHA256.HashData(canonical);
+
+        return SchemePrefix + ToBase32Lower(hash);
+    }
+
+    /// <summary>
+    ///     RFC 4648 base32, lowercase, no padding. Chosen over hex (shorter) and base64url (the <c>VersionKey</c> column
+    ///     compares ordinally, and an all-lowercase key is case-robust and filename-safe).
+    /// </summary>
+    private static string ToBase32Lower(ReadOnlySpan<byte> data)
+    {
+        const string alphabet = "abcdefghijklmnopqrstuvwxyz234567";
+
+        var output = new StringBuilder((data.Length * 8 + 4) / 5);
+        var accumulator = 0;
+        var bitsBuffered = 0;
+
+        foreach (var value in data)
+        {
+            accumulator = (accumulator << 8) | value;
+            bitsBuffered += 8;
+
+            while (bitsBuffered >= 5)
+            {
+                bitsBuffered -= 5;
+                output.Append(alphabet[(accumulator >> bitsBuffered) & 0x1F]);
+            }
+
+            accumulator &= (1 << bitsBuffered) - 1;
+        }
+
+        if (bitsBuffered > 0)
+        {
+            output.Append(alphabet[(accumulator << (5 - bitsBuffered)) & 0x1F]);
+        }
+
+        return output.ToString();
+    }
+}

--- a/src/EventLogExpert.Provider.Database/Maintenance/ProviderDetailsMerger.cs
+++ b/src/EventLogExpert.Provider.Database/Maintenance/ProviderDetailsMerger.cs
@@ -118,7 +118,13 @@ internal static class ProviderDetailsMerger
                 (winner, value) => throw new DatabaseUpgradeException(
                     databasePath,
                     $"Provider '{canonicalName}' has conflicting ResolvedFromOwningPublisher values: " +
-                    $"'{winner}' vs '{value}'."))
+                    $"'{winner}' vs '{value}'.")),
+
+            SourceOsBuild = group.Select(static row => row.SourceOsBuild).FirstOrDefault(static value => value.HasValue),
+            SourceOsRevision = group.Select(static row => row.SourceOsRevision).FirstOrDefault(static value => value.HasValue),
+            SourceOsEdition = group.Select(static row => row.SourceOsEdition).FirstOrDefault(static value => !string.IsNullOrEmpty(value)),
+            SourceOsDisplayVersion = group.Select(static row => row.SourceOsDisplayVersion).FirstOrDefault(static value => !string.IsNullOrEmpty(value)),
+            MessageFileVersion = group.Select(static row => row.MessageFileVersion).FirstOrDefault(static value => !string.IsNullOrEmpty(value))
         };
     }
 }

--- a/src/EventLogExpert.Provider.Database/Maintenance/ProviderDetailsMerger.cs
+++ b/src/EventLogExpert.Provider.Database/Maintenance/ProviderDetailsMerger.cs
@@ -13,13 +13,13 @@ internal static class ProviderDetailsMerger
         string databasePath)
     {
         var merged = new List<ProviderDetails>(rows.Count);
-        var firstIndexByGroup = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-        var groupedRows = new Dictionary<string, List<ProviderDetails>>(StringComparer.OrdinalIgnoreCase);
+        var firstIndexByGroup = new Dictionary<(string ProviderName, string VersionKey), int>(ProviderIdentityComparer.Instance);
+        var groupedRows = new Dictionary<(string ProviderName, string VersionKey), List<ProviderDetails>>(ProviderIdentityComparer.Instance);
 
         for (var i = 0; i < rows.Count; i++)
         {
             var row = rows[i];
-            var key = row.ProviderName;
+            var key = (row.ProviderName, row.VersionKey);
 
             if (firstIndexByGroup.TryAdd(key, i))
             {
@@ -33,8 +33,8 @@ internal static class ProviderDetailsMerger
 
         foreach (var (_, firstIndex) in firstIndexByGroup.OrderBy(kvp => kvp.Value))
         {
-            var groupKey = rows[firstIndex].ProviderName;
-            var group = groupedRows[groupKey];
+            var first = rows[firstIndex];
+            var group = groupedRows[(first.ProviderName, first.VersionKey)];
 
             if (group.Count == 1)
             {
@@ -105,20 +105,8 @@ internal static class ProviderDetailsMerger
     {
         var canonicalName = group[0].ProviderName;
 
-        var distinctVersionKeys = group
-            .Select(row => row.VersionKey)
-            .Where(versionKey => !string.IsNullOrEmpty(versionKey))
-            .Distinct(StringComparer.Ordinal)
-            .ToList();
-
-        if (distinctVersionKeys.Count > 1)
-        {
-            throw new DatabaseUpgradeException(
-                databasePath,
-                $"Provider '{canonicalName}' has rows with distinct VersionKeys ({string.Join(", ", distinctVersionKeys)}). " +
-                "Merging by provider name alone would discard distinct provider versions; a tuple-keyed merge is required.");
-        }
-
+        // Rows in a group share the same (ProviderName, VersionKey) identity (the grouping key), so the merged row
+        // carries that VersionKey forward; only name case-folding differences and duplicate content are collapsed.
         return new ProviderDetails
         {
             ProviderName = canonicalName,
@@ -279,6 +267,20 @@ internal static class ProviderDetailsMerger
     private static bool MessagesAreEquivalent(MessageModel a, MessageModel b) =>
         string.Equals(a.Text, b.Text, StringComparison.Ordinal) &&
         string.Equals(a.Template, b.Template, StringComparison.Ordinal);
+
+    private sealed class ProviderIdentityComparer : IEqualityComparer<(string ProviderName, string VersionKey)>
+    {
+        public static readonly ProviderIdentityComparer Instance = new();
+
+        public bool Equals((string ProviderName, string VersionKey) x, (string ProviderName, string VersionKey) y) =>
+            string.Equals(x.ProviderName, y.ProviderName, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(x.VersionKey, y.VersionKey, StringComparison.Ordinal);
+
+        public int GetHashCode((string ProviderName, string VersionKey) obj) =>
+            HashCode.Combine(
+                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.ProviderName),
+                StringComparer.Ordinal.GetHashCode(obj.VersionKey));
+    }
 
     private readonly record struct MessageIdentity(short ShortId, long RawId, string? LogLink, string? Tag);
 

--- a/src/EventLogExpert.Provider.Database/Maintenance/ProviderDetailsMerger.cs
+++ b/src/EventLogExpert.Provider.Database/Maintenance/ProviderDetailsMerger.cs
@@ -49,6 +49,35 @@ internal static class ProviderDetailsMerger
         return merged;
     }
 
+    private static int CompareOrdinalNullLowest(string? candidate, string? current)
+    {
+        if (candidate is null && current is null) { return 0; }
+
+        if (candidate is null) { return -1; }
+
+        return current is null ? 1 : string.CompareOrdinal(candidate, current);
+    }
+
+    // A total order over provenance for a deterministic merge pick: recency first (the shared order), then the
+    // non-ordinal fields by ordinal string comparison (null lowest), so two rows that tie on recency but differ on
+    // edition / display version / raw file-version string still resolve to the same winner regardless of row order.
+    private static int CompareProvenanceForMerge(ProviderDetails candidate, ProviderDetails current)
+    {
+        var byRecency = ProviderSourceRecency.Compare(candidate, current);
+
+        if (byRecency != 0) { return byRecency; }
+
+        var byEdition = CompareOrdinalNullLowest(candidate.SourceOsEdition, current.SourceOsEdition);
+
+        if (byEdition != 0) { return byEdition; }
+
+        var byDisplayVersion = CompareOrdinalNullLowest(candidate.SourceOsDisplayVersion, current.SourceOsDisplayVersion);
+
+        return byDisplayVersion != 0 ?
+            byDisplayVersion :
+            CompareOrdinalNullLowest(candidate.MessageFileVersion, current.MessageFileVersion);
+    }
+
     // Rows in a group share the same (ProviderName, VersionKey) identity (the grouping key), so the merged row carries
     // that VersionKey forward; only name case-folding differences and duplicate content are collapsed. The identity keys
     // and equivalence rules come from ProviderContentMerge so the database-merge path and the resolve-time multi-version
@@ -57,6 +86,8 @@ internal static class ProviderDetailsMerger
     private static ProviderDetails MergeGroup(List<ProviderDetails> group, string databasePath)
     {
         var canonicalName = group[0].ProviderName;
+
+        var newestProvenance = SelectNewestProvenanceRow(group);
 
         return new ProviderDetails
         {
@@ -120,11 +151,23 @@ internal static class ProviderDetailsMerger
                     $"Provider '{canonicalName}' has conflicting ResolvedFromOwningPublisher values: " +
                     $"'{winner}' vs '{value}'.")),
 
-            SourceOsBuild = group.Select(static row => row.SourceOsBuild).FirstOrDefault(static value => value.HasValue),
-            SourceOsRevision = group.Select(static row => row.SourceOsRevision).FirstOrDefault(static value => value.HasValue),
-            SourceOsEdition = group.Select(static row => row.SourceOsEdition).FirstOrDefault(static value => !string.IsNullOrEmpty(value)),
-            SourceOsDisplayVersion = group.Select(static row => row.SourceOsDisplayVersion).FirstOrDefault(static value => !string.IsNullOrEmpty(value)),
-            MessageFileVersion = group.Select(static row => row.MessageFileVersion).FirstOrDefault(static value => !string.IsNullOrEmpty(value))
+            SourceOsBuild = newestProvenance.SourceOsBuild,
+            SourceOsRevision = newestProvenance.SourceOsRevision,
+            SourceOsEdition = newestProvenance.SourceOsEdition,
+            SourceOsDisplayVersion = newestProvenance.SourceOsDisplayVersion,
+            MessageFileVersion = newestProvenance.MessageFileVersion
         };
+    }
+
+    private static ProviderDetails SelectNewestProvenanceRow(List<ProviderDetails> group)
+    {
+        var newest = group[0];
+
+        for (var index = 1; index < group.Count; index++)
+        {
+            if (CompareProvenanceForMerge(group[index], newest) > 0) { newest = group[index]; }
+        }
+
+        return newest;
     }
 }

--- a/src/EventLogExpert.Provider.Database/Maintenance/ProviderDetailsMerger.cs
+++ b/src/EventLogExpert.Provider.Database/Maintenance/ProviderDetailsMerger.cs
@@ -13,13 +13,13 @@ internal static class ProviderDetailsMerger
         string databasePath)
     {
         var merged = new List<ProviderDetails>(rows.Count);
-        var firstIndexByGroup = new Dictionary<(string ProviderName, string VersionKey), int>(ProviderIdentityComparer.Instance);
-        var groupedRows = new Dictionary<(string ProviderName, string VersionKey), List<ProviderDetails>>(ProviderIdentityComparer.Instance);
+        var firstIndexByGroup = new Dictionary<ProviderIdentity, int>();
+        var groupedRows = new Dictionary<ProviderIdentity, List<ProviderDetails>>();
 
         for (var i = 0; i < rows.Count; i++)
         {
             var row = rows[i];
-            var key = (row.ProviderName, row.VersionKey);
+            var key = ProviderIdentity.Of(row);
 
             if (firstIndexByGroup.TryAdd(key, i))
             {
@@ -34,7 +34,7 @@ internal static class ProviderDetailsMerger
         foreach (var (_, firstIndex) in firstIndexByGroup.OrderBy(kvp => kvp.Value))
         {
             var first = rows[firstIndex];
-            var group = groupedRows[(first.ProviderName, first.VersionKey)];
+            var group = groupedRows[ProviderIdentity.Of(first)];
 
             if (group.Count == 1)
             {
@@ -267,20 +267,6 @@ internal static class ProviderDetailsMerger
     private static bool MessagesAreEquivalent(MessageModel a, MessageModel b) =>
         string.Equals(a.Text, b.Text, StringComparison.Ordinal) &&
         string.Equals(a.Template, b.Template, StringComparison.Ordinal);
-
-    private sealed class ProviderIdentityComparer : IEqualityComparer<(string ProviderName, string VersionKey)>
-    {
-        public static readonly ProviderIdentityComparer Instance = new();
-
-        public bool Equals((string ProviderName, string VersionKey) x, (string ProviderName, string VersionKey) y) =>
-            string.Equals(x.ProviderName, y.ProviderName, StringComparison.OrdinalIgnoreCase) &&
-            string.Equals(x.VersionKey, y.VersionKey, StringComparison.Ordinal);
-
-        public int GetHashCode((string ProviderName, string VersionKey) obj) =>
-            HashCode.Combine(
-                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.ProviderName),
-                StringComparer.Ordinal.GetHashCode(obj.VersionKey));
-    }
 
     private readonly record struct MessageIdentity(short ShortId, long RawId, string? LogLink, string? Tag);
 

--- a/src/EventLogExpert.Provider.Database/Maintenance/ProviderDetailsMerger.cs
+++ b/src/EventLogExpert.Provider.Database/Maintenance/ProviderDetailsMerger.cs
@@ -67,6 +67,9 @@ internal static class ProviderDetailsMerger
         return setA.SetEquals(setB);
     }
 
+    private static bool MapsAreEquivalent(ValueMapDefinition a, ValueMapDefinition b) =>
+        a.IsBitMap == b.IsBitMap && a.Entries.SequenceEqual(b.Entries);
+
     private static IReadOnlyList<EventModel> MergeEvents(
         IEnumerable<EventModel> events,
         string canonicalProviderName,
@@ -102,9 +105,24 @@ internal static class ProviderDetailsMerger
     {
         var canonicalName = group[0].ProviderName;
 
+        var distinctVersionKeys = group
+            .Select(row => row.VersionKey)
+            .Where(versionKey => !string.IsNullOrEmpty(versionKey))
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        if (distinctVersionKeys.Count > 1)
+        {
+            throw new DatabaseUpgradeException(
+                databasePath,
+                $"Provider '{canonicalName}' has rows with distinct VersionKeys ({string.Join(", ", distinctVersionKeys)}). " +
+                "Merging by provider name alone would discard distinct provider versions; a tuple-keyed merge is required.");
+        }
+
         return new ProviderDetails
         {
             ProviderName = canonicalName,
+            VersionKey = group[0].VersionKey,
             Messages = MergeMessages(group.SelectMany(r => r.Messages), canonicalName, databasePath),
             Parameters = MergeMessages(group.SelectMany(r => r.Parameters), canonicalName, databasePath),
             Events = MergeEvents(group.SelectMany(r => r.Events), canonicalName, databasePath),
@@ -126,11 +144,43 @@ internal static class ProviderDetailsMerger
                 databasePath,
                 "Tasks",
                 key => key.ToString()),
+            Maps = MergeMaps(group.Select(r => r.Maps), canonicalName, databasePath),
             ResolvedFromOwningPublisher = MergeResolvedFromOwningPublisher(
                 group.Select(r => r.ResolvedFromOwningPublisher),
                 canonicalName,
                 databasePath)
         };
+    }
+
+    private static IReadOnlyDictionary<string, ValueMapDefinition> MergeMaps(
+        IEnumerable<IReadOnlyDictionary<string, ValueMapDefinition>> maps,
+        string canonicalProviderName,
+        string databasePath)
+    {
+        var merged = new Dictionary<string, ValueMapDefinition>(StringComparer.Ordinal);
+
+        foreach (var map in maps)
+        {
+            foreach (var (name, definition) in map)
+            {
+                if (!merged.TryGetValue(name, out var existing))
+                {
+                    merged[name] = definition;
+
+                    continue;
+                }
+
+                if (!MapsAreEquivalent(existing, definition))
+                {
+                    throw new DatabaseUpgradeException(
+                        databasePath,
+                        $"Provider '{canonicalProviderName}' has conflicting Map entries for '{name}'. " +
+                        $"Cannot merge case-insensitive duplicates with different value-map definitions.");
+                }
+            }
+        }
+
+        return merged;
     }
 
     private static IReadOnlyList<MessageModel> MergeMessages(

--- a/src/EventLogExpert.Provider.Database/Maintenance/ProviderDetailsMerger.cs
+++ b/src/EventLogExpert.Provider.Database/Maintenance/ProviderDetailsMerger.cs
@@ -49,226 +49,76 @@ internal static class ProviderDetailsMerger
         return merged;
     }
 
-    private static bool EventsAreEquivalent(EventModel a, EventModel b) =>
-        a.Level == b.Level &&
-        a.Opcode == b.Opcode &&
-        a.Task == b.Task &&
-        KeywordsEqual(a.Keywords, b.Keywords) &&
-        string.Equals(a.Template, b.Template, StringComparison.Ordinal) &&
-        string.Equals(a.Description, b.Description, StringComparison.Ordinal);
-
-    private static bool KeywordsEqual(long[] a, long[] b)
-    {
-        if (a.Length == 0 && b.Length == 0) { return true; }
-
-        var setA = new HashSet<long>(a);
-        var setB = new HashSet<long>(b);
-
-        return setA.SetEquals(setB);
-    }
-
-    private static bool MapsAreEquivalent(ValueMapDefinition a, ValueMapDefinition b) =>
-        a.IsBitMap == b.IsBitMap && a.Entries.SequenceEqual(b.Entries);
-
-    private static IReadOnlyList<EventModel> MergeEvents(
-        IEnumerable<EventModel> events,
-        string canonicalProviderName,
-        string databasePath)
-    {
-        var seen = new Dictionary<EventIdentity, EventModel>();
-
-        foreach (var evt in events)
-        {
-            var identity = new EventIdentity(evt.Id, evt.Version, evt.LogName);
-
-            if (!seen.TryGetValue(identity, out var existing))
-            {
-                seen[identity] = evt;
-
-                continue;
-            }
-
-            if (!EventsAreEquivalent(existing, evt))
-            {
-                throw new DatabaseUpgradeException(
-                    databasePath,
-                    $"Provider '{canonicalProviderName}' has conflicting Event rows for Id={evt.Id}, " +
-                    $"Version={evt.Version}, LogName='{evt.LogName}'. " +
-                    $"Cannot merge case-insensitive duplicates with different Level/Opcode/Task/Keywords/Template/Description values.");
-            }
-        }
-
-        return seen.Values.ToList();
-    }
-
+    // Rows in a group share the same (ProviderName, VersionKey) identity (the grouping key), so the merged row carries
+    // that VersionKey forward; only name case-folding differences and duplicate content are collapsed. The identity keys
+    // and equivalence rules come from ProviderContentMerge so the database-merge path and the resolve-time multi-version
+    // union cannot drift. Here every non-equivalent collision is corruption: the onConflict callbacks throw, which
+    // short-circuits the merge exactly as the previous inline loops did.
     private static ProviderDetails MergeGroup(List<ProviderDetails> group, string databasePath)
     {
         var canonicalName = group[0].ProviderName;
 
-        // Rows in a group share the same (ProviderName, VersionKey) identity (the grouping key), so the merged row
-        // carries that VersionKey forward; only name case-folding differences and duplicate content are collapsed.
         return new ProviderDetails
         {
             ProviderName = canonicalName,
             VersionKey = group[0].VersionKey,
-            Messages = MergeMessages(group.SelectMany(r => r.Messages), canonicalName, databasePath),
-            Parameters = MergeMessages(group.SelectMany(r => r.Parameters), canonicalName, databasePath),
-            Events = MergeEvents(group.SelectMany(r => r.Events), canonicalName, databasePath),
-            Keywords = MergeStringDictionary(
-                group.Select(r => r.Keywords),
-                canonicalName,
-                databasePath,
-                "Keywords",
-                key => key.ToString()),
-            Opcodes = MergeStringDictionary(
-                group.Select(r => r.Opcodes),
-                canonicalName,
-                databasePath,
-                "Opcodes",
-                key => key.ToString()),
-            Tasks = MergeStringDictionary(
-                group.Select(r => r.Tasks),
-                canonicalName,
-                databasePath,
-                "Tasks",
-                key => key.ToString()),
-            Maps = MergeMaps(group.Select(r => r.Maps), canonicalName, databasePath),
-            ResolvedFromOwningPublisher = MergeResolvedFromOwningPublisher(
-                group.Select(r => r.ResolvedFromOwningPublisher),
-                canonicalName,
-                databasePath)
+            Messages = ProviderContentMerge.Deduplicate(
+                group.SelectMany(static row => row.Messages),
+                ProviderContentMerge.IdentityOf,
+                ProviderContentMerge.MessagesAreEquivalent,
+                (_, duplicate) => throw new DatabaseUpgradeException(
+                    databasePath,
+                    $"Provider '{canonicalName}' has conflicting Message rows for ShortId={duplicate.ShortId}, " +
+                    $"RawId={duplicate.RawId}, LogLink='{duplicate.LogLink}', Tag='{duplicate.Tag}'. " +
+                    $"Cannot merge case-insensitive duplicates with different Text or Template values.")),
+            Parameters = ProviderContentMerge.Deduplicate(
+                group.SelectMany(static row => row.Parameters),
+                ProviderContentMerge.IdentityOf,
+                ProviderContentMerge.MessagesAreEquivalent,
+                (_, duplicate) => throw new DatabaseUpgradeException(
+                    databasePath,
+                    $"Provider '{canonicalName}' has conflicting Message rows for ShortId={duplicate.ShortId}, " +
+                    $"RawId={duplicate.RawId}, LogLink='{duplicate.LogLink}', Tag='{duplicate.Tag}'. " +
+                    $"Cannot merge case-insensitive duplicates with different Text or Template values.")),
+            Events = ProviderContentMerge.Deduplicate(
+                group.SelectMany(static row => row.Events),
+                ProviderContentMerge.IdentityOf,
+                ProviderContentMerge.EventsAreEquivalent,
+                (_, duplicate) => throw new DatabaseUpgradeException(
+                    databasePath,
+                    $"Provider '{canonicalName}' has conflicting Event rows for Id={duplicate.Id}, " +
+                    $"Version={duplicate.Version}, LogName='{duplicate.LogName}'. " +
+                    $"Cannot merge case-insensitive duplicates with different Level/Opcode/Task/Keywords/Template/Description values.")),
+            Keywords = ProviderContentMerge.MergeStringDictionary(
+                group.Select(static row => row.Keywords),
+                (key, existing, value) => throw new DatabaseUpgradeException(
+                    databasePath,
+                    $"Provider '{canonicalName}' has conflicting Keywords entries for key {key}: " +
+                    $"'{existing}' vs '{value}'.")),
+            Opcodes = ProviderContentMerge.MergeStringDictionary(
+                group.Select(static row => row.Opcodes),
+                (key, existing, value) => throw new DatabaseUpgradeException(
+                    databasePath,
+                    $"Provider '{canonicalName}' has conflicting Opcodes entries for key {key}: " +
+                    $"'{existing}' vs '{value}'.")),
+            Tasks = ProviderContentMerge.MergeStringDictionary(
+                group.Select(static row => row.Tasks),
+                (key, existing, value) => throw new DatabaseUpgradeException(
+                    databasePath,
+                    $"Provider '{canonicalName}' has conflicting Tasks entries for key {key}: " +
+                    $"'{existing}' vs '{value}'.")),
+            Maps = ProviderContentMerge.MergeMaps(
+                group.Select(static row => row.Maps),
+                (name, _, _) => throw new DatabaseUpgradeException(
+                    databasePath,
+                    $"Provider '{canonicalName}' has conflicting Map entries for '{name}'. " +
+                    $"Cannot merge case-insensitive duplicates with different value-map definitions.")),
+            ResolvedFromOwningPublisher = ProviderContentMerge.MergeScalarFirstNonEmpty(
+                group.Select(static row => row.ResolvedFromOwningPublisher),
+                (winner, value) => throw new DatabaseUpgradeException(
+                    databasePath,
+                    $"Provider '{canonicalName}' has conflicting ResolvedFromOwningPublisher values: " +
+                    $"'{winner}' vs '{value}'."))
         };
     }
-
-    private static IReadOnlyDictionary<string, ValueMapDefinition> MergeMaps(
-        IEnumerable<IReadOnlyDictionary<string, ValueMapDefinition>> maps,
-        string canonicalProviderName,
-        string databasePath)
-    {
-        var merged = new Dictionary<string, ValueMapDefinition>(StringComparer.Ordinal);
-
-        foreach (var map in maps)
-        {
-            foreach (var (name, definition) in map)
-            {
-                if (!merged.TryGetValue(name, out var existing))
-                {
-                    merged[name] = definition;
-
-                    continue;
-                }
-
-                if (!MapsAreEquivalent(existing, definition))
-                {
-                    throw new DatabaseUpgradeException(
-                        databasePath,
-                        $"Provider '{canonicalProviderName}' has conflicting Map entries for '{name}'. " +
-                        $"Cannot merge case-insensitive duplicates with different value-map definitions.");
-                }
-            }
-        }
-
-        return merged;
-    }
-
-    private static IReadOnlyList<MessageModel> MergeMessages(
-        IEnumerable<MessageModel> messages,
-        string canonicalProviderName,
-        string databasePath)
-    {
-        var seen = new Dictionary<MessageIdentity, MessageModel>();
-
-        foreach (var message in messages)
-        {
-            var identity = new MessageIdentity(message.ShortId, message.RawId, message.LogLink, message.Tag);
-
-            if (!seen.TryGetValue(identity, out var existing))
-            {
-                seen[identity] = message;
-                continue;
-            }
-
-            if (!MessagesAreEquivalent(existing, message))
-            {
-                throw new DatabaseUpgradeException(
-                    databasePath,
-                    $"Provider '{canonicalProviderName}' has conflicting Message rows for ShortId={message.ShortId}, " +
-                    $"RawId={message.RawId}, LogLink='{message.LogLink}', Tag='{message.Tag}'. " +
-                    $"Cannot merge case-insensitive duplicates with different Text or Template values.");
-            }
-        }
-
-        return seen.Values.ToList();
-    }
-
-    private static string? MergeResolvedFromOwningPublisher(
-        IEnumerable<string?> values,
-        string canonicalProviderName,
-        string databasePath)
-    {
-        string? winner = null;
-
-        foreach (var value in values)
-        {
-            if (string.IsNullOrEmpty(value)) { continue; }
-
-            if (winner is null)
-            {
-                winner = value;
-                continue;
-            }
-
-            if (!string.Equals(winner, value, StringComparison.Ordinal))
-            {
-                throw new DatabaseUpgradeException(
-                    databasePath,
-                    $"Provider '{canonicalProviderName}' has conflicting ResolvedFromOwningPublisher values: " +
-                    $"'{winner}' vs '{value}'.");
-            }
-        }
-
-        return winner;
-    }
-
-    private static IDictionary<TKey, string> MergeStringDictionary<TKey>(
-        IEnumerable<IDictionary<TKey, string>> dictionaries,
-        string canonicalProviderName,
-        string databasePath,
-        string memberName,
-        Func<TKey, string> keyDescriber)
-        where TKey : notnull
-    {
-        var merged = new Dictionary<TKey, string>();
-
-        foreach (var dict in dictionaries)
-        {
-            foreach (var (key, value) in dict)
-            {
-                if (!merged.TryGetValue(key, out var existing))
-                {
-                    merged[key] = value;
-
-                    continue;
-                }
-
-                if (!string.Equals(existing, value, StringComparison.Ordinal))
-                {
-                    throw new DatabaseUpgradeException(
-                        databasePath,
-                        $"Provider '{canonicalProviderName}' has conflicting {memberName} entries for key {keyDescriber(key)}: " +
-                        $"'{existing}' vs '{value}'.");
-                }
-            }
-        }
-
-        return merged;
-    }
-
-    private static bool MessagesAreEquivalent(MessageModel a, MessageModel b) =>
-        string.Equals(a.Text, b.Text, StringComparison.Ordinal) &&
-        string.Equals(a.Template, b.Template, StringComparison.Ordinal);
-
-    private readonly record struct MessageIdentity(short ShortId, long RawId, string? LogLink, string? Tag);
-
-    private readonly record struct EventIdentity(long Id, byte Version, string? LogName);
 }

--- a/src/EventLogExpert.Provider.Database/Serialization/ProviderJsonContext.cs
+++ b/src/EventLogExpert.Provider.Database/Serialization/ProviderJsonContext.cs
@@ -17,4 +17,8 @@ namespace EventLogExpert.ProviderDatabase.Serialization;
 [JsonSerializable(typeof(List<EventModel>))]
 [JsonSerializable(typeof(Dictionary<long, string>))]
 [JsonSerializable(typeof(Dictionary<int, string>))]
+[JsonSerializable(typeof(IReadOnlyDictionary<string, ValueMapDefinition>))]
+[JsonSerializable(typeof(Dictionary<string, ValueMapDefinition>))]
+[JsonSerializable(typeof(ValueMapDefinition))]
+[JsonSerializable(typeof(ValueMapEntry))]
 internal partial class ProviderJsonContext : JsonSerializerContext;

--- a/src/EventLogExpert.Provider/Lookup/IProviderDetailsLookup.cs
+++ b/src/EventLogExpert.Provider/Lookup/IProviderDetailsLookup.cs
@@ -10,6 +10,8 @@ public interface IProviderDetailsLookup : IDisposable
 {
     string Name { get; }
 
+    IReadOnlyList<ProviderDetails> FindAllProviderVersions(string providerName);
+
     ProviderDetails? FindProvider(string providerName);
 
     DatabaseSchemaState IsUpgradeNeeded();

--- a/src/EventLogExpert.Provider/Resolution/DatabasePathSorter.cs
+++ b/src/EventLogExpert.Provider/Resolution/DatabasePathSorter.cs
@@ -3,23 +3,6 @@
 
 namespace EventLogExpert.Provider.Resolution;
 
-/// <summary>
-///     Sorts provider-database identifiers (full paths or bare file names) into resolver load-priority order, so that
-///     load-priority cascading works the same regardless of which layer is invoking it.
-/// </summary>
-/// <remarks>
-///     <para>
-///         Order is: ascending by product name, then descending by version (numeric where the version token parses as an
-///         integer so "10" sorts after "2"), then descending by raw version string for tie-breaks. Inputs whose
-///         extensionless file name does not end in a space-delimited version token are sorted by their full extensionless
-///         name with no version key.
-///     </para>
-///     <para>
-///         Returned strings are the originals — directory and extension are used only for key extraction, never for
-///         reconstruction. A caller passing full paths gets full paths back; a caller passing bare file names gets bare
-///         file names back.
-///     </para>
-/// </remarks>
 public static class DatabasePathSorter
 {
     /// <summary>Sort identifiers in resolver load-priority order. Returns originals unchanged.</summary>

--- a/src/EventLogExpert.Provider/Resolution/ProviderContentMerge.cs
+++ b/src/EventLogExpert.Provider/Resolution/ProviderContentMerge.cs
@@ -1,0 +1,189 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Provider.Resolution;
+
+/// <summary>
+///     Shared deduplication primitives for collapsing the content of two or more provider rows that describe the same
+///     logical provider. Two callers consume these: the database upgrade/merge path (which treats a non-equivalent
+///     collision as corruption and throws) and, later, the resolve-time multi-version union (which treats a non-equivalent
+///     collision as legitimate version divergence and records it). Keeping the identity keys and equivalence rules in one
+///     place stops the two paths from drifting - a field one path collapses on but the other does not would desynchronize
+///     merge from union and silently change which row wins.
+/// </summary>
+public static class ProviderContentMerge
+{
+    /// <summary>
+    ///     Deduplicates <paramref name="items" /> by identity, keeping the first occurrence of each identity in
+    ///     first-seen order (matching the prior <c>Dictionary.Values</c> enumeration with no removals). When a later item
+    ///     shares an earlier item's identity but is not equivalent to it, <paramref name="onConflict" /> is invoked
+    ///     synchronously with (existing, duplicate) - so a throwing callback short-circuits the merge exactly as before - and
+    ///     the existing winner is otherwise retained.
+    /// </summary>
+    public static List<TModel> Deduplicate<TIdentity, TModel>(
+        IEnumerable<TModel> items,
+        Func<TModel, TIdentity> identitySelector,
+        Func<TModel, TModel, bool> areEquivalent,
+        Action<TModel, TModel> onConflict)
+        where TIdentity : notnull
+    {
+        var winners = new Dictionary<TIdentity, TModel>();
+        var order = new List<TIdentity>();
+
+        foreach (var item in items)
+        {
+            var identity = identitySelector(item);
+
+            if (!winners.TryGetValue(identity, out var existing))
+            {
+                winners[identity] = item;
+                order.Add(identity);
+
+                continue;
+            }
+
+            if (!areEquivalent(existing, item))
+            {
+                onConflict(existing, item);
+            }
+        }
+
+        var result = new List<TModel>(order.Count);
+
+        foreach (var identity in order)
+        {
+            result.Add(winners[identity]);
+        }
+
+        return result;
+    }
+
+    public static bool EventsAreEquivalent(EventModel left, EventModel right) =>
+        left.Level == right.Level &&
+        left.Opcode == right.Opcode &&
+        left.Task == right.Task &&
+        KeywordsEqual(left.Keywords, right.Keywords) &&
+        string.Equals(left.Template, right.Template, StringComparison.Ordinal) &&
+        string.Equals(left.Description, right.Description, StringComparison.Ordinal);
+
+    /// <summary>Extracts the <see cref="MessageIdentity" /> of a message row.</summary>
+    public static MessageIdentity IdentityOf(MessageModel message) =>
+        new(message.ShortId, message.RawId, message.LogLink, message.Tag);
+
+    /// <summary>Extracts the <see cref="EventIdentity" /> of an event row.</summary>
+    public static EventIdentity IdentityOf(EventModel @event) =>
+        new(@event.Id, @event.Version, @event.LogName);
+
+    public static bool MapsAreEquivalent(ValueMapDefinition left, ValueMapDefinition right) =>
+        left.IsBitMap == right.IsBitMap && left.Entries.SequenceEqual(right.Entries);
+
+    /// <summary>
+    ///     Merges value-map dictionaries (ordinal key comparison), keeping the first definition seen for each name. When
+    ///     a later dictionary maps a known name to a non-equivalent definition, <paramref name="onConflict" /> is invoked with
+    ///     (name, existing, duplicate).
+    /// </summary>
+    public static Dictionary<string, ValueMapDefinition> MergeMaps(
+        IEnumerable<IReadOnlyDictionary<string, ValueMapDefinition>> maps,
+        Action<string, ValueMapDefinition, ValueMapDefinition> onConflict)
+    {
+        var merged = new Dictionary<string, ValueMapDefinition>(StringComparer.Ordinal);
+
+        foreach (var map in maps)
+        {
+            foreach (var (name, definition) in map)
+            {
+                if (!merged.TryGetValue(name, out var existing))
+                {
+                    merged[name] = definition;
+
+                    continue;
+                }
+
+                if (!MapsAreEquivalent(existing, definition))
+                {
+                    onConflict(name, existing, definition);
+                }
+            }
+        }
+
+        return merged;
+    }
+
+    /// <summary>
+    ///     Picks the first non-empty value, invoking <paramref name="onConflict" /> with (winner, duplicate) when a later
+    ///     non-empty value disagrees with the winner. Returns null when every value is null or empty.
+    /// </summary>
+    public static string? MergeScalarFirstNonEmpty(IEnumerable<string?> values, Action<string, string> onConflict)
+    {
+        string? winner = null;
+
+        foreach (var value in values)
+        {
+            if (string.IsNullOrEmpty(value)) { continue; }
+
+            if (winner is null)
+            {
+                winner = value;
+
+                continue;
+            }
+
+            if (!string.Equals(winner, value, StringComparison.Ordinal))
+            {
+                onConflict(winner, value);
+            }
+        }
+
+        return winner;
+    }
+
+    /// <summary>
+    ///     Merges string-valued dictionaries, keeping the first value seen for each key (default
+    ///     <typeparamref name="TKey" /> equality). When a later dictionary maps a known key to a different value,
+    ///     <paramref name="onConflict" /> is invoked with (key, existing, duplicate).
+    /// </summary>
+    public static Dictionary<TKey, string> MergeStringDictionary<TKey>(
+        IEnumerable<IDictionary<TKey, string>> dictionaries,
+        Action<TKey, string, string> onConflict)
+        where TKey : notnull
+    {
+        var merged = new Dictionary<TKey, string>();
+
+        foreach (var dictionary in dictionaries)
+        {
+            foreach (var (key, value) in dictionary)
+            {
+                if (!merged.TryGetValue(key, out var existing))
+                {
+                    merged[key] = value;
+
+                    continue;
+                }
+
+                if (!string.Equals(existing, value, StringComparison.Ordinal))
+                {
+                    onConflict(key, existing, value);
+                }
+            }
+        }
+
+        return merged;
+    }
+
+    public static bool MessagesAreEquivalent(MessageModel left, MessageModel right) =>
+        string.Equals(left.Text, right.Text, StringComparison.Ordinal) &&
+        string.Equals(left.Template, right.Template, StringComparison.Ordinal);
+
+    private static bool KeywordsEqual(long[] left, long[] right)
+    {
+        if (left.Length == 0 && right.Length == 0) { return true; }
+
+        return new HashSet<long>(left).SetEquals(right);
+    }
+
+    /// <summary>Identity of a message-table row, matching the database merge key exactly.</summary>
+    public readonly record struct MessageIdentity(short ShortId, long RawId, string? LogLink, string? Tag);
+
+    /// <summary>Identity of a modern event row, matching the database merge key exactly.</summary>
+    public readonly record struct EventIdentity(long Id, byte Version, string? LogName);
+}

--- a/src/EventLogExpert.Provider/Resolution/ProviderDetails.cs
+++ b/src/EventLogExpert.Provider/Resolution/ProviderDetails.cs
@@ -71,6 +71,13 @@ public sealed class ProviderDetails
 
     public IDictionary<int, string> Tasks { get; set; } = new Dictionary<int, string>();
 
+    /// <summary>
+    ///     Content version of this provider - a hash of the rendering payload, stamped at db-create, so identical
+    ///     providers collapse to one row and genuinely different versions coexist. Empty for single-version / legacy
+    ///     databases.
+    /// </summary>
+    public string VersionKey { get; set; } = string.Empty;
+
     /// <summary>Gets events matching the given Id using a pre-built lookup dictionary.</summary>
     public IReadOnlyList<EventModel> GetEventsById(long id)
     {

--- a/src/EventLogExpert.Provider/Resolution/ProviderDetails.cs
+++ b/src/EventLogExpert.Provider/Resolution/ProviderDetails.cs
@@ -69,6 +69,16 @@ public sealed class ProviderDetails
 
     public string? ResolvedFromOwningPublisher { get; set; }
 
+    public int? SourceOsBuild { get; set; }
+
+    public int? SourceOsRevision { get; set; }
+
+    public string? SourceOsEdition { get; set; }
+
+    public string? SourceOsDisplayVersion { get; set; }
+
+    public string? MessageFileVersion { get; set; }
+
     public IDictionary<int, string> Tasks { get; set; } = new Dictionary<int, string>();
 
     /// <summary>
@@ -78,7 +88,6 @@ public sealed class ProviderDetails
     /// </summary>
     public string VersionKey { get; set; } = string.Empty;
 
-    /// <summary>Gets events matching the given Id using a pre-built lookup dictionary.</summary>
     public IReadOnlyList<EventModel> GetEventsById(long id)
     {
         _eventsByIdLookup ??= BuildEventsByIdLookup();
@@ -86,17 +95,9 @@ public sealed class ProviderDetails
         return _eventsByIdLookup.TryGetValue(id, out var list) ? list : [];
     }
 
-    /// <summary>
-    ///     Gets messages matching the given ShortId (compared as unsigned, matching the implicit ushort-to-int promotion
-    ///     used by callers). Materialized on demand from the compact store and cached.
-    /// </summary>
     public IReadOnlyList<MessageModel> GetMessagesByShortId(int shortId) =>
         _messageStore?.GetByShortId(shortId) ?? [];
 
-    /// <summary>
-    ///     Gets the first parameter message with the given RawId, or null when none matches. Duplicate RawIds resolve
-    ///     first-wins. Materialized on demand from the compact store and cached.
-    /// </summary>
     public MessageModel? GetParameterByRawId(long rawId) => _parameterStore?.GetByRawIdFirst(rawId);
 
     public void SetLazyMessageSource(ILazyMessageSource source)

--- a/src/EventLogExpert.Provider/Resolution/ProviderIdentity.cs
+++ b/src/EventLogExpert.Provider/Resolution/ProviderIdentity.cs
@@ -1,0 +1,32 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Provider.Resolution;
+
+/// <summary>
+///     Identity of a provider row: its name (case-insensitive, matching the database's NOCASE primary key) paired
+///     with its content <see cref="ProviderDetails.VersionKey" /> (ordinal). Two rows share an identity only when both the
+///     case-folded name and the version key match, so case-only name duplicates collapse while genuinely different
+///     versions of the same provider are kept apart. This is the single identity type used wherever provider rows are
+///     deduplicated, skipped, or deleted by identity.
+/// </summary>
+/// <remarks>
+///     Equality is overridden because the default record-struct equality compares <see cref="ProviderName" />
+///     ordinally (case-sensitive), which disagrees with the database's NOCASE key. Equality and hashing are null-safe, so
+///     a <c>default</c> instance (null members) is inert rather than a crash hazard; construct real identities through the
+///     primary constructor or <see cref="Of" />.
+/// </remarks>
+public readonly record struct ProviderIdentity(string ProviderName, string VersionKey)
+{
+    public bool Equals(ProviderIdentity other) =>
+        string.Equals(ProviderName, other.ProviderName, StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(VersionKey, other.VersionKey, StringComparison.Ordinal);
+
+    public override int GetHashCode() =>
+        HashCode.Combine(
+            ProviderName?.GetHashCode(StringComparison.OrdinalIgnoreCase) ?? 0,
+            VersionKey?.GetHashCode(StringComparison.Ordinal) ?? 0);
+
+    /// <summary>Extracts the <see cref="ProviderIdentity" /> of a provider row.</summary>
+    public static ProviderIdentity Of(ProviderDetails provider) => new(provider.ProviderName, provider.VersionKey);
+}

--- a/src/EventLogExpert.Provider/Resolution/ProviderIdentity.cs
+++ b/src/EventLogExpert.Provider/Resolution/ProviderIdentity.cs
@@ -4,29 +4,59 @@
 namespace EventLogExpert.Provider.Resolution;
 
 /// <summary>
-///     Identity of a provider row: its name (case-insensitive, matching the database's NOCASE primary key) paired
-///     with its content <see cref="ProviderDetails.VersionKey" /> (ordinal). Two rows share an identity only when both the
-///     case-folded name and the version key match, so case-only name duplicates collapse while genuinely different
-///     versions of the same provider are kept apart. This is the single identity type used wherever provider rows are
-///     deduplicated, skipped, or deleted by identity.
+///     Identity of a provider row: its name (case-insensitive over ASCII only, matching the database's NOCASE primary
+///     key) paired with its content <see cref="ProviderDetails.VersionKey" /> (ordinal). Two rows share an identity only
+///     when both the ASCII-case-folded name and the version key match, so case-only ASCII name duplicates collapse while
+///     names that differ by non-ASCII case (which SQLite NOCASE keeps distinct) and genuinely different versions are kept
+///     apart. This is the single identity type used wherever provider rows are deduplicated, skipped, or deleted by
+///     identity.
 /// </summary>
 /// <remarks>
-///     Equality is overridden because the default record-struct equality compares <see cref="ProviderName" />
-///     ordinally (case-sensitive), which disagrees with the database's NOCASE key. Equality and hashing are null-safe, so
-///     a <c>default</c> instance (null members) is inert rather than a crash hazard; construct real identities through the
-///     primary constructor or <see cref="Of" />.
+///     Equality matches the database's <c>NOCASE</c> collation EXACTLY: NOCASE folds only ASCII A-Z/a-z, so an
+///     in-memory identity that used full-Unicode case folding (e.g. <see cref="StringComparison.OrdinalIgnoreCase" />)
+///     would treat two distinct primary-key rows as one and desynchronize dedup/skip/delete from what the composite key
+///     enforces. Equality and hashing are null-safe, so a <c>default</c> instance (null members) is inert rather than a
+///     crash hazard; construct real identities through the primary constructor or <see cref="Of" />.
 /// </remarks>
 public readonly record struct ProviderIdentity(string ProviderName, string VersionKey)
 {
     public bool Equals(ProviderIdentity other) =>
-        string.Equals(ProviderName, other.ProviderName, StringComparison.OrdinalIgnoreCase) &&
+        NameEquals(ProviderName, other.ProviderName) &&
         string.Equals(VersionKey, other.VersionKey, StringComparison.Ordinal);
 
-    public override int GetHashCode() =>
-        HashCode.Combine(
-            ProviderName?.GetHashCode(StringComparison.OrdinalIgnoreCase) ?? 0,
-            VersionKey?.GetHashCode(StringComparison.Ordinal) ?? 0);
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+
+        foreach (var character in ProviderName ?? string.Empty)
+        {
+            hash.Add(AsciiToUpper(character));
+        }
+
+        hash.Add(VersionKey is null ? 0 : VersionKey.GetHashCode(StringComparison.Ordinal));
+
+        return hash.ToHashCode();
+    }
 
     /// <summary>Extracts the <see cref="ProviderIdentity" /> of a provider row.</summary>
     public static ProviderIdentity Of(ProviderDetails provider) => new(provider.ProviderName, provider.VersionKey);
+
+    // SQLite's NOCASE collation folds ONLY ASCII A-Z/a-z (characters with diacritics stay distinct), so fold the name
+    // the same way here. Hashing folds identically, so equal names always produce equal hash codes.
+    private static bool NameEquals(string? left, string? right)
+    {
+        if (ReferenceEquals(left, right)) { return true; }
+
+        if (left is null || right is null || left.Length != right.Length) { return false; }
+
+        for (var index = 0; index < left.Length; index++)
+        {
+            if (AsciiToUpper(left[index]) != AsciiToUpper(right[index])) { return false; }
+        }
+
+        return true;
+    }
+
+    private static char AsciiToUpper(char character) =>
+        character is >= 'a' and <= 'z' ? (char)(character - ('a' - 'A')) : character;
 }

--- a/src/EventLogExpert.Provider/Resolution/ProviderSourceRecency.cs
+++ b/src/EventLogExpert.Provider/Resolution/ProviderSourceRecency.cs
@@ -1,0 +1,58 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Provider.Resolution;
+
+/// <summary>
+///     Orders two providers by source recency (newest first): OS build, then update revision (UBR), then the newest
+///     message-DLL file version. Component-wise lexicographic - at each level a present value outranks a null/unparseable
+///     one, and equal/absent values fall through to the next. Shared by <see cref="ProviderVersionSelector" /> (the
+///     resolve-time tiebreak) and <c>ProviderDetailsMerger</c> (the deterministic provenance carry when collapsing
+///     duplicates) so the two paths can never disagree on which source is newer.
+/// </summary>
+public static class ProviderSourceRecency
+{
+    /// <summary>
+    ///     Returns &gt; 0 when <paramref name="candidate" /> is the newer source, &lt; 0 when <paramref name="current" />
+    ///     is, and 0 when neither can be ordered (all provenance absent or equal - the caller then keeps its own stable
+    ///     order).
+    /// </summary>
+    public static int Compare(ProviderDetails candidate, ProviderDetails current)
+    {
+        var byBuild = CompareNullableInt(candidate.SourceOsBuild, current.SourceOsBuild);
+
+        if (byBuild != 0) { return byBuild; }
+
+        var byRevision = CompareNullableInt(candidate.SourceOsRevision, current.SourceOsRevision);
+
+        if (byRevision != 0) { return byRevision; }
+
+        return CompareFileVersion(candidate.MessageFileVersion, current.MessageFileVersion);
+    }
+
+    private static int CompareFileVersion(string? candidate, string? current)
+    {
+        var candidateVersion = TryParseVersion(candidate);
+        var currentVersion = TryParseVersion(current);
+
+        if (candidateVersion is not null && currentVersion is not null)
+        {
+            return candidateVersion.CompareTo(currentVersion);
+        }
+
+        if (candidateVersion is not null) { return 1; }
+
+        return currentVersion is not null ? -1 : 0;
+    }
+
+    private static int CompareNullableInt(int? candidate, int? current)
+    {
+        if (candidate.HasValue && current.HasValue) { return candidate.Value.CompareTo(current.Value); }
+
+        if (candidate.HasValue) { return 1; }
+
+        return current.HasValue ? -1 : 0;
+    }
+
+    private static Version? TryParseVersion(string? value) => Version.TryParse(value, out var version) ? version : null;
+}

--- a/src/EventLogExpert.Provider/Resolution/ProviderVersionSelector.cs
+++ b/src/EventLogExpert.Provider/Resolution/ProviderVersionSelector.cs
@@ -23,9 +23,14 @@ public static class ProviderVersionSelector
             var candidate = candidates[index];
             var score = ScoreOf(candidate);
 
-            // Strictly-greater wins; a tie keeps the current best, so the newest-first load order is the final
-            // deterministic tiebreak.
-            if (score.CompareTo(bestScore) > 0)
+            var comparison = score.CompareTo(bestScore);
+
+            // Completeness is primary; recency (newest source) breaks completeness ties so a newer-but-empty capture
+            // never beats an older-but-populated one. A full tie keeps the current best, so the newest-first load
+            // order remains the final deterministic tiebreak.
+            if (comparison == 0) { comparison = CompareRecency(candidate, best); }
+
+            if (comparison > 0)
             {
                 best = candidate;
                 bestScore = score;
@@ -33,6 +38,43 @@ public static class ProviderVersionSelector
         }
 
         return best;
+    }
+
+    private static int CompareFileVersion(string? candidate, string? current)
+    {
+        var candidateVersion = TryParseVersion(candidate);
+        var currentVersion = TryParseVersion(current);
+
+        if (candidateVersion is not null && currentVersion is not null)
+        {
+            return candidateVersion.CompareTo(currentVersion);
+        }
+
+        if (candidateVersion is not null) { return 1; }
+
+        return currentVersion is not null ? -1 : 0;
+    }
+
+    private static int CompareNullableInt(int? candidate, int? current)
+    {
+        if (candidate.HasValue && current.HasValue) { return candidate.Value.CompareTo(current.Value); }
+
+        if (candidate.HasValue) { return 1; }
+
+        return current.HasValue ? -1 : 0;
+    }
+
+    private static int CompareRecency(ProviderDetails candidate, ProviderDetails current)
+    {
+        var byBuild = CompareNullableInt(candidate.SourceOsBuild, current.SourceOsBuild);
+
+        if (byBuild != 0) { return byBuild; }
+
+        var byRevision = CompareNullableInt(candidate.SourceOsRevision, current.SourceOsRevision);
+
+        return byRevision != 0 ?
+            byRevision :
+            CompareFileVersion(candidate.MessageFileVersion, current.MessageFileVersion);
     }
 
     private static CompletenessScore ScoreOf(ProviderDetails provider)
@@ -52,6 +94,8 @@ public static class ProviderVersionSelector
 
         return new CompletenessScore(nonEmptyDescriptions, totalDescriptionLength, provider.MessageSource?.Count ?? 0);
     }
+
+    private static Version? TryParseVersion(string? value) => Version.TryParse(value, out var version) ? version : null;
 
     private readonly record struct CompletenessScore(int NonEmptyDescriptions, long TotalDescriptionLength, int MessageCount)
         : IComparable<CompletenessScore>

--- a/src/EventLogExpert.Provider/Resolution/ProviderVersionSelector.cs
+++ b/src/EventLogExpert.Provider/Resolution/ProviderVersionSelector.cs
@@ -1,0 +1,70 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Provider.Resolution;
+
+public static class ProviderVersionSelector
+{
+    /// <summary>
+    ///     Returns null when <paramref name="candidates" /> is empty, the only candidate when there is one (unchanged,
+    ///     same reference), or the most-complete version when several coexist.
+    /// </summary>
+    public static ProviderDetails? SelectMostComplete(IReadOnlyList<ProviderDetails> candidates)
+    {
+        if (candidates.Count == 0) { return null; }
+
+        if (candidates.Count == 1) { return candidates[0]; }
+
+        var best = candidates[0];
+        var bestScore = ScoreOf(best);
+
+        for (var index = 1; index < candidates.Count; index++)
+        {
+            var candidate = candidates[index];
+            var score = ScoreOf(candidate);
+
+            // Strictly-greater wins; a tie keeps the current best, so the newest-first load order is the final
+            // deterministic tiebreak.
+            if (score.CompareTo(bestScore) > 0)
+            {
+                best = candidate;
+                bestScore = score;
+            }
+        }
+
+        return best;
+    }
+
+    private static CompletenessScore ScoreOf(ProviderDetails provider)
+    {
+        var nonEmptyDescriptions = 0;
+        long totalDescriptionLength = 0;
+
+        foreach (var @event in provider.Events)
+        {
+            var description = @event.Description;
+
+            if (string.IsNullOrEmpty(description)) { continue; }
+
+            nonEmptyDescriptions++;
+            totalDescriptionLength += description.Length;
+        }
+
+        return new CompletenessScore(nonEmptyDescriptions, totalDescriptionLength, provider.MessageSource?.Count ?? 0);
+    }
+
+    private readonly record struct CompletenessScore(int NonEmptyDescriptions, long TotalDescriptionLength, int MessageCount)
+        : IComparable<CompletenessScore>
+    {
+        public int CompareTo(CompletenessScore other)
+        {
+            var byDescriptions = NonEmptyDescriptions.CompareTo(other.NonEmptyDescriptions);
+
+            if (byDescriptions != 0) { return byDescriptions; }
+
+            var byLength = TotalDescriptionLength.CompareTo(other.TotalDescriptionLength);
+
+            return byLength != 0 ? byLength : MessageCount.CompareTo(other.MessageCount);
+        }
+    }
+}

--- a/src/EventLogExpert.Provider/Resolution/ProviderVersionSelector.cs
+++ b/src/EventLogExpert.Provider/Resolution/ProviderVersionSelector.cs
@@ -28,7 +28,7 @@ public static class ProviderVersionSelector
             // Completeness is primary; recency (newest source) breaks completeness ties so a newer-but-empty capture
             // never beats an older-but-populated one. A full tie keeps the current best, so the newest-first load
             // order remains the final deterministic tiebreak.
-            if (comparison == 0) { comparison = CompareRecency(candidate, best); }
+            if (comparison == 0) { comparison = ProviderSourceRecency.Compare(candidate, best); }
 
             if (comparison > 0)
             {
@@ -38,43 +38,6 @@ public static class ProviderVersionSelector
         }
 
         return best;
-    }
-
-    private static int CompareFileVersion(string? candidate, string? current)
-    {
-        var candidateVersion = TryParseVersion(candidate);
-        var currentVersion = TryParseVersion(current);
-
-        if (candidateVersion is not null && currentVersion is not null)
-        {
-            return candidateVersion.CompareTo(currentVersion);
-        }
-
-        if (candidateVersion is not null) { return 1; }
-
-        return currentVersion is not null ? -1 : 0;
-    }
-
-    private static int CompareNullableInt(int? candidate, int? current)
-    {
-        if (candidate.HasValue && current.HasValue) { return candidate.Value.CompareTo(current.Value); }
-
-        if (candidate.HasValue) { return 1; }
-
-        return current.HasValue ? -1 : 0;
-    }
-
-    private static int CompareRecency(ProviderDetails candidate, ProviderDetails current)
-    {
-        var byBuild = CompareNullableInt(candidate.SourceOsBuild, current.SourceOsBuild);
-
-        if (byBuild != 0) { return byBuild; }
-
-        var byRevision = CompareNullableInt(candidate.SourceOsRevision, current.SourceOsRevision);
-
-        return byRevision != 0 ?
-            byRevision :
-            CompareFileVersion(candidate.MessageFileVersion, current.MessageFileVersion);
     }
 
     private static CompletenessScore ScoreOf(ProviderDetails provider)
@@ -94,8 +57,6 @@ public static class ProviderVersionSelector
 
         return new CompletenessScore(nonEmptyDescriptions, totalDescriptionLength, provider.MessageSource?.Count ?? 0);
     }
-
-    private static Version? TryParseVersion(string? value) => Version.TryParse(value, out var version) ? version : null;
 
     private readonly record struct CompletenessScore(int NonEmptyDescriptions, long TotalDescriptionLength, int MessageCount)
         : IComparable<CompletenessScore>

--- a/src/EventLogExpert.Provider/Schema/DatabaseSchemaState.cs
+++ b/src/EventLogExpert.Provider/Schema/DatabaseSchemaState.cs
@@ -5,5 +5,5 @@ namespace EventLogExpert.Provider.Schema;
 
 public sealed record DatabaseSchemaState(int CurrentVersion)
 {
-    public bool NeedsUpgrade => CurrentVersion < DatabaseSchemaVersion.Current;
+    public bool NeedsUpgrade { get; init; } = CurrentVersion < DatabaseSchemaVersion.Current;
 }

--- a/src/EventLogExpert.Provider/Schema/DatabaseSchemaVersion.cs
+++ b/src/EventLogExpert.Provider/Schema/DatabaseSchemaVersion.cs
@@ -6,5 +6,6 @@ namespace EventLogExpert.Provider.Schema;
 public static class DatabaseSchemaVersion
 {
     public const int Current = 4;
+
     public const int Unknown = 0;
 }

--- a/src/EventLogExpert.Runtime/Database/DatabaseClassificationService.cs
+++ b/src/EventLogExpert.Runtime/Database/DatabaseClassificationService.cs
@@ -86,14 +86,17 @@ internal sealed class DatabaseClassificationService
             });
     }
 
-    private static DatabaseStatus MapSchemaVersionToStatus(int currentVersion) =>
-        currentVersion switch
+    private static DatabaseStatus MapSchemaStateToStatus(DatabaseSchemaState state)
+    {
+        if (!state.NeedsUpgrade) { return DatabaseStatus.Ready; }
+
+        return state.CurrentVersion switch
         {
-            DatabaseSchemaVersion.Current => DatabaseStatus.Ready,
-            3 => DatabaseStatus.UpgradeRequired,
             1 or 2 => DatabaseStatus.ObsoleteSchema,
-            _ => DatabaseStatus.UnrecognizedSchema,
+            DatabaseSchemaVersion.Unknown => DatabaseStatus.UnrecognizedSchema,
+            _ => DatabaseStatus.UpgradeRequired,
         };
+    }
 
     private (DatabaseStatus Status, bool BackupExists) ClassifyEntry(
         DatabaseEntry entry,
@@ -109,7 +112,7 @@ internal sealed class DatabaseClassificationService
             }
 
             var state = _maintenance.CheckSchemaState(entry.FullPath);
-            var status = MapSchemaVersionToStatus(state.CurrentVersion);
+            var status = MapSchemaStateToStatus(state);
             var backupExists = ProbeOrCleanupBackup(entry, status);
 
             return (status, backupExists);

--- a/src/EventLogExpert.Runtime/Database/DatabaseFileOperations.cs
+++ b/src/EventLogExpert.Runtime/Database/DatabaseFileOperations.cs
@@ -94,8 +94,7 @@ internal static class DatabaseFileOperations
     {
         try
         {
-            return maintenance.CheckSchemaState(fullPath, readOnly: true)
-                .CurrentVersion == DatabaseSchemaVersion.Current;
+            return !maintenance.CheckSchemaState(fullPath, readOnly: true).NeedsUpgrade;
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -109,8 +108,6 @@ internal static class DatabaseFileOperations
     private static void SafeLog(Action log)
     {
         try { log(); }
-        catch
-        { /* Logger faults must not propagate from defensive logging sites. */
-        }
+        catch { /* Logger faults must not propagate from defensive logging sites. */ }
     }
 }

--- a/tests/Integration/EventLogExpert.DatabaseTools.IntegrationTests/Operations/CreateDatabaseOperationTests.cs
+++ b/tests/Integration/EventLogExpert.DatabaseTools.IntegrationTests/Operations/CreateDatabaseOperationTests.cs
@@ -7,6 +7,7 @@ using EventLogExpert.Eventing.TestUtils.Constants;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Logging.Abstractions.Handlers;
 using EventLogExpert.ProviderDatabase.Context;
+using EventLogExpert.ProviderDatabase.Hashing;
 using NSubstitute;
 using System.Text.RegularExpressions;
 
@@ -16,6 +17,58 @@ public sealed class CreateDatabaseCommandTests : IDisposable
 {
     private readonly List<string> _tempDirs = [];
     private readonly List<string> _tempPaths = [];
+
+    [Fact]
+    public async Task CreateDatabase_FolderSourceWithSameContentUnderDifferentKeys_CollapsesInsteadOfColliding()
+    {
+        // Two source files hold the SAME provider with byte-identical content but different stored VersionKeys (one
+        // unstamped legacy row, one already hashed). The cross-file dedup keys on the source key, so both survive
+        // load, then both re-hash to the same key. Without a post-stamp guard they would collide on the composite
+        // primary key and abort the create; they must instead collapse to one row.
+        var dir = CreateTempDir();
+
+        var unstamped = DatabaseTestUtils.BuildProviderDetails(Constants.FirstProviderName);
+        var stamped = DatabaseTestUtils.BuildProviderDetails(Constants.FirstProviderName);
+        stamped.VersionKey = VersionKeyCalculator.Compute(stamped);
+
+        DatabaseTestUtils.CreateV4Database(Path.Combine(dir, "a.db"), unstamped);
+        DatabaseTestUtils.CreateV4Database(Path.Combine(dir, "b.db"), stamped);
+
+        var path = CreateTempPath();
+        var logger = Substitute.For<ITraceLogger>();
+
+        await new CreateDatabaseOperation(new CreateDatabaseRequest(path, dir, null, null)).ExecuteAsync(logger, null, CancellationToken.None);
+
+        Assert.True(File.Exists(path), "Create should have produced a database (collapsed, not aborted).");
+
+        using var verify = new ProviderDbContext(path, readOnly: true, ensureCreated: false);
+        var single = Assert.Single(verify.ProviderDetails.ToList());
+        Assert.Equal(Constants.FirstProviderName, single.ProviderName);
+        Assert.StartsWith("vk1:", single.VersionKey);
+        logger.DidNotReceive().Error(Arg.Any<ErrorLogHandler>());
+    }
+
+    [Fact]
+    public async Task CreateDatabase_StampsContentHashVersionKey()
+    {
+        // A source provider with an empty (unstamped) VersionKey must come out of create with its content hash
+        // stamped, so the composite (name, version) primary key can hold genuinely different versions of a provider
+        // and identical providers collapse to one row.
+        var source = CreateTempPath();
+        DatabaseTestUtils.CreateV4Database(source, DatabaseTestUtils.BuildProviderDetails(Constants.FirstProviderName));
+
+        var path = CreateTempPath();
+        var logger = Substitute.For<ITraceLogger>();
+
+        await new CreateDatabaseOperation(new CreateDatabaseRequest(path, source, null, null)).ExecuteAsync(logger, null, CancellationToken.None);
+
+        await using var context = new ProviderDbContext(path, readOnly: true, ensureCreated: false);
+        var created = context.ProviderDetails.Single();
+
+        Assert.Equal(Constants.FirstProviderName, created.ProviderName);
+        Assert.StartsWith("vk1:", created.VersionKey);
+        Assert.Equal(VersionKeyCalculator.Compute(created), created.VersionKey);
+    }
 
     [Fact]
     public async Task CreateDatabase_WhenExtensionNotDb_LogsErrorAndDoesNotCreateFile()
@@ -255,6 +308,14 @@ public sealed class CreateDatabaseCommandTests : IDisposable
         {
             DatabaseTestUtils.DeleteDirectoryRecursive(dir);
         }
+    }
+
+    private string CreateTempDir()
+    {
+        var dir = DatabaseTestUtils.CreateTempDirectory();
+        _tempDirs.Add(dir);
+
+        return dir;
     }
 
     private string CreateTempPath()

--- a/tests/Integration/EventLogExpert.DatabaseTools.IntegrationTests/Operations/DiffDatabaseOperationTests.cs
+++ b/tests/Integration/EventLogExpert.DatabaseTools.IntegrationTests/Operations/DiffDatabaseOperationTests.cs
@@ -16,6 +16,40 @@ public sealed class DiffDatabaseCommandTests : IDisposable
     private readonly List<string> _tempPaths = [];
 
     [Fact]
+    public async Task DiffDatabase_CopiesNewVersionOfNameAlsoPresentInFirstSource()
+    {
+        var first = CreateTempDb();
+        var second = CreateTempDb();
+        var output = CreateTempDb();
+
+        var firstV1 = DatabaseTestUtils.BuildProviderDetails(Constants.SharedProviderName);
+        firstV1.VersionKey = "vk1";
+        DatabaseTestUtils.CreateV4Database(first, firstV1);
+
+        var secondV1 = DatabaseTestUtils.BuildProviderDetails(Constants.SharedProviderName);
+        secondV1.VersionKey = "vk1";
+        var secondV2 = DatabaseTestUtils.BuildProviderDetails(Constants.SharedProviderName);
+        secondV2.VersionKey = "vk2";
+        DatabaseTestUtils.CreateV4Database(second, secondV1, secondV2);
+
+        File.Delete(output);
+
+        var logger = Substitute.For<ITraceLogger>();
+
+        // The diff skips by identity, so the second source's new vk2 version of a name also in the first source (only
+        // as vk1) is still treated as "missing from first" and copied. A name-level skip would drop it entirely.
+        await new DiffDatabaseOperation(new DiffDatabaseRequest(first, second, output)).ExecuteAsync(logger, null, CancellationToken.None);
+
+        Assert.True(File.Exists(output), "Diff should have created the output database.");
+
+        await using var verify = new ProviderDbContext(output, readOnly: true, ensureCreated: false);
+        var rows = verify.ProviderDetails.ToList();
+        var copied = Assert.Single(rows);
+        Assert.Equal(Constants.SharedProviderName, copied.ProviderName);
+        Assert.Equal("vk2", copied.VersionKey);
+    }
+
+    [Fact]
     public async Task DiffDatabase_PreservesResolvedFromOwningPublisher()
     {
         // Arrange — first source has Shared, second source has Shared and Second.

--- a/tests/Integration/EventLogExpert.DatabaseTools.IntegrationTests/Operations/MergeDatabaseOperationTests.cs
+++ b/tests/Integration/EventLogExpert.DatabaseTools.IntegrationTests/Operations/MergeDatabaseOperationTests.cs
@@ -6,6 +6,7 @@ using EventLogExpert.Eventing.TestUtils;
 using EventLogExpert.Eventing.TestUtils.Constants;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Logging.Abstractions.Handlers;
+using EventLogExpert.ProviderDatabase.Context;
 using NSubstitute;
 
 namespace EventLogExpert.DatabaseTools.IntegrationTests.Operations;
@@ -74,6 +75,98 @@ public sealed class MergeDatabaseCommandTests : IDisposable
 
         logger.Received().Error(Arg.Is<ErrorLogHandler>(handler =>
             handler.ToString().Contains("unrecognized schema") && handler.ToString().Contains(target)));
+    }
+
+    [Fact]
+    public async Task MergeDatabaseWithoutOverwrite_CopiesNewVersionOfExistingProviderName()
+    {
+        var source = CreateTempDb();
+        var target = CreateTempDb();
+
+        var targetV1 = DatabaseTestUtils.BuildProviderDetails(Constants.FirstProviderName);
+        targetV1.VersionKey = "vk1";
+        DatabaseTestUtils.CreateV4Database(target, targetV1);
+
+        var sourceV1 = DatabaseTestUtils.BuildProviderDetails(Constants.FirstProviderName);
+        sourceV1.VersionKey = "vk1";
+        var sourceV2 = DatabaseTestUtils.BuildProviderDetails(Constants.FirstProviderName);
+        sourceV2.VersionKey = "vk2";
+        DatabaseTestUtils.CreateV4Database(source, sourceV1, sourceV2);
+
+        var logger = Substitute.For<ITraceLogger>();
+
+        // Without overwrite, the merge skips only the (name, vk1) identity already in the target and still copies the
+        // source's new vk2 version of the same name. A name-level skip would drop vk2 as a duplicate name.
+        await new MergeDatabaseOperation(new MergeDatabaseRequest(source, target, false)).ExecuteAsync(logger, null, CancellationToken.None);
+
+        Assert.Equal(["vk1", "vk2"], ReadVersionKeys(target, Constants.FirstProviderName));
+    }
+
+    [Fact]
+    public async Task MergeDatabaseWithOverwrite_NonAsciiCaseVariantNames_DoesNotCollide()
+    {
+        var source = CreateTempDb();
+        var target = CreateTempDb();
+
+        // Provider names differing only by NON-ASCII case (U+00C4 vs U+00E4). SQLite NOCASE folds only ASCII, so
+        // these are DISTINCT primary-key rows; the in-memory identity must treat them as distinct too, or an overwrite
+        // merge deletes only one and then re-inserts both, hitting a primary-key collision.
+        DatabaseTestUtils.CreateV4Database(source,
+            DatabaseTestUtils.BuildProviderDetails("Provider-\u00c4"),
+            DatabaseTestUtils.BuildProviderDetails("Provider-\u00e4"));
+        DatabaseTestUtils.CreateV4Database(target,
+            DatabaseTestUtils.BuildProviderDetails("Provider-\u00c4"),
+            DatabaseTestUtils.BuildProviderDetails("Provider-\u00e4"));
+
+        var logger = Substitute.For<ITraceLogger>();
+
+        await new MergeDatabaseOperation(new MergeDatabaseRequest(source, target, true)).ExecuteAsync(logger, null, CancellationToken.None);
+
+        using var context = new ProviderDbContext(target, readOnly: true, ensureCreated: false);
+        var names = context.ProviderDetails
+            .Select(p => p.ProviderName)
+            .AsEnumerable()
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(["Provider-\u00c4", "Provider-\u00e4"], names);
+    }
+
+    [Fact]
+    public async Task MergeDatabaseWithOverwrite_RemovesOnlyCollidingVersionAndKeepsOtherTargetVersion()
+    {
+        var source = CreateTempDb();
+        var target = CreateTempDb();
+
+        var targetV1 = DatabaseTestUtils.BuildProviderDetails(Constants.FirstProviderName);
+        targetV1.VersionKey = "vk1";
+        var targetV2 = DatabaseTestUtils.BuildProviderDetails(Constants.FirstProviderName);
+        targetV2.VersionKey = "vk2";
+        DatabaseTestUtils.CreateV4Database(target, targetV1, targetV2);
+
+        var sourceV1 = DatabaseTestUtils.BuildProviderDetails(Constants.FirstProviderName);
+        sourceV1.VersionKey = "vk1";
+        DatabaseTestUtils.CreateV4Database(source, sourceV1);
+
+        var logger = Substitute.For<ITraceLogger>();
+
+        // Overwrite deletes only the colliding (name, vk1) identity by composite key and re-copies it from the source;
+        // the target's vk2 version, which the source does not carry, must survive. A name-level delete would drop vk2.
+        await new MergeDatabaseOperation(new MergeDatabaseRequest(source, target, true)).ExecuteAsync(logger, null, CancellationToken.None);
+
+        Assert.Equal(["vk1", "vk2"], ReadVersionKeys(target, Constants.FirstProviderName));
+    }
+
+    private static string[] ReadVersionKeys(string databasePath, string providerName)
+    {
+        using var context = new ProviderDbContext(databasePath, readOnly: true, ensureCreated: false);
+
+        return context.ProviderDetails
+            .Where(p => p.ProviderName == providerName)
+            .Select(p => p.VersionKey)
+            .AsEnumerable()
+            .OrderBy(versionKey => versionKey, StringComparer.Ordinal)
+            .ToArray();
     }
 
     private string CreateTempDb()

--- a/tests/Integration/EventLogExpert.DatabaseTools.IntegrationTests/Operations/MergeDatabaseOperationTests.cs
+++ b/tests/Integration/EventLogExpert.DatabaseTools.IntegrationTests/Operations/MergeDatabaseOperationTests.cs
@@ -1,6 +1,7 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.DatabaseTools.Common.Operations;
 using EventLogExpert.DatabaseTools.MergeDatabase;
 using EventLogExpert.Eventing.TestUtils;
 using EventLogExpert.Eventing.TestUtils.Constants;
@@ -57,6 +58,26 @@ public sealed class MergeDatabaseCommandTests : IDisposable
 
         logger.Received().Error(Arg.Is<ErrorLogHandler>(handler =>
             handler.ToString().Contains("unrecognized schema") && handler.ToString().Contains(target)));
+    }
+
+    [Fact]
+    public async Task MergeDatabase_WithSourceNeedingUpgrade_FailsInsteadOfReportingSuccess()
+    {
+        var source = CreateTempDb();
+        var target = CreateTempDb();
+
+        // A pre-stamp (v3) source is classified as needing an upgrade. Merge must FAIL with a clear error rather than
+        // silently reporting success while copying nothing (mirrors the diff operation's source-schema validation).
+        DatabaseTestUtils.CreateV3Database(source);
+        DatabaseTestUtils.CreateV4Database(target, DatabaseTestUtils.BuildProviderDetails(Constants.FirstProviderName));
+
+        var logger = Substitute.For<ITraceLogger>();
+
+        var outcome = await new MergeDatabaseOperation(new MergeDatabaseRequest(source, target, false))
+            .ExecuteAsync(logger, null, CancellationToken.None);
+
+        Assert.Equal(DatabaseToolsOutcome.Failed, outcome);
+        logger.Received().Error(Arg.Is<ErrorLogHandler>(handler => handler.ToString().Contains(source)));
     }
 
     [Fact]

--- a/tests/Integration/EventLogExpert.DatabaseTools.IntegrationTests/Sources/ProviderSourceTests.cs
+++ b/tests/Integration/EventLogExpert.DatabaseTools.IntegrationTests/Sources/ProviderSourceTests.cs
@@ -6,6 +6,7 @@ using EventLogExpert.Eventing.TestUtils;
 using EventLogExpert.Eventing.TestUtils.Constants;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Logging.Abstractions.Handlers;
+using EventLogExpert.Provider.Resolution;
 using NSubstitute;
 
 namespace EventLogExpert.DatabaseTools.IntegrationTests.Sources;
@@ -26,6 +27,69 @@ public sealed class ProviderSourceTests : IDisposable
         {
             DatabaseTestUtils.DeleteDirectoryRecursive(dir);
         }
+    }
+
+    [Fact]
+    public async Task LoadProviders_NonAsciiCaseVariantNamesInOneDatabase_LoadsBoth()
+    {
+        // Arrange - SQLite's NOCASE primary-key collation folds only ASCII, so provider names differing solely by
+        // non-ASCII case (here U+00E9 vs U+00C9) are DISTINCT rows that coexist in one database. The reload-by-name
+        // path must de-duplicate names ordinally; folding them via OrdinalIgnoreCase or the identity HashSet (both of
+        // which fold all of Unicode) would collapse the two names to one and silently drop a row.
+        var dbPath = CreateTempDb();
+        var lower = DatabaseTestUtils.BuildProviderDetails("Provider-\u00e9");
+        var upper = DatabaseTestUtils.BuildProviderDetails("Provider-\u00c9");
+        DatabaseTestUtils.CreateV4Database(dbPath, lower, upper);
+        var logger = Substitute.For<ITraceLogger>();
+
+        // Act
+        var loaded = new List<ProviderDetails>();
+
+        await foreach (var provider in ProviderSource.LoadProvidersAsync(
+            dbPath, logger, cancellationToken: TestContext.Current.CancellationToken))
+        {
+            loaded.Add(provider);
+        }
+
+        // Assert - both case variants load; neither is collapsed away.
+        Assert.Equal(2, loaded.Count);
+        Assert.Contains(loaded, provider => provider.ProviderName == "Provider-\u00e9");
+        Assert.Contains(loaded, provider => provider.ProviderName == "Provider-\u00c9");
+    }
+
+    [Fact]
+    public async Task LoadProviders_SameNameDistinctVersionsAcrossFiles_LoadsBothVersions()
+    {
+        // Arrange - two source files carry the same provider name but distinct VersionKeys, i.e. different provider
+        // versions. The cross-file `seen` dedup is keyed by identity (name, version), not name alone, so both must
+        // load rather than the second file's version being dropped as a name-duplicate. VersionKey is empty in
+        // production today; this guards the behavior once content hashing makes versions coexist.
+        var dir = CreateTempDir();
+        var first = Path.Combine(dir, "first.db");
+        var second = Path.Combine(dir, "second.db");
+
+        var firstVersion = DatabaseTestUtils.BuildProviderDetails(Constants.FirstProviderName);
+        firstVersion.VersionKey = "vk1";
+        var secondVersion = DatabaseTestUtils.BuildProviderDetails(Constants.FirstProviderName);
+        secondVersion.VersionKey = "vk2";
+
+        DatabaseTestUtils.CreateV4Database(first, firstVersion);
+        DatabaseTestUtils.CreateV4Database(second, secondVersion);
+        var logger = Substitute.For<ITraceLogger>();
+
+        // Act
+        var loaded = new List<ProviderDetails>();
+
+        await foreach (var provider in ProviderSource.LoadProvidersAsync(
+            dir, logger, cancellationToken: TestContext.Current.CancellationToken))
+        {
+            loaded.Add(provider);
+        }
+
+        // Assert
+        Assert.Equal(2, loaded.Count);
+        Assert.Equal(["vk1", "vk2"], loaded.Select(p => p.VersionKey).OrderBy(v => v, StringComparer.Ordinal).ToArray());
+        Assert.All(loaded, provider => Assert.Equal(Constants.FirstProviderName, provider.ProviderName));
     }
 
     [Fact]

--- a/tests/Integration/EventLogExpert.DatabaseTools.IntegrationTests/Sources/ProviderSourceTests.cs
+++ b/tests/Integration/EventLogExpert.DatabaseTools.IntegrationTests/Sources/ProviderSourceTests.cs
@@ -30,6 +30,26 @@ public sealed class ProviderSourceTests : IDisposable
     }
 
     [Fact]
+    public async Task LoadProviderIdentities_NonAsciiCaseVariantNames_ReturnsDeterministicOrder()
+    {
+        // Two names differing only by non-ASCII case (U+00C9 vs U+00E9) are distinct identities but tie under the
+        // OrdinalIgnoreCase primary sort; the ordinal tiebreak must order them deterministically (U+00C9 < U+00E9)
+        // regardless of the source HashSet's iteration order.
+        var dbPath = CreateTempDb();
+        DatabaseTestUtils.CreateV4Database(dbPath,
+            DatabaseTestUtils.BuildProviderDetails("Provider-\u00e9"),
+            DatabaseTestUtils.BuildProviderDetails("Provider-\u00c9"));
+        var logger = Substitute.For<ITraceLogger>();
+
+        var identities = await ProviderSource.LoadProviderIdentitiesAsync(
+            dbPath, logger, cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(
+            ["Provider-\u00c9", "Provider-\u00e9"],
+            identities.Select(identity => identity.ProviderName).ToList());
+    }
+
+    [Fact]
     public async Task LoadProviders_NonAsciiCaseVariantNamesInOneDatabase_LoadsBoth()
     {
         // Arrange - SQLite's NOCASE primary-key collation folds only ASCII, so provider names differing solely by

--- a/tests/Integration/EventLogExpert.Eventing.IntegrationTests/PublisherMetadata/HostOsProvenanceTests.cs
+++ b/tests/Integration/EventLogExpert.Eventing.IntegrationTests/PublisherMetadata/HostOsProvenanceTests.cs
@@ -1,0 +1,62 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.PublisherMetadata;
+using Microsoft.Win32;
+
+namespace EventLogExpert.Eventing.IntegrationTests.PublisherMetadata;
+
+public sealed class HostOsProvenanceTests
+{
+    [Fact]
+    public void Empty_HasAllNullFields()
+    {
+        var empty = HostOsProvenance.Empty;
+
+        Assert.Null(empty.Build);
+        Assert.Null(empty.Revision);
+        Assert.Null(empty.Edition);
+        Assert.Null(empty.DisplayVersion);
+    }
+
+    [Fact]
+    public void Read_OnWindowsHost_PopulatesEditionRevisionAndDisplayVersion()
+    {
+        using var hklm = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Default);
+        using var currentVersion = hklm.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion");
+
+        Assert.NotNull(currentVersion);
+
+        var expectedEdition = currentVersion.GetValue("EditionID") as string;
+        var expectedDisplayVersion = currentVersion.GetValue("DisplayVersion") as string;
+
+        // UBR is present on every supported build; the read must surface it as the recency secondary.
+        var expectedRevision = currentVersion.GetValue("UBR") is int ubr ? ubr : (int?)null;
+
+        var provenance = HostOsProvenance.Read();
+
+        Assert.Equal(expectedEdition, provenance.Edition);
+        Assert.Equal(expectedRevision, provenance.Revision);
+        Assert.Equal(expectedDisplayVersion, provenance.DisplayVersion);
+    }
+
+    [Fact]
+    public void Read_OnWindowsHost_ReturnsBuildMatchingRegistry()
+    {
+        // The host always has CurrentBuildNumber under CurrentVersion, so a live read must populate the recency
+        // primary (Build). Compare against a direct registry read so the test is self-validating, not hard-coded.
+        using var hklm = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Default);
+        using var currentVersion = hklm.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion");
+
+        Assert.NotNull(currentVersion);
+
+        var expectedBuild = int.TryParse(currentVersion.GetValue("CurrentBuildNumber") as string, out var build)
+            ? build
+            : (int?)null;
+
+        var provenance = HostOsProvenance.Read();
+
+        Assert.Equal(expectedBuild, provenance.Build);
+        Assert.NotNull(provenance.Build);
+    }
+}

--- a/tests/Integration/EventLogExpert.Eventing.IntegrationTests/Resolvers/EventProviderDatabaseEventResolverTests.cs
+++ b/tests/Integration/EventLogExpert.Eventing.IntegrationTests/Resolvers/EventProviderDatabaseEventResolverTests.cs
@@ -229,6 +229,23 @@ public sealed class EventResolverDatabaseTests
     }
 
     [Fact]
+    public void Dispose_ThenResolveEvent_ShouldThrowObjectDisposedException()
+    {
+        // Arrange
+        var dbCollection = Substitute.For<IActiveDatabases>();
+        dbCollection.Paths.Returns([]);
+        var resolver = new EventResolver(dbCollection, factory: new ProviderDbContextFactory());
+
+        var eventRecord = EventUtils.CreateBasicEvent();
+
+        // Act
+        resolver.Dispose();
+
+        // Assert
+        Assert.Throws<ObjectDisposedException>(() => resolver.ResolveEvent(eventRecord));
+    }
+
+    [Fact]
     public void Dispose_ThenResolveEventViaBaseReference_ShouldThrowObjectDisposedException()
     {
         // Arrange
@@ -246,23 +263,6 @@ public sealed class EventResolverDatabaseTests
 
         // Assert - This should throw because ResolveEvent is overridden, not hidden with 'new'
         Assert.Throws<ObjectDisposedException>(() => baseResolver.ResolveEvent(eventRecord));
-    }
-
-    [Fact]
-    public void Dispose_ThenResolveEvent_ShouldThrowObjectDisposedException()
-    {
-        // Arrange
-        var dbCollection = Substitute.For<IActiveDatabases>();
-        dbCollection.Paths.Returns([]);
-        var resolver = new EventResolver(dbCollection, factory: new ProviderDbContextFactory());
-
-        var eventRecord = EventUtils.CreateBasicEvent();
-
-        // Act
-        resolver.Dispose();
-
-        // Assert
-        Assert.Throws<ObjectDisposedException>(() => resolver.ResolveEvent(eventRecord));
     }
 
     [Fact]
@@ -412,6 +412,72 @@ public sealed class EventResolverDatabaseTests
     }
 
     [Fact]
+    public void LoadProviderDetails_WhenProviderInMultipleDatabases_ShouldSelectMostCompleteVersion()
+    {
+        // Arrange
+        // "Exchange 2019" sorts before "Windows 2019", so the less-complete version is loaded FIRST. Selection must be
+        // by completeness, not load order / file name, so the more-complete Windows version must still win.
+        string lessCompletePath = Path.Combine(Path.GetTempPath(), $"Exchange 2019_{Guid.NewGuid()}.db");
+        string moreCompletePath = Path.Combine(Path.GetTempPath(), $"Windows 2019_{Guid.NewGuid()}.db");
+
+        const string winningDescription = "Selected from the more complete database";
+
+        try
+        {
+            // Less-complete version: this event's description is an empty capture gap.
+            using (var lessComplete = new ProviderDbContext(lessCompletePath, false))
+            {
+                lessComplete.ProviderDetails.Add(EventUtils.CreateProvider(
+                    Constants.TestProviderName,
+                    events: [EventUtils.CreateEventModel(1000, "", version: 0, logName: Constants.ApplicationLogName, template: "")]));
+
+                lessComplete.SaveChanges();
+            }
+
+            // More-complete version: the same event carries a real description.
+            using (var moreComplete = new ProviderDbContext(moreCompletePath, false))
+            {
+                moreComplete.ProviderDetails.Add(EventUtils.CreateProvider(
+                    Constants.TestProviderName,
+                    events: [EventUtils.CreateEventModel(1000, winningDescription, version: 0, logName: Constants.ApplicationLogName, template: "")]));
+
+                moreComplete.SaveChanges();
+            }
+
+            var dbCollection = Substitute.For<IActiveDatabases>();
+            dbCollection.Paths.Returns(ImmutableList.Create(lessCompletePath, moreCompletePath));
+            var logger = Substitute.For<ITraceLogger>();
+
+            using var resolver = new EventResolver(dbCollection, logger: logger, factory: new ProviderDbContextFactory());
+
+            var eventRecord = new EventRecord
+            {
+                ProviderName = Constants.TestProviderName,
+                Id = 1000,
+                Version = 0,
+                LogName = Constants.ApplicationLogName
+            };
+
+            // Act
+            var resolved = resolver.ResolveEvent(eventRecord);
+
+            // Assert
+            // Resolution gathered both versions across all active databases and selected the most-complete one (no
+            // file-name "first database wins" pick), so the populated description wins over the other database's empty.
+            Assert.Contains(winningDescription, resolved.Description);
+            logger.Received(1).Debug(Arg.Is<DebugLogHandler>(h =>
+                h.ToString().Contains("Resolved") &&
+                h.ToString().Contains(Constants.TestProviderName) &&
+                h.ToString().Contains("2 database version(s)")));
+        }
+        finally
+        {
+            DeleteDatabaseFile(lessCompletePath);
+            DeleteDatabaseFile(moreCompletePath);
+        }
+    }
+
+    [Fact]
     public void LoadProviderDetails_WithCaseInsensitiveProviderName_ShouldResolve()
     {
         // Arrange
@@ -448,58 +514,6 @@ public sealed class EventResolverDatabaseTests
         finally
         {
             DeleteDatabaseFile(dbPath);
-        }
-    }
-
-    [Fact]
-    public void LoadProviderDetails_WithFirstDatabaseContainingProvider_ShouldUseFirstDatabase()
-    {
-        // Arrange
-        string dbPath1 = Path.Combine(Path.GetTempPath(), $"Exchange 2019_{Guid.NewGuid()}.db");
-        string dbPath2 = Path.Combine(Path.GetTempPath(), $"Windows 2019_{Guid.NewGuid()}.db");
-
-        try
-        {
-            using (var context1 = new ProviderDbContext(dbPath1, false))
-            {
-                context1.ProviderDetails.Add(EventUtils.CreateProvider(Constants.TestProviderName));
-
-                context1.SaveChanges();
-            }
-
-            using (var context2 = new ProviderDbContext(dbPath2, false))
-            {
-                context2.ProviderDetails.Add(EventUtils.CreateProvider(Constants.TestProviderName));
-
-                context2.SaveChanges();
-            }
-
-            var dbCollection = Substitute.For<IActiveDatabases>();
-            dbCollection.Paths.Returns(ImmutableList.Create(dbPath1, dbPath2));
-            var logger = Substitute.For<ITraceLogger>();
-
-            using var resolver = new EventResolver(dbCollection, logger: logger, factory: new ProviderDbContextFactory());
-
-            var eventRecord = new EventRecord
-            {
-                ProviderName = Constants.TestProviderName,
-                Id = 1000
-            };
-
-            // Act
-            resolver.LoadProviderDetails(eventRecord);
-
-            // Assert
-            // Should use Exchange database (first in sorted order)
-            logger.Received(1).Debug(Arg.Is<DebugLogHandler>(h =>
-                h.ToString().Contains("Resolved") &&
-                h.ToString().Contains(Constants.TestProviderName) &&
-                h.ToString().Contains("Exchange")));
-        }
-        finally
-        {
-            DeleteDatabaseFile(dbPath1);
-            DeleteDatabaseFile(dbPath2);
         }
     }
 

--- a/tests/Integration/EventLogExpert.Provider.Database.IntegrationTests/Context/ProviderDbContextTests.cs
+++ b/tests/Integration/EventLogExpert.Provider.Database.IntegrationTests/Context/ProviderDbContextTests.cs
@@ -20,6 +20,33 @@ public sealed class ProviderDbContextTests : IDisposable
     private readonly List<string> _tempDatabases = [];
 
     [Fact]
+    public void CompositePrimaryKey_AllowsSameNameDifferentVersionKey()
+    {
+        var dbPath = CreateTempDatabasePath();
+
+        using (var context = new ProviderDbContext(dbPath, false))
+        {
+            var first = EventUtils.CreateProvider("Test-Provider");
+            first.VersionKey = "vk1:aaa";
+            var second = EventUtils.CreateProvider("Test-Provider");
+            second.VersionKey = "vk1:bbb";
+            context.ProviderDetails.Add(first);
+            context.ProviderDetails.Add(second);
+            context.SaveChanges();
+        }
+
+        using var readContext = new ProviderDbContext(dbPath, true);
+
+        var versionKeys = readContext.ProviderDetails
+            .Where(p => p.ProviderName == "Test-Provider")
+            .Select(p => p.VersionKey)
+            .OrderBy(v => v)
+            .ToList();
+
+        Assert.Equal(["vk1:aaa", "vk1:bbb"], versionKeys);
+    }
+
+    [Fact]
     public void Constructor_ShouldCreateNewDatabase()
     {
         // Arrange
@@ -162,6 +189,79 @@ public sealed class ProviderDbContextTests : IDisposable
     }
 
     [Fact]
+    public void Detection_FreshDatabase_StampsCanonicalUserVersion()
+    {
+        // Arrange / Act - a freshly created writable database is built from the canonical model.
+        var dbPath = CreateTempDatabasePath();
+
+        using (var context = new ProviderDbContext(dbPath, false))
+        {
+            context.SaveChanges();
+        }
+
+        // Assert - the canonical user_version stamp is what marks the database current.
+        Assert.Equal(DatabaseSchemaVersion.Current, ReadUserVersion(dbPath));
+    }
+
+    [Fact]
+    public void Detection_FutureUserVersion_ReportsUnknownAndNeedsUpgradeWithoutDowngrading()
+    {
+        // Arrange - a database stamped by a newer build than this one understands.
+        var dbPath = CreateTempDatabasePath();
+
+        using (var context = new ProviderDbContext(dbPath, false))
+        {
+            context.SaveChanges();
+        }
+
+        SetUserVersion(dbPath, DatabaseSchemaVersion.Current + 1);
+
+        // Assert - detection refuses to treat it as canonical and reports Unknown (never a downgrade-rebuild).
+        using var readContext = new ProviderDbContext(dbPath, true);
+
+        var state = readContext.IsUpgradeNeeded();
+
+        Assert.Equal(DatabaseSchemaVersion.Unknown, state.CurrentVersion);
+        Assert.True(state.NeedsUpgrade);
+    }
+
+    [Fact]
+    public void Detection_UnstampedCurrentShapeDatabase_NeedsUpgradeThenRebuildsAndStamps()
+    {
+        // Arrange - a canonical-shaped database that predates the user_version stamp (an unfinalized prerelease
+        // database): identical columns and composite key, but user_version reset to 0.
+        var dbPath = CreateTempDatabasePath();
+
+        using (var context = new ProviderDbContext(dbPath, false))
+        {
+            context.ProviderDetails.Add(EventUtils.CreateProvider("Test-Provider"));
+            context.SaveChanges();
+        }
+
+        SetUserVersion(dbPath, 0);
+
+        // Assert - detection keys on the stamp, so the current-shape-but-unstamped database is flagged for rebuild.
+        using (var readContext = new ProviderDbContext(dbPath, true))
+        {
+            Assert.True(readContext.IsUpgradeNeeded().NeedsUpgrade);
+        }
+
+        // Act - the upgrade rebuilds the table and re-stamps the canonical user_version.
+        using (var upgradeContext = new ProviderDbContext(dbPath, false))
+        {
+            upgradeContext.PerformUpgradeIfNeeded();
+        }
+
+        // Assert - now stamped current, no further upgrade, and the row survived the rebuild.
+        Assert.Equal(DatabaseSchemaVersion.Current, ReadUserVersion(dbPath));
+
+        using var verifyContext = new ProviderDbContext(dbPath, true);
+
+        Assert.False(verifyContext.IsUpgradeNeeded().NeedsUpgrade);
+        Assert.NotNull(verifyContext.FindProvider("Test-Provider"));
+    }
+
+    [Fact]
     public void Detection_V3Schema_NeedsV4Upgrade()
     {
         // Arrange — V3 schema has BLOB columns but no ResolvedFromOwningPublisher and BINARY PK.
@@ -183,6 +283,33 @@ public sealed class ProviderDbContextTests : IDisposable
         {
             DeleteDatabaseFile(dbPath);
         }
+    }
+
+    [Fact]
+    public void FindProvider_RoundTripsPersistedValueMaps()
+    {
+        var dbPath = CreateTempDatabasePath();
+
+        var provider = EventUtils.CreateProvider("Test-Provider");
+        provider.Maps = new Dictionary<string, ValueMapDefinition>
+        {
+            ["BusType"] = new(isBitMap: false, [new ValueMapEntry(10, "SAS"), new ValueMapEntry(11, "SATA")])
+        };
+
+        using (var context = new ProviderDbContext(dbPath, false))
+        {
+            context.ProviderDetails.Add(provider);
+            context.SaveChanges();
+        }
+
+        using var readContext = new ProviderDbContext(dbPath, true);
+
+        var restored = readContext.FindProvider("Test-Provider");
+
+        Assert.NotNull(restored);
+        Assert.Single(restored.Maps);
+        Assert.Equal(2, restored.Maps["BusType"].Entries.Count);
+        Assert.Equal("SAS", restored.Maps["BusType"].Entries[0].Name);
     }
 
     [Fact]
@@ -527,6 +654,27 @@ public sealed class ProviderDbContextTests : IDisposable
         {
             Assert.Empty(context.ProviderDetails.Where(p => p.ProviderName == providerName));
         }
+    }
+
+    [Fact]
+    public void ProviderDetails_RoundTripsVersionKey()
+    {
+        var dbPath = CreateTempDatabasePath();
+
+        using (var context = new ProviderDbContext(dbPath, false))
+        {
+            var provider = EventUtils.CreateProvider("Test-Provider");
+            provider.VersionKey = "vk1:abc123";
+            context.ProviderDetails.Add(provider);
+            context.SaveChanges();
+        }
+
+        using var readContext = new ProviderDbContext(dbPath, true);
+
+        var restored = readContext.FindProvider("Test-Provider");
+
+        Assert.NotNull(restored);
+        Assert.Equal("vk1:abc123", restored.VersionKey);
     }
 
     [Fact]
@@ -1213,6 +1361,17 @@ public sealed class ProviderDbContextTests : IDisposable
         return string.Empty;
     }
 
+    private static int ReadUserVersion(string dbPath)
+    {
+        using var connection = new SqliteConnection($"Data Source={dbPath};Mode=ReadOnly");
+        connection.Open();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "PRAGMA user_version";
+
+        return Convert.ToInt32(command.ExecuteScalar());
+    }
+
     private static void SeedLegacySchema(
         string dbPath,
         bool includeParameters,
@@ -1268,6 +1427,16 @@ public sealed class ProviderDbContextTests : IDisposable
             "\"Tasks\" BLOB NOT NULL)";
 
         cmd.ExecuteNonQuery();
+    }
+
+    private static void SetUserVersion(string dbPath, int value)
+    {
+        using var connection = new SqliteConnection($"Data Source={dbPath}");
+        connection.Open();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = $"PRAGMA user_version = {value}";
+        command.ExecuteNonQuery();
     }
 
     private string CreateTempDatabasePath()

--- a/tests/Integration/EventLogExpert.Provider.Database.IntegrationTests/Context/ProviderDbContextTests.cs
+++ b/tests/Integration/EventLogExpert.Provider.Database.IntegrationTests/Context/ProviderDbContextTests.cs
@@ -172,6 +172,46 @@ public sealed class ProviderDbContextTests : IDisposable
         Assert.All(results, count => Assert.Equal(10, count));
     }
 
+#if DEBUG
+    [Fact]
+    public void Detection_DevMode_StampedCurrentButStaleShape_RebuildsInPlace()
+    {
+        // Arrange - a database stamped with the current version whose physical shape was built from an earlier model
+        // (a provenance column dropped). Only the DEBUG model-vs-actual self-heal catches this.
+        var dbPath = CreateTempDatabasePath();
+
+        using (var context = new ProviderDbContext(dbPath, false))
+        {
+            context.ProviderDetails.Add(EventUtils.CreateProvider("Dev-Prov"));
+            context.SaveChanges();
+        }
+
+        Assert.Equal(DatabaseSchemaVersion.Current, ReadUserVersion(dbPath));
+
+        DropColumn(dbPath, nameof(ProviderDetails.MessageFileVersion));
+        Assert.False(TableHasColumn(dbPath, nameof(ProviderDetails.MessageFileVersion)));
+
+        // Assert - despite the current stamp, the model mismatch flags a rebuild.
+        using (var readContext = new ProviderDbContext(dbPath, true))
+        {
+            Assert.True(readContext.IsUpgradeNeeded().NeedsUpgrade);
+        }
+
+        // Act - the in-place rebuild restores the model shape and re-stamps.
+        using (var upgrade = new ProviderDbContext(dbPath, false))
+        {
+            upgrade.PerformUpgradeIfNeeded();
+        }
+
+        // Assert - column restored, stamped current, row survived.
+        Assert.True(TableHasColumn(dbPath, nameof(ProviderDetails.MessageFileVersion)));
+
+        using var verify = new ProviderDbContext(dbPath, true);
+        Assert.False(verify.IsUpgradeNeeded().NeedsUpgrade);
+        Assert.NotNull(verify.FindProvider("Dev-Prov"));
+    }
+#endif
+
     [Fact]
     public void Detection_FreshDatabase_ReportsV4()
     {
@@ -628,6 +668,36 @@ public sealed class ProviderDbContextTests : IDisposable
     }
 
     [Fact]
+    public void Provenance_RoundTripsThroughDatabase()
+    {
+        // Arrange
+        var dbPath = CreateTempDatabasePath();
+
+        var provider = EventUtils.CreateProvider("ProvenanceRoundTrip");
+        provider.SourceOsBuild = 22621;
+        provider.SourceOsRevision = 2861;
+        provider.SourceOsEdition = "ServerDatacenter";
+        provider.SourceOsDisplayVersion = "23H2";
+        provider.MessageFileVersion = "10.0.22621.2861";
+
+        // Act
+        using (var context = new ProviderDbContext(dbPath, false))
+        {
+            context.ProviderDetails.Add(provider);
+            context.SaveChanges();
+        }
+
+        // Assert
+        using var verify = new ProviderDbContext(dbPath, true);
+        var retrieved = verify.ProviderDetails.Single(p => p.ProviderName == "ProvenanceRoundTrip");
+        Assert.Equal(22621, retrieved.SourceOsBuild);
+        Assert.Equal(2861, retrieved.SourceOsRevision);
+        Assert.Equal("ServerDatacenter", retrieved.SourceOsEdition);
+        Assert.Equal("23H2", retrieved.SourceOsDisplayVersion);
+        Assert.Equal("10.0.22621.2861", retrieved.MessageFileVersion);
+    }
+
+    [Fact]
     public void ProviderDetails_Delete_ShouldRemoveRecord()
     {
         // Arrange
@@ -1007,6 +1077,74 @@ public sealed class ProviderDbContextTests : IDisposable
     }
 
     [Fact]
+    public void Upgrade_RebuildPreservesProvenance()
+    {
+        // Arrange - a current-shape database carrying provenance whose stamp was reset to 0 (an interrupted stamp):
+        // the rebuild must carry the provenance forward, not drop it.
+        var dbPath = CreateTempDatabasePath();
+
+        var provider = EventUtils.CreateProvider("Provenanced");
+        provider.SourceOsBuild = 19041;
+        provider.SourceOsRevision = 3636;
+        provider.SourceOsEdition = "ServerStandard";
+        provider.SourceOsDisplayVersion = "2009";
+        provider.MessageFileVersion = "10.0.19041.3636";
+
+        using (var context = new ProviderDbContext(dbPath, false))
+        {
+            context.ProviderDetails.Add(provider);
+            context.SaveChanges();
+        }
+
+        SetUserVersion(dbPath, 0);
+
+        // Act
+        using (var upgrade = new ProviderDbContext(dbPath, false))
+        {
+            upgrade.PerformUpgradeIfNeeded();
+        }
+
+        // Assert - provenance survives the destructive rebuild.
+        using var verify = new ProviderDbContext(dbPath, true);
+        var row = verify.FindProvider("Provenanced");
+        Assert.NotNull(row);
+        Assert.Equal(19041, row.SourceOsBuild);
+        Assert.Equal(3636, row.SourceOsRevision);
+        Assert.Equal("ServerStandard", row.SourceOsEdition);
+        Assert.Equal("2009", row.SourceOsDisplayVersion);
+        Assert.Equal("10.0.19041.3636", row.MessageFileVersion);
+    }
+
+    [Fact]
+    public void Upgrade_V3_To_V4_AddsProvenanceColumnsWithNullValues()
+    {
+        // Arrange - a true v3 database with no provenance columns.
+        var dbPath = CreateTempDatabasePath();
+        SeedV3Schema(dbPath);
+        InsertV3Row(dbPath, EventUtils.CreateProvider("V3-Prov", [EventUtils.CreateMessageModel("V3-Prov", 1, "msg")]));
+
+        // Act
+        using (var context = new ProviderDbContext(dbPath, false))
+        {
+            context.PerformUpgradeIfNeeded();
+        }
+
+        // Assert - the rebuild adds the provenance columns; the legacy row carries null provenance (the intended
+        // degrade; re-captured on a live recreate).
+        Assert.True(TableHasColumn(dbPath, nameof(ProviderDetails.SourceOsBuild)));
+        Assert.True(TableHasColumn(dbPath, nameof(ProviderDetails.MessageFileVersion)));
+
+        using var verify = new ProviderDbContext(dbPath, true);
+        var row = verify.FindProvider("V3-Prov");
+        Assert.NotNull(row);
+        Assert.Null(row.SourceOsBuild);
+        Assert.Null(row.SourceOsRevision);
+        Assert.Null(row.SourceOsEdition);
+        Assert.Null(row.SourceOsDisplayVersion);
+        Assert.Null(row.MessageFileVersion);
+    }
+
+    [Fact]
     public void Upgrade_V3_To_V4_HappyPath()
     {
         // Arrange
@@ -1226,6 +1364,16 @@ public sealed class ProviderDbContextTests : IDisposable
 
     private static void DeleteDatabaseFile(string path) => SqliteTestDb.Delete(path);
 
+    private static void DropColumn(string dbPath, string columnName)
+    {
+        using var connection = new SqliteConnection($"Data Source={dbPath}");
+        connection.Open();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = $"ALTER TABLE \"ProviderDetails\" DROP COLUMN \"{columnName}\"";
+        command.ExecuteNonQuery();
+    }
+
     private static void InsertLegacyRow(
         string dbPath,
         string providerName,
@@ -1437,6 +1585,24 @@ public sealed class ProviderDbContextTests : IDisposable
         using var command = connection.CreateCommand();
         command.CommandText = $"PRAGMA user_version = {value}";
         command.ExecuteNonQuery();
+    }
+
+    private static bool TableHasColumn(string dbPath, string columnName)
+    {
+        using var connection = new SqliteConnection($"Data Source={dbPath}");
+        connection.Open();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "PRAGMA table_info(\"ProviderDetails\")";
+
+        using var reader = command.ExecuteReader();
+
+        while (reader.Read())
+        {
+            if (string.Equals(reader["name"]?.ToString(), columnName, StringComparison.Ordinal)) { return true; }
+        }
+
+        return false;
     }
 
     private string CreateTempDatabasePath()

--- a/tests/Unit/EventLogExpert.Provider.Database.Tests/Hashing/VersionKeyCalculatorTests.cs
+++ b/tests/Unit/EventLogExpert.Provider.Database.Tests/Hashing/VersionKeyCalculatorTests.cs
@@ -1,0 +1,211 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.TestUtils;
+using EventLogExpert.Provider.Resolution;
+using EventLogExpert.ProviderDatabase.Hashing;
+
+namespace EventLogExpert.Provider.Database.Tests.Hashing;
+
+public sealed class VersionKeyCalculatorTests
+{
+    [Fact]
+    public void Compute_DictionaryInsertionOrder_DoesNotChangeKey()
+    {
+        var first = EventUtils.CreateProvider("P", tasks: new Dictionary<int, string> { { 1, "A" }, { 2, "B" } });
+        var second = EventUtils.CreateProvider("P", tasks: new Dictionary<int, string> { { 2, "B" }, { 1, "A" } });
+
+        Assert.Equal(VersionKeyCalculator.Compute(first), VersionKeyCalculator.Compute(second));
+    }
+
+    [Fact]
+    public void Compute_DifferentEventDescription_ChangesKey()
+    {
+        var first = EventUtils.CreateProvider("P", events: [EventUtils.CreateEventModel(1, description: "first")]);
+        var second = EventUtils.CreateProvider("P", events: [EventUtils.CreateEventModel(1, description: "second")]);
+
+        Assert.NotEqual(VersionKeyCalculator.Compute(first), VersionKeyCalculator.Compute(second));
+    }
+
+    [Fact]
+    public void Compute_DifferentResolvedFromOwningPublisher_ChangesKey()
+    {
+        var first = EventUtils.CreateProvider("P", resolvedFromOwningPublisher: "Owner-A");
+        var second = EventUtils.CreateProvider("P", resolvedFromOwningPublisher: "Owner-B");
+
+        Assert.NotEqual(VersionKeyCalculator.Compute(first), VersionKeyCalculator.Compute(second));
+    }
+
+    [Fact]
+    public void Compute_EmptyProvider_IsStableAndNonEmpty()
+    {
+        var first = EventUtils.CreateProvider("P");
+        var second = EventUtils.CreateProvider("DifferentName");
+
+        var firstKey = VersionKeyCalculator.Compute(first);
+
+        Assert.StartsWith("vk1:", firstKey);
+        Assert.Equal(firstKey, VersionKeyCalculator.Compute(second));
+    }
+
+    [Fact]
+    public void Compute_EventKeywordOrderAndDuplicates_DoNotChangeKey()
+    {
+        // The merger compares keywords as a SET, so the hash must too: [1, 2, 2] and [2, 1] are the same version.
+        var ordered = EventUtils.CreateProvider("P", events: [EventUtils.CreateEventModel(1, keywords: [1L, 2L, 2L])]);
+        var shuffled = EventUtils.CreateProvider("P", events: [EventUtils.CreateEventModel(1, keywords: [2L, 1L])]);
+
+        Assert.Equal(VersionKeyCalculator.Compute(ordered), VersionKeyCalculator.Compute(shuffled));
+    }
+
+    [Fact]
+    public void Compute_EventListOrder_DoesNotChangeKey()
+    {
+        var first = EventUtils.CreateProvider("P",
+            events: [EventUtils.CreateEventModel(1), EventUtils.CreateEventModel(2)]);
+        var second = EventUtils.CreateProvider("P",
+            events: [EventUtils.CreateEventModel(2), EventUtils.CreateEventModel(1)]);
+
+        Assert.Equal(VersionKeyCalculator.Compute(first), VersionKeyCalculator.Compute(second));
+    }
+
+    [Fact]
+    public void Compute_ExcludesTopLevelAndMessageProviderName()
+    {
+        // Neither the top-level provider name (the identity key) nor the per-message ProviderName (which mirrors it)
+        // is content, so two recordings of the same provider under different names collapse to the same key.
+        var alpha = EventUtils.CreateProvider("Alpha",
+            messages: [EventUtils.CreateMessageModel("Alpha", 100, "shared text", shortId: 100)],
+            events: [EventUtils.CreateEventModel(100)]);
+        var beta = EventUtils.CreateProvider("Beta",
+            messages: [EventUtils.CreateMessageModel("Beta", 100, "shared text", shortId: 100)],
+            events: [EventUtils.CreateEventModel(100)]);
+
+        Assert.Equal(VersionKeyCalculator.Compute(alpha), VersionKeyCalculator.Compute(beta));
+    }
+
+    [Fact]
+    public void Compute_IsDeterministic_ForTheSamePayload()
+    {
+        var first = BuildProvider();
+        var second = BuildProvider();
+
+        Assert.Equal(VersionKeyCalculator.Compute(first), VersionKeyCalculator.Compute(second));
+    }
+
+    [Fact]
+    public void Compute_IsDeterministic_WithNullStringFieldsAndMaps()
+    {
+        Assert.Equal(
+            VersionKeyCalculator.Compute(BuildProviderWithNullsAndMaps()),
+            VersionKeyCalculator.Compute(BuildProviderWithNullsAndMaps()));
+    }
+
+    [Fact]
+    public void Compute_MapEntryOrder_ChangesKey()
+    {
+        // Bitmap decoding iterates ValueMap entries in order, so entry order is content - a reordering is a different
+        // rendering and must hash differently.
+        var first = EventUtils.CreateProvider("P");
+        first.Maps = new Dictionary<string, ValueMapDefinition>
+        {
+            ["flags"] = new(isBitMap: true, [new ValueMapEntry(1, "A"), new ValueMapEntry(2, "B")])
+        };
+
+        var second = EventUtils.CreateProvider("P");
+        second.Maps = new Dictionary<string, ValueMapDefinition>
+        {
+            ["flags"] = new(isBitMap: true, [new ValueMapEntry(2, "B"), new ValueMapEntry(1, "A")])
+        };
+
+        Assert.NotEqual(VersionKeyCalculator.Compute(first), VersionKeyCalculator.Compute(second));
+    }
+
+    [Fact]
+    public void Compute_MessageProviderNameCasing_DoesNotChangeKey()
+    {
+        // The merger ignores MessageModel.ProviderName and the DB key is case-insensitive, so the same provider
+        // recorded under different name casing (its messages tracking that casing) must still collapse.
+        var upper = EventUtils.CreateProvider("Provider",
+            messages: [EventUtils.CreateMessageModel("Provider", 1, "text", shortId: 1)]);
+        var lower = EventUtils.CreateProvider("Provider",
+            messages: [EventUtils.CreateMessageModel("provider", 1, "text", shortId: 1)]);
+
+        Assert.Equal(VersionKeyCalculator.Compute(upper), VersionKeyCalculator.Compute(lower));
+    }
+
+    [Fact]
+    public void Compute_NullVsEmptyString_ChangesKey()
+    {
+        var nullTemplate = EventUtils.CreateProvider("P",
+            messages: [EventUtils.CreateMessageModel("P", 1, "text", template: null)]);
+        var emptyTemplate = EventUtils.CreateProvider("P",
+            messages: [EventUtils.CreateMessageModel("P", 1, "text", template: "")]);
+
+        Assert.NotEqual(VersionKeyCalculator.Compute(nullTemplate), VersionKeyCalculator.Compute(emptyTemplate));
+    }
+
+    [Fact]
+    public void Compute_ResolvedFromOwningPublisher_NullVsEmpty_AreTheSameKey()
+    {
+        // The merger treats a null and an empty owning publisher as the same "no owner", so the hash must too.
+        var nullOwner = EventUtils.CreateProvider("P", resolvedFromOwningPublisher: null);
+        var emptyOwner = EventUtils.CreateProvider("P", resolvedFromOwningPublisher: "");
+
+        Assert.Equal(VersionKeyCalculator.Compute(nullOwner), VersionKeyCalculator.Compute(emptyOwner));
+    }
+
+    [Fact]
+    public void Compute_StartsWithSchemePrefix()
+    {
+        var key = VersionKeyCalculator.Compute(BuildProvider());
+
+        Assert.StartsWith("vk1:", key);
+        Assert.True(key.Length > "vk1:".Length, "VersionKey must carry a non-empty hash body.");
+    }
+
+    [Fact]
+    public void EventModelProperties_AreAllAccountedForInTheHash()
+    {
+        // Drift guard: adding or removing an EventModel property fails this. When it does, update EncodeEvent in
+        // ProviderContentCanonicalizer AND ProviderDetailsMerger.EventsAreEquivalent in lockstep, then this set.
+        var properties = typeof(EventModel).GetProperties().Select(property => property.Name).OrderBy(name => name, StringComparer.Ordinal);
+
+        Assert.Equal(
+            ["Description", "Id", "Keywords", "Level", "LogName", "Opcode", "Task", "Template", "Version"],
+            properties);
+    }
+
+    [Fact]
+    public void MessageModelProperties_AreAllAccountedForInTheHash()
+    {
+        // Drift guard (see EventModel test). ProviderName is intentionally NOT hashed (it mirrors the excluded
+        // provider name); every other property is content the hash must cover.
+        var properties = typeof(MessageModel).GetProperties().Select(property => property.Name).OrderBy(name => name, StringComparer.Ordinal);
+
+        Assert.Equal(
+            ["LogLink", "ProviderName", "RawId", "ShortId", "Tag", "Template", "Text"],
+            properties);
+    }
+
+    private static ProviderDetails BuildProvider() =>
+        EventUtils.CreateProvider("Provider",
+            messages: [EventUtils.CreateMessageModel("Provider", 100, "Some message %1", shortId: 100)],
+            events: [EventUtils.CreateEventModel(1000, description: "An event", keywords: [4L, 8L], template: "<template/>")],
+            keywords: new Dictionary<long, string> { { 4L, "Audit" } },
+            tasks: new Dictionary<int, string> { { 1, "Connect" } });
+
+    private static ProviderDetails BuildProviderWithNullsAndMaps()
+    {
+        var provider = EventUtils.CreateProvider("P",
+            messages: [EventUtils.CreateMessageModel("P", 1, "text", shortId: 1, logLink: null, tag: null, template: null)],
+            events: [EventUtils.CreateEventModel(1, description: null, logName: null, template: null)]);
+
+        provider.Maps = new Dictionary<string, ValueMapDefinition>
+        {
+            ["map"] = new(isBitMap: false, [new ValueMapEntry(1, "One")])
+        };
+
+        return provider;
+    }
+}

--- a/tests/Unit/EventLogExpert.Provider.Database.Tests/Hashing/VersionKeyCalculatorTests.cs
+++ b/tests/Unit/EventLogExpert.Provider.Database.Tests/Hashing/VersionKeyCalculatorTests.cs
@@ -28,6 +28,29 @@ public sealed class VersionKeyCalculatorTests
     }
 
     [Fact]
+    public void Compute_DifferentProvenance_DoesNotChangeKey()
+    {
+        // Provenance is source metadata, not rendering content: two byte-identical providers from different OS
+        // sources must keep the SAME VersionKey so they collapse to one row on a future merge.
+        var first = EventUtils.CreateProvider("P", events: [EventUtils.CreateEventModel(1, description: "same")]);
+        var second = EventUtils.CreateProvider("P", events: [EventUtils.CreateEventModel(1, description: "same")]);
+
+        first.SourceOsBuild = 19041;
+        first.SourceOsRevision = 1;
+        first.SourceOsEdition = "ServerStandard";
+        first.SourceOsDisplayVersion = "1809";
+        first.MessageFileVersion = "10.0.19041.1";
+
+        second.SourceOsBuild = 22621;
+        second.SourceOsRevision = 999;
+        second.SourceOsEdition = "ServerDatacenter";
+        second.SourceOsDisplayVersion = "23H2";
+        second.MessageFileVersion = "10.0.22621.900";
+
+        Assert.Equal(VersionKeyCalculator.Compute(first), VersionKeyCalculator.Compute(second));
+    }
+
+    [Fact]
     public void Compute_DifferentResolvedFromOwningPublisher_ChangesKey()
     {
         var first = EventUtils.CreateProvider("P", resolvedFromOwningPublisher: "Owner-A");

--- a/tests/Unit/EventLogExpert.Provider.Database.Tests/Hashing/VersionKeyCalculatorTests.cs
+++ b/tests/Unit/EventLogExpert.Provider.Database.Tests/Hashing/VersionKeyCalculatorTests.cs
@@ -191,7 +191,7 @@ public sealed class VersionKeyCalculatorTests
     public void EventModelProperties_AreAllAccountedForInTheHash()
     {
         // Drift guard: adding or removing an EventModel property fails this. When it does, update EncodeEvent in
-        // ProviderContentCanonicalizer AND ProviderDetailsMerger.EventsAreEquivalent in lockstep, then this set.
+        // ProviderContentCanonicalizer AND ProviderContentMerge.EventsAreEquivalent in lockstep, then this set.
         var properties = typeof(EventModel).GetProperties().Select(property => property.Name).OrderBy(name => name, StringComparer.Ordinal);
 
         Assert.Equal(

--- a/tests/Unit/EventLogExpert.Provider.Database.Tests/Maintenance/ProviderDetailsMergerTests.cs
+++ b/tests/Unit/EventLogExpert.Provider.Database.Tests/Maintenance/ProviderDetailsMergerTests.cs
@@ -12,6 +12,43 @@ public sealed class ProviderDetailsMergerTests
 {
     private const string TestDatabasePath = @"C:\test\fake.db";
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void MergeCaseInsensitiveDuplicates_CarriesNewestSourceProvenanceAsCoherentUnit_RegardlessOfOrder(bool newerFirst)
+    {
+        // Same identity (case-folded name + shared VersionKey) from two OS sources. The merged row must take the
+        // NEWEST source's provenance as one coherent unit, deterministically, not whichever row SELECT returned first.
+        var older = EventUtils.CreateProvider("Same-Provider");
+        older.VersionKey = "vk1:shared";
+        older.SourceOsBuild = 17763;
+        older.SourceOsRevision = 100;
+        older.SourceOsEdition = "ServerStandard";
+        older.SourceOsDisplayVersion = "1809";
+        older.MessageFileVersion = "10.0.17763.100";
+
+        var newer = EventUtils.CreateProvider("same-provider");
+        newer.VersionKey = "vk1:shared";
+        newer.SourceOsBuild = 20348;
+        newer.SourceOsRevision = 2000;
+        newer.SourceOsEdition = "ServerDatacenter";
+        newer.SourceOsDisplayVersion = "21H2";
+        newer.MessageFileVersion = "10.0.20348.2000";
+
+        var rows = newerFirst
+            ? new List<ProviderDetails> { newer, older }
+            : new List<ProviderDetails> { older, newer };
+
+        var merged = ProviderDetailsMerger.MergeCaseInsensitiveDuplicates(rows, TestDatabasePath);
+
+        var row = Assert.Single(merged);
+        Assert.Equal(20348, row.SourceOsBuild);
+        Assert.Equal(2000, row.SourceOsRevision);
+        Assert.Equal("ServerDatacenter", row.SourceOsEdition);
+        Assert.Equal("21H2", row.SourceOsDisplayVersion);
+        Assert.Equal("10.0.20348.2000", row.MessageFileVersion);
+    }
+
     [Fact]
     public void MergeCaseInsensitiveDuplicates_CarriesSharedVersionKeyThroughMerge()
     {
@@ -436,5 +473,36 @@ public sealed class ProviderDetailsMergerTests
 
         Assert.Single(merged);
         Assert.Equal("MICROSOFT-Foo", merged[0].ProviderName);
+    }
+
+    [Fact]
+    public void MergeCaseInsensitiveDuplicates_WhenRecencyTies_PicksProvenanceDeterministicallyAcrossRowOrder()
+    {
+        // Same recency key (build, revision, file version) but different edition: the merge must still pick the same
+        // winner regardless of source row order, since SELECT * has no defined order.
+        static ProviderDetails WithEdition(string nameCase, string edition)
+        {
+            var provider = EventUtils.CreateProvider(nameCase);
+            provider.VersionKey = "vk1:shared";
+            provider.SourceOsBuild = 20348;
+            provider.SourceOsRevision = 2000;
+            provider.SourceOsEdition = edition;
+            provider.SourceOsDisplayVersion = "21H2";
+            provider.MessageFileVersion = "10.0.20348.2000";
+
+            return provider;
+        }
+
+        var forward = ProviderDetailsMerger.MergeCaseInsensitiveDuplicates(
+            [WithEdition("Same-Provider", "ServerStandard"), WithEdition("same-provider", "ServerDatacenter")],
+            TestDatabasePath);
+
+        var reverse = ProviderDetailsMerger.MergeCaseInsensitiveDuplicates(
+            [WithEdition("Same-Provider", "ServerDatacenter"), WithEdition("same-provider", "ServerStandard")],
+            TestDatabasePath);
+
+        // "ServerStandard" sorts after "ServerDatacenter" ordinally, so it is the deterministic winner either way.
+        Assert.Equal("ServerStandard", Assert.Single(forward).SourceOsEdition);
+        Assert.Equal("ServerStandard", Assert.Single(reverse).SourceOsEdition);
     }
 }

--- a/tests/Unit/EventLogExpert.Provider.Database.Tests/Maintenance/ProviderDetailsMergerTests.cs
+++ b/tests/Unit/EventLogExpert.Provider.Database.Tests/Maintenance/ProviderDetailsMergerTests.cs
@@ -13,6 +13,21 @@ public sealed class ProviderDetailsMergerTests
     private const string TestDatabasePath = @"C:\test\fake.db";
 
     [Fact]
+    public void MergeCaseInsensitiveDuplicates_CarriesSharedVersionKeyThroughMerge()
+    {
+        var first = EventUtils.CreateProvider("Same-Provider");
+        first.VersionKey = "vk1:shared";
+
+        var second = EventUtils.CreateProvider("same-provider");
+        second.VersionKey = "vk1:shared";
+
+        var merged = ProviderDetailsMerger.MergeCaseInsensitiveDuplicates([first, second], TestDatabasePath);
+
+        Assert.Single(merged);
+        Assert.Equal("vk1:shared", merged[0].VersionKey);
+    }
+
+    [Fact]
     public void MergeCaseInsensitiveDuplicates_DeduplicatesIdenticalMessages()
     {
         var msg = EventUtils.CreateMessageModel("Same-Provider", 100, "duplicate-text", 100);
@@ -28,6 +43,29 @@ public sealed class ProviderDetailsMergerTests
         Assert.Single(merged);
         Assert.Single(merged[0].Messages);
         Assert.Equal("duplicate-text", merged[0].Messages[0].Text);
+    }
+
+    [Fact]
+    public void MergeCaseInsensitiveDuplicates_MergesDistinctMapsAcrossDuplicates()
+    {
+        var alpha = EventUtils.CreateProvider("Same-Provider");
+        alpha.Maps = new Dictionary<string, ValueMapDefinition>
+        {
+            ["BusType"] = new(isBitMap: false, [new ValueMapEntry(10, "SAS")])
+        };
+
+        var beta = EventUtils.CreateProvider("same-provider");
+        beta.Maps = new Dictionary<string, ValueMapDefinition>
+        {
+            ["State"] = new(isBitMap: false, [new ValueMapEntry(1, "Online")])
+        };
+
+        var merged = ProviderDetailsMerger.MergeCaseInsensitiveDuplicates([alpha, beta], TestDatabasePath);
+
+        Assert.Single(merged);
+        Assert.Equal(2, merged[0].Maps.Count);
+        Assert.Equal("SAS", merged[0].Maps["BusType"].Entries[0].Name);
+        Assert.Equal("Online", merged[0].Maps["State"].Entries[0].Name);
     }
 
     [Fact]
@@ -87,6 +125,28 @@ public sealed class ProviderDetailsMergerTests
     }
 
     [Fact]
+    public void MergeCaseInsensitiveDuplicates_OnConflictingMapDefinition_Throws()
+    {
+        var alpha = EventUtils.CreateProvider("Same-Provider");
+        alpha.Maps = new Dictionary<string, ValueMapDefinition>
+        {
+            ["BusType"] = new(isBitMap: false, [new ValueMapEntry(10, "SAS")])
+        };
+
+        var beta = EventUtils.CreateProvider("same-provider");
+        beta.Maps = new Dictionary<string, ValueMapDefinition>
+        {
+            ["BusType"] = new(isBitMap: false, [new ValueMapEntry(10, "NVMe")])
+        };
+
+        var ex = Assert.Throws<DatabaseUpgradeException>(() =>
+            ProviderDetailsMerger.MergeCaseInsensitiveDuplicates([alpha, beta], TestDatabasePath));
+
+        Assert.Contains("Map", ex.Reason);
+        Assert.Contains("BusType", ex.Reason);
+    }
+
+    [Fact]
     public void MergeCaseInsensitiveDuplicates_OnConflictingMessageText_Throws()
     {
         var rows = new List<ProviderDetails>
@@ -135,6 +195,21 @@ public sealed class ProviderDetailsMergerTests
             ProviderDetailsMerger.MergeCaseInsensitiveDuplicates(rows, TestDatabasePath));
 
         Assert.Contains("Tasks", ex.Reason);
+    }
+
+    [Fact]
+    public void MergeCaseInsensitiveDuplicates_OnDistinctVersionKeys_Throws()
+    {
+        var first = EventUtils.CreateProvider("Same-Provider");
+        first.VersionKey = "vk1:aaa";
+
+        var second = EventUtils.CreateProvider("same-provider");
+        second.VersionKey = "vk1:bbb";
+
+        var ex = Assert.Throws<DatabaseUpgradeException>(() =>
+            ProviderDetailsMerger.MergeCaseInsensitiveDuplicates([first, second], TestDatabasePath));
+
+        Assert.Contains("VersionKey", ex.Reason);
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Provider.Database.Tests/Maintenance/ProviderDetailsMergerTests.cs
+++ b/tests/Unit/EventLogExpert.Provider.Database.Tests/Maintenance/ProviderDetailsMergerTests.cs
@@ -198,7 +198,48 @@ public sealed class ProviderDetailsMergerTests
     }
 
     [Fact]
-    public void MergeCaseInsensitiveDuplicates_OnDistinctVersionKeys_Throws()
+    public void MergeCaseInsensitiveDuplicates_OnDistinctVersionKeys_ConflictingContentCoexists()
+    {
+        var first = EventUtils.CreateProvider("Same-Provider",
+            events: [EventUtils.CreateEventModel(100, "first", logName: "App")]);
+        first.VersionKey = "vk1:aaa";
+
+        var second = EventUtils.CreateProvider("same-provider",
+            events: [EventUtils.CreateEventModel(100, "second", logName: "App")]);
+        second.VersionKey = "vk1:bbb";
+
+        // Same name + same event Id but DISTINCT VersionKeys are different provider versions, so they form separate
+        // groups and the conflicting event content is never compared. Name-only grouping would have merged them and
+        // thrown on the event conflict; tuple-keying lets both versions coexist.
+        var merged = ProviderDetailsMerger.MergeCaseInsensitiveDuplicates([first, second], TestDatabasePath);
+
+        Assert.Equal(2, merged.Count);
+        Assert.Equal(["vk1:aaa", "vk1:bbb"], merged.Select(p => p.VersionKey).OrderBy(v => v, StringComparer.Ordinal).ToArray());
+    }
+
+    [Fact]
+    public void MergeCaseInsensitiveDuplicates_OnDistinctVersionKeys_MergesWithinVersionAndCoexistsAcross()
+    {
+        var firstV1 = EventUtils.CreateProvider("Foo");
+        firstV1.VersionKey = "vk1";
+
+        var secondV1 = EventUtils.CreateProvider("foo");
+        secondV1.VersionKey = "vk1";
+
+        var v2 = EventUtils.CreateProvider("Foo");
+        v2.VersionKey = "vk2";
+
+        var merged = ProviderDetailsMerger.MergeCaseInsensitiveDuplicates([firstV1, secondV1, v2], TestDatabasePath);
+
+        // The two vk1 rows case-fold into one (name, vk1) group and merge to a single canonical "Foo" row; vk2 is a
+        // distinct version and coexists - the realistic post-hashing shape (mixed versions of one name) yields 2 rows.
+        Assert.Equal(2, merged.Count);
+        Assert.Equal(["vk1", "vk2"], merged.Select(p => p.VersionKey).OrderBy(v => v, StringComparer.Ordinal).ToArray());
+        Assert.Equal("Foo", merged.Single(p => p.VersionKey == "vk1").ProviderName);
+    }
+
+    [Fact]
+    public void MergeCaseInsensitiveDuplicates_OnDistinctVersionKeys_PreservesBothVersions()
     {
         var first = EventUtils.CreateProvider("Same-Provider");
         first.VersionKey = "vk1:aaa";
@@ -206,10 +247,11 @@ public sealed class ProviderDetailsMergerTests
         var second = EventUtils.CreateProvider("same-provider");
         second.VersionKey = "vk1:bbb";
 
-        var ex = Assert.Throws<DatabaseUpgradeException>(() =>
-            ProviderDetailsMerger.MergeCaseInsensitiveDuplicates([first, second], TestDatabasePath));
+        var merged = ProviderDetailsMerger.MergeCaseInsensitiveDuplicates([first, second], TestDatabasePath);
 
-        Assert.Contains("VersionKey", ex.Reason);
+        // Distinct VersionKeys are distinct provider versions and must coexist, not collapse to one row.
+        Assert.Equal(2, merged.Count);
+        Assert.Equal(["vk1:aaa", "vk1:bbb"], merged.Select(p => p.VersionKey).OrderBy(v => v, StringComparer.Ordinal).ToArray());
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Provider.Database.Tests/Serialization/ProviderJsonContextTests.cs
+++ b/tests/Unit/EventLogExpert.Provider.Database.Tests/Serialization/ProviderJsonContextTests.cs
@@ -20,6 +20,10 @@ public sealed class ProviderJsonContextTests
         typeof(List<EventModel>),
         typeof(Dictionary<long, string>),
         typeof(Dictionary<int, string>),
+        typeof(IReadOnlyDictionary<string, ValueMapDefinition>),
+        typeof(Dictionary<string, ValueMapDefinition>),
+        typeof(ValueMapDefinition),
+        typeof(ValueMapEntry),
     ];
 
     [Theory]
@@ -48,6 +52,31 @@ public sealed class ProviderJsonContextTests
         Assert.Equal(2, restored.Count);
         Assert.Equal("one", restored[1L]);
         Assert.Equal("big", restored[0x100000000L]);
+    }
+
+    [Fact]
+    public void RoundTrip_IReadOnlyDictionaryStringValueMapDefinition_PreservesData()
+    {
+        IReadOnlyDictionary<string, ValueMapDefinition> original = new Dictionary<string, ValueMapDefinition>
+        {
+            ["BusType"] = new(isBitMap: false, [new ValueMapEntry(10, "SAS"), new ValueMapEntry(11, "SATA")]),
+            ["Flags"] = new(isBitMap: true, [new ValueMapEntry(1, "Compressed"), new ValueMapEntry(2, "Encrypted")])
+        };
+
+        var bytes = CompressedJsonValueConverter<IReadOnlyDictionary<string, ValueMapDefinition>>.ConvertToCompressedJson(original);
+        var restored = CompressedJsonValueConverter<IReadOnlyDictionary<string, ValueMapDefinition>>.ConvertFromCompressedJson(bytes);
+
+        Assert.NotNull(restored);
+        Assert.Equal(2, restored.Count);
+
+        Assert.False(restored["BusType"].IsBitMap);
+        Assert.Equal(2, restored["BusType"].Entries.Count);
+        Assert.Equal(10u, restored["BusType"].Entries[0].Value);
+        Assert.Equal("SAS", restored["BusType"].Entries[0].Name);
+
+        Assert.True(restored["Flags"].IsBitMap);
+        Assert.Equal(2u, restored["Flags"].Entries[1].Value);
+        Assert.Equal("Encrypted", restored["Flags"].Entries[1].Name);
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Provider.Tests/Resolution/ProviderIdentityTests.cs
+++ b/tests/Unit/EventLogExpert.Provider.Tests/Resolution/ProviderIdentityTests.cs
@@ -1,0 +1,81 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Provider.Resolution;
+
+namespace EventLogExpert.Provider.Tests.Resolution;
+
+public sealed class ProviderIdentityTests
+{
+    [Fact]
+    public void DefaultInstance_IsInert_AndDoesNotThrow()
+    {
+        // A default instance has null members; equality and hashing are null-safe, so it is inert (usable in a set
+        // without throwing) even though it does not correspond to any real provider.
+        var first = default(ProviderIdentity);
+        var second = default(ProviderIdentity);
+
+        Assert.Equal(first, second);
+        Assert.Equal(first.GetHashCode(), second.GetHashCode());
+        Assert.NotEqual(first, new ProviderIdentity(string.Empty, string.Empty));
+        Assert.Contains(first, new HashSet<ProviderIdentity> { second });
+    }
+
+    [Fact]
+    public void Equals_DistinctVersionKeys_AreNotEqual()
+    {
+        var first = new ProviderIdentity("Foo", "vk1");
+        var second = new ProviderIdentity("Foo", "vk2");
+
+        Assert.NotEqual(first, second);
+    }
+
+    [Fact]
+    public void Equals_NameDiffersOnlyByCase_AreEqual()
+    {
+        var upper = new ProviderIdentity("Foo", "");
+        var lower = new ProviderIdentity("foo", "");
+
+        Assert.Equal(upper, lower);
+        Assert.True(upper == lower);
+        Assert.Equal(upper.GetHashCode(), lower.GetHashCode());
+    }
+
+    [Fact]
+    public void Equals_VersionKeyDiffersByCase_AreNotEqual()
+    {
+        // VersionKey is compared ordinally (it is an opaque content hash), so case matters for the version
+        // even though it does not for the name.
+        var lower = new ProviderIdentity("Foo", "a");
+        var upper = new ProviderIdentity("Foo", "A");
+
+        Assert.NotEqual(lower, upper);
+        Assert.True(lower != upper);
+    }
+
+    [Fact]
+    public void HashSet_UsesBakedInCollation_WithoutAnExplicitComparer()
+    {
+        // The struct's overridden equality means a default HashSet dedups case-insensitively on name and
+        // ordinally on version key, with no comparer threaded through the call site.
+        var set = new HashSet<ProviderIdentity>
+        {
+            new("Foo", ""),
+            new("foo", ""),
+            new("Foo", "vk2")
+        };
+
+        Assert.Equal(2, set.Count);
+        Assert.Contains(new ProviderIdentity("FOO", ""), set);
+    }
+
+    [Fact]
+    public void Of_ExtractsNameAndVersionKey()
+    {
+        var provider = new ProviderDetails { ProviderName = "Foo", VersionKey = "vk1" };
+
+        var identity = ProviderIdentity.Of(provider);
+
+        Assert.Equal(new ProviderIdentity("Foo", "vk1"), identity);
+    }
+}

--- a/tests/Unit/EventLogExpert.Provider.Tests/Resolution/ProviderIdentityTests.cs
+++ b/tests/Unit/EventLogExpert.Provider.Tests/Resolution/ProviderIdentityTests.cs
@@ -31,6 +31,19 @@ public sealed class ProviderIdentityTests
     }
 
     [Fact]
+    public void Equals_NameDiffersByNonAsciiCase_AreNotEqual()
+    {
+        // SQLite NOCASE (the ProviderName primary-key collation) folds only ASCII, so names differing solely by
+        // non-ASCII case (U+00C4 vs U+00E4) are DISTINCT rows; the identity must keep them distinct to stay consistent
+        // with the database, or version-aware dedup/skip/delete would collide with the composite key.
+        var upper = new ProviderIdentity("Provider-\u00c4", "");
+        var lower = new ProviderIdentity("Provider-\u00e4", "");
+
+        Assert.NotEqual(upper, lower);
+        Assert.True(upper != lower);
+    }
+
+    [Fact]
     public void Equals_NameDiffersOnlyByCase_AreEqual()
     {
         var upper = new ProviderIdentity("Foo", "");

--- a/tests/Unit/EventLogExpert.Provider.Tests/Resolution/ProviderSourceRecencyTests.cs
+++ b/tests/Unit/EventLogExpert.Provider.Tests/Resolution/ProviderSourceRecencyTests.cs
@@ -1,0 +1,65 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Provider.Resolution;
+
+namespace EventLogExpert.Provider.Tests.Resolution;
+
+public sealed class ProviderSourceRecencyTests
+{
+    [Fact]
+    public void Compare_PrefersNewerOsBuild()
+    {
+        var older = WithProvenance(build: 17763);
+        var newer = WithProvenance(build: 20348);
+
+        Assert.True(ProviderSourceRecency.Compare(newer, older) > 0);
+        Assert.True(ProviderSourceRecency.Compare(older, newer) < 0);
+    }
+
+    [Fact]
+    public void Compare_PresentProvenanceOutranksAbsent()
+    {
+        var present = WithProvenance(build: 17763);
+        var absent = WithProvenance();
+
+        Assert.True(ProviderSourceRecency.Compare(present, absent) > 0);
+        Assert.True(ProviderSourceRecency.Compare(absent, present) < 0);
+    }
+
+    [Fact]
+    public void Compare_WhenBothAbsent_ReturnsZero() =>
+        Assert.Equal(0, ProviderSourceRecency.Compare(WithProvenance(), WithProvenance()));
+
+    [Fact]
+    public void Compare_WhenBuildTies_PrefersNewerRevisionThenFileVersion()
+    {
+        var older = WithProvenance(build: 20348, revision: 100, messageFileVersion: "10.0.20348.100");
+        var newerRevision = WithProvenance(build: 20348, revision: 2000, messageFileVersion: "10.0.20348.100");
+
+        Assert.True(ProviderSourceRecency.Compare(newerRevision, older) > 0);
+
+        var olderFile = WithProvenance(build: 20348, revision: 2000, messageFileVersion: "10.0.20348.100");
+        var newerFile = WithProvenance(build: 20348, revision: 2000, messageFileVersion: "10.0.20348.900");
+
+        Assert.True(ProviderSourceRecency.Compare(newerFile, olderFile) > 0);
+    }
+
+    [Fact]
+    public void Compare_WhenMessageFileVersionUnparseable_TreatsAsAbsentAndDoesNotThrow()
+    {
+        var parseable = WithProvenance(build: 20348, revision: 2000, messageFileVersion: "10.0.20348.900");
+        var unparseable = WithProvenance(build: 20348, revision: 2000, messageFileVersion: "not-a-version");
+
+        Assert.True(ProviderSourceRecency.Compare(parseable, unparseable) > 0);
+    }
+
+    private static ProviderDetails WithProvenance(int? build = null, int? revision = null, string? messageFileVersion = null) =>
+        new()
+        {
+            ProviderName = "P",
+            SourceOsBuild = build,
+            SourceOsRevision = revision,
+            MessageFileVersion = messageFileVersion
+        };
+}

--- a/tests/Unit/EventLogExpert.Provider.Tests/Resolution/ProviderVersionSelectorTests.cs
+++ b/tests/Unit/EventLogExpert.Provider.Tests/Resolution/ProviderVersionSelectorTests.cs
@@ -53,6 +53,64 @@ public sealed class ProviderVersionSelectorTests
     }
 
     [Fact]
+    public void SelectMostComplete_RecencyIsBelowCompleteness_MoreCompleteOlderSourceWins()
+    {
+        // A newer source that captured fewer descriptions must NOT beat an older, more-complete one.
+        var newerButSparse = TiedProvider(build: 22621);
+        var olderButComplete = ProviderWith((1, "one"), (2, "two"));
+        olderButComplete.SourceOsBuild = 19041;
+
+        var result = ProviderVersionSelector.SelectMostComplete([newerButSparse, olderButComplete]);
+
+        Assert.Same(olderButComplete, result);
+    }
+
+    [Fact]
+    public void SelectMostComplete_WhenBuildAndRevisionTie_PrefersNewerMessageFileVersion()
+    {
+        var olderFile = TiedProvider(build: 22621, revision: 1000, messageFileVersion: "10.0.22621.1");
+        var newerFile = TiedProvider(build: 22621, revision: 1000, messageFileVersion: "10.0.22621.900");
+
+        var result = ProviderVersionSelector.SelectMostComplete([olderFile, newerFile]);
+
+        Assert.Same(newerFile, result);
+    }
+
+    [Fact]
+    public void SelectMostComplete_WhenBuildTies_PrefersNewerRevision()
+    {
+        var olderRevision = TiedProvider(build: 22621, revision: 1000);
+        var newerRevision = TiedProvider(build: 22621, revision: 2000);
+
+        var result = ProviderVersionSelector.SelectMostComplete([olderRevision, newerRevision]);
+
+        Assert.Same(newerRevision, result);
+    }
+
+    [Fact]
+    public void SelectMostComplete_WhenCompletenessTies_PrefersNewerOsBuild()
+    {
+        // Older loads first; recency must override the load-order-keeps-first tiebreak and pick the newer build.
+        var olderBuild = TiedProvider(build: 19041);
+        var newerBuild = TiedProvider(build: 22621);
+
+        var result = ProviderVersionSelector.SelectMostComplete([olderBuild, newerBuild]);
+
+        Assert.Same(newerBuild, result);
+    }
+
+    [Fact]
+    public void SelectMostComplete_WhenCompletenessTies_PresentProvenanceOutranksNull()
+    {
+        var noProvenance = TiedProvider();
+        var withProvenance = TiedProvider(build: 19041);
+
+        var result = ProviderVersionSelector.SelectMostComplete([noProvenance, withProvenance]);
+
+        Assert.Same(withProvenance, result);
+    }
+
+    [Fact]
     public void SelectMostComplete_WhenDescriptionsTie_PrefersMoreLegacyMessages()
     {
         var fewerMessages = EventUtils.CreateProvider(Provider, [new MessageModel { ShortId = 1, RawId = 1, Text = "a" }]);
@@ -63,6 +121,17 @@ public sealed class ProviderVersionSelectorTests
         var result = ProviderVersionSelector.SelectMostComplete([fewerMessages, moreMessages]);
 
         Assert.Same(moreMessages, result);
+    }
+
+    [Fact]
+    public void SelectMostComplete_WhenMessageFileVersionUnparseable_DoesNotThrowAndKeepsLoadOrder()
+    {
+        var first = TiedProvider(build: 22621, revision: 1000, messageFileVersion: "not-a-version");
+        var second = TiedProvider(build: 22621, revision: 1000, messageFileVersion: "also-bad");
+
+        var result = ProviderVersionSelector.SelectMostComplete([first, second]);
+
+        Assert.Same(first, result);
     }
 
     [Fact]
@@ -81,6 +150,17 @@ public sealed class ProviderVersionSelectorTests
     }
 
     [Fact]
+    public void SelectMostComplete_WhenProvenanceAbsentOnAllCandidates_FallsBackToLoadOrder()
+    {
+        var first = TiedProvider();
+        var second = TiedProvider();
+
+        var result = ProviderVersionSelector.SelectMostComplete([first, second]);
+
+        Assert.Same(first, result);
+    }
+
+    [Fact]
     public void SelectMostComplete_WhenSingleCandidate_ReturnsSameReference()
     {
         var only = ProviderWith((1, "desc"));
@@ -92,4 +172,17 @@ public sealed class ProviderVersionSelectorTests
         EventUtils.CreateProvider(
             Provider,
             events: [.. events.Select(e => EventUtils.CreateEventModel(e.Id, e.Description, logName: LogName))]);
+
+    private static ProviderDetails TiedProvider(int? build = null, int? revision = null, string? messageFileVersion = null)
+    {
+        var provider = EventUtils.CreateProvider(
+            Provider,
+            events: [EventUtils.CreateEventModel(1, "same", logName: LogName)]);
+
+        provider.SourceOsBuild = build;
+        provider.SourceOsRevision = revision;
+        provider.MessageFileVersion = messageFileVersion;
+
+        return provider;
+    }
 }

--- a/tests/Unit/EventLogExpert.Provider.Tests/Resolution/ProviderVersionSelectorTests.cs
+++ b/tests/Unit/EventLogExpert.Provider.Tests/Resolution/ProviderVersionSelectorTests.cs
@@ -1,0 +1,95 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.TestUtils;
+using EventLogExpert.Eventing.TestUtils.Constants;
+using EventLogExpert.Provider.Resolution;
+
+namespace EventLogExpert.Provider.Tests.Resolution;
+
+public sealed class ProviderVersionSelectorTests
+{
+    private const string LogName = Constants.ApplicationLogName;
+    private const string Provider = Constants.TestProviderLongName;
+
+    [Fact]
+    public void SelectMostComplete_EmptyDescriptionsDoNotCountTowardCompleteness()
+    {
+        var withCaptureGaps = ProviderWith((1, "real"), (2, ""), (3, ""));
+        var fullyPopulated = ProviderWith((1, "a"), (2, "b"));
+
+        var result = ProviderVersionSelector.SelectMostComplete([withCaptureGaps, fullyPopulated]);
+
+        Assert.Same(fullyPopulated, result);
+    }
+
+    [Fact]
+    public void SelectMostComplete_OnTrueTie_KeepsFirstCandidate()
+    {
+        // Equal completeness defers to candidate load order (the resolver loads newest-OS first).
+        var first = ProviderWith((1, "same"));
+        var second = ProviderWith((1, "same"));
+
+        var result = ProviderVersionSelector.SelectMostComplete([first, second]);
+
+        Assert.Same(first, result);
+    }
+
+    [Fact]
+    public void SelectMostComplete_PrefersMoreNonEmptyDescriptions_AndReturnsThatCandidateUnchanged()
+    {
+        // Both candidates carry an empty VersionKey (the legacy/unstamped shape): selection is by completeness score,
+        // NOT by version identity (a gate keyed on identity would collapse these), and the winner is returned as-is -
+        // one version's whole provider, coherent, never a per-event blend.
+        var sparse = ProviderWith((1, "only one"));
+        var complete = ProviderWith((1, "one"), (2, "two"));
+
+        Assert.Equal(string.Empty, sparse.VersionKey);
+        Assert.Equal(string.Empty, complete.VersionKey);
+
+        var result = ProviderVersionSelector.SelectMostComplete([sparse, complete]);
+
+        Assert.Same(complete, result);
+    }
+
+    [Fact]
+    public void SelectMostComplete_WhenDescriptionsTie_PrefersMoreLegacyMessages()
+    {
+        var fewerMessages = EventUtils.CreateProvider(Provider, [new MessageModel { ShortId = 1, RawId = 1, Text = "a" }]);
+        var moreMessages = EventUtils.CreateProvider(
+            Provider,
+            [new MessageModel { ShortId = 1, RawId = 1, Text = "a" }, new MessageModel { ShortId = 2, RawId = 2, Text = "b" }]);
+
+        var result = ProviderVersionSelector.SelectMostComplete([fewerMessages, moreMessages]);
+
+        Assert.Same(moreMessages, result);
+    }
+
+    [Fact]
+    public void SelectMostComplete_WhenNoCandidates_ReturnsNull() =>
+        Assert.Null(ProviderVersionSelector.SelectMostComplete([]));
+
+    [Fact]
+    public void SelectMostComplete_WhenNonEmptyCountTies_PrefersLongerTotalDescription()
+    {
+        var shorter = ProviderWith((1, "ab"));
+        var longer = ProviderWith((1, "abcdef"));
+
+        var result = ProviderVersionSelector.SelectMostComplete([shorter, longer]);
+
+        Assert.Same(longer, result);
+    }
+
+    [Fact]
+    public void SelectMostComplete_WhenSingleCandidate_ReturnsSameReference()
+    {
+        var only = ProviderWith((1, "desc"));
+
+        Assert.Same(only, ProviderVersionSelector.SelectMostComplete([only]));
+    }
+
+    private static ProviderDetails ProviderWith(params (int Id, string? Description)[] events) =>
+        EventUtils.CreateProvider(
+            Provider,
+            events: [.. events.Select(e => EventUtils.CreateEventModel(e.Id, e.Description, logName: LogName))]);
+}


### PR DESCRIPTION
## Summary

Makes provider-database resolution version-aware so an older OS's provider can never resolve a newer OS's
events, removes the dependence on database file names for picking a version, and keeps the per-event
resolution hot path allocation-free. Builds the foundation incrementally: distinct provider versions can
coexist in one database, resolution selects the most complete version across all loaded databases, and each
provider row now records its source provenance so resolution prefers the newest source as a deterministic
tiebreak.

## Motivation

Provider databases are built per OS (for example Windows Server 2012 R2, 2016, 2019, 2022). Previously a
merged or multi-database setup could resolve an event's description from an arbitrary version (the first row
returned), and cross-database selection leaned on the database file name as a fragile recency proxy. Research
on a real 215k-event corpus confirmed that an EVTX record carries no OS build, file version, or manifest
wording version, so the source version cannot be matched per event; recency is a global tiebreak only, and
"newest source wins" is the correct default. This branch realizes that without any file-name dependence.

## What changed (commit arc)

- Canonical multi-version schema and an upgrade that force-rebuilds older databases to it.
- Providers merge by (name, content version) so genuinely different versions coexist instead of colliding,
  with cross-file dedup keyed on the same identity.
- A content-hash VersionKey is stamped at database creation so identical providers across machines collapse
  to one row and different versions get distinct composite keys.
- The shared provider-content merge primitive is extracted so the database-merge path and the resolve-time
  selection cannot drift.
- Resolution gathers every provider version across all loaded databases and returns the single most complete
  one, unchanged (one coherent version's events, templates, maps, parameters, and messages), fixing a live
  arbitrary-version bug where a merged multi-OS database resolved a random version.
- Each provider row records source provenance (OS build, update revision, edition, display version, and the
  newest message-DLL file version), captured at database creation. Resolution consumes it as a recency
  tiebreak below completeness: a newer-but-empty capture never beats an older populated one.

## Schema and migration

The persisted schema stays at version 4; the provenance columns are added within v4 because no build that
stamps the canonical user_version has shipped yet (the stamp lives only on this branch). Every existing
database is therefore unstamped and rebuilds through the existing upgrade path, gaining the new columns with
null provenance (re-captured on a live recreate). The rebuild reader and the merge path carry provenance
forward so a future rebuild cannot silently drop it. A developer-only (DEBUG) self-heal rebuilds a
stamped-current database whose physical columns no longer match the model; in Release the detection is
byte-identical to before (no behavior change for shipped builds).

## Resolution behavior and performance

Selection runs once per provider under the existing single-flight gate and reads only in-memory scalar
fields, so there is no per-event cost and no lazy materialization on the hot path. The selection ladder is:
row-count gate, then completeness (non-empty description count, total description length, message count),
then recency (OS build, update revision, message-DLL file version) with component-wise present-outranks-null
ordering, then load order. The winner is always an existing candidate returned by reference, so no per-event
content blending occurs.

## Testing

All suites pass: Provider unit, Provider.Database unit and integration, Eventing unit and integration,
DatabaseTools integration, and Runtime unit. New tests cover version coexistence and the composite key, the
content-hash VersionKey, most-complete selection, the recency ladder (including null and unparseable
degradation), provenance round-trip and rebuild preservation, the v3-to-v4 upgrade adding null-provenance
columns, the developer-only in-place self-heal, host OS provenance reads, and that provenance does not
perturb the VersionKey.

## Notes and follow-ups (not in this PR)

- Offline merge-tiebreak (per-event best-of plus a variants store) and a pin UI are deferred; this PR keeps
  the coherent whole-version selection model.
- Offline image (ISO/WIM) extraction to build provenanced multi-OS databases from images is a separate later
  phase.
