### PR TITLE
Skip the wevtapi size-probe with a pinned per-thread grow-only buffer

### DIFF
--- a/src/EventLogExpert.Eventing/Interop/NativeMethods.Evt.cs
+++ b/src/EventLogExpert.Eventing/Interop/NativeMethods.Evt.cs
@@ -4,7 +4,6 @@
 using EventLogExpert.Eventing.Common.Channels;
 using EventLogExpert.Eventing.Readers;
 using Microsoft.Win32.SafeHandles;
-using System.Buffers;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
 
@@ -13,7 +12,65 @@ namespace EventLogExpert.Eventing.Interop;
 internal static partial class NativeMethods
 {
     private const string EventLogApi = "wevtapi.dll";
-    private const int MaxStackAllocChars = 4096;
+
+    // Per-thread, grow-only scratch buffers reused by the wevtapi wrappers below (each family owns its buffer so the
+    // "no same-family reentrancy" invariant stays local; the three families never nest on a thread). [ThreadStatic]
+    // (not shared) because EventLogWatcher renders on overlapping ThreadPool callback threads; each thread owns its
+    // buffer, so no lock is needed. Retained up to MaxRetainedChars (below the ~85 KB LOH threshold); a call larger than
+    // that uses a transient array that is not stored back, bounding steady-state per-thread retention to ~64 KB each.
+#if DEBUG
+    // Debug-settable so a test can force the grow / retained-cap / skip-probe paths deterministically without a
+    // multi-KB event (const in Release).
+    internal static int InitialRenderChars = 4096;
+    internal static int MaxRetainedChars = 32768;
+#else
+    private const int InitialRenderChars = 4096;
+    private const int MaxRetainedChars = 32768;
+#endif
+
+    [ThreadStatic]
+    private static char[]? t_renderBuffer;
+
+    [ThreadStatic]
+    private static char[]? t_formatBuffer;
+
+    [ThreadStatic]
+    private static char[]? t_objectArrayBuffer;
+
+#if DEBUG
+    // Invoked by the variant-reading processors immediately before the first EVT_VARIANT read, while the buffer is still
+    // pinned, so a GC-move regression test can force a compacting collection at the moment of highest vulnerability.
+    internal static Action? BeforeVariantReadForTest;
+
+    // Count native P/Invokes on the calling thread, so the "one call = one P/Invoke" gate (probe eliminated) can be
+    // asserted without tearing under parallel tests.
+    [ThreadStatic]
+    internal static int RenderPInvokeCountForTest;
+
+    [ThreadStatic]
+    internal static int FormatPInvokeCountForTest;
+
+    [ThreadStatic]
+    internal static int ObjectArrayPInvokeCountForTest;
+
+    internal static int? RetainedRenderBufferChars => t_renderBuffer?.Length;
+
+    internal static int? RetainedFormatBufferChars => t_formatBuffer?.Length;
+
+    internal static int? RetainedObjectArrayBufferChars => t_objectArrayBuffer?.Length;
+
+    // Resets the calling thread's scratch buffers + P/Invoke counters so a test can deterministically drive the
+    // first-touch / grow / retained-cap paths (pair with lowering InitialRenderChars / MaxRetainedChars).
+    internal static void ResetRenderScratchForTest()
+    {
+        t_renderBuffer = null;
+        t_formatBuffer = null;
+        t_objectArrayBuffer = null;
+        RenderPInvokeCountForTest = 0;
+        FormatPInvokeCountForTest = 0;
+        ObjectArrayPInvokeCountForTest = 0;
+    }
+#endif
 
     internal static object? ConvertVariant(EvtVariant variant)
     {
@@ -373,70 +430,70 @@ internal static partial class NativeMethods
 
     /// <summary>Formats a message string</summary>
     /// <param name="publisherMetadataHandle">Handle returned from <see cref="EvtOpenPublisherMetadata" /></param>
-    /// <param name="messageId">The resource identifier of the message string that you want formated</param>
+    /// <param name="messageId">The resource identifier of the message string that you want formatted</param>
     internal static string FormatMessage(EvtHandle publisherMetadataHandle, uint messageId)
     {
-        Span<char> emptyBuffer = ['\0'];
+        char[] buffer = t_formatBuffer ??= new char[InitialRenderChars];
 
-        bool success = EvtFormatMessage(
-            publisherMetadataHandle,
-            EvtHandle.Zero,
-            messageId,
-            0,
-            IntPtr.Zero,
-            EvtFormatMessageFlags.Id,
-            0,
-            emptyBuffer,
-            out int bufferUsed);
-
-        int error = Marshal.GetLastWin32Error();
-
-        if (!success &&
-            error != Win32ErrorCodes.ERROR_EVT_UNRESOLVED_VALUE_INSERT &&
-            error != Win32ErrorCodes.ERROR_EVT_UNRESOLVED_PARAMETER_INSERT &&
-            error != Win32ErrorCodes.ERROR_EVT_MAX_INSERTS_REACHED)
+        // Common path: 1 P/Invoke. Copy out only when the message actually fit the buffer.
+        if (TryFormat(buffer, out int usedChars, out int error))
         {
-            if (error != Win32ErrorCodes.ERROR_INSUFFICIENT_BUFFER)
-            {
-                ThrowEventLogException(error);
-            }
+            return Materialize(buffer, usedChars);
         }
 
-        int charCount = bufferUsed;
-        char[]? rented = null;
-        Span<char> buffer = charCount <= MaxStackAllocChars
-            ? stackalloc char[charCount]
-            : (rented = ArrayPool<char>.Shared.Rent(charCount)).AsSpan(0, charCount);
-
-        try
+        if (error != Win32ErrorCodes.ERROR_INSUFFICIENT_BUFFER)
         {
-            success = EvtFormatMessage(
-                publisherMetadataHandle,
-                EvtHandle.Zero,
-                messageId,
-                0,
-                IntPtr.Zero,
-                EvtFormatMessageFlags.Id,
-                bufferUsed,
-                buffer,
-                out bufferUsed);
+            ThrowEventLogException(error);
+        }
 
-            error = Marshal.GetLastWin32Error();
+        // usedChars carried the required char count; grow to exactly that and retry once.
+        buffer = GrowScratch(ref t_formatBuffer, usedChars);
 
-            if (!success &&
-                error != Win32ErrorCodes.ERROR_EVT_UNRESOLVED_VALUE_INSERT &&
-                error != Win32ErrorCodes.ERROR_EVT_UNRESOLVED_PARAMETER_INSERT &&
-                error != Win32ErrorCodes.ERROR_EVT_MAX_INSERTS_REACHED)
+        if (!TryFormat(buffer, out usedChars, out error))
+        {
+            ThrowEventLogException(error);
+        }
+
+        return Materialize(buffer, usedChars);
+
+        // EvtFormatMessage sizes in CHARACTERS (not bytes). An unresolved-insert code means the message was still
+        // written best-effort - tolerate + copy out, but ONLY when it fit; a too-large tolerated insert is reported as
+        // INSUFFICIENT so the caller grows. Every other failure (e.g. MESSAGE_ID_NOT_FOUND) is thrown, as before.
+        bool TryFormat(char[] target, out int chars, out int lastError)
+        {
+#if DEBUG
+            FormatPInvokeCountForTest++;
+#endif
+            if (EvtFormatMessage(publisherMetadataHandle, EvtHandle.Zero, messageId, 0, IntPtr.Zero,
+                EvtFormatMessageFlags.Id, target.Length, target, out chars))
             {
-                ThrowEventLogException(error);
+                lastError = 0;
+                return true;
             }
 
-            return bufferUsed - 1 <= 0 ? string.Empty : new string(buffer[..(bufferUsed - 1)]);
+            lastError = Marshal.GetLastWin32Error();
+
+            bool unresolvedInsert =
+                lastError == Win32ErrorCodes.ERROR_EVT_UNRESOLVED_VALUE_INSERT ||
+                lastError == Win32ErrorCodes.ERROR_EVT_UNRESOLVED_PARAMETER_INSERT ||
+                lastError == Win32ErrorCodes.ERROR_EVT_MAX_INSERTS_REACHED;
+
+            if (unresolvedInsert && chars <= target.Length)
+            {
+                lastError = 0;
+                return true;
+            }
+
+            if (unresolvedInsert)
+            {
+                lastError = Win32ErrorCodes.ERROR_INSUFFICIENT_BUFFER;
+            }
+
+            return false;
         }
-        finally
-        {
-            if (rented is not null) { ArrayPool<char>.Shared.Return(rented, clearArray: true); }
-        }
+
+        static string Materialize(char[] target, int chars) =>
+            chars - 1 <= 0 ? string.Empty : new string(target, 0, chars - 1);
     }
 
     /// <summary>Converts a buffer that was returned from <see cref="EvtRender" /> to an <see cref="EventRecord" /></summary>
@@ -518,63 +575,59 @@ internal static partial class NativeMethods
         return properties;
     }
 
-    internal static object GetObjectArrayProperty(
+    internal static unsafe object GetObjectArrayProperty(
         EvtHandle array,
         int index,
         EvtPublisherMetadataPropertyId propertyId)
     {
-        bool success = EvtGetObjectArrayProperty(array, propertyId, index, 0, 0, IntPtr.Zero, out int bufferUsed);
-        int error = Marshal.GetLastWin32Error();
+        char[] buffer = t_objectArrayBuffer ??= new char[InitialRenderChars];
+        int neededBytes;
 
-        if (!success && error != Win32ErrorCodes.ERROR_INSUFFICIENT_BUFFER)
+        fixed (char* pinned = buffer)
         {
-            ThrowEventLogException(error);
-        }
-
-        int charCount = bufferUsed;
-        char[]? rented = null;
-        Span<char> buffer = charCount <= MaxStackAllocChars
-            ? stackalloc char[charCount]
-            : (rented = ArrayPool<char>.Shared.Rent(charCount)).AsSpan(0, charCount);
-
-        try
-        {
-            unsafe
+#if DEBUG
+            ObjectArrayPInvokeCountForTest++;
+#endif
+            if (EvtGetObjectArrayProperty(array, propertyId, index, 0, buffer.Length * sizeof(char), (IntPtr)pinned, out int usedBytes))
             {
-                fixed (char* bufferPtr = buffer)
-                {
-                    success = EvtGetObjectArrayProperty(array,
-                        propertyId,
-                        index,
-                        0,
-                        bufferUsed,
-                        (IntPtr)bufferPtr,
-                        out bufferUsed);
-                }
+                return ConvertObjectArrayVariant(pinned, propertyId);
             }
 
-            error = Marshal.GetLastWin32Error();
+            int error = Marshal.GetLastWin32Error();
 
-            if (!success)
+            if (error != Win32ErrorCodes.ERROR_INSUFFICIENT_BUFFER)
             {
                 ThrowEventLogException(error);
             }
 
-            unsafe
-            {
-                fixed (char* bufferPtr = buffer)
-                {
-                    var variant = *(EvtVariant*)bufferPtr;
+            neededBytes = usedBytes;
+        }
 
-                    return ConvertVariant(variant) ??
-                        throw new InvalidDataException($"Invalid Object Array for Property: {propertyId}");
-                }
-            }
-        }
-        finally
+        buffer = GrowScratch(ref t_objectArrayBuffer, CharsForBytes(neededBytes));
+
+        fixed (char* pinned = buffer)
         {
-            if (rented is not null) { ArrayPool<char>.Shared.Return(rented, clearArray: true); }
+#if DEBUG
+            ObjectArrayPInvokeCountForTest++;
+#endif
+            if (!EvtGetObjectArrayProperty(array, propertyId, index, 0, buffer.Length * sizeof(char), (IntPtr)pinned, out int _))
+            {
+                ThrowEventLogException(Marshal.GetLastWin32Error());
+            }
+
+            return ConvertObjectArrayVariant(pinned, propertyId);
         }
+    }
+
+    // Reads the single EVT_VARIANT written by EvtGetObjectArrayProperty while the buffer is still pinned (the variant's
+    // string/SID fields point into it). The GC-move hook fires immediately before the read, shared with the render path.
+    private static unsafe object ConvertObjectArrayVariant(char* pinned, EvtPublisherMetadataPropertyId propertyId)
+    {
+#if DEBUG
+        BeforeVariantReadForTest?.Invoke();
+#endif
+        return ConvertVariant(*(EvtVariant*)pinned) ??
+            throw new InvalidDataException($"Invalid Object Array for Property: {propertyId}");
     }
 
     internal static int GetObjectArraySize(EvtHandle array)
@@ -590,196 +643,119 @@ internal static partial class NativeMethods
         return size;
     }
 
-    internal static EventRecord RenderEvent(EvtHandle eventHandle)
+    // Overflow-safe byte->char ceil for the render + object-array paths (EvtRender / EvtGetObjectArrayProperty size in
+    // bytes). Bounding neededBytes first keeps (neededBytes + sizeof(char) - 1) from overflowing int.
+    private static int CharsForBytes(int neededBytes)
     {
-        bool success = EvtRender(
-            EventLogSession.GlobalSession.SystemRenderContext,
-            eventHandle,
-            EvtRenderFlags.EventValues,
-            0,
-            IntPtr.Zero,
-            out int bufferUsed,
-            out int propertyCount);
-
-        int error = Marshal.GetLastWin32Error();
-
-        if (!success && error != Win32ErrorCodes.ERROR_INSUFFICIENT_BUFFER)
+        // Reject only the values where the ceil's `+ (sizeof(char) - 1)` would overflow int, so the bound matches the
+        // expression below exactly (int.MaxValue - 1 is still in range and allowed).
+        if (neededBytes is < 0 or > int.MaxValue - (sizeof(char) - 1))
         {
-            ThrowEventLogException(error);
+            ThrowEventLogException(Win32ErrorCodes.ERROR_INSUFFICIENT_BUFFER);
         }
 
-        int charCount = bufferUsed / sizeof(char);
-        char[]? rented = null;
-        Span<char> buffer = charCount <= MaxStackAllocChars
-            ? stackalloc char[charCount]
-            : (rented = ArrayPool<char>.Shared.Rent(charCount)).AsSpan(0, charCount);
+        return (neededBytes + sizeof(char) - 1) / sizeof(char);
+    }
 
-        try
+    // Grows a [ThreadStatic] scratch slot to at least neededChars, grow-only: reuses the retained buffer when it is
+    // already large enough (no shrink, no redundant allocation), grows + retains when within the LOH-bounded cap, or
+    // returns a transient array (not stored back) so a rare huge call cannot permanently bloat the thread.
+    private static char[] GrowScratch(ref char[]? retained, int neededChars)
+    {
+        if (retained is not null && retained.Length >= neededChars) { return retained; }
+
+        return neededChars <= MaxRetainedChars ? (retained = new char[neededChars]) : new char[neededChars];
+    }
+
+    // Renders <paramref name="fragment"/> into the per-thread grow-only buffer and invokes <paramref name="process"/>
+    // WHILE THE BUFFER IS STILL PINNED. The continuous pin is load-bearing: for EvtRenderContextValues the rendered
+    // EVT_VARIANTs hold absolute pointers into the buffer, so a GC compaction between render and variant read would
+    // leave them stale. The size-probe pass is skipped - on ERROR_INSUFFICIENT_BUFFER, EvtRender reports the required
+    // size, so the buffer is grown once and retried. INVARIANT: a processor must NOT trigger another render on the
+    // current thread - t_renderBuffer is live and pinned for the duration.
+    private static unsafe T RenderWhilePinned<T>(
+        EvtHandle context,
+        EvtHandle fragment,
+        EvtRenderFlags flags,
+        delegate*<IntPtr, int, int, T> process)
+    {
+        char[] buffer = t_renderBuffer ??= new char[InitialRenderChars];
+        int neededBytes;
+
+        fixed (char* pinned = buffer)
         {
-            unsafe
+#if DEBUG
+            RenderPInvokeCountForTest++;
+#endif
+            if (EvtRender(context, fragment, flags, buffer.Length * sizeof(char), (IntPtr)pinned, out int usedBytes, out int propertyCount))
             {
-                fixed (char* bufferPtr = buffer)
-                {
-                    success = EvtRender(
-                        EventLogSession.GlobalSession.SystemRenderContext,
-                        eventHandle,
-                        EvtRenderFlags.EventValues,
-                        bufferUsed,
-                        (IntPtr)bufferPtr,
-                        out bufferUsed,
-                        out propertyCount);
-                }
+                return process((IntPtr)pinned, usedBytes, propertyCount);
             }
 
-            error = Marshal.GetLastWin32Error();
+            int error = Marshal.GetLastWin32Error();
 
-            if (!success)
+            if (error != Win32ErrorCodes.ERROR_INSUFFICIENT_BUFFER)
             {
                 ThrowEventLogException(error);
             }
 
-            unsafe
-            {
-                fixed (char* bufferPtr = buffer)
-                {
-                    return GetEventRecord((IntPtr)bufferPtr, propertyCount);
-                }
-            }
+            neededBytes = usedBytes;
         }
-        finally
+
+        buffer = GrowScratch(ref t_renderBuffer, CharsForBytes(neededBytes));
+
+        fixed (char* pinned = buffer)
         {
-            if (rented is not null) { ArrayPool<char>.Shared.Return(rented, clearArray: true); }
+#if DEBUG
+            RenderPInvokeCountForTest++;
+#endif
+            if (!EvtRender(context, fragment, flags, buffer.Length * sizeof(char), (IntPtr)pinned, out int usedBytes, out int propertyCount))
+            {
+                ThrowEventLogException(Marshal.GetLastWin32Error());
+            }
+
+            return process((IntPtr)pinned, usedBytes, propertyCount);
         }
     }
 
-    internal static IReadOnlyList<EventProperty> RenderEventProperties(EvtHandle eventHandle)
+    private static EventRecord ProcessRenderedEventRecord(IntPtr buffer, int usedBytes, int propertyCount)
     {
-        bool success = EvtRender(
-            EventLogSession.GlobalSession.UserRenderContext,
-            eventHandle,
-            EvtRenderFlags.EventValues,
-            0,
-            IntPtr.Zero,
-            out int bufferUsed,
-            out int propertyCount);
-
-        int error = Marshal.GetLastWin32Error();
-
-        if (!success && error != Win32ErrorCodes.ERROR_INSUFFICIENT_BUFFER)
-        {
-            ThrowEventLogException(error);
-        }
-
-        int charCount = bufferUsed / sizeof(char);
-        char[]? rented = null;
-        Span<char> buffer = charCount <= MaxStackAllocChars
-            ? stackalloc char[charCount]
-            : (rented = ArrayPool<char>.Shared.Rent(charCount)).AsSpan(0, charCount);
-
-        try
-        {
-            unsafe
-            {
-                fixed (char* bufferPtr = buffer)
-                {
-                    success = EvtRender(
-                        EventLogSession.GlobalSession.UserRenderContext,
-                        eventHandle,
-                        EvtRenderFlags.EventValues,
-                        bufferUsed,
-                        (IntPtr)bufferPtr,
-                        out bufferUsed,
-                        out propertyCount);
-                }
-            }
-
-            error = Marshal.GetLastWin32Error();
-
-            if (!success)
-            {
-                ThrowEventLogException(error);
-            }
-
-            if (propertyCount <= 0) { return []; }
-
-            var properties = new EventProperty[propertyCount];
-
-            unsafe
-            {
-                fixed (char* bufferPtr = buffer)
-                {
-                    var variants = (EvtVariant*)bufferPtr;
-
-                    for (int i = 0; i < propertyCount; i++)
-                    {
-                        properties[i] = ConvertVariantToProperty(variants[i]);
-                    }
-                }
-            }
-
-            return properties;
-        }
-        finally
-        {
-            if (rented is not null) { ArrayPool<char>.Shared.Return(rented, clearArray: true); }
-        }
+#if DEBUG
+        BeforeVariantReadForTest?.Invoke();
+#endif
+        return GetEventRecord(buffer, propertyCount);
     }
 
-    internal static string? RenderEventXml(EvtHandle eventHandle)
+    private static unsafe IReadOnlyList<EventProperty> ProcessRenderedEventProperties(IntPtr buffer, int usedBytes, int propertyCount)
     {
-        bool success = EvtRender(
-            EvtHandle.Zero,
-            eventHandle,
-            EvtRenderFlags.EventXml,
-            0,
-            IntPtr.Zero,
-            out int bufferUsed,
-            out int _);
+        if (propertyCount <= 0) { return []; }
 
-        int error = Marshal.GetLastWin32Error();
+#if DEBUG
+        BeforeVariantReadForTest?.Invoke();
+#endif
 
-        if (!success && error != Win32ErrorCodes.ERROR_INSUFFICIENT_BUFFER)
+        var properties = new EventProperty[propertyCount];
+        var variants = (EvtVariant*)buffer;
+
+        for (int i = 0; i < propertyCount; i++)
         {
-            ThrowEventLogException(error);
+            properties[i] = ConvertVariantToProperty(variants[i]);
         }
 
-        int charCount = bufferUsed / sizeof(char);
-        char[]? rented = null;
-        Span<char> buffer = charCount <= MaxStackAllocChars
-            ? stackalloc char[charCount]
-            : (rented = ArrayPool<char>.Shared.Rent(charCount)).AsSpan(0, charCount);
-
-        try
-        {
-            unsafe
-            {
-                fixed (char* bufferPtr = buffer)
-                {
-                    success = EvtRender(
-                        EvtHandle.Zero,
-                        eventHandle,
-                        EvtRenderFlags.EventXml,
-                        bufferUsed,
-                        (IntPtr)bufferPtr,
-                        out bufferUsed,
-                        out int _);
-                }
-            }
-
-            error = Marshal.GetLastWin32Error();
-
-            if (!success)
-            {
-                ThrowEventLogException(error);
-            }
-
-            return bufferUsed - 1 <= 0 ? null : new string(buffer[..((bufferUsed - 1) / sizeof(char))]);
-        }
-        finally
-        {
-            if (rented is not null) { ArrayPool<char>.Shared.Return(rented, clearArray: true); }
-        }
+        return properties;
     }
+
+    private static unsafe string? ProcessRenderedEventXml(IntPtr buffer, int usedBytes, int propertyCount) =>
+        usedBytes - 1 <= 0 ? null : new string((char*)buffer, 0, (usedBytes - 1) / sizeof(char));
+
+    internal static unsafe EventRecord RenderEvent(EvtHandle eventHandle) =>
+        RenderWhilePinned(EventLogSession.GlobalSession.SystemRenderContext, eventHandle, EvtRenderFlags.EventValues, &ProcessRenderedEventRecord);
+
+    internal static unsafe IReadOnlyList<EventProperty> RenderEventProperties(EvtHandle eventHandle) =>
+        RenderWhilePinned(EventLogSession.GlobalSession.UserRenderContext, eventHandle, EvtRenderFlags.EventValues, &ProcessRenderedEventProperties);
+
+    internal static unsafe string? RenderEventXml(EvtHandle eventHandle) =>
+        RenderWhilePinned(EvtHandle.Zero, eventHandle, EvtRenderFlags.EventXml, &ProcessRenderedEventXml);
 
     internal static void ThrowEventLogException(int error)
     {

--- a/tests/Integration/EventLogExpert.Eventing.IntegrationTests/Interop/WevtapiBufferReuseTests.cs
+++ b/tests/Integration/EventLogExpert.Eventing.IntegrationTests/Interop/WevtapiBufferReuseTests.cs
@@ -1,0 +1,450 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Interop;
+using EventLogExpert.Eventing.PublisherMetadata;
+using EventLogExpert.Eventing.Readers;
+using EventLogExpert.Eventing.TestUtils.Constants;
+using System.Runtime.InteropServices;
+
+namespace EventLogExpert.Eventing.IntegrationTests.Interop;
+
+// Item 1: validates the wevtapi [ThreadStatic] buffer-reuse rewrite of NativeMethods.RenderEvent* / FormatMessage /
+// GetObjectArrayProperty - the skip-probe P/Invoke counts and the continuous-pin GC-move guarantee. Real wevtapi ->
+// container-gated integration tier (no committed .evtx exists; the convention is ProviderMetadata.Create + live
+// handles). The P/Invoke counters and the BeforeVariantReadForTest hook are #if DEBUG-only seams, so the tests that
+// use them are #if DEBUG-guarded.
+public sealed class WevtapiBufferReuseTests
+{
+    [Fact]
+    public void FormatMessage_WhenUnknownMessageId_Throws()
+    {
+        using ProviderMetadata? metadata = ProviderMetadata.Create(Constants.SecurityAuditingLogName);
+        Assert.SkipUnless(metadata is not null, "Requires the Microsoft-Windows-Security-Auditing provider on the host.");
+
+        // 0xFFFFFFFE is not a resolvable resource id. The rewrite preserves the pre-existing behavior: any error that is
+        // not a tolerated unresolved-insert and not ERROR_INSUFFICIENT_BUFFER is surfaced via ThrowEventLogException -
+        // it does NOT degrade to string.Empty (callers depend on the throw/degrade path via ToRawContent's try/catch).
+        // The concrete type varies by id / provider / host locale (FileNotFoundException for MESSAGE_ID_NOT_FOUND, a
+        // generic Exception for a missing locale resource), so assert only that it throws.
+        Assert.ThrowsAny<Exception>(() => metadata!.FormatMessageById(0xFFFFFFFEu));
+    }
+
+#if DEBUG
+    private const uint NoMessage = uint.MaxValue;
+
+    [Fact]
+    public void RenderEvent_WhenWarmed_IssuesSingleProbelessPInvoke()
+    {
+        using EvtHandle handle = FirstEventHandle(Constants.ApplicationLogName);
+
+        _ = NativeMethods.RenderEvent(handle);   // warm the [ThreadStatic] buffer on this thread
+        NativeMethods.RenderPInvokeCountForTest = 0;
+        _ = NativeMethods.RenderEvent(handle);
+
+        Assert.Equal(1, NativeMethods.RenderPInvokeCountForTest);
+    }
+
+    [Fact]
+    public void FormatMessage_WhenWarmed_IssuesSingleProbelessPInvoke()
+    {
+        using ProviderMetadata? metadata = ProviderMetadata.Create(Constants.SecurityAuditingLogName);
+        Assert.SkipUnless(metadata is not null, "Requires the Microsoft-Windows-Security-Auditing provider on the host.");
+
+        uint messageId = FirstResolvableMessageId(metadata!);
+        Assert.SkipUnless(messageId != NoMessage, "No resolvable message id on this provider.");
+
+        _ = metadata!.FormatMessageById(messageId);   // warm
+        NativeMethods.FormatPInvokeCountForTest = 0;
+        _ = metadata.FormatMessageById(messageId);
+
+        Assert.Equal(1, NativeMethods.FormatPInvokeCountForTest);
+    }
+
+    [Fact]
+    public void RenderEvent_WhenCompactingGcDuringVariantRead_ReturnsIntactRecord()
+    {
+        using EvtHandle handle = FirstEventHandle(Constants.ApplicationLogName);
+
+        EventRecord expected = NativeMethods.RenderEvent(handle);
+
+        try
+        {
+            NativeMethods.BeforeVariantReadForTest = ForceCompactingGc;
+            EventRecord actual = NativeMethods.RenderEvent(handle);
+
+            Assert.Equal(expected.Id, actual.Id);
+            Assert.Equal(expected.ProviderName, actual.ProviderName);
+            Assert.Equal(expected.ComputerName, actual.ComputerName);
+            Assert.Equal(expected.LogName, actual.LogName);
+        }
+        finally
+        {
+            NativeMethods.BeforeVariantReadForTest = null;
+        }
+    }
+
+    [Fact]
+    public void RenderEventProperties_WhenCompactingGcDuringVariantRead_ReturnsIntactValues()
+    {
+        using EvtHandle handle = FirstEventHandle(Constants.ApplicationLogName);
+
+        var expected = NativeMethods.RenderEventProperties(handle).ToList();
+
+        try
+        {
+            NativeMethods.BeforeVariantReadForTest = ForceCompactingGc;
+            var actual = NativeMethods.RenderEventProperties(handle).ToList();
+
+            Assert.Equal(expected, actual);
+        }
+        finally
+        {
+            NativeMethods.BeforeVariantReadForTest = null;
+        }
+    }
+
+    [Fact]
+    public void GetObjectArrayProperty_WhenCompactingGcDuringVariantRead_ReturnsIntactChannels()
+    {
+        using ProviderMetadata? reference = ProviderMetadata.Create(Constants.SecurityAuditingLogName);
+        Assert.SkipUnless(reference is not null, "Requires the Microsoft-Windows-Security-Auditing provider on the host.");
+
+        var expected = reference!.ToRawContent(Constants.SecurityAuditingLogName, null).Channels;
+        Assert.NotEmpty(expected);
+
+        using ProviderMetadata? underGc = ProviderMetadata.Create(Constants.SecurityAuditingLogName);
+        Assert.SkipUnless(underGc is not null, "Requires the Microsoft-Windows-Security-Auditing provider on the host.");
+
+        try
+        {
+            NativeMethods.BeforeVariantReadForTest = ForceCompactingGc;
+            var actual = underGc!.ToRawContent(Constants.SecurityAuditingLogName, null).Channels;
+
+            Assert.Equal(expected, actual);
+        }
+        finally
+        {
+            NativeMethods.BeforeVariantReadForTest = null;
+        }
+    }
+
+    // Forces a compacting collection with a released heap gap so the movable [ThreadStatic] scratch buffer is a
+    // relocation candidate at the moment of the variant read. If the buffer is (correctly) pinned across the read, the
+    // marshalled strings/SIDs survive; a future edit that read the variant OUTSIDE the fixed scope would corrupt or AV.
+    private static void ForceCompactingGc()
+    {
+        byte[]? gap = new byte[1 << 20];
+        GC.KeepAlive(gap);
+        gap = null;
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+    }
+
+    private static uint FirstResolvableMessageId(ProviderMetadata metadata)
+    {
+        RawProviderContent content = metadata.ToRawContent(Constants.SecurityAuditingLogName, null);
+
+        var candidates = content.Events.Select(providerEvent => providerEvent.MessageId)
+            .Concat(content.Keywords.Select(keyword => keyword.MessageId))
+            .Where(messageId => messageId != NoMessage && messageId != 0);
+
+        foreach (uint messageId in candidates)
+        {
+            try
+            {
+                if (!string.IsNullOrEmpty(metadata.FormatMessageById(messageId))) { return messageId; }
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+            {
+                // Skip ids that do not resolve on this host and keep looking.
+            }
+        }
+
+        return NoMessage;
+    }
+
+    private static EvtHandle FirstEventHandle(string channelName)
+    {
+        EvtHandle query = NativeMethods.EvtQuery(EventLogSession.GlobalSession.Handle, channelName, null, LogPathType.Channel);
+        Assert.False(query.IsInvalid, $"EvtQuery failed for channel '{channelName}'.");
+
+        try
+        {
+            var batch = new IntPtr[1];
+            int returned = 0;
+
+            Assert.True(
+                NativeMethods.EvtNext(query, batch.Length, batch, 0, 0, ref returned) && returned == 1,
+                $"Channel '{channelName}' has no readable events.");
+
+            return new EvtHandle(batch[0]);
+        }
+        finally
+        {
+            query.Dispose();
+        }
+    }
+
+    [Fact]
+    public void RenderEvent_WhenItemExceedsInitialBuffer_GrowsRetriesThenReuses()
+    {
+        using EvtHandle handle = FirstEventHandle(Constants.ApplicationLogName);
+        EventRecord expected = NativeMethods.RenderEvent(handle);
+
+        int savedInitial = NativeMethods.InitialRenderChars;
+
+        try
+        {
+            NativeMethods.InitialRenderChars = 1;   // force the initial render to under-fit -> grow + retry
+            NativeMethods.ResetRenderScratchForTest();
+
+            EventRecord grown = NativeMethods.RenderEvent(handle);
+
+            Assert.Equal(2, NativeMethods.RenderPInvokeCountForTest);   // probe-less: failed render + one retry
+            Assert.Equal(expected.Id, grown.Id);
+            Assert.Equal(expected.ProviderName, grown.ProviderName);
+            Assert.Equal(expected.ComputerName, grown.ComputerName);
+
+            NativeMethods.RenderPInvokeCountForTest = 0;
+            _ = NativeMethods.RenderEvent(handle);
+
+            Assert.Equal(1, NativeMethods.RenderPInvokeCountForTest);   // buffer grew for good -> single call thereafter
+        }
+        finally
+        {
+            NativeMethods.InitialRenderChars = savedInitial;
+            NativeMethods.ResetRenderScratchForTest();
+        }
+    }
+
+    [Fact]
+    public void RenderEvent_WhenItemExceedsRetentionCap_UsesTransientAndKeepsRetainedBounded()
+    {
+        using EvtHandle handle = FirstEventHandle(Constants.ApplicationLogName);
+        EventRecord expected = NativeMethods.RenderEvent(handle);
+
+        int savedInitial = NativeMethods.InitialRenderChars;
+        int savedCap = NativeMethods.MaxRetainedChars;
+
+        try
+        {
+            NativeMethods.InitialRenderChars = 8;
+            NativeMethods.MaxRetainedChars = 8;   // any real event exceeds this -> transient array, not retained
+            NativeMethods.ResetRenderScratchForTest();
+
+            EventRecord viaTransient = NativeMethods.RenderEvent(handle);
+
+            Assert.Equal(expected.Id, viaTransient.Id);   // correct output produced through the transient buffer
+            Assert.Equal(expected.ProviderName, viaTransient.ProviderName);
+            Assert.True(
+                NativeMethods.RetainedRenderBufferChars is int retained && retained <= NativeMethods.MaxRetainedChars,
+                $"retained {NativeMethods.RetainedRenderBufferChars} exceeded cap {NativeMethods.MaxRetainedChars}");
+        }
+        finally
+        {
+            NativeMethods.InitialRenderChars = savedInitial;
+            NativeMethods.MaxRetainedChars = savedCap;
+            NativeMethods.ResetRenderScratchForTest();
+        }
+    }
+
+    [Fact]
+    public void FormatMessage_WhenMessageExceedsInitialBuffer_GrowsRetriesThenReuses()
+    {
+        using ProviderMetadata? metadata = ProviderMetadata.Create(Constants.SecurityAuditingLogName);
+        Assert.SkipUnless(metadata is not null, "Requires the Microsoft-Windows-Security-Auditing provider on the host.");
+
+        uint messageId = FirstResolvableMessageId(metadata!);
+        Assert.SkipUnless(messageId != NoMessage, "No resolvable message id on this provider.");
+
+        string expected = metadata!.FormatMessageById(messageId);
+
+        int savedInitial = NativeMethods.InitialRenderChars;
+
+        try
+        {
+            NativeMethods.InitialRenderChars = 1;
+            NativeMethods.ResetRenderScratchForTest();
+
+            string grown = metadata.FormatMessageById(messageId);
+
+            Assert.Equal(2, NativeMethods.FormatPInvokeCountForTest);
+            Assert.Equal(expected, grown);
+
+            NativeMethods.FormatPInvokeCountForTest = 0;
+            _ = metadata.FormatMessageById(messageId);
+
+            Assert.Equal(1, NativeMethods.FormatPInvokeCountForTest);
+        }
+        finally
+        {
+            NativeMethods.InitialRenderChars = savedInitial;
+            NativeMethods.ResetRenderScratchForTest();
+        }
+    }
+
+    [Fact]
+    public void FormatMessage_WhenMessageHasInserts_ReturnsBestEffortTextWithoutThrowing()
+    {
+        using ProviderMetadata? metadata = ProviderMetadata.Create(Constants.SecurityAuditingLogName);
+        Assert.SkipUnless(metadata is not null, "Requires the Microsoft-Windows-Security-Auditing provider on the host.");
+
+        // Event messages formatted by id (with no insert values) exercise the unresolved-insert tolerance:
+        // EvtFormatMessage returns ERROR_EVT_UNRESOLVED_*_INSERT with best-effort text, which the wrapper must copy out
+        // rather than throw (callers depend on that best-effort text via ToRawContent).
+        uint messageId = metadata!.ToRawContent(Constants.SecurityAuditingLogName, null)
+            .Events.Select(providerEvent => providerEvent.MessageId)
+            .FirstOrDefault(id => id != NoMessage && id != 0);
+
+        Assert.SkipUnless(messageId != 0, "Provider has no event messages on this host.");
+
+        string text = metadata.FormatMessageById(messageId);   // must not throw on unresolved inserts
+
+        Assert.False(string.IsNullOrEmpty(text));
+    }
+
+    [Fact]
+    public void GetObjectArrayProperty_WhenWarmed_IssuesSingleProbelessPInvoke()
+    {
+        (EvtHandle metadata, EvtHandle array) = OpenKeywordArray(Constants.KernelPowerLogName);
+
+        using (metadata)
+        {
+            using (array)
+            {
+                Assert.SkipUnless(!array.IsInvalid && NativeMethods.GetObjectArraySize(array) > 0, "Provider has no keyword items on this host.");
+
+                _ = NativeMethods.GetObjectArrayProperty(array, 0, EvtPublisherMetadataPropertyId.KeywordName);   // warm
+                NativeMethods.ObjectArrayPInvokeCountForTest = 0;
+                _ = NativeMethods.GetObjectArrayProperty(array, 0, EvtPublisherMetadataPropertyId.KeywordName);
+
+                Assert.Equal(1, NativeMethods.ObjectArrayPInvokeCountForTest);
+            }
+        }
+    }
+
+    [Fact]
+    public void GetObjectArrayProperty_WhenItemExceedsInitialBuffer_GrowsRetriesThenReuses()
+    {
+        (EvtHandle metadata, EvtHandle array) = OpenKeywordArray(Constants.KernelPowerLogName);
+
+        using (metadata)
+        {
+            using (array)
+            {
+                Assert.SkipUnless(!array.IsInvalid && NativeMethods.GetObjectArraySize(array) > 0, "Provider has no keyword items on this host.");
+
+                var expected = (string)NativeMethods.GetObjectArrayProperty(array, 0, EvtPublisherMetadataPropertyId.KeywordName);
+
+                int savedInitial = NativeMethods.InitialRenderChars;
+
+                try
+                {
+                    NativeMethods.InitialRenderChars = 1;
+                    NativeMethods.ResetRenderScratchForTest();
+
+                    var grown = (string)NativeMethods.GetObjectArrayProperty(array, 0, EvtPublisherMetadataPropertyId.KeywordName);
+
+                    Assert.Equal(2, NativeMethods.ObjectArrayPInvokeCountForTest);
+                    Assert.Equal(expected, grown);
+
+                    NativeMethods.ObjectArrayPInvokeCountForTest = 0;
+                    _ = NativeMethods.GetObjectArrayProperty(array, 0, EvtPublisherMetadataPropertyId.KeywordName);
+
+                    Assert.Equal(1, NativeMethods.ObjectArrayPInvokeCountForTest);
+                }
+                finally
+                {
+                    NativeMethods.InitialRenderChars = savedInitial;
+                    NativeMethods.ResetRenderScratchForTest();
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void RenderEvent_WhenRenderedConcurrentlyOnManyThreads_EachThreadGetsIntactRecords()
+    {
+        const int threads = 8;
+        List<EvtHandle> handles = FirstEventHandles(Constants.ApplicationLogName, threads);
+
+        try
+        {
+            Assert.SkipUnless(handles.Count == threads, "Not enough readable events for the concurrency test.");
+
+            // Each thread renders its OWN distinct handle repeatedly on its OWN [ThreadStatic] buffer (the watcher's
+            // overlapping-callback shape). No torn reads if the per-thread buffers stay isolated.
+            var expected = handles.Select(handle => NativeMethods.RenderEvent(handle).Id).ToList();
+
+            Parallel.For(0, threads, thread =>
+            {
+                for (int rep = 0; rep < 50; rep++)
+                {
+                    Assert.Equal(expected[thread], NativeMethods.RenderEvent(handles[thread]).Id);
+                }
+            });
+        }
+        finally
+        {
+            foreach (EvtHandle handle in handles) { handle.Dispose(); }
+        }
+    }
+
+    private static (EvtHandle Metadata, EvtHandle Array) OpenKeywordArray(string providerName)
+    {
+        EvtHandle metadata = NativeMethods.EvtOpenPublisherMetadata(EventLogSession.GlobalSession.Handle, providerName, null, 0, 0);
+        Assert.False(metadata.IsInvalid, $"EvtOpenPublisherMetadata failed for '{providerName}'.");
+
+        NativeMethods.EvtGetPublisherMetadataProperty(metadata, EvtPublisherMetadataPropertyId.Keywords, 0, 0, IntPtr.Zero, out int bufferUsed);
+
+        // The size-probe reports the required byte count via ERROR_INSUFFICIENT_BUFFER; if it fails for any other reason
+        // (e.g. the provider exposes no Keywords), bufferUsed is 0/garbage - return an invalid array so the caller skips
+        // rather than allocating a bad buffer.
+        if (bufferUsed <= 0) { return (metadata, EvtHandle.Zero); }
+
+        IntPtr buffer = Marshal.AllocHGlobal(bufferUsed);
+
+        try
+        {
+            Assert.True(
+                NativeMethods.EvtGetPublisherMetadataProperty(metadata, EvtPublisherMetadataPropertyId.Keywords, 0, bufferUsed, buffer, out bufferUsed),
+                $"EvtGetPublisherMetadataProperty(Keywords) failed for '{providerName}'.");
+
+            var variant = Marshal.PtrToStructure<EvtVariant>(buffer);
+
+            return (metadata, variant.EvtHandleVal == IntPtr.Zero ? EvtHandle.Zero : new EvtHandle(variant.EvtHandleVal));
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(buffer);
+        }
+    }
+
+    private static List<EvtHandle> FirstEventHandles(string channelName, int count)
+    {
+        var handles = new List<EvtHandle>(count);
+        EvtHandle query = NativeMethods.EvtQuery(EventLogSession.GlobalSession.Handle, channelName, null, LogPathType.Channel);
+        Assert.False(query.IsInvalid, $"EvtQuery failed for channel '{channelName}'.");
+
+        try
+        {
+            var batch = new IntPtr[count];
+            int returned = 0;
+
+            if (NativeMethods.EvtNext(query, batch.Length, batch, 0, 0, ref returned))
+            {
+                for (int i = 0; i < returned; i++) { handles.Add(new EvtHandle(batch[i])); }
+            }
+        }
+        finally
+        {
+            query.Dispose();
+        }
+
+        return handles;
+    }
+#endif
+}


### PR DESCRIPTION
Item 1 (impl-p6-render, expanded to all three wevtapi wrapper families) eliminates the per-call size-probe P/Invoke and reuses a per-thread grow-only `[ThreadStatic]` buffer, processing each result while the buffer is still pinned (continuous pin) to close a GC-move hazard.

## What changed (`NativeMethods.Evt.cs`)
- **EvtRender wrappers** (`RenderEvent` / `RenderEventProperties` / `RenderEventXml`, per-event view path): a `delegate*`-based `RenderWhilePinned<T>` helper + 3 static processors run the variant read inside the render `fixed`.
- **FormatMessage** (EvtFormatMessage, DB-build path): plain-string copy-out, char-sized, best-effort tolerant of `ERROR_EVT_UNRESOLVED_*_INSERT`, size-aware.
- **GetObjectArrayProperty** (EvtGetObjectArrayProperty, DB-build path): single variant read under continuous pin - also closes the same latent GC-move hazard the old two-`fixed` code had.
- Shared `CharsForBytes` (overflow-safe byte to char ceil) + `GrowScratch` (retain up to 32768 chars, transient above to bound LOH retention). Separate `[ThreadStatic]` buffer per family.

## Why continuous pin
For `EvtRenderContextValues`/object-array reads the `EVT_VARIANT` string/SID fields are absolute pointers into the buffer; a heap-array move between render and read would leave them stale. The processor runs inside the render `fixed` so the buffer never unpins across the variant read.

## Validation
- Build 0/0 Debug + Release (TreatWarningsAsErrors).
- Eventing unit 558/558; integration ProviderMetadata+Readers 248 pass / 2 host-skip / 0 fail; new `WevtapiBufferReuseTests` 13/13 (container-gated) - skip-probe counts, grow-on-error, retained-cap, FormatMessage tolerance, and a forced-compacting-GC tripwire on the continuous pin.
- Benchmarks (same VM, before/after): RenderEvent 9.45->5.33 ms, RenderEventProperties 12.56->7.02 ms, RenderEventXml 37.59->18.72 ms (~1.8-2x, alloc unchanged); GetObjectArrayProperty 6.09->3.98 ms (1.53x); FormatMessage 931->487 ms (1.91x, alloc 1.27 MB->983 KB), aggregated across all 1453 publishers.