### PR TITLE
Add UserData structured field extraction foundation

### DIFF
--- a/src/EventLogExpert.Eventing/Interop/NativeMethods.Evt.cs
+++ b/src/EventLogExpert.Eventing/Interop/NativeMethods.Evt.cs
@@ -231,7 +231,7 @@ internal static partial class NativeMethods
     [LibraryImport(EventLogApi, SetLastError = true)]
     internal static partial EvtHandle EvtCreateRenderContext(
         int valuePathsCount,
-        [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr)][Out] string[]? valuePaths,
+        [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr)][In] string[]? valuePaths,
         EvtRenderContextFlags flags);
 
     /// <summary>Formats a message string</summary>
@@ -749,11 +749,45 @@ internal static partial class NativeMethods
     private static unsafe string? ProcessRenderedEventXml(IntPtr buffer, int usedBytes, int propertyCount) =>
         usedBytes - 1 <= 0 ? null : new string((char*)buffer, 0, (usedBytes - 1) / sizeof(char));
 
+    // A value-path that is absent on the event renders as Null; map it to a null-reference property (surfaced as
+    // EventFieldValueKind.Null) instead of letting ConvertVariantToProperty throw on it.
+    private static unsafe ImmutableArray<EventProperty> ProcessRenderedValuePaths(IntPtr buffer, int usedBytes, int propertyCount)
+    {
+        if (propertyCount <= 0) { return ImmutableArray<EventProperty>.Empty; }
+
+#if DEBUG
+        BeforeVariantReadForTest?.Invoke();
+#endif
+
+        var properties = new EventProperty[propertyCount];
+        var variants = (EvtVariant*)buffer;
+
+        for (int i = 0; i < propertyCount; i++)
+        {
+            properties[i] = variants[i].Type == (int)EvtVariantType.Null
+                ? EventProperty.FromReference(null)
+                : ConvertVariantToProperty(variants[i]);
+        }
+
+        return ImmutableCollectionsMarshal.AsImmutableArray(properties);
+    }
+
     internal static unsafe EventRecord RenderEvent(EvtHandle eventHandle) =>
-        RenderWhilePinned(EventLogSession.GlobalSession.SystemRenderContext, eventHandle, EvtRenderFlags.EventValues, &ProcessRenderedEventRecord);
+        RenderWhilePinned(EventLogSession.GlobalSession.SystemRenderContext,
+            eventHandle,
+            EvtRenderFlags.EventValues,
+            &ProcessRenderedEventRecord);
 
     internal static unsafe ImmutableArray<EventProperty> RenderEventProperties(EvtHandle eventHandle) =>
-        RenderWhilePinned(EventLogSession.GlobalSession.UserRenderContext, eventHandle, EvtRenderFlags.EventValues, &ProcessRenderedEventProperties);
+        RenderWhilePinned(EventLogSession.GlobalSession.UserRenderContext,
+            eventHandle,
+            EvtRenderFlags.EventValues,
+            &ProcessRenderedEventProperties);
+
+    internal static unsafe ImmutableArray<EventProperty> RenderEventValues(
+        EvtHandle valuePathsContext,
+        EvtHandle eventHandle) =>
+        RenderWhilePinned(valuePathsContext, eventHandle, EvtRenderFlags.EventValues, &ProcessRenderedValuePaths);
 
     internal static unsafe string? RenderEventXml(EvtHandle eventHandle) =>
         RenderWhilePinned(EvtHandle.Zero, eventHandle, EvtRenderFlags.EventXml, &ProcessRenderedEventXml);

--- a/src/EventLogExpert.Eventing/Structured/StructuredFieldPath.cs
+++ b/src/EventLogExpert.Eventing/Structured/StructuredFieldPath.cs
@@ -28,7 +28,7 @@ internal static class StructuredFieldPath
     /// </summary>
     internal static StructuredFieldResult CollectValues(ReadOnlySpan<char> xml, string[] elements, string? attribute, int cap)
     {
-        if (elements.Length == 0) { return s_absent; }
+        if (elements.Length == 0 || cap <= 0) { return s_absent; }
 
         List<string>? values = null;
         bool truncated = false;

--- a/src/EventLogExpert.Eventing/Structured/StructuredFieldPath.cs
+++ b/src/EventLogExpert.Eventing/Structured/StructuredFieldPath.cs
@@ -88,7 +88,7 @@ internal static class StructuredFieldPath
 
             if (index == segments.Length - 1 && segment.StartsWith('@'))
             {
-                if (!IsValidName(segment[1..])) { return false; }
+                if (index == 0 || !IsValidName(segment[1..])) { return false; }
 
                 continue;
             }

--- a/src/EventLogExpert.Eventing/Structured/StructuredFieldPath.cs
+++ b/src/EventLogExpert.Eventing/Structured/StructuredFieldPath.cs
@@ -1,0 +1,170 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Eventing.Readers;
+
+namespace EventLogExpert.Eventing.Structured;
+
+/// <summary>
+///     Canonical UserData path grammar and extraction. A canonical path is a <c>/</c>-separated chain of element
+///     local names, optionally ending in an <c>@attribute</c>, with <c>[*]</c> marking a repeating element. UserData
+///     content inherits the event's default namespace with no explicit prefix, so matching is by local name only.
+/// </summary>
+internal static class StructuredFieldPath
+{
+    internal const int MaxWildcardValues = 256;
+
+    private const string WildcardMarker = "[*]";
+
+    private static readonly StructuredFieldResult s_absent =
+        new(EventFieldValue.FromProperty(EventProperty.FromReference(null)), false);
+
+    /// <summary>
+    ///     Extracts every leaf value matching the element chain (a repeating element yields all same-name siblings) by
+    ///     scanning <paramref name="xml" /> with a forward, DOM-free reader. Returns the values as a <c>StringArray</c>-kind
+    ///     result, or an absent (Null) result when nothing matches; the result is flagged truncated when more than
+    ///     <paramref name="cap" /> values were present.
+    /// </summary>
+    internal static StructuredFieldResult CollectValues(ReadOnlySpan<char> xml, string[] elements, string? attribute, int cap)
+    {
+        if (elements.Length == 0) { return s_absent; }
+
+        List<string>? values = null;
+        bool truncated = false;
+        int depth = 0;
+        int matched = 0;
+        var scanner = new XmlSpanScanner(xml);
+
+        while (scanner.Read())
+        {
+            if (scanner.NodeType == XmlSpanNode.EndElement)
+            {
+                if (depth > 0)
+                {
+                    depth--;
+
+                    if (matched > depth) { matched = depth; }
+                }
+
+                continue;
+            }
+
+            bool matchesHere = matched == depth && matched < elements.Length && scanner.LocalName.SequenceEqual(elements[matched]);
+
+            if (matchesHere && matched + 1 == elements.Length && TryReadLeaf(ref scanner, attribute, out string value))
+            {
+                if ((values ??= []).Count >= cap) { truncated = true; break; }
+
+                values.Add(value);
+            }
+
+            if (!scanner.IsEmptyElement)
+            {
+                if (matchesHere) { matched++; }
+
+                depth++;
+            }
+        }
+
+        return values is null ?
+            s_absent :
+            new StructuredFieldResult(
+                EventFieldValue.FromProperty(
+                    EventProperty.FromReference(values.ToArray())),
+                truncated);
+    }
+
+    /// <summary>Validates the canonical grammar so a malformed path is rejected before any use.</summary>
+    internal static bool IsValidCanonical(string path)
+    {
+        if (string.IsNullOrEmpty(path)) { return false; }
+
+        string[] segments = path.Split('/');
+
+        for (int index = 0; index < segments.Length; index++)
+        {
+            string segment = segments[index];
+
+            if (index == segments.Length - 1 && segment.StartsWith('@'))
+            {
+                if (!IsValidName(segment[1..])) { return false; }
+
+                continue;
+            }
+
+            string name = segment.EndsWith(WildcardMarker, StringComparison.Ordinal) ?
+                segment[..^WildcardMarker.Length] : segment;
+
+            if (!IsValidName(name)) { return false; }
+        }
+
+        return true;
+    }
+
+    internal static bool IsWildcard(string path) => path.Contains(WildcardMarker, StringComparison.Ordinal);
+
+    /// <summary>Splits a path into its element local names (any <c>[*]</c> stripped) and the optional attribute leaf.</summary>
+    internal static (string[] Elements, string? Attribute) Parse(string path)
+    {
+        string[] segments = path.Split('/');
+        string? attribute = null;
+        int elementCount = segments.Length;
+
+        if (segments[^1].StartsWith('@'))
+        {
+            attribute = segments[^1][1..];
+            elementCount--;
+        }
+
+        var elements = new string[elementCount];
+
+        for (int index = 0; index < elementCount; index++)
+        {
+            string segment = segments[index];
+            int marker = segment.IndexOf(WildcardMarker, StringComparison.Ordinal);
+            elements[index] = marker >= 0 ? segment[..marker] : segment;
+        }
+
+        return (elements, attribute);
+    }
+
+    private static bool IsValidName(string name)
+    {
+        if (name.Length == 0 || !(char.IsLetter(name[0]) || name[0] == '_')) { return false; }
+
+        foreach (char character in name)
+        {
+            if (!(char.IsLetterOrDigit(character) || character is '_' or '-' or '.')) { return false; }
+        }
+
+        return true;
+    }
+
+    private static bool TryReadLeaf(ref XmlSpanScanner scanner, string? attribute, out string value)
+    {
+        if (attribute is null)
+        {
+            ReadOnlySpan<char> text = scanner.RawText(out bool isCData);
+            value = isCData ? text.ToString() : XmlSpanScanner.DecodeToString(text);
+
+            return true;
+        }
+
+        XmlAttributeLister attributes = scanner.Attributes;
+
+        while (attributes.MoveNext())
+        {
+            if (attributes.LocalName.SequenceEqual(attribute))
+            {
+                value = XmlSpanScanner.DecodeToString(attributes.RawValue);
+
+                return true;
+            }
+        }
+
+        value = string.Empty;
+
+        return false;
+    }
+}

--- a/src/EventLogExpert.Eventing/Structured/StructuredFieldResult.cs
+++ b/src/EventLogExpert.Eventing/Structured/StructuredFieldResult.cs
@@ -1,0 +1,18 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+
+namespace EventLogExpert.Eventing.Structured;
+
+/// <summary>
+///     The value of one structured (UserData) field extracted from an event. A repeating field materializes as a
+///     <c>StringArray</c>-kind <see cref="EventFieldValue" />; <see cref="IsTruncated" /> is set when a repeating field
+///     had more values than the extraction cap, so the present values are kept and the loss is still visible.
+/// </summary>
+public readonly struct StructuredFieldResult(EventFieldValue value, bool isTruncated)
+{
+    public EventFieldValue Value { get; } = value;
+
+    public bool IsTruncated { get; } = isTruncated;
+}

--- a/src/EventLogExpert.Eventing/Structured/StructuredSchemaDiscovery.cs
+++ b/src/EventLogExpert.Eventing/Structured/StructuredSchemaDiscovery.cs
@@ -21,7 +21,7 @@ public static class StructuredSchemaDiscovery
 
         foreach (string xml in eventXmlSamples)
         {
-            if (!string.IsNullOrEmpty(xml)) { samples.Add(xml); }
+            if (!string.IsNullOrWhiteSpace(xml)) { samples.Add(xml); }
         }
 
         if (samples.Count == 0) { return []; }

--- a/src/EventLogExpert.Eventing/Structured/StructuredSchemaDiscovery.cs
+++ b/src/EventLogExpert.Eventing/Structured/StructuredSchemaDiscovery.cs
@@ -1,0 +1,140 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Eventing.Structured;
+
+/// <summary>
+///     Discovers the canonical UserData field paths across one or more event XML samples, for a field picker. A leaf
+///     is a value-bearing attribute or a text-only element; an element that repeats (≥2 same-name siblings under one
+///     parent) in any sample is emitted with a <c>[*]</c> marker so a single sample never hides multi-value content a
+///     later event would show. The samples are scanned forward without building a DOM.
+/// </summary>
+public static class StructuredSchemaDiscovery
+{
+    private const string UserDataPrefix = "Event/UserData/";
+
+    public static IReadOnlyList<string> DiscoverUserDataPaths(IEnumerable<string> eventXmlSamples)
+    {
+        ArgumentNullException.ThrowIfNull(eventXmlSamples);
+
+        var samples = new List<string>();
+
+        foreach (string xml in eventXmlSamples)
+        {
+            if (!string.IsNullOrEmpty(xml)) { samples.Add(xml); }
+        }
+
+        if (samples.Count == 0) { return []; }
+
+        var repeating = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (string xml in samples) { CollectRepeating(xml, repeating); }
+
+        var paths = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (string xml in samples) { EmitPaths(xml, repeating, paths); }
+
+        var ordered = new List<string>(paths);
+        ordered.Sort(StringComparer.Ordinal);
+
+        return ordered;
+    }
+
+    private static void CollectRepeating(string xml, HashSet<string> repeating)
+    {
+        var stack = new List<(string StructuralPath, Dictionary<string, int> ChildCounts)>();
+        var scanner = new XmlSpanScanner(xml);
+
+        while (scanner.Read())
+        {
+            if (scanner.NodeType == XmlSpanNode.EndElement)
+            {
+                if (stack.Count > 0) { stack.RemoveAt(stack.Count - 1); }
+
+                continue;
+            }
+
+            string localName = scanner.LocalName.ToString();
+            string structuralPath = stack.Count == 0 ? localName : stack[^1].StructuralPath + "/" + localName;
+
+            if (stack.Count > 0)
+            {
+                Dictionary<string, int> childCounts = stack[^1].ChildCounts;
+                int count = childCounts.GetValueOrDefault(localName) + 1;
+                childCounts[localName] = count;
+
+                if (count == 2) { repeating.Add(structuralPath); }
+            }
+
+            if (!scanner.IsEmptyElement)
+            {
+                stack.Add((structuralPath, new Dictionary<string, int>(StringComparer.Ordinal)));
+            }
+        }
+    }
+
+    private static void EmitPaths(string xml, HashSet<string> repeating, HashSet<string> paths)
+    {
+        var stack = new List<Frame>();
+        var scanner = new XmlSpanScanner(xml);
+
+        while (scanner.Read())
+        {
+            if (scanner.NodeType == XmlSpanNode.EndElement)
+            {
+                if (stack.Count == 0) { continue; }
+
+                Frame closed = stack[^1];
+                stack.RemoveAt(stack.Count - 1);
+
+                if (closed is { HasChild: false, Text.Length: > 0 } &&
+                    closed.CanonicalPath.StartsWith(UserDataPrefix, StringComparison.Ordinal))
+                {
+                    paths.Add(closed.CanonicalPath);
+                }
+
+                continue;
+            }
+
+            string localName = scanner.LocalName.ToString();
+            Frame? parent = stack.Count > 0 ? stack[^1] : null;
+            string structuralPath = parent is null ? localName : parent.StructuralPath + "/" + localName;
+            string segment = repeating.Contains(structuralPath) ? localName + "[*]" : localName;
+            string canonicalPath = parent is null ? segment : parent.CanonicalPath + "/" + segment;
+
+            parent?.HasChild = true;
+
+            if (canonicalPath.StartsWith(UserDataPrefix, StringComparison.Ordinal))
+            {
+                XmlAttributeLister attributes = scanner.Attributes;
+
+                while (attributes.MoveNext())
+                {
+                    paths.Add(canonicalPath + "/@" + attributes.LocalName.ToString());
+                }
+            }
+
+            if (scanner.IsEmptyElement) { continue; }
+
+            ReadOnlySpan<char> text = scanner.RawText(out _);
+
+            stack.Add(new Frame
+            {
+                CanonicalPath = canonicalPath,
+                StructuralPath = structuralPath,
+                Text = text.IsWhiteSpace() ? string.Empty : text.ToString()
+            });
+        }
+    }
+
+    private sealed class Frame
+    {
+        public required string CanonicalPath { get; init; }
+
+        public bool HasChild { get; set; }
+
+        public required string StructuralPath { get; init; }
+
+        public required string Text { get; init; }
+    }
+}

--- a/src/EventLogExpert.Eventing/Structured/XmlSpanScanner.cs
+++ b/src/EventLogExpert.Eventing/Structured/XmlSpanScanner.cs
@@ -1,0 +1,309 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Buffers;
+using System.Globalization;
+using System.Text;
+
+namespace EventLogExpert.Eventing.Structured;
+
+internal enum XmlSpanNode : byte
+{
+    Element,
+    EndElement
+}
+
+/// <summary>
+///     Forward-only, DOM-free scanner over rendered event XML. Elements are read by local name (any namespace prefix
+///     is dropped), and attribute names, attribute values, and element text are exposed as spans into the source so a
+///     caller extracts only the values it wants, allocating a string just for those. Handles the shapes wevtapi emits: the
+///     XML declaration, comments, CDATA, single- or double-quoted attributes, and self-closing elements.
+/// </summary>
+internal ref struct XmlSpanScanner(ReadOnlySpan<char> xml)
+{
+    private static readonly SearchValues<char> s_whitespace = SearchValues.Create(" \t\r\n");
+
+    private readonly ReadOnlySpan<char> _xml = xml;
+    private int _position;
+    private ReadOnlySpan<char> _attributes;
+    private int _contentStart = -1;
+
+    public XmlSpanNode NodeType { get; private set; }
+
+    public ReadOnlySpan<char> LocalName { get; private set; }
+
+    public bool IsEmptyElement { get; private set; }
+
+    public bool Read()
+    {
+        IsEmptyElement = false;
+        _attributes = default;
+        _contentStart = -1;
+
+        while (_position < _xml.Length)
+        {
+            int relativeStart = _xml[_position..].IndexOf('<');
+
+            if (relativeStart < 0) { break; }
+
+            _position += relativeStart;
+            ReadOnlySpan<char> rest = _xml[_position..];
+
+            if (rest.StartsWith("<?")) { Skip("?>"); continue; }
+
+            if (rest.StartsWith("<!--")) { Skip("-->"); continue; }
+
+            if (rest.StartsWith("<![CDATA[")) { Skip("]]>"); continue; }
+
+            if (rest.StartsWith("<!")) { SkipTag(); continue; }
+
+            int closeRelative = IndexOfTagEnd(rest);
+
+            if (closeRelative < 0) { break; }
+
+            int closeAbsolute = _position + closeRelative;
+
+            if (rest[1] == '/')
+            {
+                LocalName = LocalNameOf(_xml[(_position + 2)..closeAbsolute].Trim());
+                _position = closeAbsolute + 1;
+                NodeType = XmlSpanNode.EndElement;
+
+                return true;
+            }
+
+            ReadOnlySpan<char> tag = _xml[(_position + 1)..closeAbsolute];
+
+            if (tag.EndsWith("/"))
+            {
+                tag = tag[..^1];
+                IsEmptyElement = true;
+            }
+
+            int nameEnd = tag.IndexOfAny(s_whitespace);
+
+            LocalName = LocalNameOf(nameEnd < 0 ? tag : tag[..nameEnd]);
+            _attributes = nameEnd < 0 ? default : tag[nameEnd..];
+            _position = closeAbsolute + 1;
+            _contentStart = _position;
+            NodeType = XmlSpanNode.Element;
+
+            return true;
+        }
+
+        _position = _xml.Length;
+
+        return false;
+    }
+
+    public XmlAttributeLister Attributes => new(_attributes);
+
+    /// <summary>
+    ///     Text content of the element just read: entity-encoded text up to the next tag, or, when
+    ///     <paramref name="isCData" /> is set, the literal contents of a leading CDATA section.
+    /// </summary>
+    public readonly ReadOnlySpan<char> RawText(out bool isCData)
+    {
+        isCData = false;
+
+        if (_contentStart < 0) { return default; }
+
+        ReadOnlySpan<char> rest = _xml[_contentStart..];
+        int relativeEnd = rest.IndexOf('<');
+
+        if (relativeEnd < 0 || !rest[relativeEnd..].StartsWith("<![CDATA["))
+        {
+            return relativeEnd < 0 ? rest : rest[..relativeEnd];
+        }
+
+        isCData = true;
+
+        ReadOnlySpan<char> cdataRest = rest[(relativeEnd + 9)..];
+        int cdataEnd = cdataRest.IndexOf("]]>");
+
+        return cdataEnd < 0 ? cdataRest : cdataRest[..cdataEnd];
+
+    }
+
+    /// <summary>Materializes a value span, decoding XML entities only when the span actually contains one.</summary>
+    public static string DecodeToString(ReadOnlySpan<char> value)
+    {
+        if (value.IndexOf('&') < 0) { return value.ToString(); }
+
+        var builder = new StringBuilder(value.Length);
+
+        for (int index = 0; index < value.Length;)
+        {
+            char current = value[index];
+
+            if (current != '&') { builder.Append(current); index++; continue; }
+
+            int semicolon = value[index..].IndexOf(';');
+
+            if (semicolon < 0) { builder.Append(current); index++; continue; }
+
+            ReadOnlySpan<char> entity = value.Slice(index + 1, semicolon - 1);
+
+            if (TryDecodeEntity(entity, out char decoded))
+            {
+                builder.Append(decoded);
+            }
+            else
+            {
+                builder.Append(value.Slice(index, semicolon + 1));
+            }
+
+            index += semicolon + 1;
+        }
+
+        return builder.ToString();
+    }
+
+    private static bool TryDecodeEntity(ReadOnlySpan<char> entity, out char decoded)
+    {
+        switch (entity)
+        {
+            case "amp": decoded = '&'; return true;
+            case "lt": decoded = '<'; return true;
+            case "gt": decoded = '>'; return true;
+            case "quot": decoded = '"'; return true;
+            case "apos": decoded = '\''; return true;
+        }
+
+        if (entity.Length >= 2 && entity[0] == '#')
+        {
+            bool hex = entity[1] is 'x' or 'X';
+            ReadOnlySpan<char> digits = hex ? entity[2..] : entity[1..];
+
+            if (int.TryParse(digits,
+                    hex ? NumberStyles.HexNumber : NumberStyles.Integer,
+                    CultureInfo.InvariantCulture,
+                    out int code) &&
+                code is > 0 and <= char.MaxValue)
+            {
+                decoded = (char)code;
+
+                return true;
+            }
+        }
+
+        decoded = '\0';
+
+        return false;
+    }
+
+    private static ReadOnlySpan<char> LocalNameOf(ReadOnlySpan<char> name)
+    {
+        int colon = name.LastIndexOf(':');
+
+        return colon < 0 ? name : name[(colon + 1)..];
+    }
+
+    // Finds the '>' that closes a tag, ignoring any '>' inside a single- or double-quoted attribute value.
+    private static int IndexOfTagEnd(ReadOnlySpan<char> tag)
+    {
+        char quote = '\0';
+
+        for (int index = 1; index < tag.Length; index++)
+        {
+            char character = tag[index];
+
+            if (quote != '\0')
+            {
+                if (character == quote) { quote = '\0'; }
+            }
+            else if (character is '\'' or '"')
+            {
+                quote = character;
+            }
+            else if (character == '>')
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    private void Skip(ReadOnlySpan<char> terminator)
+    {
+        int relativeEnd = _xml[_position..].IndexOf(terminator);
+
+        _position = relativeEnd < 0 ? _xml.Length : _position + relativeEnd + terminator.Length;
+    }
+
+    private void SkipTag()
+    {
+        int relativeEnd = _xml[_position..].IndexOf('>');
+
+        _position = relativeEnd < 0 ? _xml.Length : _position + relativeEnd + 1;
+    }
+}
+
+/// <summary>Forward-only enumerator over an element's attributes, skipping xmlns declarations, without allocating.</summary>
+internal ref struct XmlAttributeLister(ReadOnlySpan<char> attributes)
+{
+    private static readonly SearchValues<char> s_whitespace = SearchValues.Create(" \t\r\n");
+
+    private ReadOnlySpan<char> _remaining = attributes;
+
+    public ReadOnlySpan<char> LocalName { get; private set; }
+
+    public ReadOnlySpan<char> RawValue { get; private set; }
+
+    public bool MoveNext()
+    {
+        while (true)
+        {
+            int nameStart = IndexOfNonWhitespace(_remaining);
+
+            if (nameStart < 0) { return false; }
+
+            ReadOnlySpan<char> fromName = _remaining[nameStart..];
+            int equals = fromName.IndexOf('=');
+
+            if (equals < 0) { return false; }
+
+            ReadOnlySpan<char> name = fromName[..equals].TrimEnd();
+            ReadOnlySpan<char> afterEquals = fromName[(equals + 1)..];
+            int quoteStart = IndexOfNonWhitespace(afterEquals);
+
+            if (quoteStart < 0) { return false; }
+
+            char quote = afterEquals[quoteStart];
+
+            if (quote is not ('\'' or '"')) { return false; }
+
+            ReadOnlySpan<char> fromQuote = afterEquals[(quoteStart + 1)..];
+            int valueEnd = fromQuote.IndexOf(quote);
+
+            if (valueEnd < 0) { return false; }
+
+            _remaining = fromQuote[(valueEnd + 1)..];
+
+            if (name.StartsWith("xmlns") && (name.Length == 5 || name[5] == ':')) { continue; }
+
+            LocalName = LocalNameOf(name);
+            RawValue = fromQuote[..valueEnd];
+
+            return true;
+        }
+    }
+
+    private static ReadOnlySpan<char> LocalNameOf(ReadOnlySpan<char> name)
+    {
+        int colon = name.LastIndexOf(':');
+
+        return colon < 0 ? name : name[(colon + 1)..];
+    }
+
+    private static int IndexOfNonWhitespace(ReadOnlySpan<char> span)
+    {
+        for (int index = 0; index < span.Length; index++)
+        {
+            if (!s_whitespace.Contains(span[index])) { return index; }
+        }
+
+        return -1;
+    }
+}

--- a/src/EventLogExpert.Eventing/Structured/XmlSpanScanner.cs
+++ b/src/EventLogExpert.Eventing/Structured/XmlSpanScanner.cs
@@ -144,11 +144,7 @@ internal ref struct XmlSpanScanner(ReadOnlySpan<char> xml)
 
             ReadOnlySpan<char> entity = value.Slice(index + 1, semicolon - 1);
 
-            if (TryDecodeEntity(entity, out char decoded))
-            {
-                builder.Append(decoded);
-            }
-            else
+            if (!TryDecodeEntity(entity, builder))
             {
                 builder.Append(value.Slice(index, semicolon + 1));
             }
@@ -159,37 +155,38 @@ internal ref struct XmlSpanScanner(ReadOnlySpan<char> xml)
         return builder.ToString();
     }
 
-    private static bool TryDecodeEntity(ReadOnlySpan<char> entity, out char decoded)
+    private static bool TryDecodeEntity(ReadOnlySpan<char> entity, StringBuilder builder)
     {
         switch (entity)
         {
-            case "amp": decoded = '&'; return true;
-            case "lt": decoded = '<'; return true;
-            case "gt": decoded = '>'; return true;
-            case "quot": decoded = '"'; return true;
-            case "apos": decoded = '\''; return true;
+            case "amp": builder.Append('&'); return true;
+            case "lt": builder.Append('<'); return true;
+            case "gt": builder.Append('>'); return true;
+            case "quot": builder.Append('"'); return true;
+            case "apos": builder.Append('\''); return true;
         }
 
-        if (entity.Length >= 2 && entity[0] == '#')
+        if (entity.Length < 2 || entity[0] != '#') { return false; }
+
+        bool hex = entity[1] is 'x' or 'X';
+        ReadOnlySpan<char> digits = hex ? entity[2..] : entity[1..];
+
+        if (!int.TryParse(digits,
+                hex ? NumberStyles.HexNumber : NumberStyles.Integer,
+                CultureInfo.InvariantCulture,
+                out int code) ||
+            code <= 0 ||
+            !Rune.TryCreate(code, out Rune rune))
         {
-            bool hex = entity[1] is 'x' or 'X';
-            ReadOnlySpan<char> digits = hex ? entity[2..] : entity[1..];
-
-            if (int.TryParse(digits,
-                    hex ? NumberStyles.HexNumber : NumberStyles.Integer,
-                    CultureInfo.InvariantCulture,
-                    out int code) &&
-                code is > 0 and <= char.MaxValue)
-            {
-                decoded = (char)code;
-
-                return true;
-            }
+            return false;
         }
 
-        decoded = '\0';
+        Span<char> utf16 = stackalloc char[2];
+        int written = rune.EncodeToUtf16(utf16);
+        builder.Append(utf16[..written]);
 
-        return false;
+        return true;
+
     }
 
     private static ReadOnlySpan<char> LocalNameOf(ReadOnlySpan<char> name)

--- a/tests/Integration/EventLogExpert.Eventing.IntegrationTests/Interop/ValuePathsRenderTests.cs
+++ b/tests/Integration/EventLogExpert.Eventing.IntegrationTests/Interop/ValuePathsRenderTests.cs
@@ -1,0 +1,273 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Eventing.Interop;
+using EventLogExpert.Eventing.Readers;
+using EventLogExpert.Eventing.TestUtils.Constants;
+using System.Xml;
+
+namespace EventLogExpert.Eventing.IntegrationTests.Interop;
+
+public sealed class ValuePathsRenderTests
+{
+    private const string Capi2EvtxEnvVar = "EVENTLOG_CAPI2_EVTX";
+
+    [Fact]
+    public void RenderEventValues_ForAllAbsentPaths_YieldsNullsWithoutThrowing()
+    {
+        using EvtHandle handle = FirstEventHandle(Constants.ApplicationLogName, LogPathType.Channel);
+        Assert.SkipUnless(!handle.IsInvalid, "Application log has no readable events on this host.");
+
+        string[] paths =
+        [
+            "Event/System/NoSuchElementOne",
+            "Event/UserData/NoSuchProviderRoot/NoSuchLeaf",
+            "Event/EventData/Data[@Name='__no_such_field__']"
+        ];
+
+        var values = RenderValues(paths, handle);
+
+        Assert.Equal(paths.Length, values.Length);
+        Assert.All(values, value => Assert.Equal(EventFieldValueKind.Null, value.Kind));
+    }
+
+    // Grounded check against a real Microsoft-Windows-CAPI2 log, gated on an env var so hosts without the data skip.
+    // Proves the value-paths engine and a local-name System.Xml parse agree on a real UserData attribute whose
+    // element chain carries no explicit xmlns and inherits the event default namespace.
+    [Fact]
+    public void RenderEventValues_ForRealUserDataAttribute_MatchesLocalNameXmlParse()
+    {
+        string? evtxPath = Environment.GetEnvironmentVariable(Capi2EvtxEnvVar);
+        Assert.SkipUnless(
+            !string.IsNullOrWhiteSpace(evtxPath) && File.Exists(evtxPath),
+            $"Set {Capi2EvtxEnvVar} to a UserData-bearing .evtx to run the grounded CAPI2 parity check.");
+
+        EvtHandle query = NativeMethods.EvtQuery(EventLogSession.GlobalSession.Handle, evtxPath!, null, LogPathType.File);
+        Assert.False(query.IsInvalid, $"EvtQuery failed for file '{evtxPath}'.");
+
+        try
+        {
+            (EvtHandle handle, XmlElement root, string userDataPath, string expected) = FirstUserDataAttribute(query);
+
+            using (handle)
+            {
+                Assert.SkipUnless(!handle.IsInvalid, "No <UserData> event with a value-bearing attribute was found in the file.");
+
+                string absentPath = SiblingAbsentPath(userDataPath);
+                string[] paths = [userDataPath, absentPath];
+
+                var values = RenderValues(paths, handle);
+
+                Assert.Equal(2, values.Length);
+                Assert.Equal(expected, values[0].AsString());               // value-paths == local-name XML parse
+                Assert.Equal(EventFieldValueKind.Null, values[1].Kind);     // absent sibling -> Null
+            }
+        }
+        finally
+        {
+            query.Dispose();
+        }
+    }
+
+    // Test A - mechanical, provider-agnostic. Well-known System value-paths are present on every event, so this runs
+    // on any host with a readable Application log and validates the whole native pipeline plus the namespace behavior
+    // (unqualified value-paths resolving against the event default namespace) without any external data.
+    [Fact]
+    public void RenderEventValues_ForSystemPaths_MatchesXmlAndYieldsNullForAbsent()
+    {
+        using EvtHandle handle = FirstEventHandle(Constants.ApplicationLogName, LogPathType.Channel);
+        Assert.SkipUnless(!handle.IsInvalid, "Application log has no readable events on this host.");
+
+        string xml = NativeMethods.RenderEventXml(handle) ?? throw new InvalidOperationException("RenderEventXml returned null.");
+        XmlElement root = LoadEventXml(xml);
+
+        string[] paths =
+        [
+            "Event/System/EventID",
+            "Event/System/Provider/@Name",
+            "Event/System/Computer",
+            "Event/System/ThisElementDoesNotExist"   // absent -> must render as Null, not throw
+        ];
+
+        var values = RenderValues(paths, handle);
+
+        // The whole path array marshalled and the render is index-aligned to it.
+        Assert.Equal(paths.Length, values.Length);
+
+        // Present paths agree with the local-name XML parse.
+        Assert.Equal(LocalNameText(root, "EventID"), values[0].AsString());
+        Assert.Equal(LocalNameAttribute(root, "Provider", "Name"), values[1].AsString());
+        Assert.Equal(LocalNameText(root, "Computer"), values[2].AsString());
+
+        // Absent path -> Null; the common absent case must not throw.
+        Assert.Equal(EventFieldValueKind.Null, values[3].Kind);
+    }
+
+    // Builds an Event-rooted value-path of element local names down to @attribute, e.g.
+    // Event/UserData/CertVerifyCertificateChainPolicy/EventAuxInfo/@ProcessName.
+    private static string BuildValuePath(XmlElement leaf, string attributeLocalName)
+    {
+        var names = new List<string>();
+
+        for (XmlNode? node = leaf; node is XmlElement element; node = node.ParentNode)
+        {
+            names.Insert(0, element.LocalName);
+        }
+
+        return string.Join('/', names) + "/@" + attributeLocalName;
+    }
+
+    private static IEnumerable<XmlNode> EnumerateElements(XmlNode node)
+    {
+        foreach (XmlNode child in node.ChildNodes)
+        {
+            if (child.NodeType != XmlNodeType.Element) { continue; }
+
+            yield return child;
+
+            foreach (XmlNode nested in EnumerateElements(child)) { yield return nested; }
+        }
+    }
+
+    private static EvtHandle FirstEventHandle(string path, LogPathType pathType)
+    {
+        EvtHandle query = NativeMethods.EvtQuery(EventLogSession.GlobalSession.Handle, path, null, pathType);
+        Assert.False(query.IsInvalid, $"EvtQuery failed for '{path}'.");
+
+        try
+        {
+            var batch = new IntPtr[1];
+            int returned = 0;
+
+            if (!NativeMethods.EvtNext(query, batch.Length, batch, 0, 0, ref returned) || returned != 1)
+            {
+                return EvtHandle.Zero;
+            }
+
+            return new EvtHandle(batch[0]);
+        }
+        finally
+        {
+            query.Dispose();
+        }
+    }
+
+    private static XmlNode? FirstLocalName(XmlNode node, string localName)
+    {
+        foreach (XmlNode element in EnumerateElements(node))
+        {
+            if (element.LocalName == localName) { return element; }
+        }
+
+        return null;
+    }
+
+    // Scans events until it finds one whose <UserData> subtree has an attribute with a non-empty value, then returns
+    // that event handle, its parsed XML, the canonical local-name value-path to the attribute, and the expected value.
+    private static (EvtHandle Handle, XmlElement Root, string Path, string Expected) FirstUserDataAttribute(EvtHandle query)
+    {
+        const int scanLimit = 2000;
+        int scanned = 0;
+
+        while (scanned < scanLimit)
+        {
+            var batch = new IntPtr[16];
+            int returned = 0;
+
+            if (!NativeMethods.EvtNext(query, batch.Length, batch, 0, 0, ref returned) || returned == 0) { break; }
+
+            for (int i = 0; i < returned; i++)
+            {
+                var handle = new EvtHandle(batch[i]);
+                scanned++;
+
+                string? xml = NativeMethods.RenderEventXml(handle);
+
+                if (xml is not null && TryFindUserDataAttribute(xml, out XmlElement root, out string path, out string expected))
+                {
+                    // Dispose the other handles in this batch; keep the match.
+                    for (int j = i + 1; j < returned; j++) { new EvtHandle(batch[j]).Dispose(); }
+
+                    return (handle, root, path, expected);
+                }
+
+                handle.Dispose();
+            }
+        }
+
+        return (EvtHandle.Zero, null!, string.Empty, string.Empty);
+    }
+
+    private static XmlElement LoadEventXml(string xml)
+    {
+        var document = new XmlDocument();
+        document.LoadXml(xml);
+
+        return document.DocumentElement ?? throw new InvalidOperationException("Event XML has no root element.");
+    }
+
+    private static string LocalNameAttribute(XmlElement root, string elementLocalName, string attributeLocalName)
+    {
+        if (FirstLocalName(root, elementLocalName) is not XmlElement element) { return string.Empty; }
+
+        foreach (XmlAttribute attribute in element.Attributes)
+        {
+            if (attribute.LocalName == attributeLocalName) { return attribute.Value; }
+        }
+
+        return string.Empty;
+    }
+
+    private static string LocalNameText(XmlElement root, string localName) =>
+        FirstLocalName(root, localName)?.InnerText ?? string.Empty;
+
+    private static EventFieldValue[] RenderValues(string[] paths, EvtHandle handle)
+    {
+        using EvtHandle context = NativeMethods.EvtCreateRenderContext(paths.Length, paths, EvtRenderContextFlags.Values);
+        Assert.False(context.IsInvalid, "EvtCreateRenderContext(Values) failed.");
+
+        var rendered = NativeMethods.RenderEventValues(context, handle);
+
+        var values = new EventFieldValue[rendered.Length];
+        for (int i = 0; i < rendered.Length; i++) { values[i] = EventFieldValue.FromProperty(rendered[i]); }
+
+        return values;
+    }
+
+    private static string SiblingAbsentPath(string valuePath)
+    {
+        int lastSlash = valuePath.LastIndexOf('/');
+
+        return valuePath[..(lastSlash + 1)] + "@__no_such_attribute__";
+    }
+
+    private static bool TryFindUserDataAttribute(string xml, out XmlElement root, out string path, out string expected)
+    {
+        root = LoadEventXml(xml);
+        path = string.Empty;
+        expected = string.Empty;
+
+        XmlNode? userData = FirstLocalName(root, "UserData");
+        if (userData is null) { return false; }
+
+        foreach (XmlNode descendant in EnumerateElements(userData))
+        {
+            if (descendant.Attributes is null) { continue; }
+
+            foreach (XmlAttribute attribute in descendant.Attributes)
+            {
+                if (attribute.Name.StartsWith("xmlns", StringComparison.Ordinal)) { continue; }
+                if (string.IsNullOrEmpty(attribute.Value)) { continue; }
+
+                path = BuildValuePath((XmlElement)descendant, attribute.LocalName);
+                expected = attribute.Value;
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Integration/EventLogExpert.Eventing.IntegrationTests/Structured/StructuredUserDataTests.cs
+++ b/tests/Integration/EventLogExpert.Eventing.IntegrationTests/Structured/StructuredUserDataTests.cs
@@ -1,0 +1,91 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Interop;
+using EventLogExpert.Eventing.Readers;
+using EventLogExpert.Eventing.Structured;
+using System.Xml;
+
+namespace EventLogExpert.Eventing.IntegrationTests.Structured;
+
+// Cross-checks the span-based schema discovery and value extraction against a System.Xml oracle on real rendered
+// event XML. Gated on an env var pointing at a UserData-bearing .evtx (a real Microsoft-Windows-CAPI2 log) so hosts
+// without the data skip cleanly rather than depending on a committed cert log.
+public sealed class StructuredUserDataTests
+{
+    private const string Capi2EvtxEnvVar = "EVENTLOG_CAPI2_EVTX";
+
+    [Fact]
+    public void DiscoverAndCollect_OnRealUserData_AgreeWithSystemXml()
+    {
+        string? evtxPath = Environment.GetEnvironmentVariable(Capi2EvtxEnvVar);
+        Assert.SkipUnless(
+            !string.IsNullOrWhiteSpace(evtxPath) && File.Exists(evtxPath),
+            $"Set {Capi2EvtxEnvVar} to a UserData-bearing .evtx to run the grounded discovery/extraction check.");
+
+        string xml = FirstUserDataXml(evtxPath!);
+        Assert.SkipUnless(xml.Length > 0, "No <UserData> event found in the file.");
+
+        var discovered = StructuredSchemaDiscovery.DiscoverUserDataPaths([xml]);
+        Assert.NotEmpty(discovered);
+        Assert.All(discovered, path => Assert.StartsWith("Event/UserData/", path));
+
+        string? scalarPath = discovered.FirstOrDefault(path => !StructuredFieldPath.IsWildcard(path) && path.Contains("/@", StringComparison.Ordinal));
+        Assert.SkipUnless(scalarPath is not null, "No scalar UserData attribute discovered in the sample.");
+
+        (string[] elements, string? attribute) = StructuredFieldPath.Parse(scalarPath!);
+        StructuredFieldResult result = StructuredFieldPath.CollectValues(xml.AsSpan(), elements, attribute, StructuredFieldPath.MaxWildcardValues);
+
+        Assert.Equal(OracleValues(xml, elements, attribute), result.Value.AsString());
+    }
+
+    private static string FirstUserDataXml(string evtxPath)
+    {
+        EvtHandle query = NativeMethods.EvtQuery(EventLogSession.GlobalSession.Handle, evtxPath, null, LogPathType.File);
+        Assert.False(query.IsInvalid, $"EvtQuery failed for file '{evtxPath}'.");
+
+        try
+        {
+            for (int scanned = 0; scanned < 2000;)
+            {
+                var batch = new IntPtr[16];
+                int returned = 0;
+
+                if (!NativeMethods.EvtNext(query, batch.Length, batch, 0, 0, ref returned) || returned == 0) { break; }
+
+                for (int index = 0; index < returned; index++)
+                {
+                    using var handle = new EvtHandle(batch[index]);
+                    scanned++;
+
+                    string? xml = NativeMethods.RenderEventXml(handle);
+
+                    if (xml is not null && xml.Contains("<UserData", StringComparison.Ordinal)) { return xml; }
+                }
+            }
+        }
+        finally
+        {
+            query.Dispose();
+        }
+
+        return string.Empty;
+    }
+
+    // Independent System.Xml oracle: navigate the same element chain by local name and read the leaf value.
+    private static string OracleValues(string xml, string[] elements, string? attribute)
+    {
+        string elementXPath = "/" + string.Join('/', elements.Select(name => $"*[local-name()='{name}']"));
+        string xpath = attribute is null ? elementXPath : $"{elementXPath}/@*[local-name()='{attribute}']";
+
+        var document = new XmlDocument();
+        document.LoadXml(xml);
+
+        XmlNodeList? nodes = document.SelectNodes(xpath);
+
+        if (nodes is null) { return string.Empty; }
+
+        return string.Join(", ", nodes.Cast<XmlNode>().Select(node => attribute is null ? node.InnerText : node.Value ?? string.Empty));
+    }
+}

--- a/tests/Integration/EventLogExpert.Eventing.IntegrationTests/Structured/StructuredUserDataTests.cs
+++ b/tests/Integration/EventLogExpert.Eventing.IntegrationTests/Structured/StructuredUserDataTests.cs
@@ -61,7 +61,15 @@ public sealed class StructuredUserDataTests
 
                     string? xml = NativeMethods.RenderEventXml(handle);
 
-                    if (xml is not null && xml.Contains("<UserData", StringComparison.Ordinal)) { return xml; }
+                    if (xml is not null && xml.Contains("<UserData", StringComparison.Ordinal))
+                    {
+                        for (int remaining = index + 1; remaining < returned; remaining++)
+                        {
+                            new EvtHandle(batch[remaining]).Dispose();
+                        }
+
+                        return xml;
+                    }
                 }
             }
         }

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Structured/StructuredFieldPathTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Structured/StructuredFieldPathTests.cs
@@ -171,6 +171,7 @@ public sealed class StructuredFieldPathTests
     [InlineData("Event/System/@Name/Extra")]
     [InlineData("Event/System/@")]
     [InlineData("Event/1System/EventID")]
+    [InlineData("@Name")]
     public void IsValidCanonical_RejectsMalformedPaths(string path) =>
         Assert.False(StructuredFieldPath.IsValidCanonical(path));
 

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Structured/StructuredFieldPathTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Structured/StructuredFieldPathTests.cs
@@ -1,0 +1,184 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Eventing.Structured;
+
+namespace EventLogExpert.Eventing.Tests.Structured;
+
+public sealed class StructuredFieldPathTests
+{
+    // Samples declare the event default namespace and leave the payload unprefixed, like real rendered event XML, so
+    // local-name matching is exercised against the namespace it must ignore.
+    private const string Ns = "xmlns='http://schemas.microsoft.com/win/2004/08/events/event'";
+
+    [Fact]
+    public void CollectValues_AbsentPath_IsNull()
+    {
+        StructuredFieldResult result = Collect(
+            $"<Event {Ns}><UserData><Root><Item value='x'/></Root></UserData></Event>",
+            "Event/UserData/Root/Missing/@value");
+
+        Assert.Equal(EventFieldValueKind.Null, result.Value.Kind);
+        Assert.False(result.IsTruncated);
+    }
+
+    [Fact]
+    public void CollectValues_AttributeValueWithRawGreaterThan_IsExtracted()
+    {
+        StructuredFieldResult result = Collect(
+            $"<Event {Ns}><UserData><Root><Item value='a > b'/></Root></UserData></Event>",
+            "Event/UserData/Root/Item/@value");
+
+        Assert.Equal("a > b", result.Value.AsString());
+    }
+
+    [Fact]
+    public void CollectValues_DecodesEntitiesInValues()
+    {
+        StructuredFieldResult result = Collect(
+            $"<Event {Ns}><UserData><Root><Item value='a &amp; b &lt; c'/></Root></UserData></Event>",
+            "Event/UserData/Root/Item/@value");
+
+        Assert.Equal("a & b < c", result.Value.AsString());
+    }
+
+    [Fact]
+    public void CollectValues_ElementTextLeaf_ReturnsCDataText()
+    {
+        StructuredFieldResult result = Collect(
+            $"<Event {Ns}><UserData><Root><Status><![CDATA[Success &amp; Failure]]></Status></Root></UserData></Event>",
+            "Event/UserData/Root/Status");
+
+        Assert.Equal("Success &amp; Failure", result.Value.AsString());
+    }
+
+    [Fact]
+    public void CollectValues_ElementTextLeaf_ReturnsInnerText()
+    {
+        StructuredFieldResult result = Collect(
+            $"<Event {Ns}><UserData><Root><Status>Success</Status></Root></UserData></Event>",
+            "Event/UserData/Root/Status");
+
+        Assert.Equal("Success", result.Value.AsString());
+    }
+
+    [Fact]
+    public void CollectValues_ExceedingCap_IncludesUpToCapAndFlagsTruncation()
+    {
+        string items = string.Concat(Enumerable.Range(0, 5).Select(index => $"<Item value='{index}'/>"));
+        StructuredFieldResult result = StructuredFieldPath.CollectValues(
+            $"<Event {Ns}><UserData><Root>{items}</Root></UserData></Event>".AsSpan(),
+            ["Event", "UserData", "Root", "Item"],
+            "value",
+            cap: 3);
+
+        Assert.Equal("0, 1, 2", result.Value.AsString());
+        Assert.True(result.IsTruncated);
+    }
+
+    [Fact]
+    public void CollectValues_MalformedLeadingEndTag_DoesNotThrowAndStillExtracts()
+    {
+        StructuredFieldResult result = Collect(
+            $"</Stray><Event {Ns}><UserData><Root><Item value='ok'/></Root></UserData></Event>",
+            "Event/UserData/Root/Item/@value");
+
+        Assert.Equal("ok", result.Value.AsString());
+    }
+
+    [Fact]
+    public void CollectValues_MatchesByLocalNameAcrossDefaultNamespace()
+    {
+        StructuredFieldResult result = Collect(
+            $"<Event {Ns}><UserData><Root><Item value='only'/></Root></UserData></Event>",
+            "Event/UserData/Root/Item/@value");
+
+        Assert.Equal(EventFieldValueKind.StringArray, result.Value.Kind);
+        Assert.Equal("only", result.Value.AsString());
+        Assert.False(result.IsTruncated);
+    }
+
+    [Fact]
+    public void CollectValues_PresentButEmptyAttribute_IsEmptyString()
+    {
+        StructuredFieldResult result = Collect(
+            $"<Event {Ns}><UserData><Root><Item value=''/></Root></UserData></Event>",
+            "Event/UserData/Root/Item/@value");
+
+        Assert.Equal(EventFieldValueKind.StringArray, result.Value.Kind);
+        Assert.Equal(string.Empty, result.Value.AsString());
+    }
+
+    [Fact]
+    public void CollectValues_RepeatingElement_ReturnsAllValuesInDocumentOrder()
+    {
+        StructuredFieldResult result = Collect(
+            $"<Event {Ns}><UserData><Root><Item value='a'/><Item value='b'/><Item value='c'/></Root></UserData></Event>",
+            "Event/UserData/Root/Item[*]/@value");
+
+        Assert.Equal("a, b, c", result.Value.AsString());
+        Assert.False(result.IsTruncated);
+    }
+
+    [Fact]
+    public void CollectValues_RepeatingUnderRepeatingParent_ReturnsEveryLeaf()
+    {
+        StructuredFieldResult result = Collect(
+            $"<Event {Ns}><UserData><Root><Item value='a'/></Root><Root><Item value='b'/></Root></UserData></Event>",
+            "Event/UserData/Root/Item/@value");
+
+        Assert.Equal("a, b", result.Value.AsString());
+    }
+
+    [Theory]
+    [InlineData("Event/System/EventID")]
+    [InlineData("Event/System/Provider/@Name")]
+    [InlineData("Event/UserData/CertVerifyCertificateChainPolicy/Certificate/@subjectName")]
+    [InlineData("Event/UserData/Root/Item[*]/@value")]
+    [InlineData("Event/UserData/Root/Item[*]")]
+    public void IsValidCanonical_AcceptsWellFormedPaths(string path) =>
+        Assert.True(StructuredFieldPath.IsValidCanonical(path));
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("Event//EventID")]
+    [InlineData("Event/Sys tem/EventID")]
+    [InlineData("Event/System/@Name/Extra")]
+    [InlineData("Event/System/@")]
+    [InlineData("Event/1System/EventID")]
+    public void IsValidCanonical_RejectsMalformedPaths(string path) =>
+        Assert.False(StructuredFieldPath.IsValidCanonical(path));
+
+    [Theory]
+    [InlineData("Event/UserData/Root/Item[*]/@value", true)]
+    [InlineData("Event/UserData/Root/Item/@value", false)]
+    [InlineData("Event/System/EventID", false)]
+    public void IsWildcard_DetectsRepeatingMarker(string path, bool expected) =>
+        Assert.Equal(expected, StructuredFieldPath.IsWildcard(path));
+
+    [Fact]
+    public void Parse_ElementTextLeaf_HasNoAttribute()
+    {
+        (string[] elements, string? attribute) = StructuredFieldPath.Parse("Event/UserData/Root/Status");
+
+        Assert.Equal(["Event", "UserData", "Root", "Status"], elements);
+        Assert.Null(attribute);
+    }
+
+    [Fact]
+    public void Parse_SplitsElementsAndAttributeAndStripsWildcard()
+    {
+        (string[] elements, string? attribute) = StructuredFieldPath.Parse("Event/UserData/Root/Item[*]/@value");
+
+        Assert.Equal(["Event", "UserData", "Root", "Item"], elements);
+        Assert.Equal("value", attribute);
+    }
+
+    private static StructuredFieldResult Collect(string xml, string path)
+    {
+        (string[] elements, string? attribute) = StructuredFieldPath.Parse(path);
+
+        return StructuredFieldPath.CollectValues(xml.AsSpan(), elements, attribute, StructuredFieldPath.MaxWildcardValues);
+    }
+}

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Structured/StructuredFieldPathTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Structured/StructuredFieldPathTests.cs
@@ -34,6 +34,16 @@ public sealed class StructuredFieldPathTests
     }
 
     [Fact]
+    public void CollectValues_DecodesAstralNumericEntity()
+    {
+        StructuredFieldResult result = Collect(
+            $"<Event {Ns}><UserData><Root><Item value='&#x1F600;'/></Root></UserData></Event>",
+            "Event/UserData/Root/Item/@value");
+
+        Assert.Equal("\U0001F600", result.Value.AsString());
+    }
+
+    [Fact]
     public void CollectValues_DecodesEntitiesInValues()
     {
         StructuredFieldResult result = Collect(
@@ -97,6 +107,20 @@ public sealed class StructuredFieldPathTests
         Assert.Equal(EventFieldValueKind.StringArray, result.Value.Kind);
         Assert.Equal("only", result.Value.AsString());
         Assert.False(result.IsTruncated);
+    }
+
+    [Fact]
+    public void CollectValues_NonPositiveCap_IsAbsent()
+    {
+        (string[] elements, string? attribute) = StructuredFieldPath.Parse("Event/UserData/Root/Item/@value");
+
+        StructuredFieldResult result = StructuredFieldPath.CollectValues(
+            $"<Event {Ns}><UserData><Root><Item value='x'/></Root></UserData></Event>".AsSpan(),
+            elements,
+            attribute,
+            cap: 0);
+
+        Assert.Equal(EventFieldValueKind.Null, result.Value.Kind);
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Structured/StructuredSchemaDiscoveryTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Structured/StructuredSchemaDiscoveryTests.cs
@@ -1,0 +1,101 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Structured;
+
+namespace EventLogExpert.Eventing.Tests.Structured;
+
+public sealed class StructuredSchemaDiscoveryTests
+{
+    private const string Ns = "xmlns='http://schemas.microsoft.com/win/2004/08/events/event'";
+
+    [Fact]
+    public void DiscoverUserDataPaths_AttributeAndTextLeaves_AreEmitted()
+    {
+        string xml = $"<Event {Ns}><UserData><Root><Cert subjectName='x'/><Status>ok</Status></Root></UserData></Event>";
+
+        var paths = StructuredSchemaDiscovery.DiscoverUserDataPaths([xml]);
+
+        Assert.Contains("Event/UserData/Root/Cert/@subjectName", paths);
+        Assert.Contains("Event/UserData/Root/Status", paths);
+    }
+
+    [Fact]
+    public void DiscoverUserDataPaths_EventWithoutUserData_ReturnsEmpty()
+    {
+        string xml = $"<Event {Ns}><System><EventID>1</EventID></System><EventData><Data Name='A'>v</Data></EventData></Event>";
+
+        var paths = StructuredSchemaDiscovery.DiscoverUserDataPaths([xml]);
+
+        Assert.Empty(paths);
+    }
+
+    [Fact]
+    public void DiscoverUserDataPaths_IgnoresXmlnsDeclarationAttributes()
+    {
+        string xml = $"<Event {Ns}><UserData><Root xmlns:e='urn:x'><Cert subjectName='x'/></Root></UserData></Event>";
+
+        var paths = StructuredSchemaDiscovery.DiscoverUserDataPaths([xml]);
+
+        Assert.DoesNotContain(paths, path => path.Contains("xmlns", StringComparison.Ordinal));
+        Assert.Contains("Event/UserData/Root/Cert/@subjectName", paths);
+    }
+
+    [Fact]
+    public void DiscoverUserDataPaths_MalformedXmlSample_IsSkipped()
+    {
+        string good = $"<Event {Ns}><UserData><Root><Cert subjectName='x'/></Root></UserData></Event>";
+        const string malformed = "<Event><UserData><unclosed>";
+
+        var paths = StructuredSchemaDiscovery.DiscoverUserDataPaths([malformed, good]);
+
+        Assert.Contains("Event/UserData/Root/Cert/@subjectName", paths);
+    }
+
+    [Fact]
+    public void DiscoverUserDataPaths_RepeatingElementInOneSample_EmitsWildcard()
+    {
+        string xml = $"<Event {Ns}><UserData><Root><Item value='a'/><Item value='b'/></Root></UserData></Event>";
+
+        var paths = StructuredSchemaDiscovery.DiscoverUserDataPaths([xml]);
+
+        Assert.Contains("Event/UserData/Root/Item[*]/@value", paths);
+        Assert.DoesNotContain("Event/UserData/Root/Item/@value", paths);
+    }
+
+    [Fact]
+    public void DiscoverUserDataPaths_RepeatingInAnySample_PromotesUnionToWildcard()
+    {
+        // Sample 1 shows a single Certificate; sample 2 shows two. Any sample with >=2 siblings promotes the
+        // canonical path to [*], and the scalar form must NOT survive in the union.
+        string single = $"<Event {Ns}><UserData><Root><Certificate subjectName='one'/></Root></UserData></Event>";
+        string repeated = $"<Event {Ns}><UserData><Root><Certificate subjectName='two'/><Certificate subjectName='three'/></Root></UserData></Event>";
+
+        var paths = StructuredSchemaDiscovery.DiscoverUserDataPaths([single, repeated]);
+
+        Assert.Contains("Event/UserData/Root/Certificate[*]/@subjectName", paths);
+        Assert.DoesNotContain("Event/UserData/Root/Certificate/@subjectName", paths);
+    }
+
+    [Fact]
+    public void DiscoverUserDataPaths_ResultIsOrdered()
+    {
+        string xml = $"<Event {Ns}><UserData><Root><Zeta z='1'/><Alpha a='2'/></Root></UserData></Event>";
+
+        var paths = StructuredSchemaDiscovery.DiscoverUserDataPaths([xml]);
+
+        Assert.Equal(paths.OrderBy(path => path, StringComparer.Ordinal), paths);
+    }
+
+    [Fact]
+    public void DiscoverUserDataPaths_UnionsDistinctLeavesAcrossSamples()
+    {
+        string first = $"<Event {Ns}><UserData><Root><A x='1'/></Root></UserData></Event>";
+        string second = $"<Event {Ns}><UserData><Root><B y='2'/></Root></UserData></Event>";
+
+        var paths = StructuredSchemaDiscovery.DiscoverUserDataPaths([first, second]);
+
+        Assert.Contains("Event/UserData/Root/A/@x", paths);
+        Assert.Contains("Event/UserData/Root/B/@y", paths);
+    }
+}

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Structured/StructuredSchemaDiscoveryTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Structured/StructuredSchemaDiscoveryTests.cs
@@ -100,7 +100,7 @@ public sealed class StructuredSchemaDiscoveryTests
     }
 
     [Fact]
-    public void DiscoverUserDataPaths_WhitespaceOnlySamples_ReturnEmpty()
+    public void DiscoverUserDataPaths_WhitespaceOnlySamples_ReturnsEmpty()
     {
         var paths = StructuredSchemaDiscovery.DiscoverUserDataPaths(["   ", "\n\t"]);
 

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Structured/StructuredSchemaDiscoveryTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Structured/StructuredSchemaDiscoveryTests.cs
@@ -98,4 +98,12 @@ public sealed class StructuredSchemaDiscoveryTests
         Assert.Contains("Event/UserData/Root/A/@x", paths);
         Assert.Contains("Event/UserData/Root/B/@y", paths);
     }
+
+    [Fact]
+    public void DiscoverUserDataPaths_WhitespaceOnlySamples_ReturnEmpty()
+    {
+        var paths = StructuredSchemaDiscovery.DiscoverUserDataPaths(["   ", "\n\t"]);
+
+        Assert.Empty(paths);
+    }
 }


### PR DESCRIPTION
## Summary
Foundation for filtering on structured UserData fields. This PR delivers the low-level pieces the filter integration (a later stacked PR) will consume; there is no UI or filter wiring here.

## What's here
- **Native value-paths render primitive** — `NativeMethods.RenderEventValues` plus a Null-tolerant value-paths processor, and an `[Out]`->`[In]` marshalling fix on `EvtCreateRenderContext`'s value-path array. An absent value-path renders as `Null` rather than throwing.
- **`StructuredFieldPath`** — canonical UserData path grammar (validation + parse) and local-name field extraction.
- **`StructuredSchemaDiscovery`** — discovers UserData field paths across event samples for a field picker, marking a repeating element with `[*]` when any sample shows it repeating.
- **`StructuredFieldResult`** — the extracted value plus a truncation flag.
- **`XmlSpanScanner`** — a forward-only, DOM-free span reader over rendered event XML (no `System.Xml`); the only allocations are the final extracted value strings.

## Scope
UserData/EventData are reachable only via the filter and the details-pane XML tab, not as event-grid columns, so this foundation has no on-demand grid-display path.

## Namespace handling
UserData content inherits the `<Event>` default namespace with no explicit prefix, so all matching is by local name. Verified against a real Microsoft-Windows-CAPI2 log that the value-paths engine and a local-name parse agree.

## Tests
- Eventing unit 486/486; integration 335 pass / 2 pre-existing skip / 0 fail.
- A value-paths parity gate, plus a real-CAPI2 cross-check of the span discovery/extraction against a `System.Xml` oracle (env-gated so CI skips cleanly).

Stacked on `jschick/operation-log-progress-naming`.
