### PR TITLE
Read cold-path metadata variants by pointer instead of PtrToStructure

### DIFF
--- a/src/EventLogExpert.Eventing/ProviderMetadata/EventMessageProvider.cs
+++ b/src/EventLogExpert.Eventing/ProviderMetadata/EventMessageProvider.cs
@@ -194,7 +194,7 @@ public sealed class EventMessageProvider(
         target.ResolvedFromOwningPublisher = owningPublisher;
     }
 
-    private bool TryGetChannelOwningPublisher(string channelName, out string? publisher)
+    private unsafe bool TryGetChannelOwningPublisher(string channelName, out string? publisher)
     {
         publisher = null;
 
@@ -255,7 +255,7 @@ public sealed class EventMessageProvider(
                 return false;
             }
 
-            var variant = Marshal.PtrToStructure<EvtVariant>(buffer);
+            var variant = *(EvtVariant*)buffer;
             var value = NativeMethods.ConvertVariant(variant) as string;
 
             if (string.IsNullOrWhiteSpace(value))

--- a/src/EventLogExpert.Eventing/ProviderMetadata/PublisherMetadataHandle.cs
+++ b/src/EventLogExpert.Eventing/ProviderMetadata/PublisherMetadataHandle.cs
@@ -199,7 +199,7 @@ internal sealed class PublisherMetadataHandle : IDisposable
         };
     }
 
-    private static object GetEventMetadataProperty(EvtHandle metadataHandle, EvtEventMetadataPropertyId propertyId)
+    private static unsafe object GetEventMetadataProperty(EvtHandle metadataHandle, EvtEventMetadataPropertyId propertyId)
     {
         IntPtr buffer = IntPtr.Zero;
 
@@ -223,7 +223,7 @@ internal sealed class PublisherMetadataHandle : IDisposable
                 NativeMethods.ThrowEventLogException(error);
             }
 
-            var variant = Marshal.PtrToStructure<EvtVariant>(buffer);
+            var variant = *(EvtVariant*)buffer;
 
             return NativeMethods.ConvertVariant(variant) ??
                 throw new InvalidDataException($"Invalid Metadata for PropertyId: {propertyId}");
@@ -249,7 +249,7 @@ internal sealed class PublisherMetadataHandle : IDisposable
         return null;
     }
 
-    private object? GetPublisherMetadataObject(EvtPublisherMetadataPropertyId propertyId)
+    private unsafe object? GetPublisherMetadataObject(EvtPublisherMetadataPropertyId propertyId)
     {
         IntPtr buffer = IntPtr.Zero;
 
@@ -287,7 +287,7 @@ internal sealed class PublisherMetadataHandle : IDisposable
                 NativeMethods.ThrowEventLogException(error);
             }
 
-            var variant = Marshal.PtrToStructure<EvtVariant>(buffer);
+            var variant = *(EvtVariant*)buffer;
 
             return NativeMethods.ConvertVariant(variant);
         }
@@ -297,7 +297,7 @@ internal sealed class PublisherMetadataHandle : IDisposable
         }
     }
 
-    private string GetPublisherMetadataProperty(EvtPublisherMetadataPropertyId propertyId)
+    private unsafe string GetPublisherMetadataProperty(EvtPublisherMetadataPropertyId propertyId)
     {
         IntPtr buffer = IntPtr.Zero;
 
@@ -335,7 +335,7 @@ internal sealed class PublisherMetadataHandle : IDisposable
                 NativeMethods.ThrowEventLogException(error);
             }
 
-            var variant = Marshal.PtrToStructure<EvtVariant>(buffer);
+            var variant = *(EvtVariant*)buffer;
 
             return (string?)NativeMethods.ConvertVariant(variant) ?? string.Empty;
         }
@@ -345,7 +345,7 @@ internal sealed class PublisherMetadataHandle : IDisposable
         }
     }
 
-    private EvtHandle GetPublisherMetadataPropertyHandle(EvtPublisherMetadataPropertyId propertyId)
+    private unsafe EvtHandle GetPublisherMetadataPropertyHandle(EvtPublisherMetadataPropertyId propertyId)
     {
         IntPtr buffer = IntPtr.Zero;
 
@@ -383,7 +383,7 @@ internal sealed class PublisherMetadataHandle : IDisposable
                 NativeMethods.ThrowEventLogException(error);
             }
 
-            var variant = Marshal.PtrToStructure<EvtVariant>(buffer);
+            var variant = *(EvtVariant*)buffer;
 
             return variant.EvtHandleVal == IntPtr.Zero ?
                 EvtHandle.Zero :

--- a/src/EventLogExpert.Eventing/Readers/EventLogInformation.cs
+++ b/src/EventLogExpert.Eventing/Readers/EventLogInformation.cs
@@ -49,7 +49,7 @@ public sealed class EventLogInformation
 
     public long? RecordCount { get; }
 
-    private static object? GetLogProperty(EvtHandle handle, EvtLogPropertyId property)
+    private static unsafe object? GetLogProperty(EvtHandle handle, EvtLogPropertyId property)
     {
         IntPtr buffer = IntPtr.Zero;
 
@@ -73,7 +73,7 @@ public sealed class EventLogInformation
                 NativeMethods.ThrowEventLogException(error);
             }
 
-            var variant = Marshal.PtrToStructure<EvtVariant>(buffer);
+            var variant = *(EvtVariant*)buffer;
 
             return NativeMethods.ConvertVariant(variant);
         }


### PR DESCRIPTION
## Item 2 — cold-path variant marshalling (`p2a-followup-coldpath-marshalling`)

Part of the perf-polish workstream. Independent of #632 (no overlapping files).

### What
Six cold provider-metadata scalar reads stop marshalling the `EVT_VARIANT` union via `Marshal.PtrToStructure<EvtVariant>` and read it in place with `*(EvtVariant*)buffer` (each method gains `unsafe`). Nothing else changes — `AllocHGlobal`/`FreeHGlobal`, the 2-P/Invoke probe+read, error handling, and `ConvertVariant` are untouched.

Sites: `ProviderMetadata` (`GetEventMetadataProperty`, `GetPublisherMetadataObject`, `GetPublisherMetadataProperty`, `GetPublisherMetadataPropertyHandle`), `EventLogInformation.GetLogProperty`, `EventMessageProvider.TryGetChannelOwningPublisher`.

### Why
`EVT_VARIANT` is a non-blittable explicit-layout union, so `PtrToStructure<EvtVariant>` runs the reflection marshaller and allocates on every read; the raw pointer read is byte-identical and allocation-free.

### Safety
`AllocHGlobal` is unmanaged, fixed-address memory the GC never moves, so no `fixed`/pin is needed. The variant's inner pointers reference the same buffer, which stays alive until the existing `finally { FreeHGlobal }`; `ConvertVariant` copies out every reference shape before the free. Same buffer-alive-until-`finally` invariant as before, minus the marshalling allocation — strictly ≤ current risk.

### Benchmark (real production, all ~1453 installed publishers, git-stash before/after)
| | Mean | Gen0 | Allocated |
|---|---:|---:|---:|
| Before (`PtrToStructure`) | 2.148 ms | 50.78 | 834.63 KB |
| After (`*(EvtVariant*)`) | 1.934 ms | 39.06 | 654.49 KB |
| Delta | **-10.0% ns** | **-23.1% Gen0** | **-21.6% alloc** |

### Validation
- Build 0/0 Debug + Release (standalone on main)
- Eventing unit 558/558; container-gated integration field-parity 76/1-skip (4 exercising classes) + full assembly 334/2-skip/0-fail
- Pre-impl design panel + post-code review panel: unanimous, 3 cross-family reviewers each

Deferred (out of scope): the blittable hot-path `Guid`/`SystemTime` variant-field reads (would need `Unsafe.ReadUnaligned`).
