### PR TITLE
Add UserData structured-field filtering with scenarios and wildcard globs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -65,3 +65,13 @@ project references.
   needs to perform a database operation that requires Administrator rights. Communicates
   with the host over a named pipe. Depends on `Runtime` so it can reuse the shared
   Fluxor-free service surface for filter / database helpers.
+
+## Event Log Performance
+
+The log-loading pipeline (`Runtime/EventLog/` plus the `Eventing` reader and `Runtime/LogTable/`
+store) is tuned to open very large logs with a fast first paint, bounded memory, and smooth
+scrolling. The design intent behind each mechanism - eager first paint, reverse-read batching,
+non-boxing property marshalling, bounded-parallel resolution, the segmented sorted store and
+combined merge view, viewport virtualization, render-buffer reuse, and the retained
+structured-field filtering model - is documented, with its owning code and its guarding tests,
+in [Performance](Performance.md).

--- a/docs/Opening-Logs.md
+++ b/docs/Opening-Logs.md
@@ -17,6 +17,8 @@ If EventLogExpert is installed as the packaged (MSIX) app, two right-click conte
 
 `File` → `Open` → `File` (`Ctrl+O`) opens the system file picker filtered to `.evtx`. Pick one file or many — each selected `.evtx` is enqueued as a separate log in order; the actual load work then runs in parallel under a per-machine throttle (roughly your CPU count), so multiple logs can be loading at once. The same applies for `File` → `Combine` → `File`, which adds the picked files to the existing log set.
 
+The newest events paint first (usually within about a second) while the rest stream in behind them; see [Performance](Performance.md) for how the parallel throttle and eager first paint work.
+
 ### Folder
 
 `File` → `Open` → `Folder` opens a folder picker. Every `.evtx` in the picked folder (top-level only, no recursion) is loaded as a separate log.

--- a/docs/Performance.md
+++ b/docs/Performance.md
@@ -1,0 +1,127 @@
+# Event Log Performance
+
+EventLogExpert is built to open very large logs (hundreds of thousands to millions of
+events), paint the newest rows almost immediately, and stay responsive while scrolling,
+sorting, grouping, and filtering - without holding the whole rendered log in memory twice.
+This page maps each performance goal to the concrete mechanism that delivers it and to the
+code that owns it, so the design intent survives future refactors.
+
+## The load pipeline (P1-P6)
+
+Loading a log is a streaming pipeline: read raw records from `wevtapi.dll`, resolve each into
+a display-ready `ResolvedEvent`, and merge the results into a sorted, virtualized table. Six
+mechanisms keep it fast.
+
+### P1 - Eager first paint
+
+**Problem:** waiting for a whole log to load before showing anything feels broken on a large
+log. **Mechanism:** the newest screenful is dispatched as soon as it is resolved. Reading is
+newest-first, and once `OpenLogEffects.EagerFirstPaintThreshold` (200) events are resolved the
+first paint fires, so the newest rows appear in about a second instead of waiting for the
+partial-load timer. The remaining events continue streaming in behind that first paint.
+
+### P2 - Reverse read and the EvtNext batch gate
+
+**Problem:** the interesting events are the newest, but the Windows API enumerates oldest-first,
+and the batch size that maximizes `EvtNext` throughput is version-dependent. **Mechanism:**
+`EventLogReader` reads in reverse (newest-first) and captures the newest event's bookmark once,
+which is also the correct resume point for a live-tail watcher. The `EvtNext` batch size
+(`OpenLogEffects.ReadBatchSize`, 256) is the benchmarked Windows 11 sweet spot; larger sizes
+regress. Pre-Windows 11 a batch was capped at the smaller of the requested count and a 2 MB
+buffer (about 30 max-size events), so the reader requests a larger batch on Windows 11+, where
+`EvtNext` simply returns fewer when the 2 MB buffer fills first.
+
+### P3 - Zero-allocation property marshalling
+
+**Problem:** every event carries several rendered `EventData` values; boxing each one on the
+hot read path produces gigabytes of garbage over a large log. **Mechanism:** `EventProperty`
+stores a rendered property without boxing - numeric, bool, and `DateTime` kinds pack into a
+64-bit field tagged by a shared per-kind sentinel, while reference shapes (string, byte[], Guid,
+SID, arrays, handle) live in the object slot. The marshalling path in `NativeMethods.Evt`
+converts the common scalar variants directly into that packed form and only falls back to the
+boxing converter for genuine reference shapes.
+
+### P4 - Bounded parallel resolution
+
+**Problem:** resolving descriptions and metadata is CPU-bound and embarrassingly parallel, but
+unbounded parallelism starves the UI thread and thrashes the provider caches. **Mechanism:**
+resolution runs under a global gate (`OpenLogEffects` uses a `PrioritySemaphore` sized to
+`ProcessorCount - 1`), so multiple readers resolve in parallel while leaving a core for the UI,
+and foreground work can jump the queue ahead of background prefetch.
+
+### P5 - Segmented sorted store and the combined merge view
+
+**Problem:** a sorted, growing list that is re-sorted or copied on every append is O(n^2) over a
+streaming load; a combined (multi-log) view must stay globally sorted without materializing a
+single giant array. **Mechanism:** `SegmentedSortedList` keeps immutable, globally
+non-interleaving sorted segments (segment *i* entirely `<=` segment *i+1*), so the logical
+sequence is their concatenation and indexing is a prefix-sum binary search; an append that sits
+before or after the existing data adds a segment with no copy, and only a genuinely interleaving
+append falls back to a merge. `CombinedEventView` merges several such lists with a K-way cursor
+walk plus a periodic checkpoint index (stride 64) so a positional read seeks in log(segments)
+rather than walking from the start, with per-read offset scratch stack-allocated up to a capped
+K.
+
+### P6 - Viewport virtualization and render-buffer reuse
+
+**Problem:** rendering every row of a million-event table, or re-seeking the K-way merge once per
+visible row, defeats the streaming store. **Mechanism:** the ungrouped table uses a Blazor
+`Virtualize` component whose `ItemsProvider` (`LogTablePane.ComputeEventViewport`) fetches one
+`Slice` per viewport window - a single cursor walk - instead of an `Items=` binding that re-seeks
+per row. Underneath, `NativeMethods.Evt` renders each event into a per-thread, grow-only scratch
+buffer: the size-probe pass is skipped (on `ERROR_INSUFFICIENT_BUFFER` the API reports the
+required size, so the buffer grows once and retries), the buffer is reused across events, and a
+rare huge render uses a transient array that is not stored back, bounding steady-state retention
+to about 64 KB per thread. The buffers are `[ThreadStatic]` because the live-tail watcher renders
+on overlapping thread-pool callbacks.
+
+## Structured-field filtering memory model
+
+Filtering on `EventData` and `UserData` fields (the `EventData["Field"]` / `UserData["path"]`
+grammar, the built-in scenarios, and the `*` field-name globs) is served from values retained on
+each `ResolvedEvent`, not by re-rendering XML per event at filter time. The retained shape is
+deliberately compact:
+
+- **EventData** keeps one `EventProperty` per field (16 bytes, packed, no boxing). Measured
+  retention is roughly 2-3x smaller than retaining the rendered XML that field-filtering
+  replaces.
+- **UserData** (nested payloads such as CAPI2 certificate chains) is extracted once at resolve
+  time into deduped `UserDataField` structs: repeats of a path collapse into a single multi-value
+  field, so retention scales with distinct paths, not raw leaf count. Distinct values are interned
+  and bounded.
+- **Caps** bound a pathological event: a per-event distinct-path cap, a per-field value cap, and a
+  per-value character cap. Hitting a cap flags the event so a filter on a dropped path stays
+  visible (a keep-visible "unknown") rather than silently deciding no-match.
+
+Rendered XML is still available on demand for the details pane, but it is never retained for
+filtering.
+
+## Mechanism status
+
+| Area | Mechanism | Owner |
+| ---- | --------- | ----- |
+| First paint | Eager newest-screenful dispatch | `OpenLogEffects` |
+| Read | Reverse read, newest bookmark, tuned `EvtNext` batch | `EventLogReader` |
+| Marshalling | Non-boxing packed `EventProperty` | `EventProperty`, `NativeMethods.Evt` |
+| Resolve | `ProcessorCount - 1` priority-gated parallelism | `OpenLogEffects` |
+| Store | Segmented sorted list + K-way combined view | `SegmentedSortedList`, `CombinedEventView` |
+| Viewport | `Virtualize` + one-slice-per-window provider | `LogTablePane` |
+| Render | Per-thread grow-only render buffer, skip-probe | `NativeMethods.Evt` |
+| Filter memory | Retained structured `EventData` / `UserData` fields | `ResolvedEvent`, `UserDataValueExtractor` |
+
+## How performance is guarded
+
+There is no separate benchmark harness in the repository; the performance-critical shapes are
+guarded by deterministic tests that fail if a regression bloats them:
+
+- **Retained-bytes budgets** lock the per-field retained struct sizes (`EventProperty` is 16
+  bytes, `UserDataField` is within its budget) and the caps that bound a pathological event
+  (`RetainedBytesBudgetTests`, `EventFieldValueTests`).
+- **Allocation budgets** assert that hot predicates allocate nothing per evaluation
+  (`AllocationUtils` + the filter compilation tests).
+- **Slice and viewport** correctness is pinned by the segmented-store, combined-view, and
+  `ComputeEventViewport` tests, so the O(log) seek behavior cannot silently degrade to a linear
+  walk.
+
+When adding a mechanism here, add or extend the matching budget/correctness test so the intent is
+enforced, not just documented.

--- a/docs/Viewing-Events.md
+++ b/docs/Viewing-Events.md
@@ -17,6 +17,8 @@ The main view has three regions: the **tab strip** (one tab per open log, plus a
 
 The table is virtualized — only the rows currently in view are rendered, so loading large `.evtx` files stays responsive.
 
+See [Performance](Performance.md) for how the virtualized table, the segmented sorted store, and streaming resolution keep very large logs fast to open and scroll.
+
 **Configurable columns.** Right-click a column header to open the column menu:
 
 - A toggle per column (checked = visible). The available columns are `Level`, `Date and Time`, `Activity ID`, `Log`, `Computer Name`, `Source`, `Event ID`, `Task Category`, `Keywords`, `Process ID`, `Thread ID`, and `User`. The `Description` column is fixed and always rightmost.

--- a/src/EventLogExpert.Eventing/Common/Events/EventFieldValue.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/EventFieldValue.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Eventing.Readers;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Security.Principal;
 
@@ -102,7 +103,21 @@ public readonly struct EventFieldValue
     {
         if (_kind == EventFieldValueKind.Guid && _reference is Guid guid) { value = guid; return true; }
 
-        value = default;
+        value = Guid.Empty;
+
+        return false;
+    }
+
+    public bool TryGetStringArray([NotNullWhen(true)] out string[]? values)
+    {
+        if (_kind == EventFieldValueKind.StringArray && _reference is string[] array)
+        {
+            values = array;
+
+            return true;
+        }
+
+        values = null;
 
         return false;
     }

--- a/src/EventLogExpert.Eventing/Common/Events/ResolvedEvent.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/ResolvedEvent.cs
@@ -4,7 +4,9 @@
 using EventLogExpert.Eventing.Common.Channels;
 using EventLogExpert.Eventing.Readers;
 using EventLogExpert.Eventing.Resolvers;
+using EventLogExpert.Eventing.Structured;
 using System.Collections.Immutable;
+using System.Runtime.InteropServices;
 using System.Security.Principal;
 
 namespace EventLogExpert.Eventing.Common.Events;
@@ -13,6 +15,9 @@ public sealed record ResolvedEvent(
     string OwningLog /*This is the name of the log file or the live log, which we use internally*/,
     LogPathType LogPathType)
 {
+    private static readonly StructuredFieldResult s_absentUserData =
+        new(EventFieldValue.FromProperty(EventProperty.FromReference(null)), false);
+
     public Guid? ActivityId { get; init; }
 
     public string ComputerName { get; init; } = string.Empty;
@@ -57,10 +62,55 @@ public sealed record ResolvedEvent(
     internal TemplateFieldSchema? EventDataSchema { get; init; }
 
     /// <summary>
+    ///     Deduped nested-UserData fields extracted once at resolve time (flat UserData surfaces as
+    ///     <see cref="EventData" /> instead). Each field's <see cref="UserDataField.Path" /> is a storage key; repeats
+    ///     collapse into one multi-value field. <c>default</c> / empty when the event has no nested UserData.
+    /// </summary>
+    public ImmutableArray<UserDataField> UserData { get; init; }
+
+    /// <summary>
+    ///     <c>true</c> when extraction hit the per-event distinct-path cap, so a path absent from <see cref="UserData" />
+    ///     may still have existed. <see cref="TryGetUserDataValues" /> then returns a keep-visible (truncated) result rather
+    ///     than a decisive no-match.
+    /// </summary>
+    public bool UserDataIncomplete { get; init; }
+
+    /// <summary>
     ///     Named &lt;EventData&gt; fields for this event, or <see cref="EventDataKind.None" /> for legacy / template-less
     ///     events. The underlying values also remain reachable positionally through the description and XML.
     /// </summary>
     public EventDataView EventData => EventDataValues.IsDefaultOrEmpty
         ? EventDataView.Empty
         : new(EventDataValues, EventDataSchema);
+
+    /// <summary>
+    ///     Looks up a stored UserData field by its <paramref name="storageKey" /> and returns its values, or an absent
+    ///     result when none was stored. When <see cref="UserDataIncomplete" /> is set, an absent field instead yields a
+    ///     present-but-empty truncated result so a filter keeps the row visible (Unknown) rather than a wrong no-match.
+    /// </summary>
+    public StructuredFieldResult TryGetUserDataValues(string storageKey)
+    {
+        if (!UserData.IsDefaultOrEmpty)
+        {
+            foreach (UserDataField field in UserData)
+            {
+                if (!string.Equals(field.Path, storageKey, StringComparison.Ordinal)) { continue; }
+
+                string[] values = ImmutableCollectionsMarshal.AsArray(field.Values) ?? [];
+
+                return new StructuredFieldResult(
+                    EventFieldValue.FromProperty(EventProperty.FromReference(values)),
+                    field.IsTruncated || UserDataIncomplete);
+            }
+        }
+
+        if (!UserDataIncomplete) { return s_absentUserData; }
+
+        string[] empty = [];
+
+        return new StructuredFieldResult(
+            EventFieldValue.FromProperty(EventProperty.FromReference(empty)),
+            isTruncated: true);
+
+    }
 }

--- a/src/EventLogExpert.Eventing/Readers/EventLogReader.cs
+++ b/src/EventLogExpert.Eventing/Readers/EventLogReader.cs
@@ -3,16 +3,22 @@
 
 using EventLogExpert.Eventing.Common.Channels;
 using EventLogExpert.Eventing.Interop;
+using EventLogExpert.Eventing.Structured;
 using System.Buffers;
 using System.Runtime.InteropServices;
 
 namespace EventLogExpert.Eventing.Readers;
 
-public sealed class EventLogReader(string path, LogPathType pathType, bool renderXml = false, bool reverseDirection = false) : IEventLogReader
+public sealed class EventLogReader(
+    string path,
+    LogPathType pathType,
+    bool renderXml = false,
+    bool reverseDirection = false) : IEventLogReader
 {
     private const int EvtQueryReverseDirection = 0x200;
 
     private readonly Lock _eventLock = new();
+
     private readonly EvtHandle _handle = reverseDirection
         ? NativeMethods.EvtQueryWithFlags(EventLogSession.GlobalSession.Handle, path, null,
             (int)pathType | EvtQueryReverseDirection)
@@ -133,9 +139,20 @@ public sealed class EventLogReader(string path, LogPathType pathType, bool rende
                     events[i] = NativeMethods.RenderEvent(eventHandle);
                     events[i].Properties = NativeMethods.RenderEventProperties(eventHandle);
 
-                    if (renderXml)
+                    bool needsUserData = events[i].Properties.Length == 0;
+
+                    if (renderXml || needsUserData)
                     {
-                        events[i].Xml = NativeMethods.RenderEventXml(eventHandle);
+                        var xml = NativeMethods.RenderEventXml(eventHandle);
+
+                        if (renderXml) { events[i].Xml = xml; }
+
+                        if (needsUserData)
+                        {
+                            var (fields, incomplete) = UserDataValueExtractor.Extract(xml);
+                            events[i].UserData = fields;
+                            events[i].UserDataIncomplete = incomplete;
+                        }
                     }
                 }
                 catch (Exception ex)

--- a/src/EventLogExpert.Eventing/Readers/EventLogWatcher.cs
+++ b/src/EventLogExpert.Eventing/Readers/EventLogWatcher.cs
@@ -3,6 +3,7 @@
 
 using EventLogExpert.Eventing.Common.Channels;
 using EventLogExpert.Eventing.Interop;
+using EventLogExpert.Eventing.Structured;
 using System.Collections.Concurrent;
 using System.Runtime.InteropServices;
 
@@ -40,7 +41,8 @@ public sealed class EventLogWatcher : IDisposable
         NativeMethods.ThrowEventLogException(error);
     }
 
-    public EventLogWatcher(string path, bool renderXml = false) : this(path, null, renderXml) { }
+    public EventLogWatcher(string path, bool renderXml = false)
+        : this(path, null, renderXml) { }
 
     ~EventLogWatcher()
     {
@@ -161,9 +163,20 @@ public sealed class EventLogWatcher : IDisposable
                         @event = NativeMethods.RenderEvent(eventHandle);
                         @event.Properties = NativeMethods.RenderEventProperties(eventHandle);
 
-                        if (_renderXml)
+                        bool needsUserData = @event.Properties.Length == 0;
+
+                        if (_renderXml || needsUserData)
                         {
-                            @event.Xml = NativeMethods.RenderEventXml(eventHandle);
+                            var xml = NativeMethods.RenderEventXml(eventHandle);
+
+                            if (_renderXml) { @event.Xml = xml; }
+
+                            if (needsUserData)
+                            {
+                                var (fields, incomplete) = UserDataValueExtractor.Extract(xml);
+                                @event.UserData = fields;
+                                @event.UserDataIncomplete = incomplete;
+                            }
                         }
                     }
                     catch (Exception ex)

--- a/src/EventLogExpert.Eventing/Readers/EventRecord.cs
+++ b/src/EventLogExpert.Eventing/Readers/EventRecord.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Structured;
 using System.Collections.Immutable;
 using System.Security.Principal;
 
@@ -46,6 +47,10 @@ public sealed record EventRecord
     public byte? Version { get; set; }
 
     public string? Xml { get; set; }
+
+    public ImmutableArray<UserDataField> UserData { get; set; }
+
+    public bool UserDataIncomplete { get; set; }
 
     public string? Error { get; init; }
 

--- a/src/EventLogExpert.Eventing/Resolvers/EventResolverBase.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/EventResolverBase.cs
@@ -3,6 +3,7 @@
 
 using EventLogExpert.Eventing.Common.Events;
 using EventLogExpert.Eventing.Readers;
+using EventLogExpert.Eventing.Structured;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Provider.Resolution;
 using System.Collections.Concurrent;
@@ -159,7 +160,33 @@ public class EventResolverBase : IDisposable
             ThreadId = eventRecord.ThreadId,
             TimeCreated = eventRecord.TimeCreated,
             UserId = _cache?.GetOrAddSid(eventRecord.UserId) ?? eventRecord.UserId,
-            Xml = eventRecord.Xml ?? string.Empty
+            Xml = eventRecord.Xml ?? string.Empty,
+            UserData = InternUserData(eventRecord.UserData),
+            UserDataIncomplete = eventRecord.UserDataIncomplete
         };
+    }
+
+    private ImmutableArray<UserDataField> InternUserData(ImmutableArray<UserDataField> fields)
+    {
+        if (_cache is null || fields.IsDefaultOrEmpty) { return fields; }
+
+        var builder = ImmutableArray.CreateBuilder<UserDataField>(fields.Length);
+
+        foreach (UserDataField field in fields)
+        {
+            var values = ImmutableArray.CreateBuilder<string>(field.Values.Length);
+
+            foreach (string value in field.Values)
+            {
+                values.Add(_cache.GetOrAddUserDataString(value));
+            }
+
+            builder.Add(new UserDataField(
+                _cache.GetOrAddUserDataString(field.Path),
+                values.MoveToImmutable(),
+                field.IsTruncated));
+        }
+
+        return builder.MoveToImmutable();
     }
 }

--- a/src/EventLogExpert.Eventing/Resolvers/EventResolverCache.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/EventResolverCache.cs
@@ -17,47 +17,48 @@ public sealed class EventResolverCache : IEventResolverCache
     // number of writer threads.
     private const int DefaultMaxDescriptionCacheSize = 131072;
 
+    // Independent bound for interned UserData path + value strings, same discipline as the description cap: a
+    // UserData-heavy log cannot grow this table without limit; at the cap we stop adding but keep serving existing hits.
+    private const int DefaultMaxUserDataStringCacheSize = 131072;
+
     private readonly ConcurrentDictionary<string, string> _descriptionCache = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<IReadOnlyList<string>, IReadOnlyList<string>> _keywordsCache = new(KeywordListComparer.Instance);
 
     private readonly int _maxDescriptionCacheSize;
+    private readonly int _maxUserDataStringCacheSize;
     private readonly ConcurrentDictionary<SecurityIdentifier, SecurityIdentifier> _sidCache = new();
+    private readonly ConcurrentDictionary<string, string> _userDataCache = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, string> _valueCache = new(StringComparer.Ordinal);
 
     private int _descriptionCount;
+    private int _userDataCount;
 
     public EventResolverCache() : this(DefaultMaxDescriptionCacheSize) { }
 
-    // Test seam: lets a unit test exercise the cap without inserting 131072 entries.
-    internal EventResolverCache(int maxDescriptionCacheSize) => _maxDescriptionCacheSize = maxDescriptionCacheSize;
+    // Test seam: lets a unit test exercise a cap without inserting hundreds of thousands of entries.
+    internal EventResolverCache(int maxDescriptionCacheSize, int maxUserDataStringCacheSize = DefaultMaxUserDataStringCacheSize)
+    {
+        _maxDescriptionCacheSize = maxDescriptionCacheSize;
+        _maxUserDataStringCacheSize = maxUserDataStringCacheSize;
+    }
 
     public void ClearAll()
     {
         _descriptionCache.Clear();
         _keywordsCache.Clear();
         _sidCache.Clear();
+        _userDataCache.Clear();
         _valueCache.Clear();
         Interlocked.Exchange(ref _descriptionCount, 0);
+        Interlocked.Exchange(ref _userDataCount, 0);
     }
 
     /// <summary>
     ///     Returns a shared instance equal to <paramref name="description" />, interning it on first sight. Bounded by
-    ///     the configured cap: once full, an uncached description is returned as-is (not stored) so the table stays at the
-    ///     cap (plus at most a few concurrent inserts) while all prior sharing is retained.
+    ///     the configured cap: once full an uncached description is returned as-is (not stored) so prior sharing is retained.
     /// </summary>
-    public string GetOrAddDescription(string description)
-    {
-        if (_descriptionCache.TryGetValue(description, out string? existing)) { return existing; }
-
-        if (Volatile.Read(ref _descriptionCount) >= _maxDescriptionCacheSize) { return description; }
-
-        var shared = _descriptionCache.GetOrAdd(description, static key => key);
-
-        // Count only entries this call inserted: the returned instance is ours iff we won the add race.
-        if (ReferenceEquals(shared, description)) { Interlocked.Increment(ref _descriptionCount); }
-
-        return shared;
-    }
+    public string GetOrAddDescription(string description) =>
+        InternBounded(_descriptionCache, ref _descriptionCount, _maxDescriptionCacheSize, description);
 
     /// <summary>Returns a shared read-only list with the same contents, adding a frozen copy to the cache on first sight.</summary>
     public IReadOnlyList<string> GetOrAddKeywords(IReadOnlyList<string> keywords)
@@ -76,8 +77,31 @@ public sealed class EventResolverCache : IEventResolverCache
     public SecurityIdentifier? GetOrAddSid(SecurityIdentifier? sid) =>
         sid is null ? null : _sidCache.GetOrAdd(sid, static key => key);
 
+    /// <summary>
+    ///     Interns a UserData path or value, returning a shared instance equal to <paramref name="value" />. Bounded like
+    ///     <see cref="GetOrAddDescription" />: at the cap an uncached string is returned as-is so the table stays bounded.
+    /// </summary>
+    public string GetOrAddUserDataString(string value) =>
+        InternBounded(_userDataCache, ref _userDataCount, _maxUserDataStringCacheSize, value);
+
     /// <summary>Returns the value if it exists in the cache, otherwise adds it to the cache and returns it.</summary>
     public string GetOrAddValue(string value) => _valueCache.GetOrAdd(value, static key => key);
+
+    // Bounded intern for the description and UserData tables: serve a hit, else add under the cap (counting only inserts
+    // this call won) and stop adding at the cap. The counter is Interlocked, not ConcurrentDictionary.Count (which locks
+    // every stripe), so an all-miss log pays no per-call lock and inserts can overshoot the cap by the writer-thread count.
+    private static string InternBounded(ConcurrentDictionary<string, string> cache, ref int count, int max, string value)
+    {
+        if (cache.TryGetValue(value, out string? existing)) { return existing; }
+
+        if (Volatile.Read(ref count) >= max) { return value; }
+
+        var shared = cache.GetOrAdd(value, static key => key);
+
+        if (ReferenceEquals(shared, value)) { Interlocked.Increment(ref count); }
+
+        return shared;
+    }
 
     private sealed class KeywordListComparer : IEqualityComparer<IReadOnlyList<string>>
     {

--- a/src/EventLogExpert.Eventing/Resolvers/IEventResolverCache.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/IEventResolverCache.cs
@@ -15,5 +15,7 @@ public interface IEventResolverCache
 
     SecurityIdentifier? GetOrAddSid(SecurityIdentifier? sid);
 
+    string GetOrAddUserDataString(string value);
+
     string GetOrAddValue(string value);
 }

--- a/src/EventLogExpert.Eventing/Structured/FilterMatch.cs
+++ b/src/EventLogExpert.Eventing/Structured/FilterMatch.cs
@@ -1,0 +1,11 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Eventing.Structured;
+
+public enum FilterMatch : byte
+{
+    NoMatch = 0,
+    Match = 1,
+    Unknown = 2
+}

--- a/src/EventLogExpert.Eventing/Structured/StructuredFieldPath.cs
+++ b/src/EventLogExpert.Eventing/Structured/StructuredFieldPath.cs
@@ -89,7 +89,7 @@ internal static class StructuredFieldPath
 
             if (index == segments.Length - 1 && segment.StartsWith('@'))
             {
-                if (index == 0 || !IsValidName(segment[1..])) { return false; }
+                if (index == 0 || !IsValidNameOrGlob(segment[1..])) { return false; }
 
                 continue;
             }
@@ -97,7 +97,7 @@ internal static class StructuredFieldPath
             string name = segment.EndsWith(WildcardMarker, StringComparison.Ordinal) ?
                 segment[..^WildcardMarker.Length] : segment;
 
-            if (!IsValidName(name)) { return false; }
+            if (!IsValidNameOrGlob(name)) { return false; }
         }
 
         return true;
@@ -155,13 +155,17 @@ internal static class StructuredFieldPath
         return builder.ToString();
     }
 
-    private static bool IsValidName(string name)
+    // A canonical name segment (or attribute) or a wildcard glob of one: the exact-name characters plus '*', which
+    // matches any run of characters. Allowing '*' lets a field-name glob such as *cert* validate and lower; a path that
+    // contains '*' is treated as a glob at emit time (detection is on the storage-key form, so the [*] repeating-element
+    // marker - stripped by ToStorageKey - is never mistaken for a name glob).
+    private static bool IsValidNameOrGlob(string name)
     {
-        if (name.Length == 0 || !(char.IsLetter(name[0]) || name[0] == '_')) { return false; }
+        if (name.Length == 0 || !(char.IsLetter(name[0]) || name[0] is '_' or '*')) { return false; }
 
         foreach (char character in name)
         {
-            if (!(char.IsLetterOrDigit(character) || character is '_' or '-' or '.')) { return false; }
+            if (!(char.IsLetterOrDigit(character) || character is '_' or '-' or '.' or '*')) { return false; }
         }
 
         return true;

--- a/src/EventLogExpert.Eventing/Structured/StructuredFieldPath.cs
+++ b/src/EventLogExpert.Eventing/Structured/StructuredFieldPath.cs
@@ -3,6 +3,7 @@
 
 using EventLogExpert.Eventing.Common.Events;
 using EventLogExpert.Eventing.Readers;
+using System.Text;
 
 namespace EventLogExpert.Eventing.Structured;
 
@@ -127,6 +128,31 @@ internal static class StructuredFieldPath
         }
 
         return (elements, attribute);
+    }
+
+    /// <summary>
+    ///     Maps a canonical UserData path to its storage key on a resolved event (local-name chain under <c>UserData</c>,
+    ///     <c>/@attr</c> for an attribute). A leading <c>Event/UserData</c> envelope is dropped so a rooted grammar path and
+    ///     an already-plain picker key normalize alike; idempotent and tolerant of unrooted input.
+    /// </summary>
+    internal static string ToStorageKey(string canonicalPath)
+    {
+        (string[] elements, string? attribute) = Parse(canonicalPath);
+
+        int start = elements is ["Event", "UserData", ..] ? 2 : 0;
+
+        var builder = new StringBuilder();
+
+        for (int index = start; index < elements.Length; index++)
+        {
+            if (builder.Length > 0) { builder.Append('/'); }
+
+            builder.Append(elements[index]);
+        }
+
+        if (attribute is not null) { builder.Append("/@").Append(attribute); }
+
+        return builder.ToString();
     }
 
     private static bool IsValidName(string name)

--- a/src/EventLogExpert.Eventing/Structured/StructuredFieldResult.cs
+++ b/src/EventLogExpert.Eventing/Structured/StructuredFieldResult.cs
@@ -15,4 +15,10 @@ public readonly struct StructuredFieldResult(EventFieldValue value, bool isTrunc
     public EventFieldValue Value { get; } = value;
 
     public bool IsTruncated { get; } = isTruncated;
+
+    /// <summary><c>true</c> when the path matched no element on the event (zero present values).</summary>
+    public bool IsAbsent => !Value.TryGetStringArray(out _);
+
+    /// <summary>The present values of the field (empty when absent), read without allocating.</summary>
+    public ReadOnlySpan<string> PresentValues => Value.TryGetStringArray(out string[]? values) ? values : null;
 }

--- a/src/EventLogExpert.Eventing/Structured/StructuredFieldResult.cs
+++ b/src/EventLogExpert.Eventing/Structured/StructuredFieldResult.cs
@@ -20,5 +20,5 @@ public readonly struct StructuredFieldResult(EventFieldValue value, bool isTrunc
     public bool IsAbsent => !Value.TryGetStringArray(out _);
 
     /// <summary>The present values of the field (empty when absent), read without allocating.</summary>
-    public ReadOnlySpan<string> PresentValues => Value.TryGetStringArray(out string[]? values) ? values : null;
+    public ReadOnlySpan<string> PresentValues => Value.TryGetStringArray(out string[]? values) ? values : [];
 }

--- a/src/EventLogExpert.Eventing/Structured/UserDataField.cs
+++ b/src/EventLogExpert.Eventing/Structured/UserDataField.cs
@@ -1,7 +1,10 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Eventing.Readers;
 using System.Collections.Immutable;
+using System.Runtime.InteropServices;
 
 namespace EventLogExpert.Eventing.Structured;
 
@@ -10,4 +13,18 @@ namespace EventLogExpert.Eventing.Structured;
 ///     <c>UserData</c>, <c>/@attr</c> for an attribute) and its values. <see cref="IsTruncated" /> flags a field whose
 ///     values exceeded the per-field cap, keeping the retained values visible to the keep-visible filter fail-safe.
 /// </summary>
-public readonly record struct UserDataField(string Path, ImmutableArray<string> Values, bool IsTruncated);
+public readonly record struct UserDataField(string Path, ImmutableArray<string> Values, bool IsTruncated)
+{
+    /// <summary>
+    ///     Projects this stored field into a <see cref="StructuredFieldResult" /> so a filter can evaluate it the same
+    ///     way as a point-looked-up field. Kept in the Eventing assembly because it builds an <see cref="EventFieldValue" />
+    ///     from the internal property primitives, which the filtering layer cannot construct across the assembly boundary.
+    ///     <paramref name="forceTruncated" /> lets a caller fold an event-level "extraction was capped" signal into this
+    ///     field's truncation, mirroring the point-lookup fold in <c>ResolvedEvent.TryGetUserDataValues</c>.
+    /// </summary>
+    public StructuredFieldResult ToFieldResult(bool forceTruncated = false) =>
+        new(
+            EventFieldValue.FromProperty(
+                EventProperty.FromReference(ImmutableCollectionsMarshal.AsArray(Values) ?? [])),
+            IsTruncated || forceTruncated);
+}

--- a/src/EventLogExpert.Eventing/Structured/UserDataField.cs
+++ b/src/EventLogExpert.Eventing/Structured/UserDataField.cs
@@ -1,0 +1,13 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Collections.Immutable;
+
+namespace EventLogExpert.Eventing.Structured;
+
+/// <summary>
+///     One deduped nested-UserData field on a resolved event: the storage-key path (local-name chain under
+///     <c>UserData</c>, <c>/@attr</c> for an attribute) and its values. <see cref="IsTruncated" /> flags a field whose
+///     values exceeded the per-field cap, keeping the retained values visible to the keep-visible filter fail-safe.
+/// </summary>
+public readonly record struct UserDataField(string Path, ImmutableArray<string> Values, bool IsTruncated);

--- a/src/EventLogExpert.Eventing/Structured/UserDataFieldPath.cs
+++ b/src/EventLogExpert.Eventing/Structured/UserDataFieldPath.cs
@@ -1,0 +1,67 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace EventLogExpert.Eventing.Structured;
+
+/// <summary>
+///     Public boundary for UserData canonical paths (rooted at <c>Event/UserData/</c>). <see cref="TryNormalize" />
+///     roots and validates a discovered or user-typed path so a malformed or unrooted path is rejected once, before any
+///     lowering or extraction.
+/// </summary>
+public static class UserDataFieldPath
+{
+    public const string RootPrefix = "Event/UserData/";
+
+    /// <summary>Validates an already-canonical (Event-rooted) path without re-rooting it.</summary>
+    public static bool IsValid(string canonicalPath) => StructuredFieldPath.IsValidCanonical(canonicalPath);
+
+    /// <summary>
+    ///     Maps a canonical UserData filter path to its storage key on a resolved event, via the shared
+    ///     <see cref="StructuredFieldPath.ToStorageKey" /> so the compiled filter and the stored fields agree on keys.
+    /// </summary>
+    public static string ToStorageKey(string canonicalPath) => StructuredFieldPath.ToStorageKey(canonicalPath);
+
+    /// <summary>
+    ///     Roots <paramref name="input" /> at <see cref="RootPrefix" /> and validates it. Returns the canonical
+    ///     Event-rooted path on success, or an error describing why the path is invalid.
+    /// </summary>
+    public static bool TryNormalize(
+        string? input,
+        [NotNullWhen(true)] out string? canonical,
+        [NotNullWhen(false)] out string? error)
+    {
+        canonical = null;
+        error = null;
+
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            error = "A UserData path is required.";
+
+            return false;
+        }
+
+        string rooted = Root(input.Trim());
+
+        if (!StructuredFieldPath.IsValidCanonical(rooted))
+        {
+            error = $"'{input.Trim()}' is not a valid UserData path.";
+
+            return false;
+        }
+
+        canonical = rooted;
+
+        return true;
+    }
+
+    private static string Root(string path)
+    {
+        // Strip only a full Event/UserData/ envelope so Root is the exact inverse of StructuredFieldPath.ToStorageKey
+        // and store keys round-trip; a bare Event/ or UserData/ is content, not the root, and is re-rooted verbatim.
+        string rest = path.StartsWith(RootPrefix, StringComparison.Ordinal) ? path[RootPrefix.Length..] : path;
+
+        return RootPrefix + rest;
+    }
+}

--- a/src/EventLogExpert.Eventing/Structured/UserDataValueExtractor.cs
+++ b/src/EventLogExpert.Eventing/Structured/UserDataValueExtractor.cs
@@ -1,0 +1,171 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Collections.Immutable;
+
+namespace EventLogExpert.Eventing.Structured;
+
+/// <summary>
+///     Extracts every nested-UserData value from one event's rendered XML in a single forward, DOM-free scan. Each
+///     field's path is a storage key (<see cref="StructuredFieldPath.ToStorageKey" /> form: the plain local-name chain
+///     under <c>UserData</c>, <c>/@attr</c> for an attribute); repeats of a path collapse into one multi-value field.
+/// </summary>
+public static class UserDataValueExtractor
+{
+    /// <summary>
+    ///     Most distinct paths kept per event; on overflow, new paths are dropped and the result flagged incomplete
+    ///     (tracked paths keep collecting), bounding the stored set for a pathological event.
+    /// </summary>
+    internal const int MaxDistinctPathsPerEvent = 1024;
+
+    /// <summary>
+    ///     Most characters kept per value; a longer value is truncated and its field flagged, so a compare against the
+    ///     full value reads the truncated value as <c>Unknown</c> (kept visible) rather than a wrong no-match.
+    /// </summary>
+    internal const int MaxValueChars = 4096;
+
+    private const string UserDataEnvelopePrefix = "Event/UserData/";
+
+    /// <summary>
+    ///     Scans <paramref name="xml" /> once, returning the deduped UserData values and a flag set when the
+    ///     distinct-path cap dropped paths (a not-found path is then ambiguous). Null/empty xml is decisively absent.
+    /// </summary>
+    public static (ImmutableArray<UserDataField> Fields, bool Incomplete) Extract(string? xml) =>
+        Extract(xml, MaxDistinctPathsPerEvent);
+
+    /// <summary>Test seam letting a test drive the distinct-path cap without a thousand-path document.</summary>
+    internal static (ImmutableArray<UserDataField> Fields, bool Incomplete) Extract(string? xml, int maxDistinctPaths)
+    {
+        if (string.IsNullOrEmpty(xml)) { return (ImmutableArray<UserDataField>.Empty, false); }
+
+        var fields = new List<MutableField>();
+        var indexByPath = new Dictionary<string, int>(StringComparer.Ordinal);
+        bool incomplete = false;
+
+        var stack = new List<Frame>();
+        var scanner = new XmlSpanScanner(xml);
+
+        // xml is always a complete, well-formed RenderEventXml document, so the scan never terminates early.
+        while (scanner.Read())
+        {
+            if (scanner.NodeType == XmlSpanNode.EndElement)
+            {
+                if (stack.Count == 0) { continue; }
+
+                Frame closed = stack[^1];
+                stack.RemoveAt(stack.Count - 1);
+
+                if (closed is { HasChild: false, StorageKey: { Length: > 0 } textKey, Text.Length: > 0 })
+                {
+                    AddValue(textKey, closed.Text);
+                }
+
+                continue;
+            }
+
+            string localName = scanner.LocalName.ToString();
+            Frame? parent = stack.Count > 0 ? stack[^1] : null;
+            string structuralPath = parent is null ? localName : parent.StructuralPath + "/" + localName;
+            string? storageKey = StorageKeyFor(structuralPath);
+
+            parent?.HasChild = true;
+
+            if (storageKey is { Length: > 0 })
+            {
+                XmlAttributeLister attributes = scanner.Attributes;
+
+                while (attributes.MoveNext())
+                {
+                    AddValue(storageKey + "/@" + attributes.LocalName.ToString(), XmlSpanScanner.DecodeToString(attributes.RawValue));
+                }
+            }
+
+            if (scanner.IsEmptyElement) { continue; }
+
+            ReadOnlySpan<char> text = scanner.RawText(out bool isCData);
+            string content = text.IsWhiteSpace()
+                ? string.Empty
+                : isCData ? text.ToString() : XmlSpanScanner.DecodeToString(text);
+
+            stack.Add(new Frame
+            {
+                StorageKey = storageKey,
+                StructuralPath = structuralPath,
+                Text = content
+            });
+        }
+
+        if (fields.Count == 0) { return (ImmutableArray<UserDataField>.Empty, incomplete); }
+
+        ImmutableArray<UserDataField>.Builder builder = ImmutableArray.CreateBuilder<UserDataField>(fields.Count);
+
+        foreach (MutableField field in fields)
+        {
+            builder.Add(new UserDataField(field.Path, [.. field.Values], field.IsTruncated));
+        }
+
+        return (builder.MoveToImmutable(), incomplete);
+
+        void AddValue(string path, string value)
+        {
+            bool valueTruncated = value.Length > MaxValueChars;
+
+            if (valueTruncated) { value = value[..MaxValueChars]; }
+
+            if (indexByPath.TryGetValue(path, out int existing))
+            {
+                MutableField tracked = fields[existing];
+
+                if (valueTruncated) { tracked.IsTruncated = true; }
+
+                if (tracked.Values.Count >= StructuredFieldPath.MaxWildcardValues)
+                {
+                    tracked.IsTruncated = true;
+
+                    return;
+                }
+
+                tracked.Values.Add(value);
+
+                return;
+            }
+
+            if (fields.Count >= maxDistinctPaths)
+            {
+                incomplete = true;
+
+                return;
+            }
+
+            MutableField created = new(path) { IsTruncated = valueTruncated };
+            created.Values.Add(value);
+            indexByPath[path] = fields.Count;
+            fields.Add(created);
+        }
+    }
+
+    private static string? StorageKeyFor(string structuralPath) =>
+        structuralPath.StartsWith(UserDataEnvelopePrefix, StringComparison.Ordinal)
+            ? structuralPath[UserDataEnvelopePrefix.Length..]
+            : null;
+
+    private sealed class Frame
+    {
+        public bool HasChild { get; set; }
+
+        public required string? StorageKey { get; init; }
+
+        public required string StructuralPath { get; init; }
+
+        public required string Text { get; init; }
+    }
+
+    private sealed class MutableField(string path)
+    {
+        public bool IsTruncated { get; set; }
+
+        public string Path { get; } = path;
+
+        public List<string> Values { get; } = [];
+    }
+}

--- a/src/EventLogExpert.Filtering/Basic/BasicFilterDecomposer.cs
+++ b/src/EventLogExpert.Filtering/Basic/BasicFilterDecomposer.cs
@@ -1,6 +1,7 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Eventing.Structured;
 using EventLogExpert.Filtering.Common.Filtering;
 using EventLogExpert.Filtering.Lowering;
 using EventLogExpert.Filtering.Parsing;
@@ -400,6 +401,15 @@ internal static class BasicFilterDecomposer
             case EventDataMultiEqualsNode eventDataMulti:
                 return TryMapEventDataMultiEquals(eventDataMulti, out comparison);
 
+            case UserDataComparisonNode userDataComparison:
+                return TryMapUserDataComparison(userDataComparison, out comparison);
+
+            case UserDataContainsNode userDataContains:
+                return TryMapUserDataContains(userDataContains, out comparison);
+
+            case UserDataMultiEqualsNode userDataMulti:
+                return TryMapUserDataMultiEquals(userDataMulti, out comparison);
+
             case NotNode not:
                 return TryMapNegatedLeaf(not, out comparison);
 
@@ -470,5 +480,77 @@ internal static class BasicFilterDecomposer
             default:
                 return false;
         }
+    }
+
+    private static bool TryMapUserDataComparison(
+        UserDataComparisonNode node,
+        [NotNullWhen(true)] out FilterComparison? comparison)
+    {
+        comparison = null;
+
+        if (string.IsNullOrWhiteSpace(node.CanonicalPath) || string.IsNullOrWhiteSpace(node.Literal))
+        {
+            return false;
+        }
+
+        comparison = new FilterComparison
+        {
+            Property = EventProperty.UserData,
+            UserDataFieldName = UserDataFieldPath.ToStorageKey(node.CanonicalPath),
+            Operator = node.Op == FilterBinaryOperator.Equal
+                ? ComparisonOperator.Equals
+                : ComparisonOperator.NotEqual,
+            MatchMode = MatchMode.Single,
+            Value = node.Literal
+        };
+
+        return true;
+    }
+
+    private static bool TryMapUserDataContains(
+        UserDataContainsNode node,
+        [NotNullWhen(true)] out FilterComparison? comparison)
+    {
+        comparison = null;
+
+        // A case-sensitive contains is not Basic vocabulary (Basic is always OrdinalIgnoreCase); leave it Advanced-only.
+        if (!node.IgnoreCase || string.IsNullOrWhiteSpace(node.CanonicalPath) || string.IsNullOrWhiteSpace(node.Needle))
+        {
+            return false;
+        }
+
+        comparison = new FilterComparison
+        {
+            Property = EventProperty.UserData,
+            UserDataFieldName = UserDataFieldPath.ToStorageKey(node.CanonicalPath),
+            Operator = node.Negated ? ComparisonOperator.NotContains : ComparisonOperator.Contains,
+            MatchMode = MatchMode.Single,
+            Value = node.Needle
+        };
+
+        return true;
+    }
+
+    private static bool TryMapUserDataMultiEquals(
+        UserDataMultiEqualsNode node,
+        [NotNullWhen(true)] out FilterComparison? comparison)
+    {
+        comparison = null;
+
+        if (node.Literals.Count == 0 || string.IsNullOrWhiteSpace(node.CanonicalPath))
+        {
+            return false;
+        }
+
+        comparison = new FilterComparison
+        {
+            Property = EventProperty.UserData,
+            UserDataFieldName = UserDataFieldPath.ToStorageKey(node.CanonicalPath),
+            Operator = ComparisonOperator.Equals,
+            MatchMode = MatchMode.Many,
+            Values = [.. node.Literals]
+        };
+
+        return true;
     }
 }

--- a/src/EventLogExpert.Filtering/Basic/BasicFilterFormatter.cs
+++ b/src/EventLogExpert.Filtering/Basic/BasicFilterFormatter.cs
@@ -64,6 +64,11 @@ public static class BasicFilterFormatter
             return false;
         }
 
+        if (comparison.Property is EventProperty.UserData && string.IsNullOrWhiteSpace(comparison.UserDataFieldName))
+        {
+            return false;
+        }
+
         var propertyExpression = FormatPropertyExpression(comparison);
 
         StringBuilder stringBuilder = new(joinPrefix ?? string.Empty);
@@ -171,12 +176,15 @@ public static class BasicFilterFormatter
         return builder.ToString();
     }
 
-    // The Advanced-text reference for a comparison's property: `EventData["escaped field name"]` for an EventData
-    // row, otherwise the bare property name (which the tokenizer reads as an identifier).
+    // The Advanced-text reference for a comparison's property: `EventData["field"]` for an EventData row,
+    // `UserData["storage-key path"]` for a UserData row, otherwise the bare property name.
     private static string FormatPropertyExpression(FilterComparison comparison) =>
-        comparison.Property is EventProperty.EventData
-            ? $"EventData[\"{EscapeStringLiteral(comparison.EventDataFieldName)}\"]"
-            : comparison.Property.ToString();
+        comparison.Property switch
+        {
+            EventProperty.EventData => $"EventData[\"{EscapeStringLiteral(comparison.EventDataFieldName)}\"]",
+            EventProperty.UserData => $"UserData[\"{EscapeStringLiteral(comparison.UserDataFieldName)}\"]",
+            _ => comparison.Property.ToString()
+        };
 
     private static string GetComparisonString(
         EventProperty property,

--- a/src/EventLogExpert.Filtering/Basic/FilterComparison.cs
+++ b/src/EventLogExpert.Filtering/Basic/FilterComparison.cs
@@ -11,7 +11,7 @@ namespace EventLogExpert.Filtering.Basic;
 [JsonConverter(typeof(FilterComparisonJsonConverter))]
 public sealed record FilterComparison
 {
-    public EventProperty Property { get; init; }
+    public EventProperty Property { get; init; } = EventProperty.Id;
 
     public ComparisonOperator Operator { get; init; }
 
@@ -28,9 +28,15 @@ public sealed record FilterComparison
     public string? EventDataFieldName { get; init; }
 
     /// <summary>
-    ///     Returns a copy with the new <paramref name="property" /> and Value/Values/EventDataFieldName cleared, since
-    ///     the available value space (and whether a field name applies) changes when the property changes.
+    ///     The structured &lt;UserData&gt; path (storage-key form, e.g. <c>X509Objects/Certificate/SubjectName</c>) this
+    ///     row targets. Meaningful only when <see cref="Property" /> is <see cref="EventProperty.UserData" />, else null.
+    /// </summary>
+    public string? UserDataFieldName { get; init; }
+
+    /// <summary>
+    ///     Returns a copy with the new <paramref name="property" /> and Value/Values/EventDataFieldName/UserDataFieldName
+    ///     cleared, since the available value space (and whether a field name applies) changes when the property changes.
     /// </summary>
     public FilterComparison WithProperty(EventProperty property) =>
-        this with { Property = property, Value = null, Values = [], EventDataFieldName = null };
+        this with { Property = property, Value = null, Values = [], EventDataFieldName = null, UserDataFieldName = null };
 }

--- a/src/EventLogExpert.Filtering/Basic/FilterComparisonJsonConverter.cs
+++ b/src/EventLogExpert.Filtering/Basic/FilterComparisonJsonConverter.cs
@@ -24,6 +24,7 @@ internal sealed class FilterComparisonJsonConverter : JsonConverter<FilterCompar
         bool matchModeSet = false;
         string? value = null;
         string? eventDataFieldName = null;
+        string? userDataFieldName = null;
         ImmutableList<string> values = [];
 
         while (reader.Read())
@@ -70,6 +71,9 @@ internal sealed class FilterComparisonJsonConverter : JsonConverter<FilterCompar
                 case "EventDataFieldName":
                     eventDataFieldName = reader.TokenType == JsonTokenType.Null ? null : reader.GetString();
                     break;
+                case "UserDataFieldName":
+                    userDataFieldName = reader.TokenType == JsonTokenType.Null ? null : reader.GetString();
+                    break;
                 case "Values":
                     values = ReadStringList(ref reader);
                     break;
@@ -88,6 +92,9 @@ internal sealed class FilterComparisonJsonConverter : JsonConverter<FilterCompar
             Values = values,
             EventDataFieldName = property is EventProperty.EventData && !string.IsNullOrWhiteSpace(eventDataFieldName)
                 ? eventDataFieldName
+                : null,
+            UserDataFieldName = property is EventProperty.UserData && !string.IsNullOrWhiteSpace(userDataFieldName)
+                ? userDataFieldName
                 : null
         };
     }
@@ -114,6 +121,11 @@ internal sealed class FilterComparisonJsonConverter : JsonConverter<FilterCompar
         if (value.Property is EventProperty.EventData && !string.IsNullOrWhiteSpace(value.EventDataFieldName))
         {
             writer.WriteString("EventDataFieldName", value.EventDataFieldName);
+        }
+
+        if (value.Property is EventProperty.UserData && !string.IsNullOrWhiteSpace(value.UserDataFieldName))
+        {
+            writer.WriteString("UserDataFieldName", value.UserDataFieldName);
         }
 
         writer.WriteEndObject();

--- a/src/EventLogExpert.Filtering/Common/Filtering/EventProperty.cs
+++ b/src/EventLogExpert.Filtering/Common/Filtering/EventProperty.cs
@@ -19,5 +19,6 @@ public enum EventProperty
     Description,
     Xml,
     [EnumMember(Value = "Log Name")] LogName,
-    [EnumMember(Value = "Event Data")] EventData
+    [EnumMember(Value = "Event Data")] EventData,
+    [EnumMember(Value = "User Data")] UserData
 }

--- a/src/EventLogExpert.Filtering/Drafts/FilterComparisonDraft.cs
+++ b/src/EventLogExpert.Filtering/Drafts/FilterComparisonDraft.cs
@@ -8,18 +8,21 @@ namespace EventLogExpert.Filtering.Drafts;
 
 public sealed class FilterComparisonDraft
 {
+    /// <summary>The named EventData field this row targets; meaningful only when <see cref="Property" /> is EventData.</summary>
+    public string? EventDataFieldName { get; set; }
+
     public MatchMode MatchMode { get; set; }
 
     public ComparisonOperator Operator { get; set; }
 
-    public EventProperty Property { get; set; }
+    public EventProperty Property { get; set; } = EventProperty.Id;
+
+    /// <summary>The structured UserData path this row targets; meaningful only when <see cref="Property" /> is UserData.</summary>
+    public string? UserDataFieldName { get; set; }
 
     public string? Value { get; set; }
 
     public List<string> Values { get; set; } = [];
-
-    /// <summary>The named EventData field this row targets; meaningful only when <see cref="Property" /> is EventData.</summary>
-    public string? EventDataFieldName { get; set; }
 
     public static FilterComparisonDraft FromComparison(FilterComparison comparison) =>
         new()
@@ -29,7 +32,8 @@ public sealed class FilterComparisonDraft
             MatchMode = comparison.MatchMode,
             Value = comparison.Value,
             Values = [.. comparison.Values],
-            EventDataFieldName = comparison.EventDataFieldName
+            EventDataFieldName = comparison.EventDataFieldName,
+            UserDataFieldName = comparison.UserDataFieldName
         };
 
     public void ChangeProperty(EventProperty property)
@@ -38,6 +42,7 @@ public sealed class FilterComparisonDraft
         Value = null;
         Values.Clear();
         EventDataFieldName = null;
+        UserDataFieldName = null;
     }
 
     public FilterComparison ToComparison() =>
@@ -48,6 +53,7 @@ public sealed class FilterComparisonDraft
             MatchMode = MatchMode,
             Value = Value,
             Values = [.. Values],
-            EventDataFieldName = EventDataFieldName
+            EventDataFieldName = EventDataFieldName,
+            UserDataFieldName = UserDataFieldName
         };
 }

--- a/src/EventLogExpert.Filtering/Drafts/FilterPredicateDraft.cs
+++ b/src/EventLogExpert.Filtering/Drafts/FilterPredicateDraft.cs
@@ -22,6 +22,10 @@ public sealed class FilterPredicateDraft
     ///             An <see cref="EventProperty.EventData" /> row additionally requires a non-whitespace
     ///             <see cref="FilterComparisonDraft.EventDataFieldName" />.
     ///         </item>
+    ///         <item>
+    ///             A <see cref="EventProperty.UserData" /> row additionally requires a non-whitespace
+    ///             <see cref="FilterComparisonDraft.UserDataFieldName" />.
+    ///         </item>
     ///     </list>
     ///     Mirrors the formatter's strict-mode validation so the in-flight UI state matches the eventual save guard.
     /// </summary>
@@ -31,6 +35,12 @@ public sealed class FilterPredicateDraft
         {
             if (Comparison.Property is EventProperty.EventData
                 && string.IsNullOrWhiteSpace(Comparison.EventDataFieldName))
+            {
+                return false;
+            }
+
+            if (Comparison.Property is EventProperty.UserData
+                && string.IsNullOrWhiteSpace(Comparison.UserDataFieldName))
             {
                 return false;
             }

--- a/src/EventLogExpert.Filtering/Emit/Emitter.cs
+++ b/src/EventLogExpert.Filtering/Emit/Emitter.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Eventing.Structured;
 using EventLogExpert.Filtering.Evaluation;
 using EventLogExpert.Filtering.Lowering;
 using System.Diagnostics.CodeAnalysis;
@@ -22,6 +23,19 @@ internal static class Emitter
         try
         {
             var requiresXml = ContainsXmlReference(root);
+
+            if (ContainsUserDataNode(root))
+            {
+                var evaluate = EmitTriState(root);
+
+                compiled = new CompiledFilter(e => evaluate(e) == FilterMatch.Match, requiresXml)
+                {
+                    Evaluate = evaluate
+                };
+
+                return true;
+            }
+
             var predicate = EmitNode(root);
             compiled = new CompiledFilter(predicate, requiresXml);
 
@@ -34,6 +48,16 @@ internal static class Emitter
             return false;
         }
     }
+
+    private static bool ContainsUserDataNode(SemanticNode node) =>
+        node switch
+        {
+            UserDataComparisonNode or UserDataContainsNode or UserDataMultiEqualsNode => true,
+            AndNode and => ContainsUserDataNode(and.Left) || ContainsUserDataNode(and.Right),
+            OrNode or => ContainsUserDataNode(or.Left) || ContainsUserDataNode(or.Right),
+            NotNode not => ContainsUserDataNode(not.Operand),
+            _ => false
+        };
 
     private static bool ContainsXmlReference(SemanticNode node) =>
         node switch
@@ -641,6 +665,143 @@ internal static class Emitter
             _ => throw new EmitException($"Unsupported field '{field}' for string comparison.")
         };
 
+    // A UserData-bearing filter compiles to a Kleene three-valued predicate: non-UserData subtrees (never a NotNode over
+    // UserData, per LowerNegation) reuse the bool emitter lifted to Match|NoMatch, And/Or combine tri-state, and a
+    // UserData term reads its stored values from ResolvedEvent.UserData by storage key.
+    private static Func<ResolvedEvent, FilterMatch> EmitTriState(SemanticNode node)
+    {
+        if (!ContainsUserDataNode(node))
+        {
+            var boolPredicate = EmitNode(node);
+
+            return e => boolPredicate(e) ? FilterMatch.Match : FilterMatch.NoMatch;
+        }
+
+        switch (node)
+        {
+            case AndNode and:
+            {
+                var parts = FlattenAndChain(and).Select(EmitTriState).ToArray();
+
+                return e => EvaluateKleeneAnd(parts, e);
+            }
+            case OrNode or:
+            {
+                var parts = FlattenOrChain(or).Select(EmitTriState).ToArray();
+
+                return e => EvaluateKleeneOr(parts, e);
+            }
+            case UserDataComparisonNode comparison:
+                return EmitUserDataFieldMatcher(comparison.CanonicalPath, EmitUserDataComparison(comparison));
+            case UserDataContainsNode contains:
+                return EmitUserDataFieldMatcher(contains.CanonicalPath, EmitUserDataContains(contains));
+            case UserDataMultiEqualsNode multi:
+                return EmitUserDataFieldMatcher(multi.CanonicalPath, EmitUserDataMultiEquals(multi));
+            default:
+                throw new EmitException($"Unsupported UserData-bearing node {node.GetType().Name}.");
+        }
+    }
+
+    private static Func<StructuredFieldResult, FilterMatch> EmitUserDataComparison(UserDataComparisonNode node)
+    {
+        var literal = node.Literal;
+
+        if (node.Op == FilterBinaryOperator.Equal)
+        {
+            return result =>
+            {
+                var values = result.PresentValues;
+
+                for (var i = 0; i < values.Length; i++)
+                {
+                    if (string.Equals(values[i], literal, StringComparison.Ordinal)) { return FilterMatch.Match; }
+                }
+
+                return result.IsTruncated ? FilterMatch.Unknown : FilterMatch.NoMatch;
+            };
+        }
+
+        return result =>
+        {
+            var values = result.PresentValues;
+
+            if (values.Length == 0) { return result.IsTruncated ? FilterMatch.Unknown : FilterMatch.NoMatch; }
+
+            for (var i = 0; i < values.Length; i++)
+            {
+                if (string.Equals(values[i], literal, StringComparison.Ordinal)) { return FilterMatch.NoMatch; }
+            }
+
+            return result.IsTruncated ? FilterMatch.Unknown : FilterMatch.Match;
+        };
+    }
+
+    private static Func<StructuredFieldResult, FilterMatch> EmitUserDataContains(UserDataContainsNode node)
+    {
+        var needle = node.Needle;
+        var comparison = node.IgnoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+        if (!node.Negated)
+        {
+            return result =>
+            {
+                var values = result.PresentValues;
+
+                for (var i = 0; i < values.Length; i++)
+                {
+                    if (values[i].Contains(needle, comparison)) { return FilterMatch.Match; }
+                }
+
+                return result.IsTruncated ? FilterMatch.Unknown : FilterMatch.NoMatch;
+            };
+        }
+
+        return result =>
+        {
+            var values = result.PresentValues;
+
+            if (values.Length == 0) { return result.IsTruncated ? FilterMatch.Unknown : FilterMatch.NoMatch; }
+
+            for (var i = 0; i < values.Length; i++)
+            {
+                if (values[i].Contains(needle, comparison)) { return FilterMatch.NoMatch; }
+            }
+
+            return result.IsTruncated ? FilterMatch.Unknown : FilterMatch.Match;
+        };
+    }
+
+    private static Func<StructuredFieldResult, FilterMatch> EmitUserDataMultiEquals(UserDataMultiEqualsNode node)
+    {
+        var literals = node.Literals;
+
+        return result =>
+        {
+            var values = result.PresentValues;
+
+            for (var i = 0; i < values.Length; i++)
+            {
+                var value = values[i];
+
+                for (var j = 0; j < literals.Count; j++)
+                {
+                    if (string.Equals(value, literals[j], StringComparison.Ordinal)) { return FilterMatch.Match; }
+                }
+            }
+
+            return result.IsTruncated ? FilterMatch.Unknown : FilterMatch.NoMatch;
+        };
+    }
+
+    private static Func<ResolvedEvent, FilterMatch> EmitUserDataFieldMatcher(
+        string canonicalPath,
+        Func<StructuredFieldResult, FilterMatch> evaluate)
+    {
+        var storageKey = UserDataFieldPath.ToStorageKey(canonicalPath);
+
+        return e => evaluate(e.TryGetUserDataValues(storageKey));
+    }
+
     private static Func<ResolvedEvent, bool> EmitUserIdStringCompare(FilterBinaryOperator op, string value) =>
         op switch
         {
@@ -651,6 +812,38 @@ internal static class Emitter
                 e.UserId is not null && !string.Equals(e.UserId.Value, value, StringComparison.Ordinal),
             _ => throw new EmitException($"Operator '{op}' is not supported on UserId.")
         };
+
+    private static FilterMatch EvaluateKleeneAnd(Func<ResolvedEvent, FilterMatch>[] parts, ResolvedEvent @event)
+    {
+        var result = FilterMatch.Match;
+
+        foreach (var part in parts)
+        {
+            var match = part(@event);
+
+            if (match == FilterMatch.NoMatch) { return FilterMatch.NoMatch; }
+
+            if (match == FilterMatch.Unknown) { result = FilterMatch.Unknown; }
+        }
+
+        return result;
+    }
+
+    private static FilterMatch EvaluateKleeneOr(Func<ResolvedEvent, FilterMatch>[] parts, ResolvedEvent @event)
+    {
+        var result = FilterMatch.NoMatch;
+
+        foreach (var part in parts)
+        {
+            var match = part(@event);
+
+            if (match == FilterMatch.Match) { return FilterMatch.Match; }
+
+            if (match == FilterMatch.Unknown) { result = FilterMatch.Unknown; }
+        }
+
+        return result;
+    }
 
     private static List<SemanticNode> FlattenAndChain(SemanticNode node)
     {

--- a/src/EventLogExpert.Filtering/Emit/Emitter.cs
+++ b/src/EventLogExpert.Filtering/Emit/Emitter.cs
@@ -205,8 +205,24 @@ internal static class Emitter
     {
         var name = node.FieldName;
         var literal = node.Literal;
+        var equal = node.Op == FilterBinaryOperator.Equal;
 
-        if (node.Op == FilterBinaryOperator.Equal)
+        if (WildcardMatcher.ContainsWildcard(name))
+        {
+            var matchesName = WildcardMatcher.Compile(name);
+
+            return e =>
+            {
+                foreach (var field in e.EventData)
+                {
+                    if (matchesName(field.Name) && literal.MatchesValue(field.Value) == equal) { return true; }
+                }
+
+                return false;
+            };
+        }
+
+        if (equal)
         {
             return e => e.EventData.TryGetValue(name, out var value) && literal.MatchesValue(value);
         }
@@ -219,8 +235,27 @@ internal static class Emitter
         var name = node.FieldName;
         var needle = node.Needle;
         var comparison = node.IgnoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        var negated = node.Negated;
 
-        if (node.Negated)
+        if (WildcardMatcher.ContainsWildcard(name))
+        {
+            var matchesName = WildcardMatcher.Compile(name);
+
+            return e =>
+            {
+                foreach (var field in e.EventData)
+                {
+                    if (matchesName(field.Name) && field.Value.AsString().Contains(needle, comparison) != negated)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            };
+        }
+
+        if (negated)
         {
             return e => e.EventData.TryGetValue(name, out var value)
                 && !value.AsString().Contains(needle, comparison);
@@ -234,6 +269,26 @@ internal static class Emitter
     {
         var name = node.FieldName;
         var literals = node.Literals;
+
+        if (WildcardMatcher.ContainsWildcard(name))
+        {
+            var matchesName = WildcardMatcher.Compile(name);
+
+            return e =>
+            {
+                foreach (var field in e.EventData)
+                {
+                    if (!matchesName(field.Name)) { continue; }
+
+                    for (var i = 0; i < literals.Count; i++)
+                    {
+                        if (literals[i].MatchesValue(field.Value)) { return true; }
+                    }
+                }
+
+                return false;
+            };
+        }
 
         return e =>
         {
@@ -771,6 +826,25 @@ internal static class Emitter
         };
     }
 
+    private static Func<ResolvedEvent, FilterMatch> EmitUserDataFieldMatcher(
+        string canonicalPath,
+        Func<StructuredFieldResult, FilterMatch> evaluate)
+    {
+        var storageKey = UserDataFieldPath.ToStorageKey(canonicalPath);
+
+        // A '*' in the storage key marks a field-name glob (ToStorageKey has already stripped the [*] repeating-element
+        // marker, so only a genuine name glob survives). Evaluate the term as if each matching stored path were its own
+        // OR'd filter row.
+        if (WildcardMatcher.ContainsWildcard(storageKey))
+        {
+            var matchesPath = WildcardMatcher.Compile(storageKey);
+
+            return e => EvaluateUserDataGlob(e, matchesPath, evaluate);
+        }
+
+        return e => evaluate(e.TryGetUserDataValues(storageKey));
+    }
+
     private static Func<StructuredFieldResult, FilterMatch> EmitUserDataMultiEquals(UserDataMultiEqualsNode node)
     {
         var literals = node.Literals;
@@ -791,15 +865,6 @@ internal static class Emitter
 
             return result.IsTruncated ? FilterMatch.Unknown : FilterMatch.NoMatch;
         };
-    }
-
-    private static Func<ResolvedEvent, FilterMatch> EmitUserDataFieldMatcher(
-        string canonicalPath,
-        Func<StructuredFieldResult, FilterMatch> evaluate)
-    {
-        var storageKey = UserDataFieldPath.ToStorageKey(canonicalPath);
-
-        return e => evaluate(e.TryGetUserDataValues(storageKey));
     }
 
     private static Func<ResolvedEvent, bool> EmitUserIdStringCompare(FilterBinaryOperator op, string value) =>
@@ -843,6 +908,36 @@ internal static class Emitter
         }
 
         return result;
+    }
+
+    private static FilterMatch EvaluateUserDataGlob(
+        ResolvedEvent @event,
+        Func<string, bool> matchesPath,
+        Func<StructuredFieldResult, FilterMatch> evaluate)
+    {
+        // UserData is a default array for every flat-EventData / error event; guard before iterating, mirroring
+        // ResolvedEvent.TryGetUserDataValues (an absent field set is NoMatch, or Unknown when the extraction was capped).
+        if (@event.UserData.IsDefaultOrEmpty)
+        {
+            return @event.UserDataIncomplete ? FilterMatch.Unknown : FilterMatch.NoMatch;
+        }
+
+        var result = FilterMatch.NoMatch;
+
+        foreach (var field in @event.UserData)
+        {
+            if (!matchesPath(field.Path)) { continue; }
+
+            var fieldMatch = evaluate(field.ToFieldResult(@event.UserDataIncomplete));
+
+            if (fieldMatch == FilterMatch.Match) { return FilterMatch.Match; }
+
+            if (fieldMatch == FilterMatch.Unknown) { result = FilterMatch.Unknown; }
+        }
+
+        // A capped field set may also have dropped a whole matching path, so a would-be decisive NoMatch (no path matched
+        // the glob at all) becomes keep-visible Unknown.
+        return result == FilterMatch.NoMatch && @event.UserDataIncomplete ? FilterMatch.Unknown : result;
     }
 
     private static List<SemanticNode> FlattenAndChain(SemanticNode node)

--- a/src/EventLogExpert.Filtering/Emit/WildcardMatcher.cs
+++ b/src/EventLogExpert.Filtering/Emit/WildcardMatcher.cs
@@ -1,0 +1,71 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Filtering.Emit;
+
+/// <summary>
+///     Case-insensitive <c>*</c> glob matcher for field names and UserData storage-key paths. <c>*</c> matches any
+///     run of characters (including empty); every other character is literal. A pattern is compiled once (at emit time)
+///     into a reusable match delegate so the per-event hot path parses nothing and allocates nothing.
+/// </summary>
+internal static class WildcardMatcher
+{
+    /// <summary>Compiles a <c>*</c> glob into a case-insensitive matcher. Call once per emitted term and reuse it.</summary>
+    internal static Func<string, bool> Compile(string pattern)
+    {
+        // Literal runs split by the '*' wildcards: the first run anchors the start, the last anchors the end, and the
+        // middle runs must appear in order between them. An empty run (a leading, trailing, or doubled '*') is a no-op.
+        string[] segments = pattern.Split('*');
+
+        return candidate => IsMatch(candidate, segments);
+    }
+
+    /// <summary><c>true</c> when the pattern carries at least one <c>*</c> wildcard (so it is a glob, not an exact name).</summary>
+    internal static bool ContainsWildcard(string pattern) => pattern.Contains('*');
+
+    private static bool IsMatch(string candidate, string[] segments)
+    {
+        const StringComparison OrdinalIgnoreCase = StringComparison.OrdinalIgnoreCase;
+        ReadOnlySpan<char> span = candidate;
+
+        // No wildcard: whole-string equality (defensive; callers gate on ContainsWildcard).
+        if (segments.Length == 1) { return span.Equals(segments[0], OrdinalIgnoreCase); }
+
+        int start = 0;
+        int end = span.Length;
+        string prefix = segments[0];
+
+        if (prefix.Length > 0)
+        {
+            if (!span.StartsWith(prefix, OrdinalIgnoreCase)) { return false; }
+
+            start = prefix.Length;
+        }
+
+        string suffix = segments[^1];
+
+        if (suffix.Length > 0)
+        {
+            if (!span.EndsWith(suffix, OrdinalIgnoreCase)) { return false; }
+
+            end -= suffix.Length;
+        }
+
+        for (int index = 1; index < segments.Length - 1; index++)
+        {
+            string segment = segments[index];
+
+            if (segment.Length == 0) { continue; }
+
+            if (start > end) { return false; }
+
+            int found = span[start..end].IndexOf(segment, OrdinalIgnoreCase);
+
+            if (found < 0) { return false; }
+
+            start += found + segment.Length;
+        }
+
+        return start <= end;
+    }
+}

--- a/src/EventLogExpert.Filtering/Evaluation/CompiledFilter.cs
+++ b/src/EventLogExpert.Filtering/Evaluation/CompiledFilter.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Eventing.Structured;
 
 namespace EventLogExpert.Filtering.Evaluation;
 
@@ -9,6 +10,13 @@ namespace EventLogExpert.Filtering.Evaluation;
 ///     Immutable compiled artifact: the runnable predicate plus the cached XML-access flag used to decide whether
 ///     logs must be opened with pre-rendered XML.
 /// </summary>
-/// <param name="Predicate">The compiled lambda evaluated against each <see cref="ResolvedEvent" />.</param>
+/// <param name="Predicate">
+///     The bool predicate evaluated against each <see cref="ResolvedEvent" />; for a UserData filter
+///     it is the tri-state <see cref="Evaluate" /> collapsed to bool (absent field and <see cref="FilterMatch.Unknown" />
+///     read as non-match).
+/// </param>
 /// <param name="RequiresXml"><c>true</c> when the source expression references <see cref="ResolvedEvent.Xml" />.</param>
-public sealed record CompiledFilter(Func<ResolvedEvent, bool> Predicate, bool RequiresXml);
+public sealed record CompiledFilter(Func<ResolvedEvent, bool> Predicate, bool RequiresXml)
+{
+    public Func<ResolvedEvent, FilterMatch>? Evaluate { get; init; }
+}

--- a/src/EventLogExpert.Filtering/Evaluation/ResolvedEventExtensions.cs
+++ b/src/EventLogExpert.Filtering/Evaluation/ResolvedEventExtensions.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Eventing.Structured;
 using EventLogExpert.Filtering.Persistence;
 
 namespace EventLogExpert.Filtering.Evaluation;
@@ -19,13 +20,25 @@ internal static class ResolvedEventExtensions
 
             foreach (var filter in filters)
             {
-                if (filter.Compiled is null) { continue; }
+                var compiled = filter.Compiled;
 
-                if (filter.IsExcluded && filter.Compiled.Predicate(@event)) { return false; }
+                if (compiled is null) { continue; }
 
-                if (!filter.IsExcluded) { isEmpty = false; }
+                FilterMatch match = compiled.Evaluate?.Invoke(@event) ??
+                    (compiled.Predicate(@event) ? FilterMatch.Match : FilterMatch.NoMatch);
 
-                if (!filter.IsExcluded && filter.Compiled.Predicate(@event)) { isFiltered = true; }
+                if (filter.IsExcluded)
+                {
+                    // Exclude hides only on a decisive Match; Unknown and NoMatch keep the row visible.
+                    if (match == FilterMatch.Match) { return false; }
+
+                    continue;
+                }
+
+                isEmpty = false;
+
+                // Include keeps the row on a Match OR an Unknown; only a decisive NoMatch fails to satisfy it.
+                if (match != FilterMatch.NoMatch) { isFiltered = true; }
             }
 
             return isEmpty || isFiltered;

--- a/src/EventLogExpert.Filtering/EventData/EventLogDataQueryExtensions.cs
+++ b/src/EventLogExpert.Filtering/EventData/EventLogDataQueryExtensions.cs
@@ -59,5 +59,49 @@ internal static class EventLogDataQueryExtensions
                 EventProperty.LogName => events.Select(e => e.LogName).Distinct(),
                 _ => [],
             };
+
+        /// <summary>
+        ///     Distinct structured &lt;UserData&gt; field paths (storage keys) across <paramref name="events" />, for the
+        ///     Basic editor's UserData field-name picker. Compared Ordinal, matching the storage-key lookup.
+        /// </summary>
+        public IEnumerable<string> GetUserDataFieldNames()
+        {
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var resolvedEvent in events)
+            {
+                if (resolvedEvent.UserData.IsDefaultOrEmpty) { continue; }
+
+                foreach (var field in resolvedEvent.UserData)
+                {
+                    if (seen.Add(field.Path)) { yield return field.Path; }
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Values of the structured UserData field <paramref name="fieldName" /> (a storage key) across every event that
+        ///     has it; a repeating field contributes each collapsed value. The caller de-duplicates and sorts.
+        /// </summary>
+        public IEnumerable<string> GetUserDataFieldValues(string fieldName)
+        {
+            foreach (var resolvedEvent in events)
+            {
+                if (resolvedEvent.UserData.IsDefaultOrEmpty) { continue; }
+
+                foreach (var field in resolvedEvent.UserData)
+                {
+                    if (!string.Equals(field.Path, fieldName, StringComparison.Ordinal) || field.Values.IsDefaultOrEmpty)
+                    {
+                        continue;
+                    }
+
+                    foreach (var value in field.Values)
+                    {
+                        yield return value;
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/EventLogExpert.Filtering/EventData/EventPropertyValuesCache.cs
+++ b/src/EventLogExpert.Filtering/EventData/EventPropertyValuesCache.cs
@@ -24,6 +24,10 @@ public static class EventPropertyValuesCache
         object,
         ConcurrentDictionary<string, Lazy<ImmutableArray<string>>>> s_fieldValueCache = new();
     private static readonly ImmutableArray<string> s_levelValues = [.. Enum.GetNames<SeverityLevel>()];
+    private static readonly ConditionalWeakTable<object, Lazy<ImmutableArray<string>>> s_userDataFieldNameCache = new();
+    private static readonly ConditionalWeakTable<
+        object,
+        ConcurrentDictionary<string, Lazy<ImmutableArray<string>>>> s_userDataFieldValueCache = new();
 
     /// <summary>
     ///     Returns the distinct, sorted &lt;EventData&gt; field names across <paramref name="events" />, cached per
@@ -72,6 +76,51 @@ public static class EventPropertyValuesCache
             .Value;
     }
 
+    /// <summary>
+    ///     Distinct, sorted structured &lt;UserData&gt; field paths (storage keys) across <paramref name="events" />,
+    ///     cached per snapshot <paramref name="cacheKey" /> (auto-evicted when the snapshot changes).
+    /// </summary>
+    public static ImmutableArray<string> GetUserDataFieldNames(object cacheKey, IEnumerable<ResolvedEvent> events) =>
+        s_userDataFieldNameCache
+            .GetValue(
+                cacheKey,
+                _ => new Lazy<ImmutableArray<string>>(
+                    () => [.. events.GetUserDataFieldNames().Order(StringComparer.Ordinal)]))
+            .Value;
+
+    /// <summary>
+    ///     Distinct, sorted values of the structured UserData field <paramref name="fieldName" /> (a storage key) across
+    ///     <paramref name="events" />, cached per <c>(snapshot, fieldName)</c> so each field keeps its own value list.
+    /// </summary>
+    public static ImmutableArray<string> GetUserDataFieldValues(
+        object cacheKey,
+        IEnumerable<ResolvedEvent> events,
+        string? fieldName)
+    {
+        if (string.IsNullOrEmpty(fieldName))
+        {
+            return [];
+        }
+
+        // Only cache values for field names that exist in the snapshot (bounded-membership guard), so an arbitrary or
+        // partial typed path adds no cache entry or full log scan per keystroke; the field-name list is itself cached.
+        if (!GetUserDataFieldNames(cacheKey, events).Contains(fieldName, StringComparer.Ordinal))
+        {
+            return [];
+        }
+
+        var perSnapshot = s_userDataFieldValueCache.GetValue(
+            cacheKey,
+            static _ => new ConcurrentDictionary<string, Lazy<ImmutableArray<string>>>(StringComparer.Ordinal));
+
+        return perSnapshot
+            .GetOrAdd(
+                fieldName,
+                name => new Lazy<ImmutableArray<string>>(
+                    () => [.. events.GetUserDataFieldValues(name).Distinct().Order(StringComparer.Ordinal)]))
+            .Value;
+    }
+
     public static ImmutableArray<string> GetValues(
         object cacheKey,
         IEnumerable<ResolvedEvent> events,
@@ -102,6 +151,8 @@ public static class EventPropertyValuesCache
         s_cache.Clear();
         s_fieldNameCache.Clear();
         s_fieldValueCache.Clear();
+        s_userDataFieldNameCache.Clear();
+        s_userDataFieldValueCache.Clear();
     }
 
     private static ImmutableArray<string> Compute(

--- a/src/EventLogExpert.Filtering/Lowering/Lowerer.cs
+++ b/src/EventLogExpert.Filtering/Lowering/Lowerer.cs
@@ -1,6 +1,7 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Eventing.Structured;
 using EventLogExpert.Filtering.Basic;
 using EventLogExpert.Filtering.Parsing;
 using System.Diagnostics.CodeAnalysis;
@@ -98,6 +99,16 @@ internal static class Lowerer
             _ => false
         };
 
+    private static bool ContainsUserDataNode(SemanticNode node) =>
+        node switch
+        {
+            UserDataComparisonNode or UserDataContainsNode or UserDataMultiEqualsNode => true,
+            AndNode and => ContainsUserDataNode(and.Left) || ContainsUserDataNode(and.Right),
+            OrNode or => ContainsUserDataNode(or.Left) || ContainsUserDataNode(or.Right),
+            NotNode not => ContainsUserDataNode(not.Operand),
+            _ => false
+        };
+
     private static IReadOnlyList<string> ExtractStringArray(ArrayCreationSyntax array, int position)
     {
         if (array.Elements.Count == 0)
@@ -141,6 +152,15 @@ internal static class Lowerer
             LiteralKind.Int => literal.Text,
             _ => throw new LowerException(
                 $"EventData comparison value must be a string or integer literal (position {literal.Position}).")
+        };
+
+    private static string GetUserDataLiteralText(LiteralSyntax literal) =>
+        literal.Kind switch
+        {
+            LiteralKind.String => literal.Text,
+            LiteralKind.Int => literal.Text,
+            _ => throw new LowerException(
+                $"UserData comparison value must be a string or integer literal (position {literal.Position}).")
         };
 
     private static bool IsCaseInsensitiveMatch(string left, string right) =>
@@ -258,6 +278,11 @@ internal static class Lowerer
             return LowerEventDataComparison(eventDataFieldName, bin);
         }
 
+        if (TryResolveUserDataField(bin.Left, out var userDataPath))
+        {
+            return LowerUserDataComparison(userDataPath, bin);
+        }
+
         // Property <op> Literal  -or-  Property.ToString() <op> Literal (formatter shape, normalized away)
         var (field, fieldExpression) = ResolveFieldOrToString(bin.Left, bin.Position);
 
@@ -351,6 +376,12 @@ internal static class Lowerer
                     [.. elements.Select(EventDataLiteral.Parse)]);
             }
 
+            // UserData any-of, recognized before ResolveFieldOrToString for the same reason.
+            if (TryResolveUserDataField(call.Arguments[0], out var userDataAnyOfPath))
+            {
+                return new UserDataMultiEqualsNode(userDataAnyOfPath, elements);
+            }
+
             var argField = ResolveFieldOrToString(call.Arguments[0], call.Arguments[0].Position).Field;
 
             return new MultiEqualsNode(argField, elements);
@@ -363,6 +394,15 @@ internal static class Lowerer
             var (needle, ignoreCase) = ParseContainsArgs(call.Arguments, call.Position);
 
             return new EventDataContainsNode(eventDataContainsName, needle, ignoreCase, negated: false);
+        }
+
+        // UserData["Event/UserData/..."].Contains(needle, OIC)
+        if (IsCaseInsensitiveMatch(call.Name, "Contains")
+            && TryResolveUserDataField(call.Target, out var userDataContainsPath))
+        {
+            var (needle, ignoreCase) = ParseContainsArgs(call.Arguments, call.Position);
+
+            return new UserDataContainsNode(userDataContainsPath, needle, ignoreCase, negated: false);
         }
 
         // P.Contains(needle, StringComparison.OrdinalIgnoreCase) for any Contains-supported field. Denylist
@@ -432,6 +472,21 @@ internal static class Lowerer
             case EventDataMultiEqualsNode:
                 throw new LowerException(
                     $"Negating an EventData any-of match is not supported; use separate '!=' conditions (position {neg.Position}).");
+            case UserDataComparisonNode userComparison:
+                var userFlipped = userComparison.Op == FilterBinaryOperator.Equal
+                    ? FilterBinaryOperator.NotEqual
+                    : FilterBinaryOperator.Equal;
+
+                return new UserDataComparisonNode(userComparison.CanonicalPath, userFlipped, userComparison.Literal);
+            case UserDataContainsNode userContains:
+                return new UserDataContainsNode(
+                    userContains.CanonicalPath,
+                    userContains.Needle,
+                    userContains.IgnoreCase,
+                    !userContains.Negated);
+            case UserDataMultiEqualsNode:
+                throw new LowerException(
+                    $"Negating a UserData any-of match is not supported; use separate '!=' conditions (position {neg.Position}).");
             default:
                 if (ContainsEventDataNode(inner))
                 {
@@ -439,8 +494,33 @@ internal static class Lowerer
                         $"Negating a group that contains EventData conditions is not supported; negate each EventData condition individually (position {neg.Position}).");
                 }
 
+                if (ContainsUserDataNode(inner))
+                {
+                    throw new LowerException(
+                        $"Negating a group that contains UserData conditions is not supported; negate each UserData condition individually (position {neg.Position}).");
+                }
+
                 return new NotNode(inner);
         }
+    }
+
+    private static SemanticNode LowerUserDataComparison(string canonicalPath, BinarySyntax bin)
+    {
+        if (bin.Op is not (TokenKind.EqEq or TokenKind.NotEq))
+        {
+            throw new LowerException(
+                $"Operator '{bin.Op}' is not supported on UserData paths; use '==' or '!=' (position {bin.Position}).");
+        }
+
+        if (bin.Right is not LiteralSyntax literal)
+        {
+            throw new LowerException(
+                $"Right-hand side of a UserData comparison must be a literal (position {bin.Right.Position}).");
+        }
+
+        var op = bin.Op == TokenKind.EqEq ? FilterBinaryOperator.Equal : FilterBinaryOperator.NotEqual;
+
+        return new UserDataComparisonNode(canonicalPath, op, GetUserDataLiteralText(literal));
     }
 
     private static FilterBinaryOperator MapBinaryOp(TokenKind op) =>
@@ -585,6 +665,35 @@ internal static class Lowerer
         }
 
         fieldName = key.Text;
+
+        return true;
+    }
+
+    // True for a well-formed `UserData["path"]` access (normalizing/validating the canonical path); throws a
+    // descriptive LowerException for a malformed UserData index; false for any non-UserData expression.
+    private static bool TryResolveUserDataField(SyntaxNode expr, [NotNullWhen(true)] out string? canonicalPath)
+    {
+        canonicalPath = null;
+
+        if (expr is not IndexAccessSyntax index
+            || index.Target is not IdentifierSyntax id
+            || !IsCaseInsensitiveMatch(id.Name, "UserData"))
+        {
+            return false;
+        }
+
+        if (index.Argument is not LiteralSyntax { Kind: LiteralKind.String } key)
+        {
+            throw new LowerException(
+                $"UserData path must be a string literal (position {index.Argument.Position}).");
+        }
+
+        if (!UserDataFieldPath.TryNormalize(key.Text, out var normalized, out var pathError))
+        {
+            throw new LowerException($"{pathError} (position {key.Position}).");
+        }
+
+        canonicalPath = normalized;
 
         return true;
     }

--- a/src/EventLogExpert.Filtering/Lowering/SemanticNode.cs
+++ b/src/EventLogExpert.Filtering/Lowering/SemanticNode.cs
@@ -135,3 +135,46 @@ internal sealed class EventDataMultiEqualsNode(string fieldName, IReadOnlyList<E
 
     public IReadOnlyList<EventDataLiteral> Literals { get; } = literals;
 }
+
+/// <summary>
+///     <c>UserData["Event/UserData/..."] == v</c> / <c>!= v</c>: ordinal all-string equality on a structured UserData
+///     path, presence-required (an absent path never matches, positive or negative). Evaluated to a tri-state so a
+///     truncated field surfaces <c>Unknown</c>; negation flips <see cref="Op" /> in the Lowerer, so no NotNode wraps it.
+/// </summary>
+internal sealed class UserDataComparisonNode(string canonicalPath, FilterBinaryOperator op, string literal)
+    : SemanticNode
+{
+    public string CanonicalPath { get; } = canonicalPath;
+
+    public string Literal { get; } = literal;
+
+    public FilterBinaryOperator Op { get; } = op;
+}
+
+/// <summary>
+///     <c>UserData["Event/UserData/..."].Contains(Needle, OIC)</c> on a structured UserData path, ordinal over each
+///     present value. <see cref="Negated" /> is the <c>!...Contains(...)</c> (Basic <c>NotContains</c>) form;
+///     presence-required.
+/// </summary>
+internal sealed class UserDataContainsNode(string canonicalPath, string needle, bool ignoreCase, bool negated)
+    : SemanticNode
+{
+    public string CanonicalPath { get; } = canonicalPath;
+
+    public bool IgnoreCase { get; } = ignoreCase;
+
+    public string Needle { get; } = needle;
+
+    public bool Negated { get; } = negated;
+}
+
+/// <summary>
+///     <c>(new[] {...}).Contains(UserData["Event/UserData/..."])</c>: any-of ordinal equality on a structured
+///     UserData path, presence-required. Positive only; <c>!(any-of)</c> has no Basic form and is rejected by the Lowerer.
+/// </summary>
+internal sealed class UserDataMultiEqualsNode(string canonicalPath, IReadOnlyList<string> literals) : SemanticNode
+{
+    public string CanonicalPath { get; } = canonicalPath;
+
+    public IReadOnlyList<string> Literals { get; } = literals;
+}

--- a/src/EventLogExpert.Runtime/EventLog/EventLogQueries.cs
+++ b/src/EventLogExpert.Runtime/EventLog/EventLogQueries.cs
@@ -52,4 +52,21 @@ internal sealed class EventLogQueries(
 
         return EventPropertyValuesCache.GetValues(byLog, byLog.Values.SelectMany(events => events), property);
     }
+
+    public ImmutableArray<string> GetUserDataFieldNames()
+    {
+        var byLog = _rawEventStore.Value.ByLog;
+
+        return EventPropertyValuesCache.GetUserDataFieldNames(byLog, byLog.Values.SelectMany(events => events));
+    }
+
+    public ImmutableArray<string> GetUserDataFieldValues(string fieldName)
+    {
+        var byLog = _rawEventStore.Value.ByLog;
+
+        return EventPropertyValuesCache.GetUserDataFieldValues(
+            byLog,
+            byLog.Values.SelectMany(events => events),
+            fieldName);
+    }
 }

--- a/src/EventLogExpert.Runtime/EventLog/EventLogReaderFactory.cs
+++ b/src/EventLogExpert.Runtime/EventLog/EventLogReaderFactory.cs
@@ -8,6 +8,10 @@ namespace EventLogExpert.Runtime.EventLog;
 
 internal sealed class EventLogReaderFactory : IEventLogReaderFactory
 {
-    public IEventLogReader CreateReader(string path, LogPathType pathType, bool renderXml = false, bool reverseDirection = false) =>
+    public IEventLogReader CreateReader(
+        string path,
+        LogPathType pathType,
+        bool renderXml = false,
+        bool reverseDirection = false) =>
         new EventLogReader(path, pathType, renderXml, reverseDirection);
 }

--- a/src/EventLogExpert.Runtime/EventLog/FilteringEffects.cs
+++ b/src/EventLogExpert.Runtime/EventLog/FilteringEffects.cs
@@ -84,6 +84,8 @@ internal sealed class FilteringEffects(
 
         bool newRequiresXml = action.Filter.RequiresXml;
 
+        // Reopen a log only when it lacks the XML the new filter needs; UserData resolves from stored fields at resolve
+        // time, so a UserData filter change never forces a reload.
         var logsNeedingReload = newRequiresXml && !_eventLogState.Value.OpenLogs.IsEmpty
             ? _eventLogState.Value.OpenLogs
                 .Where(kvp => !_concurrencyState.IsLoadedWithXml(kvp.Value.Id))

--- a/src/EventLogExpert.Runtime/EventLog/IEventLogQueries.cs
+++ b/src/EventLogExpert.Runtime/EventLog/IEventLogQueries.cs
@@ -38,4 +38,16 @@ public interface IEventLogQueries
     ///     from event data.
     /// </summary>
     ImmutableArray<string> GetPropertyValues(EventProperty property);
+
+    /// <summary>
+    ///     Distinct, sorted structured &lt;UserData&gt; field paths (storage keys) across all open raw events, for the
+    ///     Basic editor's UserData field-name picker.
+    /// </summary>
+    ImmutableArray<string> GetUserDataFieldNames();
+
+    /// <summary>
+    ///     Distinct, sorted values of the structured UserData field <paramref name="fieldName" /> (a storage key) across
+    ///     all open raw events, for the value picker of a UserData filter row.
+    /// </summary>
+    ImmutableArray<string> GetUserDataFieldValues(string fieldName);
 }

--- a/src/EventLogExpert.Runtime/EventLog/IEventLogReaderFactory.cs
+++ b/src/EventLogExpert.Runtime/EventLog/IEventLogReaderFactory.cs
@@ -8,5 +8,9 @@ namespace EventLogExpert.Runtime.EventLog;
 
 internal interface IEventLogReaderFactory
 {
-    IEventLogReader CreateReader(string path, LogPathType pathType, bool renderXml = false, bool reverseDirection = false);
+    IEventLogReader CreateReader(
+        string path,
+        LogPathType pathType,
+        bool renderXml = false,
+        bool reverseDirection = false);
 }

--- a/src/EventLogExpert.Scenarios/Catalog/ScenarioExporter.cs
+++ b/src/EventLogExpert.Scenarios/Catalog/ScenarioExporter.cs
@@ -103,6 +103,8 @@ public static class ScenarioExporter
         return new ComparisonDto
         {
             Property = comparison.Property.ToString(),
+            EventDataFieldName = comparison.Property == EventProperty.EventData ? comparison.EventDataFieldName : null,
+            UserDataFieldName = comparison.Property == EventProperty.UserData ? comparison.UserDataFieldName : null,
             Operator = isMany || comparison.Operator == ComparisonOperator.Equals ? null : comparison.Operator.ToString(),
             MatchMode = isMany ? comparison.MatchMode.ToString() : null,
             Value = isMany ? null : comparison.Value,

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/capi2.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/capi2.json
@@ -1,0 +1,126 @@
+{
+  "schemaVersion": 1,
+  "scenarios": [
+    {
+      "id": "capi2-pki-chain-failure-triage",
+      "name": "PKI chain-build failure triage",
+      "purpose": "All failed certificate chain builds (Event ID 11) color-coded by root cause: untrusted root (Red), expired cert (Orange), revoked cert (Purple), CRL/OCSP server offline (DarkYellow), revocation status indeterminate (Yellow), partial chain / missing issuer (Blue), wrong EKU (Magenta), and invalid signature (DarkRed). Requires CAPI2 Operational logging enabled by an administrator (disabled by default).",
+      "group": "Security",
+      "channels": [ "Microsoft-Windows-CAPI2/Operational" ],
+      "requiresAdmin": true,
+      "priority": 0,
+      "order": 0,
+      "version": 1,
+      "filters": [
+        { "color": "Red", "comparison": { "property": "Id", "value": "11" }, "predicates": [ { "comparison": { "property": "UserData", "userDataFieldName": "CertGetCertificateChain/CertificateChain/TrustStatus/ErrorStatus/@CERT_TRUST_IS_UNTRUSTED_ROOT", "value": "true" } } ] },
+        { "color": "Orange", "comparison": { "property": "Id", "value": "11" }, "predicates": [ { "comparison": { "property": "UserData", "userDataFieldName": "CertGetCertificateChain/CertificateChain/TrustStatus/ErrorStatus/@CERT_TRUST_IS_NOT_TIME_VALID", "value": "true" } } ] },
+        { "color": "Purple", "comparison": { "property": "Id", "value": "11" }, "predicates": [ { "comparison": { "property": "UserData", "userDataFieldName": "CertGetCertificateChain/CertificateChain/TrustStatus/ErrorStatus/@CERT_TRUST_IS_REVOKED", "value": "true" } } ] },
+        { "color": "DarkYellow", "comparison": { "property": "Id", "value": "11" }, "predicates": [ { "comparison": { "property": "UserData", "userDataFieldName": "CertGetCertificateChain/CertificateChain/TrustStatus/ErrorStatus/@CERT_TRUST_IS_OFFLINE_REVOCATION", "value": "true" } } ] },
+        { "color": "Yellow", "comparison": { "property": "Id", "value": "11" }, "predicates": [ { "comparison": { "property": "UserData", "userDataFieldName": "CertGetCertificateChain/CertificateChain/TrustStatus/ErrorStatus/@CERT_TRUST_REVOCATION_STATUS_UNKNOWN", "value": "true" } } ] },
+        { "color": "Blue", "comparison": { "property": "Id", "value": "11" }, "predicates": [ { "comparison": { "property": "UserData", "userDataFieldName": "CertGetCertificateChain/CertificateChain/TrustStatus/ErrorStatus/@CERT_TRUST_IS_PARTIAL_CHAIN", "value": "true" } } ] },
+        { "color": "Magenta", "comparison": { "property": "Id", "value": "11" }, "predicates": [ { "comparison": { "property": "UserData", "userDataFieldName": "CertGetCertificateChain/CertificateChain/TrustStatus/ErrorStatus/@CERT_TRUST_IS_NOT_VALID_FOR_USAGE", "value": "true" } } ] },
+        { "color": "DarkRed", "comparison": { "property": "Id", "value": "11" }, "predicates": [ { "comparison": { "property": "UserData", "userDataFieldName": "CertGetCertificateChain/CertificateChain/TrustStatus/ErrorStatus/@CERT_TRUST_IS_NOT_SIGNATURE_VALID", "value": "true" } } ] }
+      ]
+    },
+    {
+      "id": "capi2-untrusted-root",
+      "name": "Untrusted root CA chain failures",
+      "purpose": "Chain builds that terminated at a root certificate absent from the Trusted Root CA store (CERT_TRUST_IS_UNTRUSTED_ROOT). Diagnoses un-distributed internal CA roots, new public CA roots not yet pre-installed, and pinned-root failures across TLS, LDAPS, smart-card logon, and code-signing. Requires CAPI2 Operational logging enabled by an administrator.",
+      "group": "Security",
+      "channels": [ "Microsoft-Windows-CAPI2/Operational" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 1,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "11" }, "predicates": [ { "comparison": { "property": "UserData", "userDataFieldName": "CertGetCertificateChain/CertificateChain/TrustStatus/ErrorStatus/@CERT_TRUST_IS_UNTRUSTED_ROOT", "value": "true" } } ] }
+      ]
+    },
+    {
+      "id": "capi2-expired-certificate",
+      "name": "Expired certificate chain failures",
+      "purpose": "Chain builds where any certificate in the chain (end-entity or a CA) has passed its NotAfter validity date (CERT_TRUST_IS_NOT_TIME_VALID). Catches TLS server cert expiry, forgotten intermediate CA expiry, and expired code-signing certs. Requires CAPI2 Operational logging enabled by an administrator.",
+      "group": "Security",
+      "channels": [ "Microsoft-Windows-CAPI2/Operational" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 2,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "11" }, "predicates": [ { "comparison": { "property": "UserData", "userDataFieldName": "CertGetCertificateChain/CertificateChain/TrustStatus/ErrorStatus/@CERT_TRUST_IS_NOT_TIME_VALID", "value": "true" } } ] }
+      ]
+    },
+    {
+      "id": "capi2-revocation-offline",
+      "name": "Revocation service offline / unreachable",
+      "purpose": "Chain builds where revocation checking failed due to an unreachable CRL or OCSP responder, color-coded by sub-cause. DarkYellow: server definitively offline or response stale (CERT_TRUST_IS_OFFLINE_REVOCATION, 0x01000000), from a broken CDP URL, a firewall blocking port 80/443 to the CDP host, or an air-gapped machine. Yellow: revocation status indeterminate (CERT_TRUST_REVOCATION_STATUS_UNKNOWN, 0x00000040), which also fires when the certificate carries no CDP extension. Requires CAPI2 Operational logging enabled by an administrator.",
+      "group": "Security",
+      "channels": [ "Microsoft-Windows-CAPI2/Operational" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 3,
+      "version": 1,
+      "filters": [
+        { "color": "DarkYellow", "comparison": { "property": "Id", "value": "11" }, "predicates": [ { "comparison": { "property": "UserData", "userDataFieldName": "CertGetCertificateChain/CertificateChain/TrustStatus/ErrorStatus/@CERT_TRUST_IS_OFFLINE_REVOCATION", "value": "true" } } ] },
+        { "color": "Yellow", "comparison": { "property": "Id", "value": "11" }, "predicates": [ { "comparison": { "property": "UserData", "userDataFieldName": "CertGetCertificateChain/CertificateChain/TrustStatus/ErrorStatus/@CERT_TRUST_REVOCATION_STATUS_UNKNOWN", "value": "true" } } ] }
+      ]
+    },
+    {
+      "id": "capi2-revoked-certificate",
+      "name": "Revoked certificate chain failures",
+      "purpose": "Chain builds where a certificate has been explicitly revoked by its issuing CA (CERT_TRUST_IS_REVOKED). Positively confirmed revocation, distinct from revocation-offline. Scenarios: compromised private keys, terminated-employee smart-card certs, and mis-issued certs recalled by a public CA. Requires CAPI2 Operational logging enabled by an administrator.",
+      "group": "Security",
+      "channels": [ "Microsoft-Windows-CAPI2/Operational" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 4,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "11" }, "predicates": [ { "comparison": { "property": "UserData", "userDataFieldName": "CertGetCertificateChain/CertificateChain/TrustStatus/ErrorStatus/@CERT_TRUST_IS_REVOKED", "value": "true" } } ] }
+      ]
+    },
+    {
+      "id": "capi2-partial-chain",
+      "name": "Partial chain / missing issuer cert",
+      "purpose": "Chain builds that could not reach a trusted root because an intermediate CA certificate was unavailable (CERT_TRUST_IS_PARTIAL_CHAIN). Diagnoses servers not including intermediates in the TLS handshake, AIA issuer-cert retrieval failures (HTTP 404, network error), and missing intermediate CAs in the local certificate store. Requires CAPI2 Operational logging enabled by an administrator.",
+      "group": "Security",
+      "channels": [ "Microsoft-Windows-CAPI2/Operational" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 5,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "11" }, "predicates": [ { "comparison": { "property": "UserData", "userDataFieldName": "CertGetCertificateChain/CertificateChain/TrustStatus/ErrorStatus/@CERT_TRUST_IS_PARTIAL_CHAIN", "value": "true" } } ] }
+      ]
+    },
+    {
+      "id": "capi2-wrong-eku",
+      "name": "Wrong EKU / certificate purpose mismatch",
+      "purpose": "Chain builds where the certificate is not valid for the requested usage (CERT_TRUST_IS_NOT_VALID_FOR_USAGE). Diagnoses role mismatches: a client-auth cert used for server authentication, a code-signing cert presented for TLS, or an email-protection cert with a non-matching OID. Requires CAPI2 Operational logging enabled by an administrator.",
+      "group": "Security",
+      "channels": [ "Microsoft-Windows-CAPI2/Operational" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 6,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "11" }, "predicates": [ { "comparison": { "property": "UserData", "userDataFieldName": "CertGetCertificateChain/CertificateChain/TrustStatus/ErrorStatus/@CERT_TRUST_IS_NOT_VALID_FOR_USAGE", "value": "true" } } ] }
+      ]
+    },
+    {
+      "id": "capi2-signature-failures",
+      "name": "Weak / invalid certificate signature",
+      "purpose": "Chain builds that failed due to signature issues, color-coded by sub-cause. DarkRed: signature cryptographically invalid (CERT_TRUST_IS_NOT_SIGNATURE_VALID, 0x00000008), from a tampered or corrupted cert or an issuer public-key mismatch. Pink: weak hash algorithm deprecated by Windows policy (CERT_TRUST_HAS_WEAK_SIGNATURE, 0x00100000), where SHA-1 or MD2/MD5 certs are now rejected; surfaces SHA-1 migration gaps in internal PKI. Requires CAPI2 Operational logging enabled by an administrator.",
+      "group": "Security",
+      "channels": [ "Microsoft-Windows-CAPI2/Operational" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 7,
+      "version": 1,
+      "filters": [
+        { "color": "DarkRed", "comparison": { "property": "Id", "value": "11" }, "predicates": [ { "comparison": { "property": "UserData", "userDataFieldName": "CertGetCertificateChain/CertificateChain/TrustStatus/ErrorStatus/@CERT_TRUST_IS_NOT_SIGNATURE_VALID", "value": "true" } } ] },
+        { "color": "Pink", "comparison": { "property": "Id", "value": "11" }, "predicates": [ { "comparison": { "property": "UserData", "userDataFieldName": "CertGetCertificateChain/CertificateChain/TrustStatus/ErrorStatus/@CERT_TRUST_HAS_WEAK_SIGNATURE", "value": "true" } } ] }
+      ]
+    }
+  ]
+}

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/file-print-and-storage.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/file-print-and-storage.json
@@ -259,6 +259,36 @@
         { "color": "Blue", "comparison": { "property": "Id", "value": "5143" } },
         { "color": "Red", "comparison": { "property": "Id", "value": "5144" } }
       ]
+    },
+    {
+      "id": "print-jobs-by-printer",
+      "name": "Print job story - one printer queue",
+      "purpose": "Successful print jobs (307, Green) and print failures (372, Red) for one specific printer queue. Replace 'PRINTER-NAME' with the printer name as it appears in the event (partial match). Event 307 EventData field param5 = printer; event 372 EventData field param3 = printer (classic spooler positional fields).",
+      "group": "FilePrintAndStorage",
+      "channels": [ "Microsoft-Windows-PrintService/Operational", "Microsoft-Windows-PrintService/Admin" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 21,
+      "version": 1,
+      "filters": [
+        { "color": "Green", "comparison": { "property": "LogName", "value": "Microsoft-Windows-PrintService/Operational" }, "predicates": [ { "comparison": { "property": "Id", "value": "307" } }, { "comparison": { "property": "EventData", "eventDataFieldName": "param5", "operator": "Contains", "value": "PRINTER-NAME" } } ] },
+        { "color": "Red", "comparison": { "property": "LogName", "value": "Microsoft-Windows-PrintService/Admin" }, "predicates": [ { "comparison": { "property": "Id", "value": "372" } }, { "comparison": { "property": "EventData", "eventDataFieldName": "param3", "operator": "Contains", "value": "PRINTER-NAME" } } ] }
+      ]
+    },
+    {
+      "id": "print-jobs-by-user",
+      "name": "Print job story - one user",
+      "purpose": "Successful print jobs (307, Green) and print failures (372, Red) submitted by one user. Replace 'USERNAME' with the owner name as it appears in the event (partial match). Event 307 EventData field param3 = owner; event 372 EventData field param2 = owner (classic spooler positional fields).",
+      "group": "FilePrintAndStorage",
+      "channels": [ "Microsoft-Windows-PrintService/Operational", "Microsoft-Windows-PrintService/Admin" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 22,
+      "version": 1,
+      "filters": [
+        { "color": "Green", "comparison": { "property": "LogName", "value": "Microsoft-Windows-PrintService/Operational" }, "predicates": [ { "comparison": { "property": "Id", "value": "307" } }, { "comparison": { "property": "EventData", "eventDataFieldName": "param3", "operator": "Contains", "value": "USERNAME" } } ] },
+        { "color": "Red", "comparison": { "property": "LogName", "value": "Microsoft-Windows-PrintService/Admin" }, "predicates": [ { "comparison": { "property": "Id", "value": "372" } }, { "comparison": { "property": "EventData", "eventDataFieldName": "param2", "operator": "Contains", "value": "USERNAME" } } ] }
+      ]
     }
   ]
 }

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/nps-and-rras.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/nps-and-rras.json
@@ -92,6 +92,80 @@
         { "color": "Red", "comparison": { "property": "Id", "value": "6273" } },
         { "color": "Orange", "comparison": { "property": "Id", "value": "6274" } }
       ]
+    },
+    {
+      "id": "nps-per-policy-access-triage",
+      "name": "NPS access triage - one network policy",
+      "purpose": "Color-coded NPS grants (6272, Green) and denials (6273, Red) scoped to a single NetworkPolicyName. Replace 'POLICY-NAME' with a partial policy name (Contains match). Isolates VPN, Wi-Fi, or NAP policy decisions from a busy Security log.",
+      "group": "NpsAndRras",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 10,
+      "version": 1,
+      "filters": [
+        { "color": "Green", "comparison": { "property": "Id", "value": "6272" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "NetworkPolicyName", "operator": "Contains", "value": "POLICY-NAME" } } ] },
+        { "color": "Red", "comparison": { "property": "Id", "value": "6273" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "NetworkPolicyName", "operator": "Contains", "value": "POLICY-NAME" } } ] }
+      ]
+    },
+    {
+      "id": "nps-per-nas-device-triage",
+      "name": "NPS access triage - one NAS device",
+      "purpose": "Color-coded NPS grants (6272, Green) and denials (6273, Red) for a single NAS device identified by NASIdentifier. Replace 'NAS-HOSTNAME' with the device hostname or IP. Isolates one switch, wireless controller, or VPN gateway's RADIUS traffic.",
+      "group": "NpsAndRras",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 11,
+      "version": 1,
+      "filters": [
+        { "color": "Green", "comparison": { "property": "Id", "value": "6272" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "NASIdentifier", "operator": "Contains", "value": "NAS-HOSTNAME" } } ] },
+        { "color": "Red", "comparison": { "property": "Id", "value": "6273" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "NASIdentifier", "operator": "Contains", "value": "NAS-HOSTNAME" } } ] }
+      ]
+    },
+    {
+      "id": "nps-user-auth-story",
+      "name": "NPS authentication story - one user",
+      "purpose": "All NPS access decisions for one user: granted (6272, Green) and denied (6273, Red). Replace 'USERNAME' with the SAMAccountName (partial match via Contains). Answers 'why can't this user connect?' without sifting through all accounts.",
+      "group": "NpsAndRras",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 12,
+      "version": 1,
+      "filters": [
+        { "color": "Green", "comparison": { "property": "Id", "value": "6272" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "SubjectUserName", "operator": "Contains", "value": "USERNAME" } } ] },
+        { "color": "Red", "comparison": { "property": "Id", "value": "6273" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "SubjectUserName", "operator": "Contains", "value": "USERNAME" } } ] }
+      ]
+    },
+    {
+      "id": "nps-per-endpoint-triage",
+      "name": "NPS access triage - one endpoint (802.1x / CallingStationID)",
+      "purpose": "Color-coded NPS grants (6272, Green) and denials (6273, Red) for a specific client endpoint by CallingStationID (MAC address for 802.1x/Wi-Fi; IP or phone number for VPN). Replace 'MAC-ADDRESS' with a partial identifier. Answers 'why won't this device connect?' independently of user account or NAS.",
+      "group": "NpsAndRras",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 13,
+      "version": 1,
+      "filters": [
+        { "color": "Green", "comparison": { "property": "Id", "value": "6272" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "CallingStationID", "operator": "Contains", "value": "MAC-ADDRESS" } } ] },
+        { "color": "Red", "comparison": { "property": "Id", "value": "6273" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "CallingStationID", "operator": "Contains", "value": "MAC-ADDRESS" } } ] }
+      ]
+    },
+    {
+      "id": "nps-denial-by-reason",
+      "name": "NPS denied access - by reason code",
+      "purpose": "All NPS denied-access events (6273) for one specific ReasonCode. Replace '23' with the numeric code to isolate a single denial cause: 23 = dial-in disabled, 65 = tunnel-type mismatch, 262 = rejected by proxy. Useful when multiple denial reasons are present simultaneously.",
+      "group": "NpsAndRras",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 14,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "6273" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "ReasonCode", "value": "23" } } ] }
+      ]
     }
   ]
 }

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/security.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/security.json
@@ -228,6 +228,79 @@
         { "color": "Green", "comparison": { "property": "Id", "value": "4767" } },
         { "color": "Purple", "comparison": { "property": "Id", "value": "4724" } }
       ]
+    },
+    {
+      "id": "rdp-network-failed-logon-triage",
+      "name": "Failed logon - network & RDP triage",
+      "purpose": "Color-coded 4625 failed logons by access channel: network credential spray (LogonType 3, Red), interactive RDP brute force (LogonType 10, Orange), and workstation-unlock retries (LogonType 7, Blue). Splits a high-volume 4625 stream into distinct attack vectors at a glance. Requires Audit Logon. ATT&CK T1110, T1110.003.",
+      "group": "Security",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 0,
+      "order": 14,
+      "version": 1,
+      "filters": [
+        { "color": "Red", "comparison": { "property": "Id", "value": "4625" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "LogonType", "value": "3" } } ] },
+        { "color": "Orange", "comparison": { "property": "Id", "value": "4625" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "LogonType", "value": "10" } } ] },
+        { "color": "Blue", "comparison": { "property": "Id", "value": "4625" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "LogonType", "value": "7" } } ] }
+      ]
+    },
+    {
+      "id": "kerberoasting-rc4-ticket",
+      "name": "Kerberoasting - RC4 service-ticket request",
+      "purpose": "4769 Kerberos TGS requests using RC4-HMAC-NT encryption (TicketEncryptionType = 23, hex 0x17). In a modern AES-only Active Directory, RC4 TGS requests targeting user-account SPNs are the primary Kerberoasting offline-cracking indicator. Requires Audit Kerberos Service Ticket Operations on domain controllers. ATT&CK T1558.003.",
+      "group": "Security",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 15,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "4769" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "TicketEncryptionType", "value": "23" } } ] }
+      ]
+    },
+    {
+      "id": "kerberos-ticket-encryption-triage",
+      "name": "Kerberos service-ticket encryption triage",
+      "purpose": "Color-coded 4769 TGS stream focused on anomalous encryption: RC4-HMAC-NT (decimal 23, hex 0x17; DarkRed, Kerberoasting risk) and DES variants (decimal 1 or 3; Red, obsolete or downgrade). Expected AES traffic is not highlighted so anomalies stand out. Requires Audit Kerberos Service Ticket Operations on domain controllers. ATT&CK T1558.003, T1600.001.",
+      "group": "Security",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 0,
+      "order": 16,
+      "version": 1,
+      "filters": [
+        { "color": "DarkRed", "comparison": { "property": "Id", "value": "4769" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "TicketEncryptionType", "value": "23" } } ] },
+        { "color": "Red", "comparison": { "property": "Id", "value": "4769" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "TicketEncryptionType", "matchMode": "Many", "values": [ "1", "3" ] } } ] }
+      ]
+    },
+    {
+      "id": "pass-the-hash-ntlm-network-logon",
+      "name": "Pass-the-Hash - NTLM network logon",
+      "purpose": "4624 successful network logons (LogonType 3) authenticated via NTLM rather than Kerberos. In a modern Active Directory environment NTLM network logons are anomalous and the primary Pass-the-Hash indicator; both predicates must match (AND). Requires Audit Logon. ATT&CK T1550.002.",
+      "group": "Security",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 17,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "4624" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "AuthenticationPackageName", "value": "NTLM" } }, { "comparison": { "property": "EventData", "eventDataFieldName": "LogonType", "value": "3" } } ] }
+      ]
+    },
+    {
+      "id": "lateral-movement-explicit-creds",
+      "name": "Explicit credentials - remote target (lateral movement)",
+      "purpose": "4648 explicit-credential logons where TargetServerName is not 'localhost', identifying RunAs or credential-stuffing used to reach a remote machine. Eliminates high-volume background noise from local service starts and scheduled tasks while surfacing the lateral-movement signal. Requires Audit Logon. ATT&CK T1550, T1078.",
+      "group": "Security",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 18,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "4648" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "TargetServerName", "operator": "NotEqual", "value": "localhost" } } ] }
+      ]
     }
   ]
 }

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/threats-and-incident-response.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/threats-and-incident-response.json
@@ -541,6 +541,104 @@
         { "comparison": { "property": "LogName", "value": "Microsoft-Windows-TaskScheduler/Operational" }, "predicates": [ { "comparison": { "property": "Id", "matchMode": "Many", "values": [ "106", "140", "141" ] } } ] },
         { "comparison": { "property": "LogName", "value": "Microsoft-Windows-PowerShell/Operational" }, "predicates": [ { "comparison": { "property": "Id", "value": "4104" } } ] }
       ]
+    },
+    {
+      "id": "lolbin-process-creation-by-name",
+      "name": "LOLBin process creation (NewProcessName field)",
+      "purpose": "4688 process-creation events filtered on the NewProcessName EventData field, eliminating false positives from description-text matching. Color-coded by risk tier: scripting hosts with no legitimate standalone-execution use (DarkRed), binary-proxy loaders (Red), and download or indirect-execution utilities (Orange). Requires Audit Process Creation. ATT&CK T1218, T1202.",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 37,
+      "version": 1,
+      "filters": [
+        { "color": "DarkRed", "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "NewProcessName", "operator": "Contains", "value": "mshta.exe" } } ] },
+        { "color": "DarkRed", "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "NewProcessName", "operator": "Contains", "value": "wscript.exe" } } ] },
+        { "color": "DarkRed", "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "NewProcessName", "operator": "Contains", "value": "cscript.exe" } } ] },
+        { "color": "Red", "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "NewProcessName", "operator": "Contains", "value": "rundll32.exe" } } ] },
+        { "color": "Red", "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "NewProcessName", "operator": "Contains", "value": "regsvr32.exe" } } ] },
+        { "color": "Red", "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "NewProcessName", "operator": "Contains", "value": "installutil.exe" } } ] },
+        { "color": "Orange", "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "NewProcessName", "operator": "Contains", "value": "certutil.exe" } } ] },
+        { "color": "Orange", "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "NewProcessName", "operator": "Contains", "value": "bitsadmin.exe" } } ] }
+      ]
+    },
+    {
+      "id": "office-spawned-process",
+      "name": "Office application spawned a child process",
+      "purpose": "4688 process-creation events where ParentProcessName is a Microsoft Office application (Word, Excel, PowerPoint, Outlook, OneNote), the primary indicator of a weaponised document executing a payload. Requires Audit Process Creation and Windows 10 or Server 2016 or later (ParentProcessName was added in event version 2). ATT&CK T1566.001, T1059, T1204.002.",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 38,
+      "version": 1,
+      "filters": [
+        { "color": "Red", "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "ParentProcessName", "operator": "Contains", "value": "winword.exe" } } ] },
+        { "color": "Red", "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "ParentProcessName", "operator": "Contains", "value": "excel.exe" } } ] },
+        { "color": "Red", "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "ParentProcessName", "operator": "Contains", "value": "powerpnt.exe" } } ] },
+        { "color": "Red", "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "ParentProcessName", "operator": "Contains", "value": "outlook.exe" } } ] },
+        { "color": "Red", "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "ParentProcessName", "operator": "Contains", "value": "onenote.exe" } } ] }
+      ]
+    },
+    {
+      "id": "encoded-powershell-commandline-field",
+      "name": "Encoded / hidden PowerShell (CommandLine field)",
+      "purpose": "4688 process-creation events where the CommandLine EventData field contains encoded or obfuscated PowerShell indicators. More precise than description-text matching: targets only the command-line field, avoiding false positives from document paths and parent arguments. Requires Audit Process Creation and the 'Include command line in process creation events' policy. ATT&CK T1059.001, T1027.010, T1140.",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Security" ],
+      "requiresAdmin": true,
+      "priority": 1,
+      "order": 39,
+      "version": 1,
+      "filters": [
+        { "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "CommandLine", "operator": "Contains", "value": "-EncodedCommand" } } ] },
+        { "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "CommandLine", "operator": "Contains", "value": "FromBase64String" } } ] },
+        { "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "CommandLine", "operator": "Contains", "value": "IEX" } } ] },
+        { "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "CommandLine", "operator": "Contains", "value": "DownloadString" } } ] },
+        { "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "CommandLine", "operator": "Contains", "value": "-w hidden" } } ] },
+        { "comparison": { "property": "Id", "value": "4688" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "CommandLine", "operator": "Contains", "value": "-nop" } } ] }
+      ]
+    },
+    {
+      "id": "suspicious-ps-scriptblock-ioc-triage",
+      "name": "PowerShell script block - IOC content triage",
+      "purpose": "Color-coded 4104 script-block triage: Red rows match ScriptBlockText containing in-memory decode-and-execute constructs (FromBase64String, Invoke-Expression); Orange rows match download cradles and in-memory assembly loading; the Blue row catches blocks flagged at Warning level by PowerShell's AMSI integration. Combines content-based field filtering with AMSI auto-flagging in one view. Requires PowerShell Script Block Logging. ATT&CK T1059.001, T1027.010, T1140, T1071.001.",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Microsoft-Windows-PowerShell/Operational" ],
+      "requiresAdmin": false,
+      "priority": 0,
+      "order": 40,
+      "version": 1,
+      "filters": [
+        { "color": "Red", "comparison": { "property": "Id", "value": "4104" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "ScriptBlockText", "operator": "Contains", "value": "FromBase64String" } } ] },
+        { "color": "Red", "comparison": { "property": "Id", "value": "4104" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "ScriptBlockText", "operator": "Contains", "value": "Invoke-Expression" } } ] },
+        { "color": "Orange", "comparison": { "property": "Id", "value": "4104" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "ScriptBlockText", "operator": "Contains", "value": "DownloadString" } } ] },
+        { "color": "Orange", "comparison": { "property": "Id", "value": "4104" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "ScriptBlockText", "operator": "Contains", "value": "New-Object Net.WebClient" } } ] },
+        { "color": "Orange", "comparison": { "property": "Id", "value": "4104" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "ScriptBlockText", "operator": "Contains", "value": "Reflection.Assembly]::Load" } } ] },
+        { "color": "Blue", "comparison": { "property": "Level", "value": "Warning" }, "predicates": [ { "comparison": { "property": "Id", "value": "4104" } } ] }
+      ]
+    },
+    {
+      "id": "sysmon-lolbin-initiated-network",
+      "name": "Sysmon - LOLBin & script engine network connection",
+      "purpose": "Sysmon Event 3 network-connect events filtered to connections initiated by scripting hosts and Living-off-the-Land binaries. Color-coded by tier: scripting hosts with no legitimate outbound use (DarkRed), PowerShell variants (Red), and binary-proxy loaders (Orange). Requires Sysmon with NetworkConnect logging enabled. ATT&CK T1071.001, T1218, T1059.",
+      "group": "ThreatsAndIncidentResponse",
+      "channels": [ "Microsoft-Windows-Sysmon/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 41,
+      "version": 1,
+      "filters": [
+        { "color": "DarkRed", "comparison": { "property": "Id", "value": "3" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "Image", "operator": "Contains", "value": "mshta.exe" } } ] },
+        { "color": "DarkRed", "comparison": { "property": "Id", "value": "3" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "Image", "operator": "Contains", "value": "wscript.exe" } } ] },
+        { "color": "DarkRed", "comparison": { "property": "Id", "value": "3" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "Image", "operator": "Contains", "value": "cscript.exe" } } ] },
+        { "color": "Red", "comparison": { "property": "Id", "value": "3" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "Image", "operator": "Contains", "value": "powershell.exe" } } ] },
+        { "color": "Red", "comparison": { "property": "Id", "value": "3" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "Image", "operator": "Contains", "value": "pwsh.exe" } } ] },
+        { "color": "Orange", "comparison": { "property": "Id", "value": "3" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "Image", "operator": "Contains", "value": "rundll32.exe" } } ] },
+        { "color": "Orange", "comparison": { "property": "Id", "value": "3" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "Image", "operator": "Contains", "value": "regsvr32.exe" } } ] },
+        { "color": "Orange", "comparison": { "property": "Id", "value": "3" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "Image", "operator": "Contains", "value": "certutil.exe" } } ] }
+      ]
     }
   ]
 }

--- a/src/EventLogExpert.Scenarios/Scenarios/built-in/virtualization-and-clustering.json
+++ b/src/EventLogExpert.Scenarios/Scenarios/built-in/virtualization-and-clustering.json
@@ -222,6 +222,23 @@
       "filters": [
         { "comparison": { "property": "Level", "matchMode": "Many", "values": [ "Critical", "Error", "Warning" ] } }
       ]
+    },
+    {
+      "id": "s2d-physical-disk-story",
+      "name": "Storage Spaces physical disk story (by serial number)",
+      "purpose": "Full event history for one physical disk in a Storage Spaces / S2D pool by DriveSerial: IO failure (203, Red), failed while arriving (208, Red), SMART / impending failure (204, Orange), lost communication (205, Yellow), and disk arrival baseline (207, Blue). Replace 'DISK-SERIAL' with the value from Get-PhysicalDisk SerialNumber. Complements s2d-disk-volume-health which covers virtual disk issues.",
+      "group": "VirtualizationAndClustering",
+      "channels": [ "Microsoft-Windows-StorageSpaces-Driver/Operational" ],
+      "requiresAdmin": false,
+      "priority": 1,
+      "order": 12,
+      "version": 1,
+      "filters": [
+        { "color": "Red", "comparison": { "property": "Id", "matchMode": "Many", "values": [ "203", "208" ] }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "DriveSerial", "operator": "Contains", "value": "DISK-SERIAL" } } ] },
+        { "color": "Orange", "comparison": { "property": "Id", "value": "204" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "DriveSerial", "operator": "Contains", "value": "DISK-SERIAL" } } ] },
+        { "color": "Yellow", "comparison": { "property": "Id", "value": "205" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "DriveSerial", "operator": "Contains", "value": "DISK-SERIAL" } } ] },
+        { "color": "Blue", "comparison": { "property": "Id", "value": "207" }, "predicates": [ { "comparison": { "property": "EventData", "eventDataFieldName": "DriveSerial", "operator": "Contains", "value": "DISK-SERIAL" } } ] }
+      ]
     }
   ]
 }

--- a/src/EventLogExpert.Scenarios/Serialization/ComparisonDto.cs
+++ b/src/EventLogExpert.Scenarios/Serialization/ComparisonDto.cs
@@ -5,11 +5,15 @@ namespace EventLogExpert.Scenarios.Serialization;
 
 internal sealed class ComparisonDto
 {
+    public string? EventDataFieldName { get; set; }
+
     public string? MatchMode { get; set; }
 
     public string? Operator { get; set; }
 
     public string? Property { get; set; }
+
+    public string? UserDataFieldName { get; set; }
 
     public string? Value { get; set; }
 

--- a/src/EventLogExpert.Scenarios/Serialization/ScenarioCatalogLoader.cs
+++ b/src/EventLogExpert.Scenarios/Serialization/ScenarioCatalogLoader.cs
@@ -328,13 +328,29 @@ internal static partial class ScenarioCatalogLoader
 
         if (!propertyOk) { return false; }
 
+        if (property == EventProperty.EventData && string.IsNullOrWhiteSpace(dto.EventDataFieldName))
+        {
+            errors.Add($"{context}: an EventData comparison requires a non-empty eventDataFieldName.");
+
+            return false;
+        }
+
+        if (property == EventProperty.UserData && string.IsNullOrWhiteSpace(dto.UserDataFieldName))
+        {
+            errors.Add($"{context}: a UserData comparison requires a non-empty userDataFieldName.");
+
+            return false;
+        }
+
         comparison = new FilterComparison
         {
             Property = property,
             Operator = op,
             MatchMode = matchMode,
             Value = dto.Value,
-            Values = dto.Values is null ? [] : [.. dto.Values]
+            Values = dto.Values is null ? [] : [.. dto.Values],
+            EventDataFieldName = property == EventProperty.EventData ? dto.EventDataFieldName : null,
+            UserDataFieldName = property == EventProperty.UserData ? dto.UserDataFieldName : null
         };
 
         return true;

--- a/src/EventLogExpert.UI/FilterEditor/Comparison/FilterComparisonEditor.razor
+++ b/src/EventLogExpert.UI/FilterEditor/Comparison/FilterComparisonEditor.razor
@@ -4,7 +4,7 @@
     CssClass="input filter-dropdown"
     T="EventProperty"
     ToStringFunc="x => x.ToFullString()">
-    @foreach (var item in Enum.GetValues<EventProperty>())
+    @foreach (var item in Enum.GetValues<EventProperty>().OrderBy(p => p.ToFullString(), StringComparer.CurrentCulture))
     {
         <ValueSelectItem T="EventProperty" Value="item" />
     }
@@ -21,6 +21,23 @@
         Value="Comparison.EventDataFieldName"
         ValueChanged="HandleEventDataFieldNameChanged">
         @foreach (var name in EventDataFieldNames)
+        {
+            <ValueSelectItem T="string" Value="name" />
+        }
+    </ValueSelect>
+}
+
+@if (IsUserDataProperty)
+{
+    <label class="visually-hidden" id="@($"{Id}_UserDataFieldName")">Field name</label>
+
+    <ValueSelect AriaLabelledBy="@($"{Id}_UserDataFieldName")"
+        CssClass="input filter-value-dropdown"
+        IsInput
+        T="string"
+        Value="Comparison.UserDataFieldName"
+        ValueChanged="HandleUserDataFieldNameChanged">
+        @foreach (var name in UserDataFieldNames)
         {
             <ValueSelectItem T="string" Value="name" />
         }

--- a/src/EventLogExpert.UI/FilterEditor/Comparison/FilterComparisonEditor.razor.cs
+++ b/src/EventLogExpert.UI/FilterEditor/Comparison/FilterComparisonEditor.razor.cs
@@ -56,9 +56,14 @@ public sealed partial class FilterComparisonEditor : ComponentBase
 
     private bool IsEventDataProperty => Comparison.Property is EventProperty.EventData;
 
-    private ImmutableArray<string> Items => Comparison.Property is EventProperty.EventData
-        ? EventLogQueries.GetEventDataFieldValues(Comparison.EventDataFieldName ?? string.Empty)
-        : EventLogQueries.GetPropertyValues(Comparison.Property);
+    private bool IsUserDataProperty => Comparison.Property is EventProperty.UserData;
+
+    private ImmutableArray<string> Items => Comparison.Property switch
+    {
+        EventProperty.EventData => EventLogQueries.GetEventDataFieldValues(Comparison.EventDataFieldName ?? string.Empty),
+        EventProperty.UserData => EventLogQueries.GetUserDataFieldValues(Comparison.UserDataFieldName ?? string.Empty),
+        _ => EventLogQueries.GetPropertyValues(Comparison.Property)
+    };
 
     private EventProperty PropertyBinding
     {
@@ -77,6 +82,8 @@ public sealed partial class FilterComparisonEditor : ComponentBase
         }
     }
 
+    private ImmutableArray<string> UserDataFieldNames => EventLogQueries.GetUserDataFieldNames();
+
     private static bool IsTextOnlyProperty(EventProperty property) => FilterPropertyConstraints.IsTextOnly(property);
 
     private async Task HandleEventDataFieldNameChanged(string? fieldName)
@@ -93,6 +100,16 @@ public sealed partial class FilterComparisonEditor : ComponentBase
     {
         Comparison.Operator = value.Op;
         Comparison.MatchMode = value.Mode;
+        await OnChanged.InvokeAsync();
+    }
+
+    private async Task HandleUserDataFieldNameChanged(string? fieldName)
+    {
+        Comparison.UserDataFieldName = fieldName;
+
+        // The available value space is field-specific, so a field-name change invalidates the current value(s).
+        Comparison.Value = null;
+        Comparison.Values.Clear();
         await OnChanged.InvokeAsync();
     }
 

--- a/src/EventLogExpert.UI/Inputs/ValueSelect.razor.js
+++ b/src/EventLogExpert.UI/Inputs/ValueSelect.razor.js
@@ -76,10 +76,12 @@ export function registerDropdown(root, dotNetRef) {
     // Native title tooltip, only when the text is actually clipped (scrollWidth > clientWidth): recovers a long
     // selected value or option that overflows the fixed dropdown width, and stays silent when it already fits.
     root.addEventListener("mouseover", (e) => {
-        const el = e.target.closest("input, [role='option']");
+        // e.target is an Element for mouseover in practice, but normalize defensively (a Text node has no closest).
+        const target = e.target instanceof Element ? e.target : e.target?.parentElement;
+        const el = target?.closest("input, [role='option']");
         if (!el || !root.contains(el)) { return; }
 
-        const text = el.tagName === "INPUT" ? el.value : el.textContent.trim();
+        const text = el.tagName === "INPUT" ? el.value : (el.textContent ?? "").trim();
 
         if (text && el.scrollWidth > el.clientWidth) {
             el.title = text;

--- a/src/EventLogExpert.UI/Inputs/ValueSelect.razor.js
+++ b/src/EventLogExpert.UI/Inputs/ValueSelect.razor.js
@@ -73,6 +73,21 @@ export function registerDropdown(root, dotNetRef) {
     input.addEventListener("blur", (e) => closeDropdown(e), { signal: controller.signal });
     dropdown.addEventListener("blur", (e) => closeDropdown(e), { signal: controller.signal });
 
+    // Native title tooltip, only when the text is actually clipped (scrollWidth > clientWidth): recovers a long
+    // selected value or option that overflows the fixed dropdown width, and stays silent when it already fits.
+    root.addEventListener("mouseover", (e) => {
+        const el = e.target.closest("input, [role='option']");
+        if (!el || !root.contains(el)) { return; }
+
+        const text = el.tagName === "INPUT" ? el.value : el.textContent.trim();
+
+        if (text && el.scrollWidth > el.clientWidth) {
+            el.title = text;
+        } else if (el.hasAttribute("title")) {
+            el.removeAttribute("title");
+        }
+    }, { signal: controller.signal });
+
     root._dropdownController = controller;
 }
 

--- a/src/EventLogExpert.UI/Inputs/ValueSelectItem.razor.css
+++ b/src/EventLogExpert.UI/Inputs/ValueSelectItem.razor.css
@@ -5,6 +5,9 @@
     display: block;
     clear: both;
     color: var(--text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 
     &:hover,
     &[highlighted] { background-color: var(--background-darkgray); }

--- a/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
@@ -115,6 +115,22 @@ public sealed partial class LogTablePane
         }
     }
 
+    // Extracted from the ItemsProvider so the viewport clamp - an empty list, a start past the end, and a window that
+    // overruns the tail - is unit-testable without driving the Virtualize component.
+    internal static ItemsProviderResult<ResolvedEvent> ComputeEventViewport(
+        IReadOnlyList<ResolvedEvent> displayedEvents,
+        ItemsProviderRequest request)
+    {
+        int totalCount = displayedEvents.Count;
+        int start = Math.Min(request.StartIndex, totalCount);
+        int count = Math.Min(request.Count, totalCount - start);
+
+        IReadOnlyList<ResolvedEvent> window =
+            count <= 0 ? [] : ResolvedEventIndex.Slice(displayedEvents, start, count);
+
+        return new ItemsProviderResult<ResolvedEvent>(window, totalCount);
+    }
+
     protected override async ValueTask DisposeAsyncCore(bool disposing)
     {
         if (disposing)
@@ -790,18 +806,8 @@ public sealed partial class LogTablePane
         return false;
     }
 
-    private ValueTask<ItemsProviderResult<ResolvedEvent>> LoadEventViewport(ItemsProviderRequest request)
-    {
-        var displayedEvents = _activeDisplayedEvents;
-        int totalCount = displayedEvents.Count;
-        int start = Math.Min(request.StartIndex, totalCount);
-        int count = Math.Min(request.Count, totalCount - start);
-
-        IReadOnlyList<ResolvedEvent> window =
-            count <= 0 ? [] : ResolvedEventIndex.Slice(displayedEvents, start, count);
-
-        return ValueTask.FromResult(new ItemsProviderResult<ResolvedEvent>(window, totalCount));
-    }
+    private ValueTask<ItemsProviderResult<ResolvedEvent>> LoadEventViewport(ItemsProviderRequest request) =>
+        ValueTask.FromResult(ComputeEventViewport(_activeDisplayedEvents, request));
 
     private void NavigateGroupedTo(
         IReadOnlyList<ResolvedEvent> displayedEvents,

--- a/tests/Integration/EventLogExpert.Eventing.IntegrationTests/Structured/UserDataFilterExtractionTests.cs
+++ b/tests/Integration/EventLogExpert.Eventing.IntegrationTests/Structured/UserDataFilterExtractionTests.cs
@@ -1,0 +1,190 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Eventing.Interop;
+using EventLogExpert.Eventing.Readers;
+using EventLogExpert.Eventing.Structured;
+using System.Xml;
+
+namespace EventLogExpert.Eventing.IntegrationTests.Structured;
+
+// Proves the resolve-time UserData extraction pipeline end to end on real Microsoft-Windows-CAPI2 events: the
+// EventLogReader gates on the empty User render context, span-scans each nested-UserData event, and stores its deduped
+// values on EventRecord.UserData. A filter reads them back by storage key via TryGetUserDataValues, and every value is
+// cross-checked against an independent System.Xml oracle. Gated on a UserData-bearing .evtx so hosts without it skip.
+public sealed class UserDataFilterExtractionTests
+{
+    private const string Capi2EvtxEnvVar = "EVENTLOG_CAPI2_EVTX";
+
+    [Fact]
+    public void Reader_ExtractsUserDataLeaves_MatchingAnOracle()
+    {
+        string? evtxPath = Environment.GetEnvironmentVariable(Capi2EvtxEnvVar);
+        Assert.SkipUnless(
+            !string.IsNullOrWhiteSpace(evtxPath) && File.Exists(evtxPath),
+            $"Set {Capi2EvtxEnvVar} to a UserData-bearing .evtx to run the grounded filter-extraction check.");
+
+        string sampleXml = FirstNestedUserDataXml(evtxPath!);
+        Assert.SkipUnless(sampleXml.Length > 0, "No nested <UserData> event found in the file.");
+
+        var discovered = StructuredSchemaDiscovery.DiscoverUserDataPaths([sampleXml]);
+
+        string? scalarPath = discovered.FirstOrDefault(path =>
+            !StructuredFieldPath.IsWildcard(path) && path.Contains("/@", StringComparison.Ordinal));
+
+        Assert.SkipUnless(scalarPath is not null, "No scalar UserData attribute discovered in the sample.");
+
+        (string[] elements, string? attribute) = StructuredFieldPath.Parse(scalarPath!);
+
+        string? targetValue = OracleValues(sampleXml, elements, attribute).FirstOrDefault(value => value.Length > 0);
+        Assert.SkipUnless(targetValue is not null, "The discovered scalar attribute had no value to target.");
+
+        // The reader stores each value under its storage key, so ToStorageKey(discoveredPath) is how the stored field is
+        // keyed; == and != are re-evaluated from the stored result and cross-checked against the oracle for the same path.
+        string storageKey = StructuredFieldPath.ToStorageKey(scalarPath!);
+
+        using var reader = new EventLogReader(evtxPath!, LogPathType.File, renderXml: true);
+        Assert.True(reader.IsValid, $"EventLogReader could not open '{evtxPath}'.");
+
+        int equalMatches = 0;
+        int checkedEvents = 0;
+        bool anyUserDataPopulated = false;
+
+        while (reader.TryGetEvents(out var events))
+        {
+            foreach (var record in events)
+            {
+                // Only nested-UserData events (empty User render context) are extraction-gated, as in production; flat
+                // UserData surfaces as EventData and is not stored here.
+                if (!record.IsSuccess || record.Xml is null || record.Properties.Length != 0) { continue; }
+
+                var oracleValues = OracleValues(record.Xml, elements, attribute);
+                bool present = oracleValues.Count > 0;
+                bool anyEqual = oracleValues.Contains(targetValue!, StringComparer.Ordinal);
+
+                // Scalar attribute: single-valued, never truncated, so no Unknown is expected here.
+                FilterMatch expectedEqual = anyEqual ? FilterMatch.Match : FilterMatch.NoMatch;
+                FilterMatch expectedNotEqual = present && !anyEqual ? FilterMatch.Match : FilterMatch.NoMatch;
+
+                // The reader stamps EventRecord.UserData; the resolver copies it onto ResolvedEvent for a compiled filter.
+                // Reconstruct that lookup surface from the raw record to exercise the same TryGetUserDataValues path.
+                var resolved = new ResolvedEvent("UserDataFilterExtractionTests", LogPathType.File)
+                {
+                    UserData = record.UserData,
+                    UserDataIncomplete = record.UserDataIncomplete
+                };
+
+                var result = resolved.TryGetUserDataValues(storageKey);
+
+                if (!record.UserData.IsDefaultOrEmpty) { anyUserDataPopulated = true; }
+
+                // The stored field's values equal the independent oracle's values for the same path.
+                Assert.Equal(oracleValues, result.PresentValues.ToArray());
+
+                Assert.Equal(expectedEqual, EqualsAny(result, targetValue!));
+                Assert.Equal(expectedNotEqual, NotEqualsPresent(result, targetValue!));
+
+                if (expectedEqual == FilterMatch.Match) { equalMatches++; }
+
+                checkedEvents++;
+            }
+        }
+
+        Assert.True(checkedEvents > 0, "No nested-UserData events were read from the file.");
+        Assert.True(anyUserDataPopulated, "The reader never populated stored UserData leaves.");
+        Assert.True(equalMatches > 0, "No event matched the target UserData value the sample was seeded from.");
+    }
+
+    private static FilterMatch EqualsAny(StructuredFieldResult result, string target)
+    {
+        var values = result.PresentValues;
+
+        for (int index = 0; index < values.Length; index++)
+        {
+            if (string.Equals(values[index], target, StringComparison.Ordinal)) { return FilterMatch.Match; }
+        }
+
+        return result.IsTruncated ? FilterMatch.Unknown : FilterMatch.NoMatch;
+    }
+
+    private static string FirstNestedUserDataXml(string evtxPath)
+    {
+        EvtHandle query = NativeMethods.EvtQuery(EventLogSession.GlobalSession.Handle, evtxPath, null, LogPathType.File);
+        Assert.False(query.IsInvalid, $"EvtQuery failed for file '{evtxPath}'.");
+
+        try
+        {
+            for (int scanned = 0; scanned < 2000;)
+            {
+                var batch = new IntPtr[16];
+                int returned = 0;
+
+                if (!NativeMethods.EvtNext(query, batch.Length, batch, 0, 0, ref returned) || returned == 0) { break; }
+
+                for (int index = 0; index < returned; index++)
+                {
+                    using var handle = new EvtHandle(batch[index]);
+                    scanned++;
+
+                    string? xml = NativeMethods.RenderEventXml(handle);
+
+                    if (xml is not null
+                        && xml.Contains("<UserData", StringComparison.Ordinal)
+                        && NativeMethods.RenderEventProperties(handle).Length == 0)
+                    {
+                        for (int remaining = index + 1; remaining < returned; remaining++)
+                        {
+                            new EvtHandle(batch[remaining]).Dispose();
+                        }
+
+                        return xml;
+                    }
+                }
+            }
+        }
+        finally
+        {
+            query.Dispose();
+        }
+
+        return string.Empty;
+    }
+
+    private static FilterMatch NotEqualsPresent(StructuredFieldResult result, string target)
+    {
+        var values = result.PresentValues;
+
+        if (values.Length == 0) { return FilterMatch.NoMatch; }
+
+        for (int index = 0; index < values.Length; index++)
+        {
+            if (string.Equals(values[index], target, StringComparison.Ordinal)) { return FilterMatch.NoMatch; }
+        }
+
+        return result.IsTruncated ? FilterMatch.Unknown : FilterMatch.Match;
+    }
+
+    // Independent System.Xml oracle: navigate the same element chain by local name and read each value.
+    private static List<string> OracleValues(string xml, string[] elements, string? attribute)
+    {
+        string elementXPath = "/" + string.Join('/', elements.Select(name => $"*[local-name()='{name}']"));
+        string xpath = attribute is null ? elementXPath : $"{elementXPath}/@*[local-name()='{attribute}']";
+
+        var document = new XmlDocument();
+        document.LoadXml(xml);
+
+        XmlNodeList? nodes = document.SelectNodes(xpath);
+        var values = new List<string>();
+
+        if (nodes is null) { return values; }
+
+        foreach (XmlNode node in nodes)
+        {
+            values.Add(attribute is null ? node.InnerText : node.Value ?? string.Empty);
+        }
+
+        return values;
+    }
+}

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Structured/ResolvedEventUserDataTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Structured/ResolvedEventUserDataTests.cs
@@ -1,0 +1,82 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Eventing.Structured;
+
+namespace EventLogExpert.Eventing.Tests.Structured;
+
+// Guards the tri-state contract of the stored-UserData accessor: a found field surfaces its values (truncated if the
+// field or event is incomplete), an absent path on a complete event is decisively absent, and an absent path on an
+// incomplete event is a present-but-empty truncated result so a filter keeps the row visible.
+public sealed class ResolvedEventUserDataTests
+{
+    [Fact]
+    public void TryGetUserDataValues_AbsentPathOnCompleteEvent_IsDecisivelyAbsent()
+    {
+        StructuredFieldResult result = EventWith(incomplete: false, new UserDataField("Foo/Bar", ["x"], false))
+            .TryGetUserDataValues("Other/Path");
+
+        Assert.True(result.IsAbsent);
+        Assert.False(result.IsTruncated);
+    }
+
+    // An absent path on an Incomplete event must not be decisively absent (that would hide the row under an include
+    // filter); it is present-but-empty and truncated so the comparison yields Unknown.
+    [Fact]
+    public void TryGetUserDataValues_AbsentPathOnIncompleteEvent_IsPresentEmptyAndTruncated()
+    {
+        StructuredFieldResult result = EventWith(incomplete: true, new UserDataField("Foo/Bar", ["x"], false))
+            .TryGetUserDataValues("Other/Path");
+
+        Assert.False(result.IsAbsent);
+        Assert.True(result.IsTruncated);
+        Assert.Empty(result.PresentValues.ToArray());
+    }
+
+    [Fact]
+    public void TryGetUserDataValues_EventWithoutUserData_IsDecisivelyAbsent()
+    {
+        StructuredFieldResult result = new ResolvedEvent("TestLog", LogPathType.Channel).TryGetUserDataValues("Foo/Bar");
+
+        Assert.True(result.IsAbsent);
+        Assert.False(result.IsTruncated);
+    }
+
+    [Fact]
+    public void TryGetUserDataValues_FoundField_ReturnsPresentValues()
+    {
+        StructuredFieldResult result = EventWith(incomplete: false, new UserDataField("Foo/Bar", ["x", "y"], false))
+            .TryGetUserDataValues("Foo/Bar");
+
+        Assert.False(result.IsAbsent);
+        Assert.False(result.IsTruncated);
+        Assert.Equal(["x", "y"], result.PresentValues.ToArray());
+    }
+
+    // A found value on an Incomplete event is still tainted truncated: treating every result on an incomplete event as
+    // non-decisive keeps the fail-safe simple (an early scan bail could also have cut this field's tail).
+    [Fact]
+    public void TryGetUserDataValues_FoundFieldOnIncompleteEvent_IsTaintedTruncated()
+    {
+        StructuredFieldResult result = EventWith(incomplete: true, new UserDataField("Foo/Bar", ["x"], IsTruncated: false))
+            .TryGetUserDataValues("Foo/Bar");
+
+        Assert.False(result.IsAbsent);
+        Assert.True(result.IsTruncated);
+    }
+
+    [Fact]
+    public void TryGetUserDataValues_FoundTruncatedField_IsTruncated()
+    {
+        StructuredFieldResult result = EventWith(incomplete: false, new UserDataField("Foo/Bar", ["x"], IsTruncated: true))
+            .TryGetUserDataValues("Foo/Bar");
+
+        Assert.False(result.IsAbsent);
+        Assert.True(result.IsTruncated);
+    }
+
+    private static ResolvedEvent EventWith(bool incomplete, params UserDataField[] fields) =>
+        new("TestLog", LogPathType.Channel) { UserData = [.. fields], UserDataIncomplete = incomplete };
+}

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Structured/RetainedBytesBudgetTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Structured/RetainedBytesBudgetTests.cs
@@ -1,0 +1,85 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Readers;
+using EventLogExpert.Eventing.Structured;
+using System.Runtime.CompilerServices;
+
+namespace EventLogExpert.Eventing.Tests.Structured;
+
+public sealed class RetainedBytesBudgetTests
+{
+    private const string Ns = "xmlns='http://schemas.microsoft.com/win/2004/08/events/event'";
+
+    // The distinct-path cap actually drops paths (and flags the event incomplete) so the retained struct count can
+    // never exceed the cap, no matter how many distinct paths the event carries.
+    [Fact]
+    public void ExtractedUserData_NeverRetainsMorePathStructsThanTheCap()
+    {
+        string leaves = string.Concat(Enumerable.Range(0, 10).Select(index => $"<F{index}>v</F{index}>"));
+        string xml = $"<Event {Ns}><UserData><Root>{leaves}</Root></UserData></Event>";
+
+        var (fields, incomplete) = UserDataValueExtractor.Extract(xml, maxDistinctPaths: 4);
+
+        Assert.True(incomplete);
+        Assert.True(fields.Length <= 4, $"retained {fields.Length} path structs above the cap of 4.");
+    }
+
+    // Dedup lever: repeats of a path collapse into one multi-value field, so the retained path-struct array is sized by
+    // DISTINCT paths, not raw leaf count. A certificate chain with many repeated leaves must not retain one struct per
+    // leaf.
+    [Fact]
+    public void ExtractedUserData_RetainedPathStructs_ScaleWithDistinctPathsNotRawLeaves()
+    {
+        const int repeats = 200;
+        string leaves = string.Concat(
+            Enumerable.Range(0, repeats).Select(index => $"<Cert><Thumbprint>{index:X4}</Thumbprint></Cert>"));
+        string xml =
+            $"<Event {Ns}><UserData><Chain>{leaves}</Chain><Result>0</Result><Issuer>CA</Issuer></UserData></Event>";
+
+        var (fields, incomplete) = UserDataValueExtractor.Extract(xml);
+
+        Assert.False(incomplete);
+
+        // The 200 repeated <Thumbprint> leaves collapse to one path; two more distinct paths -> 3 retained structs, not 202.
+        Assert.Equal(3, fields.Length);
+        Assert.Equal(repeats, Assert.Single(fields, field => field.Path == "Chain/Cert/Thumbprint").Values.Length);
+
+        long retainedPathStructBytes = (long)fields.Length * Unsafe.SizeOf<UserDataField>();
+        long rawLeafStructBytes = (long)(repeats + 2) * Unsafe.SizeOf<UserDataField>();
+        Assert.True(
+            retainedPathStructBytes * 10 < rawLeafStructBytes,
+            $"dedup did not bound retained path structs: {retainedPathStructBytes} B retained vs {rawLeafStructBytes} B raw.");
+    }
+
+    // Caps lever: a pathological event cannot retain unbounded UserData. The distinct-path cap bounds the path-struct
+    // array, the per-field value cap bounds a field's values, and the per-value char cap bounds a single value. Locks
+    // each ceiling so none regresses to effectively unbounded, and asserts the worst-case retained path-struct ceiling
+    // they imply stays within budget.
+    [Fact]
+    public void RetentionCaps_BoundWorstCasePerEvent()
+    {
+        Assert.InRange(UserDataValueExtractor.MaxDistinctPathsPerEvent, 1, 4096);
+        Assert.InRange(StructuredFieldPath.MaxWildcardValues, 1, 4096);
+        Assert.InRange(UserDataValueExtractor.MaxValueChars, 1, 65536);
+
+        long pathStructCeiling =
+            (long)UserDataValueExtractor.MaxDistinctPathsPerEvent * Unsafe.SizeOf<UserDataField>();
+        Assert.True(
+            pathStructCeiling <= 64 * 1024,
+            $"per-event path-struct retained ceiling {pathStructCeiling} B exceeds the 64 KB budget.");
+    }
+
+    // Per-field retained cost, multiplied across every retained event. EventData stores one EventProperty per field
+    // (a 16-byte packed tagged scalar, no boxing); UserData stores one UserDataField per distinct path (a string ref +
+    // an ImmutableArray ref + a bool = 24 bytes). Adding a field to either type is the most likely silent regression,
+    // so both sizes are budgeted here.
+    [Fact]
+    public void StoreModel_PerFieldRetainedStructs_AreWithinBudget()
+    {
+        Assert.Equal(16, Unsafe.SizeOf<EventProperty>());
+        Assert.True(
+            Unsafe.SizeOf<UserDataField>() <= 24,
+            $"UserDataField retained struct grew to {Unsafe.SizeOf<UserDataField>()} bytes (budget 24).");
+    }
+}

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Structured/StructuredFieldPathTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Structured/StructuredFieldPathTests.cs
@@ -165,6 +165,21 @@ public sealed class StructuredFieldPathTests
         Assert.True(StructuredFieldPath.IsValidCanonical(path));
 
     [Theory]
+    [InlineData("Event/UserData/*cert*")]
+    [InlineData("Event/UserData/X509Objects/*/@subjectName")]
+    [InlineData("Event/UserData/*/@*Name")]
+    [InlineData("Event/UserData/X509*")]
+    [InlineData("Event/UserData/*")]
+    public void IsValidCanonical_AcceptsWildcardGlobs(string path) =>
+        Assert.True(StructuredFieldPath.IsValidCanonical(path));
+
+    [Theory]
+    [InlineData("Event/UserData/*@subjectName")] // '@' is valid only as an attribute-segment lead, not mid-name
+    [InlineData("Event/UserData/ce rt*")] // a space is still invalid inside a glob
+    public void IsValidCanonical_RejectsMalformedGlobs(string path) =>
+        Assert.False(StructuredFieldPath.IsValidCanonical(path));
+
+    [Theory]
     [InlineData("")]
     [InlineData("Event//EventID")]
     [InlineData("Event/Sys tem/EventID")]

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Structured/UserDataFieldPathToStorageKeyTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Structured/UserDataFieldPathToStorageKeyTests.cs
@@ -1,0 +1,79 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Structured;
+
+namespace EventLogExpert.Eventing.Tests.Structured;
+
+// Guards the canonical-path -> storage-key normalization the emitter and resolver both depend on: the exact two-element
+// Event/UserData envelope drop, the [*] strip, the attribute suffix, and idempotency are all load-bearing.
+public sealed class UserDataFieldPathToStorageKeyTests
+{
+    // Full store-key round-trip: a store key must survive TryNormalize (re-rooting) then ToStorageKey (envelope drop)
+    // back to itself, so a picker-created filter looks up exactly the stored field - even a key starting "Event"/"UserData".
+    [Theory]
+    [InlineData("X509Objects/Certificate/SubjectName")]
+    [InlineData("X509Objects/Certificate/@subjectName")]
+    [InlineData("Operation")]
+    [InlineData("Event/MyPayload")]
+    [InlineData("UserData/Something")]
+    public void StoreKey_RoundTripsThroughNormalizeAndBack(string storageKey)
+    {
+        Assert.True(UserDataFieldPath.TryNormalize(storageKey, out string? canonical, out string? error), error);
+        Assert.Equal(storageKey, UserDataFieldPath.ToStorageKey(canonical!));
+    }
+
+    [Fact]
+    public void ToStorageKey_AlreadyPlainPickerKey_PassesThroughUnchanged()
+    {
+        Assert.Equal(
+            "X509Objects/Certificate/SubjectName",
+            UserDataFieldPath.ToStorageKey("X509Objects/Certificate/SubjectName"));
+    }
+
+    [Fact]
+    public void ToStorageKey_AttributeValue_KeepsAttributeSuffix()
+    {
+        Assert.Equal(
+            "X509Objects/Certificate/@subjectName",
+            UserDataFieldPath.ToStorageKey("Event/UserData/X509Objects/Certificate/@subjectName"));
+    }
+
+    [Fact]
+    public void ToStorageKey_FullyRootedPath_DropsEventUserDataEnvelope()
+    {
+        Assert.Equal(
+            "X509Objects/Certificate/SubjectName",
+            UserDataFieldPath.ToStorageKey("Event/UserData/X509Objects/Certificate/SubjectName"));
+    }
+
+    [Fact]
+    public void ToStorageKey_IsIdempotent()
+    {
+        string once = UserDataFieldPath.ToStorageKey("Event/UserData/X509Objects/Certificate/@subjectName");
+
+        Assert.Equal(once, UserDataFieldPath.ToStorageKey(once));
+    }
+
+    [Fact]
+    public void ToStorageKey_SingleElementUnderEnvelope_ReturnsThatElement()
+    {
+        Assert.Equal("Operation", UserDataFieldPath.ToStorageKey("Event/UserData/Operation"));
+    }
+
+    // The exact two-element match (not a per-element "strip Event") protects an unrooted payload whose first element is
+    // literally "Event": a sequential strip would corrupt it to "MyPayload".
+    [Fact]
+    public void ToStorageKey_UnrootedPayloadNamedEvent_IsNotCorrupted()
+    {
+        Assert.Equal("Event/MyPayload", UserDataFieldPath.ToStorageKey("Event/MyPayload"));
+    }
+
+    [Fact]
+    public void ToStorageKey_WildcardMarker_IsStripped()
+    {
+        Assert.Equal(
+            "Certificate/SubjectName",
+            UserDataFieldPath.ToStorageKey("Event/UserData/Certificate[*]/SubjectName"));
+    }
+}

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Structured/UserDataFieldTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Structured/UserDataFieldTests.cs
@@ -1,0 +1,40 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Eventing.Structured;
+
+namespace EventLogExpert.Eventing.Tests.Structured;
+
+/// <summary>
+///     Coverage for the <see cref="UserDataField.ToFieldResult" /> seam, which projects a stored field into a
+///     <see cref="StructuredFieldResult" /> inside the Eventing assembly so the filtering layer can evaluate a wildcard
+///     glob match without reaching Eventing-internal value primitives.
+/// </summary>
+public sealed class UserDataFieldTests
+{
+    [Fact]
+    public void ToFieldResult_PreservesSingleValueAndNoTruncation()
+    {
+        var field = new UserDataField("Foo", ["only"], IsTruncated: false);
+
+        StructuredFieldResult result = field.ToFieldResult();
+
+        Assert.False(result.IsTruncated);
+        Assert.False(result.IsAbsent);
+        Assert.Equal("only", result.Value.AsString());
+    }
+
+    [Fact]
+    public void ToFieldResult_ProjectsValuesAndTruncationFlag()
+    {
+        var field = new UserDataField("Foo/Bar", ["a", "b"], IsTruncated: true);
+
+        StructuredFieldResult result = field.ToFieldResult();
+
+        Assert.True(result.IsTruncated);
+        Assert.Equal(EventFieldValueKind.StringArray, result.Value.Kind);
+        Assert.True(result.Value.TryGetStringArray(out string[]? values));
+        Assert.Equal(["a", "b"], values);
+    }
+}

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Structured/UserDataValueExtractorTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Structured/UserDataValueExtractorTests.cs
@@ -1,0 +1,136 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Structured;
+
+namespace EventLogExpert.Eventing.Tests.Structured;
+
+// Guards the resolve-time value scan: find every nested-UserData value (text + attribute), collapse repeats into one
+// multi-value field, key each field as UserDataFieldPath.ToStorageKey would, and flag the event Incomplete when the
+// distinct-path cap drops a path (so a filter on a not-found path is kept visible, not decided absent).
+public sealed class UserDataValueExtractorTests
+{
+    private const string Ns = "xmlns='http://schemas.microsoft.com/win/2004/08/events/event'";
+
+    [Fact]
+    public void Extract_AttributeValue_IsStoredWithAttributeSuffix()
+    {
+        var (fields, _) = UserDataValueExtractor.Extract(
+            $"<Event {Ns}><UserData><Root><Item value='x'/></Root></UserData></Event>");
+
+        UserDataField field = Assert.Single(fields);
+        Assert.Equal("Root/Item/@value", field.Path);
+        Assert.Equal(["x"], field.Values);
+    }
+
+    // A container element (one with child elements) is not itself a value; only its value-bearing descendants are stored.
+    [Fact]
+    public void Extract_ContainerElement_IsNotAStoredTextValue()
+    {
+        var (fields, _) = UserDataValueExtractor.Extract(
+            $"<Event {Ns}><UserData><Certificate><SubjectName>foo</SubjectName></Certificate></UserData></Event>");
+
+        UserDataField field = Assert.Single(fields);
+        Assert.Equal("Certificate/SubjectName", field.Path);
+        Assert.DoesNotContain(fields, f => f.Path == "Certificate");
+    }
+
+    // On cap trip the event is flagged Incomplete and new paths dropped, but already-tracked paths keep collecting (the
+    // scan does not stop): here A and B are tracked, C is dropped, and A's later value is still collected.
+    [Fact]
+    public void Extract_DistinctPathCapTrips_FlagsIncompleteButKeepsCollectingTrackedPaths()
+    {
+        var (fields, incomplete) = UserDataValueExtractor.Extract(
+            $"<Event {Ns}><UserData><Root><A>1</A><B>2</B><A>3</A><C>4</C></Root></UserData></Event>",
+            maxDistinctPaths: 2);
+
+        Assert.True(incomplete);
+        Assert.Equal(2, fields.Length);
+        Assert.Equal(["1", "3"], Assert.Single(fields, f => f.Path == "Root/A").Values);
+        Assert.Equal(["2"], Assert.Single(fields, f => f.Path == "Root/B").Values);
+        Assert.DoesNotContain(fields, f => f.Path == "Root/C");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Extract_NullOrEmptyXml_IsDecisivelyAbsentNotIncomplete(string? xml)
+    {
+        var (fields, incomplete) = UserDataValueExtractor.Extract(xml);
+
+        Assert.Empty(fields);
+        Assert.False(incomplete);
+    }
+
+    [Fact]
+    public void Extract_PerFieldValueCapExceeded_FlagsFieldTruncated()
+    {
+        string items = string.Concat(
+            Enumerable.Range(0, StructuredFieldPath.MaxWildcardValues + 5).Select(index => $"<Item value='{index}'/>"));
+
+        var (fields, _) = UserDataValueExtractor.Extract(
+            $"<Event {Ns}><UserData><Root>{items}</Root></UserData></Event>");
+
+        UserDataField field = Assert.Single(fields);
+        Assert.True(field.IsTruncated);
+        Assert.Equal(StructuredFieldPath.MaxWildcardValues, field.Values.Length);
+    }
+
+    [Fact]
+    public void Extract_RepeatedValue_CollapsesIntoOneMultiValueField()
+    {
+        var (fields, _) = UserDataValueExtractor.Extract(
+            $"<Event {Ns}><UserData><Root><Item value='a'/><Item value='b'/><Item value='c'/></Root></UserData></Event>");
+
+        UserDataField field = Assert.Single(fields);
+        Assert.Equal("Root/Item/@value", field.Path);
+        Assert.Equal(["a", "b", "c"], field.Values);
+    }
+
+    [Fact]
+    public void Extract_TextValue_IsStoredUnderPlainKey()
+    {
+        var (fields, incomplete) = UserDataValueExtractor.Extract(
+            $"<Event {Ns}><UserData><Root><Status>Success</Status></Root></UserData></Event>");
+
+        Assert.False(incomplete);
+        UserDataField field = Assert.Single(fields);
+        Assert.Equal("Root/Status", field.Path);
+        Assert.Equal(["Success"], field.Values);
+        Assert.False(field.IsTruncated);
+    }
+
+    [Fact]
+    public void Extract_UnderDistinctPathCap_IsNotIncomplete()
+    {
+        var (_, incomplete) = UserDataValueExtractor.Extract(
+            $"<Event {Ns}><UserData><Root><A>1</A><B>2</B></Root></UserData></Event>",
+            maxDistinctPaths: 2);
+
+        Assert.False(incomplete);
+    }
+
+    // A value longer than the per-value char cap is truncated and its field flagged, so retained memory stays bounded
+    // and a comparison against the full value reads it as Unknown (kept visible) not a wrong no-match.
+    [Fact]
+    public void Extract_ValueExceedingCharCap_IsTruncatedToCapAndFlagged()
+    {
+        string huge = new('a', UserDataValueExtractor.MaxValueChars + 100);
+
+        var (fields, _) = UserDataValueExtractor.Extract(
+            $"<Event {Ns}><UserData><Root><Blob>{huge}</Blob></Root></UserData></Event>");
+
+        UserDataField field = Assert.Single(fields);
+        Assert.True(field.IsTruncated);
+        Assert.Equal(UserDataValueExtractor.MaxValueChars, field.Values[0].Length);
+    }
+
+    [Fact]
+    public void Extract_WhitespaceOnlyText_IsNotStored()
+    {
+        var (fields, _) = UserDataValueExtractor.Extract(
+            $"<Event {Ns}><UserData><Root><Blank>   </Blank></Root></UserData></Event>");
+
+        Assert.Empty(fields);
+    }
+}

--- a/tests/Unit/EventLogExpert.Filtering.Tests/Basic/FilterComparisonJsonConverterTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/Basic/FilterComparisonJsonConverterTests.cs
@@ -11,7 +11,8 @@ public sealed class FilterComparisonJsonConverterTests
     [Fact]
     public void EventProperty_MemberCount_IsFrozenForWireCompatibility()
     {
-        Assert.Equal(13, Enum.GetValues<EventProperty>().Length);
+        // UserData was appended as member 14 (after EventData); appending at the end is JSON-by-name wire-safe.
+        Assert.Equal(14, Enum.GetValues<EventProperty>().Length);
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Filtering.Tests/Emit/WildcardMatcherTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/Emit/WildcardMatcherTests.cs
@@ -1,0 +1,43 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Emit;
+
+namespace EventLogExpert.Filtering.Tests.Emit;
+
+/// <summary>
+///     Unit coverage for the case-insensitive <c>*</c> glob matcher that backs EventData / UserData field-name
+///     wildcards: anchored prefix/suffix, floating middles, doubled and edge <c>*</c>, and case-insensitivity.
+/// </summary>
+public sealed class WildcardMatcherTests
+{
+    [Theory]
+    [InlineData("*", "anything", true)]
+    [InlineData("*", "", true)]
+    [InlineData("*cert*", "Certificate", true)]
+    [InlineData("*cert*", "IssuerCertName", true)]
+    [InlineData("*cert*", "CERTIFICATE", true)] // case-insensitive
+    [InlineData("*cert*", "Subject", false)]
+    [InlineData("cert*", "Certificate", true)] // anchored prefix
+    [InlineData("cert*", "MyCertificate", false)]
+    [InlineData("*name", "SubjectName", true)] // anchored suffix
+    [InlineData("*name", "NameValue", false)]
+    [InlineData("a*b*c", "axbyc", true)]
+    [InlineData("a*b*c", "abc", true)]
+    [InlineData("a*b*c", "ac", false)] // missing middle
+    [InlineData("a**b", "axb", true)] // doubled star
+    [InlineData("a*a", "a", false)] // prefix and suffix cannot overlap
+    [InlineData("a*a", "aa", true)]
+    [InlineData("aa*b*aa", "aaa", false)] // prefix + suffix overlap with a middle segment (start > end guard)
+    [InlineData("X509*/@subjectName", "X509Objects/Certificate/@subjectName", true)] // path + attribute glob
+    [InlineData("*/@*Name", "X509Objects/Certificate/@subjectName", true)]
+    public void Compile_Matches(string pattern, string candidate, bool expected) =>
+        Assert.Equal(expected, WildcardMatcher.Compile(pattern)(candidate));
+
+    [Theory]
+    [InlineData("*cert*", true)]
+    [InlineData("cert", false)]
+    [InlineData("", false)]
+    public void ContainsWildcard(string pattern, bool expected) =>
+        Assert.Equal(expected, WildcardMatcher.ContainsWildcard(pattern));
+}

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataRoundTripTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventDataRoundTripTests.cs
@@ -21,6 +21,7 @@ public sealed class EventDataRoundTripTests
     [InlineData("with]bracket")]
     [InlineData("with\\backslash")]
     [InlineData("with\ttab")]
+    [InlineData("*cert*")]
     public void FieldNameWithSpecialCharacters_RoundTrips(string fieldName) =>
         AssertSingleRoundTrips(ComparisonOperator.Equals, fieldName, "value");
 

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventData/FieldNameGlobTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventData/FieldNameGlobTests.cs
@@ -1,0 +1,264 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Eventing.Structured;
+using EventLogExpert.Eventing.TestUtils;
+using EventLogExpert.Filtering.Parsing;
+
+namespace EventLogExpert.Filtering.Tests.EventData;
+
+/// <summary>
+///     Behavioral coverage for EventData / UserData field-name wildcard globs. A glob (<c>EventData["*cert*"]</c> /
+///     <c>UserData["*cert*"]</c>) is evaluated as if each field whose name/path matches the glob were its own OR'd filter
+///     row, using the existing single-field per-value semantics. EventData is boolean (fully enumerated); UserData is the
+///     Kleene tri-state, keep-visible on per-field truncation and on a capped (incomplete) field set.
+/// </summary>
+public sealed class FieldNameGlobTests
+{
+    [Fact]
+    public void EventDataGlob_AnyOf_OrsAcrossMatches()
+    {
+        var predicate = CompileBool("(new[] {\"a\", \"b\"}).Contains(EventData[\"*cert*\"])");
+
+        Assert.True(predicate(Event(("IssuerCert", "b"))));
+        Assert.False(predicate(Event(("IssuerCert", "c"))));
+    }
+
+    [Fact]
+    public void EventDataGlob_Contains_OrsAcrossMatches()
+    {
+        var predicate = CompileBool("EventData[\"*cert*\"].Contains(\"ab\", StringComparison.OrdinalIgnoreCase)");
+
+        Assert.True(predicate(Event(("MyCert", "xabz"))));
+        Assert.False(predicate(Event(("MyCert", "xyz"))));
+        Assert.False(predicate(Event(("Other", "xabz")))); // matching value but non-matching name
+    }
+    // --- EventData glob (boolean, OR across matching fields). ---
+
+    [Fact]
+    public void EventDataGlob_Equal_OrsAcrossMatchingFields()
+    {
+        var predicate = CompileBool("EventData[\"*cert*\"] == \"x\"");
+
+        Assert.True(predicate(Event(("IssuerCert", "x"), ("Subject", "y")))); // a cert-named field equals x
+        Assert.True(predicate(Event(("Subject", "y"), ("RootCertName", "x")))); // a different cert field equals x
+        Assert.False(predicate(Event(("IssuerCert", "y")))); // cert field present but wrong value
+        Assert.False(predicate(Event(("Subject", "x")))); // no cert-named field
+    }
+
+    [Fact]
+    public void EventDataGlob_NameMatch_IsCaseInsensitive()
+    {
+        var predicate = CompileBool("EventData[\"*CERT*\"] == \"x\"");
+
+        Assert.True(predicate(Event(("issuercert", "x"))));
+    }
+
+    [Fact]
+    public void EventDataGlob_NoEventData_NoMatch()
+    {
+        var predicate = CompileBool("EventData[\"*cert*\"] == \"x\"");
+
+        Assert.Equal(EventDataKind.None, new ResolvedEvent("TestLog", LogPathType.Channel).EventData.Kind);
+        Assert.False(predicate(new ResolvedEvent("TestLog", LogPathType.Channel)));
+    }
+
+    [Fact]
+    public void EventDataGlob_NotEqual_IsPresentAndDiffersPerField()
+    {
+        var predicate = CompileBool("EventData[\"*cert*\"] != \"x\"");
+
+        Assert.True(predicate(Event(("IssuerCert", "y")))); // present cert field, differs
+        Assert.False(predicate(Event(("IssuerCert", "x")))); // present cert field, equal
+        Assert.False(predicate(Event(("Subject", "y")))); // no cert field present -> no match
+    }
+
+    [Fact]
+    public void EventDataGlob_NotEqual_MatchesWhenAnyMatchingFieldDiffers()
+    {
+        var predicate = CompileBool("EventData[\"*cert*\"] != \"x\"");
+
+        // IssuerCert == x fails "!= x", but SubjectCert == y satisfies it; each match is its own OR'd row -> match.
+        Assert.True(predicate(Event(("IssuerCert", "x"), ("SubjectCert", "y"))));
+        // Every matching field equals x -> none satisfies "!= x" -> no match.
+        Assert.False(predicate(Event(("IssuerCert", "x"), ("SubjectCert", "x"))));
+    }
+
+    [Fact]
+    public void EventDataGlob_StarMatchesEveryField()
+    {
+        var predicate = CompileBool("EventData[\"*\"] == \"x\"");
+
+        Assert.True(predicate(Event(("Anything", "x"))));
+        Assert.False(predicate(Event(("Anything", "y"))));
+    }
+
+    [Fact]
+    public void UserDataGlob_AnyOf_OrsAcrossMatchingPaths()
+    {
+        // Exercises the UserDataMultiEqualsNode routed through the glob matcher.
+        var compiled = CompileEval("(new[] {\"a\", \"b\"}).Contains(UserData[\"*cert*\"])");
+
+        Assert.Equal(FilterMatch.Match, compiled.Evaluate!(UserDataEvent(
+            new UserDataField("IssuerCert", ["b"], IsTruncated: false))));
+        Assert.Equal(FilterMatch.NoMatch, compiled.Evaluate!(UserDataEvent(
+            new UserDataField("IssuerCert", ["c"], IsTruncated: false))));
+    }
+
+    [Fact]
+    public void UserDataGlob_AttributePathGlob_Matches()
+    {
+        var compiled = CompileEval("UserData[\"*/@subjectName\"] == \"acme\"");
+
+        Assert.Equal(FilterMatch.Match, compiled.Evaluate!(UserDataEvent(
+            new UserDataField("X509Objects/Certificate/@subjectName", ["acme"], IsTruncated: false))));
+    }
+
+    [Fact]
+    public void UserDataGlob_DefaultUserData_IsNoMatch_NoThrow() // B1
+    {
+        var compiled = CompileEval("UserData[\"*cert*\"] == \"x\"");
+
+        Assert.Equal(FilterMatch.NoMatch, compiled.Evaluate!(new ResolvedEvent("TestLog", LogPathType.Channel)));
+    }
+
+    [Fact]
+    public void UserDataGlob_DefaultUserDataButIncomplete_IsUnknown() // B1 + incomplete
+    {
+        var compiled = CompileEval("UserData[\"*cert*\"] == \"x\"");
+
+        Assert.Equal(FilterMatch.Unknown, compiled.Evaluate!(
+            new ResolvedEvent("TestLog", LogPathType.Channel) { UserDataIncomplete = true }));
+    }
+
+    // --- UserData glob (Kleene tri-state, OR across matching stored paths). ---
+
+    [Fact]
+    public void UserDataGlob_Equal_OrsAcrossMatchingPaths()
+    {
+        var compiled = CompileEval("UserData[\"*cert*\"] == \"x\"");
+
+        Assert.Equal(FilterMatch.Match, compiled.Evaluate!(UserDataEvent(
+            new UserDataField("IssuerCert", ["x"], IsTruncated: false),
+            new UserDataField("Subject", ["y"], IsTruncated: false))));
+        Assert.Equal(FilterMatch.NoMatch, compiled.Evaluate!(UserDataEvent(
+            new UserDataField("IssuerCert", ["y"], IsTruncated: false))));
+        Assert.Equal(FilterMatch.NoMatch, compiled.Evaluate!(UserDataEvent(
+            new UserDataField("Subject", ["x"], IsTruncated: false)))); // no cert path
+    }
+
+    [Fact]
+    public void UserDataGlob_MatchingTruncatedField_IsUnknown()
+    {
+        var compiled = CompileEval("UserData[\"*cert*\"] == \"x\"");
+
+        // A matching path whose values were capped: a dropped value might equal x, so keep the row visible (Unknown).
+        Assert.Equal(FilterMatch.Unknown, compiled.Evaluate!(UserDataEvent(
+            new UserDataField("MyCert", ["y"], IsTruncated: true))));
+    }
+
+    [Fact]
+    public void UserDataGlob_NoMatchingPathButIncomplete_IsUnknown()
+    {
+        var compiled = CompileEval("UserData[\"*cert*\"] == \"x\"");
+
+        // A capped field set with no cert path present: a dropped cert path might have matched, so Unknown, not NoMatch.
+        Assert.Equal(FilterMatch.Unknown, compiled.Evaluate!(new ResolvedEvent("TestLog", LogPathType.Channel)
+        {
+            UserData = [new UserDataField("Other", ["y"], IsTruncated: false)],
+            UserDataIncomplete = true
+        }));
+    }
+
+    [Fact]
+    public void UserDataGlob_NotEqual_IsPresentAndDiffersPerPath()
+    {
+        var compiled = CompileEval("UserData[\"*cert*\"] != \"x\"");
+
+        Assert.Equal(FilterMatch.Match, compiled.Evaluate!(UserDataEvent(
+            new UserDataField("MyCert", ["y"], IsTruncated: false)))); // present cert path, differs
+        Assert.Equal(FilterMatch.NoMatch, compiled.Evaluate!(UserDataEvent(
+            new UserDataField("MyCert", ["x"], IsTruncated: false)))); // present cert path, equal
+    }
+
+    [Fact]
+    public void UserDataGlob_NotEqual_MatchesWhenAnyMatchingPathDiffers()
+    {
+        var compiled = CompileEval("UserData[\"*cert*\"] != \"x\"");
+
+        // One matching path equals x, another differs; the differing path satisfies "!= x" -> Match (OR-sugar).
+        Assert.Equal(FilterMatch.Match, compiled.Evaluate!(UserDataEvent(
+            new UserDataField("IssuerCert", ["x"], IsTruncated: false),
+            new UserDataField("SubjectCert", ["y"], IsTruncated: false))));
+        // Every matching path equals x -> no path satisfies "!= x" -> NoMatch.
+        Assert.Equal(FilterMatch.NoMatch, compiled.Evaluate!(UserDataEvent(
+            new UserDataField("IssuerCert", ["x"], IsTruncated: false),
+            new UserDataField("SubjectCert", ["x"], IsTruncated: false))));
+    }
+
+    [Fact]
+    public void UserDataGlob_NotEqual_PresentDifferingButIncomplete_IsUnknown()
+    {
+        // Regression pin (post-code review): on an incomplete (capped) event a present-differing matched field is Unknown
+        // - a dropped value might equal x - not a decisive Match, exactly as the exact single-field path folds the
+        // incomplete signal. This keeps an excluded row visible (fail-safe), and makes the glob the OR of exact rows.
+        var compiled = CompileEval("UserData[\"*cert*\"] != \"x\"");
+
+        var incomplete = new ResolvedEvent("TestLog", LogPathType.Channel)
+        {
+            UserData = [new UserDataField("MyCert", ["y"], IsTruncated: false)],
+            UserDataIncomplete = true
+        };
+
+        Assert.Equal(FilterMatch.Unknown, compiled.Evaluate!(incomplete));
+
+        // The glob's tri-state equals the exact single-field filter on that same path.
+        var exact = CompileEval("UserData[\"MyCert\"] != \"x\"");
+        Assert.Equal(exact.Evaluate!(incomplete), compiled.Evaluate!(incomplete));
+    }
+
+    [Fact]
+    public void UserDataGlob_Predicate_HighlightsOnlyOnDecisiveMatch()
+    {
+        var compiled = CompileEval("UserData[\"*cert*\"] == \"x\"");
+
+        Assert.True(compiled.Predicate(UserDataEvent(new UserDataField("MyCert", ["x"], IsTruncated: false))));
+        Assert.False(compiled.Predicate(UserDataEvent(new UserDataField("MyCert", ["y"], IsTruncated: true)))); // Unknown
+        Assert.False(compiled.Predicate(new ResolvedEvent("TestLog", LogPathType.Channel)));
+    }
+
+    [Fact]
+    public void UserDataRepeatMarker_RoutesToExactMatcher_NotGlob() // N1
+    {
+        // "Root/Item[*]" carries the repeating-element marker, which ToStorageKey strips to "Root/Item"; it is an exact
+        // lookup, NOT a name glob, so it matches only that stored path.
+        var compiled = CompileEval("UserData[\"Root/Item[*]\"] == \"x\"");
+
+        Assert.Equal(FilterMatch.Match, compiled.Evaluate!(UserDataEvent(
+            new UserDataField("Root/Item", ["x"], IsTruncated: false))));
+        Assert.Equal(FilterMatch.NoMatch, compiled.Evaluate!(UserDataEvent(
+            new UserDataField("Root/Other", ["x"], IsTruncated: false))));
+    }
+
+    private static Func<ResolvedEvent, bool> CompileBool(string filter)
+    {
+        Assert.True(FilterParser.TryCompile(filter, out var compiled, out var error), error);
+
+        return compiled.Predicate;
+    }
+
+    private static CompiledFilter CompileEval(string filter)
+    {
+        Assert.True(FilterParser.TryCompile(filter, out var compiled, out var error), error);
+
+        return compiled;
+    }
+
+    private static ResolvedEvent Event(params (string Name, object? Value)[] fields) =>
+        EventDataTestFactory.CreateEventWithData(fields);
+
+    private static ResolvedEvent UserDataEvent(params UserDataField[] fields) =>
+        new("TestLog", LogPathType.Channel) { UserData = [.. fields] };
+}

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventData/UserDataFilterAggregateTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventData/UserDataFilterAggregateTests.cs
@@ -1,0 +1,114 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Eventing.Structured;
+using EventLogExpert.Filtering.Persistence;
+
+namespace EventLogExpert.Filtering.Tests.EventData;
+
+/// <summary>
+///     The aggregate side of UserData filtering: how <c>MatchesFilters</c> reads each filter's stored-field tri-state
+///     and collapses it under include / exclude polarity (a truncated Unknown never silently hides a row), and how several
+///     UserData filters over the same event each evaluate their own stored field independently.
+/// </summary>
+public sealed class UserDataFilterAggregateTests
+{
+    private const string NonMatchingValue = "\u0001__no_match__";
+
+    [Fact]
+    public void MatchesFilters_AbsentPathOnCompleteEvent_HidesUnderInclude()
+    {
+        var filters = new[] { UserDataFilter("UserData[\"Missing\"] == \"x\"", isExcluded: false) };
+
+        var complete = new ResolvedEvent("TestLog", LogPathType.Channel)
+        {
+            UserData = [new UserDataField("Other", ["v"], IsTruncated: false)]
+        };
+
+        Assert.False(complete.MatchesFilters(filters));
+    }
+
+    // Distinct-path-cap fail-safe end to end: on an incomplete event an unstored path keeps the row visible under both
+    // polarities (the accessor returns a truncated result the emitter reads as Unknown); on a complete event the same
+    // absent path is decisive, so an include filter hides it.
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void MatchesFilters_AbsentPathOnIncompleteEvent_KeepsRowVisible(bool isExcluded)
+    {
+        var filters = new[] { UserDataFilter("UserData[\"Missing\"] == \"x\"", isExcluded) };
+
+        var incomplete = new ResolvedEvent("TestLog", LogPathType.Channel)
+        {
+            UserData = [new UserDataField("Other", ["v"], IsTruncated: false)],
+            UserDataIncomplete = true
+        };
+
+        Assert.True(incomplete.MatchesFilters(filters));
+    }
+
+    [Theory]
+    [InlineData(FilterMatch.Match, false)] // exclude hides only on a decisive match
+    [InlineData(FilterMatch.Unknown, true)] // exclude must NOT hide on Unknown
+    [InlineData(FilterMatch.NoMatch, true)]
+    public void MatchesFilters_ExcludePolarity(FilterMatch state, bool expectedVisible)
+    {
+        var filters = new[] { UserDataFilter("UserData[\"Foo\"] == \"x\"", isExcluded: true) };
+        var @event = EventWith(Value("Foo", state, "x"));
+
+        Assert.Equal(expectedVisible, @event.MatchesFilters(filters));
+    }
+
+    [Theory]
+    [InlineData(FilterMatch.Match, true)]
+    [InlineData(FilterMatch.Unknown, true)] // include keeps a truncated potential match visible
+    [InlineData(FilterMatch.NoMatch, false)]
+    public void MatchesFilters_IncludePolarity(FilterMatch state, bool expectedVisible)
+    {
+        var filters = new[] { UserDataFilter("UserData[\"Foo\"] == \"x\"", isExcluded: false) };
+        var @event = EventWith(Value("Foo", state, "x"));
+
+        Assert.Equal(expectedVisible, @event.MatchesFilters(filters));
+    }
+
+    [Fact]
+    public void MatchesFilters_TwoFilters_EachEvaluatesIndependently()
+    {
+        var filters = new[]
+        {
+            UserDataFilter("UserData[\"A\"] == \"x\"", isExcluded: false),
+            UserDataFilter("UserData[\"B\"] == \"y\"", isExcluded: false)
+        };
+
+        // Only the second include filter matches its own stored field -> included.
+        Assert.True(
+            EventWith(Value("A", FilterMatch.NoMatch, "x"), Value("B", FilterMatch.Match, "y")).MatchesFilters(filters));
+
+        // Neither include filter matches its stored field -> hidden.
+        Assert.False(
+            EventWith(Value("A", FilterMatch.NoMatch, "x"), Value("B", FilterMatch.NoMatch, "y")).MatchesFilters(filters));
+    }
+
+    private static ResolvedEvent EventWith(params UserDataField[] fields) =>
+        new("TestLog", LogPathType.Channel) { UserData = [.. fields] };
+
+    private static SavedFilter UserDataFilter(string expression, bool isExcluded = false)
+    {
+        var filter = SavedFilter.TryCreate(expression, isExcluded: isExcluded);
+        Assert.NotNull(filter);
+
+        return filter;
+    }
+
+    // Builds a stored field whose "== literal" comparison yields the requested tri-state: Match (literal present),
+    // NoMatch (a non-matching value), or Unknown (a non-matching value on a truncated field, so a match may be dropped).
+    private static UserDataField Value(string storageKey, FilterMatch state, string literal) => state switch
+    {
+        FilterMatch.Match => new UserDataField(storageKey, [literal], IsTruncated: false),
+        FilterMatch.NoMatch => new UserDataField(storageKey, [NonMatchingValue], IsTruncated: false),
+        FilterMatch.Unknown => new UserDataField(storageKey, [NonMatchingValue], IsTruncated: true),
+        _ => throw new ArgumentOutOfRangeException(nameof(state))
+    };
+}

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventData/UserDataFilterCompilationTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventData/UserDataFilterCompilationTests.cs
@@ -1,0 +1,177 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Eventing.Structured;
+using EventLogExpert.Filtering.Parsing;
+
+namespace EventLogExpert.Filtering.Tests.EventData;
+
+/// <summary>
+///     Compile coverage for UserData structured-path filtering: canonical-path normalization to a storage key, the
+///     presence-required grammar mirror of EventData, negation folding (no NotNode wraps a UserData term), and the
+///     tri-state Kleene predicate over stored <see cref="ResolvedEvent.UserData" />. Events carry hand-built fields whose
+///     values and truncation flag drive each to Match / NoMatch / Unknown.
+/// </summary>
+public sealed class UserDataFilterCompilationTests
+{
+    private const string NonMatchingValue = "\u0001__no_match__";
+
+    [Theory]
+    [InlineData("UserData[\"Foo\"].Contains(\"x\", StringComparison.OrdinalIgnoreCase)")]
+    [InlineData("!UserData[\"Foo\"].Contains(\"x\", StringComparison.OrdinalIgnoreCase)")]
+    [InlineData("(new[] {\"a\", \"b\"}).Contains(UserData[\"Foo\"])")]
+    public void ContainsAndAnyOf_Compile(string filter)
+    {
+        var compiled = Compile(filter);
+
+        Assert.NotNull(compiled.Evaluate);
+    }
+
+    [Fact]
+    public void Equal_EvaluatesTriStateFromStoredValue()
+    {
+        var compiled = Compile("UserData[\"Foo\"] == \"x\"");
+
+        Assert.NotNull(compiled.Evaluate);
+        Assert.Equal(FilterMatch.Match, compiled.Evaluate!(EventWith(Value("Foo", FilterMatch.Match, "x"))));
+        Assert.Equal(FilterMatch.NoMatch, compiled.Evaluate!(EventWith(Value("Foo", FilterMatch.NoMatch, "x"))));
+        Assert.Equal(FilterMatch.Unknown, compiled.Evaluate!(EventWith(Value("Foo", FilterMatch.Unknown, "x"))));
+    }
+
+    [Fact]
+    public void EventWithoutStoredUserData_ReadsAsNoMatch()
+    {
+        var compiled = Compile("UserData[\"Foo\"] == \"x\"");
+
+        // An event with no stored UserData leaves (and not flagged incomplete) is decisively absent: NoMatch, never a throw.
+        Assert.Equal(FilterMatch.NoMatch, compiled.Evaluate!(new ResolvedEvent("TestLog", LogPathType.Channel)));
+    }
+
+    [Theory]
+    [InlineData(FilterMatch.Match, FilterMatch.Match, FilterMatch.Match)]
+    [InlineData(FilterMatch.Match, FilterMatch.NoMatch, FilterMatch.NoMatch)]
+    [InlineData(FilterMatch.Match, FilterMatch.Unknown, FilterMatch.Unknown)]
+    [InlineData(FilterMatch.NoMatch, FilterMatch.Unknown, FilterMatch.NoMatch)] // U ∧ F = F
+    [InlineData(FilterMatch.Unknown, FilterMatch.Unknown, FilterMatch.Unknown)]
+    public void KleeneAnd(FilterMatch left, FilterMatch right, FilterMatch expected)
+    {
+        var compiled = Compile("UserData[\"A\"] == \"x\" && UserData[\"B\"] == \"y\"");
+
+        var @event = EventWith(Value("A", left, "x"), Value("B", right, "y"));
+
+        Assert.Equal(expected, compiled.Evaluate!(@event));
+    }
+
+    [Theory]
+    [InlineData(FilterMatch.NoMatch, FilterMatch.NoMatch, FilterMatch.NoMatch)]
+    [InlineData(FilterMatch.NoMatch, FilterMatch.Match, FilterMatch.Match)]
+    [InlineData(FilterMatch.NoMatch, FilterMatch.Unknown, FilterMatch.Unknown)]
+    [InlineData(FilterMatch.Match, FilterMatch.Unknown, FilterMatch.Match)] // U ∨ T = T
+    [InlineData(FilterMatch.Unknown, FilterMatch.Unknown, FilterMatch.Unknown)]
+    public void KleeneOr(FilterMatch left, FilterMatch right, FilterMatch expected)
+    {
+        var compiled = Compile("UserData[\"A\"] == \"x\" || UserData[\"B\"] == \"y\"");
+
+        var @event = EventWith(Value("A", left, "x"), Value("B", right, "y"));
+
+        Assert.Equal(expected, compiled.Evaluate!(@event));
+    }
+
+    [Fact]
+    public void MixedUserDataAndScalar_LiftsScalarTermTrivially()
+    {
+        var compiled = Compile("UserData[\"Foo\"] == \"x\" && Source == \"Contoso\"");
+
+        var matchingSource = new ResolvedEvent("TestLog", LogPathType.Channel)
+        {
+            Source = "Contoso",
+            UserData = [Value("Foo", FilterMatch.Match, "x")]
+        };
+
+        var wrongSource = matchingSource with { Source = "Other" };
+
+        Assert.Equal(FilterMatch.Match, compiled.Evaluate!(matchingSource));
+        Assert.Equal(FilterMatch.NoMatch, compiled.Evaluate!(wrongSource)); // scalar F short-circuits the AND
+    }
+
+    [Fact]
+    public void NotEqual_ViaNegation_FoldsWithoutRenegatingUnknown()
+    {
+        var direct = Compile("UserData[\"Foo\"] != \"x\"");
+        var negated = Compile("!(UserData[\"Foo\"] == \"x\")");
+
+        // A truncated non-matching field makes "!= x" ambiguous (a dropped value might equal x), so Unknown propagates
+        // unchanged; negation folds into the NotEqual operator (no NotNode), so the negated form equals the direct "!= x".
+        var unknownEvent = EventWith(Value("Foo", FilterMatch.Unknown, "x"));
+
+        Assert.Equal(FilterMatch.Unknown, negated.Evaluate!(unknownEvent));
+        Assert.Equal(direct.Evaluate!(unknownEvent), negated.Evaluate!(unknownEvent));
+    }
+
+    [Theory]
+    [InlineData("UserData[\"Event/UserData/Foo/Bar\"] == \"x\"")]
+    [InlineData("UserData[\"Foo/Bar\"] == \"x\"")]
+    public void Path_SpellingsResolveToSameStoredValue(string filter)
+    {
+        var compiled = Compile(filter);
+
+        // Both spellings canonicalize to Event/UserData/Foo/Bar then to the storage key Foo/Bar, so each reads the same
+        // stored field. ("UserData/Foo/Bar" is NOT equivalent: only a full Event/UserData/ envelope is treated as rooted.)
+        var matching = EventWith(new UserDataField("Foo/Bar", ["x"], IsTruncated: false));
+
+        Assert.NotNull(compiled.Evaluate);
+        Assert.Equal(FilterMatch.Match, compiled.Evaluate!(matching));
+    }
+
+    // The highlight surface is the bool Predicate (= Evaluate == Match): a UserData highlight colors a row only on a
+    // decisive Match, never on Unknown or an absent field, so a truncated row stays visible but uncolored.
+    [Fact]
+    public void Predicate_HighlightsOnlyOnDecisiveMatch()
+    {
+        var compiled = Compile("UserData[\"Foo\"] == \"x\"");
+
+        Assert.True(compiled.Predicate(EventWith(Value("Foo", FilterMatch.Match, "x"))));
+        Assert.False(compiled.Predicate(EventWith(Value("Foo", FilterMatch.Unknown, "x"))));
+        Assert.False(compiled.Predicate(EventWith(Value("Foo", FilterMatch.NoMatch, "x"))));
+        Assert.False(compiled.Predicate(new ResolvedEvent("TestLog", LogPathType.Channel)));
+    }
+
+    [Theory]
+    [InlineData("UserData[\"Foo\"] < \"5\"")] // relational not supported
+    [InlineData("UserData[\"Foo\"] >= \"5\"")]
+    [InlineData("UserData[\"\"] == \"x\"")] // empty path
+    [InlineData("UserData[\"   \"] == \"x\"")] // whitespace path
+    [InlineData("UserData[5] == \"x\"")] // non-string path
+    [InlineData("UserData[\"Foo/@\"] == \"x\"")] // malformed canonical path
+    [InlineData("!(new[] {\"a\", \"b\"}).Contains(UserData[\"Foo\"])")] // none-of
+    [InlineData("!(UserData[\"Foo\"] == \"a\" || UserData[\"Foo\"] == \"b\")")] // grouped negation
+    [InlineData("!(UserData[\"Foo\"] == \"a\" && Source == \"x\")")] // grouped negation, mixed
+    public void UnsupportedShapes_FailToCompile(string filter)
+    {
+        Assert.False(FilterParser.TryCompile(filter, out var compiled, out var error));
+        Assert.Null(compiled);
+        Assert.False(string.IsNullOrEmpty(error));
+    }
+
+    private static CompiledFilter Compile(string filter)
+    {
+        Assert.True(FilterParser.TryCompile(filter, out var compiled, out var error), error);
+
+        return compiled;
+    }
+
+    private static ResolvedEvent EventWith(params UserDataField[] fields) =>
+        new("TestLog", LogPathType.Channel) { UserData = [.. fields] };
+
+    // Builds a stored field whose "== literal" comparison yields the requested tri-state: Match (literal present),
+    // NoMatch (a non-matching value), or Unknown (a non-matching value on a truncated field, so a match may be dropped).
+    private static UserDataField Value(string storageKey, FilterMatch state, string literal) => state switch
+    {
+        FilterMatch.Match => new UserDataField(storageKey, [literal], IsTruncated: false),
+        FilterMatch.NoMatch => new UserDataField(storageKey, [NonMatchingValue], IsTruncated: false),
+        FilterMatch.Unknown => new UserDataField(storageKey, [NonMatchingValue], IsTruncated: true),
+        _ => throw new ArgumentOutOfRangeException(nameof(state))
+    };
+}

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventData/UserDataPicklistTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventData/UserDataPicklistTests.cs
@@ -1,0 +1,123 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Eventing.Structured;
+
+namespace EventLogExpert.Filtering.Tests.EventData;
+
+/// <summary>
+///     Field-name and per-field value picklists that feed the Basic editor's UserData row. Field names are stored
+///     storage keys; values aggregate every stored value of the matching field. Exercises the composite
+///     <c>(snapshot, storageKey)</c> cache key and the bounded-membership guard that rejects a mid-typed path.
+/// </summary>
+[Collection("EventPropertyValuesCache")]
+public sealed class UserDataPicklistTests : IDisposable
+{
+    public UserDataPicklistTests() => EventPropertyValuesCache.Clear();
+
+    public void Dispose() => EventPropertyValuesCache.Clear();
+
+    [Fact]
+    public void GetUserDataFieldNames_ReturnsDistinctSortedNames()
+    {
+        var snapshot = new object();
+        var events = new[]
+        {
+            EventWith(
+                new UserDataField("X509Objects/Certificate/SubjectName", ["a"], IsTruncated: false),
+                new UserDataField("Status", ["1"], IsTruncated: false)),
+            EventWith(
+                new UserDataField("Status", ["2"], IsTruncated: false),
+                new UserDataField("X509Objects/Certificate/@subjectName", ["b"], IsTruncated: false))
+        };
+
+        var names = EventPropertyValuesCache.GetUserDataFieldNames(snapshot, events);
+
+        Assert.Equal(
+            ["Status", "X509Objects/Certificate/@subjectName", "X509Objects/Certificate/SubjectName"],
+            names);
+    }
+
+    [Fact]
+    public void GetUserDataFieldNames_SortsOrdinal()
+    {
+        var snapshot = new object();
+        var events = new[]
+        {
+            EventWith(new UserDataField("b", ["1"], IsTruncated: false)),
+            EventWith(new UserDataField("A", ["2"], IsTruncated: false)),
+            EventWith(new UserDataField("a", ["3"], IsTruncated: false))
+        };
+
+        // Ordinal orders uppercase before lowercase ('A'=65, 'a'=97, 'b'=98), unlike a culture-sensitive sort.
+        Assert.Equal(["A", "a", "b"], EventPropertyValuesCache.GetUserDataFieldNames(snapshot, events));
+    }
+
+    [Fact]
+    public void GetUserDataFieldValues_DifferentFields_ProduceDifferentLists()
+    {
+        var snapshot = new object();
+        var events = new[]
+        {
+            EventWith(
+                new UserDataField("A", ["1"], IsTruncated: false),
+                new UserDataField("B", ["2"], IsTruncated: false))
+        };
+
+        Assert.Equal(["1"], EventPropertyValuesCache.GetUserDataFieldValues(snapshot, events, "A"));
+        Assert.Equal(["2"], EventPropertyValuesCache.GetUserDataFieldValues(snapshot, events, "B"));
+    }
+
+    [Fact]
+    public void GetUserDataFieldValues_EmptyFieldName_ReturnsEmpty()
+    {
+        var snapshot = new object();
+        var events = new[] { EventWith(new UserDataField("A", ["1"], IsTruncated: false)) };
+
+        Assert.Empty(EventPropertyValuesCache.GetUserDataFieldValues(snapshot, events, string.Empty));
+    }
+
+    [Fact]
+    public void GetUserDataFieldValues_RepeatingField_ContributesEachCollapsedValue()
+    {
+        var snapshot = new object();
+
+        // A single repeating field collapses to one field with multiple stored values; each is offered, distinct + sorted.
+        var events = new[] { EventWith(new UserDataField("Roles", ["reader", "admin", "reader"], IsTruncated: false)) };
+
+        Assert.Equal(["admin", "reader"], EventPropertyValuesCache.GetUserDataFieldValues(snapshot, events, "Roles"));
+    }
+
+    [Fact]
+    public void GetUserDataFieldValues_ReturnsDistinctSortedValues()
+    {
+        var snapshot = new object();
+        var events = new[]
+        {
+            EventWith(new UserDataField("User", ["admin"], IsTruncated: false)),
+            EventWith(new UserDataField("User", ["guest"], IsTruncated: false)),
+            EventWith(new UserDataField("User", ["admin"], IsTruncated: false)),
+            EventWith(new UserDataField("Other", ["x"], IsTruncated: false))
+        };
+
+        var values = EventPropertyValuesCache.GetUserDataFieldValues(snapshot, events, "User");
+
+        Assert.Equal(["admin", "guest"], values);
+    }
+
+    [Fact]
+    public void GetUserDataFieldValues_UnknownFieldName_ReturnsEmptyWithoutCaching()
+    {
+        var snapshot = new object();
+        var events = new[] { EventWith(new UserDataField("A", ["1"], IsTruncated: false)) };
+
+        // A name that isn't a real stored field (mid-typing in an editable picker) is bounded out: returns empty and is not cached.
+        Assert.Empty(EventPropertyValuesCache.GetUserDataFieldValues(snapshot, events, "NotAField"));
+        Assert.Equal(["1"], EventPropertyValuesCache.GetUserDataFieldValues(snapshot, events, "A"));
+    }
+
+    private static ResolvedEvent EventWith(params UserDataField[] fields) =>
+        new("TestLog", LogPathType.Channel) { UserData = [.. fields] };
+}

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventData/UserDataRoundTripTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventData/UserDataRoundTripTests.cs
@@ -1,0 +1,213 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Structured;
+using EventLogExpert.Filtering.Parsing;
+using System.Text.Json;
+
+namespace EventLogExpert.Filtering.Tests.EventData;
+
+/// <summary>
+///     Advanced-text to/from Basic round-trip fidelity and JSON persistence for UserData rows. The path-form
+///     invariant: <see cref="FilterComparison.UserDataFieldName" /> holds the storage key, the formatter emits
+///     <c>UserData["storage-key"]</c>, and re-parsing re-roots it, so a storage key survives format -> compile ->
+///     decompose unchanged (element and attribute leaves).
+/// </summary>
+public sealed class UserDataRoundTripTests
+{
+    [Fact]
+    public void EmptyFieldName_DoesNotFormat() =>
+        Assert.False(BasicFilterFormatter.TryFormatComparison(Single(ComparisonOperator.Equals, "", "admin"), null, out _));
+
+    [Fact]
+    public void Format_EmitsUserDataIndexerExpression()
+    {
+        Assert.True(
+            BasicFilterFormatter.TryFormat(
+                new BasicFilter(Single(ComparisonOperator.Equals, "X509Objects/Certificate/SubjectName", "value"), []),
+                out var text),
+            "format failed");
+
+        Assert.Equal("UserData[\"X509Objects/Certificate/SubjectName\"] == \"value\"", text);
+    }
+
+    [Fact]
+    public void Json_NonUserDataRow_OmitsUserDataFieldName_EvenWhenSet()
+    {
+        var comparison = new FilterComparison
+        {
+            Property = EventProperty.Source,
+            Operator = ComparisonOperator.Equals,
+            MatchMode = MatchMode.Single,
+            Value = "x",
+            UserDataFieldName = "stale"
+        };
+
+        var json = JsonSerializer.Serialize(comparison);
+
+        Assert.DoesNotContain("UserDataFieldName", json);
+    }
+
+    [Fact]
+    public void Json_PreservesUserDataFieldName()
+    {
+        var original = Single(ComparisonOperator.Contains, "X509Objects/Certificate/SubjectName", "admin");
+
+        var json = JsonSerializer.Serialize(original);
+        var restored = JsonSerializer.Deserialize<FilterComparison>(json);
+
+        Assert.NotNull(restored);
+        Assert.Equal(EventProperty.UserData, restored!.Property);
+        Assert.Equal("X509Objects/Certificate/SubjectName", restored.UserDataFieldName);
+        Assert.Equal(ComparisonOperator.Contains, restored.Operator);
+        Assert.Equal("admin", restored.Value);
+    }
+
+    [Fact]
+    public void Json_Read_DropsUserDataFieldName_ForNonUserDataRow()
+    {
+        const string json =
+            """{"Property":"Source","Operator":"Equals","MatchMode":"Single","Value":"x","UserDataFieldName":"stale"}""";
+
+        var restored = JsonSerializer.Deserialize<FilterComparison>(json);
+
+        Assert.NotNull(restored);
+        Assert.Equal(EventProperty.Source, restored!.Property);
+        Assert.Null(restored.UserDataFieldName);
+    }
+
+    [Fact]
+    public void Json_Read_NormalizesWhitespaceFieldName_ToNull()
+    {
+        const string json =
+            """{"Property":"UserData","Operator":"Equals","MatchMode":"Single","Value":"x","UserDataFieldName":"   "}""";
+
+        var restored = JsonSerializer.Deserialize<FilterComparison>(json);
+
+        Assert.NotNull(restored);
+        Assert.Equal(EventProperty.UserData, restored!.Property);
+        Assert.Null(restored.UserDataFieldName);
+    }
+
+    [Fact]
+    public void ManyValues_RoundTrips()
+    {
+        var original = new FilterComparison
+        {
+            Property = EventProperty.UserData,
+            UserDataFieldName = "X509Objects/Certificate/SubjectName",
+            Operator = ComparisonOperator.Equals,
+            MatchMode = MatchMode.Many,
+            Values = ["admin", "root"]
+        };
+
+        var result = RoundTrip(original);
+
+        Assert.Equal(EventProperty.UserData, result.Property);
+        Assert.Equal("X509Objects/Certificate/SubjectName", result.UserDataFieldName);
+        Assert.Equal(MatchMode.Many, result.MatchMode);
+        Assert.Equal<IEnumerable<string>>(["admin", "root"], result.Values);
+    }
+
+    [Fact]
+    public void NegatedContains_MapsToNotContains()
+    {
+        Assert.True(
+            BasicFilterDecomposer.TryDecompose(
+                "!UserData[\"X509Objects/Certificate/SubjectName\"].Contains(\"adm\", StringComparison.OrdinalIgnoreCase)",
+                out var structured),
+            "decompose failed");
+
+        Assert.Equal(ComparisonOperator.NotContains, structured!.Comparison.Operator);
+        Assert.Equal("X509Objects/Certificate/SubjectName", structured.Comparison.UserDataFieldName);
+    }
+
+    [Fact]
+    public void NegatedNotEqual_CanonicalizesToEquals()
+    {
+        Assert.True(
+            BasicFilterDecomposer.TryDecompose(
+                "!(UserData[\"X509Objects/Certificate/SubjectName\"] != \"admin\")",
+                out var structured),
+            "decompose failed");
+
+        Assert.Equal(ComparisonOperator.Equals, structured!.Comparison.Operator);
+        Assert.Equal("X509Objects/Certificate/SubjectName", structured.Comparison.UserDataFieldName);
+    }
+
+    [Theory]
+    [InlineData(ComparisonOperator.Equals)]
+    [InlineData(ComparisonOperator.NotEqual)]
+    [InlineData(ComparisonOperator.Contains)]
+    [InlineData(ComparisonOperator.NotContains)]
+    public void SingleValue_RoundTrips(ComparisonOperator op) =>
+        AssertSingleRoundTrips(op, "X509Objects/Certificate/SubjectName", "admin");
+
+    // Core invariant: a storage key survives the full Basic -> Advanced-text -> compile -> decompose loop unchanged, for
+    // both element and attribute (@name) leaves, so the value the field picker shows equals the stored field's key.
+    [Theory]
+    [InlineData("Foo")]
+    [InlineData("Foo/Bar")]
+    [InlineData("X509Objects/Certificate/SubjectName")]
+    [InlineData("X509Objects/Certificate/@subjectName")]
+    public void StorageKey_RoundTripsThroughCanonicalAndCompiles(string storageKey)
+    {
+        // Direct invariant: rooting then re-keying is identity on a storage key.
+        Assert.True(UserDataFieldPath.TryNormalize(storageKey, out var canonical, out var normalizeError), normalizeError);
+        Assert.Equal(storageKey, UserDataFieldPath.ToStorageKey(canonical!));
+
+        // Text invariant: the formatted row is valid grammar (compiles) and decomposes back to the same storage key.
+        Assert.True(
+            BasicFilterFormatter.TryFormat(
+                new BasicFilter(Single(ComparisonOperator.Equals, storageKey, "value"), []),
+                out var text),
+            "format failed");
+
+        Assert.True(FilterParser.TryCompile(text, out var compiled, out var compileError), compileError);
+        Assert.NotNull(compiled.Evaluate);
+
+        Assert.True(BasicFilterDecomposer.TryDecompose(text, out var structured), $"decompose failed: {text}");
+        Assert.Equal(EventProperty.UserData, structured!.Comparison.Property);
+        Assert.Equal(storageKey, structured.Comparison.UserDataFieldName);
+    }
+
+    [Fact]
+    public void StoredGrammarText_DecomposesFormatsToSameText()
+    {
+        const string original = "UserData[\"X509Objects/Certificate/SubjectName\"] == \"value\"";
+
+        Assert.True(BasicFilterDecomposer.TryDecompose(original, out var structured), "decompose failed");
+        Assert.True(BasicFilterFormatter.TryFormat(new BasicFilter(structured!.Comparison, []), out var text), "format failed");
+
+        Assert.Equal(original, text);
+    }
+
+    private static void AssertSingleRoundTrips(ComparisonOperator op, string fieldName, string value)
+    {
+        var result = RoundTrip(Single(op, fieldName, value));
+
+        Assert.Equal(EventProperty.UserData, result.Property);
+        Assert.Equal(fieldName, result.UserDataFieldName);
+        Assert.Equal(op, result.Operator);
+        Assert.Equal(MatchMode.Single, result.MatchMode);
+        Assert.Equal(value, result.Value);
+    }
+
+    private static FilterComparison RoundTrip(FilterComparison original)
+    {
+        Assert.True(BasicFilterFormatter.TryFormat(new BasicFilter(original, []), out var text), "format failed");
+        Assert.True(BasicFilterDecomposer.TryDecompose(text, out var structured), $"decompose failed: {text}");
+
+        return structured!.Comparison;
+    }
+
+    private static FilterComparison Single(ComparisonOperator op, string fieldName, string value) =>
+        new()
+        {
+            Property = EventProperty.UserData,
+            UserDataFieldName = fieldName,
+            Operator = op,
+            MatchMode = MatchMode.Single,
+            Value = value
+        };
+}

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventData/UserDataRoundTripTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventData/UserDataRoundTripTests.cs
@@ -150,6 +150,8 @@ public sealed class UserDataRoundTripTests
     [InlineData("Foo/Bar")]
     [InlineData("X509Objects/Certificate/SubjectName")]
     [InlineData("X509Objects/Certificate/@subjectName")]
+    [InlineData("*cert*")]
+    [InlineData("X509Objects/*/@subjectName")]
     public void StorageKey_RoundTripsThroughCanonicalAndCompiles(string storageKey)
     {
         // Direct invariant: rooting then re-keying is identity on a storage key.

--- a/tests/Unit/EventLogExpert.Filtering.Tests/Lowering/PropertyResolverSchemaTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/Lowering/PropertyResolverSchemaTests.cs
@@ -18,7 +18,9 @@ public sealed class PropertyResolverSchemaTests
         "OwningLog", // Internal: identifies the log file/live channel; not user-visible filter target.
         "LogPathType", // Enum discriminator paired with OwningLog; not a user-facing filter target.
         "KeywordsDisplayName", // Computed convenience accessor; users filter via Keywords directly.
-        "EventData" // Structured field accessor; named-field filtering arrives with the filter DSL, not as a scalar column.
+        "EventData", // Structured field accessor; named-field filtering arrives with the filter DSL, not as a scalar column.
+        "UserData", // Resolve-time stored nested-UserData leaves; UserData filtering uses the UserData[...] DSL, not a scalar column.
+        "UserDataIncomplete" // Extraction-cap flag paired with UserData; surfaced through the UserData[...] tri-state, not as a scalar column.
     ];
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Provider.Tests/Resolution/ProviderDetailsTests.cs
+++ b/tests/Unit/EventLogExpert.Provider.Tests/Resolution/ProviderDetailsTests.cs
@@ -85,6 +85,21 @@ public sealed class ProviderDetailsTests
         Assert.Contains(result, e => e.Version == 1);
     }
 
+    // CompactMessageStore memoizes each id's result, so a repeated lookup returns the same instance rather than
+    // re-materializing - the property that lets the resolver hit the message store per event without re-parsing.
+    [Fact]
+    public void GetMessagesByShortId_RepeatedLookup_ReturnsCachedInstance()
+    {
+        var details = EventUtils.CreateProvider(
+            Constants.TestProviderLongName,
+            [
+                new MessageModel { ShortId = 7, RawId = 0x00010007, Text = "first" },
+                new MessageModel { ShortId = 7, RawId = 0x00020007, Text = "second" }
+            ]);
+
+        Assert.Same(details.GetMessagesByShortId(7), details.GetMessagesByShortId(7));
+    }
+
     [Fact]
     public void GetMessagesByShortId_WhenIdDoesNotExist_ReturnsEmptyList()
     {
@@ -169,6 +184,15 @@ public sealed class ProviderDetailsTests
         // Assert
         Assert.Single(result);
         Assert.Equal("positive", result[0].Text);
+    }
+
+    [Fact]
+    public void GetParameterByRawId_RepeatedLookup_ReturnsCachedInstance()
+    {
+        var details = EventUtils.CreateProvider(Constants.TestProviderLongName);
+        details.Parameters = [new MessageModel { RawId = 42, Text = "only" }];
+
+        Assert.Same(details.GetParameterByRawId(42), details.GetParameterByRawId(42));
     }
 
     [Fact]
@@ -347,5 +371,97 @@ public sealed class ProviderDetailsTests
         var replaced = details.GetParameterByRawId(2);
         Assert.NotNull(replaced);
         Assert.Equal("replaced", replaced.Text);
+    }
+
+    // A lazy source is consulted per id and its view is materialized on demand; setting it and doing point lookups must
+    // never force a full MaterializeAll (which would defeat the lazy message loading the source exists to provide).
+    [Fact]
+    public void SetLazyMessageSource_LooksUpPerIdWithoutMaterializingEverything()
+    {
+        var details = EventUtils.CreateProvider(Constants.TestProviderLongName);
+        var source = new CountingLazySource(
+            byShortId: new Dictionary<int, IReadOnlyList<MessageModel>>
+            {
+                [7] = [new MessageModel { ShortId = 7, RawId = 7, Text = "a" }]
+            },
+            byRawId: new Dictionary<long, MessageModel>());
+
+        details.SetLazyMessageSource(source);
+        _ = details.GetMessagesByShortId(7);
+        _ = details.GetMessagesByShortId(8);
+
+        Assert.Equal(0, source.MaterializeAllCalls);
+    }
+
+    // SetLazyMessageSource swaps in an external lazy source (used by the offline/WEVT readers) so message lookups and
+    // the Messages view route through it instead of a built-in CompactMessageStore.
+    [Fact]
+    public void SetLazyMessageSource_RoutesMessageLookupsAndViewToTheSource()
+    {
+        var details = EventUtils.CreateProvider(Constants.TestProviderLongName);
+        var message = new MessageModel { ShortId = 7, RawId = 7, Text = "lazy", ProviderName = Constants.TestProviderLongName };
+        var source = new CountingLazySource(
+            byShortId: new Dictionary<int, IReadOnlyList<MessageModel>> { [7] = [message] },
+            byRawId: new Dictionary<long, MessageModel>());
+
+        details.SetLazyMessageSource(source);
+
+        Assert.Same(source, details.MessageSource);
+        Assert.Equal([message], details.GetMessagesByShortId(7));
+        Assert.Equal(1, source.ShortIdCalls);
+        Assert.Equal(["lazy"], details.Messages.Select(m => m.Text));
+    }
+
+    [Fact]
+    public void SetLazyParameterSource_RoutesParameterLookupsToTheSource()
+    {
+        var details = EventUtils.CreateProvider(Constants.TestProviderLongName);
+        var parameter = new MessageModel { RawId = 42, Text = "lazy-param", ProviderName = Constants.TestProviderLongName };
+        var source = new CountingLazySource(
+            byShortId: new Dictionary<int, IReadOnlyList<MessageModel>>(),
+            byRawId: new Dictionary<long, MessageModel> { [42] = parameter });
+
+        details.SetLazyParameterSource(source);
+
+        Assert.Same(source, details.ParameterSource);
+        Assert.Same(parameter, details.GetParameterByRawId(42));
+        Assert.Null(details.GetParameterByRawId(999));
+        Assert.Equal(2, source.RawIdCalls);
+    }
+
+    private sealed class CountingLazySource(
+        IReadOnlyDictionary<int, IReadOnlyList<MessageModel>> byShortId,
+        IReadOnlyDictionary<long, MessageModel> byRawId) : ILazyMessageSource
+    {
+        public int Count => byShortId.Values.Sum(list => list.Count);
+
+        public int MaterializeAllCalls { get; private set; }
+
+        public int RawIdCalls { get; private set; }
+
+        public int ShortIdCalls { get; private set; }
+
+        public IReadOnlyList<MessageModel> AsView() => [.. byShortId.Values.SelectMany(list => list)];
+
+        public MessageModel? GetByRawIdFirst(long rawId)
+        {
+            RawIdCalls++;
+
+            return byRawId.GetValueOrDefault(rawId);
+        }
+
+        public IReadOnlyList<MessageModel> GetByShortId(int shortId)
+        {
+            ShortIdCalls++;
+
+            return byShortId.TryGetValue(shortId, out var list) ? list : [];
+        }
+
+        public IReadOnlyList<MessageModel> MaterializeAll()
+        {
+            MaterializeAllCalls++;
+
+            return AsView();
+        }
     }
 }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Common/Display/FilterPropertyDisplayOrderTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Common/Display/FilterPropertyDisplayOrderTests.cs
@@ -1,0 +1,49 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Drafts;
+using EventLogExpert.Runtime.Common.Display;
+
+namespace EventLogExpert.Runtime.Tests.Common.Display;
+
+/// <summary>
+///     Locks the Basic filter editor's property dropdown contract: ordered alphabetically by display text (
+///     <see cref="DisplayExtensions.ToFullString" />), and a new comparison/draft defaults its property to Event ID.
+/// </summary>
+public sealed class FilterPropertyDisplayOrderTests
+{
+    [Fact]
+    public void PropertyDropdown_DefaultComparison_IsEventId() =>
+        Assert.Equal(EventProperty.Id, new FilterComparison().Property);
+
+    [Fact]
+    public void PropertyDropdown_DefaultDraft_IsEventId() =>
+        Assert.Equal(EventProperty.Id, new FilterComparisonDraft().Property);
+
+    [Fact]
+    public void PropertyDropdown_OrdersAlphabeticallyByDisplayText()
+    {
+        var ordered = Enum.GetValues<EventProperty>()
+            .OrderBy(property => property.ToFullString(), StringComparer.CurrentCulture)
+            .Select(property => property.ToFullString());
+
+        Assert.Equal(
+            [
+                "Activity ID",
+                "Description",
+                "Event Data",
+                "Event ID",
+                "Keywords",
+                "Level",
+                "Log Name",
+                "Process ID",
+                "Source",
+                "Task Category",
+                "Thread ID",
+                "User Data",
+                "User ID",
+                "Xml"
+            ],
+            ordered);
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EffectsTests.cs
@@ -1,4 +1,4 @@
-﻿// // Copyright (c) Microsoft Corporation.
+// // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
 using EventLogExpert.Eventing.Common.Channels;

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterPane/HighlightSelectorTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterPane/HighlightSelectorTests.cs
@@ -14,6 +14,26 @@ public sealed class HighlightSelectorTests
     private static readonly HighlightSelector s_selector = new();
 
     [Fact]
+    public void ComputeHighlightKey_TreatsUserDataFilterAsEligible()
+    {
+        // Arrange
+        var userData = FilterBuilder.CreateTestFilter(
+            "UserData[\"Foo\"] == \"x\"",
+            HighlightColor.Red,
+            true);
+
+        var scalar = FilterBuilder.CreateTestFilter(
+            FilterTestConstants.FilterIdEquals100,
+            HighlightColor.Blue,
+            true);
+
+        // Act + Assert: an eligible UserData filter contributes to the key, so adding it changes the key.
+        Assert.NotEqual(
+            s_selector.ComputeHighlightKey(ImmutableList.Create(scalar)),
+            s_selector.ComputeHighlightKey(ImmutableList.Create(scalar, userData)));
+    }
+
+    [Fact]
     public void ComputeHighlightKey_WhenCandidateAdded_ReturnsDifferentKey()
     {
         // Arrange
@@ -257,6 +277,32 @@ public sealed class HighlightSelectorTests
         {
             Assert.Same(fromEnabled[i], fromDisabled[i]);
         }
+    }
+
+    [Fact]
+    public void Select_ShouldIncludeUserDataFilters()
+    {
+        // A colored, enabled, non-excluded UserData filter is highlight-eligible and flows through Select like any other;
+        // its tri-state Evaluate drives the highlight (an absent / Unknown result just leaves the row visible-but-uncolored).
+        var userData = FilterBuilder.CreateTestFilter(
+            "UserData[\"Foo\"] == \"x\"",
+            HighlightColor.Red,
+            true);
+
+        var scalar = FilterBuilder.CreateTestFilter(
+            FilterTestConstants.FilterIdEquals100,
+            HighlightColor.Blue,
+            true);
+
+        var state = new FilterPaneState { Filters = ImmutableList.Create(userData, scalar) };
+
+        // Act
+        var result = s_selector.Select(state.Filters);
+
+        // Assert: both filters are highlight-eligible; the UserData filter is no longer gated out.
+        Assert.Equal(2, result.Length);
+        Assert.Same(userData, result[0]);
+        Assert.Same(scalar, result[1]);
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Scenarios.Tests/ScenarioCatalogLoaderTests.cs
+++ b/tests/Unit/EventLogExpert.Scenarios.Tests/ScenarioCatalogLoaderTests.cs
@@ -152,6 +152,32 @@ public sealed class ScenarioCatalogLoaderTests
     }
 
     [Fact]
+    public void Load_EventDataComparisonWithoutFieldName_IsError()
+    {
+        var result = Load(Wrap("""
+            { "id": "x", "name": "X", "purpose": "p", "group": "Security", "requiresAdmin": true,
+              "channels": [ "Security" ],
+              "filters": [ { "comparison": { "property": "EventData", "value": "3" } } ] }
+            """));
+
+        Assert.Contains(result.Errors, error => error.Contains("eventDataFieldName"));
+    }
+
+    [Fact]
+    public void Load_EventDataFieldComparison_Succeeds()
+    {
+        var result = Load(Wrap("""
+            { "id": "x", "name": "X", "purpose": "p", "group": "Security", "requiresAdmin": true,
+              "channels": [ "Security" ],
+              "filters": [ { "comparison": { "property": "EventData", "eventDataFieldName": "LogonType", "value": "3" } } ] }
+            """));
+
+        Assert.Empty(result.Errors);
+        var scenario = Assert.Single(result.Scenarios);
+        Assert.Equal("LogonType", scenario.Filters[0].Filter.Comparison.EventDataFieldName);
+    }
+
+    [Fact]
     public void Load_ExcludedRowWithColor_IsError()
     {
         var result = Load(Wrap("""
@@ -295,6 +321,32 @@ public sealed class ScenarioCatalogLoaderTests
 
         Assert.Empty(result.Scenarios);
         Assert.Contains(result.Errors, error => error.Contains("schemaVersion"));
+    }
+
+    [Fact]
+    public void Load_UserDataComparisonWithoutFieldName_IsError()
+    {
+        var result = Load(Wrap("""
+            { "id": "x", "name": "X", "purpose": "p", "group": "Security", "requiresAdmin": true,
+              "channels": [ "Security" ],
+              "filters": [ { "comparison": { "property": "UserData", "value": "x" } } ] }
+            """));
+
+        Assert.Contains(result.Errors, error => error.Contains("userDataFieldName"));
+    }
+
+    [Fact]
+    public void Load_UserDataFieldComparison_Succeeds()
+    {
+        var result = Load(Wrap("""
+            { "id": "x", "name": "X", "purpose": "p", "group": "Security", "requiresAdmin": true,
+              "channels": [ "Security" ],
+              "filters": [ { "comparison": { "property": "UserData", "userDataFieldName": "X509Objects/Certificate/@subjectName", "value": "CN=Test" } } ] }
+            """));
+
+        Assert.Empty(result.Errors);
+        var scenario = Assert.Single(result.Scenarios);
+        Assert.Equal("X509Objects/Certificate/@subjectName", scenario.Filters[0].Filter.Comparison.UserDataFieldName);
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneViewportTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneViewportTests.cs
@@ -1,0 +1,83 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.UI.LogTable;
+using Microsoft.AspNetCore.Components.Web.Virtualization;
+
+namespace EventLogExpert.UI.Tests.LogTable;
+
+public sealed class LogTablePaneViewportTests
+{
+    [Fact]
+    public void ComputeEventViewport_EmptyList_ReturnsEmptyWindowAndZeroTotal()
+    {
+        var result = LogTablePane.ComputeEventViewport([], Request(startIndex: 0, count: 50));
+
+        Assert.Empty(result.Items);
+        Assert.Equal(0, result.TotalItemCount);
+    }
+
+    [Fact]
+    public void ComputeEventViewport_NormalWindow_SlicesRequestedRange()
+    {
+        var events = Events(10);
+
+        var result = LogTablePane.ComputeEventViewport(events, Request(startIndex: 2, count: 4));
+
+        Assert.Equal([events[2], events[3], events[4], events[5]], result.Items);
+        Assert.Equal(10, result.TotalItemCount);
+    }
+
+    [Fact]
+    public void ComputeEventViewport_RequestOverrunsTail_ClampsCountToRemaining()
+    {
+        var events = Events(5);
+
+        // Start at index 3 and ask for 50 rows; only indices 3 and 4 remain.
+        var result = LogTablePane.ComputeEventViewport(events, Request(startIndex: 3, count: 50));
+
+        Assert.Equal([events[3], events[4]], result.Items);
+        Assert.Equal(5, result.TotalItemCount);
+    }
+
+    [Fact]
+    public void ComputeEventViewport_StartPastEnd_ReturnsEmptyWindowWithTrueTotal()
+    {
+        var events = Events(3);
+
+        var result = LogTablePane.ComputeEventViewport(events, Request(startIndex: 10, count: 50));
+
+        Assert.Empty(result.Items);
+        Assert.Equal(3, result.TotalItemCount);
+    }
+
+    [Fact]
+    public void ComputeEventViewport_Window_MatchesResolvedEventIndexSlice()
+    {
+        var events = Events(20);
+
+        var result = LogTablePane.ComputeEventViewport(events, Request(startIndex: 7, count: 6));
+
+        Assert.Equal(ResolvedEventIndex.Slice(events, 7, 6), result.Items);
+    }
+
+    [Fact]
+    public void ComputeEventViewport_ZeroCountRequest_ReturnsEmptyWindow()
+    {
+        var events = Events(3);
+
+        var result = LogTablePane.ComputeEventViewport(events, Request(startIndex: 1, count: 0));
+
+        Assert.Empty(result.Items);
+        Assert.Equal(3, result.TotalItemCount);
+    }
+
+    private static IReadOnlyList<ResolvedEvent> Events(int count) =>
+        [.. Enumerable.Range(0, count).Select(id => new ResolvedEvent("Application", LogPathType.Channel) { Id = id })];
+
+    private static ItemsProviderRequest Request(int startIndex, int count) =>
+        new(startIndex, count, CancellationToken.None);
+}


### PR DESCRIPTION
Completes the EventData/UserData structured-field filtering workstream (6b-U-2 tail, 6e, and wildcard globs), stacked on the merged 6b-U-1 foundation.

## Commits

1. **UserData structured-field filtering via stored values** — extracts deduped nested-UserData fields once at resolve time (gated on empty User context), stores path→values on `ResolvedEvent`, and enables in-memory `UserData["path"]` filtering with the same friendly field/value dropdowns as EventData. Tri-state Kleene evaluation keeps truncated/incomplete rows visible rather than wrongly hiding them.
2. **ValueSelect overflow tooltip** — adds a `title` tooltip to a dropdown value only when it is actually clipped (precise overflow detection).
3. **EventData/UserData field filters in built-in scenarios** — extends the scenario `ComparisonDto` with field-name targeting (wired through the loader with validation and the exporter for round-trip) and authors 26 field-level built-in scenarios (CAPI2/PKI chain-failure triage, security/threat DFIR, NPS/print/storage), with field names verified against live Windows manifests.
4. **Wildcard field-name matching** — `EventData["*cert*"]` / `UserData["*cert*"]` match any field whose name/path matches a `*` glob, evaluated as if each match were its own OR'd filter row (present-required negatives per field; EventData boolean; UserData Kleene tri-state, keep-visible on truncation/incomplete).

## Validation

Build 0/0; Filtering 1084/0, Eventing 528/0, Scenarios 580/0, Runtime 1730/0, UI 1020/0. Each feature went through cross-family design and code-review panels.
