### PR TITLE
Read the display-ready sort context and version from a single snapshot

### DIFF
--- a/src/EventLogExpert.Runtime/EventLog/FilteringEffects.cs
+++ b/src/EventLogExpert.Runtime/EventLog/FilteringEffects.cs
@@ -113,8 +113,9 @@ internal sealed class FilteringEffects(
         if (_concurrencyState.GetCurrentFilterToken() != filterToken) { return; }
 
         var filter = _eventLogState.Value.AppliedFilter;
-        var context = _logTableState.Value.SortContext;
-        var version = _logTableState.Value.DisplayListVersion;
+        var logTable = _logTableState.Value;
+        var context = logTable.SortContext;
+        var version = logTable.DisplayListVersion;
 
         var targets = ResidualOpenStale(action.StaleIds);
 
@@ -228,8 +229,9 @@ internal sealed class FilteringEffects(
     private async Task ApplyFilterAndPublishAsync(Filter filter, long filterToken, IDispatcher dispatcher)
     {
         var snapshot = SnapshotOpenLogEvents();
-        var capturedContext = _logTableState.Value.SortContext;
-        var version = _logTableState.Value.DisplayListVersion;
+        var logTable = _logTableState.Value;
+        var capturedContext = logTable.SortContext;
+        var version = logTable.DisplayListVersion;
 
         dispatcher.Dispatch(new SetFilterProgressAction(true));
 

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/LogTableStoreTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/LogTableStoreTests.cs
@@ -1081,6 +1081,44 @@ public sealed class LogTableStoreTests
     }
 
     [Fact]
+    public void ReduceDisplayReady_WhenSecondLogOpensAcrossTheGap_HealsOneLogListToTwoLogDefault()
+    {
+        var first = new EventLogData(Constants.LogNameLog1, LogPathType.Channel);
+        var second = new EventLogData(Constants.LogNameLog2, LogPathType.Channel);
+        var state = new LogTableState();
+        state = Reducers.ReduceAddTable(state, new AddTableAction(first));
+        state = Reducers.ReduceAddTable(state, new AddTableAction(second));
+
+        state = Reducers.ReduceUpdateTable(
+            state,
+            new UpdateTableAction(second.Id, new List<ResolvedEvent>
+            {
+                new(Constants.LogNameLog2, LogPathType.Channel) { Id = 200, RecordId = 20 }
+            }));
+
+        var baseTime = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var firstEvents = new List<ResolvedEvent>
+        {
+            new(Constants.LogNameLog1, LogPathType.Channel) { Id = 10, RecordId = 1, TimeCreated = baseTime.AddMinutes(3) },
+            new(Constants.LogNameLog1, LogPathType.Channel) { Id = 20, RecordId = 2, TimeCreated = baseTime.AddMinutes(2) },
+            new(Constants.LogNameLog1, LogPathType.Channel) { Id = 30, RecordId = 3, TimeCreated = baseTime.AddMinutes(1) }
+        };
+
+        var prebuiltOneLog = SegmentedSortedList.CreateSorted(firstEvents, new SortContext(null, true, null, false));
+        Assert.Equal(new[] { 30, 20, 10 }, prebuiltOneLog.Select(e => e.Id).ToArray());
+
+        var lists = new Dictionary<EventLogId, SegmentedSortedList> { { first.Id, prebuiltOneLog } };
+
+        var after = Reducers.ReduceDisplayReady(
+            state, new DisplayReadyAction { Lists = lists, Version = state.DisplayListVersion });
+
+        var healed = after.PerLogEvents[first.Id];
+        Assert.NotSame(prebuiltOneLog, healed);
+        Assert.True(healed.HasContext(new SortContext(ColumnName.DateAndTime, true, null, false)));
+        Assert.Equal(new[] { 10, 20, 30 }, healed.Select(e => e.Id).ToArray());
+    }
+
+    [Fact]
     public void ReduceDisplayReady_WhenSomeLogsOmitted_ShouldReplaceIncludedAndPreserveOmitted()
     {
         // Arrange - two logs, both populated via UpdateTable. Filter dispatch arrives for log A


### PR DESCRIPTION
## Item 5 — display-ready sort-context/version capture (`followup-displayready-reduce-toctou`)

Part of the perf-polish workstream, stacked on #626. **Honest scope note:** this is correctness-hygiene, **not** a race fix, and has **no measurable performance delta** — see below.

### What
Two display-ready effect handlers (`FilteringEffects.HandleConvergeFilter`, `ApplyFilterAndPublishAsync`) read `_logTableState.Value` twice — once for `SortContext`, once for `DisplayListVersion`. This collapses each pair into a single named snapshot, deriving both from one immutable instance.

### Why (not a race fix)
Verified against Fluxor 6.9.0: dispatch is serialized — reducers run inside `DequeueActions` under `lock(SyncRoot)` guarded by `IsDispatching`, and an effect's synchronous prefix (where both reads live, before the first `await`) runs on that same dispatch thread holding the lock. A concurrent dispatch can only enqueue, so `.Value` **cannot** be swapped between the two reads. The mixed `context(N)/version(N+1)` pair is unreachable under the stock store.

So the value is: **reader-clarity** (the two properties must be internally consistent — a single snapshot states that invariant), **defense-in-depth** (future-proof against a custom dispatcher / future Fluxor), and coalescing two getter calls. Behavior-preserving; no observable change; no perf delta.

### Log-count residual (approach A, documented)
`SortContext.OrderBy` depends on `PerLogEvents.Count` (flips at the 1↔2-log boundary), but `DisplayListVersion` isn't bumped by log-count reducers — so a 1↔2 crossing in the async gap heals via a re-sort. This is **intended and correct** (a 1↔2 crossing legitimately changes the default ordering; folding it into the version gate would drop otherwise-valid updates since no log-count reducer re-queues a filter). A new reducer test pins this residual so the "no redundant re-sort" guarantee is correctly scoped to sort/group/filter interleaves.

### Validation
- Build 0/0 Debug + Release (full solution)
- Full `EventLogExpert.Runtime.Tests` 1725/1725 (incl. the new residual test)
- Pre-impl design panel + post-code review panel: unanimous, 3 cross-family reviewers each (the design was reframed from an overstated "TOCTOU fix" to honest hygiene after a source-verified panel finding)
