### PR TITLE
Add EventData named-field filtering with typed value equality

### DIFF
--- a/src/EventLogExpert.Filtering/Basic/BasicFilterDecomposer.cs
+++ b/src/EventLogExpert.Filtering/Basic/BasicFilterDecomposer.cs
@@ -198,6 +198,79 @@ internal static class BasicFilterDecomposer
         return true;
     }
 
+    private static bool TryMapEventDataComparison(
+        EventDataComparisonNode node,
+        [NotNullWhen(true)] out FilterComparison? comparison)
+    {
+        comparison = null;
+
+        if (string.IsNullOrWhiteSpace(node.FieldName) || string.IsNullOrWhiteSpace(node.Literal.Raw))
+        {
+            return false;
+        }
+
+        comparison = new FilterComparison
+        {
+            Property = EventProperty.EventData,
+            EventDataFieldName = node.FieldName,
+            Operator = node.Op == FilterBinaryOperator.Equal
+                ? ComparisonOperator.Equals
+                : ComparisonOperator.NotEqual,
+            MatchMode = MatchMode.Single,
+            Value = node.Literal.Raw
+        };
+
+        return true;
+    }
+
+    private static bool TryMapEventDataContains(
+        EventDataContainsNode node,
+        [NotNullWhen(true)] out FilterComparison? comparison)
+    {
+        comparison = null;
+
+        // Mirror the ContainsNode guard: a case-sensitive Advanced contains is not Basic vocabulary (Basic is always
+        // OrdinalIgnoreCase), so leave it Advanced-only rather than re-encode it as an OIC Basic row.
+        if (!node.IgnoreCase || string.IsNullOrWhiteSpace(node.FieldName) || string.IsNullOrWhiteSpace(node.Needle))
+        {
+            return false;
+        }
+
+        comparison = new FilterComparison
+        {
+            Property = EventProperty.EventData,
+            EventDataFieldName = node.FieldName,
+            Operator = node.Negated ? ComparisonOperator.NotContains : ComparisonOperator.Contains,
+            MatchMode = MatchMode.Single,
+            Value = node.Needle
+        };
+
+        return true;
+    }
+
+    private static bool TryMapEventDataMultiEquals(
+        EventDataMultiEqualsNode node,
+        [NotNullWhen(true)] out FilterComparison? comparison)
+    {
+        comparison = null;
+
+        if (node.Literals.Count == 0 || string.IsNullOrWhiteSpace(node.FieldName))
+        {
+            return false;
+        }
+
+        comparison = new FilterComparison
+        {
+            Property = EventProperty.EventData,
+            EventDataFieldName = node.FieldName,
+            Operator = ComparisonOperator.Equals,
+            MatchMode = MatchMode.Many,
+            Values = [.. node.Literals.Select(literal => literal.Raw)]
+        };
+
+        return true;
+    }
+
     private static bool TryMapField(ResolvedEventField field, out EventProperty property)
     {
         switch (field)
@@ -317,6 +390,15 @@ internal static class BasicFilterDecomposer
                 };
 
                 return true;
+
+            case EventDataComparisonNode eventDataComparison:
+                return TryMapEventDataComparison(eventDataComparison, out comparison);
+
+            case EventDataContainsNode eventDataContains:
+                return TryMapEventDataContains(eventDataContains, out comparison);
+
+            case EventDataMultiEqualsNode eventDataMulti:
+                return TryMapEventDataMultiEquals(eventDataMulti, out comparison);
 
             case NotNode not:
                 return TryMapNegatedLeaf(not, out comparison);

--- a/src/EventLogExpert.Filtering/Basic/BasicFilterFormatter.cs
+++ b/src/EventLogExpert.Filtering/Basic/BasicFilterFormatter.cs
@@ -59,13 +59,21 @@ public static class BasicFilterFormatter
             return false;
         }
 
+        if (comparison.Property is EventProperty.EventData && string.IsNullOrWhiteSpace(comparison.EventDataFieldName))
+        {
+            return false;
+        }
+
+        var propertyExpression = FormatPropertyExpression(comparison);
+
         StringBuilder stringBuilder = new(joinPrefix ?? string.Empty);
 
         // The Many+non-Keywords shape is `(new[]{...}).Contains(property)` — the property-reference template
         // moves to the suffix. Everything else prepends the operator+property template.
         if (comparison.MatchMode != MatchMode.Many || comparison.Property is EventProperty.Keywords)
         {
-            stringBuilder.Append(GetComparisonString(comparison.Property, comparison.Operator, comparison.MatchMode));
+            stringBuilder.Append(
+                GetComparisonString(comparison.Property, propertyExpression, comparison.Operator, comparison.MatchMode));
         }
 
         if (comparison.MatchMode == MatchMode.Many)
@@ -79,7 +87,8 @@ public static class BasicFilterFormatter
 
         if (comparison is { MatchMode: MatchMode.Many, Property: not EventProperty.Keywords })
         {
-            stringBuilder.Append(GetComparisonString(comparison.Property, comparison.Operator, comparison.MatchMode));
+            stringBuilder.Append(
+                GetComparisonString(comparison.Property, propertyExpression, comparison.Operator, comparison.MatchMode));
         }
 
         formatted = stringBuilder.ToString();
@@ -162,7 +171,18 @@ public static class BasicFilterFormatter
         return builder.ToString();
     }
 
-    private static string GetComparisonString(EventProperty property, ComparisonOperator op, MatchMode matchMode)
+    // The Advanced-text reference for a comparison's property: `EventData["escaped field name"]` for an EventData
+    // row, otherwise the bare property name (which the tokenizer reads as an identifier).
+    private static string FormatPropertyExpression(FilterComparison comparison) =>
+        comparison.Property is EventProperty.EventData
+            ? $"EventData[\"{EscapeStringLiteral(comparison.EventDataFieldName)}\"]"
+            : comparison.Property.ToString();
+
+    private static string GetComparisonString(
+        EventProperty property,
+        string propertyExpression,
+        ComparisonOperator op,
+        MatchMode matchMode)
     {
         if (matchMode == MatchMode.Many)
         {
@@ -171,7 +191,7 @@ public static class BasicFilterFormatter
             return property switch
             {
                 EventProperty.Keywords => $"{property}.Any",
-                _ => $"{property})"
+                _ => $"{propertyExpression})"
             };
         }
 
@@ -181,25 +201,25 @@ public static class BasicFilterFormatter
             {
                 EventProperty.Keywords => $"{property}.Any(e => string.Equals(e, ",
                 EventProperty.UserId => $"{property} != null && {property}.Value == ",
-                _ => $"{property} == "
+                _ => $"{propertyExpression} == "
             },
             ComparisonOperator.Contains => property switch
             {
                 EventProperty.Keywords => $"{property}.Any(e => e.Contains",
                 EventProperty.UserId => $"{property} != null && {property}.Value.Contains",
-                _ => $"{property}.Contains"
+                _ => $"{propertyExpression}.Contains"
             },
             ComparisonOperator.NotEqual => property switch
             {
                 EventProperty.Keywords => $"!{property}.Any(e => string.Equals(e, ",
                 EventProperty.UserId => $"{property} != null && {property}.Value != ",
-                _ => $"{property} != "
+                _ => $"{propertyExpression} != "
             },
             ComparisonOperator.NotContains => property switch
             {
                 EventProperty.Keywords => $"!{property}.Any(e => e.Contains",
                 EventProperty.UserId => $"{property} != null && !{property}.Value.Contains",
-                _ => $"!{property}.Contains"
+                _ => $"!{propertyExpression}.Contains"
             },
             _ => string.Empty
         };

--- a/src/EventLogExpert.Filtering/Basic/FilterComparison.cs
+++ b/src/EventLogExpert.Filtering/Basic/FilterComparison.cs
@@ -22,9 +22,15 @@ public sealed record FilterComparison
     public ImmutableList<string> Values { get; init; } = [];
 
     /// <summary>
-    ///     Returns a copy with the new <paramref name="property" /> and Value/Values cleared, since the available value
-    ///     space changes when the property changes.
+    ///     The named &lt;EventData&gt; field this row targets. Meaningful only when <see cref="Property" /> is
+    ///     <see cref="EventProperty.EventData" /> (null for every other property).
+    /// </summary>
+    public string? EventDataFieldName { get; init; }
+
+    /// <summary>
+    ///     Returns a copy with the new <paramref name="property" /> and Value/Values/EventDataFieldName cleared, since
+    ///     the available value space (and whether a field name applies) changes when the property changes.
     /// </summary>
     public FilterComparison WithProperty(EventProperty property) =>
-        this with { Property = property, Value = null, Values = [] };
+        this with { Property = property, Value = null, Values = [], EventDataFieldName = null };
 }

--- a/src/EventLogExpert.Filtering/Basic/FilterComparisonJsonConverter.cs
+++ b/src/EventLogExpert.Filtering/Basic/FilterComparisonJsonConverter.cs
@@ -86,7 +86,9 @@ internal sealed class FilterComparisonJsonConverter : JsonConverter<FilterCompar
             MatchMode = matchMode,
             Value = value,
             Values = values,
-            EventDataFieldName = property is EventProperty.EventData ? eventDataFieldName : null
+            EventDataFieldName = property is EventProperty.EventData && !string.IsNullOrWhiteSpace(eventDataFieldName)
+                ? eventDataFieldName
+                : null
         };
     }
 

--- a/src/EventLogExpert.Filtering/Basic/FilterComparisonJsonConverter.cs
+++ b/src/EventLogExpert.Filtering/Basic/FilterComparisonJsonConverter.cs
@@ -86,7 +86,7 @@ internal sealed class FilterComparisonJsonConverter : JsonConverter<FilterCompar
             MatchMode = matchMode,
             Value = value,
             Values = values,
-            EventDataFieldName = eventDataFieldName
+            EventDataFieldName = property is EventProperty.EventData ? eventDataFieldName : null
         };
     }
 
@@ -109,7 +109,7 @@ internal sealed class FilterComparisonJsonConverter : JsonConverter<FilterCompar
 
         writer.WriteEndArray();
 
-        if (value.EventDataFieldName is not null)
+        if (value.Property is EventProperty.EventData && !string.IsNullOrWhiteSpace(value.EventDataFieldName))
         {
             writer.WriteString("EventDataFieldName", value.EventDataFieldName);
         }

--- a/src/EventLogExpert.Filtering/Basic/FilterComparisonJsonConverter.cs
+++ b/src/EventLogExpert.Filtering/Basic/FilterComparisonJsonConverter.cs
@@ -23,6 +23,7 @@ internal sealed class FilterComparisonJsonConverter : JsonConverter<FilterCompar
         bool operatorSet = false;
         bool matchModeSet = false;
         string? value = null;
+        string? eventDataFieldName = null;
         ImmutableList<string> values = [];
 
         while (reader.Read())
@@ -66,6 +67,9 @@ internal sealed class FilterComparisonJsonConverter : JsonConverter<FilterCompar
                 case "Value":
                     value = reader.TokenType == JsonTokenType.Null ? null : reader.GetString();
                     break;
+                case "EventDataFieldName":
+                    eventDataFieldName = reader.TokenType == JsonTokenType.Null ? null : reader.GetString();
+                    break;
                 case "Values":
                     values = ReadStringList(ref reader);
                     break;
@@ -81,7 +85,8 @@ internal sealed class FilterComparisonJsonConverter : JsonConverter<FilterCompar
             Operator = op,
             MatchMode = matchMode,
             Value = value,
-            Values = values
+            Values = values,
+            EventDataFieldName = eventDataFieldName
         };
     }
 
@@ -103,6 +108,12 @@ internal sealed class FilterComparisonJsonConverter : JsonConverter<FilterCompar
         foreach (var item in value.Values) { writer.WriteStringValue(item); }
 
         writer.WriteEndArray();
+
+        if (value.EventDataFieldName is not null)
+        {
+            writer.WriteString("EventDataFieldName", value.EventDataFieldName);
+        }
+
         writer.WriteEndObject();
     }
 

--- a/src/EventLogExpert.Filtering/Common/Filtering/EventProperty.cs
+++ b/src/EventLogExpert.Filtering/Common/Filtering/EventProperty.cs
@@ -18,5 +18,6 @@ public enum EventProperty
     [EnumMember(Value = "User ID")] UserId,
     Description,
     Xml,
-    [EnumMember(Value = "Log Name")] LogName
+    [EnumMember(Value = "Log Name")] LogName,
+    [EnumMember(Value = "Event Data")] EventData
 }

--- a/src/EventLogExpert.Filtering/Drafts/FilterComparisonDraft.cs
+++ b/src/EventLogExpert.Filtering/Drafts/FilterComparisonDraft.cs
@@ -18,6 +18,9 @@ public sealed class FilterComparisonDraft
 
     public List<string> Values { get; set; } = [];
 
+    /// <summary>The named EventData field this row targets; meaningful only when <see cref="Property" /> is EventData.</summary>
+    public string? EventDataFieldName { get; set; }
+
     public static FilterComparisonDraft FromComparison(FilterComparison comparison) =>
         new()
         {
@@ -25,7 +28,8 @@ public sealed class FilterComparisonDraft
             Operator = comparison.Operator,
             MatchMode = comparison.MatchMode,
             Value = comparison.Value,
-            Values = [.. comparison.Values]
+            Values = [.. comparison.Values],
+            EventDataFieldName = comparison.EventDataFieldName
         };
 
     public void ChangeProperty(EventProperty property)
@@ -33,6 +37,7 @@ public sealed class FilterComparisonDraft
         Property = property;
         Value = null;
         Values.Clear();
+        EventDataFieldName = null;
     }
 
     public FilterComparison ToComparison() =>
@@ -42,6 +47,7 @@ public sealed class FilterComparisonDraft
             Operator = Operator,
             MatchMode = MatchMode,
             Value = Value,
-            Values = [.. Values]
+            Values = [.. Values],
+            EventDataFieldName = EventDataFieldName
         };
 }

--- a/src/EventLogExpert.Filtering/Drafts/FilterPredicateDraft.cs
+++ b/src/EventLogExpert.Filtering/Drafts/FilterPredicateDraft.cs
@@ -18,13 +18,28 @@ public sealed class FilterPredicateDraft
     ///     <list type="bullet">
     ///         <item><c>Single</c> match mode requires a non-whitespace <see cref="FilterComparisonDraft.Value" />.</item>
     ///         <item><c>Many</c> match mode requires at least one entry in <see cref="FilterComparisonDraft.Values" />.</item>
+    ///         <item>
+    ///             An <see cref="EventProperty.EventData" /> row additionally requires a non-whitespace
+    ///             <see cref="FilterComparisonDraft.EventDataFieldName" />.
+    ///         </item>
     ///     </list>
     ///     Mirrors the formatter's strict-mode validation so the in-flight UI state matches the eventual save guard.
     /// </summary>
-    public bool IsComplete =>
-        Comparison.MatchMode == MatchMode.Many
-            ? Comparison.Values.Count > 0
-            : !string.IsNullOrWhiteSpace(Comparison.Value);
+    public bool IsComplete
+    {
+        get
+        {
+            if (Comparison.Property is EventProperty.EventData
+                && string.IsNullOrWhiteSpace(Comparison.EventDataFieldName))
+            {
+                return false;
+            }
+
+            return Comparison.MatchMode == MatchMode.Many
+                ? Comparison.Values.Count > 0
+                : !string.IsNullOrWhiteSpace(Comparison.Value);
+        }
+    }
 
     public bool JoinWithAny { get; set; }
 

--- a/src/EventLogExpert.Filtering/Emit/Emitter.cs
+++ b/src/EventLogExpert.Filtering/Emit/Emitter.cs
@@ -177,6 +177,53 @@ internal static class Emitter
             _ => throw new EmitException($"Operator '{op}' is not supported on string properties.")
         };
 
+    private static Func<ResolvedEvent, bool> EmitEventDataComparison(EventDataComparisonNode node)
+    {
+        var name = node.FieldName;
+        var literal = node.Literal;
+
+        if (node.Op == FilterBinaryOperator.Equal)
+        {
+            return e => e.EventData.TryGetValue(name, out var value) && literal.MatchesValue(value);
+        }
+
+        return e => e.EventData.TryGetValue(name, out var value) && !literal.MatchesValue(value);
+    }
+
+    private static Func<ResolvedEvent, bool> EmitEventDataContains(EventDataContainsNode node)
+    {
+        var name = node.FieldName;
+        var needle = node.Needle;
+        var comparison = node.IgnoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+        if (node.Negated)
+        {
+            return e => e.EventData.TryGetValue(name, out var value)
+                && !value.AsString().Contains(needle, comparison);
+        }
+
+        return e => e.EventData.TryGetValue(name, out var value)
+            && value.AsString().Contains(needle, comparison);
+    }
+
+    private static Func<ResolvedEvent, bool> EmitEventDataMultiEquals(EventDataMultiEqualsNode node)
+    {
+        var name = node.FieldName;
+        var literals = node.Literals;
+
+        return e =>
+        {
+            if (!e.EventData.TryGetValue(name, out var value)) { return false; }
+
+            for (var i = 0; i < literals.Count; i++)
+            {
+                if (literals[i].MatchesValue(value)) { return true; }
+            }
+
+            return false;
+        };
+    }
+
     private static Func<ResolvedEvent, bool> EmitIntComparison(
         Func<ResolvedEvent, int> getter,
         FilterBinaryOperator op,
@@ -408,6 +455,9 @@ internal static class Emitter
             NotNode not => EmitNot(not),
             ComparisonNode cmp => EmitComparison(cmp),
             ContainsNode cn => EmitContains(cn),
+            EventDataComparisonNode edCmp => EmitEventDataComparison(edCmp),
+            EventDataContainsNode edContains => EmitEventDataContains(edContains),
+            EventDataMultiEqualsNode edMulti => EmitEventDataMultiEquals(edMulti),
             KeywordsAnyEqualsNode kn => EmitKeywordsAnyEquals(kn),
             KeywordsAnyContainsNode kn => EmitKeywordsAnyContains(kn),
             KeywordsMatchAnyOfNode kn => EmitKeywordsMatchAnyOf(kn),

--- a/src/EventLogExpert.Filtering/EventData/EventLogDataQueryExtensions.cs
+++ b/src/EventLogExpert.Filtering/EventData/EventLogDataQueryExtensions.cs
@@ -9,20 +9,55 @@ namespace EventLogExpert.Filtering.EventData;
 
 internal static class EventLogDataQueryExtensions
 {
-    /// <summary>
-    ///     Gets a distinct list of values for the specified <paramref name="property" /> across
-    ///     <paramref name="events" />.
-    /// </summary>
-    public static IEnumerable<string> GetEventValues(this IEnumerable<ResolvedEvent> events, EventProperty property) =>
-        property switch
+    extension(IEnumerable<ResolvedEvent> events)
+    {
+        /// <summary>
+        ///     Gets the distinct set of &lt;EventData&gt; field names present across <paramref name="events" /> (used to
+        ///     populate the Basic editor's field-name picker). Names are compared Ordinal, matching the schema lookup.
+        /// </summary>
+        public IEnumerable<string> GetEventDataFieldNames()
         {
-            EventProperty.Id => events.Select(e => e.Id.ToString(CultureInfo.InvariantCulture)).Distinct(),
-            EventProperty.ActivityId => events.Select(e => e.ActivityId?.ToString() ?? string.Empty).Distinct(),
-            EventProperty.Level => Enum.GetNames<SeverityLevel>(),
-            EventProperty.Keywords => events.SelectMany(e => e.Keywords).Distinct(),
-            EventProperty.Source => events.Select(e => e.Source).Distinct(),
-            EventProperty.TaskCategory => events.Select(e => e.TaskCategory).Distinct(),
-            EventProperty.LogName => events.Select(e => e.LogName).Distinct(),
-            _ => [],
-        };
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var resolvedEvent in events)
+            {
+                foreach (var field in resolvedEvent.EventData)
+                {
+                    if (seen.Add(field.Name)) { yield return field.Name; }
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Gets the values of the named EventData <paramref name="fieldName" /> across every event that has it (as
+        ///     rendered by <see cref="EventFieldValue.AsString" />); the caller de-duplicates and sorts.
+        /// </summary>
+        public IEnumerable<string> GetEventDataFieldValues(string fieldName)
+        {
+            foreach (var resolvedEvent in events)
+            {
+                if (resolvedEvent.EventData.TryGetValue(fieldName, out var value))
+                {
+                    yield return value.AsString();
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Gets a distinct list of values for the specified <paramref name="property" /> across
+        ///     <paramref name="events" />.
+        /// </summary>
+        public IEnumerable<string> GetEventValues(EventProperty property) =>
+            property switch
+            {
+                EventProperty.Id => events.Select(e => e.Id.ToString(CultureInfo.InvariantCulture)).Distinct(),
+                EventProperty.ActivityId => events.Select(e => e.ActivityId?.ToString() ?? string.Empty).Distinct(),
+                EventProperty.Level => Enum.GetNames<SeverityLevel>(),
+                EventProperty.Keywords => events.SelectMany(e => e.Keywords).Distinct(),
+                EventProperty.Source => events.Select(e => e.Source).Distinct(),
+                EventProperty.TaskCategory => events.Select(e => e.TaskCategory).Distinct(),
+                EventProperty.LogName => events.Select(e => e.LogName).Distinct(),
+                _ => [],
+            };
+    }
 }

--- a/src/EventLogExpert.Filtering/EventData/EventPropertyValuesCache.cs
+++ b/src/EventLogExpert.Filtering/EventData/EventPropertyValuesCache.cs
@@ -19,7 +19,55 @@ public static class EventPropertyValuesCache
     private static readonly ConditionalWeakTable<
         object,
         ConcurrentDictionary<EventProperty, Lazy<ImmutableArray<string>>>> s_cache = new();
+    private static readonly ConditionalWeakTable<object, Lazy<ImmutableArray<string>>> s_fieldNameCache = new();
+    private static readonly ConditionalWeakTable<
+        object,
+        ConcurrentDictionary<string, Lazy<ImmutableArray<string>>>> s_fieldValueCache = new();
     private static readonly ImmutableArray<string> s_levelValues = [.. Enum.GetNames<SeverityLevel>()];
+
+    /// <summary>
+    ///     Returns the distinct, sorted &lt;EventData&gt; field names across <paramref name="events" />, cached per
+    ///     snapshot <paramref name="cacheKey" /> (auto-evicted when the snapshot changes).
+    /// </summary>
+    public static ImmutableArray<string> GetEventDataFieldNames(object cacheKey, IEnumerable<ResolvedEvent> events) =>
+        s_fieldNameCache
+            .GetValue(cacheKey, _ => new Lazy<ImmutableArray<string>>(() => [.. events.GetEventDataFieldNames().Order()]))
+            .Value;
+
+    /// <summary>
+    ///     Returns the distinct, sorted values of the named EventData <paramref name="fieldName" /> across
+    ///     <paramref name="events" />, cached per <c>(snapshot, fieldName)</c> so each field keeps its own value list.
+    /// </summary>
+    public static ImmutableArray<string> GetEventDataFieldValues(
+        object cacheKey,
+        IEnumerable<ResolvedEvent> events,
+        string? fieldName)
+    {
+        if (string.IsNullOrEmpty(fieldName))
+        {
+            return [];
+        }
+
+        // Only enumerate/cache values for field names that actually exist in the snapshot. The Basic editor's
+        // field-name picker is editable, so without this an arbitrary or partial typed name would add a cache entry
+        // and a full log scan per keystroke (R7). The field-name list is itself cached per snapshot, so the
+        // membership check is cheap and does not re-scan.
+        if (!GetEventDataFieldNames(cacheKey, events).Contains(fieldName, StringComparer.Ordinal))
+        {
+            return [];
+        }
+
+        var perSnapshot = s_fieldValueCache.GetValue(
+            cacheKey,
+            static _ => new ConcurrentDictionary<string, Lazy<ImmutableArray<string>>>(StringComparer.Ordinal));
+
+        return perSnapshot
+            .GetOrAdd(
+                fieldName,
+                name => new Lazy<ImmutableArray<string>>(
+                    () => [.. events.GetEventDataFieldValues(name).Distinct().Order()]))
+            .Value;
+    }
 
     public static ImmutableArray<string> GetValues(
         object cacheKey,
@@ -46,7 +94,12 @@ public static class EventPropertyValuesCache
     }
 
     /// <summary>Test-only hook to clear the snapshot cache between scenarios.</summary>
-    internal static void Clear() => s_cache.Clear();
+    internal static void Clear()
+    {
+        s_cache.Clear();
+        s_fieldNameCache.Clear();
+        s_fieldValueCache.Clear();
+    }
 
     private static ImmutableArray<string> Compute(
         IEnumerable<ResolvedEvent> events,

--- a/src/EventLogExpert.Filtering/EventData/EventPropertyValuesCache.cs
+++ b/src/EventLogExpert.Filtering/EventData/EventPropertyValuesCache.cs
@@ -31,7 +31,10 @@ public static class EventPropertyValuesCache
     /// </summary>
     public static ImmutableArray<string> GetEventDataFieldNames(object cacheKey, IEnumerable<ResolvedEvent> events) =>
         s_fieldNameCache
-            .GetValue(cacheKey, _ => new Lazy<ImmutableArray<string>>(() => [.. events.GetEventDataFieldNames().Order()]))
+            .GetValue(
+                cacheKey,
+                _ => new Lazy<ImmutableArray<string>>(
+                    () => [.. events.GetEventDataFieldNames().Order(StringComparer.Ordinal)]))
             .Value;
 
     /// <summary>
@@ -65,7 +68,7 @@ public static class EventPropertyValuesCache
             .GetOrAdd(
                 fieldName,
                 name => new Lazy<ImmutableArray<string>>(
-                    () => [.. events.GetEventDataFieldValues(name).Distinct().Order()]))
+                    () => [.. events.GetEventDataFieldValues(name).Distinct().Order(StringComparer.Ordinal)]))
             .Value;
     }
 

--- a/src/EventLogExpert.Filtering/Lowering/EventDataLiteral.cs
+++ b/src/EventLogExpert.Filtering/Lowering/EventDataLiteral.cs
@@ -1,0 +1,88 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+using System.Globalization;
+
+namespace EventLogExpert.Filtering.Lowering;
+
+/// <summary>
+///     A filter comparison operand pre-parsed once at lower-time into a candidate value for every scalar
+///     <see cref="EventFieldValueKind" />, so the per-event hot path does no parsing and no allocation for packed-scalar /
+///     <see cref="Guid" /> / <see cref="EventFieldValueKind.String" /> field kinds. Implements the
+///     <em>typed value equality</em> model: a numeric / bool / date / Guid field is matched by its parsed value (so
+///     <c>"5"</c> and <c>"05"</c> both match a numeric <c>5</c>, and a Guid matches in any parseable format), while
+///     reference/blob kinds (<see cref="EventFieldValueKind.Sid" />, <see cref="EventFieldValueKind.Bytes" />, the array
+///     kinds, and <see cref="EventFieldValueKind.Null" />) fall back to an ordinal compare against
+///     <see cref="EventFieldValue.AsString" />.
+/// </summary>
+internal sealed class EventDataLiteral
+{
+    private readonly bool? _boolean;
+    private readonly DateTime? _dateTime;
+    private readonly double? _double;
+    private readonly Guid? _guid;
+    private readonly long? _int64;
+    private readonly string _raw;
+    private readonly float? _single;
+    private readonly ulong? _uint64;
+
+    private EventDataLiteral(
+        string raw,
+        long? int64,
+        ulong? uint64,
+        double? doubleValue,
+        float? single,
+        bool? boolean,
+        DateTime? dateTime,
+        Guid? guid)
+    {
+        _raw = raw;
+        _int64 = int64;
+        _uint64 = uint64;
+        _double = doubleValue;
+        _single = single;
+        _boolean = boolean;
+        _dateTime = dateTime;
+        _guid = guid;
+    }
+
+    /// <summary>The original literal text, used by the decomposer to round-trip back to a Basic value.</summary>
+    public string Raw => _raw;
+
+    /// <summary>Parses the raw literal into one candidate per scalar kind (each null when the literal is not that kind).</summary>
+    public static EventDataLiteral Parse(string raw)
+    {
+        long? int64 = long.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var i) ? i : null;
+        ulong? uint64 = ulong.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var u) ? u : null;
+        double? doubleValue =
+            double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var d) ? d : null;
+        float? single = float.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var f) ? f : null;
+        bool? boolean = bool.TryParse(raw, out var b) ? b : null;
+        DateTime? dateTime =
+            DateTime.TryParse(raw, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var dt) ? dt : null;
+        Guid? guid = Guid.TryParse(raw, out var g) ? g : null;
+
+        return new EventDataLiteral(raw, int64, uint64, doubleValue, single, boolean, dateTime, guid);
+    }
+
+    /// <summary>
+    ///     Typed value equality against <paramref name="value" />. Zero-allocation for the packed-scalar kinds,
+    ///     <see cref="Guid" />, and <see cref="EventFieldValueKind.String" />; the reference/blob and
+    ///     <see cref="EventFieldValueKind.Null" /> kinds compare against <see cref="EventFieldValue.AsString" />.
+    /// </summary>
+    public bool MatchesValue(in EventFieldValue value) =>
+        value.Kind switch
+        {
+            EventFieldValueKind.Int64 => _int64 is { } c && value.TryGetInt64(out var a) && a == c,
+            EventFieldValueKind.UInt64 => _uint64 is { } c && value.TryGetUInt64(out var a) && a == c,
+            // double.Equals / float.Equals treat NaN as equal to NaN (matching AsString "NaN"), unlike ==.
+            EventFieldValueKind.Double => _double is { } c && value.TryGetDouble(out var a) && a.Equals(c),
+            EventFieldValueKind.Single => _single is { } c && value.TryGetSingle(out var a) && a.Equals(c),
+            EventFieldValueKind.Boolean => _boolean is { } c && value.TryGetBoolean(out var a) && a == c,
+            EventFieldValueKind.DateTime => _dateTime is { } c && value.TryGetDateTime(out var a) && a == c,
+            EventFieldValueKind.Guid => _guid is { } c && value.TryGetGuid(out var a) && a == c,
+            EventFieldValueKind.String => string.Equals(value.AsString(), _raw, StringComparison.Ordinal),
+            _ => string.Equals(value.AsString(), _raw, StringComparison.Ordinal)
+        };
+}

--- a/src/EventLogExpert.Filtering/Lowering/EventDataLiteral.cs
+++ b/src/EventLogExpert.Filtering/Lowering/EventDataLiteral.cs
@@ -59,8 +59,12 @@ internal sealed class EventDataLiteral
             double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var d) ? d : null;
         float? single = float.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var f) ? f : null;
         bool? boolean = bool.TryParse(raw, out var b) ? b : null;
+        // Strictly the inverse of EventFieldValue.AsString's ToString("O"): only the canonical round-trip form
+        // matches (picklist values are already "O"), not lenient/ambiguous date formats.
         DateTime? dateTime =
-            DateTime.TryParse(raw, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var dt) ? dt : null;
+            DateTime.TryParseExact(raw, "O", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var dt)
+                ? dt
+                : null;
         Guid? guid = Guid.TryParse(raw, out var g) ? g : null;
 
         return new EventDataLiteral(raw, int64, uint64, doubleValue, single, boolean, dateTime, guid);

--- a/src/EventLogExpert.Filtering/Lowering/Lowerer.cs
+++ b/src/EventLogExpert.Filtering/Lowering/Lowerer.cs
@@ -88,6 +88,16 @@ internal static class Lowerer
         }
     }
 
+    private static bool ContainsEventDataNode(SemanticNode node) =>
+        node switch
+        {
+            EventDataComparisonNode or EventDataContainsNode or EventDataMultiEqualsNode => true,
+            AndNode and => ContainsEventDataNode(and.Left) || ContainsEventDataNode(and.Right),
+            OrNode or => ContainsEventDataNode(or.Left) || ContainsEventDataNode(or.Right),
+            NotNode not => ContainsEventDataNode(not.Operand),
+            _ => false
+        };
+
     private static IReadOnlyList<string> ExtractStringArray(ArrayCreationSyntax array, int position)
     {
         if (array.Elements.Count == 0)
@@ -123,6 +133,15 @@ internal static class Lowerer
             acc.Add(node);
         }
     }
+
+    private static string GetEventDataLiteralText(LiteralSyntax literal) =>
+        literal.Kind switch
+        {
+            LiteralKind.String => literal.Text,
+            LiteralKind.Int => literal.Text,
+            _ => throw new LowerException(
+                $"EventData comparison value must be a string or integer literal (position {literal.Position}).")
+        };
 
     private static bool IsCaseInsensitiveMatch(string left, string right) =>
         string.Equals(left, right, StringComparison.OrdinalIgnoreCase);
@@ -179,7 +198,7 @@ internal static class Lowerer
             case BinarySyntax bin when IsComparisonOp(bin.Op):
                 return LowerComparison(bin);
             case UnarySyntax { Op: TokenKind.Bang } neg:
-                return new NotNode(Lower(neg.Operand));
+                return LowerNegation(neg);
             case MethodCallSyntax call:
                 return LowerMethodCall(call);
             case BinarySyntax bin:
@@ -234,6 +253,11 @@ internal static class Lowerer
 
     private static SemanticNode LowerComparison(BinarySyntax bin)
     {
+        if (TryResolveEventDataField(bin.Left, out var eventDataFieldName))
+        {
+            return LowerEventDataComparison(eventDataFieldName, bin);
+        }
+
         // Property <op> Literal  -or-  Property.ToString() <op> Literal (formatter shape, normalized away)
         var (field, fieldExpression) = ResolveFieldOrToString(bin.Left, bin.Position);
 
@@ -247,6 +271,25 @@ internal static class Lowerer
         var typed = CoerceLiteral(literal, literalKind);
 
         return new ComparisonNode(field, MapBinaryOp(bin.Op), typed);
+    }
+
+    private static SemanticNode LowerEventDataComparison(string fieldName, BinarySyntax bin)
+    {
+        if (bin.Op is not (TokenKind.EqEq or TokenKind.NotEq))
+        {
+            throw new LowerException(
+                $"Operator '{bin.Op}' is not supported on EventData fields; use '==' or '!=' (position {bin.Position}).");
+        }
+
+        if (bin.Right is not LiteralSyntax literal)
+        {
+            throw new LowerException(
+                $"Right-hand side of an EventData comparison must be a literal (position {bin.Right.Position}).");
+        }
+
+        var op = bin.Op == TokenKind.EqEq ? FilterBinaryOperator.Equal : FilterBinaryOperator.NotEqual;
+
+        return new EventDataComparisonNode(fieldName, op, EventDataLiteral.Parse(GetEventDataLiteralText(literal)));
     }
 
     private static SemanticNode LowerKeywordsAnyLambda(LambdaSyntax lambda)
@@ -299,9 +342,27 @@ internal static class Lowerer
             && call is { Target: ArrayCreationSyntax array, Arguments.Count: 1 })
         {
             var elements = ExtractStringArray(array, call.Position);
+
+            // EventData any-of must be recognized before ResolveFieldOrToString, which rejects an IndexAccess argument.
+            if (TryResolveEventDataField(call.Arguments[0], out var eventDataAnyOfName))
+            {
+                return new EventDataMultiEqualsNode(
+                    eventDataAnyOfName,
+                    [.. elements.Select(EventDataLiteral.Parse)]);
+            }
+
             var argField = ResolveFieldOrToString(call.Arguments[0], call.Arguments[0].Position).Field;
 
             return new MultiEqualsNode(argField, elements);
+        }
+
+        // EventData["Name"].Contains(needle, OIC)
+        if (IsCaseInsensitiveMatch(call.Name, "Contains")
+            && TryResolveEventDataField(call.Target, out var eventDataContainsName))
+        {
+            var (needle, ignoreCase) = ParseContainsArgs(call.Arguments, call.Position);
+
+            return new EventDataContainsNode(eventDataContainsName, needle, ignoreCase, negated: false);
         }
 
         // P.Contains(needle, StringComparison.OrdinalIgnoreCase) for any Contains-supported field. Denylist
@@ -345,6 +406,41 @@ internal static class Lowerer
 
         throw new LowerException(
             $"Unsupported method call '{call.Name}' (position {call.Position}).");
+    }
+
+    // Normalizes `!` over EventData so a NotNode never wraps an EventData node (presence-required must hold at any
+    // depth): comparison flips Equal<->NotEqual, Contains toggles Negated; the unrepresentable none-of and any group
+    // that contains an EventData node are rejected. Non-EventData operands wrap in NotNode as before.
+    private static SemanticNode LowerNegation(UnarySyntax neg)
+    {
+        var inner = Lower(neg.Operand);
+
+        switch (inner)
+        {
+            case EventDataComparisonNode comparison:
+                var flipped = comparison.Op == FilterBinaryOperator.Equal
+                    ? FilterBinaryOperator.NotEqual
+                    : FilterBinaryOperator.Equal;
+
+                return new EventDataComparisonNode(comparison.FieldName, flipped, comparison.Literal);
+            case EventDataContainsNode contains:
+                return new EventDataContainsNode(
+                    contains.FieldName,
+                    contains.Needle,
+                    contains.IgnoreCase,
+                    !contains.Negated);
+            case EventDataMultiEqualsNode:
+                throw new LowerException(
+                    $"Negating an EventData any-of match is not supported; use separate '!=' conditions (position {neg.Position}).");
+            default:
+                if (ContainsEventDataNode(inner))
+                {
+                    throw new LowerException(
+                        $"Negating a group that contains EventData conditions is not supported; negate each EventData condition individually (position {neg.Position}).");
+                }
+
+                return new NotNode(inner);
+        }
     }
 
     private static FilterBinaryOperator MapBinaryOp(TokenKind op) =>
@@ -461,6 +557,36 @@ internal static class Lowerer
         }
 
         return false;
+    }
+
+    // Returns true for a well-formed `EventData["FieldName"]` access (case-insensitive target, Ordinal field name);
+    // throws a descriptive LowerException for a malformed EventData index (non-string / empty key); returns false for
+    // any non-EventData expression.
+    private static bool TryResolveEventDataField(SyntaxNode expr, [NotNullWhen(true)] out string? fieldName)
+    {
+        fieldName = null;
+
+        if (expr is not IndexAccessSyntax index
+            || index.Target is not IdentifierSyntax id
+            || !IsCaseInsensitiveMatch(id.Name, "EventData"))
+        {
+            return false;
+        }
+
+        if (index.Argument is not LiteralSyntax { Kind: LiteralKind.String } key)
+        {
+            throw new LowerException(
+                $"EventData field name must be a string literal (position {index.Argument.Position}).");
+        }
+
+        if (string.IsNullOrWhiteSpace(key.Text))
+        {
+            throw new LowerException($"EventData field name must not be empty (position {key.Position}).");
+        }
+
+        fieldName = key.Text;
+
+        return true;
     }
 
     private sealed class LowerException(string message) : Exception(message);

--- a/src/EventLogExpert.Filtering/Lowering/SemanticNode.cs
+++ b/src/EventLogExpert.Filtering/Lowering/SemanticNode.cs
@@ -89,3 +89,49 @@ internal sealed class MultiEqualsNode(ResolvedEventField field, IReadOnlyList<st
 
     public IReadOnlyList<string> Values { get; } = values;
 }
+
+/// <summary>
+///     <c>EventData["Name"] == v</c> / <c>!= v</c> against a dynamic named EventData field. Presence-required: the
+///     emitter gates on <c>EventData.TryGetValue(FieldName, …)</c>, so an absent field never matches (positive OR
+///     negative). Negation is normalized in the Lowerer by flipping <see cref="Op" /> (no separate negated flag), so the
+///     decomposer maps <see cref="Op" /> directly with no ambiguity.
+/// </summary>
+internal sealed class EventDataComparisonNode(string fieldName, FilterBinaryOperator op, EventDataLiteral literal)
+    : SemanticNode
+{
+    public string FieldName { get; } = fieldName;
+
+    public EventDataLiteral Literal { get; } = literal;
+
+    public FilterBinaryOperator Op { get; } = op;
+}
+
+/// <summary>
+///     <c>EventData["Name"].Contains(Needle, OIC)</c> against a dynamic named EventData field, string-based over
+///     <see cref="EventLogExpert.Eventing.Common.Events.EventFieldValue.AsString" />. <see cref="Negated" /> carries the
+///     <c>!…Contains(…)</c> form (Basic's <c>NotContains</c>); presence-required either way.
+/// </summary>
+internal sealed class EventDataContainsNode(string fieldName, string needle, bool ignoreCase, bool negated)
+    : SemanticNode
+{
+    public string FieldName { get; } = fieldName;
+
+    public bool IgnoreCase { get; } = ignoreCase;
+
+    public string Needle { get; } = needle;
+
+    public bool Negated { get; } = negated;
+}
+
+/// <summary>
+///     <c>(new[] {...}).Contains(EventData["Name"])</c> — any-of typed value equality against a dynamic named
+///     EventData field. Presence-required. Positive only: <c>!(any-of)</c> ("none-of") has no Basic representation and is
+///     rejected by the Lowerer.
+/// </summary>
+internal sealed class EventDataMultiEqualsNode(string fieldName, IReadOnlyList<EventDataLiteral> literals)
+    : SemanticNode
+{
+    public string FieldName { get; } = fieldName;
+
+    public IReadOnlyList<EventDataLiteral> Literals { get; } = literals;
+}

--- a/src/EventLogExpert.Filtering/Parsing/Parser.cs
+++ b/src/EventLogExpert.Filtering/Parsing/Parser.cs
@@ -12,7 +12,7 @@ namespace EventLogExpert.Filtering.Parsing;
 /// </summary>
 internal static class Parser
 {
-    public static bool TryParse(IReadOnlyList<Token> tokens, out SyntaxNode? root, [NotNullWhen(false)] out string? error)
+    public static bool TryParse(IReadOnlyList<Token>? tokens, out SyntaxNode? root, [NotNullWhen(false)] out string? error)
     {
         root = null;
         error = null;
@@ -30,15 +30,13 @@ internal static class Parser
         {
             root = ParseExpression(state, 0);
 
-            if (state.Current.Kind != TokenKind.End)
-            {
-                error = $"Unexpected token '{state.Current.Text}' (position {state.Current.Position}).";
-                root = null;
+            if (state.Current.Kind == TokenKind.End) { return true; }
 
-                return false;
-            }
+            error = $"Unexpected token '{state.Current.Text}' (position {state.Current.Position}).";
+            root = null;
 
-            return true;
+            return false;
+
         }
         catch (ParseException ex)
         {
@@ -213,6 +211,20 @@ internal static class Parser
                         Position = dotPosition
                     };
                 }
+            }
+            else if (state.Current.Kind == TokenKind.LBracket)
+            {
+                var bracketPosition = state.Current.Position;
+                state.Advance();
+                var argument = ParseExpression(state, 0);
+                Expect(state, TokenKind.RBracket);
+
+                node = new IndexAccessSyntax
+                {
+                    Target = node,
+                    Argument = argument,
+                    Position = bracketPosition
+                };
             }
             else
             {

--- a/src/EventLogExpert.Filtering/Parsing/SyntaxNode.cs
+++ b/src/EventLogExpert.Filtering/Parsing/SyntaxNode.cs
@@ -63,6 +63,13 @@ internal sealed class MethodCallSyntax : SyntaxNode
     public required SyntaxNode Target { get; init; }
 }
 
+internal sealed class IndexAccessSyntax : SyntaxNode
+{
+    public required SyntaxNode Argument { get; init; }
+
+    public required SyntaxNode Target { get; init; }
+}
+
 internal sealed class ArrayCreationSyntax : SyntaxNode
 {
     public required IReadOnlyList<SyntaxNode> Elements { get; init; }

--- a/src/EventLogExpert.Runtime/EventLog/EventLogQueries.cs
+++ b/src/EventLogExpert.Runtime/EventLog/EventLogQueries.cs
@@ -26,6 +26,23 @@ internal sealed class EventLogQueries(
             .Distinct(StringComparer.OrdinalIgnoreCase)
     ];
 
+    public ImmutableArray<string> GetEventDataFieldNames()
+    {
+        var byLog = _rawEventStore.Value.ByLog;
+
+        return EventPropertyValuesCache.GetEventDataFieldNames(byLog, byLog.Values.SelectMany(events => events));
+    }
+
+    public ImmutableArray<string> GetEventDataFieldValues(string fieldName)
+    {
+        var byLog = _rawEventStore.Value.ByLog;
+
+        return EventPropertyValuesCache.GetEventDataFieldValues(
+            byLog,
+            byLog.Values.SelectMany(events => events),
+            fieldName);
+    }
+
     public (DateTime After, DateTime Before) GetEventDateRange(DateTime fallbackUtcNow) =>
         _rawEventStore.Value.TryGetRawEventDateRange().RoundOrFallback(fallbackUtcNow);
 

--- a/src/EventLogExpert.Runtime/EventLog/IEventLogQueries.cs
+++ b/src/EventLogExpert.Runtime/EventLog/IEventLogQueries.cs
@@ -15,6 +15,18 @@ public interface IEventLogQueries
     IReadOnlyList<string> GetChannelNames();
 
     /// <summary>
+    ///     Returns the distinct, sorted &lt;EventData&gt; field names present across all open raw events (used to
+    ///     populate the Basic editor's EventData field-name picker).
+    /// </summary>
+    ImmutableArray<string> GetEventDataFieldNames();
+
+    /// <summary>
+    ///     Returns the distinct, sorted values of the named EventData <paramref name="fieldName" /> across all open raw
+    ///     events (used to populate the value picker for an EventData filter row).
+    /// </summary>
+    ImmutableArray<string> GetEventDataFieldValues(string fieldName);
+
+    /// <summary>
     ///     Returns the UTC date range covering all events across the active logs, with bounds rounded outward to the
     ///     hour, falling back to <paramref name="fallbackUtcNow" /> when no log has events.
     /// </summary>

--- a/src/EventLogExpert.UI/FilterEditor/Comparison/FilterComparisonEditor.razor
+++ b/src/EventLogExpert.UI/FilterEditor/Comparison/FilterComparisonEditor.razor
@@ -10,6 +10,23 @@
     }
 </ValueSelect>
 
+@if (IsEventDataProperty)
+{
+    <label class="visually-hidden" id="@($"{Id}_FieldName")">Field name</label>
+
+    <ValueSelect AriaLabelledBy="@($"{Id}_FieldName")"
+        CssClass="input filter-value-dropdown"
+        IsInput
+        T="string"
+        Value="Comparison.EventDataFieldName"
+        ValueChanged="HandleEventDataFieldNameChanged">
+        @foreach (var name in EventDataFieldNames)
+        {
+            <ValueSelectItem T="string" Value="name" />
+        }
+    </ValueSelect>
+}
+
 <label class="visually-hidden" id="@($"{Id}_Comparison")">Comparison</label>
 <ComparisonOperatorSelect AriaLabelledBy="@($"{Id}_Comparison")"
     MatchMode="Comparison.MatchMode"

--- a/src/EventLogExpert.UI/FilterEditor/Comparison/FilterComparisonEditor.razor.cs
+++ b/src/EventLogExpert.UI/FilterEditor/Comparison/FilterComparisonEditor.razor.cs
@@ -29,6 +29,8 @@ public sealed partial class FilterComparisonEditor : ComponentBase
 
     [Parameter] public string? PropertyAriaLabelledBy { get; set; }
 
+    private ImmutableArray<string> EventDataFieldNames => EventLogQueries.GetEventDataFieldNames();
+
     [Inject] private IEventLogQueries EventLogQueries { get; init; } = null!;
 
     private List<string> FilteredItems
@@ -52,7 +54,11 @@ public sealed partial class FilterComparisonEditor : ComponentBase
         }
     } = [];
 
-    private ImmutableArray<string> Items => EventLogQueries.GetPropertyValues(Comparison.Property);
+    private bool IsEventDataProperty => Comparison.Property is EventProperty.EventData;
+
+    private ImmutableArray<string> Items => Comparison.Property is EventProperty.EventData
+        ? EventLogQueries.GetEventDataFieldValues(Comparison.EventDataFieldName ?? string.Empty)
+        : EventLogQueries.GetPropertyValues(Comparison.Property);
 
     private EventProperty PropertyBinding
     {
@@ -72,6 +78,16 @@ public sealed partial class FilterComparisonEditor : ComponentBase
     }
 
     private static bool IsTextOnlyProperty(EventProperty property) => FilterPropertyConstraints.IsTextOnly(property);
+
+    private async Task HandleEventDataFieldNameChanged(string? fieldName)
+    {
+        Comparison.EventDataFieldName = fieldName;
+
+        // The available value space is field-specific, so a field-name change invalidates the current value(s).
+        Comparison.Value = null;
+        Comparison.Values.Clear();
+        await OnChanged.InvokeAsync();
+    }
 
     private async Task HandleOperatorChanged((ComparisonOperator Op, MatchMode Mode) value)
     {

--- a/tests/Shared/EventLogExpert.Eventing.TestUtils/EventDataTestFactory.cs
+++ b/tests/Shared/EventLogExpert.Eventing.TestUtils/EventDataTestFactory.cs
@@ -1,0 +1,62 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Eventing.Readers;
+using EventLogExpert.Eventing.Resolvers;
+using System.Collections.Immutable;
+using System.Security;
+using System.Security.Principal;
+
+namespace EventLogExpert.Eventing.TestUtils;
+
+/// <summary>
+///     Builds <see cref="ResolvedEvent" /> instances carrying structured &lt;EventData&gt; named fields for filter
+///     and view tests. The field value's CLR type determines the resulting <see cref="EventFieldValueKind" /> (e.g.
+///     <see cref="string" /> to String, <see cref="long" /> to Int64, <see cref="Guid" /> to Guid). Field name order is
+///     preserved; duplicate names exercise the schema's first-wins lookup.
+/// </summary>
+public static class EventDataTestFactory
+{
+    public static ResolvedEvent CreateEventWithData(params (string Name, object? Value)[] fields) =>
+        new ResolvedEvent("TestLog", LogPathType.Channel).WithEventData(fields);
+
+    public static ResolvedEvent WithEventData(this ResolvedEvent source, params (string Name, object? Value)[] fields)
+    {
+        var template = "<template>"
+            + string.Concat(fields.Select(field => $"<data name=\"{SecurityElement.Escape(field.Name)}\"/>"))
+            + "</template>";
+
+        var schema = new TemplateAnalyzer().GetTemplateInfo(template).Schema;
+
+        var builder = ImmutableArray.CreateBuilder<EventProperty>(fields.Length);
+
+        foreach (var (_, value) in fields)
+        {
+            builder.Add(ToEventProperty(value));
+        }
+
+        return source with { EventDataValues = builder.MoveToImmutable(), EventDataSchema = schema };
+    }
+
+    private static EventProperty ToEventProperty(object? value) =>
+        value switch
+        {
+            null => EventProperty.FromReference(null),
+            string text => text,
+            bool boolean => boolean,
+            long int64 => int64,
+            int int32 => int32,
+            ulong uint64 => uint64,
+            uint uint32 => uint32,
+            double doubleValue => doubleValue,
+            float single => single,
+            DateTime dateTime => dateTime,
+            Guid guid => guid,
+            SecurityIdentifier sid => sid,
+            byte[] bytes => bytes,
+            string[] strings => strings,
+            _ => value.ToString() ?? string.Empty
+        };
+}

--- a/tests/Unit/EventLogExpert.Filtering.Tests/Basic/FilterComparisonJsonConverterTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/Basic/FilterComparisonJsonConverterTests.cs
@@ -11,9 +11,7 @@ public sealed class FilterComparisonJsonConverterTests
     [Fact]
     public void EventProperty_MemberCount_IsFrozenForWireCompatibility()
     {
-        // Pairs with the per-ordinal Read_LegacyCategoryKey theory: adding or removing an EventProperty
-        // value would leave that theory passing while still corrupting legacy reads for the missing ordinal.
-        Assert.Equal(12, Enum.GetValues<EventProperty>().Length);
+        Assert.Equal(13, Enum.GetValues<EventProperty>().Length);
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataAllocationTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataAllocationTests.cs
@@ -1,0 +1,46 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.TestUtils;
+using EventLogExpert.Filtering.Parsing;
+using EventLogExpert.Filtering.Tests.TestUtils;
+
+namespace EventLogExpert.Filtering.Tests.EventData;
+
+/// <summary>
+///     Per-event allocation budget for EventData predicates. Zero allocation is required for the String and packed
+///     scalar / Guid field kinds (R4) so an active EventData filter doesn't add GC pressure on a hot virtualization
+///     scroll. (Sid / Bytes / array kinds use the documented AsString fallback and are not covered here.)
+/// </summary>
+public sealed class EventDataAllocationTests
+{
+    [Fact]
+    public void GuidEquality_OverWarmEvent_AllocatesZeroBytes()
+    {
+        var id = new Guid("11111111-2222-3333-4444-555555555555");
+
+        Assert.True(FilterParser.TryCompile($"EventData[\"Id\"] == \"{id}\"", out var compiled, out var error), error);
+
+        var warmEvent = EventDataTestFactory.CreateEventWithData(("Id", id));
+
+        var bytes = AllocationUtils.MeasurePredicateAllocations(compiled.Predicate, warmEvent);
+
+        Assert.Equal(0, bytes);
+    }
+
+    [Theory]
+    [InlineData("EventData[\"User\"] == \"admin\"")]
+    [InlineData("EventData[\"User\"].Contains(\"adm\", StringComparison.OrdinalIgnoreCase)")]
+    [InlineData("EventData[\"Code\"] == \"5\"")]
+    [InlineData("(new[] {\"5\", \"6\"}).Contains(EventData[\"Code\"])")]
+    public void Predicate_OverWarmEvent_AllocatesZeroBytes(string filter)
+    {
+        Assert.True(FilterParser.TryCompile(filter, out var compiled, out var error), error);
+
+        var warmEvent = EventDataTestFactory.CreateEventWithData(("User", "admin"), ("Code", 5L));
+
+        var bytes = AllocationUtils.MeasurePredicateAllocations(compiled.Predicate, warmEvent);
+
+        Assert.Equal(0, bytes);
+    }
+}

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataDraftTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataDraftTests.cs
@@ -1,0 +1,77 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Drafts;
+
+namespace EventLogExpert.Filtering.Tests.EventData;
+
+/// <summary>
+///     <see cref="FilterPredicateDraft.IsComplete" /> must mirror the formatter's strict-mode guard: an EventData row
+///     is only complete once it has both a field name and a value, so the editor's Done/Add affordance never enables a row
+///     the formatter would silently reject (R3).
+/// </summary>
+public sealed class EventDataDraftTests
+{
+    [Fact]
+    public void IsComplete_EventDataMany_RequiresFieldName()
+    {
+        var draft = new FilterPredicateDraft
+        {
+            Comparison = new FilterComparisonDraft
+            {
+                Property = EventProperty.EventData,
+                Operator = ComparisonOperator.Equals,
+                MatchMode = MatchMode.Many,
+                Values = ["admin"]
+            }
+        };
+
+        Assert.False(draft.IsComplete);
+
+        draft.Comparison.EventDataFieldName = "User";
+
+        Assert.True(draft.IsComplete);
+    }
+
+    [Fact]
+    public void IsComplete_False_WhenFieldNameMissing() => Assert.False(EventDataDraft(null, "admin").IsComplete);
+
+    [Fact]
+    public void IsComplete_False_WhenFieldNameWhitespace() => Assert.False(EventDataDraft("   ", "admin").IsComplete);
+
+    [Fact]
+    public void IsComplete_False_WhenValueMissing() => Assert.False(EventDataDraft("User", null).IsComplete);
+
+    [Fact]
+    public void IsComplete_NonEventDataRow_IgnoresFieldName()
+    {
+        var draft = new FilterPredicateDraft
+        {
+            Comparison = new FilterComparisonDraft
+            {
+                Property = EventProperty.Source,
+                Operator = ComparisonOperator.Equals,
+                MatchMode = MatchMode.Single,
+                Value = "x"
+            }
+        };
+
+        Assert.True(draft.IsComplete);
+    }
+
+    [Fact]
+    public void IsComplete_True_WhenFieldNameAndValuePresent() => Assert.True(EventDataDraft("User", "admin").IsComplete);
+
+    private static FilterPredicateDraft EventDataDraft(string? fieldName, string? value) =>
+        new()
+        {
+            Comparison = new FilterComparisonDraft
+            {
+                Property = EventProperty.EventData,
+                Operator = ComparisonOperator.Equals,
+                MatchMode = MatchMode.Single,
+                EventDataFieldName = fieldName,
+                Value = value
+            }
+        };
+}

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataFilterCompilationTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataFilterCompilationTests.cs
@@ -88,6 +88,16 @@ public sealed class EventDataFilterCompilationTests
     }
 
     [Fact]
+    public void DateTimeEquality_RejectsNonRoundTripLiteral()
+    {
+        // Only the canonical "O" round-trip form parses to a DateTime candidate; a lenient date string does not,
+        // so it never matches a DateTime field (even the same instant).
+        var predicate = Compile("EventData[\"When\"] == \"2024-01-01\"");
+
+        Assert.False(predicate(Event(("When", new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc)))));
+    }
+
+    [Fact]
     public void DoubleEquality_MatchesNaN()
     {
         var predicate = Compile("EventData[\"Ratio\"] == \"NaN\"");

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataFilterCompilationTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataFilterCompilationTests.cs
@@ -1,0 +1,289 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Eventing.TestUtils;
+using EventLogExpert.Filtering.Parsing;
+using System.Globalization;
+
+namespace EventLogExpert.Filtering.Tests.EventData;
+
+/// <summary>
+///     End-to-end compile + evaluate coverage for EventData named-field filtering: the presence-required semantics
+///     (R1″), the typed value-equality model (R4), and the closed-vocabulary rejections.
+/// </summary>
+public sealed class EventDataFilterCompilationTests
+{
+    private static readonly Guid s_sampleGuid = new("11111111-2222-3333-4444-555555555555");
+
+    // --- Presence-required (R1″): absent field / EventDataKind.None never matches, positive OR negative. ---
+
+    public static IEnumerable<object[]> AllOperators() =>
+    [
+        ["EventData[\"User\"] == \"admin\""],
+        ["EventData[\"User\"] != \"admin\""],
+        ["EventData[\"User\"].Contains(\"adm\", StringComparison.OrdinalIgnoreCase)"],
+        ["!EventData[\"User\"].Contains(\"adm\", StringComparison.OrdinalIgnoreCase)"],
+        ["(new[] {\"admin\", \"root\"}).Contains(EventData[\"User\"])"]
+    ];
+
+    [Theory]
+    [MemberData(nameof(AllOperators))]
+    public void AbsentField_NeverMatches(string filter)
+    {
+        var predicate = Compile(filter);
+
+        // Event has EventData, but not the "User" field.
+        Assert.False(predicate(Event(("Other", "x"))));
+    }
+
+    [Fact]
+    public void AnyOf_MatchesAnyListedValue()
+    {
+        var predicate = Compile("(new[] {\"admin\", \"root\"}).Contains(EventData[\"User\"])");
+
+        Assert.True(predicate(Event(("User", "admin"))));
+        Assert.True(predicate(Event(("User", "root"))));
+        Assert.False(predicate(Event(("User", "guest"))));
+    }
+
+    [Theory]
+    [InlineData("true")]
+    [InlineData("True")]
+    [InlineData("TRUE")]
+    public void BooleanEquality_IsCaseInsensitive(string literal)
+    {
+        var predicate = Compile($"EventData[\"Flag\"] == \"{literal}\"");
+
+        Assert.True(predicate(Event(("Flag", true))));
+        Assert.False(predicate(Event(("Flag", false))));
+    }
+
+    [Fact]
+    public void BooleanField_DoesNotMatchNumericLiteral()
+    {
+        var predicate = Compile("EventData[\"Flag\"] == \"1\"");
+
+        Assert.False(predicate(Event(("Flag", true))));
+    }
+
+    [Fact]
+    public void Contains_IsCaseInsensitiveSubstring()
+    {
+        var predicate = Compile("EventData[\"Path\"].Contains(\"system32\", StringComparison.OrdinalIgnoreCase)");
+
+        Assert.True(predicate(Event(("Path", @"C:\Windows\System32\cmd.exe"))));
+        Assert.False(predicate(Event(("Path", @"C:\Temp\x"))));
+    }
+
+    [Fact]
+    public void DateTimeEquality_MatchesRoundTripString()
+    {
+        var when = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        var predicate = Compile($"EventData[\"When\"] == \"{when.ToString("O", CultureInfo.InvariantCulture)}\"");
+
+        Assert.True(predicate(Event(("When", when))));
+        Assert.False(predicate(Event(("When", when.AddDays(1)))));
+    }
+
+    [Fact]
+    public void DoubleEquality_MatchesNaN()
+    {
+        var predicate = Compile("EventData[\"Ratio\"] == \"NaN\"");
+
+        Assert.True(predicate(Event(("Ratio", double.NaN))));
+        Assert.False(predicate(Event(("Ratio", 1.5d))));
+    }
+
+    [Fact]
+    public void DoubleNegatedContains_EqualsContains()
+    {
+        var contains = Compile("EventData[\"User\"].Contains(\"adm\", StringComparison.OrdinalIgnoreCase)");
+        var doubleNegated = Compile("!!EventData[\"User\"].Contains(\"adm\", StringComparison.OrdinalIgnoreCase)");
+
+        foreach (var evt in new[] { Event(("User", "admin")), Event(("User", "guest")), Event(("Other", "x")) })
+        {
+            Assert.Equal(contains(evt), doubleNegated(evt));
+        }
+    }
+
+    [Fact]
+    public void DuplicateFieldName_ResolvesToFirstOccurrence()
+    {
+        var predicate = Compile("EventData[\"Data\"] == \"first\"");
+
+        Assert.True(predicate(Event(("Data", "first"), ("Data", "second"))));
+    }
+
+    // --- Negation normalization equivalence (R1″). ---
+
+    [Theory]
+    [InlineData("admin")]
+    [InlineData("guest")]
+    public void ExplicitNegatedEquality_EqualsNotEqual(string userValue)
+    {
+        var notEqual = Compile("EventData[\"User\"] != \"admin\"");
+        var negatedEqual = Compile("!(EventData[\"User\"] == \"admin\")");
+
+        var withField = Event(("User", userValue));
+        var absent = Event(("Other", "x"));
+
+        Assert.Equal(notEqual(withField), negatedEqual(withField));
+        Assert.Equal(notEqual(absent), negatedEqual(absent));
+    }
+
+    [Fact]
+    public void FieldNameKey_IsCaseSensitiveOrdinal()
+    {
+        var predicate = Compile("EventData[\"user\"] == \"admin\"");
+
+        // Field is named "User"; the Ordinal schema lookup does not match the lowercase key.
+        Assert.False(predicate(Event(("User", "admin"))));
+    }
+
+    [Fact]
+    public void GroupedNegation_WithoutEventData_StillCompiles()
+    {
+        // Regression guard: negating a group of regular fields is unaffected by the EventData rejection.
+        Assert.True(FilterParser.TryCompile("!(Source == \"a\" || Level == \"b\")", out _, out var error), error);
+    }
+
+    [Theory]
+    [InlineData("11111111-2222-3333-4444-555555555555")]
+    [InlineData("{11111111-2222-3333-4444-555555555555}")]
+    public void GuidEquality_AcceptsAnyParseableFormat(string literal)
+    {
+        var predicate = Compile($"EventData[\"Id\"] == \"{literal}\"");
+
+        Assert.True(predicate(Event(("Id", s_sampleGuid))));
+        Assert.False(predicate(Event(("Id", Guid.Empty))));
+    }
+
+    [Fact]
+    public void Int64Equality_MatchesNegativeValue()
+    {
+        var predicate = Compile("EventData[\"Delta\"] == \"-5\"");
+
+        Assert.True(predicate(Event(("Delta", -5L))));
+        Assert.False(predicate(Event(("Delta", 5L))));
+    }
+
+    [Theory]
+    [MemberData(nameof(AllOperators))]
+    public void NoneEventData_NeverMatches(string filter)
+    {
+        var predicate = Compile(filter);
+
+        Assert.Equal(EventDataKind.None, NoEventData().EventData.Kind);
+        Assert.False(predicate(NoEventData()));
+    }
+
+    [Fact]
+    public void NotContains_RequiresPresence()
+    {
+        var predicate = Compile("!EventData[\"User\"].Contains(\"adm\", StringComparison.OrdinalIgnoreCase)");
+
+        Assert.True(predicate(Event(("User", "guest"))));
+        Assert.False(predicate(Event(("User", "admin"))));
+        Assert.False(predicate(Event(("Other", "x")))); // absent -> no match
+    }
+
+    [Fact]
+    public void NotEqual_RequiresPresence()
+    {
+        var predicate = Compile("EventData[\"User\"] != \"admin\"");
+
+        Assert.True(predicate(Event(("User", "guest")))); // present and different
+        Assert.False(predicate(Event(("User", "admin")))); // present and equal
+        Assert.False(predicate(Event(("Other", "x")))); // absent -> no match (not "true")
+    }
+
+    [Fact]
+    public void SingleEquality_Matches()
+    {
+        var predicate = Compile("EventData[\"Ratio\"] == \"1.5\"");
+
+        Assert.True(predicate(Event(("Ratio", 1.5f))));
+        Assert.False(predicate(Event(("Ratio", 2.5f))));
+    }
+
+    [Fact]
+    public void StringEquality_MatchesOnlyExactValue()
+    {
+        var predicate = Compile("EventData[\"User\"] == \"admin\"");
+
+        Assert.True(predicate(Event(("User", "admin"))));
+        Assert.False(predicate(Event(("User", "guest"))));
+    }
+
+    // --- Key handling. ---
+
+    [Fact]
+    public void Target_IsCaseInsensitive()
+    {
+        var predicate = Compile("eventdata[\"User\"] == \"admin\"");
+
+        Assert.True(predicate(Event(("User", "admin"))));
+    }
+
+    [Fact]
+    public void TypedEquality_IsScopedToTheFieldKind()
+    {
+        // "05" matches an Int64 5 by value, but a String field "5" is compared as text and does not equal "05".
+        var predicate = Compile("EventData[\"Code\"] == \"05\"");
+
+        Assert.True(predicate(Event(("Code", 5L))));
+        Assert.False(predicate(Event(("Code", "5"))));
+    }
+
+    [Theory]
+    [InlineData("EventData[\"Code\"] == \"5\"")]
+    [InlineData("EventData[\"Code\"] == \"05\"")] // typed value equality: "05" parses to the numeric 5
+    public void TypedIntegerEquality_IgnoresLeadingZeros(string filter)
+    {
+        var predicate = Compile(filter);
+
+        Assert.True(predicate(Event(("Code", 5L))));
+        Assert.False(predicate(Event(("Code", 6L))));
+    }
+
+    [Fact]
+    public void UInt64Equality_MatchesValuesAboveInt64Max()
+    {
+        var predicate = Compile($"EventData[\"Mask\"] == \"{ulong.MaxValue}\"");
+
+        Assert.True(predicate(Event(("Mask", ulong.MaxValue))));
+        Assert.False(predicate(Event(("Mask", ulong.MaxValue - 1))));
+    }
+
+    // --- Rejections (closed vocabulary). ---
+
+    [Theory]
+    [InlineData("EventData[\"Code\"] < \"5\"")] // relational not supported
+    [InlineData("EventData[\"Code\"] >= \"5\"")]
+    [InlineData("EventData[\"\"] == \"x\"")] // empty key
+    [InlineData("EventData[\"   \"] == \"x\"")] // whitespace key
+    [InlineData("EventData[5] == \"x\"")] // non-string key
+    [InlineData("!(new[] {\"a\", \"b\"}).Contains(EventData[\"User\"])")] // none-of
+    [InlineData("!(EventData[\"User\"] == \"a\" || EventData[\"User\"] == \"b\")")] // grouped negation
+    [InlineData("!(EventData[\"User\"] == \"a\" && Source == \"x\")")] // grouped negation, mixed
+    public void UnsupportedShapes_FailToCompile(string filter)
+    {
+        Assert.False(FilterParser.TryCompile(filter, out var compiled, out var error));
+        Assert.Null(compiled);
+        Assert.False(string.IsNullOrEmpty(error));
+    }
+
+    private static Func<ResolvedEvent, bool> Compile(string filter)
+    {
+        Assert.True(FilterParser.TryCompile(filter, out var compiled, out var error), error);
+
+        return compiled.Predicate;
+    }
+
+    private static ResolvedEvent Event(params (string Name, object? Value)[] fields) =>
+        EventDataTestFactory.CreateEventWithData(fields);
+
+    private static ResolvedEvent NoEventData() => new("TestLog", LogPathType.Channel);
+}

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataPicklistTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataPicklistTests.cs
@@ -9,6 +9,7 @@ namespace EventLogExpert.Filtering.Tests.EventData;
 ///     Field-name and per-field value picklists that feed the Basic editor's EventData row. Exercises the composite
 ///     <c>(snapshot, fieldName)</c> cache key (R7) so distinct fields keep distinct value lists.
 /// </summary>
+[Collection("EventPropertyValuesCache")]
 public sealed class EventDataPicklistTests : IDisposable
 {
     public EventDataPicklistTests() => EventPropertyValuesCache.Clear();

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataPicklistTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataPicklistTests.cs
@@ -1,0 +1,80 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.TestUtils;
+
+namespace EventLogExpert.Filtering.Tests.EventData;
+
+/// <summary>
+///     Field-name and per-field value picklists that feed the Basic editor's EventData row. Exercises the composite
+///     <c>(snapshot, fieldName)</c> cache key (R7) so distinct fields keep distinct value lists.
+/// </summary>
+public sealed class EventDataPicklistTests : IDisposable
+{
+    public EventDataPicklistTests() => EventPropertyValuesCache.Clear();
+
+    public void Dispose() => EventPropertyValuesCache.Clear();
+
+    [Fact]
+    public void GetEventDataFieldNames_ReturnsDistinctSortedNames()
+    {
+        var snapshot = new object();
+        var events = new[]
+        {
+            EventDataTestFactory.CreateEventWithData(("TargetUserName", "a"), ("Status", 1L)),
+            EventDataTestFactory.CreateEventWithData(("Status", 2L), ("SubjectUserName", "b"))
+        };
+
+        var names = EventPropertyValuesCache.GetEventDataFieldNames(snapshot, events);
+
+        Assert.Equal(["Status", "SubjectUserName", "TargetUserName"], names);
+    }
+
+    [Fact]
+    public void GetEventDataFieldValues_DifferentFields_ProduceDifferentLists()
+    {
+        var snapshot = new object();
+        var events = new[] { EventDataTestFactory.CreateEventWithData(("A", "1"), ("B", "2")) };
+
+        Assert.Equal(["1"], EventPropertyValuesCache.GetEventDataFieldValues(snapshot, events, "A"));
+        Assert.Equal(["2"], EventPropertyValuesCache.GetEventDataFieldValues(snapshot, events, "B"));
+    }
+
+    [Fact]
+    public void GetEventDataFieldValues_EmptyFieldName_ReturnsEmpty()
+    {
+        var snapshot = new object();
+        var events = new[] { EventDataTestFactory.CreateEventWithData(("A", "1")) };
+
+        Assert.Empty(EventPropertyValuesCache.GetEventDataFieldValues(snapshot, events, string.Empty));
+    }
+
+    [Fact]
+    public void GetEventDataFieldValues_ReturnsDistinctSortedValues()
+    {
+        var snapshot = new object();
+        var events = new[]
+        {
+            EventDataTestFactory.CreateEventWithData(("User", "admin")),
+            EventDataTestFactory.CreateEventWithData(("User", "guest")),
+            EventDataTestFactory.CreateEventWithData(("User", "admin")),
+            EventDataTestFactory.CreateEventWithData(("Other", "x"))
+        };
+
+        var values = EventPropertyValuesCache.GetEventDataFieldValues(snapshot, events, "User");
+
+        Assert.Equal(["admin", "guest"], values);
+    }
+
+    [Fact]
+    public void GetEventDataFieldValues_UnknownFieldName_ReturnsEmptyWithoutCaching()
+    {
+        var snapshot = new object();
+        var events = new[] { EventDataTestFactory.CreateEventWithData(("A", "1")) };
+
+        // A name that isn't a real field (as an editable picker would produce mid-typing) is bounded out: it
+        // returns empty and is not admitted to the per-snapshot value cache.
+        Assert.Empty(EventPropertyValuesCache.GetEventDataFieldValues(snapshot, events, "NotAField"));
+        Assert.Equal(["1"], EventPropertyValuesCache.GetEventDataFieldValues(snapshot, events, "A"));
+    }
+}

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataPicklistTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataPicklistTests.cs
@@ -32,6 +32,21 @@ public sealed class EventDataPicklistTests : IDisposable
     }
 
     [Fact]
+    public void GetEventDataFieldNames_SortsOrdinal()
+    {
+        var snapshot = new object();
+        var events = new[]
+        {
+            EventDataTestFactory.CreateEventWithData(("b", "1")),
+            EventDataTestFactory.CreateEventWithData(("A", "2")),
+            EventDataTestFactory.CreateEventWithData(("a", "3"))
+        };
+
+        // Ordinal orders uppercase before lowercase ('A'=65, 'a'=97, 'b'=98), unlike a culture-sensitive sort.
+        Assert.Equal(["A", "a", "b"], EventPropertyValuesCache.GetEventDataFieldNames(snapshot, events));
+    }
+
+    [Fact]
     public void GetEventDataFieldValues_DifferentFields_ProduceDifferentLists()
     {
         var snapshot = new object();

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataRoundTripTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataRoundTripTests.cs
@@ -70,6 +70,19 @@ public sealed class EventDataRoundTripTests
     }
 
     [Fact]
+    public void Json_Read_NormalizesWhitespaceFieldName_ToNull()
+    {
+        const string json =
+            """{"Property":"EventData","Operator":"Equals","MatchMode":"Single","Value":"x","EventDataFieldName":"   "}""";
+
+        var restored = JsonSerializer.Deserialize<FilterComparison>(json);
+
+        Assert.NotNull(restored);
+        Assert.Equal(EventProperty.EventData, restored!.Property);
+        Assert.Null(restored.EventDataFieldName);
+    }
+
+    [Fact]
     public void ManyValues_RoundTrips()
     {
         var original = new FilterComparison

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataRoundTripTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataRoundTripTests.cs
@@ -25,14 +25,15 @@ public sealed class EventDataRoundTripTests
         AssertSingleRoundTrips(ComparisonOperator.Equals, fieldName, "value");
 
     [Fact]
-    public void Json_NonEventDataRow_OmitsEventDataFieldName()
+    public void Json_NonEventDataRow_OmitsEventDataFieldName_EvenWhenSet()
     {
         var comparison = new FilterComparison
         {
             Property = EventProperty.Source,
             Operator = ComparisonOperator.Equals,
             MatchMode = MatchMode.Single,
-            Value = "x"
+            Value = "x",
+            EventDataFieldName = "stale"
         };
 
         var json = JsonSerializer.Serialize(comparison);
@@ -53,6 +54,19 @@ public sealed class EventDataRoundTripTests
         Assert.Equal("TargetUserName", restored.EventDataFieldName);
         Assert.Equal(ComparisonOperator.Contains, restored.Operator);
         Assert.Equal("admin", restored.Value);
+    }
+
+    [Fact]
+    public void Json_Read_DropsEventDataFieldName_ForNonEventDataRow()
+    {
+        const string json =
+            """{"Property":"Source","Operator":"Equals","MatchMode":"Single","Value":"x","EventDataFieldName":"stale"}""";
+
+        var restored = JsonSerializer.Deserialize<FilterComparison>(json);
+
+        Assert.NotNull(restored);
+        Assert.Equal(EventProperty.Source, restored!.Property);
+        Assert.Null(restored.EventDataFieldName);
     }
 
     [Fact]
@@ -89,7 +103,7 @@ public sealed class EventDataRoundTripTests
     }
 
     [Fact]
-    public void NegatedEquality_CanonicalizesToNotEqual()
+    public void NegatedNotEqual_CanonicalizesToEquals()
     {
         Assert.True(
             BasicFilterDecomposer.TryDecompose("!(EventData[\"User\"] != \"admin\")", out var structured),

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataRoundTripTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataRoundTripTests.cs
@@ -1,0 +1,138 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Text.Json;
+
+namespace EventLogExpert.Filtering.Tests.EventData;
+
+/// <summary>
+///     Advanced-text ↔ Basic round-trip fidelity and JSON persistence for EventData rows, including the negation
+///     canonicalizations (<c>!(!=)</c> → <c>==</c>, <c>!.Contains</c> → NotContains) and field-name escaping.
+/// </summary>
+public sealed class EventDataRoundTripTests
+{
+    [Fact]
+    public void EmptyFieldName_DoesNotFormat() =>
+        Assert.False(BasicFilterFormatter.TryFormatComparison(Single(ComparisonOperator.Equals, "", "admin"), null, out _));
+
+    [Theory]
+    [InlineData("with space")]
+    [InlineData("with\"quote")]
+    [InlineData("with]bracket")]
+    [InlineData("with\\backslash")]
+    [InlineData("with\ttab")]
+    public void FieldNameWithSpecialCharacters_RoundTrips(string fieldName) =>
+        AssertSingleRoundTrips(ComparisonOperator.Equals, fieldName, "value");
+
+    [Fact]
+    public void Json_NonEventDataRow_OmitsEventDataFieldName()
+    {
+        var comparison = new FilterComparison
+        {
+            Property = EventProperty.Source,
+            Operator = ComparisonOperator.Equals,
+            MatchMode = MatchMode.Single,
+            Value = "x"
+        };
+
+        var json = JsonSerializer.Serialize(comparison);
+
+        Assert.DoesNotContain("EventDataFieldName", json);
+    }
+
+    [Fact]
+    public void Json_PreservesEventDataFieldName()
+    {
+        var original = Single(ComparisonOperator.Contains, "TargetUserName", "admin");
+
+        var json = JsonSerializer.Serialize(original);
+        var restored = JsonSerializer.Deserialize<FilterComparison>(json);
+
+        Assert.NotNull(restored);
+        Assert.Equal(EventProperty.EventData, restored!.Property);
+        Assert.Equal("TargetUserName", restored.EventDataFieldName);
+        Assert.Equal(ComparisonOperator.Contains, restored.Operator);
+        Assert.Equal("admin", restored.Value);
+    }
+
+    [Fact]
+    public void ManyValues_RoundTrips()
+    {
+        var original = new FilterComparison
+        {
+            Property = EventProperty.EventData,
+            EventDataFieldName = "User",
+            Operator = ComparisonOperator.Equals,
+            MatchMode = MatchMode.Many,
+            Values = ["admin", "root"]
+        };
+
+        var result = RoundTrip(original);
+
+        Assert.Equal(EventProperty.EventData, result.Property);
+        Assert.Equal("User", result.EventDataFieldName);
+        Assert.Equal(MatchMode.Many, result.MatchMode);
+        Assert.Equal<IEnumerable<string>>(["admin", "root"], result.Values);
+    }
+
+    [Fact]
+    public void NegatedContains_MapsToNotContains()
+    {
+        Assert.True(
+            BasicFilterDecomposer.TryDecompose(
+                "!EventData[\"User\"].Contains(\"adm\", StringComparison.OrdinalIgnoreCase)",
+                out var structured),
+            "decompose failed");
+
+        Assert.Equal(ComparisonOperator.NotContains, structured!.Comparison.Operator);
+        Assert.Equal("User", structured.Comparison.EventDataFieldName);
+    }
+
+    [Fact]
+    public void NegatedEquality_CanonicalizesToNotEqual()
+    {
+        Assert.True(
+            BasicFilterDecomposer.TryDecompose("!(EventData[\"User\"] != \"admin\")", out var structured),
+            "decompose failed");
+
+        Assert.Equal(ComparisonOperator.Equals, structured!.Comparison.Operator);
+        Assert.Equal("User", structured.Comparison.EventDataFieldName);
+    }
+
+    [Theory]
+    [InlineData(ComparisonOperator.Equals)]
+    [InlineData(ComparisonOperator.NotEqual)]
+    [InlineData(ComparisonOperator.Contains)]
+    [InlineData(ComparisonOperator.NotContains)]
+    public void SingleValue_RoundTrips(ComparisonOperator op) =>
+        AssertSingleRoundTrips(op, "TargetUserName", "admin");
+
+    private static void AssertSingleRoundTrips(ComparisonOperator op, string fieldName, string value)
+    {
+        var result = RoundTrip(Single(op, fieldName, value));
+
+        Assert.Equal(EventProperty.EventData, result.Property);
+        Assert.Equal(fieldName, result.EventDataFieldName);
+        Assert.Equal(op, result.Operator);
+        Assert.Equal(MatchMode.Single, result.MatchMode);
+        Assert.Equal(value, result.Value);
+    }
+
+    private static FilterComparison RoundTrip(FilterComparison original)
+    {
+        Assert.True(BasicFilterFormatter.TryFormat(new BasicFilter(original, []), out var text), "format failed");
+        Assert.True(BasicFilterDecomposer.TryDecompose(text, out var structured), $"decompose failed: {text}");
+
+        return structured!.Comparison;
+    }
+
+    private static FilterComparison Single(ComparisonOperator op, string fieldName, string value) =>
+        new()
+        {
+            Property = EventProperty.EventData,
+            EventDataFieldName = fieldName,
+            Operator = op,
+            MatchMode = MatchMode.Single,
+            Value = value
+        };
+}

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventPropertyValuesCacheCollection.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventPropertyValuesCacheCollection.cs
@@ -1,0 +1,12 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Filtering.Tests.EventData;
+
+/// <summary>
+///     Serializes the test classes that share <c>EventPropertyValuesCache</c>'s process-wide static caches (each
+///     calls <c>Clear()</c> in setup/teardown). Without a shared collection, xUnit runs these classes in parallel and one
+///     class's <c>Clear()</c> can wipe another class's cache entries mid-test, causing intermittent failures.
+/// </summary>
+[CollectionDefinition("EventPropertyValuesCache")]
+public sealed class EventPropertyValuesCacheCollection;

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventPropertyValuesCacheTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventPropertyValuesCacheTests.cs
@@ -7,6 +7,7 @@ using EventLogExpert.Filtering.Tests.TestUtils.Constants;
 
 namespace EventLogExpert.Filtering.Tests.EventData;
 
+[Collection("EventPropertyValuesCache")]
 public sealed class EventPropertyValuesCacheTests : IDisposable
 {
     public EventPropertyValuesCacheTests() => EventPropertyValuesCache.Clear();

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventLogExpert.Filtering.Tests.csproj
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventLogExpert.Filtering.Tests.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Shared\EventLogExpert.Filtering.TestUtils\EventLogExpert.Filtering.TestUtils.csproj" />
+    <ProjectReference Include="..\..\Shared\EventLogExpert.Eventing.TestUtils\EventLogExpert.Eventing.TestUtils.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Adds filtering on the structured `<EventData>` named fields promoted onto `ResolvedEvent` in 6b — the additive half of Item 6c. **Purely additive**: the raw-`Xml` filter target and its retention plumbing are removed separately in 6c-B. Stacked on #635.

## What

- **Advanced grammar**: a general indexer so `EventData["FieldName"]` is filterable, e.g. `EventData["TargetUserName"] == "admin"`, `EventData["Path"].Contains("system32", StringComparison.OrdinalIgnoreCase)`, and any-of `(new[]{"a","b"}).Contains(EventData["User"])`.
- **Basic editor**: a new `EventData` row with a field-name picker (populated from the loaded events) plus the value picker.

## Semantics

- **Presence-required**: a predicate matches only when the field is present, for positive *and* negative forms (`!=`, `!Contains`). Absent field / template-less events never match. Negation is normalized in the lowerer (op-flip for comparisons; a `NotNode` never wraps an EventData node), so `!=` ≡ `!(==)` at any nesting depth; unrepresentable `!(any-of)` and grouped negation over EventData are rejected with a diagnostic.
- **Typed value equality**: numeric / bool / DateTime / Guid fields are compared *by value* (`"5"` and `"05"` both match a numeric `5`; a Guid matches in any parseable format), with per-kind candidates parsed once at lower-time (InvariantCulture; DateTime round-trip). **Zero per-event allocation** for String + packed scalars + Guid; Sid/Bytes/array kinds use a documented `AsString` fallback. `Contains` stays string-based (OrdinalIgnoreCase).
- Basic ↔ Advanced round-trip and JSON persistence preserve the field name (escaped).

## Tests

New EventData suites cover the operator × field-kind matrix, presence-required across all shapes, negation equivalence/rejections, key case-sensitivity, duplicate-name first-wins, round-trip (incl. field-name escaping), JSON, zero-allocation, and the field-name/value picklists. Solution builds clean; Filtering 971 / UI 1020 / Runtime 1725 / Scenarios 524 / Eventing 451 pass.
