### PR TITLE
Rename CompositeLogSink to BroadcastLogProgress and align logging naming

### DIFF
--- a/src/EventLogExpert.Logging/Configuration/LoggingOptions.cs
+++ b/src/EventLogExpert.Logging/Configuration/LoggingOptions.cs
@@ -8,7 +8,7 @@ namespace EventLogExpert.Logging.Configuration;
 
 public sealed class LoggingOptions
 {
-    public const string FileSink = "FileLogSink";
+    public const string FileLogSink = "FileLogSink";
 
     public Dictionary<string, LogSinkOptions> Sinks { get; set; } = [];
 
@@ -16,7 +16,7 @@ public sealed class LoggingOptions
     {
         options.Sinks = new Dictionary<string, LogSinkOptions>(StringComparer.Ordinal)
         {
-            [FileSink] = new LogSinkOptions
+            [FileLogSink] = new LogSinkOptions
             {
                 Categories = new Dictionary<string, LogLevel>(StringComparer.Ordinal)
                 {

--- a/src/EventLogExpert.Logging/README.md
+++ b/src/EventLogExpert.Logging/README.md
@@ -76,15 +76,17 @@ Concrete `ILogSink` implementations (the `ILogSink` contract itself lives under 
   the lowest across the sinks for the category.
 - `StreamingTraceLogger(IProgress<LogRecord> progress, LogLevel minimumLevel = Information, string category = "")` -
   a lightweight `ITraceLogger` that reports each record to an `IProgress<LogRecord>` (used for per-operation
-  progress). An empty `category` lets a downstream `CompositeLogSink` stamp the operation category.
-- `CompositeLogSink(IReadOnlyList<ILogSink> sinks, string category)` - an `IProgress<LogRecord>` that stamps a
+  progress). An empty `category` lets a downstream `BroadcastLogProgress` stamp the operation category.
+- `BroadcastLogProgress(IReadOnlyList<ILogSink> sinks, string category)` - an `IProgress<LogRecord>` that stamps a
   category and fans out to several sinks (used to build a per-operation logger that also writes to the shared
   file sink).
 
 ### Configuration
 - `LoggingOptions { Dictionary<string, LogSinkOptions> Sinks }` + `LogSinkOptions { Dictionary<string, LogLevel> Categories }` -
-  per-sink, per-category level throttles. `LoggingOptions.FileSink` is the config KEY name for the file sink's
-  throttle map (a data key, not a type name). `CreateShippedDefaults()` builds this solution's defaults.
+  per-sink, per-category level throttles. `LoggingOptions.FileLogSink` is the config dictionary KEY for the file
+  sink's throttle map; its value `"FileLogSink"` matches the `FileLogSink` sink type by design but is a stable
+  config key, not a type reference (changing the string breaks config compatibility). `CreateShippedDefaults()`
+  builds this solution's defaults.
 
 ## Composing a logger
 

--- a/src/EventLogExpert.Logging/Routing/BroadcastLogProgress.cs
+++ b/src/EventLogExpert.Logging/Routing/BroadcastLogProgress.cs
@@ -5,7 +5,7 @@ using EventLogExpert.Logging.Abstractions;
 
 namespace EventLogExpert.Logging.Routing;
 
-public sealed class CompositeLogSink(IReadOnlyList<ILogSink> sinks, string category) : IProgress<LogRecord>
+public sealed class BroadcastLogProgress(IReadOnlyList<ILogSink> sinks, string category) : IProgress<LogRecord>
 {
     private readonly IReadOnlyList<ILogSink> _sinks = sinks ?? throw new ArgumentNullException(nameof(sinks));
 

--- a/src/EventLogExpert.Logging/Routing/LogRoutingPolicy.cs
+++ b/src/EventLogExpert.Logging/Routing/LogRoutingPolicy.cs
@@ -18,7 +18,7 @@ public sealed class LogRoutingPolicy
     {
         ArgumentNullException.ThrowIfNull(options);
 
-        _fileOverrides = BuildOverrides(options, LoggingOptions.FileSink);
+        _fileOverrides = BuildOverrides(options, LoggingOptions.FileLogSink);
         _globalBaseline = globalBaseline;
     }
 

--- a/src/EventLogExpert.Logging/Routing/StreamingTraceLogger.cs
+++ b/src/EventLogExpert.Logging/Routing/StreamingTraceLogger.cs
@@ -31,11 +31,11 @@ namespace EventLogExpert.Logging.Routing;
 ///     </para>
 /// </remarks>
 public sealed class StreamingTraceLogger(
-    IProgress<LogRecord> logSink,
+    IProgress<LogRecord> progress,
     LogLevel minimumLevel = LogLevel.Information,
     string category = "") : ITraceLogger
 {
-    private readonly IProgress<LogRecord> _logSink = logSink ?? throw new ArgumentNullException(nameof(logSink));
+    private readonly IProgress<LogRecord> _progress = progress ?? throw new ArgumentNullException(nameof(progress));
 
     public LogLevel MinimumLevel { get; } = minimumLevel;
 
@@ -52,7 +52,7 @@ public sealed class StreamingTraceLogger(
     {
         ArgumentException.ThrowIfNullOrEmpty(category);
 
-        return new StreamingTraceLogger(_logSink, MinimumLevel, category);
+        return new StreamingTraceLogger(_progress, MinimumLevel, category);
     }
 
     public void Information([InterpolatedStringHandlerArgument("")] InformationLogHandler handler) =>
@@ -70,6 +70,6 @@ public sealed class StreamingTraceLogger(
 
         if (string.IsNullOrEmpty(message)) { return; }
 
-        _logSink.Report(new LogRecord(DateTime.UtcNow, level, message, category));
+        _progress.Report(new LogRecord(DateTime.UtcNow, level, message, category));
     }
 }

--- a/src/EventLogExpert.Runtime/DebugLog/OperationLogSinkFactory.cs
+++ b/src/EventLogExpert.Runtime/DebugLog/OperationLogSinkFactory.cs
@@ -17,6 +17,6 @@ internal sealed class OperationLogSinkFactory(FileLogSink fileSink, LogRoutingPo
 
         List<ILogSink> sinks = [new UiStreamingSink(uiProgress, routingPolicy.UiMinimumFor(verbose)), fileSink];
 
-        return new CompositeLogSink(sinks, category);
+        return new BroadcastLogProgress(sinks, category);
     }
 }

--- a/tests/Unit/EventLogExpert.Logging.Tests/Routing/BroadcastLogProgressTests.cs
+++ b/tests/Unit/EventLogExpert.Logging.Tests/Routing/BroadcastLogProgressTests.cs
@@ -7,14 +7,14 @@ using Microsoft.Extensions.Logging;
 
 namespace EventLogExpert.Logging.Tests.Routing;
 
-public sealed class CompositeLogSinkTests
+public sealed class BroadcastLogProgressTests
 {
     [Fact]
     public void Report_EachSinkAppliesItsOwnLevel_ReproducingTheUiAllFileWarningSplit()
     {
         var ui = new RecordingSink(_ => LogLevel.Information);
         var file = new RecordingSink(_ => LogLevel.Warning);
-        var composite = new CompositeLogSink([ui, file], "DatabaseTools.Create");
+        var composite = new BroadcastLogProgress([ui, file], "DatabaseTools.Create");
 
         composite.Report(new LogRecord(DateTime.UtcNow, LogLevel.Information, "progress"));
         composite.Report(new LogRecord(DateTime.UtcNow, LogLevel.Warning, "problem"));
@@ -26,7 +26,7 @@ public sealed class CompositeLogSinkTests
     [Fact]
     public void Report_NullValue_Throws()
     {
-        var composite = new CompositeLogSink([new RecordingSink(_ => LogLevel.Trace)], "DatabaseTools.Create");
+        var composite = new BroadcastLogProgress([new RecordingSink(_ => LogLevel.Trace)], "DatabaseTools.Create");
 
         Assert.Throws<ArgumentNullException>(() => composite.Report(null!));
     }
@@ -36,7 +36,7 @@ public sealed class CompositeLogSinkTests
     {
         var first = new RecordingSink(_ => LogLevel.Trace);
         var second = new RecordingSink(_ => LogLevel.Trace);
-        var composite = new CompositeLogSink([first, second], "DatabaseTools.Create");
+        var composite = new BroadcastLogProgress([first, second], "DatabaseTools.Create");
 
         composite.Report(new LogRecord(DateTime.UtcNow, LogLevel.Warning, "warn"));
 
@@ -48,7 +48,7 @@ public sealed class CompositeLogSinkTests
     public void Report_PreservesExistingCategory_WhenAlreadyCategorized()
     {
         var sink = new RecordingSink(_ => LogLevel.Trace);
-        var composite = new CompositeLogSink([sink], "DatabaseTools.Create");
+        var composite = new BroadcastLogProgress([sink], "DatabaseTools.Create");
 
         composite.Report(new LogRecord(DateTime.UtcNow, LogLevel.Information, "hi", "Offline.Wim"));
 
@@ -59,7 +59,7 @@ public sealed class CompositeLogSinkTests
     public void Report_StampsOperationCategory_WhenRecordIsUncategorized()
     {
         var sink = new RecordingSink(_ => LogLevel.Trace);
-        var composite = new CompositeLogSink([sink], "DatabaseTools.Create");
+        var composite = new BroadcastLogProgress([sink], "DatabaseTools.Create");
 
         composite.Report(new LogRecord(DateTime.UtcNow, LogLevel.Information, "hi"));
 
@@ -70,7 +70,7 @@ public sealed class CompositeLogSinkTests
     public void Report_WhenASinkThrows_IsolatesTheFault_AndStillReachesTheOtherSinks()
     {
         var healthy = new RecordingSink(_ => LogLevel.Trace);
-        var composite = new CompositeLogSink([new ThrowingSink(), healthy], "DatabaseTools.Create");
+        var composite = new BroadcastLogProgress([new ThrowingSink(), healthy], "DatabaseTools.Create");
 
         Exception? exception = Record.Exception(() =>
             composite.Report(new LogRecord(DateTime.UtcNow, LogLevel.Warning, "warn")));

--- a/tests/Unit/EventLogExpert.Logging.Tests/Routing/LogRoutingPolicyTests.cs
+++ b/tests/Unit/EventLogExpert.Logging.Tests/Routing/LogRoutingPolicyTests.cs
@@ -50,7 +50,7 @@ public sealed class LogRoutingPolicyTests
         {
             Sinks = new Dictionary<string, LogSinkOptions>(StringComparer.Ordinal)
             {
-                [LoggingOptions.FileSink] = new LogSinkOptions
+                [LoggingOptions.FileLogSink] = new LogSinkOptions
                 {
                     Categories = new Dictionary<string, LogLevel>(StringComparer.Ordinal)
                     {

--- a/tests/Unit/EventLogExpert.Logging.Tests/Routing/StreamingTraceLoggerTests.cs
+++ b/tests/Unit/EventLogExpert.Logging.Tests/Routing/StreamingTraceLoggerTests.cs
@@ -85,7 +85,7 @@ public sealed class StreamingTraceLoggerTests
     }
 
     [Fact]
-    public void Emit_WithoutForCategory_LeavesCategoryEmpty_SoTheCompositeSinkCanStampTheOperationCategory()
+    public void Emit_WithoutForCategory_LeavesCategoryEmpty_SoTheBroadcastLogProgressCanStampTheOperationCategory()
     {
         var captured = new List<LogRecord>();
         var sink = new SynchronousProgress<LogRecord>(captured.Add);


### PR DESCRIPTION
## What

Several identifiers in `EventLogExpert.Logging` were named `*Sink` but are actually
`IProgress<LogRecord>` implementations (they have `Report(...)`, not `Emit(...)`), which
contradicted the library's own vocabulary. This aligns the names with the contracts.

## Changes

- **Rename `CompositeLogSink` → `BroadcastLogProgress`** (type + file): it is an
  `IProgress<LogRecord>` that stamps a category onto category-less records and broadcasts each
  record to several `ILogSink`s. Updates the one consumer (`OperationLogSinkFactory`), the unit
  test, and the README.
- **Rename the `LoggingOptions.FileSink` constant → `FileLogSink`** so the identifier matches its
  value. The string value `"FileLogSink"` (the config dictionary key) is unchanged, so existing
  configuration and routing behavior are preserved.
- **Rename `StreamingTraceLogger`'s `logSink`/`_logSink` → `progress`/`_progress`**, matching
  `UiStreamingSink` and the README (which already documented `progress`).
- Refresh the README wording that documented around these naming mismatches.

The `*TraceLogger` names and the `ILogSink`/`Emit()` contract are intentionally unchanged.

## Verification

- Solution builds clean (0 warnings, 0 errors).
- `EventLogExpert.Logging.Tests`: 68 passed.
- No behavior change — renames only; the config key value is preserved.
