### PR TITLE
Add a bulk SegmentedSortedList.Slice for single-log viewport paging

### DIFF
--- a/src/EventLogExpert.Runtime/LogTable/CombinedEventView.cs
+++ b/src/EventLogExpert.Runtime/LogTable/CombinedEventView.cs
@@ -210,9 +210,14 @@ internal sealed class CombinedEventView : IReadOnlyList<ResolvedEvent>, IList<Re
         Span<int> listOffsets = k <= MaxStackOffsets ? stackalloc int[k] : new int[k];
         int position = SeekTo(start, listOffsets);
 
+        Span<int> segment = k <= MaxStackOffsets ? stackalloc int[k] : new int[k];
+        Span<int> offset = k <= MaxStackOffsets ? stackalloc int[k] : new int[k];
+        Span<int> heap = k <= MaxStackOffsets ? stackalloc int[k] : new int[k];
+        var merger = new PerLogMerger(_lists.AsSpan(), _comparer, segment, offset, heap, listOffsets);
+
         while (position < start)
         {
-            listOffsets[PickBest(listOffsets)]++;
+            merger.AdvanceBest();
             position++;
         }
 
@@ -220,9 +225,8 @@ internal sealed class CombinedEventView : IReadOnlyList<ResolvedEvent>, IList<Re
 
         for (int i = 0; position < end; i++, position++)
         {
-            int best = PickBest(listOffsets);
-            result[i] = _lists[best][listOffsets[best]];
-            listOffsets[best]++;
+            result[i] = merger.Current(merger.PeekBest());
+            merger.AdvanceBest();
         }
 
         return result;
@@ -307,5 +311,118 @@ internal sealed class CombinedEventView : IReadOnlyList<ResolvedEvent>, IList<Re
         checkpoints[checkpoint - 1].CopyTo(listOffsets);
 
         return checkpoint * Stride;
+    }
+
+    /// <summary>
+    ///     Walks the per-log lists as one globally-sorted stream via per-list positions and a min-heap of the active
+    ///     heads, byte-identical to <see cref="PickBest" /> (ties broken by ascending list index). All state is
+    ///     caller-provided <c>stackalloc</c> spans, so the merge allocates nothing, and a <see langword="ref" /> struct so it
+    ///     cannot escape or be shared. Parity relies on the comparer being a strict weak ordering.
+    /// </summary>
+    private ref struct PerLogMerger
+    {
+        private readonly ReadOnlySpan<SegmentedSortedList> _lists;
+        private readonly Comparison<ResolvedEvent> _comparer;
+        private readonly Span<int> _segment;
+        private readonly Span<int> _offset;
+        private readonly Span<int> _heap;
+        private int _count;
+
+        internal PerLogMerger(
+            ReadOnlySpan<SegmentedSortedList> lists,
+            Comparison<ResolvedEvent> comparer,
+            Span<int> segment,
+            Span<int> offset,
+            Span<int> heap,
+            ReadOnlySpan<int> flatOffsets)
+        {
+            _lists = lists;
+            _comparer = comparer;
+            _segment = segment;
+            _offset = offset;
+            _heap = heap;
+            _count = 0;
+
+            for (int list = 0; list < lists.Length; list++)
+            {
+                if (lists[list].TryGetSegmentOffset(flatOffsets[list], out int seg, out int off))
+                {
+                    _segment[list] = seg;
+                    _offset[list] = off;
+                    Push(list);
+                }
+            }
+        }
+
+        internal readonly int PeekBest() => _count > 0 ? _heap[0] : -1;
+
+        internal readonly ResolvedEvent Current(int list) => _lists[list].GetAt(_segment[list], _offset[list]);
+
+        internal void AdvanceBest()
+        {
+            Debug.Assert(_count > 0, "AdvanceBest called on an empty heap.");
+
+            int best = _heap[0];
+
+            if (_lists[best].TryAdvance(ref _segment[best], ref _offset[best]))
+            {
+                // The root's key only increased, so a single sift-down from the root restores the heap.
+                SiftDown(0);
+            }
+            else
+            {
+                _count--;
+
+                if (_count > 0)
+                {
+                    _heap[0] = _heap[_count];
+                    SiftDown(0);
+                }
+            }
+        }
+
+        private void Push(int list)
+        {
+            int child = _count++;
+            _heap[child] = list;
+
+            while (child > 0)
+            {
+                int parent = (child - 1) >> 1;
+
+                if (!Less(_heap[child], _heap[parent])) { break; }
+
+                (_heap[parent], _heap[child]) = (_heap[child], _heap[parent]);
+                child = parent;
+            }
+        }
+
+        private void SiftDown(int parent)
+        {
+            while (true)
+            {
+                int smallest = parent;
+                int left = (parent << 1) + 1;
+                int right = left + 1;
+
+                if (left < _count && Less(_heap[left], _heap[smallest])) { smallest = left; }
+
+                if (right < _count && Less(_heap[right], _heap[smallest])) { smallest = right; }
+
+                if (smallest == parent) { break; }
+
+                (_heap[parent], _heap[smallest]) = (_heap[smallest], _heap[parent]);
+                parent = smallest;
+            }
+        }
+
+        // Strict total order over list indices: the full comparer on the two heads, ties broken by ascending list
+        // index (earliest wins, matching PickBest's strict-< scan).
+        private readonly bool Less(int a, int b)
+        {
+            int comparison = _comparer(Current(a), Current(b));
+
+            return comparison != 0 ? comparison < 0 : a < b;
+        }
     }
 }

--- a/src/EventLogExpert.Runtime/LogTable/ResolvedEventIndex.cs
+++ b/src/EventLogExpert.Runtime/LogTable/ResolvedEventIndex.cs
@@ -114,6 +114,8 @@ public static class ResolvedEventIndex
 
         if (events is CombinedEventView combined) { return combined.Slice(start, count); }
 
+        if (events is SegmentedSortedList segmented) { return segmented.Slice(start, count); }
+
         if (start < 0) { throw new ArgumentOutOfRangeException(nameof(start)); }
 
         if (count < 0) { throw new ArgumentOutOfRangeException(nameof(count)); }

--- a/src/EventLogExpert.Runtime/LogTable/SegmentedSortedList.cs
+++ b/src/EventLogExpert.Runtime/LogTable/SegmentedSortedList.cs
@@ -266,6 +266,33 @@ internal sealed class SegmentedSortedList : IReadOnlyList<ResolvedEvent>, IList<
         return null;
     }
 
+    internal ResolvedEvent[] Slice(int start, int count)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(start);
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+
+        int end = (int)Math.Min((long)start + count, Count);
+
+        if (start >= end) { return []; }
+
+        var result = new ResolvedEvent[end - start];
+        int segment = FindSegment(start);
+        int position = start;
+        int destination = 0;
+
+        while (position < end)
+        {
+            int segmentStart = position - _prefix[segment];
+            int take = Math.Min(_prefix[segment + 1] - position, end - position);
+            _segments[segment].CopyTo(segmentStart, result, destination, take);
+            destination += take;
+            position += take;
+            segment++;
+        }
+
+        return result;
+    }
+
     internal SegmentedSortedList WhereSegmented(Func<ResolvedEvent, bool> predicate)
     {
         var builder = ImmutableArray.CreateBuilder<ImmutableArray<ResolvedEvent>>(_segments.Length);
@@ -327,6 +354,9 @@ internal sealed class SegmentedSortedList : IReadOnlyList<ResolvedEvent>, IList<
 
     private int FindSegment(int index)
     {
+#if DEBUG
+        FindSegmentCallCount++;
+#endif
         int low = 0;
         int high = _segments.Length - 1;
 
@@ -372,4 +402,12 @@ internal sealed class SegmentedSortedList : IReadOnlyList<ResolvedEvent>, IList<
 
         return result.MoveToImmutable();
     }
+
+#if DEBUG
+    // Test-only (Item 4a): lets a test assert SegmentedSortedList.Slice does exactly one FindSegment. Instance-scoped
+    // so xUnit's parallel test classes never share it; DEBUG-only so Release/benchmark builds carry zero overhead.
+    internal int FindSegmentCallCount { get; private set; }
+
+    internal void ResetFindSegmentCallCount() => FindSegmentCallCount = 0;
+#endif
 }

--- a/src/EventLogExpert.Runtime/LogTable/SegmentedSortedList.cs
+++ b/src/EventLogExpert.Runtime/LogTable/SegmentedSortedList.cs
@@ -190,6 +190,8 @@ internal sealed class SegmentedSortedList : IReadOnlyList<ResolvedEvent>, IList<
         return new SegmentedSortedList([merged], _context, _comparer);
     }
 
+    internal ResolvedEvent GetAt(int segment, int offset) => _segments[segment][offset];
+
     internal bool HasContext(SortContext context) => _context == context;
 
     internal int Rank(ResolvedEvent target)
@@ -291,6 +293,37 @@ internal sealed class SegmentedSortedList : IReadOnlyList<ResolvedEvent>, IList<
         }
 
         return result;
+    }
+
+    internal bool TryAdvance(ref int segment, ref int offset)
+    {
+        offset++;
+
+        if (offset < _segments[segment].Length) { return true; }
+
+        offset = 0;
+        segment++;
+
+        // Segments are never empty (CreateSorted/Append/WhereSegmented drop empties), so the while is insurance only.
+        while (segment < _segments.Length && _segments[segment].IsEmpty) { segment++; }
+
+        return segment < _segments.Length;
+    }
+
+    internal bool TryGetSegmentOffset(int flatOffset, out int segment, out int offset)
+    {
+        if ((uint)flatOffset >= (uint)Count)
+        {
+            segment = 0;
+            offset = 0;
+
+            return false;
+        }
+
+        segment = FindSegment(flatOffset);
+        offset = flatOffset - _prefix[segment];
+
+        return true;
     }
 
     internal SegmentedSortedList WhereSegmented(Func<ResolvedEvent, bool> predicate)

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/CombinedEventViewTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/CombinedEventViewTests.cs
@@ -15,6 +15,16 @@ public sealed class CombinedEventViewTests
         [null, ColumnName.DateAndTime, ColumnName.Source, ColumnName.Level, ColumnName.EventId];
 
     [Fact]
+    public void Constructor_DuplicateOwningLog_Throws()
+    {
+        var context = new SortContext(ColumnName.DateAndTime, true, null, false);
+        var first = SegmentedSortedList.CreateSorted(MakeLog("Shared", 1, 5), context);
+        var second = SegmentedSortedList.CreateSorted(MakeLog("Shared", 100, 5), context);
+
+        Assert.Throws<UnreachableException>(() => new CombinedEventView([first, second], context));
+    }
+
+    [Fact]
     public void CopyTo_ValidatesDestinationBeforeWriting()
     {
         var (facade, oracle) = Build([MakeLog("Log0", 1, 100)], ColumnName.DateAndTime, true, null);
@@ -28,16 +38,6 @@ public sealed class CombinedEventViewTests
         Assert.Null(destination[0]);
 
         for (int i = 0; i < facade.Count; i++) { Assert.Same(oracle[i], destination[i + 1]); }
-    }
-
-    [Fact]
-    public void Constructor_DuplicateOwningLog_Throws()
-    {
-        var context = new SortContext(ColumnName.DateAndTime, true, null, false);
-        var first = SegmentedSortedList.CreateSorted(MakeLog("Shared", 1, 5), context);
-        var second = SegmentedSortedList.CreateSorted(MakeLog("Shared", 100, 5), context);
-
-        Assert.Throws<UnreachableException>(() => new CombinedEventView([first, second], context));
     }
 
     [Fact]
@@ -166,6 +166,35 @@ public sealed class CombinedEventViewTests
     }
 
     [Fact]
+    public void Slice_CrossListComparerTie_ResolvedByListIndex_MatchesEnumerator()
+    {
+        // Force a TRUE cross-list comparer tie: each list's HEAD has a distinct OwningLog (ctor requirement), but the
+        // interior "Tie" events share OwningLog + identical keys across lists, so the merged heads become comparer-equal.
+        // Production never does this (lists are per-OwningLog), but SegmentedSortedList permits mixed logs, so this
+        // exercises the heap's list-index tiebreak. Slice (heap) and the enumerator (PickBest) both break ties by
+        // ascending list index, so they must agree.
+        var context = new SortContext(ColumnName.DateAndTime, false, null, false);
+        var time = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        List<ResolvedEvent> TieList(string head) =>
+        [
+            MakeEvent(head, 1, time, 1000, "S", "Information"),
+            MakeEvent("Tie", 2, time.AddMilliseconds(10), 1000, "S", "Information"),
+            MakeEvent("Tie", 3, time.AddMilliseconds(20), 1000, "S", "Information"),
+        ];
+
+        var lists = new List<SegmentedSortedList>
+        {
+            SegmentedSortedList.CreateSorted(TieList("L0"), context),
+            SegmentedSortedList.CreateSorted(TieList("L1"), context),
+            SegmentedSortedList.CreateSorted(TieList("L2"), context),
+        };
+        var facade = new CombinedEventView(lists, context);
+
+        AssertSliceMatchesEnumerator(facade);
+    }
+
+    [Fact]
     public void Slice_HandlesBoundariesAndOverflowWithoutWrongEmpty()
     {
         var (facade, oracle) = Build([MakeLog("Log0", 1, 1000)], ColumnName.DateAndTime, true, null);
@@ -178,6 +207,85 @@ public sealed class CombinedEventViewTests
         Assert.Equal(oracle.Count - 5, tail.Count);
         Assert.Same(oracle[5], tail[0]);
         Assert.Same(oracle[^1], tail[^1]);
+    }
+
+    [Fact]
+    public void Slice_UnderHeavyPrimaryKeyTies_MatchesEnumerator()
+    {
+        // Every event shares Source, ordered by Source, so the primary key ties for ALL of them and the comparer
+        // falls to its secondary keys - heavy comparer work through the heap. Assert against the enumerator (the real
+        // PickBest merge), never the unstable SortEvents oracle.
+        var time = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var perLog = new List<List<ResolvedEvent>>();
+
+        for (int k = 0; k < 4; k++)
+        {
+            var events = new List<ResolvedEvent>(300);
+
+            for (long record = 1; record <= 300; record++)
+            {
+                events.Add(MakeEvent($"Log{k}", record, time.AddMilliseconds(record), 1000, "SameSource", "Information"));
+            }
+
+            perLog.Add(events);
+        }
+
+        var context = new SortContext(ColumnName.Source, false, null, false);
+        var facade = new CombinedEventView(perLog.Select(e => SegmentedSortedList.CreateSorted(e, context)).ToList(), context);
+
+        AssertSliceMatchesEnumerator(facade);
+    }
+
+    [Fact]
+    public void Slice_UnevenLogLengths_MatchesEnumeratorAcrossExhaustion()
+    {
+        // A short list exhausts long before the long one; slices crossing that exhaustion point must still match.
+        var context = new SortContext(ColumnName.DateAndTime, false, null, false);
+        var lists = new List<SegmentedSortedList>
+        {
+            SegmentedSortedList.CreateSorted(MakeLog("Short", 1, 5), context),
+            SegmentedSortedList.CreateSorted(MakeLog("Long", 1, 500), context),
+        };
+        var facade = new CombinedEventView(lists, context);
+
+        AssertSliceMatchesEnumerator(facade);
+    }
+
+    [Fact]
+    public void Slice_WithEmptyListPresent_MatchesEnumerator()
+    {
+        var context = new SortContext(ColumnName.DateAndTime, false, null, false);
+        var lists = new List<SegmentedSortedList>
+        {
+            SegmentedSortedList.CreateSorted(MakeLog("Log0", 1, 200), context),
+            SegmentedSortedList.CreateSorted([], context),                       // empty list among the non-empty ones
+            SegmentedSortedList.CreateSorted(MakeLog("Log2", 1, 150), context),
+        };
+        var facade = new CombinedEventView(lists, context);
+
+        AssertSliceMatchesEnumerator(facade);
+    }
+
+    private static void AssertSliceMatchesEnumerator(CombinedEventView facade)
+    {
+        var enumerated = facade.ToList();   // the current PickBest merge - the parity reference (NOT the unstable sort)
+
+        int[] starts = [0, 1, 63, 64, 65, 127, 128, 255, 256, enumerated.Count / 2, Math.Max(0, enumerated.Count - 3)];
+
+        foreach (int start in starts)
+        {
+            if (start >= enumerated.Count) { continue; }
+
+            foreach (int count in new[] { 1, 40, 100, enumerated.Count })
+            {
+                var slice = facade.Slice(start, count);
+                int expected = Math.Min(count, enumerated.Count - start);
+
+                Assert.Equal(expected, slice.Count);
+
+                for (int j = 0; j < expected; j++) { Assert.Same(enumerated[start + j], slice[j]); }
+            }
+        }
     }
 
     private static (CombinedEventView Facade, IReadOnlyList<ResolvedEvent> Oracle) Build(

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/SegmentedSortedListTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/SegmentedSortedListTests.cs
@@ -263,6 +263,68 @@ public sealed class SegmentedSortedListTests
     }
 
     [Fact]
+    public void Slice_CountOverflowingIntMax_ClampsToCount()
+    {
+        var list = BuildManySegments(segments: 3, perSegment: 4);   // 12 events
+
+        var slice = list.Slice(2, int.MaxValue);
+
+        Assert.Equal(10, slice.Length);
+        Assert.Same(list[2], slice[0]);
+        Assert.Same(list[^1], slice[^1]);
+    }
+
+    [Fact]
+    public void Slice_MatchesIndexerLoop_AcrossSegmentsAndBoundaries()
+    {
+        var list = BuildManySegments(segments: 10, perSegment: 7);   // 70 events across 10 segments
+        Assert.Equal(10, list.SegmentCount);
+        Assert.Equal(70, list.Count);
+
+        (int start, int count)[] cases =
+        [
+            (0, 5), (3, 10), (0, 70), (69, 1), (0, 1), (65, 20), (35, 7), (7, 14), (0, 0), (70, 5), (50, 0), (68, 100),
+        ];
+
+        foreach (var (start, count) in cases)
+        {
+            var actual = list.Slice(start, count);
+            var expected = ExpectedSlice(list, start, count);
+
+            Assert.Equal(expected.Length, actual.Length);
+
+            for (int i = 0; i < actual.Length; i++) { Assert.Same(expected[i], actual[i]); }
+        }
+    }
+
+    [Fact]
+    public void Slice_NegativeStartOrCount_Throws()
+    {
+        var list = BuildManySegments(segments: 3, perSegment: 4);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.Slice(-1, 5));
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.Slice(0, -1));
+    }
+
+    [Fact]
+    public void Slice_SingleSegment_MatchesIndexerLoop()
+    {
+        var list = SegmentedSortedList.CreateSorted(
+            [Ev("LogA", 10, 1), Ev("LogA", 20, 2), Ev("LogA", 30, 3), Ev("LogA", 40, 4)], s_byTime);
+        Assert.Equal(1, list.SegmentCount);
+
+        foreach (var (start, count) in new[] { (0, 4), (1, 2), (3, 1), (0, 0), (4, 2), (2, 10) })
+        {
+            var actual = list.Slice(start, count);
+            var expected = ExpectedSlice(list, start, count);
+
+            Assert.Equal(expected.Length, actual.Length);
+
+            for (int i = 0; i < actual.Length; i++) { Assert.Same(expected[i], actual[i]); }
+        }
+    }
+
+    [Fact]
     public void WhereSegmented_DropsEmptyMiddleSegment()
     {
         var middle = SegmentedSortedList.CreateSorted([Ev("LogC", 100, 1), Ev("LogC", 110, 2)], s_byTime);
@@ -294,6 +356,25 @@ public sealed class SegmentedSortedListTests
         }
     }
 
+    private static SegmentedSortedList BuildManySegments(int segments, int perSegment)
+    {
+        var list = SegmentedSortedList.CreateSorted([], s_byTime);
+        int time = 0;
+        long recordId = 0;
+
+        for (int segment = 0; segment < segments; segment++)
+        {
+            var batch = new ResolvedEvent[perSegment];
+
+            // Strictly ascending time per batch so each Append lands entirely after the previous -> a new segment.
+            for (int i = 0; i < perSegment; i++) { batch[i] = Ev("LogA", time++, recordId++); }
+
+            list = list.Append(batch);
+        }
+
+        return list;
+    }
+
     private static ResolvedEvent Ev(string owningLog, int timeMs, long? recordId, string level = "") =>
         new(owningLog, LogPathType.Channel)
         {
@@ -301,6 +382,19 @@ public sealed class SegmentedSortedListTests
             RecordId = recordId,
             Level = level
         };
+
+    private static ResolvedEvent[] ExpectedSlice(SegmentedSortedList list, int start, int count)
+    {
+        int end = (int)Math.Min((long)start + count, list.Count);
+
+        if (start >= end) { return []; }
+
+        var expected = new ResolvedEvent[end - start];
+
+        for (int i = 0; i < expected.Length; i++) { expected[i] = list[start + i]; }
+
+        return expected;
+    }
 
     private static List<ResolvedEvent> StableMerge(IReadOnlyList<ResolvedEvent> existing, IReadOnlyList<ResolvedEvent> batch)
     {
@@ -321,4 +415,31 @@ public sealed class SegmentedSortedListTests
 
         return result;
     }
+
+#if DEBUG
+    [Fact]
+    public void Slice_NonEmpty_DoesExactlyOneFindSegment()
+    {
+        var list = BuildManySegments(segments: 8, perSegment: 5);   // 40 events across 8 segments
+        list.ResetFindSegmentCallCount();
+
+        _ = list.Slice(10, 20);   // spans several segments, still a single FindSegment
+
+        Assert.Equal(1, list.FindSegmentCallCount);
+    }
+
+    [Fact]
+    public void Slice_Empty_DoesNoFindSegment()
+    {
+        var list = BuildManySegments(segments: 8, perSegment: 5);
+
+        list.ResetFindSegmentCallCount();
+        _ = list.Slice(list.Count, 5);   // start == Count -> empty, early return before FindSegment
+        Assert.Equal(0, list.FindSegmentCallCount);
+
+        list.ResetFindSegmentCallCount();
+        _ = list.Slice(5, 0);            // count == 0 -> empty
+        Assert.Equal(0, list.FindSegmentCallCount);
+    }
+#endif
 }


### PR DESCRIPTION
## Item 4a - `followup-ssl-slice` (Part A)

First code item of the perf-polish workstream. Adds `SegmentedSortedList.Slice(start, count)` that does **one** `FindSegment` for `start`, then walks segments bulk-copying runs via `ImmutableArray.CopyTo`, and dispatches `ResolvedEventIndex.Slice` to it - replacing the generic per-element indexer loop's `count` `FindSegment`s (O(count*log seg) -> O(log seg + count)).

### Benchmark (BenchmarkDotNet, 512 random-offset slices/op)
Single-log viewport slicing:

| N | page | before | after | speedup |
|---|------|--------|-------|---------|
| 1e6 | 100 | 858 us | 92 us | **9.3x** |
| 1e6 | 40 | 382 us | 57 us | 6.7x |
| 1e5 | 100 | 728 us | 77 us | 9.5x |

Allocation identical (172/412 KB) - **0 alloc regression**. Combined-view (k>1) is unchanged and deferred to Item 4b.

### Tests
`SegmentedSortedListTests`: parity vs the indexer loop across boundaries (whole-list, tail, single element, 3+ segment span, single-segment), negative-arg throw, overflow-tail clamp, and a `#if DEBUG` guard asserting exactly one `FindSegment` per non-empty slice (0 for empty). Full `Runtime.Tests` green (1719).

### Scope
This is **Part A** (single-log). The headline k-log `CombinedEventView` pathology (call-local cursor + k-way heap) is deferred to **Item 4b** with its own design + review cycle; Item 4 stays open until 4b lands.