### PR TITLE
Move the trace loggers to a Loggers folder in EventLogExpert.Logging

### DIFF
--- a/src/EventLogExpert.ElevationHelper/Operations/ListImageEditionsHandler.cs
+++ b/src/EventLogExpert.ElevationHelper/Operations/ListImageEditionsHandler.cs
@@ -8,7 +8,7 @@ using EventLogExpert.ElevationHelper.Ipc;
 using EventLogExpert.Eventing.OfflineImaging.Iso;
 using EventLogExpert.Eventing.OfflineImaging.Wim;
 using EventLogExpert.Logging.Abstractions;
-using EventLogExpert.Logging.Routing;
+using EventLogExpert.Logging.Loggers;
 using Microsoft.Extensions.Logging;
 using System.Diagnostics;
 

--- a/src/EventLogExpert.Logging/Loggers/DispatchingTraceLogger.cs
+++ b/src/EventLogExpert.Logging/Loggers/DispatchingTraceLogger.cs
@@ -6,7 +6,7 @@ using EventLogExpert.Logging.Abstractions.Handlers;
 using Microsoft.Extensions.Logging;
 using System.Runtime.CompilerServices;
 
-namespace EventLogExpert.Logging.Routing;
+namespace EventLogExpert.Logging.Loggers;
 
 public sealed class DispatchingTraceLogger(
     IReadOnlyList<ILogSink> sinks,

--- a/src/EventLogExpert.Logging/Loggers/StreamingTraceLogger.cs
+++ b/src/EventLogExpert.Logging/Loggers/StreamingTraceLogger.cs
@@ -6,7 +6,7 @@ using EventLogExpert.Logging.Abstractions.Handlers;
 using Microsoft.Extensions.Logging;
 using System.Runtime.CompilerServices;
 
-namespace EventLogExpert.Logging.Routing;
+namespace EventLogExpert.Logging.Loggers;
 
 /// <summary>
 ///     <see cref="ITraceLogger" /> implementation that streams every emitted message as a <see cref="LogRecord" />

--- a/src/EventLogExpert.Logging/Routing/LogSourceFactory.cs
+++ b/src/EventLogExpert.Logging/Routing/LogSourceFactory.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Logging.Loggers;
 
 namespace EventLogExpert.Logging.Routing;
 

--- a/src/EventLogExpert.Runtime/DatabaseTools/DatabaseToolsService.cs
+++ b/src/EventLogExpert.Runtime/DatabaseTools/DatabaseToolsService.cs
@@ -8,7 +8,7 @@ using EventLogExpert.DatabaseTools.MergeDatabase;
 using EventLogExpert.DatabaseTools.ShowProviders;
 using EventLogExpert.DatabaseTools.UpgradeDatabase;
 using EventLogExpert.Logging.Abstractions;
-using EventLogExpert.Logging.Routing;
+using EventLogExpert.Logging.Loggers;
 using Microsoft.Extensions.Logging;
 using System.Diagnostics;
 

--- a/tests/Unit/EventLogExpert.DatabaseTools.Tests/CreateDatabase/CreateDatabaseOfflineCategoryTests.cs
+++ b/tests/Unit/EventLogExpert.DatabaseTools.Tests/CreateDatabase/CreateDatabaseOfflineCategoryTests.cs
@@ -3,7 +3,7 @@
 
 using EventLogExpert.DatabaseTools.CreateDatabase;
 using EventLogExpert.Logging.Abstractions;
-using EventLogExpert.Logging.Routing;
+using EventLogExpert.Logging.Loggers;
 using Microsoft.Extensions.Logging;
 
 namespace EventLogExpert.DatabaseTools.Tests.CreateDatabase;

--- a/tests/Unit/EventLogExpert.Eventing.OfflineImaging.Tests/Extraction/OfflineImageProviderExtractorTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.OfflineImaging.Tests/Extraction/OfflineImageProviderExtractorTests.cs
@@ -1,11 +1,9 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
-using EventLogExpert.Eventing.OfflineImaging;
 using EventLogExpert.Eventing.OfflineImaging.Extraction;
-using EventLogExpert.Eventing.ProviderMetadata;
 using EventLogExpert.Logging.Abstractions;
-using EventLogExpert.Logging.Routing;
+using EventLogExpert.Logging.Loggers;
 using Microsoft.Extensions.Logging;
 using Microsoft.Win32;
 

--- a/tests/Unit/EventLogExpert.Logging.Tests/Loggers/DispatchingTraceLoggerTests.cs
+++ b/tests/Unit/EventLogExpert.Logging.Tests/Loggers/DispatchingTraceLoggerTests.cs
@@ -2,10 +2,10 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Logging.Abstractions;
-using EventLogExpert.Logging.Routing;
+using EventLogExpert.Logging.Loggers;
 using Microsoft.Extensions.Logging;
 
-namespace EventLogExpert.Logging.Tests.Routing;
+namespace EventLogExpert.Logging.Tests.Loggers;
 
 public sealed class DispatchingTraceLoggerTests
 {

--- a/tests/Unit/EventLogExpert.Logging.Tests/Loggers/StreamingTraceLoggerTests.cs
+++ b/tests/Unit/EventLogExpert.Logging.Tests/Loggers/StreamingTraceLoggerTests.cs
@@ -2,11 +2,11 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Logging.Abstractions;
-using EventLogExpert.Logging.Routing;
+using EventLogExpert.Logging.Loggers;
 using Microsoft.Extensions.Logging;
 using System.Collections.Concurrent;
 
-namespace EventLogExpert.Logging.Tests.Routing;
+namespace EventLogExpert.Logging.Tests.Loggers;
 
 public sealed class StreamingTraceLoggerTests
 {

--- a/tests/Unit/EventLogExpert.Logging.Tests/RecordingSink.cs
+++ b/tests/Unit/EventLogExpert.Logging.Tests/RecordingSink.cs
@@ -4,7 +4,7 @@
 using EventLogExpert.Logging.Abstractions;
 using Microsoft.Extensions.Logging;
 
-namespace EventLogExpert.Logging.Tests.Routing;
+namespace EventLogExpert.Logging.Tests;
 
     internal sealed class RecordingSink(Func<string, LogLevel> minimumForCategory) : ILogSink
     {


### PR DESCRIPTION
## Summary
Small VSA cleanup (item C5 from the ratified VSA plan): move the two logger types out of the `Routing/` folder in the standalone `EventLogExpert.Logging` library into a dedicated `Loggers/` folder - they are loggers, not routing.

### Change
- `StreamingTraceLogger` + `DispatchingTraceLogger`: `Routing/` -> `Loggers/` (namespace `EventLogExpert.Logging.Routing` -> `EventLogExpert.Logging.Loggers`). `Routing/` now holds exactly `BroadcastLogProgress`, `LogRoutingPolicy`, `LogSourceFactory`.
- Test files mirrored into `tests/Unit/EventLogExpert.Logging.Tests/Loggers/`.
- The shared `RecordingSink` test helper moved from `Routing/` to the `Logging.Tests` root so both the `Loggers` and `Routing` test folders reach it via parent-namespace lookup.
- Repointed 5 consumers (`LogSourceFactory`, `DatabaseToolsService`, `ListImageEditionsHandler`, and 2 tests) with `using EventLogExpert.Logging.Loggers;`.

### Validation
- `dotnet build EventLogExpert.slnx` - 0 warnings / 0 errors.
- Tests green: Logging 68, DatabaseTools 62, Runtime 1714, Eventing 416.
- Pure move + namespace/using change - zero behavior change.