### PR TITLE
Promote EventData named fields onto ResolvedEvent

### DIFF
--- a/src/EventLogExpert.Eventing/Common/Events/EventDataView.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/EventDataView.cs
@@ -1,0 +1,135 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Readers;
+using EventLogExpert.Eventing.Resolvers;
+using System.Collections.Immutable;
+
+namespace EventLogExpert.Eventing.Common.Events;
+
+public enum EventDataKind : byte
+{
+    None,
+    EventData
+}
+
+/// <summary>
+///     Named/positional access to an event's structured &lt;EventData&gt; fields. A lightweight view materialized on
+///     demand from the two references retained on <see cref="ResolvedEvent" />; it is not itself retained.
+///     <see cref="Kind" /> is <see cref="EventDataKind.None" /> for legacy, template-less, or fail-closed events, whose
+///     values remain available positionally through the event description and XML.
+/// </summary>
+public readonly struct EventDataView
+{
+    public static readonly EventDataView Empty = default;
+
+    private readonly ImmutableArray<EventProperty> _values;
+    private readonly TemplateFieldSchema? _schema;
+
+    internal EventDataView(ImmutableArray<EventProperty> values, TemplateFieldSchema? schema)
+    {
+        _values = values;
+        _schema = schema;
+    }
+
+    public EventDataKind Kind => _values.IsDefaultOrEmpty ? EventDataKind.None : EventDataKind.EventData;
+
+    public int Count => _values.IsDefaultOrEmpty ? 0 : _values.Length;
+
+    public bool TryGetValue(string? fieldName, out EventFieldValue value)
+    {
+        if (fieldName is not null
+            && TryGetOrdering(out FieldNameOrdering ordering)
+            && _schema!.TryGetIndex(ordering, fieldName, out int index)
+            && (uint)index < (uint)_values.Length)
+        {
+            value = EventFieldValue.FromProperty(_values[index]);
+
+            return true;
+        }
+
+        value = default;
+
+        return false;
+    }
+
+    public bool TryGetName(int index, out string name)
+    {
+        if (TryGetOrdering(out FieldNameOrdering ordering))
+        {
+            ImmutableArray<string> names = OrderingNames(ordering);
+
+            if ((uint)index < (uint)names.Length)
+            {
+                name = names[index];
+
+                return true;
+            }
+        }
+
+        name = string.Empty;
+
+        return false;
+    }
+
+    public Enumerator GetEnumerator() => new(this);
+
+    private ImmutableArray<string> OrderingNames(FieldNameOrdering ordering) =>
+        ordering == FieldNameOrdering.Visible ? _schema!.VisibleNames : _schema!.AllNames;
+
+    private bool TryGetOrdering(out FieldNameOrdering ordering)
+    {
+        if (_schema is not null && !_values.IsDefaultOrEmpty)
+        {
+            if (_values.Length == _schema.VisibleNames.Length) { ordering = FieldNameOrdering.Visible; return true; }
+
+            if (_values.Length == _schema.AllNames.Length) { ordering = FieldNameOrdering.All; return true; }
+        }
+
+        ordering = default;
+
+        return false;
+    }
+
+    public readonly record struct Field(string Name, EventFieldValue Value);
+
+    public struct Enumerator
+    {
+        private readonly ImmutableArray<EventProperty> _values;
+        private readonly ImmutableArray<string> _names;
+        private int _index;
+
+        internal Enumerator(in EventDataView view)
+        {
+            if (view.TryGetOrdering(out FieldNameOrdering ordering))
+            {
+                _values = view._values;
+                _names = view.OrderingNames(ordering);
+            }
+            else
+            {
+                _values = ImmutableArray<EventProperty>.Empty;
+                _names = ImmutableArray<string>.Empty;
+            }
+
+            _index = -1;
+        }
+
+        public readonly Field Current => new(_names[_index], EventFieldValue.FromProperty(_values[_index]));
+
+        public bool MoveNext()
+        {
+            int next = _index + 1;
+
+            // Bounded to the aligned name/value pair (equal lengths by the schema lockstep invariant).
+            if (next < _values.Length && next < _names.Length)
+            {
+                _index = next;
+
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/EventLogExpert.Eventing/Common/Events/EventFieldValue.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/EventFieldValue.cs
@@ -162,17 +162,21 @@ public readonly struct EventFieldValue
             case EventPropertyKind.DateTime:
                 return new(EventFieldValueKind.DateTime, property.AsDateTime.ToBinary(), null);
             default:
-                return property.Reference switch
+            {
+                object? reference = property.Reference;
+
+                return reference switch
                 {
                     null => new(EventFieldValueKind.Null, 0, null),
                     string text => new(EventFieldValueKind.String, 0, text),
-                    Guid guid => new(EventFieldValueKind.Guid, 0, guid),
+                    Guid => new(EventFieldValueKind.Guid, 0, reference),
                     SecurityIdentifier sid => new(EventFieldValueKind.Sid, 0, sid),
                     byte[] bytes => new(EventFieldValueKind.Bytes, 0, bytes),
                     string[] strings => new(EventFieldValueKind.StringArray, 0, strings),
                     Array array => new(EventFieldValueKind.Array, 0, array),
-                    var other => new(EventFieldValueKind.String, 0, other.ToString() ?? string.Empty)
+                    _ => new(EventFieldValueKind.String, 0, reference.ToString() ?? string.Empty)
                 };
+            }
         }
     }
 }

--- a/src/EventLogExpert.Eventing/Common/Events/EventFieldValue.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/EventFieldValue.cs
@@ -1,0 +1,178 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Readers;
+using System.Globalization;
+using System.Security.Principal;
+
+namespace EventLogExpert.Eventing.Common.Events;
+
+public enum EventFieldValueKind : byte
+{
+    String,
+    Int64,
+    UInt64,
+    Double,
+    Single,
+    Boolean,
+    DateTime,
+    Guid,
+    Sid,
+    Bytes,
+    StringArray,
+    Array,
+    Null
+}
+
+/// <summary>
+///     A single named EventData field value, projected without boxing from the internal rendered property: numeric /
+///     bool / DateTime / Single kinds read from a packed 64-bit field, reference shapes (string, Guid, SID, byte[],
+///     string[]) from an object slot. Transient (materialized on read from <see cref="EventDataView" />), never retained.
+/// </summary>
+public readonly struct EventFieldValue
+{
+    private readonly object? _reference;
+    private readonly long _bits;
+    private readonly EventFieldValueKind _kind;
+
+    private EventFieldValue(EventFieldValueKind kind, long bits, object? reference)
+    {
+        _kind = kind;
+        _bits = bits;
+        _reference = reference;
+    }
+
+    public EventFieldValueKind Kind => _kind;
+
+    public bool TryGetInt64(out long value)
+    {
+        if (_kind == EventFieldValueKind.Int64) { value = _bits; return true; }
+
+        value = 0;
+
+        return false;
+    }
+
+    public bool TryGetUInt64(out ulong value)
+    {
+        if (_kind == EventFieldValueKind.UInt64) { value = unchecked((ulong)_bits); return true; }
+
+        value = 0;
+
+        return false;
+    }
+
+    public bool TryGetDouble(out double value)
+    {
+        if (_kind == EventFieldValueKind.Double) { value = BitConverter.Int64BitsToDouble(_bits); return true; }
+
+        value = 0;
+
+        return false;
+    }
+
+    public bool TryGetSingle(out float value)
+    {
+        if (_kind == EventFieldValueKind.Single) { value = BitConverter.Int32BitsToSingle((int)_bits); return true; }
+
+        value = 0;
+
+        return false;
+    }
+
+    public bool TryGetBoolean(out bool value)
+    {
+        if (_kind == EventFieldValueKind.Boolean) { value = _bits != 0; return true; }
+
+        value = false;
+
+        return false;
+    }
+
+    public bool TryGetDateTime(out DateTime value)
+    {
+        if (_kind == EventFieldValueKind.DateTime) { value = DateTime.FromBinary(_bits); return true; }
+
+        value = default;
+
+        return false;
+    }
+
+    public bool TryGetGuid(out Guid value)
+    {
+        if (_kind == EventFieldValueKind.Guid && _reference is Guid guid) { value = guid; return true; }
+
+        value = default;
+
+        return false;
+    }
+
+    public string AsString() => _kind switch
+    {
+        EventFieldValueKind.String => _reference as string ?? string.Empty,
+        EventFieldValueKind.Int64 => _bits.ToString(CultureInfo.InvariantCulture),
+        EventFieldValueKind.UInt64 => unchecked((ulong)_bits).ToString(CultureInfo.InvariantCulture),
+        EventFieldValueKind.Double => BitConverter.Int64BitsToDouble(_bits).ToString(CultureInfo.InvariantCulture),
+        EventFieldValueKind.Single => BitConverter.Int32BitsToSingle((int)_bits).ToString(CultureInfo.InvariantCulture),
+        EventFieldValueKind.Boolean => (_bits != 0) ? bool.TrueString : bool.FalseString,
+        EventFieldValueKind.DateTime => DateTime.FromBinary(_bits).ToString("O", CultureInfo.InvariantCulture),
+        EventFieldValueKind.Guid => ((Guid)_reference!).ToString("D", CultureInfo.InvariantCulture),
+        EventFieldValueKind.Sid => ((SecurityIdentifier)_reference!).Value,
+        EventFieldValueKind.Bytes => Convert.ToHexString((byte[])_reference!),
+        EventFieldValueKind.StringArray => string.Join(", ", (string[])_reference!),
+        EventFieldValueKind.Array => JoinArray((Array)_reference!),
+        _ => string.Empty
+    };
+
+    public override string ToString() => AsString();
+
+    private static string JoinArray(Array array)
+    {
+        var parts = new string[array.Length];
+
+        for (int i = 0; i < array.Length; i++)
+        {
+            parts[i] = Convert.ToString(array.GetValue(i), CultureInfo.InvariantCulture) ?? string.Empty;
+        }
+
+        return string.Join(", ", parts);
+    }
+
+    internal static EventFieldValue FromProperty(in EventProperty property)
+    {
+        switch (property.Kind)
+        {
+            case EventPropertyKind.SByte:
+            case EventPropertyKind.Int16:
+            case EventPropertyKind.Int32:
+            case EventPropertyKind.Int64:
+                return new(EventFieldValueKind.Int64, property.AsInt64, null);
+            case EventPropertyKind.Byte:
+            case EventPropertyKind.UInt16:
+            case EventPropertyKind.UInt32:
+            case EventPropertyKind.UInt64:
+            case EventPropertyKind.SizeT:
+                return new(EventFieldValueKind.UInt64, unchecked((long)property.AsUInt64), null);
+            case EventPropertyKind.Single:
+                return new(EventFieldValueKind.Single, BitConverter.SingleToInt32Bits(property.AsSingle), null);
+            case EventPropertyKind.Double:
+                return new(EventFieldValueKind.Double, BitConverter.DoubleToInt64Bits(property.AsDouble), null);
+            case EventPropertyKind.Boolean:
+                return new(EventFieldValueKind.Boolean, property.AsBoolean ? 1L : 0L, null);
+            case EventPropertyKind.DateTime:
+                return new(EventFieldValueKind.DateTime, property.AsDateTime.ToBinary(), null);
+            default:
+                return property.Reference switch
+                {
+                    null => new(EventFieldValueKind.Null, 0, null),
+                    string text => new(EventFieldValueKind.String, 0, text),
+                    Guid guid => new(EventFieldValueKind.Guid, 0, guid),
+                    SecurityIdentifier sid => new(EventFieldValueKind.Sid, 0, sid),
+                    byte[] bytes => new(EventFieldValueKind.Bytes, 0, bytes),
+                    string[] strings => new(EventFieldValueKind.StringArray, 0, strings),
+                    Array array => new(EventFieldValueKind.Array, 0, array),
+                    var other => new(EventFieldValueKind.String, 0, other.ToString() ?? string.Empty)
+                };
+        }
+    }
+}

--- a/src/EventLogExpert.Eventing/Common/Events/ResolvedEvent.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/ResolvedEvent.cs
@@ -2,6 +2,9 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Readers;
+using EventLogExpert.Eventing.Resolvers;
+using System.Collections.Immutable;
 using System.Security.Principal;
 
 namespace EventLogExpert.Eventing.Common.Events;
@@ -48,4 +51,16 @@ public sealed record ResolvedEvent(
     ///     demand.
     /// </summary>
     public string Xml { get; init; } = string.Empty;
+
+    internal ImmutableArray<EventProperty> EventDataValues { get; init; }
+
+    internal TemplateFieldSchema? EventDataSchema { get; init; }
+
+    /// <summary>
+    ///     Named &lt;EventData&gt; fields for this event, or <see cref="EventDataKind.None" /> for legacy / template-less
+    ///     events. The underlying values also remain reachable positionally through the description and XML.
+    /// </summary>
+    public EventDataView EventData => EventDataValues.IsDefaultOrEmpty
+        ? EventDataView.Empty
+        : new(EventDataValues, EventDataSchema);
 }

--- a/src/EventLogExpert.Eventing/Interop/NativeMethods.Evt.cs
+++ b/src/EventLogExpert.Eventing/Interop/NativeMethods.Evt.cs
@@ -4,6 +4,7 @@
 using EventLogExpert.Eventing.Common.Channels;
 using EventLogExpert.Eventing.Readers;
 using Microsoft.Win32.SafeHandles;
+using System.Collections.Immutable;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
 
@@ -726,9 +727,9 @@ internal static partial class NativeMethods
         return GetEventRecord(buffer, propertyCount);
     }
 
-    private static unsafe IReadOnlyList<EventProperty> ProcessRenderedEventProperties(IntPtr buffer, int usedBytes, int propertyCount)
+    private static unsafe ImmutableArray<EventProperty> ProcessRenderedEventProperties(IntPtr buffer, int usedBytes, int propertyCount)
     {
-        if (propertyCount <= 0) { return []; }
+        if (propertyCount <= 0) { return ImmutableArray<EventProperty>.Empty; }
 
 #if DEBUG
         BeforeVariantReadForTest?.Invoke();
@@ -742,7 +743,7 @@ internal static partial class NativeMethods
             properties[i] = ConvertVariantToProperty(variants[i]);
         }
 
-        return properties;
+        return ImmutableCollectionsMarshal.AsImmutableArray(properties);
     }
 
     private static unsafe string? ProcessRenderedEventXml(IntPtr buffer, int usedBytes, int propertyCount) =>
@@ -751,7 +752,7 @@ internal static partial class NativeMethods
     internal static unsafe EventRecord RenderEvent(EvtHandle eventHandle) =>
         RenderWhilePinned(EventLogSession.GlobalSession.SystemRenderContext, eventHandle, EvtRenderFlags.EventValues, &ProcessRenderedEventRecord);
 
-    internal static unsafe IReadOnlyList<EventProperty> RenderEventProperties(EvtHandle eventHandle) =>
+    internal static unsafe ImmutableArray<EventProperty> RenderEventProperties(EvtHandle eventHandle) =>
         RenderWhilePinned(EventLogSession.GlobalSession.UserRenderContext, eventHandle, EvtRenderFlags.EventValues, &ProcessRenderedEventProperties);
 
     internal static unsafe string? RenderEventXml(EvtHandle eventHandle) =>

--- a/src/EventLogExpert.Eventing/Readers/EventRecord.cs
+++ b/src/EventLogExpert.Eventing/Readers/EventRecord.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Eventing.Common.Channels;
+using System.Collections.Immutable;
 using System.Security.Principal;
 
 namespace EventLogExpert.Eventing.Readers;
@@ -30,7 +31,7 @@ public sealed record EventRecord
 
     public long? RecordId { get; set; }
 
-    internal IReadOnlyList<EventProperty> Properties { get; set; } = [];
+    internal ImmutableArray<EventProperty> Properties { get; set; } = [];
 
     public string ProviderName { get; set; } = string.Empty;
 

--- a/src/EventLogExpert.Eventing/Resolvers/DescriptionFormatter.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/DescriptionFormatter.cs
@@ -44,7 +44,8 @@ internal sealed partial class DescriptionFormatter(
         ProviderDetails? descriptionDetails,
         EventModel? modernEvent,
         ProviderDetails? supplemental,
-        EventModel? supplementalModernEvent)
+        EventModel? supplementalModernEvent,
+        TemplateInfo? primaryInfo)
     {
         if (descriptionDetails is null)
         {
@@ -53,7 +54,7 @@ internal sealed partial class DescriptionFormatter(
             return DefaultNoProviderDescription;
         }
 
-        var properties = GetFormattedProperties(modernEvent?.Template, eventRecord.Properties, descriptionDetails.Maps);
+        var properties = GetFormattedProperties(primaryInfo?.Metadata ?? default, eventRecord.Properties, descriptionDetails.Maps);
 
         var descriptionFromSupplemental = supplemental is not null && ReferenceEquals(descriptionDetails, supplemental);
 
@@ -96,7 +97,10 @@ internal sealed partial class DescriptionFormatter(
                 {
                     _logger?.Debug($"{nameof(Resolve)}: Disambiguated via supplemental modern event - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}");
 
-                    var supplementalProperties = GetFormattedProperties(supplementalModernEvent!.Template, eventRecord.Properties, supplemental.Maps);
+                    var supplementalProperties = GetFormattedProperties(
+                        _templates.GetTemplateInfo(supplementalModernEvent.Template).Metadata,
+                        eventRecord.Properties,
+                        supplemental.Maps);
 
                     // Supplemental descriptions resolve %%n against supplemental parameters first.
                     return FormatDescription(supplementalProperties, supplementalModernEvent.Description,
@@ -330,6 +334,35 @@ internal sealed partial class DescriptionFormatter(
         _ => reference?.ToString() ?? string.Empty
     };
 
+    private static List<string> GetFormattedProperties(
+        in TemplateMetadata metadata,
+        ImmutableArray<EventProperty> properties,
+        IReadOnlyDictionary<string, ValueMapDefinition> maps)
+    {
+        ImmutableArray<string> dataNodes = default;
+        ImmutableArray<string> mapNodes = default;
+        List<string> formattedValues = new(properties.Length);
+
+        if (FieldNameOrderingSelector.TrySelectOrdering(metadata, properties.Length, out FieldNameOrdering ordering))
+        {
+            dataNodes = ordering == FieldNameOrdering.Visible ? metadata.VisibleOutTypes : metadata.AllOutTypes;
+            mapNodes = ordering == FieldNameOrdering.Visible ? metadata.VisibleMaps : metadata.AllMaps;
+        }
+
+        int index = 0;
+
+        foreach (EventProperty property in properties)
+        {
+            string? outType = !dataNodes.IsDefault && index < dataNodes.Length ? dataNodes[index] : null;
+            string? mapName = !mapNodes.IsDefault && index < mapNodes.Length ? mapNodes[index] : null;
+
+            formattedValues.Add(FormatProperty(property, outType, mapName, maps));
+            index++;
+        }
+
+        return formattedValues;
+    }
+
     private static void ResizeBuffer(ref char[] buffer, ref Span<char> source, int sizeToAdd)
     {
         char[] newBuffer = ArrayPool<char>.Shared.Rent(source.Length + sizeToAdd);
@@ -536,46 +569,6 @@ internal sealed partial class DescriptionFormatter(
 
             if (cleanupRented is not null) { ArrayPool<char>.Shared.Return(cleanupRented); }
         }
-    }
-
-    private List<string> GetFormattedProperties(
-        ReadOnlySpan<char> template,
-        IReadOnlyList<EventProperty> properties,
-        IReadOnlyDictionary<string, ValueMapDefinition> maps)
-    {
-        ImmutableArray<string> dataNodes = default;
-        ImmutableArray<string> mapNodes = default;
-        List<string> formattedValues = new(properties.Count);
-
-        if (!template.IsEmpty)
-        {
-            // Match outTypes to actual property count because EvtRender may omit hidden length-provider fields.
-            var meta = _templates.Analyze(template);
-
-            if (meta.VisibleOutTypes.Length == properties.Count)
-            {
-                dataNodes = meta.VisibleOutTypes;
-                mapNodes = meta.VisibleMaps;
-            }
-            else if (meta.AllOutTypes.Length == properties.Count)
-            {
-                dataNodes = meta.AllOutTypes;
-                mapNodes = meta.AllMaps;
-            }
-        }
-
-        int index = 0;
-
-        foreach (EventProperty property in properties)
-        {
-            string? outType = !dataNodes.IsDefault && index < dataNodes.Length ? dataNodes[index] : null;
-            string? mapName = !mapNodes.IsDefault && index < mapNodes.Length ? mapNodes[index] : null;
-
-            formattedValues.Add(FormatProperty(property, outType, mapName, maps));
-            index++;
-        }
-
-        return formattedValues;
     }
 
     // Bias %%n lookup toward the provider that supplied the description, lazy-loading supplemental only when needed.

--- a/src/EventLogExpert.Eventing/Resolvers/EventResolverBase.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/EventResolverBase.cs
@@ -6,6 +6,7 @@ using EventLogExpert.Eventing.Readers;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Provider.Resolution;
 using System.Collections.Concurrent;
+using System.Collections.Immutable;
 
 namespace EventLogExpert.Eventing.Resolvers;
 
@@ -112,6 +113,20 @@ public class EventResolverBase : IDisposable
     /// </summary>
     protected virtual ProviderDetails? TryGetSupplementalDetails(EventRecord eventRecord) => null;
 
+    private (ImmutableArray<EventProperty> Values, TemplateFieldSchema? Schema) BuildEventData(
+        EventRecord eventRecord,
+        TemplateInfo? primaryInfo)
+    {
+        if (eventRecord.Properties.Length == 0 || primaryInfo is not { } info)
+        {
+            return (default, null);
+        }
+
+        // Fail closed: a count matching neither ordering would mislabel fields, so expose nothing (values still format positionally).
+        return !FieldNameOrderingSelector.TrySelectOrdering(info.Metadata, eventRecord.Properties.Length, out _) ?
+            (default, null) : (eventRecord.Properties, info.Schema);
+    }
+
     private ResolvedEvent CreateEventModel(
         EventRecord eventRecord,
         EventModel? modernEvent,
@@ -122,11 +137,17 @@ public class EventResolverBase : IDisposable
     {
         var keywords = _taskKeywords.ResolveKeywords(eventRecord, details, supplemental);
 
+        TemplateInfo? primaryInfo = modernEvent?.Template is { } template ? _templates.GetTemplateInfo(template) : null;
+
+        var (eventDataValues, eventDataSchema) = BuildEventData(eventRecord, primaryInfo);
+
         return new(eventRecord.PathName, eventRecord.LogPathType)
         {
             ActivityId = eventRecord.ActivityId,
             ComputerName = _cache?.GetOrAddValue(eventRecord.ComputerName) ?? eventRecord.ComputerName,
-            Description = _descriptions.Resolve(eventRecord, details, descriptionDetails, modernEvent, supplemental, supplementalModernEvent),
+            Description = _descriptions.Resolve(eventRecord, details, descriptionDetails, modernEvent, supplemental, supplementalModernEvent, primaryInfo),
+            EventDataValues = eventDataValues,
+            EventDataSchema = eventDataSchema,
             Id = eventRecord.Id,
             Keywords = _cache?.GetOrAddKeywords(keywords) ?? keywords,
             Level = SeverityFormatter.Format(eventRecord.Level),

--- a/src/EventLogExpert.Eventing/Resolvers/FieldNameOrderingSelector.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/FieldNameOrderingSelector.cs
@@ -1,0 +1,37 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Eventing.Resolvers;
+
+internal enum FieldNameOrdering : byte
+{
+    Visible,
+    All
+}
+
+// Reproduces DescriptionFormatter's runtime length-match (Visible ordering first, then All) so field labeling and
+// description formatting resolve the same ordering; returns false (fail closed) when the value count matches neither,
+// which the accessor surfaces as EventDataKind.None rather than mislabeling.
+internal static class FieldNameOrderingSelector
+{
+    public static bool TrySelectOrdering(in TemplateMetadata meta, int valueCount, out FieldNameOrdering ordering)
+    {
+        if (!meta.VisibleOutTypes.IsDefault && meta.VisibleOutTypes.Length == valueCount)
+        {
+            ordering = FieldNameOrdering.Visible;
+
+            return true;
+        }
+
+        if (!meta.AllOutTypes.IsDefault && meta.AllOutTypes.Length == valueCount)
+        {
+            ordering = FieldNameOrdering.All;
+
+            return true;
+        }
+
+        ordering = default;
+
+        return false;
+    }
+}

--- a/src/EventLogExpert.Eventing/Resolvers/ModernEventMatcher.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/ModernEventMatcher.cs
@@ -114,7 +114,7 @@ internal sealed class ModernEventMatcher(TemplateAnalyzer templates, ITraceLogge
             return null;
         }
 
-        int eventPropertyCount = eventRecord.Properties.Count;
+        int eventPropertyCount = eventRecord.Properties.Length;
 
         var candidateEvents = details.GetEventsById(eventRecord.Id);
 

--- a/src/EventLogExpert.Eventing/Resolvers/TemplateAnalyzer.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/TemplateAnalyzer.cs
@@ -12,37 +12,19 @@ namespace EventLogExpert.Eventing.Resolvers;
 // Length-provider <data> nodes are consumed by EvtRender, so visible metadata excludes referenced length fields.
 internal sealed class TemplateAnalyzer
 {
-    private static readonly TemplateMetadata s_empty = new(
-        0,
-        ImmutableArray<string>.Empty,
-        ImmutableArray<string>.Empty,
-        ImmutableArray<string>.Empty,
-        ImmutableArray<string>.Empty);
+    private static readonly TemplateInfo s_empty = new(
+        new TemplateMetadata(
+            0,
+            ImmutableArray<string>.Empty,
+            ImmutableArray<string>.Empty,
+            ImmutableArray<string>.Empty,
+            ImmutableArray<string>.Empty),
+        TemplateFieldSchema.Empty);
 
-    private readonly ConcurrentDictionary<string, TemplateMetadata> _cache =
+    private readonly ConcurrentDictionary<string, TemplateInfo> _cache =
         new(StringComparer.Ordinal);
 
-    public TemplateMetadata Analyze(ReadOnlySpan<char> template)
-    {
-        if (template.IsEmpty)
-        {
-            return s_empty;
-        }
-
-        var lookup = _cache.GetAlternateLookup<ReadOnlySpan<char>>();
-
-        if (lookup.TryGetValue(template, out var cached))
-        {
-            return cached;
-        }
-
-        TemplateMetadata metadata = Parse(template);
-
-        // Publish to cache only after parsing completes so readers never observe partial metadata.
-        lookup.TryAdd(template, metadata);
-
-        return metadata;
-    }
+    public TemplateMetadata Analyze(ReadOnlySpan<char> template) => GetTemplateInfo(template).Metadata;
 
     // Allows one extra template node for newer manifest versions with an added optional field.
     public bool ApproximatelyMatchesPropertyCount(ReadOnlySpan<char> template, int eventPropertyCount)
@@ -59,6 +41,28 @@ internal sealed class TemplateAnalyzer
         }
 
         return templateCount - eventPropertyCount == 1;
+    }
+
+    public TemplateInfo GetTemplateInfo(ReadOnlySpan<char> template)
+    {
+        if (template.IsEmpty)
+        {
+            return s_empty;
+        }
+
+        var lookup = _cache.GetAlternateLookup<ReadOnlySpan<char>>();
+
+        if (lookup.TryGetValue(template, out var cached))
+        {
+            return cached;
+        }
+
+        TemplateInfo info = Parse(template);
+
+        // Publish to cache only after parsing completes so readers never observe partial metadata.
+        lookup.TryAdd(template, info);
+
+        return info;
     }
 
     // Accept full or visible counts because providers vary on length-provider field output.
@@ -80,26 +84,31 @@ internal sealed class TemplateAnalyzer
         return MatchesPropertyCount(template, eventPropertyCount);
     }
 
-    private static TemplateMetadata BuildMetadata(
+    private static TemplateInfo BuildInfo(
         List<(string name, string outType, string map)> elements,
         HashSet<string> lengthProviderNames)
     {
+        var allNamesArray = new string[elements.Count];
         var allOutTypesArray = new string[elements.Count];
         var allMapsArray = new string[elements.Count];
 
         for (int i = 0; i < elements.Count; i++)
         {
+            allNamesArray[i] = elements[i].name;
             allOutTypesArray[i] = elements[i].outType;
             allMapsArray[i] = elements[i].map;
         }
 
-        // ImmutableArray safely takes over this fresh local array without copying.
+        // ImmutableArray safely takes over each fresh local array without copying.
+        var allNames = ImmutableCollectionsMarshal.AsImmutableArray(allNamesArray);
         var allOutTypes = ImmutableCollectionsMarshal.AsImmutableArray(allOutTypesArray);
         var allMaps = ImmutableCollectionsMarshal.AsImmutableArray(allMapsArray);
 
         if (lengthProviderNames.Count == 0)
         {
-            return new TemplateMetadata(elements.Count, allOutTypes, allOutTypes, allMaps, allMaps);
+            var metadata = new TemplateMetadata(elements.Count, allOutTypes, allOutTypes, allMaps, allMaps);
+
+            return new TemplateInfo(metadata, new TemplateFieldSchema(allNames, allNames));
         }
 
         int visibleCount = 0;
@@ -112,6 +121,7 @@ internal sealed class TemplateAnalyzer
             }
         }
 
+        var visibleNamesArray = new string[visibleCount];
         var visibleOutTypesArray = new string[visibleCount];
         var visibleMapsArray = new string[visibleCount];
         int write = 0;
@@ -120,19 +130,23 @@ internal sealed class TemplateAnalyzer
         {
             if (string.IsNullOrEmpty(name) || !lengthProviderNames.Contains(name))
             {
+                visibleNamesArray[write] = name;
                 visibleOutTypesArray[write] = outType;
                 visibleMapsArray[write] = map;
                 write++;
             }
         }
 
+        var visibleNames = ImmutableCollectionsMarshal.AsImmutableArray(visibleNamesArray);
         var visibleOutTypes = ImmutableCollectionsMarshal.AsImmutableArray(visibleOutTypesArray);
         var visibleMaps = ImmutableCollectionsMarshal.AsImmutableArray(visibleMapsArray);
 
-        return new TemplateMetadata(visibleCount, allOutTypes, visibleOutTypes, allMaps, visibleMaps);
+        var visibleMetadata = new TemplateMetadata(visibleCount, allOutTypes, visibleOutTypes, allMaps, visibleMaps);
+
+        return new TemplateInfo(visibleMetadata, new TemplateFieldSchema(allNames, visibleNames));
     }
 
-    private static TemplateMetadata Parse(ReadOnlySpan<char> template)
+    private static TemplateInfo Parse(ReadOnlySpan<char> template)
     {
         List<(string name, string outType, string map)> elements = [];
         HashSet<string> lengthProviderNames = new(StringComparer.OrdinalIgnoreCase);
@@ -158,6 +172,6 @@ internal sealed class TemplateAnalyzer
             }
         }
 
-        return BuildMetadata(elements, lengthProviderNames);
+        return BuildInfo(elements, lengthProviderNames);
     }
 }

--- a/src/EventLogExpert.Eventing/Resolvers/TemplateFieldSchema.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/TemplateFieldSchema.cs
@@ -1,0 +1,64 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Collections.Frozen;
+using System.Collections.Immutable;
+
+namespace EventLogExpert.Eventing.Resolvers;
+
+// The per-template metadata (out-types/maps) plus the reference-shared field-name schema, cached once per template
+// string and threaded from the resolve pass into both DescriptionFormatter and EventData population.
+internal readonly record struct TemplateInfo(TemplateMetadata Metadata, TemplateFieldSchema Schema);
+
+/// <summary>
+///     Reference-shared per-template field names in both orderings (all &lt;data&gt; nodes, and the visible subset
+///     that excludes length-provider nodes), positionally aligned with the matching <see cref="TemplateMetadata" />
+///     out-type arrays. The name-to-index maps are built lazily on first lookup and published atomically.
+/// </summary>
+internal sealed class TemplateFieldSchema(ImmutableArray<string> allNames, ImmutableArray<string> visibleNames)
+{
+    public static readonly TemplateFieldSchema Empty = new(ImmutableArray<string>.Empty, ImmutableArray<string>.Empty);
+
+    private FrozenDictionary<string, int>? _allIndex;
+    private FrozenDictionary<string, int>? _visibleIndex;
+
+    public ImmutableArray<string> AllNames { get; } = allNames;
+
+    public ImmutableArray<string> VisibleNames { get; } = visibleNames;
+
+    public bool TryGetIndex(FieldNameOrdering ordering, string name, out int index)
+    {
+        FrozenDictionary<string, int> map = ordering == FieldNameOrdering.Visible
+            ? GetOrBuildIndex(ref _visibleIndex, VisibleNames)
+            : GetOrBuildIndex(ref _allIndex, AllNames);
+
+        return map.TryGetValue(name, out index);
+    }
+
+    private static FrozenDictionary<string, int> BuildIndex(ImmutableArray<string> names)
+    {
+        var map = new Dictionary<string, int>(names.Length, StringComparer.Ordinal);
+
+        for (int i = 0; i < names.Length; i++)
+        {
+            string name = names[i];
+
+            // Empty-name (raw/non-canonical) nodes are positional-only; a duplicate name keeps its first index.
+            if (!string.IsNullOrEmpty(name)) { map.TryAdd(name, i); }
+        }
+
+        return map.ToFrozenDictionary(StringComparer.Ordinal);
+    }
+
+    private static FrozenDictionary<string, int> GetOrBuildIndex(ref FrozenDictionary<string, int>? slot, ImmutableArray<string> names)
+    {
+        FrozenDictionary<string, int>? existing = Volatile.Read(ref slot);
+
+        if (existing is not null) { return existing; }
+
+        FrozenDictionary<string, int> built = BuildIndex(names);
+
+        // First writer wins; a racing reader either sees null (and builds its own discarded copy) or a complete map.
+        return Interlocked.CompareExchange(ref slot, built, null) ?? built;
+    }
+}

--- a/src/EventLogExpert.Filtering/Basic/BasicFilterDecomposer.cs
+++ b/src/EventLogExpert.Filtering/Basic/BasicFilterDecomposer.cs
@@ -198,6 +198,79 @@ internal static class BasicFilterDecomposer
         return true;
     }
 
+    private static bool TryMapEventDataComparison(
+        EventDataComparisonNode node,
+        [NotNullWhen(true)] out FilterComparison? comparison)
+    {
+        comparison = null;
+
+        if (string.IsNullOrWhiteSpace(node.FieldName) || string.IsNullOrWhiteSpace(node.Literal.Raw))
+        {
+            return false;
+        }
+
+        comparison = new FilterComparison
+        {
+            Property = EventProperty.EventData,
+            EventDataFieldName = node.FieldName,
+            Operator = node.Op == FilterBinaryOperator.Equal
+                ? ComparisonOperator.Equals
+                : ComparisonOperator.NotEqual,
+            MatchMode = MatchMode.Single,
+            Value = node.Literal.Raw
+        };
+
+        return true;
+    }
+
+    private static bool TryMapEventDataContains(
+        EventDataContainsNode node,
+        [NotNullWhen(true)] out FilterComparison? comparison)
+    {
+        comparison = null;
+
+        // Mirror the ContainsNode guard: a case-sensitive Advanced contains is not Basic vocabulary (Basic is always
+        // OrdinalIgnoreCase), so leave it Advanced-only rather than re-encode it as an OIC Basic row.
+        if (!node.IgnoreCase || string.IsNullOrWhiteSpace(node.FieldName) || string.IsNullOrWhiteSpace(node.Needle))
+        {
+            return false;
+        }
+
+        comparison = new FilterComparison
+        {
+            Property = EventProperty.EventData,
+            EventDataFieldName = node.FieldName,
+            Operator = node.Negated ? ComparisonOperator.NotContains : ComparisonOperator.Contains,
+            MatchMode = MatchMode.Single,
+            Value = node.Needle
+        };
+
+        return true;
+    }
+
+    private static bool TryMapEventDataMultiEquals(
+        EventDataMultiEqualsNode node,
+        [NotNullWhen(true)] out FilterComparison? comparison)
+    {
+        comparison = null;
+
+        if (node.Literals.Count == 0 || string.IsNullOrWhiteSpace(node.FieldName))
+        {
+            return false;
+        }
+
+        comparison = new FilterComparison
+        {
+            Property = EventProperty.EventData,
+            EventDataFieldName = node.FieldName,
+            Operator = ComparisonOperator.Equals,
+            MatchMode = MatchMode.Many,
+            Values = [.. node.Literals.Select(literal => literal.Raw)]
+        };
+
+        return true;
+    }
+
     private static bool TryMapField(ResolvedEventField field, out EventProperty property)
     {
         switch (field)
@@ -317,6 +390,15 @@ internal static class BasicFilterDecomposer
                 };
 
                 return true;
+
+            case EventDataComparisonNode eventDataComparison:
+                return TryMapEventDataComparison(eventDataComparison, out comparison);
+
+            case EventDataContainsNode eventDataContains:
+                return TryMapEventDataContains(eventDataContains, out comparison);
+
+            case EventDataMultiEqualsNode eventDataMulti:
+                return TryMapEventDataMultiEquals(eventDataMulti, out comparison);
 
             case NotNode not:
                 return TryMapNegatedLeaf(not, out comparison);

--- a/src/EventLogExpert.Filtering/Basic/BasicFilterFormatter.cs
+++ b/src/EventLogExpert.Filtering/Basic/BasicFilterFormatter.cs
@@ -59,13 +59,21 @@ public static class BasicFilterFormatter
             return false;
         }
 
+        if (comparison.Property is EventProperty.EventData && string.IsNullOrWhiteSpace(comparison.EventDataFieldName))
+        {
+            return false;
+        }
+
+        var propertyExpression = FormatPropertyExpression(comparison);
+
         StringBuilder stringBuilder = new(joinPrefix ?? string.Empty);
 
         // The Many+non-Keywords shape is `(new[]{...}).Contains(property)` — the property-reference template
         // moves to the suffix. Everything else prepends the operator+property template.
         if (comparison.MatchMode != MatchMode.Many || comparison.Property is EventProperty.Keywords)
         {
-            stringBuilder.Append(GetComparisonString(comparison.Property, comparison.Operator, comparison.MatchMode));
+            stringBuilder.Append(
+                GetComparisonString(comparison.Property, propertyExpression, comparison.Operator, comparison.MatchMode));
         }
 
         if (comparison.MatchMode == MatchMode.Many)
@@ -79,7 +87,8 @@ public static class BasicFilterFormatter
 
         if (comparison is { MatchMode: MatchMode.Many, Property: not EventProperty.Keywords })
         {
-            stringBuilder.Append(GetComparisonString(comparison.Property, comparison.Operator, comparison.MatchMode));
+            stringBuilder.Append(
+                GetComparisonString(comparison.Property, propertyExpression, comparison.Operator, comparison.MatchMode));
         }
 
         formatted = stringBuilder.ToString();
@@ -162,7 +171,18 @@ public static class BasicFilterFormatter
         return builder.ToString();
     }
 
-    private static string GetComparisonString(EventProperty property, ComparisonOperator op, MatchMode matchMode)
+    // The Advanced-text reference for a comparison's property: `EventData["escaped field name"]` for an EventData
+    // row, otherwise the bare property name (which the tokenizer reads as an identifier).
+    private static string FormatPropertyExpression(FilterComparison comparison) =>
+        comparison.Property is EventProperty.EventData
+            ? $"EventData[\"{EscapeStringLiteral(comparison.EventDataFieldName)}\"]"
+            : comparison.Property.ToString();
+
+    private static string GetComparisonString(
+        EventProperty property,
+        string propertyExpression,
+        ComparisonOperator op,
+        MatchMode matchMode)
     {
         if (matchMode == MatchMode.Many)
         {
@@ -171,7 +191,7 @@ public static class BasicFilterFormatter
             return property switch
             {
                 EventProperty.Keywords => $"{property}.Any",
-                _ => $"{property})"
+                _ => $"{propertyExpression})"
             };
         }
 
@@ -181,25 +201,25 @@ public static class BasicFilterFormatter
             {
                 EventProperty.Keywords => $"{property}.Any(e => string.Equals(e, ",
                 EventProperty.UserId => $"{property} != null && {property}.Value == ",
-                _ => $"{property} == "
+                _ => $"{propertyExpression} == "
             },
             ComparisonOperator.Contains => property switch
             {
                 EventProperty.Keywords => $"{property}.Any(e => e.Contains",
                 EventProperty.UserId => $"{property} != null && {property}.Value.Contains",
-                _ => $"{property}.Contains"
+                _ => $"{propertyExpression}.Contains"
             },
             ComparisonOperator.NotEqual => property switch
             {
                 EventProperty.Keywords => $"!{property}.Any(e => string.Equals(e, ",
                 EventProperty.UserId => $"{property} != null && {property}.Value != ",
-                _ => $"{property} != "
+                _ => $"{propertyExpression} != "
             },
             ComparisonOperator.NotContains => property switch
             {
                 EventProperty.Keywords => $"!{property}.Any(e => e.Contains",
                 EventProperty.UserId => $"{property} != null && !{property}.Value.Contains",
-                _ => $"!{property}.Contains"
+                _ => $"!{propertyExpression}.Contains"
             },
             _ => string.Empty
         };

--- a/src/EventLogExpert.Filtering/Basic/FilterComparison.cs
+++ b/src/EventLogExpert.Filtering/Basic/FilterComparison.cs
@@ -22,9 +22,15 @@ public sealed record FilterComparison
     public ImmutableList<string> Values { get; init; } = [];
 
     /// <summary>
-    ///     Returns a copy with the new <paramref name="property" /> and Value/Values cleared, since the available value
-    ///     space changes when the property changes.
+    ///     The named &lt;EventData&gt; field this row targets. Meaningful only when <see cref="Property" /> is
+    ///     <see cref="EventProperty.EventData" /> (null for every other property).
+    /// </summary>
+    public string? EventDataFieldName { get; init; }
+
+    /// <summary>
+    ///     Returns a copy with the new <paramref name="property" /> and Value/Values/EventDataFieldName cleared, since
+    ///     the available value space (and whether a field name applies) changes when the property changes.
     /// </summary>
     public FilterComparison WithProperty(EventProperty property) =>
-        this with { Property = property, Value = null, Values = [] };
+        this with { Property = property, Value = null, Values = [], EventDataFieldName = null };
 }

--- a/src/EventLogExpert.Filtering/Basic/FilterComparisonJsonConverter.cs
+++ b/src/EventLogExpert.Filtering/Basic/FilterComparisonJsonConverter.cs
@@ -86,7 +86,9 @@ internal sealed class FilterComparisonJsonConverter : JsonConverter<FilterCompar
             MatchMode = matchMode,
             Value = value,
             Values = values,
-            EventDataFieldName = property is EventProperty.EventData ? eventDataFieldName : null
+            EventDataFieldName = property is EventProperty.EventData && !string.IsNullOrWhiteSpace(eventDataFieldName)
+                ? eventDataFieldName
+                : null
         };
     }
 

--- a/src/EventLogExpert.Filtering/Basic/FilterComparisonJsonConverter.cs
+++ b/src/EventLogExpert.Filtering/Basic/FilterComparisonJsonConverter.cs
@@ -86,7 +86,7 @@ internal sealed class FilterComparisonJsonConverter : JsonConverter<FilterCompar
             MatchMode = matchMode,
             Value = value,
             Values = values,
-            EventDataFieldName = eventDataFieldName
+            EventDataFieldName = property is EventProperty.EventData ? eventDataFieldName : null
         };
     }
 
@@ -109,7 +109,7 @@ internal sealed class FilterComparisonJsonConverter : JsonConverter<FilterCompar
 
         writer.WriteEndArray();
 
-        if (value.EventDataFieldName is not null)
+        if (value.Property is EventProperty.EventData && !string.IsNullOrWhiteSpace(value.EventDataFieldName))
         {
             writer.WriteString("EventDataFieldName", value.EventDataFieldName);
         }

--- a/src/EventLogExpert.Filtering/Basic/FilterComparisonJsonConverter.cs
+++ b/src/EventLogExpert.Filtering/Basic/FilterComparisonJsonConverter.cs
@@ -23,6 +23,7 @@ internal sealed class FilterComparisonJsonConverter : JsonConverter<FilterCompar
         bool operatorSet = false;
         bool matchModeSet = false;
         string? value = null;
+        string? eventDataFieldName = null;
         ImmutableList<string> values = [];
 
         while (reader.Read())
@@ -66,6 +67,9 @@ internal sealed class FilterComparisonJsonConverter : JsonConverter<FilterCompar
                 case "Value":
                     value = reader.TokenType == JsonTokenType.Null ? null : reader.GetString();
                     break;
+                case "EventDataFieldName":
+                    eventDataFieldName = reader.TokenType == JsonTokenType.Null ? null : reader.GetString();
+                    break;
                 case "Values":
                     values = ReadStringList(ref reader);
                     break;
@@ -81,7 +85,8 @@ internal sealed class FilterComparisonJsonConverter : JsonConverter<FilterCompar
             Operator = op,
             MatchMode = matchMode,
             Value = value,
-            Values = values
+            Values = values,
+            EventDataFieldName = eventDataFieldName
         };
     }
 
@@ -103,6 +108,12 @@ internal sealed class FilterComparisonJsonConverter : JsonConverter<FilterCompar
         foreach (var item in value.Values) { writer.WriteStringValue(item); }
 
         writer.WriteEndArray();
+
+        if (value.EventDataFieldName is not null)
+        {
+            writer.WriteString("EventDataFieldName", value.EventDataFieldName);
+        }
+
         writer.WriteEndObject();
     }
 

--- a/src/EventLogExpert.Filtering/Common/Filtering/EventProperty.cs
+++ b/src/EventLogExpert.Filtering/Common/Filtering/EventProperty.cs
@@ -18,5 +18,6 @@ public enum EventProperty
     [EnumMember(Value = "User ID")] UserId,
     Description,
     Xml,
-    [EnumMember(Value = "Log Name")] LogName
+    [EnumMember(Value = "Log Name")] LogName,
+    [EnumMember(Value = "Event Data")] EventData
 }

--- a/src/EventLogExpert.Filtering/Drafts/FilterComparisonDraft.cs
+++ b/src/EventLogExpert.Filtering/Drafts/FilterComparisonDraft.cs
@@ -18,6 +18,9 @@ public sealed class FilterComparisonDraft
 
     public List<string> Values { get; set; } = [];
 
+    /// <summary>The named EventData field this row targets; meaningful only when <see cref="Property" /> is EventData.</summary>
+    public string? EventDataFieldName { get; set; }
+
     public static FilterComparisonDraft FromComparison(FilterComparison comparison) =>
         new()
         {
@@ -25,7 +28,8 @@ public sealed class FilterComparisonDraft
             Operator = comparison.Operator,
             MatchMode = comparison.MatchMode,
             Value = comparison.Value,
-            Values = [.. comparison.Values]
+            Values = [.. comparison.Values],
+            EventDataFieldName = comparison.EventDataFieldName
         };
 
     public void ChangeProperty(EventProperty property)
@@ -33,6 +37,7 @@ public sealed class FilterComparisonDraft
         Property = property;
         Value = null;
         Values.Clear();
+        EventDataFieldName = null;
     }
 
     public FilterComparison ToComparison() =>
@@ -42,6 +47,7 @@ public sealed class FilterComparisonDraft
             Operator = Operator,
             MatchMode = MatchMode,
             Value = Value,
-            Values = [.. Values]
+            Values = [.. Values],
+            EventDataFieldName = EventDataFieldName
         };
 }

--- a/src/EventLogExpert.Filtering/Drafts/FilterPredicateDraft.cs
+++ b/src/EventLogExpert.Filtering/Drafts/FilterPredicateDraft.cs
@@ -18,13 +18,28 @@ public sealed class FilterPredicateDraft
     ///     <list type="bullet">
     ///         <item><c>Single</c> match mode requires a non-whitespace <see cref="FilterComparisonDraft.Value" />.</item>
     ///         <item><c>Many</c> match mode requires at least one entry in <see cref="FilterComparisonDraft.Values" />.</item>
+    ///         <item>
+    ///             An <see cref="EventProperty.EventData" /> row additionally requires a non-whitespace
+    ///             <see cref="FilterComparisonDraft.EventDataFieldName" />.
+    ///         </item>
     ///     </list>
     ///     Mirrors the formatter's strict-mode validation so the in-flight UI state matches the eventual save guard.
     /// </summary>
-    public bool IsComplete =>
-        Comparison.MatchMode == MatchMode.Many
-            ? Comparison.Values.Count > 0
-            : !string.IsNullOrWhiteSpace(Comparison.Value);
+    public bool IsComplete
+    {
+        get
+        {
+            if (Comparison.Property is EventProperty.EventData
+                && string.IsNullOrWhiteSpace(Comparison.EventDataFieldName))
+            {
+                return false;
+            }
+
+            return Comparison.MatchMode == MatchMode.Many
+                ? Comparison.Values.Count > 0
+                : !string.IsNullOrWhiteSpace(Comparison.Value);
+        }
+    }
 
     public bool JoinWithAny { get; set; }
 

--- a/src/EventLogExpert.Filtering/Emit/Emitter.cs
+++ b/src/EventLogExpert.Filtering/Emit/Emitter.cs
@@ -177,6 +177,53 @@ internal static class Emitter
             _ => throw new EmitException($"Operator '{op}' is not supported on string properties.")
         };
 
+    private static Func<ResolvedEvent, bool> EmitEventDataComparison(EventDataComparisonNode node)
+    {
+        var name = node.FieldName;
+        var literal = node.Literal;
+
+        if (node.Op == FilterBinaryOperator.Equal)
+        {
+            return e => e.EventData.TryGetValue(name, out var value) && literal.MatchesValue(value);
+        }
+
+        return e => e.EventData.TryGetValue(name, out var value) && !literal.MatchesValue(value);
+    }
+
+    private static Func<ResolvedEvent, bool> EmitEventDataContains(EventDataContainsNode node)
+    {
+        var name = node.FieldName;
+        var needle = node.Needle;
+        var comparison = node.IgnoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+        if (node.Negated)
+        {
+            return e => e.EventData.TryGetValue(name, out var value)
+                && !value.AsString().Contains(needle, comparison);
+        }
+
+        return e => e.EventData.TryGetValue(name, out var value)
+            && value.AsString().Contains(needle, comparison);
+    }
+
+    private static Func<ResolvedEvent, bool> EmitEventDataMultiEquals(EventDataMultiEqualsNode node)
+    {
+        var name = node.FieldName;
+        var literals = node.Literals;
+
+        return e =>
+        {
+            if (!e.EventData.TryGetValue(name, out var value)) { return false; }
+
+            for (var i = 0; i < literals.Count; i++)
+            {
+                if (literals[i].MatchesValue(value)) { return true; }
+            }
+
+            return false;
+        };
+    }
+
     private static Func<ResolvedEvent, bool> EmitIntComparison(
         Func<ResolvedEvent, int> getter,
         FilterBinaryOperator op,
@@ -408,6 +455,9 @@ internal static class Emitter
             NotNode not => EmitNot(not),
             ComparisonNode cmp => EmitComparison(cmp),
             ContainsNode cn => EmitContains(cn),
+            EventDataComparisonNode edCmp => EmitEventDataComparison(edCmp),
+            EventDataContainsNode edContains => EmitEventDataContains(edContains),
+            EventDataMultiEqualsNode edMulti => EmitEventDataMultiEquals(edMulti),
             KeywordsAnyEqualsNode kn => EmitKeywordsAnyEquals(kn),
             KeywordsAnyContainsNode kn => EmitKeywordsAnyContains(kn),
             KeywordsMatchAnyOfNode kn => EmitKeywordsMatchAnyOf(kn),

--- a/src/EventLogExpert.Filtering/EventData/EventLogDataQueryExtensions.cs
+++ b/src/EventLogExpert.Filtering/EventData/EventLogDataQueryExtensions.cs
@@ -9,20 +9,55 @@ namespace EventLogExpert.Filtering.EventData;
 
 internal static class EventLogDataQueryExtensions
 {
-    /// <summary>
-    ///     Gets a distinct list of values for the specified <paramref name="property" /> across
-    ///     <paramref name="events" />.
-    /// </summary>
-    public static IEnumerable<string> GetEventValues(this IEnumerable<ResolvedEvent> events, EventProperty property) =>
-        property switch
+    extension(IEnumerable<ResolvedEvent> events)
+    {
+        /// <summary>
+        ///     Gets the distinct set of &lt;EventData&gt; field names present across <paramref name="events" /> (used to
+        ///     populate the Basic editor's field-name picker). Names are compared Ordinal, matching the schema lookup.
+        /// </summary>
+        public IEnumerable<string> GetEventDataFieldNames()
         {
-            EventProperty.Id => events.Select(e => e.Id.ToString(CultureInfo.InvariantCulture)).Distinct(),
-            EventProperty.ActivityId => events.Select(e => e.ActivityId?.ToString() ?? string.Empty).Distinct(),
-            EventProperty.Level => Enum.GetNames<SeverityLevel>(),
-            EventProperty.Keywords => events.SelectMany(e => e.Keywords).Distinct(),
-            EventProperty.Source => events.Select(e => e.Source).Distinct(),
-            EventProperty.TaskCategory => events.Select(e => e.TaskCategory).Distinct(),
-            EventProperty.LogName => events.Select(e => e.LogName).Distinct(),
-            _ => [],
-        };
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var resolvedEvent in events)
+            {
+                foreach (var field in resolvedEvent.EventData)
+                {
+                    if (seen.Add(field.Name)) { yield return field.Name; }
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Gets the values of the named EventData <paramref name="fieldName" /> across every event that has it (as
+        ///     rendered by <see cref="EventFieldValue.AsString" />); the caller de-duplicates and sorts.
+        /// </summary>
+        public IEnumerable<string> GetEventDataFieldValues(string fieldName)
+        {
+            foreach (var resolvedEvent in events)
+            {
+                if (resolvedEvent.EventData.TryGetValue(fieldName, out var value))
+                {
+                    yield return value.AsString();
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Gets a distinct list of values for the specified <paramref name="property" /> across
+        ///     <paramref name="events" />.
+        /// </summary>
+        public IEnumerable<string> GetEventValues(EventProperty property) =>
+            property switch
+            {
+                EventProperty.Id => events.Select(e => e.Id.ToString(CultureInfo.InvariantCulture)).Distinct(),
+                EventProperty.ActivityId => events.Select(e => e.ActivityId?.ToString() ?? string.Empty).Distinct(),
+                EventProperty.Level => Enum.GetNames<SeverityLevel>(),
+                EventProperty.Keywords => events.SelectMany(e => e.Keywords).Distinct(),
+                EventProperty.Source => events.Select(e => e.Source).Distinct(),
+                EventProperty.TaskCategory => events.Select(e => e.TaskCategory).Distinct(),
+                EventProperty.LogName => events.Select(e => e.LogName).Distinct(),
+                _ => [],
+            };
+    }
 }

--- a/src/EventLogExpert.Filtering/EventData/EventPropertyValuesCache.cs
+++ b/src/EventLogExpert.Filtering/EventData/EventPropertyValuesCache.cs
@@ -19,7 +19,55 @@ public static class EventPropertyValuesCache
     private static readonly ConditionalWeakTable<
         object,
         ConcurrentDictionary<EventProperty, Lazy<ImmutableArray<string>>>> s_cache = new();
+    private static readonly ConditionalWeakTable<object, Lazy<ImmutableArray<string>>> s_fieldNameCache = new();
+    private static readonly ConditionalWeakTable<
+        object,
+        ConcurrentDictionary<string, Lazy<ImmutableArray<string>>>> s_fieldValueCache = new();
     private static readonly ImmutableArray<string> s_levelValues = [.. Enum.GetNames<SeverityLevel>()];
+
+    /// <summary>
+    ///     Returns the distinct, sorted &lt;EventData&gt; field names across <paramref name="events" />, cached per
+    ///     snapshot <paramref name="cacheKey" /> (auto-evicted when the snapshot changes).
+    /// </summary>
+    public static ImmutableArray<string> GetEventDataFieldNames(object cacheKey, IEnumerable<ResolvedEvent> events) =>
+        s_fieldNameCache
+            .GetValue(cacheKey, _ => new Lazy<ImmutableArray<string>>(() => [.. events.GetEventDataFieldNames().Order()]))
+            .Value;
+
+    /// <summary>
+    ///     Returns the distinct, sorted values of the named EventData <paramref name="fieldName" /> across
+    ///     <paramref name="events" />, cached per <c>(snapshot, fieldName)</c> so each field keeps its own value list.
+    /// </summary>
+    public static ImmutableArray<string> GetEventDataFieldValues(
+        object cacheKey,
+        IEnumerable<ResolvedEvent> events,
+        string? fieldName)
+    {
+        if (string.IsNullOrEmpty(fieldName))
+        {
+            return [];
+        }
+
+        // Only enumerate/cache values for field names that actually exist in the snapshot. The Basic editor's
+        // field-name picker is editable, so without this an arbitrary or partial typed name would add a cache entry
+        // and a full log scan per keystroke (R7). The field-name list is itself cached per snapshot, so the
+        // membership check is cheap and does not re-scan.
+        if (!GetEventDataFieldNames(cacheKey, events).Contains(fieldName, StringComparer.Ordinal))
+        {
+            return [];
+        }
+
+        var perSnapshot = s_fieldValueCache.GetValue(
+            cacheKey,
+            static _ => new ConcurrentDictionary<string, Lazy<ImmutableArray<string>>>(StringComparer.Ordinal));
+
+        return perSnapshot
+            .GetOrAdd(
+                fieldName,
+                name => new Lazy<ImmutableArray<string>>(
+                    () => [.. events.GetEventDataFieldValues(name).Distinct().Order()]))
+            .Value;
+    }
 
     public static ImmutableArray<string> GetValues(
         object cacheKey,
@@ -46,7 +94,12 @@ public static class EventPropertyValuesCache
     }
 
     /// <summary>Test-only hook to clear the snapshot cache between scenarios.</summary>
-    internal static void Clear() => s_cache.Clear();
+    internal static void Clear()
+    {
+        s_cache.Clear();
+        s_fieldNameCache.Clear();
+        s_fieldValueCache.Clear();
+    }
 
     private static ImmutableArray<string> Compute(
         IEnumerable<ResolvedEvent> events,

--- a/src/EventLogExpert.Filtering/EventData/EventPropertyValuesCache.cs
+++ b/src/EventLogExpert.Filtering/EventData/EventPropertyValuesCache.cs
@@ -31,7 +31,10 @@ public static class EventPropertyValuesCache
     /// </summary>
     public static ImmutableArray<string> GetEventDataFieldNames(object cacheKey, IEnumerable<ResolvedEvent> events) =>
         s_fieldNameCache
-            .GetValue(cacheKey, _ => new Lazy<ImmutableArray<string>>(() => [.. events.GetEventDataFieldNames().Order()]))
+            .GetValue(
+                cacheKey,
+                _ => new Lazy<ImmutableArray<string>>(
+                    () => [.. events.GetEventDataFieldNames().Order(StringComparer.Ordinal)]))
             .Value;
 
     /// <summary>
@@ -65,7 +68,7 @@ public static class EventPropertyValuesCache
             .GetOrAdd(
                 fieldName,
                 name => new Lazy<ImmutableArray<string>>(
-                    () => [.. events.GetEventDataFieldValues(name).Distinct().Order()]))
+                    () => [.. events.GetEventDataFieldValues(name).Distinct().Order(StringComparer.Ordinal)]))
             .Value;
     }
 

--- a/src/EventLogExpert.Filtering/Lowering/EventDataLiteral.cs
+++ b/src/EventLogExpert.Filtering/Lowering/EventDataLiteral.cs
@@ -1,0 +1,88 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+using System.Globalization;
+
+namespace EventLogExpert.Filtering.Lowering;
+
+/// <summary>
+///     A filter comparison operand pre-parsed once at lower-time into a candidate value for every scalar
+///     <see cref="EventFieldValueKind" />, so the per-event hot path does no parsing and no allocation for packed-scalar /
+///     <see cref="Guid" /> / <see cref="EventFieldValueKind.String" /> field kinds. Implements the
+///     <em>typed value equality</em> model: a numeric / bool / date / Guid field is matched by its parsed value (so
+///     <c>"5"</c> and <c>"05"</c> both match a numeric <c>5</c>, and a Guid matches in any parseable format), while
+///     reference/blob kinds (<see cref="EventFieldValueKind.Sid" />, <see cref="EventFieldValueKind.Bytes" />, the array
+///     kinds, and <see cref="EventFieldValueKind.Null" />) fall back to an ordinal compare against
+///     <see cref="EventFieldValue.AsString" />.
+/// </summary>
+internal sealed class EventDataLiteral
+{
+    private readonly bool? _boolean;
+    private readonly DateTime? _dateTime;
+    private readonly double? _double;
+    private readonly Guid? _guid;
+    private readonly long? _int64;
+    private readonly string _raw;
+    private readonly float? _single;
+    private readonly ulong? _uint64;
+
+    private EventDataLiteral(
+        string raw,
+        long? int64,
+        ulong? uint64,
+        double? doubleValue,
+        float? single,
+        bool? boolean,
+        DateTime? dateTime,
+        Guid? guid)
+    {
+        _raw = raw;
+        _int64 = int64;
+        _uint64 = uint64;
+        _double = doubleValue;
+        _single = single;
+        _boolean = boolean;
+        _dateTime = dateTime;
+        _guid = guid;
+    }
+
+    /// <summary>The original literal text, used by the decomposer to round-trip back to a Basic value.</summary>
+    public string Raw => _raw;
+
+    /// <summary>Parses the raw literal into one candidate per scalar kind (each null when the literal is not that kind).</summary>
+    public static EventDataLiteral Parse(string raw)
+    {
+        long? int64 = long.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var i) ? i : null;
+        ulong? uint64 = ulong.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var u) ? u : null;
+        double? doubleValue =
+            double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var d) ? d : null;
+        float? single = float.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var f) ? f : null;
+        bool? boolean = bool.TryParse(raw, out var b) ? b : null;
+        DateTime? dateTime =
+            DateTime.TryParse(raw, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var dt) ? dt : null;
+        Guid? guid = Guid.TryParse(raw, out var g) ? g : null;
+
+        return new EventDataLiteral(raw, int64, uint64, doubleValue, single, boolean, dateTime, guid);
+    }
+
+    /// <summary>
+    ///     Typed value equality against <paramref name="value" />. Zero-allocation for the packed-scalar kinds,
+    ///     <see cref="Guid" />, and <see cref="EventFieldValueKind.String" />; the reference/blob and
+    ///     <see cref="EventFieldValueKind.Null" /> kinds compare against <see cref="EventFieldValue.AsString" />.
+    /// </summary>
+    public bool MatchesValue(in EventFieldValue value) =>
+        value.Kind switch
+        {
+            EventFieldValueKind.Int64 => _int64 is { } c && value.TryGetInt64(out var a) && a == c,
+            EventFieldValueKind.UInt64 => _uint64 is { } c && value.TryGetUInt64(out var a) && a == c,
+            // double.Equals / float.Equals treat NaN as equal to NaN (matching AsString "NaN"), unlike ==.
+            EventFieldValueKind.Double => _double is { } c && value.TryGetDouble(out var a) && a.Equals(c),
+            EventFieldValueKind.Single => _single is { } c && value.TryGetSingle(out var a) && a.Equals(c),
+            EventFieldValueKind.Boolean => _boolean is { } c && value.TryGetBoolean(out var a) && a == c,
+            EventFieldValueKind.DateTime => _dateTime is { } c && value.TryGetDateTime(out var a) && a == c,
+            EventFieldValueKind.Guid => _guid is { } c && value.TryGetGuid(out var a) && a == c,
+            EventFieldValueKind.String => string.Equals(value.AsString(), _raw, StringComparison.Ordinal),
+            _ => string.Equals(value.AsString(), _raw, StringComparison.Ordinal)
+        };
+}

--- a/src/EventLogExpert.Filtering/Lowering/EventDataLiteral.cs
+++ b/src/EventLogExpert.Filtering/Lowering/EventDataLiteral.cs
@@ -59,8 +59,12 @@ internal sealed class EventDataLiteral
             double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var d) ? d : null;
         float? single = float.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var f) ? f : null;
         bool? boolean = bool.TryParse(raw, out var b) ? b : null;
+        // Strictly the inverse of EventFieldValue.AsString's ToString("O"): only the canonical round-trip form
+        // matches (picklist values are already "O"), not lenient/ambiguous date formats.
         DateTime? dateTime =
-            DateTime.TryParse(raw, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var dt) ? dt : null;
+            DateTime.TryParseExact(raw, "O", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var dt)
+                ? dt
+                : null;
         Guid? guid = Guid.TryParse(raw, out var g) ? g : null;
 
         return new EventDataLiteral(raw, int64, uint64, doubleValue, single, boolean, dateTime, guid);

--- a/src/EventLogExpert.Filtering/Lowering/Lowerer.cs
+++ b/src/EventLogExpert.Filtering/Lowering/Lowerer.cs
@@ -88,6 +88,16 @@ internal static class Lowerer
         }
     }
 
+    private static bool ContainsEventDataNode(SemanticNode node) =>
+        node switch
+        {
+            EventDataComparisonNode or EventDataContainsNode or EventDataMultiEqualsNode => true,
+            AndNode and => ContainsEventDataNode(and.Left) || ContainsEventDataNode(and.Right),
+            OrNode or => ContainsEventDataNode(or.Left) || ContainsEventDataNode(or.Right),
+            NotNode not => ContainsEventDataNode(not.Operand),
+            _ => false
+        };
+
     private static IReadOnlyList<string> ExtractStringArray(ArrayCreationSyntax array, int position)
     {
         if (array.Elements.Count == 0)
@@ -123,6 +133,15 @@ internal static class Lowerer
             acc.Add(node);
         }
     }
+
+    private static string GetEventDataLiteralText(LiteralSyntax literal) =>
+        literal.Kind switch
+        {
+            LiteralKind.String => literal.Text,
+            LiteralKind.Int => literal.Text,
+            _ => throw new LowerException(
+                $"EventData comparison value must be a string or integer literal (position {literal.Position}).")
+        };
 
     private static bool IsCaseInsensitiveMatch(string left, string right) =>
         string.Equals(left, right, StringComparison.OrdinalIgnoreCase);
@@ -179,7 +198,7 @@ internal static class Lowerer
             case BinarySyntax bin when IsComparisonOp(bin.Op):
                 return LowerComparison(bin);
             case UnarySyntax { Op: TokenKind.Bang } neg:
-                return new NotNode(Lower(neg.Operand));
+                return LowerNegation(neg);
             case MethodCallSyntax call:
                 return LowerMethodCall(call);
             case BinarySyntax bin:
@@ -234,6 +253,11 @@ internal static class Lowerer
 
     private static SemanticNode LowerComparison(BinarySyntax bin)
     {
+        if (TryResolveEventDataField(bin.Left, out var eventDataFieldName))
+        {
+            return LowerEventDataComparison(eventDataFieldName, bin);
+        }
+
         // Property <op> Literal  -or-  Property.ToString() <op> Literal (formatter shape, normalized away)
         var (field, fieldExpression) = ResolveFieldOrToString(bin.Left, bin.Position);
 
@@ -247,6 +271,25 @@ internal static class Lowerer
         var typed = CoerceLiteral(literal, literalKind);
 
         return new ComparisonNode(field, MapBinaryOp(bin.Op), typed);
+    }
+
+    private static SemanticNode LowerEventDataComparison(string fieldName, BinarySyntax bin)
+    {
+        if (bin.Op is not (TokenKind.EqEq or TokenKind.NotEq))
+        {
+            throw new LowerException(
+                $"Operator '{bin.Op}' is not supported on EventData fields; use '==' or '!=' (position {bin.Position}).");
+        }
+
+        if (bin.Right is not LiteralSyntax literal)
+        {
+            throw new LowerException(
+                $"Right-hand side of an EventData comparison must be a literal (position {bin.Right.Position}).");
+        }
+
+        var op = bin.Op == TokenKind.EqEq ? FilterBinaryOperator.Equal : FilterBinaryOperator.NotEqual;
+
+        return new EventDataComparisonNode(fieldName, op, EventDataLiteral.Parse(GetEventDataLiteralText(literal)));
     }
 
     private static SemanticNode LowerKeywordsAnyLambda(LambdaSyntax lambda)
@@ -299,9 +342,27 @@ internal static class Lowerer
             && call is { Target: ArrayCreationSyntax array, Arguments.Count: 1 })
         {
             var elements = ExtractStringArray(array, call.Position);
+
+            // EventData any-of must be recognized before ResolveFieldOrToString, which rejects an IndexAccess argument.
+            if (TryResolveEventDataField(call.Arguments[0], out var eventDataAnyOfName))
+            {
+                return new EventDataMultiEqualsNode(
+                    eventDataAnyOfName,
+                    [.. elements.Select(EventDataLiteral.Parse)]);
+            }
+
             var argField = ResolveFieldOrToString(call.Arguments[0], call.Arguments[0].Position).Field;
 
             return new MultiEqualsNode(argField, elements);
+        }
+
+        // EventData["Name"].Contains(needle, OIC)
+        if (IsCaseInsensitiveMatch(call.Name, "Contains")
+            && TryResolveEventDataField(call.Target, out var eventDataContainsName))
+        {
+            var (needle, ignoreCase) = ParseContainsArgs(call.Arguments, call.Position);
+
+            return new EventDataContainsNode(eventDataContainsName, needle, ignoreCase, negated: false);
         }
 
         // P.Contains(needle, StringComparison.OrdinalIgnoreCase) for any Contains-supported field. Denylist
@@ -345,6 +406,41 @@ internal static class Lowerer
 
         throw new LowerException(
             $"Unsupported method call '{call.Name}' (position {call.Position}).");
+    }
+
+    // Normalizes `!` over EventData so a NotNode never wraps an EventData node (presence-required must hold at any
+    // depth): comparison flips Equal<->NotEqual, Contains toggles Negated; the unrepresentable none-of and any group
+    // that contains an EventData node are rejected. Non-EventData operands wrap in NotNode as before.
+    private static SemanticNode LowerNegation(UnarySyntax neg)
+    {
+        var inner = Lower(neg.Operand);
+
+        switch (inner)
+        {
+            case EventDataComparisonNode comparison:
+                var flipped = comparison.Op == FilterBinaryOperator.Equal
+                    ? FilterBinaryOperator.NotEqual
+                    : FilterBinaryOperator.Equal;
+
+                return new EventDataComparisonNode(comparison.FieldName, flipped, comparison.Literal);
+            case EventDataContainsNode contains:
+                return new EventDataContainsNode(
+                    contains.FieldName,
+                    contains.Needle,
+                    contains.IgnoreCase,
+                    !contains.Negated);
+            case EventDataMultiEqualsNode:
+                throw new LowerException(
+                    $"Negating an EventData any-of match is not supported; use separate '!=' conditions (position {neg.Position}).");
+            default:
+                if (ContainsEventDataNode(inner))
+                {
+                    throw new LowerException(
+                        $"Negating a group that contains EventData conditions is not supported; negate each EventData condition individually (position {neg.Position}).");
+                }
+
+                return new NotNode(inner);
+        }
     }
 
     private static FilterBinaryOperator MapBinaryOp(TokenKind op) =>
@@ -461,6 +557,36 @@ internal static class Lowerer
         }
 
         return false;
+    }
+
+    // Returns true for a well-formed `EventData["FieldName"]` access (case-insensitive target, Ordinal field name);
+    // throws a descriptive LowerException for a malformed EventData index (non-string / empty key); returns false for
+    // any non-EventData expression.
+    private static bool TryResolveEventDataField(SyntaxNode expr, [NotNullWhen(true)] out string? fieldName)
+    {
+        fieldName = null;
+
+        if (expr is not IndexAccessSyntax index
+            || index.Target is not IdentifierSyntax id
+            || !IsCaseInsensitiveMatch(id.Name, "EventData"))
+        {
+            return false;
+        }
+
+        if (index.Argument is not LiteralSyntax { Kind: LiteralKind.String } key)
+        {
+            throw new LowerException(
+                $"EventData field name must be a string literal (position {index.Argument.Position}).");
+        }
+
+        if (string.IsNullOrWhiteSpace(key.Text))
+        {
+            throw new LowerException($"EventData field name must not be empty (position {key.Position}).");
+        }
+
+        fieldName = key.Text;
+
+        return true;
     }
 
     private sealed class LowerException(string message) : Exception(message);

--- a/src/EventLogExpert.Filtering/Lowering/SemanticNode.cs
+++ b/src/EventLogExpert.Filtering/Lowering/SemanticNode.cs
@@ -89,3 +89,49 @@ internal sealed class MultiEqualsNode(ResolvedEventField field, IReadOnlyList<st
 
     public IReadOnlyList<string> Values { get; } = values;
 }
+
+/// <summary>
+///     <c>EventData["Name"] == v</c> / <c>!= v</c> against a dynamic named EventData field. Presence-required: the
+///     emitter gates on <c>EventData.TryGetValue(FieldName, …)</c>, so an absent field never matches (positive OR
+///     negative). Negation is normalized in the Lowerer by flipping <see cref="Op" /> (no separate negated flag), so the
+///     decomposer maps <see cref="Op" /> directly with no ambiguity.
+/// </summary>
+internal sealed class EventDataComparisonNode(string fieldName, FilterBinaryOperator op, EventDataLiteral literal)
+    : SemanticNode
+{
+    public string FieldName { get; } = fieldName;
+
+    public EventDataLiteral Literal { get; } = literal;
+
+    public FilterBinaryOperator Op { get; } = op;
+}
+
+/// <summary>
+///     <c>EventData["Name"].Contains(Needle, OIC)</c> against a dynamic named EventData field, string-based over
+///     <see cref="EventLogExpert.Eventing.Common.Events.EventFieldValue.AsString" />. <see cref="Negated" /> carries the
+///     <c>!…Contains(…)</c> form (Basic's <c>NotContains</c>); presence-required either way.
+/// </summary>
+internal sealed class EventDataContainsNode(string fieldName, string needle, bool ignoreCase, bool negated)
+    : SemanticNode
+{
+    public string FieldName { get; } = fieldName;
+
+    public bool IgnoreCase { get; } = ignoreCase;
+
+    public string Needle { get; } = needle;
+
+    public bool Negated { get; } = negated;
+}
+
+/// <summary>
+///     <c>(new[] {...}).Contains(EventData["Name"])</c> — any-of typed value equality against a dynamic named
+///     EventData field. Presence-required. Positive only: <c>!(any-of)</c> ("none-of") has no Basic representation and is
+///     rejected by the Lowerer.
+/// </summary>
+internal sealed class EventDataMultiEqualsNode(string fieldName, IReadOnlyList<EventDataLiteral> literals)
+    : SemanticNode
+{
+    public string FieldName { get; } = fieldName;
+
+    public IReadOnlyList<EventDataLiteral> Literals { get; } = literals;
+}

--- a/src/EventLogExpert.Filtering/Parsing/Parser.cs
+++ b/src/EventLogExpert.Filtering/Parsing/Parser.cs
@@ -12,7 +12,7 @@ namespace EventLogExpert.Filtering.Parsing;
 /// </summary>
 internal static class Parser
 {
-    public static bool TryParse(IReadOnlyList<Token> tokens, out SyntaxNode? root, [NotNullWhen(false)] out string? error)
+    public static bool TryParse(IReadOnlyList<Token>? tokens, out SyntaxNode? root, [NotNullWhen(false)] out string? error)
     {
         root = null;
         error = null;
@@ -30,15 +30,13 @@ internal static class Parser
         {
             root = ParseExpression(state, 0);
 
-            if (state.Current.Kind != TokenKind.End)
-            {
-                error = $"Unexpected token '{state.Current.Text}' (position {state.Current.Position}).";
-                root = null;
+            if (state.Current.Kind == TokenKind.End) { return true; }
 
-                return false;
-            }
+            error = $"Unexpected token '{state.Current.Text}' (position {state.Current.Position}).";
+            root = null;
 
-            return true;
+            return false;
+
         }
         catch (ParseException ex)
         {
@@ -213,6 +211,20 @@ internal static class Parser
                         Position = dotPosition
                     };
                 }
+            }
+            else if (state.Current.Kind == TokenKind.LBracket)
+            {
+                var bracketPosition = state.Current.Position;
+                state.Advance();
+                var argument = ParseExpression(state, 0);
+                Expect(state, TokenKind.RBracket);
+
+                node = new IndexAccessSyntax
+                {
+                    Target = node,
+                    Argument = argument,
+                    Position = bracketPosition
+                };
             }
             else
             {

--- a/src/EventLogExpert.Filtering/Parsing/SyntaxNode.cs
+++ b/src/EventLogExpert.Filtering/Parsing/SyntaxNode.cs
@@ -63,6 +63,13 @@ internal sealed class MethodCallSyntax : SyntaxNode
     public required SyntaxNode Target { get; init; }
 }
 
+internal sealed class IndexAccessSyntax : SyntaxNode
+{
+    public required SyntaxNode Argument { get; init; }
+
+    public required SyntaxNode Target { get; init; }
+}
+
 internal sealed class ArrayCreationSyntax : SyntaxNode
 {
     public required IReadOnlyList<SyntaxNode> Elements { get; init; }

--- a/src/EventLogExpert.Runtime/EventLog/EventLogQueries.cs
+++ b/src/EventLogExpert.Runtime/EventLog/EventLogQueries.cs
@@ -26,6 +26,23 @@ internal sealed class EventLogQueries(
             .Distinct(StringComparer.OrdinalIgnoreCase)
     ];
 
+    public ImmutableArray<string> GetEventDataFieldNames()
+    {
+        var byLog = _rawEventStore.Value.ByLog;
+
+        return EventPropertyValuesCache.GetEventDataFieldNames(byLog, byLog.Values.SelectMany(events => events));
+    }
+
+    public ImmutableArray<string> GetEventDataFieldValues(string fieldName)
+    {
+        var byLog = _rawEventStore.Value.ByLog;
+
+        return EventPropertyValuesCache.GetEventDataFieldValues(
+            byLog,
+            byLog.Values.SelectMany(events => events),
+            fieldName);
+    }
+
     public (DateTime After, DateTime Before) GetEventDateRange(DateTime fallbackUtcNow) =>
         _rawEventStore.Value.TryGetRawEventDateRange().RoundOrFallback(fallbackUtcNow);
 

--- a/src/EventLogExpert.Runtime/EventLog/IEventLogQueries.cs
+++ b/src/EventLogExpert.Runtime/EventLog/IEventLogQueries.cs
@@ -15,6 +15,18 @@ public interface IEventLogQueries
     IReadOnlyList<string> GetChannelNames();
 
     /// <summary>
+    ///     Returns the distinct, sorted &lt;EventData&gt; field names present across all open raw events (used to
+    ///     populate the Basic editor's EventData field-name picker).
+    /// </summary>
+    ImmutableArray<string> GetEventDataFieldNames();
+
+    /// <summary>
+    ///     Returns the distinct, sorted values of the named EventData <paramref name="fieldName" /> across all open raw
+    ///     events (used to populate the value picker for an EventData filter row).
+    /// </summary>
+    ImmutableArray<string> GetEventDataFieldValues(string fieldName);
+
+    /// <summary>
     ///     Returns the UTC date range covering all events across the active logs, with bounds rounded outward to the
     ///     hour, falling back to <paramref name="fallbackUtcNow" /> when no log has events.
     /// </summary>

--- a/src/EventLogExpert.UI/FilterEditor/Comparison/FilterComparisonEditor.razor
+++ b/src/EventLogExpert.UI/FilterEditor/Comparison/FilterComparisonEditor.razor
@@ -10,6 +10,23 @@
     }
 </ValueSelect>
 
+@if (IsEventDataProperty)
+{
+    <label class="visually-hidden" id="@($"{Id}_FieldName")">Field name</label>
+
+    <ValueSelect AriaLabelledBy="@($"{Id}_FieldName")"
+        CssClass="input filter-value-dropdown"
+        IsInput
+        T="string"
+        Value="Comparison.EventDataFieldName"
+        ValueChanged="HandleEventDataFieldNameChanged">
+        @foreach (var name in EventDataFieldNames)
+        {
+            <ValueSelectItem T="string" Value="name" />
+        }
+    </ValueSelect>
+}
+
 <label class="visually-hidden" id="@($"{Id}_Comparison")">Comparison</label>
 <ComparisonOperatorSelect AriaLabelledBy="@($"{Id}_Comparison")"
     MatchMode="Comparison.MatchMode"

--- a/src/EventLogExpert.UI/FilterEditor/Comparison/FilterComparisonEditor.razor.cs
+++ b/src/EventLogExpert.UI/FilterEditor/Comparison/FilterComparisonEditor.razor.cs
@@ -29,6 +29,8 @@ public sealed partial class FilterComparisonEditor : ComponentBase
 
     [Parameter] public string? PropertyAriaLabelledBy { get; set; }
 
+    private ImmutableArray<string> EventDataFieldNames => EventLogQueries.GetEventDataFieldNames();
+
     [Inject] private IEventLogQueries EventLogQueries { get; init; } = null!;
 
     private List<string> FilteredItems
@@ -52,7 +54,11 @@ public sealed partial class FilterComparisonEditor : ComponentBase
         }
     } = [];
 
-    private ImmutableArray<string> Items => EventLogQueries.GetPropertyValues(Comparison.Property);
+    private bool IsEventDataProperty => Comparison.Property is EventProperty.EventData;
+
+    private ImmutableArray<string> Items => Comparison.Property is EventProperty.EventData
+        ? EventLogQueries.GetEventDataFieldValues(Comparison.EventDataFieldName ?? string.Empty)
+        : EventLogQueries.GetPropertyValues(Comparison.Property);
 
     private EventProperty PropertyBinding
     {
@@ -72,6 +78,16 @@ public sealed partial class FilterComparisonEditor : ComponentBase
     }
 
     private static bool IsTextOnlyProperty(EventProperty property) => FilterPropertyConstraints.IsTextOnly(property);
+
+    private async Task HandleEventDataFieldNameChanged(string? fieldName)
+    {
+        Comparison.EventDataFieldName = fieldName;
+
+        // The available value space is field-specific, so a field-name change invalidates the current value(s).
+        Comparison.Value = null;
+        Comparison.Values.Clear();
+        await OnChanged.InvokeAsync();
+    }
 
     private async Task HandleOperatorChanged((ComparisonOperator Op, MatchMode Mode) value)
     {

--- a/tests/Integration/EventLogExpert.Eventing.IntegrationTests/Readers/EventLogReaderTests.cs
+++ b/tests/Integration/EventLogExpert.Eventing.IntegrationTests/Readers/EventLogReaderTests.cs
@@ -428,8 +428,7 @@ public sealed class EventLogReaderTests
         if (events.Length > 0)
         {
             var evt = events[0];
-            Assert.NotNull(evt.Properties);
-            // Properties might be empty array, but should not be null
+            Assert.False(evt.Properties.IsDefault);
         }
     }
 

--- a/tests/Integration/EventLogExpert.Eventing.IntegrationTests/Readers/EventLogWatcherTests.cs
+++ b/tests/Integration/EventLogExpert.Eventing.IntegrationTests/Readers/EventLogWatcherTests.cs
@@ -666,7 +666,7 @@ public sealed class EventLogWatcherTests
         var snapshot = Volatile.Read(ref capturedEvent);
         Assert.True(received, "Did not receive event within timeout period");
         Assert.NotNull(snapshot);
-        Assert.NotNull(snapshot.Properties);
+        Assert.False(snapshot.Properties.IsDefault);
     }
 
     [Fact]

--- a/tests/Shared/EventLogExpert.Eventing.TestUtils/EventDataTestFactory.cs
+++ b/tests/Shared/EventLogExpert.Eventing.TestUtils/EventDataTestFactory.cs
@@ -1,0 +1,62 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Eventing.Readers;
+using EventLogExpert.Eventing.Resolvers;
+using System.Collections.Immutable;
+using System.Security;
+using System.Security.Principal;
+
+namespace EventLogExpert.Eventing.TestUtils;
+
+/// <summary>
+///     Builds <see cref="ResolvedEvent" /> instances carrying structured &lt;EventData&gt; named fields for filter
+///     and view tests. The field value's CLR type determines the resulting <see cref="EventFieldValueKind" /> (e.g.
+///     <see cref="string" /> to String, <see cref="long" /> to Int64, <see cref="Guid" /> to Guid). Field name order is
+///     preserved; duplicate names exercise the schema's first-wins lookup.
+/// </summary>
+public static class EventDataTestFactory
+{
+    public static ResolvedEvent CreateEventWithData(params (string Name, object? Value)[] fields) =>
+        new ResolvedEvent("TestLog", LogPathType.Channel).WithEventData(fields);
+
+    public static ResolvedEvent WithEventData(this ResolvedEvent source, params (string Name, object? Value)[] fields)
+    {
+        var template = "<template>"
+            + string.Concat(fields.Select(field => $"<data name=\"{SecurityElement.Escape(field.Name)}\"/>"))
+            + "</template>";
+
+        var schema = new TemplateAnalyzer().GetTemplateInfo(template).Schema;
+
+        var builder = ImmutableArray.CreateBuilder<EventProperty>(fields.Length);
+
+        foreach (var (_, value) in fields)
+        {
+            builder.Add(ToEventProperty(value));
+        }
+
+        return source with { EventDataValues = builder.MoveToImmutable(), EventDataSchema = schema };
+    }
+
+    private static EventProperty ToEventProperty(object? value) =>
+        value switch
+        {
+            null => EventProperty.FromReference(null),
+            string text => text,
+            bool boolean => boolean,
+            long int64 => int64,
+            int int32 => int32,
+            ulong uint64 => uint64,
+            uint uint32 => uint32,
+            double doubleValue => doubleValue,
+            float single => single,
+            DateTime dateTime => dateTime,
+            Guid guid => guid,
+            SecurityIdentifier sid => sid,
+            byte[] bytes => bytes,
+            string[] strings => strings,
+            _ => value.ToString() ?? string.Empty
+        };
+}

--- a/tests/Shared/EventLogExpert.Eventing.TestUtils/EventUtils.cs
+++ b/tests/Shared/EventLogExpert.Eventing.TestUtils/EventUtils.cs
@@ -189,7 +189,7 @@ public static class EventUtils
             Id = id,
             Version = version,
             LogName = ApplicationLogName,
-            Properties = properties
+            Properties = [.. properties]
         }
     );
 }

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Common/Events/EventDataViewTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Common/Events/EventDataViewTests.cs
@@ -1,0 +1,146 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Eventing.Readers;
+using EventLogExpert.Eventing.Resolvers;
+using System.Collections.Immutable;
+
+namespace EventLogExpert.Eventing.Tests.Common.Events;
+
+public sealed class EventDataViewTests
+{
+    [Fact]
+    public void DefaultValues_AreNone()
+    {
+        var view = new EventDataView(default, Schema("<template><data name=\"A\"/></template>"));
+
+        Assert.Equal(EventDataKind.None, view.Kind);
+        Assert.Equal(0, view.Count);
+    }
+
+    [Fact]
+    public void Empty_IsNone()
+    {
+        Assert.Equal(EventDataKind.None, EventDataView.Empty.Kind);
+        Assert.Equal(0, EventDataView.Empty.Count);
+        Assert.False(EventDataView.Empty.TryGetValue("A", out _));
+    }
+
+    [Fact]
+    public void Enumeration_OverEmptyOrNone_YieldsNothingWithoutThrowing()
+    {
+        int count = 0;
+
+        foreach (EventDataView.Field field in EventDataView.Empty)
+        {
+            count++;
+        }
+
+        var none = new EventDataView(default, Schema("<template><data name=\"A\"/></template>"));
+
+        foreach (EventDataView.Field field in none)
+        {
+            count++;
+        }
+
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public void ResolvedEvent_DefaultEventData_IsNone()
+    {
+        var resolved = new ResolvedEvent("log", LogPathType.File);
+
+        Assert.Equal(EventDataKind.None, resolved.EventData.Kind);
+    }
+
+    [Fact]
+    public void TryGetName_AndEnumeration_YieldNamesInOrder()
+    {
+        TemplateFieldSchema schema = Schema("<template><data name=\"A\"/><data name=\"B\"/></template>");
+        var values = ImmutableArray.Create(1, (EventProperty)2);
+        var view = new EventDataView(values, schema);
+
+        Assert.True(view.TryGetName(0, out string name0));
+        Assert.Equal("A", name0);
+        Assert.True(view.TryGetName(1, out string name1));
+        Assert.Equal("B", name1);
+        Assert.False(view.TryGetName(2, out _));
+
+        var names = new List<string>();
+
+        foreach (EventDataView.Field field in view)
+        {
+            names.Add(field.Name);
+        }
+
+        Assert.Equal(["A", "B"], names);
+    }
+
+    [Fact]
+    public void TryGetValue_AllOrdering_WhenCountMatchesAll()
+    {
+        TemplateFieldSchema schema = Schema(
+            "<template><data name=\"Len\" inType=\"win:UInt32\"/><data name=\"Payload\" length=\"Len\"/></template>");
+        var values = ImmutableArray.Create(7u, (EventProperty)"data");
+        var view = new EventDataView(values, schema);
+
+        Assert.True(view.TryGetValue("Len", out EventFieldValue len));
+        Assert.True(len.TryGetUInt64(out ulong lenValue));
+        Assert.Equal(7UL, lenValue);
+
+        Assert.True(view.TryGetValue("Payload", out EventFieldValue payload));
+        Assert.Equal("data", payload.AsString());
+    }
+
+    [Fact]
+    public void TryGetValue_ByName_VisibleOrdering()
+    {
+        TemplateFieldSchema schema = Schema("<template><data name=\"A\"/><data name=\"B\"/></template>");
+        var values = ImmutableArray.Create(42, (EventProperty)"hello");
+        var view = new EventDataView(values, schema);
+
+        Assert.Equal(EventDataKind.EventData, view.Kind);
+        Assert.Equal(2, view.Count);
+
+        Assert.True(view.TryGetValue("A", out EventFieldValue a));
+        Assert.True(a.TryGetInt64(out long aValue));
+        Assert.Equal(42, aValue);
+
+        Assert.True(view.TryGetValue("B", out EventFieldValue b));
+        Assert.Equal("hello", b.AsString());
+
+        Assert.False(view.TryGetValue("Missing", out _));
+    }
+
+    [Fact]
+    public void TryGetValue_NumericPath_DoesNotAllocate()
+    {
+        TemplateFieldSchema schema = Schema("<template><data name=\"A\"/></template>");
+        var values = ImmutableArray.Create((EventProperty)123);
+        var view = new EventDataView(values, schema);
+
+        // Warm the lazy name-index map and JIT before measuring.
+        for (int i = 0; i < 100; i++)
+        {
+            view.TryGetValue("A", out EventFieldValue warm);
+            warm.TryGetInt64(out _);
+        }
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+
+        for (int i = 0; i < 1000; i++)
+        {
+            view.TryGetValue("A", out EventFieldValue value);
+            value.TryGetInt64(out _);
+        }
+
+        long after = GC.GetAllocatedBytesForCurrentThread();
+
+        Assert.Equal(before, after);
+    }
+
+    private static TemplateFieldSchema Schema(string template) => new TemplateAnalyzer().GetTemplateInfo(template).Schema;
+}

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Common/Events/EventFieldValueTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Common/Events/EventFieldValueTests.cs
@@ -69,6 +69,28 @@ public sealed class EventFieldValueTests
     }
 
     [Fact]
+    public void FromProperty_Guid_DoesNotReBox()
+    {
+        EventProperty property = Guid.NewGuid();
+
+        EventFieldValue.FromProperty(property).TryGetGuid(out _);
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        Guid sink = default;
+
+        for (int i = 0; i < 1000; i++)
+        {
+            EventFieldValue.FromProperty(property).TryGetGuid(out Guid read);
+            sink = read;
+        }
+
+        long after = GC.GetAllocatedBytesForCurrentThread();
+
+        Assert.Equal(before, after);
+        Assert.NotEqual(Guid.Empty, sink);
+    }
+
+    [Fact]
     public void FromProperty_IntegerArray_JoinsInvariantInAsString()
     {
         EventFieldValue value = EventFieldValue.FromProperty(EventProperty.FromReference(new uint[] { 1, 2, 3 }));

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Common/Events/EventFieldValueTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Common/Events/EventFieldValueTests.cs
@@ -1,0 +1,159 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Eventing.Readers;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Security.Principal;
+
+namespace EventLogExpert.Eventing.Tests.Common.Events;
+
+public sealed class EventFieldValueTests
+{
+    [Fact]
+    public void AsString_ByteArray_IsHex()
+    {
+        Assert.Equal("0102", EventFieldValue.FromProperty((EventProperty)(byte[])[1, 2]).AsString());
+    }
+
+    [Fact]
+    public void AsString_StringArray_IsJoined()
+    {
+        Assert.Equal("a, b", EventFieldValue.FromProperty((EventProperty)(string[])["a", "b"]).AsString());
+    }
+
+    [Fact]
+    public void AsString_UsesInvariantCulture()
+    {
+        CultureInfo prior = CultureInfo.CurrentCulture;
+
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+
+            Assert.Equal("1.5", EventFieldValue.FromProperty(1.5d).AsString());
+            Assert.Equal("1.5", EventFieldValue.FromProperty(1.5f).AsString());
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = prior;
+        }
+    }
+
+    [Fact]
+    public void FromProperty_BooleanAndDateTime_Project()
+    {
+        EventFieldValue boolean = EventFieldValue.FromProperty(true);
+
+        Assert.Equal(EventFieldValueKind.Boolean, boolean.Kind);
+        Assert.True(boolean.TryGetBoolean(out bool flag));
+        Assert.True(flag);
+
+        var when = new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+        EventFieldValue timestamp = EventFieldValue.FromProperty(when);
+
+        Assert.Equal(EventFieldValueKind.DateTime, timestamp.Kind);
+        Assert.True(timestamp.TryGetDateTime(out DateTime result));
+        Assert.Equal(when, result);
+    }
+
+    [Fact]
+    public void FromProperty_Double_ProjectsToDouble()
+    {
+        EventFieldValue value = EventFieldValue.FromProperty(1.5d);
+
+        Assert.Equal(EventFieldValueKind.Double, value.Kind);
+        Assert.True(value.TryGetDouble(out double result));
+        Assert.Equal(1.5d, result);
+    }
+
+    [Fact]
+    public void FromProperty_IntegerArray_JoinsInvariantInAsString()
+    {
+        EventFieldValue value = EventFieldValue.FromProperty(EventProperty.FromReference(new uint[] { 1, 2, 3 }));
+
+        Assert.Equal(EventFieldValueKind.Array, value.Kind);
+        Assert.Equal("1, 2, 3", value.AsString());
+    }
+
+    [Fact]
+    public void FromProperty_ReferenceShapes_DisambiguateByRuntimeType()
+    {
+        Assert.Equal(EventFieldValueKind.String, EventFieldValue.FromProperty((EventProperty)"x").Kind);
+        Assert.Equal(EventFieldValueKind.Guid, EventFieldValue.FromProperty(Guid.NewGuid()).Kind);
+        Assert.Equal(EventFieldValueKind.Sid, EventFieldValue.FromProperty((EventProperty)new SecurityIdentifier("S-1-5-18")).Kind);
+        Assert.Equal(EventFieldValueKind.Bytes, EventFieldValue.FromProperty((EventProperty)(byte[])[1, 2]).Kind);
+        Assert.Equal(EventFieldValueKind.StringArray, EventFieldValue.FromProperty((EventProperty)(string[])["a", "b"]).Kind);
+        Assert.Equal(EventFieldValueKind.Null, EventFieldValue.FromProperty((EventProperty)(string?)null).Kind);
+    }
+
+    [Fact]
+    public void FromProperty_SignedIntegrals_ProjectToInt64()
+    {
+        foreach (EventProperty property in new[]
+                 {
+                     (sbyte)-5, (short)-5, -5, (EventProperty)(-5L)
+                 })
+        {
+            EventFieldValue value = EventFieldValue.FromProperty(property);
+
+            Assert.Equal(EventFieldValueKind.Int64, value.Kind);
+            Assert.True(value.TryGetInt64(out long result));
+            Assert.Equal(-5, result);
+        }
+    }
+
+    [Fact]
+    public void FromProperty_Single_StaysSingle_AndIsNotMisreadAsDouble()
+    {
+        EventFieldValue value = EventFieldValue.FromProperty(1.5f);
+
+        Assert.Equal(EventFieldValueKind.Single, value.Kind);
+        Assert.True(value.TryGetSingle(out float single));
+        Assert.Equal(1.5f, single);
+        Assert.False(value.TryGetDouble(out _));
+    }
+
+    [Fact]
+    public void FromProperty_UInt64MaxValue_RoundTrips()
+    {
+        EventFieldValue value = EventFieldValue.FromProperty(ulong.MaxValue);
+
+        Assert.True(value.TryGetUInt64(out ulong result));
+        Assert.Equal(ulong.MaxValue, result);
+    }
+
+    [Fact]
+    public void FromProperty_UnsignedIntegralsAndSizeT_ProjectToUInt64()
+    {
+        foreach (EventProperty property in new[]
+                 {
+                     (byte)5, (ushort)5, 5u, 5UL, (EventProperty)(nuint)5
+                 })
+        {
+            EventFieldValue value = EventFieldValue.FromProperty(property);
+
+            Assert.Equal(EventFieldValueKind.UInt64, value.Kind);
+            Assert.True(value.TryGetUInt64(out ulong result));
+            Assert.Equal(5UL, result);
+        }
+    }
+
+    [Fact]
+    public void Layout_RetainedPropertyIs16Bytes_ProjectionWithinBudget()
+    {
+        Assert.Equal(16, Unsafe.SizeOf<EventProperty>());
+        Assert.True(Unsafe.SizeOf<EventFieldValue>() <= 24);
+    }
+
+    [Fact]
+    public void TryGetGuid_ReturnsStoredValue()
+    {
+        var guid = Guid.NewGuid();
+        EventFieldValue value = EventFieldValue.FromProperty(guid);
+
+        Assert.True(value.TryGetGuid(out Guid result));
+        Assert.Equal(guid, result);
+    }
+}

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Resolvers/EventResolverBaseTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Resolvers/EventResolverBaseTests.cs
@@ -1,6 +1,7 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Eventing.Common.Events;
 using EventLogExpert.Eventing.Interop;
 using EventLogExpert.Eventing.Readers;
 using EventLogExpert.Eventing.Resolvers;
@@ -100,6 +101,26 @@ public sealed class EventResolverBaseTests
     }
 
     [Fact]
+    public void ResolveEvent_ModernTemplateWithMatchingProperties_PopulatesNamedEventData()
+    {
+        var (details, eventRecord) = EventUtils.CreateModernEvent(
+            "User %1 from %2",
+            """<template><data name="User" inType="win:UnicodeString"/><data name="Source" inType="win:UnicodeString"/></template>""",
+            ["alice", "10.0.0.1"]);
+
+        var resolver = new TestEventResolver([details]);
+
+        var resolved = resolver.ResolveEvent(eventRecord);
+
+        Assert.Equal(EventDataKind.EventData, resolved.EventData.Kind);
+        Assert.Equal(2, resolved.EventData.Count);
+        Assert.True(resolved.EventData.TryGetValue("User", out var user));
+        Assert.Equal("alice", user.AsString());
+        Assert.True(resolved.EventData.TryGetValue("Source", out var source));
+        Assert.Equal("10.0.0.1", source.AsString());
+    }
+
+    [Fact]
     public void ResolveEvent_MSExchangeReplEvent_ShouldResolveCorrectly()
     {
         // Arrange
@@ -114,6 +135,33 @@ public sealed class EventResolverBaseTests
         Assert.NotNull(displayEvent);
         Assert.Equal(Constants.ExchangeFormattedDescription, displayEvent.Description);
         Assert.Equal("Service", displayEvent.TaskCategory);
+    }
+
+    [Fact]
+    public void ResolveEvent_NoModernTemplate_YieldsNoneEventData()
+    {
+        var (details, eventRecord) = EventUtils.CreateModernEvent("desc", "", ["value"]);
+
+        var resolver = new TestEventResolver([details]);
+
+        var resolved = resolver.ResolveEvent(eventRecord);
+
+        Assert.Equal(EventDataKind.None, resolved.EventData.Kind);
+    }
+
+    [Fact]
+    public void ResolveEvent_PropertyCountMatchesNeitherOrdering_FailsClosedToNone()
+    {
+        var (details, eventRecord) = EventUtils.CreateModernEvent(
+            "desc",
+            """<template><data name="A" inType="win:UnicodeString"/><data name="B" inType="win:UnicodeString"/></template>""",
+            ["one", "two", "three"]);
+
+        var resolver = new TestEventResolver([details]);
+
+        var resolved = resolver.ResolveEvent(eventRecord);
+
+        Assert.Equal(EventDataKind.None, resolved.EventData.Kind);
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Resolvers/FieldNameOrderingSelectorTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Resolvers/FieldNameOrderingSelectorTests.cs
@@ -1,0 +1,49 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Resolvers;
+
+namespace EventLogExpert.Eventing.Tests.Resolvers;
+
+public sealed class FieldNameOrderingSelectorTests
+{
+    [Fact]
+    public void TrySelectOrdering_CountMatchesNeither_FailsClosed()
+    {
+        TemplateMetadata meta = Meta("<template><data name=\"A\"/><data name=\"B\"/></template>");
+
+        Assert.False(FieldNameOrderingSelector.TrySelectOrdering(meta, 3, out _));
+        Assert.False(FieldNameOrderingSelector.TrySelectOrdering(meta, 1, out _));
+    }
+
+    [Fact]
+    public void TrySelectOrdering_DefaultMetadata_ReturnsFalseWithoutThrowing()
+    {
+        Assert.False(FieldNameOrderingSelector.TrySelectOrdering(default, 0, out _));
+        Assert.False(FieldNameOrderingSelector.TrySelectOrdering(default, 3, out _));
+    }
+
+    [Fact]
+    public void TrySelectOrdering_LengthProvider_MatchesVisibleThenAll()
+    {
+        TemplateMetadata meta = Meta(
+            "<template><data name=\"Len\" inType=\"win:UInt32\"/><data name=\"Payload\" length=\"Len\"/></template>");
+
+        Assert.True(FieldNameOrderingSelector.TrySelectOrdering(meta, 1, out FieldNameOrdering visible));
+        Assert.Equal(FieldNameOrdering.Visible, visible);
+
+        Assert.True(FieldNameOrderingSelector.TrySelectOrdering(meta, 2, out FieldNameOrdering all));
+        Assert.Equal(FieldNameOrdering.All, all);
+    }
+
+    [Fact]
+    public void TrySelectOrdering_NoLengthProvider_PrefersVisible()
+    {
+        TemplateMetadata meta = Meta("<template><data name=\"A\"/><data name=\"B\"/></template>");
+
+        Assert.True(FieldNameOrderingSelector.TrySelectOrdering(meta, 2, out FieldNameOrdering ordering));
+        Assert.Equal(FieldNameOrdering.Visible, ordering);
+    }
+
+    private static TemplateMetadata Meta(string template) => new TemplateAnalyzer().Analyze(template);
+}

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Resolvers/TemplateFieldSchemaTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Resolvers/TemplateFieldSchemaTests.cs
@@ -1,0 +1,82 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Resolvers;
+
+namespace EventLogExpert.Eventing.Tests.Resolvers;
+
+public sealed class TemplateFieldSchemaTests
+{
+    [Fact]
+    public void Schema_LengthProviderNode_KeepsRealNameInAll_ExcludedFromVisible()
+    {
+        TemplateInfo info = Info(
+            "<template><data name=\"Len\" inType=\"win:UInt32\"/><data name=\"Payload\" length=\"Len\"/></template>");
+
+        Assert.Equal(["Len", "Payload"], info.Schema.AllNames);
+        Assert.Equal(["Payload"], info.Schema.VisibleNames);
+    }
+
+    [Fact]
+    public void Schema_NameLengths_MatchOutTypeLengths_Lockstep()
+    {
+        TemplateInfo info = Info(
+            "<template>" +
+            "<data name=\"Len\" inType=\"win:UInt32\"/>" +
+            "<data name=\"Payload\" length=\"Len\"/>" +
+            "<data name=\"Extra\"/>" +
+            "</template>");
+
+        Assert.Equal(info.Metadata.AllOutTypes.Length, info.Schema.AllNames.Length);
+        Assert.Equal(info.Metadata.VisibleOutTypes.Length, info.Schema.VisibleNames.Length);
+    }
+
+    [Fact]
+    public void TryGetIndex_ConcurrentFirstAccess_BuildsOneCompleteMap()
+    {
+        TemplateInfo info = Info("<template><data name=\"A\"/><data name=\"B\"/><data name=\"C\"/></template>");
+
+        Parallel.For(0, 128, _ =>
+        {
+            Assert.True(info.Schema.TryGetIndex(FieldNameOrdering.All, "A", out int a));
+            Assert.Equal(0, a);
+            Assert.True(info.Schema.TryGetIndex(FieldNameOrdering.All, "C", out int c));
+            Assert.Equal(2, c);
+        });
+    }
+
+    [Fact]
+    public void TryGetIndex_DuplicateName_ReturnsFirstIndex()
+    {
+        TemplateInfo info = Info("<template><data name=\"Dup\"/><data name=\"Dup\"/></template>");
+
+        Assert.True(info.Schema.TryGetIndex(FieldNameOrdering.All, "Dup", out int index));
+        Assert.Equal(0, index);
+    }
+
+    [Fact]
+    public void TryGetIndex_EmptyName_IsNotIndexable()
+    {
+        var schema = new TemplateFieldSchema(["", "Named"], ["", "Named"]);
+
+        Assert.False(schema.TryGetIndex(FieldNameOrdering.All, "", out _));
+        Assert.True(schema.TryGetIndex(FieldNameOrdering.All, "Named", out int index));
+        Assert.Equal(1, index);
+    }
+
+    [Fact]
+    public void TryGetIndex_ResolvesNameInBothOrderings()
+    {
+        TemplateInfo info = Info("<template><data name=\"A\"/><data name=\"B\"/></template>");
+
+        Assert.True(info.Schema.TryGetIndex(FieldNameOrdering.All, "B", out int allIndex));
+        Assert.Equal(1, allIndex);
+
+        Assert.True(info.Schema.TryGetIndex(FieldNameOrdering.Visible, "A", out int visibleIndex));
+        Assert.Equal(0, visibleIndex);
+
+        Assert.False(info.Schema.TryGetIndex(FieldNameOrdering.All, "Missing", out _));
+    }
+
+    private static TemplateInfo Info(string template) => new TemplateAnalyzer().GetTemplateInfo(template);
+}

--- a/tests/Unit/EventLogExpert.Filtering.Tests/Basic/FilterComparisonJsonConverterTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/Basic/FilterComparisonJsonConverterTests.cs
@@ -11,9 +11,7 @@ public sealed class FilterComparisonJsonConverterTests
     [Fact]
     public void EventProperty_MemberCount_IsFrozenForWireCompatibility()
     {
-        // Pairs with the per-ordinal Read_LegacyCategoryKey theory: adding or removing an EventProperty
-        // value would leave that theory passing while still corrupting legacy reads for the missing ordinal.
-        Assert.Equal(12, Enum.GetValues<EventProperty>().Length);
+        Assert.Equal(13, Enum.GetValues<EventProperty>().Length);
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataAllocationTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataAllocationTests.cs
@@ -1,0 +1,46 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.TestUtils;
+using EventLogExpert.Filtering.Parsing;
+using EventLogExpert.Filtering.Tests.TestUtils;
+
+namespace EventLogExpert.Filtering.Tests.EventData;
+
+/// <summary>
+///     Per-event allocation budget for EventData predicates. Zero allocation is required for the String and packed
+///     scalar / Guid field kinds (R4) so an active EventData filter doesn't add GC pressure on a hot virtualization
+///     scroll. (Sid / Bytes / array kinds use the documented AsString fallback and are not covered here.)
+/// </summary>
+public sealed class EventDataAllocationTests
+{
+    [Fact]
+    public void GuidEquality_OverWarmEvent_AllocatesZeroBytes()
+    {
+        var id = new Guid("11111111-2222-3333-4444-555555555555");
+
+        Assert.True(FilterParser.TryCompile($"EventData[\"Id\"] == \"{id}\"", out var compiled, out var error), error);
+
+        var warmEvent = EventDataTestFactory.CreateEventWithData(("Id", id));
+
+        var bytes = AllocationUtils.MeasurePredicateAllocations(compiled.Predicate, warmEvent);
+
+        Assert.Equal(0, bytes);
+    }
+
+    [Theory]
+    [InlineData("EventData[\"User\"] == \"admin\"")]
+    [InlineData("EventData[\"User\"].Contains(\"adm\", StringComparison.OrdinalIgnoreCase)")]
+    [InlineData("EventData[\"Code\"] == \"5\"")]
+    [InlineData("(new[] {\"5\", \"6\"}).Contains(EventData[\"Code\"])")]
+    public void Predicate_OverWarmEvent_AllocatesZeroBytes(string filter)
+    {
+        Assert.True(FilterParser.TryCompile(filter, out var compiled, out var error), error);
+
+        var warmEvent = EventDataTestFactory.CreateEventWithData(("User", "admin"), ("Code", 5L));
+
+        var bytes = AllocationUtils.MeasurePredicateAllocations(compiled.Predicate, warmEvent);
+
+        Assert.Equal(0, bytes);
+    }
+}

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataDraftTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataDraftTests.cs
@@ -1,0 +1,77 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Drafts;
+
+namespace EventLogExpert.Filtering.Tests.EventData;
+
+/// <summary>
+///     <see cref="FilterPredicateDraft.IsComplete" /> must mirror the formatter's strict-mode guard: an EventData row
+///     is only complete once it has both a field name and a value, so the editor's Done/Add affordance never enables a row
+///     the formatter would silently reject (R3).
+/// </summary>
+public sealed class EventDataDraftTests
+{
+    [Fact]
+    public void IsComplete_EventDataMany_RequiresFieldName()
+    {
+        var draft = new FilterPredicateDraft
+        {
+            Comparison = new FilterComparisonDraft
+            {
+                Property = EventProperty.EventData,
+                Operator = ComparisonOperator.Equals,
+                MatchMode = MatchMode.Many,
+                Values = ["admin"]
+            }
+        };
+
+        Assert.False(draft.IsComplete);
+
+        draft.Comparison.EventDataFieldName = "User";
+
+        Assert.True(draft.IsComplete);
+    }
+
+    [Fact]
+    public void IsComplete_False_WhenFieldNameMissing() => Assert.False(EventDataDraft(null, "admin").IsComplete);
+
+    [Fact]
+    public void IsComplete_False_WhenFieldNameWhitespace() => Assert.False(EventDataDraft("   ", "admin").IsComplete);
+
+    [Fact]
+    public void IsComplete_False_WhenValueMissing() => Assert.False(EventDataDraft("User", null).IsComplete);
+
+    [Fact]
+    public void IsComplete_NonEventDataRow_IgnoresFieldName()
+    {
+        var draft = new FilterPredicateDraft
+        {
+            Comparison = new FilterComparisonDraft
+            {
+                Property = EventProperty.Source,
+                Operator = ComparisonOperator.Equals,
+                MatchMode = MatchMode.Single,
+                Value = "x"
+            }
+        };
+
+        Assert.True(draft.IsComplete);
+    }
+
+    [Fact]
+    public void IsComplete_True_WhenFieldNameAndValuePresent() => Assert.True(EventDataDraft("User", "admin").IsComplete);
+
+    private static FilterPredicateDraft EventDataDraft(string? fieldName, string? value) =>
+        new()
+        {
+            Comparison = new FilterComparisonDraft
+            {
+                Property = EventProperty.EventData,
+                Operator = ComparisonOperator.Equals,
+                MatchMode = MatchMode.Single,
+                EventDataFieldName = fieldName,
+                Value = value
+            }
+        };
+}

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataFilterCompilationTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataFilterCompilationTests.cs
@@ -88,6 +88,16 @@ public sealed class EventDataFilterCompilationTests
     }
 
     [Fact]
+    public void DateTimeEquality_RejectsNonRoundTripLiteral()
+    {
+        // Only the canonical "O" round-trip form parses to a DateTime candidate; a lenient date string does not,
+        // so it never matches a DateTime field (even the same instant).
+        var predicate = Compile("EventData[\"When\"] == \"2024-01-01\"");
+
+        Assert.False(predicate(Event(("When", new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc)))));
+    }
+
+    [Fact]
     public void DoubleEquality_MatchesNaN()
     {
         var predicate = Compile("EventData[\"Ratio\"] == \"NaN\"");

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataFilterCompilationTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataFilterCompilationTests.cs
@@ -1,0 +1,289 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Eventing.TestUtils;
+using EventLogExpert.Filtering.Parsing;
+using System.Globalization;
+
+namespace EventLogExpert.Filtering.Tests.EventData;
+
+/// <summary>
+///     End-to-end compile + evaluate coverage for EventData named-field filtering: the presence-required semantics
+///     (R1″), the typed value-equality model (R4), and the closed-vocabulary rejections.
+/// </summary>
+public sealed class EventDataFilterCompilationTests
+{
+    private static readonly Guid s_sampleGuid = new("11111111-2222-3333-4444-555555555555");
+
+    // --- Presence-required (R1″): absent field / EventDataKind.None never matches, positive OR negative. ---
+
+    public static IEnumerable<object[]> AllOperators() =>
+    [
+        ["EventData[\"User\"] == \"admin\""],
+        ["EventData[\"User\"] != \"admin\""],
+        ["EventData[\"User\"].Contains(\"adm\", StringComparison.OrdinalIgnoreCase)"],
+        ["!EventData[\"User\"].Contains(\"adm\", StringComparison.OrdinalIgnoreCase)"],
+        ["(new[] {\"admin\", \"root\"}).Contains(EventData[\"User\"])"]
+    ];
+
+    [Theory]
+    [MemberData(nameof(AllOperators))]
+    public void AbsentField_NeverMatches(string filter)
+    {
+        var predicate = Compile(filter);
+
+        // Event has EventData, but not the "User" field.
+        Assert.False(predicate(Event(("Other", "x"))));
+    }
+
+    [Fact]
+    public void AnyOf_MatchesAnyListedValue()
+    {
+        var predicate = Compile("(new[] {\"admin\", \"root\"}).Contains(EventData[\"User\"])");
+
+        Assert.True(predicate(Event(("User", "admin"))));
+        Assert.True(predicate(Event(("User", "root"))));
+        Assert.False(predicate(Event(("User", "guest"))));
+    }
+
+    [Theory]
+    [InlineData("true")]
+    [InlineData("True")]
+    [InlineData("TRUE")]
+    public void BooleanEquality_IsCaseInsensitive(string literal)
+    {
+        var predicate = Compile($"EventData[\"Flag\"] == \"{literal}\"");
+
+        Assert.True(predicate(Event(("Flag", true))));
+        Assert.False(predicate(Event(("Flag", false))));
+    }
+
+    [Fact]
+    public void BooleanField_DoesNotMatchNumericLiteral()
+    {
+        var predicate = Compile("EventData[\"Flag\"] == \"1\"");
+
+        Assert.False(predicate(Event(("Flag", true))));
+    }
+
+    [Fact]
+    public void Contains_IsCaseInsensitiveSubstring()
+    {
+        var predicate = Compile("EventData[\"Path\"].Contains(\"system32\", StringComparison.OrdinalIgnoreCase)");
+
+        Assert.True(predicate(Event(("Path", @"C:\Windows\System32\cmd.exe"))));
+        Assert.False(predicate(Event(("Path", @"C:\Temp\x"))));
+    }
+
+    [Fact]
+    public void DateTimeEquality_MatchesRoundTripString()
+    {
+        var when = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        var predicate = Compile($"EventData[\"When\"] == \"{when.ToString("O", CultureInfo.InvariantCulture)}\"");
+
+        Assert.True(predicate(Event(("When", when))));
+        Assert.False(predicate(Event(("When", when.AddDays(1)))));
+    }
+
+    [Fact]
+    public void DoubleEquality_MatchesNaN()
+    {
+        var predicate = Compile("EventData[\"Ratio\"] == \"NaN\"");
+
+        Assert.True(predicate(Event(("Ratio", double.NaN))));
+        Assert.False(predicate(Event(("Ratio", 1.5d))));
+    }
+
+    [Fact]
+    public void DoubleNegatedContains_EqualsContains()
+    {
+        var contains = Compile("EventData[\"User\"].Contains(\"adm\", StringComparison.OrdinalIgnoreCase)");
+        var doubleNegated = Compile("!!EventData[\"User\"].Contains(\"adm\", StringComparison.OrdinalIgnoreCase)");
+
+        foreach (var evt in new[] { Event(("User", "admin")), Event(("User", "guest")), Event(("Other", "x")) })
+        {
+            Assert.Equal(contains(evt), doubleNegated(evt));
+        }
+    }
+
+    [Fact]
+    public void DuplicateFieldName_ResolvesToFirstOccurrence()
+    {
+        var predicate = Compile("EventData[\"Data\"] == \"first\"");
+
+        Assert.True(predicate(Event(("Data", "first"), ("Data", "second"))));
+    }
+
+    // --- Negation normalization equivalence (R1″). ---
+
+    [Theory]
+    [InlineData("admin")]
+    [InlineData("guest")]
+    public void ExplicitNegatedEquality_EqualsNotEqual(string userValue)
+    {
+        var notEqual = Compile("EventData[\"User\"] != \"admin\"");
+        var negatedEqual = Compile("!(EventData[\"User\"] == \"admin\")");
+
+        var withField = Event(("User", userValue));
+        var absent = Event(("Other", "x"));
+
+        Assert.Equal(notEqual(withField), negatedEqual(withField));
+        Assert.Equal(notEqual(absent), negatedEqual(absent));
+    }
+
+    [Fact]
+    public void FieldNameKey_IsCaseSensitiveOrdinal()
+    {
+        var predicate = Compile("EventData[\"user\"] == \"admin\"");
+
+        // Field is named "User"; the Ordinal schema lookup does not match the lowercase key.
+        Assert.False(predicate(Event(("User", "admin"))));
+    }
+
+    [Fact]
+    public void GroupedNegation_WithoutEventData_StillCompiles()
+    {
+        // Regression guard: negating a group of regular fields is unaffected by the EventData rejection.
+        Assert.True(FilterParser.TryCompile("!(Source == \"a\" || Level == \"b\")", out _, out var error), error);
+    }
+
+    [Theory]
+    [InlineData("11111111-2222-3333-4444-555555555555")]
+    [InlineData("{11111111-2222-3333-4444-555555555555}")]
+    public void GuidEquality_AcceptsAnyParseableFormat(string literal)
+    {
+        var predicate = Compile($"EventData[\"Id\"] == \"{literal}\"");
+
+        Assert.True(predicate(Event(("Id", s_sampleGuid))));
+        Assert.False(predicate(Event(("Id", Guid.Empty))));
+    }
+
+    [Fact]
+    public void Int64Equality_MatchesNegativeValue()
+    {
+        var predicate = Compile("EventData[\"Delta\"] == \"-5\"");
+
+        Assert.True(predicate(Event(("Delta", -5L))));
+        Assert.False(predicate(Event(("Delta", 5L))));
+    }
+
+    [Theory]
+    [MemberData(nameof(AllOperators))]
+    public void NoneEventData_NeverMatches(string filter)
+    {
+        var predicate = Compile(filter);
+
+        Assert.Equal(EventDataKind.None, NoEventData().EventData.Kind);
+        Assert.False(predicate(NoEventData()));
+    }
+
+    [Fact]
+    public void NotContains_RequiresPresence()
+    {
+        var predicate = Compile("!EventData[\"User\"].Contains(\"adm\", StringComparison.OrdinalIgnoreCase)");
+
+        Assert.True(predicate(Event(("User", "guest"))));
+        Assert.False(predicate(Event(("User", "admin"))));
+        Assert.False(predicate(Event(("Other", "x")))); // absent -> no match
+    }
+
+    [Fact]
+    public void NotEqual_RequiresPresence()
+    {
+        var predicate = Compile("EventData[\"User\"] != \"admin\"");
+
+        Assert.True(predicate(Event(("User", "guest")))); // present and different
+        Assert.False(predicate(Event(("User", "admin")))); // present and equal
+        Assert.False(predicate(Event(("Other", "x")))); // absent -> no match (not "true")
+    }
+
+    [Fact]
+    public void SingleEquality_Matches()
+    {
+        var predicate = Compile("EventData[\"Ratio\"] == \"1.5\"");
+
+        Assert.True(predicate(Event(("Ratio", 1.5f))));
+        Assert.False(predicate(Event(("Ratio", 2.5f))));
+    }
+
+    [Fact]
+    public void StringEquality_MatchesOnlyExactValue()
+    {
+        var predicate = Compile("EventData[\"User\"] == \"admin\"");
+
+        Assert.True(predicate(Event(("User", "admin"))));
+        Assert.False(predicate(Event(("User", "guest"))));
+    }
+
+    // --- Key handling. ---
+
+    [Fact]
+    public void Target_IsCaseInsensitive()
+    {
+        var predicate = Compile("eventdata[\"User\"] == \"admin\"");
+
+        Assert.True(predicate(Event(("User", "admin"))));
+    }
+
+    [Fact]
+    public void TypedEquality_IsScopedToTheFieldKind()
+    {
+        // "05" matches an Int64 5 by value, but a String field "5" is compared as text and does not equal "05".
+        var predicate = Compile("EventData[\"Code\"] == \"05\"");
+
+        Assert.True(predicate(Event(("Code", 5L))));
+        Assert.False(predicate(Event(("Code", "5"))));
+    }
+
+    [Theory]
+    [InlineData("EventData[\"Code\"] == \"5\"")]
+    [InlineData("EventData[\"Code\"] == \"05\"")] // typed value equality: "05" parses to the numeric 5
+    public void TypedIntegerEquality_IgnoresLeadingZeros(string filter)
+    {
+        var predicate = Compile(filter);
+
+        Assert.True(predicate(Event(("Code", 5L))));
+        Assert.False(predicate(Event(("Code", 6L))));
+    }
+
+    [Fact]
+    public void UInt64Equality_MatchesValuesAboveInt64Max()
+    {
+        var predicate = Compile($"EventData[\"Mask\"] == \"{ulong.MaxValue}\"");
+
+        Assert.True(predicate(Event(("Mask", ulong.MaxValue))));
+        Assert.False(predicate(Event(("Mask", ulong.MaxValue - 1))));
+    }
+
+    // --- Rejections (closed vocabulary). ---
+
+    [Theory]
+    [InlineData("EventData[\"Code\"] < \"5\"")] // relational not supported
+    [InlineData("EventData[\"Code\"] >= \"5\"")]
+    [InlineData("EventData[\"\"] == \"x\"")] // empty key
+    [InlineData("EventData[\"   \"] == \"x\"")] // whitespace key
+    [InlineData("EventData[5] == \"x\"")] // non-string key
+    [InlineData("!(new[] {\"a\", \"b\"}).Contains(EventData[\"User\"])")] // none-of
+    [InlineData("!(EventData[\"User\"] == \"a\" || EventData[\"User\"] == \"b\")")] // grouped negation
+    [InlineData("!(EventData[\"User\"] == \"a\" && Source == \"x\")")] // grouped negation, mixed
+    public void UnsupportedShapes_FailToCompile(string filter)
+    {
+        Assert.False(FilterParser.TryCompile(filter, out var compiled, out var error));
+        Assert.Null(compiled);
+        Assert.False(string.IsNullOrEmpty(error));
+    }
+
+    private static Func<ResolvedEvent, bool> Compile(string filter)
+    {
+        Assert.True(FilterParser.TryCompile(filter, out var compiled, out var error), error);
+
+        return compiled.Predicate;
+    }
+
+    private static ResolvedEvent Event(params (string Name, object? Value)[] fields) =>
+        EventDataTestFactory.CreateEventWithData(fields);
+
+    private static ResolvedEvent NoEventData() => new("TestLog", LogPathType.Channel);
+}

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataPicklistTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataPicklistTests.cs
@@ -9,6 +9,7 @@ namespace EventLogExpert.Filtering.Tests.EventData;
 ///     Field-name and per-field value picklists that feed the Basic editor's EventData row. Exercises the composite
 ///     <c>(snapshot, fieldName)</c> cache key (R7) so distinct fields keep distinct value lists.
 /// </summary>
+[Collection("EventPropertyValuesCache")]
 public sealed class EventDataPicklistTests : IDisposable
 {
     public EventDataPicklistTests() => EventPropertyValuesCache.Clear();

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataPicklistTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataPicklistTests.cs
@@ -1,0 +1,80 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.TestUtils;
+
+namespace EventLogExpert.Filtering.Tests.EventData;
+
+/// <summary>
+///     Field-name and per-field value picklists that feed the Basic editor's EventData row. Exercises the composite
+///     <c>(snapshot, fieldName)</c> cache key (R7) so distinct fields keep distinct value lists.
+/// </summary>
+public sealed class EventDataPicklistTests : IDisposable
+{
+    public EventDataPicklistTests() => EventPropertyValuesCache.Clear();
+
+    public void Dispose() => EventPropertyValuesCache.Clear();
+
+    [Fact]
+    public void GetEventDataFieldNames_ReturnsDistinctSortedNames()
+    {
+        var snapshot = new object();
+        var events = new[]
+        {
+            EventDataTestFactory.CreateEventWithData(("TargetUserName", "a"), ("Status", 1L)),
+            EventDataTestFactory.CreateEventWithData(("Status", 2L), ("SubjectUserName", "b"))
+        };
+
+        var names = EventPropertyValuesCache.GetEventDataFieldNames(snapshot, events);
+
+        Assert.Equal(["Status", "SubjectUserName", "TargetUserName"], names);
+    }
+
+    [Fact]
+    public void GetEventDataFieldValues_DifferentFields_ProduceDifferentLists()
+    {
+        var snapshot = new object();
+        var events = new[] { EventDataTestFactory.CreateEventWithData(("A", "1"), ("B", "2")) };
+
+        Assert.Equal(["1"], EventPropertyValuesCache.GetEventDataFieldValues(snapshot, events, "A"));
+        Assert.Equal(["2"], EventPropertyValuesCache.GetEventDataFieldValues(snapshot, events, "B"));
+    }
+
+    [Fact]
+    public void GetEventDataFieldValues_EmptyFieldName_ReturnsEmpty()
+    {
+        var snapshot = new object();
+        var events = new[] { EventDataTestFactory.CreateEventWithData(("A", "1")) };
+
+        Assert.Empty(EventPropertyValuesCache.GetEventDataFieldValues(snapshot, events, string.Empty));
+    }
+
+    [Fact]
+    public void GetEventDataFieldValues_ReturnsDistinctSortedValues()
+    {
+        var snapshot = new object();
+        var events = new[]
+        {
+            EventDataTestFactory.CreateEventWithData(("User", "admin")),
+            EventDataTestFactory.CreateEventWithData(("User", "guest")),
+            EventDataTestFactory.CreateEventWithData(("User", "admin")),
+            EventDataTestFactory.CreateEventWithData(("Other", "x"))
+        };
+
+        var values = EventPropertyValuesCache.GetEventDataFieldValues(snapshot, events, "User");
+
+        Assert.Equal(["admin", "guest"], values);
+    }
+
+    [Fact]
+    public void GetEventDataFieldValues_UnknownFieldName_ReturnsEmptyWithoutCaching()
+    {
+        var snapshot = new object();
+        var events = new[] { EventDataTestFactory.CreateEventWithData(("A", "1")) };
+
+        // A name that isn't a real field (as an editable picker would produce mid-typing) is bounded out: it
+        // returns empty and is not admitted to the per-snapshot value cache.
+        Assert.Empty(EventPropertyValuesCache.GetEventDataFieldValues(snapshot, events, "NotAField"));
+        Assert.Equal(["1"], EventPropertyValuesCache.GetEventDataFieldValues(snapshot, events, "A"));
+    }
+}

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataPicklistTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataPicklistTests.cs
@@ -32,6 +32,21 @@ public sealed class EventDataPicklistTests : IDisposable
     }
 
     [Fact]
+    public void GetEventDataFieldNames_SortsOrdinal()
+    {
+        var snapshot = new object();
+        var events = new[]
+        {
+            EventDataTestFactory.CreateEventWithData(("b", "1")),
+            EventDataTestFactory.CreateEventWithData(("A", "2")),
+            EventDataTestFactory.CreateEventWithData(("a", "3"))
+        };
+
+        // Ordinal orders uppercase before lowercase ('A'=65, 'a'=97, 'b'=98), unlike a culture-sensitive sort.
+        Assert.Equal(["A", "a", "b"], EventPropertyValuesCache.GetEventDataFieldNames(snapshot, events));
+    }
+
+    [Fact]
     public void GetEventDataFieldValues_DifferentFields_ProduceDifferentLists()
     {
         var snapshot = new object();

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataRoundTripTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataRoundTripTests.cs
@@ -70,6 +70,19 @@ public sealed class EventDataRoundTripTests
     }
 
     [Fact]
+    public void Json_Read_NormalizesWhitespaceFieldName_ToNull()
+    {
+        const string json =
+            """{"Property":"EventData","Operator":"Equals","MatchMode":"Single","Value":"x","EventDataFieldName":"   "}""";
+
+        var restored = JsonSerializer.Deserialize<FilterComparison>(json);
+
+        Assert.NotNull(restored);
+        Assert.Equal(EventProperty.EventData, restored!.Property);
+        Assert.Null(restored.EventDataFieldName);
+    }
+
+    [Fact]
     public void ManyValues_RoundTrips()
     {
         var original = new FilterComparison

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataRoundTripTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataRoundTripTests.cs
@@ -25,14 +25,15 @@ public sealed class EventDataRoundTripTests
         AssertSingleRoundTrips(ComparisonOperator.Equals, fieldName, "value");
 
     [Fact]
-    public void Json_NonEventDataRow_OmitsEventDataFieldName()
+    public void Json_NonEventDataRow_OmitsEventDataFieldName_EvenWhenSet()
     {
         var comparison = new FilterComparison
         {
             Property = EventProperty.Source,
             Operator = ComparisonOperator.Equals,
             MatchMode = MatchMode.Single,
-            Value = "x"
+            Value = "x",
+            EventDataFieldName = "stale"
         };
 
         var json = JsonSerializer.Serialize(comparison);
@@ -53,6 +54,19 @@ public sealed class EventDataRoundTripTests
         Assert.Equal("TargetUserName", restored.EventDataFieldName);
         Assert.Equal(ComparisonOperator.Contains, restored.Operator);
         Assert.Equal("admin", restored.Value);
+    }
+
+    [Fact]
+    public void Json_Read_DropsEventDataFieldName_ForNonEventDataRow()
+    {
+        const string json =
+            """{"Property":"Source","Operator":"Equals","MatchMode":"Single","Value":"x","EventDataFieldName":"stale"}""";
+
+        var restored = JsonSerializer.Deserialize<FilterComparison>(json);
+
+        Assert.NotNull(restored);
+        Assert.Equal(EventProperty.Source, restored!.Property);
+        Assert.Null(restored.EventDataFieldName);
     }
 
     [Fact]
@@ -89,7 +103,7 @@ public sealed class EventDataRoundTripTests
     }
 
     [Fact]
-    public void NegatedEquality_CanonicalizesToNotEqual()
+    public void NegatedNotEqual_CanonicalizesToEquals()
     {
         Assert.True(
             BasicFilterDecomposer.TryDecompose("!(EventData[\"User\"] != \"admin\")", out var structured),

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataRoundTripTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataRoundTripTests.cs
@@ -1,0 +1,138 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Text.Json;
+
+namespace EventLogExpert.Filtering.Tests.EventData;
+
+/// <summary>
+///     Advanced-text ↔ Basic round-trip fidelity and JSON persistence for EventData rows, including the negation
+///     canonicalizations (<c>!(!=)</c> → <c>==</c>, <c>!.Contains</c> → NotContains) and field-name escaping.
+/// </summary>
+public sealed class EventDataRoundTripTests
+{
+    [Fact]
+    public void EmptyFieldName_DoesNotFormat() =>
+        Assert.False(BasicFilterFormatter.TryFormatComparison(Single(ComparisonOperator.Equals, "", "admin"), null, out _));
+
+    [Theory]
+    [InlineData("with space")]
+    [InlineData("with\"quote")]
+    [InlineData("with]bracket")]
+    [InlineData("with\\backslash")]
+    [InlineData("with\ttab")]
+    public void FieldNameWithSpecialCharacters_RoundTrips(string fieldName) =>
+        AssertSingleRoundTrips(ComparisonOperator.Equals, fieldName, "value");
+
+    [Fact]
+    public void Json_NonEventDataRow_OmitsEventDataFieldName()
+    {
+        var comparison = new FilterComparison
+        {
+            Property = EventProperty.Source,
+            Operator = ComparisonOperator.Equals,
+            MatchMode = MatchMode.Single,
+            Value = "x"
+        };
+
+        var json = JsonSerializer.Serialize(comparison);
+
+        Assert.DoesNotContain("EventDataFieldName", json);
+    }
+
+    [Fact]
+    public void Json_PreservesEventDataFieldName()
+    {
+        var original = Single(ComparisonOperator.Contains, "TargetUserName", "admin");
+
+        var json = JsonSerializer.Serialize(original);
+        var restored = JsonSerializer.Deserialize<FilterComparison>(json);
+
+        Assert.NotNull(restored);
+        Assert.Equal(EventProperty.EventData, restored!.Property);
+        Assert.Equal("TargetUserName", restored.EventDataFieldName);
+        Assert.Equal(ComparisonOperator.Contains, restored.Operator);
+        Assert.Equal("admin", restored.Value);
+    }
+
+    [Fact]
+    public void ManyValues_RoundTrips()
+    {
+        var original = new FilterComparison
+        {
+            Property = EventProperty.EventData,
+            EventDataFieldName = "User",
+            Operator = ComparisonOperator.Equals,
+            MatchMode = MatchMode.Many,
+            Values = ["admin", "root"]
+        };
+
+        var result = RoundTrip(original);
+
+        Assert.Equal(EventProperty.EventData, result.Property);
+        Assert.Equal("User", result.EventDataFieldName);
+        Assert.Equal(MatchMode.Many, result.MatchMode);
+        Assert.Equal<IEnumerable<string>>(["admin", "root"], result.Values);
+    }
+
+    [Fact]
+    public void NegatedContains_MapsToNotContains()
+    {
+        Assert.True(
+            BasicFilterDecomposer.TryDecompose(
+                "!EventData[\"User\"].Contains(\"adm\", StringComparison.OrdinalIgnoreCase)",
+                out var structured),
+            "decompose failed");
+
+        Assert.Equal(ComparisonOperator.NotContains, structured!.Comparison.Operator);
+        Assert.Equal("User", structured.Comparison.EventDataFieldName);
+    }
+
+    [Fact]
+    public void NegatedEquality_CanonicalizesToNotEqual()
+    {
+        Assert.True(
+            BasicFilterDecomposer.TryDecompose("!(EventData[\"User\"] != \"admin\")", out var structured),
+            "decompose failed");
+
+        Assert.Equal(ComparisonOperator.Equals, structured!.Comparison.Operator);
+        Assert.Equal("User", structured.Comparison.EventDataFieldName);
+    }
+
+    [Theory]
+    [InlineData(ComparisonOperator.Equals)]
+    [InlineData(ComparisonOperator.NotEqual)]
+    [InlineData(ComparisonOperator.Contains)]
+    [InlineData(ComparisonOperator.NotContains)]
+    public void SingleValue_RoundTrips(ComparisonOperator op) =>
+        AssertSingleRoundTrips(op, "TargetUserName", "admin");
+
+    private static void AssertSingleRoundTrips(ComparisonOperator op, string fieldName, string value)
+    {
+        var result = RoundTrip(Single(op, fieldName, value));
+
+        Assert.Equal(EventProperty.EventData, result.Property);
+        Assert.Equal(fieldName, result.EventDataFieldName);
+        Assert.Equal(op, result.Operator);
+        Assert.Equal(MatchMode.Single, result.MatchMode);
+        Assert.Equal(value, result.Value);
+    }
+
+    private static FilterComparison RoundTrip(FilterComparison original)
+    {
+        Assert.True(BasicFilterFormatter.TryFormat(new BasicFilter(original, []), out var text), "format failed");
+        Assert.True(BasicFilterDecomposer.TryDecompose(text, out var structured), $"decompose failed: {text}");
+
+        return structured!.Comparison;
+    }
+
+    private static FilterComparison Single(ComparisonOperator op, string fieldName, string value) =>
+        new()
+        {
+            Property = EventProperty.EventData,
+            EventDataFieldName = fieldName,
+            Operator = op,
+            MatchMode = MatchMode.Single,
+            Value = value
+        };
+}

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventPropertyValuesCacheCollection.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventPropertyValuesCacheCollection.cs
@@ -1,0 +1,12 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Filtering.Tests.EventData;
+
+/// <summary>
+///     Serializes the test classes that share <c>EventPropertyValuesCache</c>'s process-wide static caches (each
+///     calls <c>Clear()</c> in setup/teardown). Without a shared collection, xUnit runs these classes in parallel and one
+///     class's <c>Clear()</c> can wipe another class's cache entries mid-test, causing intermittent failures.
+/// </summary>
+[CollectionDefinition("EventPropertyValuesCache")]
+public sealed class EventPropertyValuesCacheCollection;

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventPropertyValuesCacheTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventPropertyValuesCacheTests.cs
@@ -7,6 +7,7 @@ using EventLogExpert.Filtering.Tests.TestUtils.Constants;
 
 namespace EventLogExpert.Filtering.Tests.EventData;
 
+[Collection("EventPropertyValuesCache")]
 public sealed class EventPropertyValuesCacheTests : IDisposable
 {
     public EventPropertyValuesCacheTests() => EventPropertyValuesCache.Clear();

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventLogExpert.Filtering.Tests.csproj
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventLogExpert.Filtering.Tests.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Shared\EventLogExpert.Filtering.TestUtils\EventLogExpert.Filtering.TestUtils.csproj" />
+    <ProjectReference Include="..\..\Shared\EventLogExpert.Eventing.TestUtils\EventLogExpert.Eventing.TestUtils.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Unit/EventLogExpert.Filtering.Tests/Lowering/PropertyResolverSchemaTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/Lowering/PropertyResolverSchemaTests.cs
@@ -17,7 +17,8 @@ public sealed class PropertyResolverSchemaTests
     [
         "OwningLog", // Internal: identifies the log file/live channel; not user-visible filter target.
         "LogPathType", // Enum discriminator paired with OwningLog; not a user-facing filter target.
-        "KeywordsDisplayName" // Computed convenience accessor; users filter via Keywords directly.
+        "KeywordsDisplayName", // Computed convenience accessor; users filter via Keywords directly.
+        "EventData" // Structured field accessor; named-field filtering arrives with the filter DSL, not as a scalar column.
     ];
 
     [Fact]


### PR DESCRIPTION
## Summary

Structured `<EventData>` named fields are now retained on `ResolvedEvent` and exposed through a new public `EventData` view, instead of being parsed for the description and then dropped.

## What's included

- `ResolvedEvent.EventData` returns a lightweight `EventDataView` (readonly struct): named access via `TryGetValue`, positional `TryGetName`, and allocation-free enumeration of `(name, value)` pairs.
- `EventFieldValue` (public, no-boxing) projects each rendered value with a typed `Kind` and typed getters (`TryGetInt64`/`UInt64`/`Double`/`Single`/`Boolean`/`DateTime`/`Guid`, `AsString`); byte/integer/string arrays render via `AsString` only (no mutable array is exposed).
- Field names are retained per template in a shared `TemplateFieldSchema`. A single fail-closed length-match selector chooses the name ordering and is shared with `DescriptionFormatter`, so labeling and description formatting cannot diverge; a value/name count mismatch surfaces as `Kind = None` (values remain available positionally) rather than mislabeling fields.

## Memory / performance

- Rendered values were already produced for every event (to format the description); this stops dropping them. No new native render and no per-event array copy - the reader returns `ImmutableArray<EventProperty>` via a zero-copy wrap.
- Per-event footprint is two references on `ResolvedEvent` (~16 B); legacy / template-less events retain nothing. Reads are allocation-free and non-boxing.
- Measured retention on real logs is 2-3x smaller than the raw event XML.

## Tests

- New unit coverage: value projection across all rendered kinds (including `float`), the fail-closed selector, schema name/index lookup (with concurrency and name/out-type length parity), the view (including empty/legacy enumeration), end-to-end resolution, plus layout and zero-allocation assertions.
- Full unit suite and the Eventing integration parity suite (real `.evtx`) pass.

Draft, stacked on the integration branch.
