### PR TITLE
Rename IpcProgressSink to IpcProgressForwarder and unify progress params

### DIFF
--- a/src/EventLogExpert.ElevationHelper/Ipc/IpcProgressForwarder.cs
+++ b/src/EventLogExpert.ElevationHelper/Ipc/IpcProgressForwarder.cs
@@ -11,7 +11,7 @@ namespace EventLogExpert.ElevationHelper.Ipc;
 ///     as <see cref="IpcLogForwarder" />: wraps each report in a <see cref="ProgressMessage" /> and writes it through the
 ///     shared semaphore-guarded <see cref="IpcMessageWriter" />.
 /// </summary>
-internal sealed class IpcProgressSink(IpcMessageWriter writer) : IProgress<DatabaseToolsProgress>
+internal sealed class IpcProgressForwarder(IpcMessageWriter writer) : IProgress<DatabaseToolsProgress>
 {
     public void Report(DatabaseToolsProgress value)
     {

--- a/src/EventLogExpert.ElevationHelper/Operations/OperationDispatcher.cs
+++ b/src/EventLogExpert.ElevationHelper/Operations/OperationDispatcher.cs
@@ -23,7 +23,7 @@ internal static class OperationDispatcher
 
         var service = services.GetRequiredService<IDatabaseToolsService>();
         var logProgress = new IpcLogForwarder(writer);
-        var progressSink = new IpcProgressSink(writer);
+        var progress = new IpcProgressForwarder(writer);
 
         // List-editions is read-only, so it bypasses destructive database recovery.
         if (request is ListImageEditionsIpcRequest listEditions)
@@ -33,23 +33,23 @@ internal static class OperationDispatcher
 
         return await DestructiveRecovery.WrapAsync(
             request,
-            (req, ct) => RawDispatchAsync(service, req, logProgress, progressSink, ct),
+            (req, ct) => RawDispatchAsync(service, req, logProgress, progress, ct),
             cancellationToken);
     }
 
     private static Task<DatabaseToolsResult> RawDispatchAsync(
         IDatabaseToolsService service,
         DatabaseToolsIpcRequest request,
-        IProgress<LogRecord> logRecord,
+        IProgress<LogRecord> logProgress,
         IProgress<DatabaseToolsProgress> progress,
         CancellationToken cancellationToken)
         => request switch
         {
-            ShowProvidersIpcRequest s => service.ShowAsync(s.Request, logRecord, progress, cancellationToken, s.Verbose),
-            CreateDatabaseIpcRequest c => service.CreateAsync(c.Request, logRecord, progress, cancellationToken, c.Verbose),
-            MergeDatabaseIpcRequest m => service.MergeAsync(m.Request, logRecord, progress, cancellationToken, m.Verbose),
-            DiffDatabaseIpcRequest d => service.DiffAsync(d.Request, logRecord, progress, cancellationToken, d.Verbose),
-            UpgradeDatabaseIpcRequest u => service.UpgradeAsync(u.Request, logRecord, progress, cancellationToken, u.Verbose),
+            ShowProvidersIpcRequest s => service.ShowAsync(s.Request, logProgress, progress, cancellationToken, s.Verbose),
+            CreateDatabaseIpcRequest c => service.CreateAsync(c.Request, logProgress, progress, cancellationToken, c.Verbose),
+            MergeDatabaseIpcRequest m => service.MergeAsync(m.Request, logProgress, progress, cancellationToken, m.Verbose),
+            DiffDatabaseIpcRequest d => service.DiffAsync(d.Request, logProgress, progress, cancellationToken, d.Verbose),
+            UpgradeDatabaseIpcRequest u => service.UpgradeAsync(u.Request, logProgress, progress, cancellationToken, u.Verbose),
             _ => Task.FromResult(new DatabaseToolsResult(DatabaseToolsOutcome.Failed, $"Unknown request type: {request.GetType().Name}", TimeSpan.Zero))
         };
 }

--- a/src/EventLogExpert.Runtime/DatabaseTools/Elevation/ElevatedDatabaseToolsRunner.cs
+++ b/src/EventLogExpert.Runtime/DatabaseTools/Elevation/ElevatedDatabaseToolsRunner.cs
@@ -93,7 +93,7 @@ internal sealed class ElevatedDatabaseToolsRunner : IElevatedDatabaseToolsRunner
         var result = await RunAsync(
             new ListImageEditionsIpcRequest(request, verbose),
             logProgress,
-            progressSink: null,
+            progress: null,
             cancellationToken,
             onDataMessage: message =>
             {
@@ -343,7 +343,7 @@ internal sealed class ElevatedDatabaseToolsRunner : IElevatedDatabaseToolsRunner
     private async Task<DatabaseToolsResult> RunAsync(
         DatabaseToolsIpcRequest request,
         IProgress<LogRecord> logProgress,
-        IProgress<DatabaseToolsProgress>? progressSink,
+        IProgress<DatabaseToolsProgress>? progress,
         CancellationToken cancellationToken,
         Action<DatabaseToolsIpcMessage>? onDataMessage = null)
     {
@@ -486,8 +486,8 @@ internal sealed class ElevatedDatabaseToolsRunner : IElevatedDatabaseToolsRunner
                             SafeReport(logProgress, new LogRecord(log.TimestampUtc, log.Level, log.Message, log.Category, log.ProcessOrigin));
                             break;
 
-                        case ProgressMessage prog when progressSink is not null:
-                            SafeReport(progressSink, new DatabaseToolsProgress(prog.Processed, prog.Total, prog.CurrentItem));
+                        case ProgressMessage prog when progress is not null:
+                            SafeReport(progress, new DatabaseToolsProgress(prog.Processed, prog.Total, prog.CurrentItem));
                             break;
 
                         case ImageEditionsMessage edition when onDataMessage is not null:

--- a/tests/Unit/EventLogExpert.Logging.Tests/Routing/StreamingTraceLoggerTests.cs
+++ b/tests/Unit/EventLogExpert.Logging.Tests/Routing/StreamingTraceLoggerTests.cs
@@ -41,7 +41,7 @@ public sealed class StreamingTraceLoggerTests
     }
 
     [Fact]
-    public void Constructor_NullLogSink_Throws() =>
+    public void Constructor_NullProgress_Throws() =>
         Assert.Throws<ArgumentNullException>(static () => new StreamingTraceLogger(null!));
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Runtime.Tests/DatabaseTools/Elevation/ElevatedDatabaseToolsRunnerTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/DatabaseTools/Elevation/ElevatedDatabaseToolsRunnerTests.cs
@@ -157,13 +157,13 @@ public sealed class ElevatedDatabaseToolsRunnerTests
         var runner = CreateRunner(host, logger);
 
         var logProgress = new ListProgress<LogRecord>();
-        var progressSink = new ListProgress<DatabaseToolsProgress>();
+        var progress = new ListProgress<DatabaseToolsProgress>();
 
         await using var clientWriter = new StreamWriter(client, s_utf8NoBom, bufferSize: 4096, leaveOpen: true) { AutoFlush = true };
         using var clientReader = new StreamReader(client, s_utf8NoBom, detectEncodingFromByteOrderMarks: false, bufferSize: 4096, leaveOpen: true);
 
         var runTask = runner.ShowAsync(
-            new ShowProvidersRequest(null, null), logProgress, progressSink, ct);
+            new ShowProvidersRequest(null, null), logProgress, progress, ct);
 
         await WriteMessageAsync(clientWriter, new HelloMessage(9999, HelloMessage.CurrentProtocolVersion), ct);
         await ReadRequestAsync(clientReader, ct);
@@ -187,10 +187,10 @@ public sealed class ElevatedDatabaseToolsRunnerTests
         Assert.Equal("second", logProgress.Entries[1].Message);
         Assert.Equal(LogLevel.Warning, logProgress.Entries[1].Level);
 
-        Assert.Single(progressSink.Entries);
-        Assert.Equal(1, progressSink.Entries[0].Processed);
-        Assert.Equal(10, progressSink.Entries[0].Total);
-        Assert.Equal("item-1", progressSink.Entries[0].CurrentItem);
+        Assert.Single(progress.Entries);
+        Assert.Equal(1, progress.Entries[0].Processed);
+        Assert.Equal(10, progress.Entries[0].Total);
+        Assert.Equal("item-1", progress.Entries[0].CurrentItem);
     }
 
     [Fact]
@@ -320,13 +320,13 @@ public sealed class ElevatedDatabaseToolsRunnerTests
         var runner = CreateRunner(host, logger);
 
         var logProgress = new ListProgress<LogRecord>();
-        var progressSink = new ListProgress<DatabaseToolsProgress>();
+        var progress = new ListProgress<DatabaseToolsProgress>();
 
         await using var clientWriter = new StreamWriter(client, s_utf8NoBom, bufferSize: 4096, leaveOpen: true) { AutoFlush = true };
         using var clientReader = new StreamReader(client, s_utf8NoBom, detectEncodingFromByteOrderMarks: false, bufferSize: 4096, leaveOpen: true);
 
         var runTask = runner.ShowAsync(
-            new ShowProvidersRequest(null, null), logProgress, progressSink, ct);
+            new ShowProvidersRequest(null, null), logProgress, progress, ct);
 
         await WriteMessageAsync(clientWriter, new HelloMessage(9999, HelloMessage.CurrentProtocolVersion), ct);
         await ReadRequestAsync(clientReader, ct);
@@ -434,13 +434,13 @@ public sealed class ElevatedDatabaseToolsRunnerTests
         var logger = new LoggerUtils.RecordingTraceLogger();
         var runner = CreateRunner(host, logger);
         var logProgress = new ListProgress<LogRecord>();
-        var progressSink = new ListProgress<DatabaseToolsProgress>();
+        var progress = new ListProgress<DatabaseToolsProgress>();
 
         await using var clientWriter = new StreamWriter(client, s_utf8NoBom, bufferSize: 4096, leaveOpen: true) { AutoFlush = true };
         using var clientReader = new StreamReader(client, s_utf8NoBom, detectEncodingFromByteOrderMarks: false, bufferSize: 4096, leaveOpen: true);
 
         var runTask = runner.ShowAsync(
-            new ShowProvidersRequest(null, null), logProgress, progressSink, ct);
+            new ShowProvidersRequest(null, null), logProgress, progress, ct);
 
         await WriteMessageAsync(clientWriter, new HelloMessage(2222, HelloMessage.CurrentProtocolVersion), ct);
         await ReadRequestAsync(clientReader, ct);
@@ -460,7 +460,7 @@ public sealed class ElevatedDatabaseToolsRunnerTests
 
         Assert.Equal(DatabaseToolsOutcome.Succeeded, result.Outcome);
         Assert.Equal(20, logProgress.Entries.Count);
-        Assert.Equal(20, progressSink.Entries.Count);
+        Assert.Equal(20, progress.Entries.Count);
 
         var allTraceMessages = logger.TraceMessages
             .Concat(logger.DebugMessages)


### PR DESCRIPTION
## What

Follow-up naming cleanup, continuing the Sink→Progress alignment (stacked on #626). The IPC
progress channel and a couple of parameters were still named `*Sink` / inconsistently.

## Changes

- Rename the type `IpcProgressSink` → `IpcProgressForwarder` (an `IProgress<DatabaseToolsProgress>`),
  matching its sibling `IpcLogForwarder` — the doc already described them as the same contract.
- Rename the `progressSink` parameters/locals → `progress` (unifying with the `RawDispatchAsync`
  parameter already named `progress`).
- Rename the `RawDispatchAsync` log parameter `logRecord` → `logProgress` (it is an
  `IProgress<LogRecord>`, not a `LogRecord`), matching the outer variable and the log-channel convention.
- Rename the stale test `Constructor_NullLogSink_Throws` → `Constructor_NullProgress_Throws`.

## Verification

- Solution builds clean (0 warnings, 0 errors).
- `EventLogExpert.Logging.Tests`: 68 passed. `EventLogExpert.Runtime.Tests`: 1714 passed.
- Pure rename — no behavior change. The `LogRecord` type is unchanged.

---
Stacked on #626 — base is that branch; will retarget to `main` after it merges.
