### PR TITLE
Allow multiple app instances and guard cross-process database schema migrations

### DIFF
--- a/docs/Explorer-Context-Menu.md
+++ b/docs/Explorer-Context-Menu.md
@@ -8,7 +8,7 @@ EventLogExpert's MSIX package registers three Windows Explorer right-click conte
 | Folder icon | **Open with EventLogExpert** | Top-level Win11 modern menu (via `desktop5:ItemType Type="Directory"`) | Same native DLL filters `Directory` items + spawns the main exe with the folder path |
 | Empty space inside an open folder | **Open with EventLogExpert** | Top-level Win11 modern menu (via `desktop5:ItemType Type="Directory\Background"`) | Same native DLL, same handler |
 
-Single-instance activation is handled by `Microsoft.Windows.AppLifecycle.AppInstance.FindOrRegisterForKey`, wired in a handwritten WinUI `Main` (`src/EventLogExpert/Platforms/Windows/Program.cs`) so secondary launches route activation args to the running primary instance via the `ActivationDispatcher` channel. Multi-select fans into a single combined view.
+Each launch runs as its own instance and window (the app is intentionally not single-instanced), wired in a handwritten WinUI `Main` (`src/EventLogExpert/Platforms/Windows/Program.cs`) that captures the shell activation args via `AppInstance.GetCurrent().GetActivatedEventArgs()` and seeds them into the `ActivationDispatcher` channel before the app starts. A multi-select right-click fans into a single activation, so the selected files open together in one new window; a separate open launches a new window. Drag-and-drop is the only path that adds logs to an existing window.
 
 ## Architecture
 
@@ -22,9 +22,9 @@ The `IExplorerCommand` implementation:
 - `IObjectWithSite::SetSite` → stores the shell-supplied site so the `Directory\Background` surface (right-click inside an open folder's empty space) can resolve the current folder via `QueryService(SID_SFolderView, IFolderView)` → `IPersistFolder2::GetCurFolder` → `SHGetPathFromIDListEx` (32K wstring buffer + `GPFIDL_DEFAULT`, long-path-safe — the legacy `SHGetPathFromIDListW` caps at `MAX_PATH` regardless of process long-path awareness). Required because the shell passes `items == null` for that surface.
 
 The MAUI receiving side:
-- `Program.Main` runs before `Application.Start`, calls `AppInstance.FindOrRegisterForKey("eventlogexpert-main")`. Secondary instances redirect their activation args to the primary and exit.
+- `Program.Main` runs before `Application.Start`, captures the shell activation args via `AppInstance.GetCurrent().GetActivatedEventArgs()`, and seeds them into `ActivationBootstrap`. Each launch is its own process/window; the app is not single-instanced.
 - `ActivationBootstrap` (thread-safe static buffer) seeds cold-launch args BEFORE MAUI DI is built, so they're not lost when `MainPage` is constructed.
-- `ActivationDispatcher` (channel + `Interlocked` idempotent start) drains the buffer + listens for redirected `AppInstance.Activated` events. UI work is marshaled via `MainThread.InvokeOnMainThreadAsync`.
+- `ActivationDispatcher` (channel + `Interlocked` idempotent start) drains the buffer. UI work is marshaled via `MainThread.InvokeOnMainThreadAsync`.
 - `ActivationArgsExtractor` discriminates per `ExtendedActivationKind`: `File` → `IFileActivatedEventArgs.Files`, `Launch` → `ILaunchActivatedEventArgs.Arguments` parsed via `CommandLineToArgvW`, `CommandLineLaunch` → `ICommandLineActivatedEventArgs.Operation.Arguments`. Tokens are classified via `ActivationTokenClassifier` (in `EventLogExpert.WindowsPlatform`) — only `.evtx`-extension files and existing directories are accepted, so the launching exe path (`argv[0]` from the shell extension's `CreateProcess` spawn) is silently dropped instead of being treated as a log to open.
 
 ## Build prerequisites
@@ -94,7 +94,7 @@ Run after any change touching the manifest, the activation pipeline, the native 
 1. **FTA single-file double-click (regression gate)** — Double-click a `.evtx` in Explorer. EventLogExpert launches and loads the file. **Required to pass** — the activation refactor changes how all FTA opens flow.
 2. **Single-file right-click** — Right-click one `.evtx` → "Open with EventLogExpert" at top level → app opens with the file.
 3. **Multi-file right-click** — Select 3–5 `.evtx` files → "Open with EventLogExpert" → **one** app instance opens with all files combined.
-4. **Secondary activation redirect** — With app already running, right-click another `.evtx` → existing window receives the file (no new window).
+4. **Separate open launches a new window** - With the app already running, right-click another `.evtx` -> "Open with EventLogExpert" -> a **new** app window opens for that file. The app is multi-instance; only drag-and-drop adds a log to an existing window.
 5. **Folder icon right-click** — Folder with `.evtx` files → "Open with EventLogExpert" → all top-level `.evtx` open in one app instance.
 6. **Folder background right-click** — Open a folder containing `.evtx` files, right-click in the empty space inside it → "Open with EventLogExpert" → all top-level `.evtx` open in one app instance. This surface relies on `IObjectWithSite` recovering the folder from the shell view; if it fails, the verb is silently absent.
 7. **Empty folder right-click** — Folder with no `.evtx` → verb still appears (filtering happens lazily) → click → silent no-op (native DLL pre-filters via `Directory.EnumerateFiles(*.evtx).Any()` before spawning).

--- a/src/EventLogExpert.DatabaseTools/Common/Operations/ProviderSource.cs
+++ b/src/EventLogExpert.DatabaseTools/Common/Operations/ProviderSource.cs
@@ -223,7 +223,18 @@ internal static class ProviderSource
 
     private static bool IsSourceSchemaCurrent(ProviderDbContext context, string file, ITraceLogger logger)
     {
-        var state = context.IsUpgradeNeeded();
+        DatabaseSchemaState state;
+
+        try
+        {
+            state = context.IsUpgradeNeeded();
+        }
+        catch (SchemaLockTimeoutException ex)
+        {
+            logger.Error($"Cannot read source database '{file}': {ex.Message}");
+
+            return false;
+        }
 
         if (!state.NeedsUpgrade) { return true; }
 

--- a/src/EventLogExpert.DatabaseTools/MergeDatabase/MergeDatabaseOperation.cs
+++ b/src/EventLogExpert.DatabaseTools/MergeDatabase/MergeDatabaseOperation.cs
@@ -62,6 +62,12 @@ internal sealed class MergeDatabaseOperation(MergeDatabaseRequest request) : Ope
 
             return DatabaseToolsOutcome.Failed;
         }
+        catch (SchemaLockTimeoutException ex)
+        {
+            logger.Error($"Cannot merge into '{request.TargetDatabasePath}': {ex.Message}");
+
+            return DatabaseToolsOutcome.Failed;
+        }
 
         if (targetState.CurrentVersion == DatabaseSchemaVersion.Unknown)
         {
@@ -79,7 +85,7 @@ internal sealed class MergeDatabaseOperation(MergeDatabaseRequest request) : Ope
 
         try
         {
-            await using var targetContext = new ProviderDbContext(request.TargetDatabasePath, false, logger);
+            await using var targetContext = new ProviderDbContext(request.TargetDatabasePath, false, false, logger);
 
             // SQLite cannot translate composite IN, so query by name and narrow exact identities in memory.
             var identitiesAlreadyInTarget = new HashSet<ProviderIdentity>();

--- a/src/EventLogExpert.DatabaseTools/UpgradeDatabase/UpgradeDatabaseOperation.cs
+++ b/src/EventLogExpert.DatabaseTools/UpgradeDatabase/UpgradeDatabaseOperation.cs
@@ -40,6 +40,12 @@ internal sealed class UpgradeDatabaseOperation(UpgradeDatabaseRequest request) :
 
             return DatabaseToolsOutcome.Failed;
         }
+        catch (SchemaLockTimeoutException ex)
+        {
+            logger.Error($"Cannot upgrade '{request.DatabasePath}': {ex.Message}");
+
+            return DatabaseToolsOutcome.Failed;
+        }
 
         if (!state.NeedsUpgrade)
         {
@@ -66,7 +72,7 @@ internal sealed class UpgradeDatabaseOperation(UpgradeDatabaseRequest request) :
 
         try
         {
-            await using var upgradeContext = new ProviderDbContext(request.DatabasePath, false, logger);
+            await using var upgradeContext = new ProviderDbContext(request.DatabasePath, false, false, logger);
 
             upgradeContext.PerformUpgradeIfNeeded();
 
@@ -79,6 +85,12 @@ internal sealed class UpgradeDatabaseOperation(UpgradeDatabaseRequest request) :
         catch (DatabaseUpgradeException ex)
         {
             logger.Error($"{ex.Message}");
+
+            return DatabaseToolsOutcome.Failed;
+        }
+        catch (SchemaLockTimeoutException ex)
+        {
+            logger.Error($"Cannot upgrade '{request.DatabasePath}': {ex.Message}");
 
             return DatabaseToolsOutcome.Failed;
         }

--- a/src/EventLogExpert.Eventing/Resolvers/EventResolver.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/EventResolver.cs
@@ -190,6 +190,14 @@ public sealed class EventResolver : EventResolverBase, IEventResolver
 
                     newLookups.Add(lookup);
                 }
+                catch (SchemaLockTimeoutException ex)
+                {
+                    // Another process is mid-upgrade on this database; skip it this pass rather than misclassifying it
+                    // as unknown or failing the whole resolution. A later load picks it up once the upgrade completes.
+                    Logger?.Warning($"Skipping provider database '{file}' for this resolve: {ex.Message}");
+
+                    lookup.Dispose();
+                }
                 catch
                 {
                     lookup.Dispose();

--- a/src/EventLogExpert.Logging/Concurrency/InterProcessFileLock.cs
+++ b/src/EventLogExpert.Logging/Concurrency/InterProcessFileLock.cs
@@ -1,0 +1,161 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Security.AccessControl;
+using System.Security.Principal;
+
+namespace EventLogExpert.Logging.Concurrency;
+
+/// <summary>
+///     Cross-process, cross-integrity-level advisory lock backed by a sentinel file held open with
+///     <see cref="FileShare.None" />. Unlike a named mutex, file access is governed by the file/directory DACL rather than
+///     the Windows mandatory integrity label, so a medium-integrity app instance and the high-integrity elevated helper
+///     coordinate on the same lock. The sentinel is created with a permissive DACL and is never deleted (deleting it would
+///     open a pending-deletion race); the OS releases the lock automatically if the holder crashes.
+/// </summary>
+public sealed class InterProcessFileLock
+{
+    private static readonly TimeSpan s_maxBackoff = TimeSpan.FromMilliseconds(500);
+    private static readonly TimeSpan s_minBackoff = TimeSpan.FromMilliseconds(50);
+
+    private readonly string _lockPath;
+    private readonly string _scope;
+
+    public InterProcessFileLock(string scope, string targetPath)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(scope);
+        ArgumentException.ThrowIfNullOrEmpty(targetPath);
+
+        _scope = scope;
+        _lockPath = $"{targetPath}.{scope}.lock";
+    }
+
+    public void Run(TimeSpan timeout, Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        if (!TryRun(timeout, action))
+        {
+            throw new TimeoutException(
+                $"Timed out after {timeout.TotalSeconds:F0}s acquiring interprocess file lock '{_lockPath}' (scope '{_scope}').");
+        }
+    }
+
+    public bool TryRun(TimeSpan timeout, Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var deadline = Environment.TickCount64 + (long)timeout.TotalMilliseconds;
+        var backoff = s_minBackoff;
+
+        while (true)
+        {
+            FileStream? stream;
+
+            try
+            {
+                stream = OpenExclusive(_lockPath);
+            }
+            catch (IOException ex) when (IsContention(ex))
+            {
+                // Held by another process. Retry with capped exponential backoff + jitter until the deadline.
+                if (Environment.TickCount64 >= deadline) { return false; }
+
+                Thread.Sleep(NextBackoff(ref backoff));
+
+                continue;
+            }
+            catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+            {
+                // Could not create/open the sentinel at all. If the directory itself is not writable there can be no
+                // concurrent writer to coordinate with, so the lock is moot and running unguarded is safe. If the
+                // directory IS writable, the sentinel's own DACL denies us (a foreign-principal lock left on disk) -
+                // fail loud rather than mutate unsynchronized.
+                if (DirectoryAllowsWrite(_lockPath)) { throw; }
+
+                action();
+
+                return true;
+            }
+
+            using (stream)
+            {
+                action();
+            }
+
+            return true;
+        }
+    }
+
+    private static bool DirectoryAllowsWrite(string filePath)
+    {
+        var directory = Path.GetDirectoryName(filePath);
+
+        if (string.IsNullOrEmpty(directory)) { return false; }
+
+        var probePath = Path.Combine(directory, $".{Guid.NewGuid():N}.wtest");
+
+        try
+        {
+            using var probe = new FileStream(
+                probePath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None,
+                bufferSize: 1,
+                FileOptions.DeleteOnClose);
+
+            return true;
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+        {
+            return false;
+        }
+    }
+
+    private static bool IsContention(IOException ex)
+    {
+        const int ErrorSharingViolation = unchecked((int)0x80070020);
+        const int ErrorLockViolation = unchecked((int)0x80070021);
+
+        return ex.HResult is ErrorSharingViolation or ErrorLockViolation;
+    }
+
+    private static TimeSpan NextBackoff(ref TimeSpan current)
+    {
+        var jitterMs = Random.Shared.Next(0, (int)current.TotalMilliseconds + 1);
+        var wait = TimeSpan.FromMilliseconds(current.TotalMilliseconds + jitterMs);
+
+        var doubled = TimeSpan.FromMilliseconds(current.TotalMilliseconds * 2);
+        current = doubled > s_maxBackoff ? s_maxBackoff : doubled;
+
+        return wait > s_maxBackoff ? s_maxBackoff : wait;
+    }
+
+    private static FileStream OpenExclusive(string lockPath)
+    {
+        // Permissive DACL on creation so a different principal (the elevated helper may run under a separate admin
+        // account) can still open the never-deleted sentinel. Applied only when the file is created; an existing file
+        // keeps its own DACL.
+        var security = new FileSecurity();
+        var authenticatedUsers = new SecurityIdentifier(WellKnownSidType.AuthenticatedUserSid, null);
+
+        security.AddAccessRule(new FileSystemAccessRule(
+            authenticatedUsers,
+            FileSystemRights.FullControl,
+            AccessControlType.Allow));
+
+        var lockFile = new FileInfo(lockPath);
+
+        // Request only Modify (read/write/delete) rather than FullControl: holding a FileShare.None handle needs no
+        // WRITE_DAC/WRITE_OWNER, and asking for less avoids a false denial when opening a sentinel a different principal
+        // created with a narrower DACL.
+        return lockFile.Create(
+            FileMode.OpenOrCreate,
+            FileSystemRights.Modify,
+            FileShare.None,
+            bufferSize: 1,
+            FileOptions.None,
+            security);
+    }
+}

--- a/src/EventLogExpert.Logging/Concurrency/InterProcessFileLock.cs
+++ b/src/EventLogExpert.Logging/Concurrency/InterProcessFileLock.cs
@@ -45,7 +45,15 @@ public sealed class InterProcessFileLock
     {
         ArgumentNullException.ThrowIfNull(action);
 
-        var deadline = Environment.TickCount64 + (long)timeout.TotalMilliseconds;
+        if (timeout != Timeout.InfiniteTimeSpan && timeout < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(timeout), timeout, "Timeout must be non-negative or Timeout.InfiniteTimeSpan.");
+        }
+
+        var infinite = timeout == Timeout.InfiniteTimeSpan;
+        var timeoutMs = (long)timeout.TotalMilliseconds;
+        var deadline = Environment.TickCount64 + timeoutMs;
         var backoff = s_minBackoff;
 
         while (true)
@@ -58,8 +66,9 @@ public sealed class InterProcessFileLock
             }
             catch (IOException ex) when (IsContention(ex))
             {
-                // Held by another process. Retry with capped exponential backoff + jitter until the deadline.
-                if (Environment.TickCount64 >= deadline) { return false; }
+                // Held by another process. Retry with capped exponential backoff + jitter until the deadline;
+                // Timeout.InfiniteTimeSpan waits indefinitely.
+                if (!infinite && Environment.TickCount64 >= deadline) { return false; }
 
                 Thread.Sleep(NextBackoff(ref backoff));
 

--- a/src/EventLogExpert.Logging/Concurrency/InterProcessFileLock.cs
+++ b/src/EventLogExpert.Logging/Concurrency/InterProcessFileLock.cs
@@ -37,7 +37,7 @@ public sealed class InterProcessFileLock
         if (!TryRun(timeout, action))
         {
             throw new TimeoutException(
-                $"Timed out after {timeout.TotalSeconds:F0}s acquiring interprocess file lock '{_lockPath}' (scope '{_scope}').");
+                $"Timed out after {timeout.TotalSeconds:0.###}s acquiring interprocess file lock '{_lockPath}' (scope '{_scope}').");
         }
     }
 

--- a/src/EventLogExpert.Logging/Concurrency/InterProcessMutex.cs
+++ b/src/EventLogExpert.Logging/Concurrency/InterProcessMutex.cs
@@ -44,7 +44,7 @@ public sealed class InterProcessMutex : IDisposable
         if (!TryRun(timeout, action))
         {
             throw new TimeoutException(
-                $"Timed out after {timeout.TotalSeconds:F0}s acquiring interprocess mutex '{_name}'.");
+                $"Timed out after {timeout.TotalSeconds:0.###}s acquiring interprocess mutex '{_name}'.");
         }
     }
 

--- a/src/EventLogExpert.Logging/Concurrency/InterProcessMutex.cs
+++ b/src/EventLogExpert.Logging/Concurrency/InterProcessMutex.cs
@@ -1,0 +1,116 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Security.AccessControl;
+using System.Security.Cryptography;
+using System.Security.Principal;
+using System.Text;
+
+namespace EventLogExpert.Logging.Concurrency;
+
+/// <summary>
+///     Named cross-process mutex for serializing same-user (medium integrity) work across concurrent EventLogExpert
+///     instances. The name is derived from a scope tag plus the canonical target path so equivalent paths coordinate and
+///     unrelated ones do not. Cross-integrity-level coordination (the elevated helper) is NOT covered here - use
+///     <see cref="InterProcessFileLock" /> for that. The mutex is created with a permissive DACL so a concurrently running
+///     prior build (which opens the name requesting full access) still coordinates on the same object.
+/// </summary>
+public sealed class InterProcessMutex : IDisposable
+{
+    private readonly Mutex? _mutex;
+    private readonly string _name;
+
+    public InterProcessMutex(string scope, string path)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(scope);
+        ArgumentException.ThrowIfNullOrEmpty(path);
+
+        _name = DeriveName(scope, path);
+        _mutex = TryCreate(_name);
+    }
+
+    public void Dispose() => _mutex?.Dispose();
+
+    public void Run(TimeSpan timeout, Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        if (_mutex is null)
+        {
+            throw new InvalidOperationException(
+                $"Interprocess mutex '{_name}' is unavailable; refusing to run guarded work unsynchronized.");
+        }
+
+        if (!TryRun(timeout, action))
+        {
+            throw new TimeoutException(
+                $"Timed out after {timeout.TotalSeconds:F0}s acquiring interprocess mutex '{_name}'.");
+        }
+    }
+
+    public bool TryRun(TimeSpan timeout, Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        if (_mutex is null) { return false; }
+
+        bool acquired;
+
+        try
+        {
+            acquired = _mutex.WaitOne(timeout);
+        }
+        catch (AbandonedMutexException)
+        {
+            // Prior owner crashed without releasing; ownership transfers to us and we proceed.
+            acquired = true;
+        }
+
+        if (!acquired) { return false; }
+
+        try
+        {
+            action();
+        }
+        finally
+        {
+            _mutex.ReleaseMutex();
+        }
+
+        return true;
+    }
+
+    internal static string DeriveName(string scope, string path)
+    {
+        // Canonicalize so equivalent paths (relative, separator drift) hash identically. Byte-for-byte compatible with
+        // the pre-refactor FileLogSink name when scope == "DebugLog" so a running prior build coordinates on the same name.
+        var canonical = Path.GetFullPath(path)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var bytes = Encoding.UTF8.GetBytes(canonical.ToUpperInvariant());
+        var hash = SHA256.HashData(bytes);
+
+        return $"Local\\EventLogExpert.{scope}.{Convert.ToHexString(hash, 0, 8)}";
+    }
+
+    private static Mutex? TryCreate(string name)
+    {
+        try
+        {
+            var security = new MutexSecurity();
+            var authenticatedUsers = new SecurityIdentifier(WellKnownSidType.AuthenticatedUserSid, null);
+
+            // FullControl (not just Synchronize|Modify) so an opener requesting MUTEX_ALL_ACCESS - e.g. a concurrently
+            // running prior build that still uses new Mutex(name) - is not denied by this DACL.
+            security.AddAccessRule(new MutexAccessRule(
+                authenticatedUsers,
+                MutexRights.FullControl,
+                AccessControlType.Allow));
+
+            return MutexAcl.Create(initiallyOwned: false, name, out _, security);
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException or IOException or WaitHandleCannotBeOpenedException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/EventLogExpert.Logging/EventLogExpert.Logging.csproj
+++ b/src/EventLogExpert.Logging/EventLogExpert.Logging.csproj
@@ -8,4 +8,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="EventLogExpert.Logging.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/EventLogExpert.Logging/Sinks/FileLogSink.cs
+++ b/src/EventLogExpert.Logging/Sinks/FileLogSink.cs
@@ -2,11 +2,10 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Logging.Concurrency;
 using EventLogExpert.Logging.Routing;
 using Microsoft.Extensions.Logging;
 using System.Diagnostics;
-using System.Security.Cryptography;
-using System.Text;
 
 namespace EventLogExpert.Logging.Sinks;
 
@@ -22,7 +21,7 @@ public sealed class FileLogSink : ILogSink, IDisposable, IAsyncDisposable
     private static readonly TimeSpan s_interprocessLockTimeout = TimeSpan.FromSeconds(2);
 
     private readonly Func<LogRecord, string> _formatter;
-    private readonly Mutex _interprocessMutex;
+    private readonly InterProcessMutex _interprocessMutex;
     private readonly string _path;
     private readonly LogRoutingPolicy _routingPolicy;
     private readonly Lock _writeLock = new();
@@ -39,7 +38,7 @@ public sealed class FileLogSink : ILogSink, IDisposable, IAsyncDisposable
         _path = path;
         _routingPolicy = routingPolicy;
         _formatter = formatter;
-        _interprocessMutex = new Mutex(false, DeriveMutexName(path));
+        _interprocessMutex = new InterProcessMutex("DebugLog", path);
 
         InitTracing();
     }
@@ -52,7 +51,8 @@ public sealed class FileLogSink : ILogSink, IDisposable, IAsyncDisposable
 
             CloseWriter();
 
-            WithInterprocessLock(
+            _interprocessMutex.Run(
+                s_interprocessLockTimeout,
                 () =>
                 {
                     // Share with concurrent writers; SetLength(0) truncates without closing them.
@@ -63,8 +63,7 @@ public sealed class FileLogSink : ILogSink, IDisposable, IAsyncDisposable
                         FileShare.ReadWrite | FileShare.Delete);
 
                     stream.SetLength(0);
-                },
-                throwOnTimeout: true);
+                });
         }
 
         return Task.CompletedTask;
@@ -142,17 +141,6 @@ public sealed class FileLogSink : ILogSink, IDisposable, IAsyncDisposable
 
     public LogLevel MinimumLevelFor(string category) => _routingPolicy.FileMinimumFor(category);
 
-    private static string DeriveMutexName(string path)
-    {
-        // Canonicalize: equivalent paths (relative, separator drift) must hash identically.
-        var canonical = Path.GetFullPath(path)
-            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        var bytes = Encoding.UTF8.GetBytes(canonical.ToUpperInvariant());
-        var hash = SHA256.HashData(bytes);
-
-        return $"Local\\EventLogExpert.DebugLog.{Convert.ToHexString(hash, 0, 8)}";
-    }
-
     private void CloseWriter()
     {
         _writer?.Dispose();
@@ -178,7 +166,8 @@ public sealed class FileLogSink : ILogSink, IDisposable, IAsyncDisposable
     {
         // Rotate under the interprocess lock (throwOnTimeout: false so transient contention skips rotation rather than
         // failing sink construction) and truncate instead of deleting so a concurrent opener never loses the file.
-        WithInterprocessLock(
+        _interprocessMutex.TryRun(
+            s_interprocessLockTimeout,
             () =>
             {
                 var fileInfo = new FileInfo(_path);
@@ -199,44 +188,7 @@ public sealed class FileLogSink : ILogSink, IDisposable, IAsyncDisposable
                 {
                     // The file was deleted, locked, or read-only between the size check and the open; skip rotation (best-effort).
                 }
-            },
-            throwOnTimeout: false);
-    }
-
-    private void WithInterprocessLock(Action action, bool throwOnTimeout)
-    {
-        bool acquired;
-
-        try
-        {
-            acquired = _interprocessMutex.WaitOne(s_interprocessLockTimeout);
-        }
-        catch (AbandonedMutexException)
-        {
-            // Prior owner crashed without releasing; we now hold it and proceed.
-            acquired = true;
-        }
-
-        if (!acquired)
-        {
-            if (throwOnTimeout)
-            {
-                throw new TimeoutException(
-                    $"Timed out acquiring debug-log interprocess lock after {s_interprocessLockTimeout.TotalSeconds:F0}s.");
-            }
-
-            // Hot path: drop this trace rather than risk interleaved/corrupted writes.
-            return;
-        }
-
-        try
-        {
-            action();
-        }
-        finally
-        {
-            _interprocessMutex.ReleaseMutex();
-        }
+            });
     }
 
     private void WriteOutput(string output)
@@ -248,7 +200,8 @@ public sealed class FileLogSink : ILogSink, IDisposable, IAsyncDisposable
             EnsureWriter();
 
             // Mutex serializes line writes so concurrent instances don't interleave.
-            WithInterprocessLock(
+            _interprocessMutex.TryRun(
+                s_interprocessLockTimeout,
                 () =>
                 {
                     if (_writer is null) { return; }
@@ -256,8 +209,7 @@ public sealed class FileLogSink : ILogSink, IDisposable, IAsyncDisposable
                     // Re-seek to EOF: another instance may have written or truncated the file.
                     _writer.BaseStream.Seek(0, SeekOrigin.End);
                     _writer.WriteLine(output);
-                },
-                throwOnTimeout: false);
+                });
 
 #if DEBUG
             Debug.WriteLine(output);

--- a/src/EventLogExpert.Provider.Database/Context/ProviderDbContext.cs
+++ b/src/EventLogExpert.Provider.Database/Context/ProviderDbContext.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Logging.Concurrency;
 using EventLogExpert.Provider.Database.Maintenance;
 using EventLogExpert.Provider.Database.Serialization;
 using EventLogExpert.Provider.Lookup;
@@ -16,8 +17,18 @@ namespace EventLogExpert.Provider.Database.Context;
 
 public sealed class ProviderDbContext : DbContext, IProviderDetailsLookup
 {
+    private const string SchemaLockScope = "ProviderDbSchema";
+
+    // Must stay in sync with DatabaseFileOperations.UpgradeBackupSuffix (Runtime layer; not referenceable here).
+    private const string UpgradeBackupSuffix = ".upgrade.bak";
+
+    private static readonly TimeSpan s_schemaCreateTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan s_schemaMutationTimeout = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan s_schemaProbeTimeout = TimeSpan.FromSeconds(5);
+
     private readonly ITraceLogger? _logger;
     private readonly bool _readOnly;
+    private readonly InterProcessFileLock _schemaLock;
 
     public ProviderDbContext(string path, bool readOnly, ITraceLogger? logger = null)
         : this(path, readOnly, true, logger) { }
@@ -32,6 +43,7 @@ public sealed class ProviderDbContext : DbContext, IProviderDetailsLookup
         Name = System.IO.Path.GetFileNameWithoutExtension(path);
         Path = path;
         _readOnly = readOnly;
+        _schemaLock = new InterProcessFileLock(SchemaLockScope, path);
 
         if (readOnly)
         {
@@ -41,12 +53,23 @@ public sealed class ProviderDbContext : DbContext, IProviderDetailsLookup
         if (!ensureCreated) { return; }
 
         // EnsureCreated builds the ProviderDetails table from the current (canonical) model only when the database did
-        // not already exist. Stamp the canonical user_version on a freshly-created writable database so it is recognized
-        // as current; an existing database is left untouched here (a stale one is rebuilt by the upgrade path, not in place).
-        if (Database.EnsureCreated() && !readOnly)
+        // not already exist. Guard cross-process (concurrent instances / the elevated helper) so two writers don't
+        // create + stamp at once. A .upgrade.bak present here signals a prior upgrade crashed mid-rebuild; creating
+        // empty tables over it would discard recoverable data, so refuse and surface recovery.
+        RunUnderSchemaLock(s_schemaCreateTimeout, () =>
         {
-            StampCanonicalUserVersion();
-        }
+            if (File.Exists(Path + UpgradeBackupSuffix))
+            {
+                throw new DatabaseUpgradeException(
+                    Path,
+                    $"An interrupted-upgrade backup ('{UpgradeBackupSuffix}') is present for {Path}; resolve recovery before the database can be opened.");
+            }
+
+            if (Database.EnsureCreated() && !readOnly)
+            {
+                StampCanonicalUserVersion();
+            }
+        });
     }
 
     public string Name { get; }
@@ -68,230 +91,20 @@ public sealed class ProviderDbContext : DbContext, IProviderDetailsLookup
 
     public DatabaseSchemaState IsUpgradeNeeded()
     {
-        var connection = Database.GetDbConnection();
-        Database.OpenConnection();
+        // Probe under the schema lock so a concurrent cross-process upgrade (mid drop/rebuild) can't be observed as a
+        // torn 'Unknown'. A short timeout keeps readers responsive; on timeout the caller treats the result as transient
+        // (retry later), never as a definitive classification.
+        DatabaseSchemaState? result = null;
 
-        try
+        if (!_schemaLock.TryRun(s_schemaProbeTimeout, () => result = IsUpgradeNeededCore()))
         {
-            int userVersion;
-
-            using (var versionCommand = connection.CreateCommand())
-            {
-                versionCommand.CommandText = "PRAGMA user_version";
-                userVersion = Convert.ToInt32(versionCommand.ExecuteScalar());
-            }
-
-            if (userVersion == DatabaseSchemaVersion.Current && IsCanonicalShape(connection))
-            {
-                // Stamped canonical database - current shape, no rebuild. Skip the structural probe.
-                return LogResult(new DatabaseSchemaState(DatabaseSchemaVersion.Current));
-            }
-
-            if (userVersion > DatabaseSchemaVersion.Current)
-            {
-                // Stamped by a newer build than this one understands; never rebuild/downgrade it.
-                return LogResult(new DatabaseSchemaState(DatabaseSchemaVersion.Unknown) { NeedsUpgrade = true });
-            }
-
-            // userVersion below Current (0 for every database created before the stamp existed; also any sub-current
-            // stamp): classify structurally below (to distinguish v1/v2-unsupported and Unknown from rebuildable v3/v4),
-            // then flag for rebuild unconditionally - an unstamped/stale database is never canonical even when its columns
-            // already match the current shape (and a future Current bump correctly rebuilds old stamped databases).
-            string? messagesType = null;
-            string? eventsType = null;
-            string? keywordsType = null;
-            string? opcodesType = null;
-            string? tasksType = null;
-            string? parametersType = null;
-            bool hasAnyColumn = false;
-            bool hasParametersColumn = false;
-            bool hasResolvedColumn = false;
-
-            using (var command = connection.CreateCommand())
-            {
-                command.CommandText = "PRAGMA table_info(\"ProviderDetails\")";
-                using var reader = command.ExecuteReader();
-
-                while (reader.Read())
-                {
-                    hasAnyColumn = true;
-
-                    var columnName = reader["name"]?.ToString();
-                    var columnType = reader["type"]?.ToString();
-
-                    if (string.Equals(columnName, "Messages", StringComparison.Ordinal))
-                    {
-                        messagesType = columnType;
-                    }
-                    else if (string.Equals(columnName, "Events", StringComparison.Ordinal))
-                    {
-                        eventsType = columnType;
-                    }
-                    else if (string.Equals(columnName, "Keywords", StringComparison.Ordinal))
-                    {
-                        keywordsType = columnType;
-                    }
-                    else if (string.Equals(columnName, "Opcodes", StringComparison.Ordinal))
-                    {
-                        opcodesType = columnType;
-                    }
-                    else if (string.Equals(columnName, "Tasks", StringComparison.Ordinal))
-                    {
-                        tasksType = columnType;
-                    }
-                    else if (string.Equals(columnName, "Parameters", StringComparison.Ordinal))
-                    {
-                        parametersType = columnType;
-                        hasParametersColumn = true;
-                    }
-                    else if (string.Equals(columnName,
-                        nameof(Provider.Resolution.ProviderDetails.ResolvedFromOwningPublisher),
-                        StringComparison.Ordinal))
-                    {
-                        hasResolvedColumn = true;
-                    }
-                }
-            }
-
-            int currentVersion;
-
-            if (!hasAnyColumn)
-            {
-                currentVersion = DatabaseSchemaVersion.Unknown;
-            }
-            else
-            {
-                var payloadColumnsAllText = IsType(messagesType, "TEXT") &&
-                    IsType(eventsType, "TEXT") &&
-                    IsType(keywordsType, "TEXT") &&
-                    IsType(opcodesType, "TEXT") &&
-                    IsType(tasksType, "TEXT");
-
-                var payloadColumnsAllBlob = IsType(messagesType, "BLOB") &&
-                    IsType(eventsType, "BLOB") &&
-                    IsType(keywordsType, "BLOB") &&
-                    IsType(opcodesType, "BLOB") &&
-                    IsType(tasksType, "BLOB");
-
-                switch (payloadColumnsAllText)
-                {
-                    case true when !hasParametersColumn: currentVersion = 1; break;
-                    case true when IsType(parametersType, "TEXT"): currentVersion = 2; break;
-                    default:
-                        {
-                            if (payloadColumnsAllBlob && IsType(parametersType, "BLOB"))
-                            {
-                                var pkIsNoCase = TryDetectPrimaryKeyNoCaseCollation(connection);
-                                currentVersion = hasResolvedColumn && pkIsNoCase ? 4 : 3;
-                            }
-                            else
-                            {
-                                currentVersion = DatabaseSchemaVersion.Unknown;
-                            }
-
-                            break;
-                        }
-                }
-            }
-
-            return LogResult(new DatabaseSchemaState(currentVersion) { NeedsUpgrade = true });
-
-            DatabaseSchemaState LogResult(DatabaseSchemaState result)
-            {
-                _logger?.Debug(
-                    $"{nameof(ProviderDbContext)}.{nameof(IsUpgradeNeeded)}() for database {Path}. currentVersion: {result.CurrentVersion} needsUpgrade: {result.NeedsUpgrade}");
-
-                return result;
-            }
+            throw new SchemaLockTimeoutException(Path);
         }
-        finally
-        {
-            Database.CloseConnection();
-        }
+
+        return result!;
     }
 
-    public void PerformUpgradeIfNeeded()
-    {
-        var state = IsUpgradeNeeded();
-
-        if (!state.NeedsUpgrade) { return; }
-
-        if (state.CurrentVersion == DatabaseSchemaVersion.Unknown)
-        {
-            throw new DatabaseUpgradeException(
-                Path,
-                SchemaStateMessages.UnrecognizedSchema(SchemaStateMessages.DefaultLabel, Path));
-        }
-
-        if (state.CurrentVersion is 1 or 2)
-        {
-            throw new DatabaseUpgradeException(
-                Path,
-                SchemaStateMessages.UnsupportedV1OrV2Schema(Path, state.CurrentVersion));
-        }
-
-        var size = new FileInfo(Path).Length;
-
-        _logger?.Information(
-            $"ProviderDbContext upgrading database (current v{state.CurrentVersion} → v{DatabaseSchemaVersion.Current}). Size: {size} Path: {Path}");
-
-        var connection = Database.GetDbConnection();
-        Database.OpenConnection();
-
-        var allProviderDetails = new List<ProviderDetails>();
-
-        try
-        {
-            using (var command = connection.CreateCommand())
-            {
-                command.CommandText = "SELECT * FROM \"ProviderDetails\"";
-
-                using var detailsReader = command.ExecuteReader();
-
-                while (detailsReader.Read())
-                {
-                    var providerName = (string)detailsReader["ProviderName"];
-
-                    var details = ReadCompressedRow(detailsReader, providerName);
-
-                    allProviderDetails.Add(details);
-                }
-            }
-
-            var merged = ProviderDetailsMerger.MergeCaseInsensitiveDuplicates(allProviderDetails, Path);
-
-            using (var dropCommand = connection.CreateCommand())
-            {
-                dropCommand.CommandText = "DROP TABLE \"ProviderDetails\"";
-                dropCommand.ExecuteNonQuery();
-                dropCommand.CommandText = "VACUUM";
-                dropCommand.ExecuteNonQuery();
-            }
-
-            allProviderDetails = merged;
-        }
-        finally
-        {
-            Database.CloseConnection();
-        }
-
-        Database.EnsureCreated();
-
-        foreach (var p in allProviderDetails)
-        {
-            ProviderDetails.Add(p);
-        }
-
-        SaveChanges();
-
-        size = new FileInfo(Path).Length;
-
-        _logger?.Information($"ProviderDbContext upgrade completed. Size: {size} Path: {Path}");
-
-        // The rebuild produced the current model's shape (EnsureCreated above). Stamp the canonical user_version so the
-        // database is recognized as current on the next open.
-        StampCanonicalUserVersion();
-    }
+    public void PerformUpgradeIfNeeded() => RunUnderSchemaLock(s_schemaMutationTimeout, PerformUpgradeIfNeededCore);
 
     protected override void OnConfiguring(DbContextOptionsBuilder options) =>
         options.UseSqlite($"Data Source={Path};Mode={(_readOnly ? "ReadOnly" : "ReadWriteCreate")}");
@@ -373,19 +186,19 @@ public sealed class ProviderDbContext : DbContext, IProviderDetailsLookup
 
             switch (reader.GetName(i))
             {
-                case nameof(Provider.Resolution.ProviderDetails.SourceOsBuild):
+                case nameof(Resolution.ProviderDetails.SourceOsBuild):
                     details.SourceOsBuild = Convert.ToInt32(reader.GetValue(i));
                     break;
-                case nameof(Provider.Resolution.ProviderDetails.SourceOsRevision):
+                case nameof(Resolution.ProviderDetails.SourceOsRevision):
                     details.SourceOsRevision = Convert.ToInt32(reader.GetValue(i));
                     break;
-                case nameof(Provider.Resolution.ProviderDetails.SourceOsEdition):
+                case nameof(Resolution.ProviderDetails.SourceOsEdition):
                     details.SourceOsEdition = reader.GetString(i);
                     break;
-                case nameof(Provider.Resolution.ProviderDetails.SourceOsDisplayVersion):
+                case nameof(Resolution.ProviderDetails.SourceOsDisplayVersion):
                     details.SourceOsDisplayVersion = reader.GetString(i);
                     break;
-                case nameof(Provider.Resolution.ProviderDetails.MessageFileVersion):
+                case nameof(Resolution.ProviderDetails.MessageFileVersion):
                     details.MessageFileVersion = reader.GetString(i);
                     break;
             }
@@ -429,7 +242,7 @@ public sealed class ProviderDbContext : DbContext, IProviderDetailsLookup
         {
             var columnName = indexInfoReader["name"]?.ToString();
 
-            if (!string.Equals(columnName, nameof(Provider.Resolution.ProviderDetails.ProviderName), StringComparison.Ordinal))
+            if (!string.Equals(columnName, nameof(Resolution.ProviderDetails.ProviderName), StringComparison.Ordinal))
             {
                 continue;
             }
@@ -447,7 +260,7 @@ public sealed class ProviderDbContext : DbContext, IProviderDetailsLookup
         for (var i = 0; i < reader.FieldCount; i++)
         {
             if (!string.Equals(reader.GetName(i),
-                nameof(Provider.Resolution.ProviderDetails.Maps),
+                nameof(Resolution.ProviderDetails.Maps),
                 StringComparison.Ordinal))
             {
                 continue;
@@ -470,7 +283,7 @@ public sealed class ProviderDbContext : DbContext, IProviderDetailsLookup
         for (var i = 0; i < reader.FieldCount; i++)
         {
             if (!string.Equals(reader.GetName(i),
-                nameof(Provider.Resolution.ProviderDetails.ResolvedFromOwningPublisher),
+                nameof(Resolution.ProviderDetails.ResolvedFromOwningPublisher),
                 StringComparison.Ordinal))
             {
                 continue;
@@ -489,7 +302,7 @@ public sealed class ProviderDbContext : DbContext, IProviderDetailsLookup
         for (var i = 0; i < reader.FieldCount; i++)
         {
             if (!string.Equals(reader.GetName(i),
-                nameof(Provider.Resolution.ProviderDetails.VersionKey),
+                nameof(Resolution.ProviderDetails.VersionKey),
                 StringComparison.Ordinal))
             {
                 continue;
@@ -547,6 +360,249 @@ public sealed class ProviderDbContext : DbContext, IProviderDetailsLookup
 
         return true;
 #endif
+    }
+
+    private DatabaseSchemaState IsUpgradeNeededCore()
+    {
+        var connection = Database.GetDbConnection();
+        Database.OpenConnection();
+
+        try
+        {
+            int userVersion;
+
+            using (var versionCommand = connection.CreateCommand())
+            {
+                versionCommand.CommandText = "PRAGMA user_version";
+                userVersion = Convert.ToInt32(versionCommand.ExecuteScalar());
+            }
+
+            if (userVersion == DatabaseSchemaVersion.Current && IsCanonicalShape(connection))
+            {
+                // Stamped canonical database - current shape, no rebuild. Skip the structural probe.
+                return LogResult(new DatabaseSchemaState(DatabaseSchemaVersion.Current));
+            }
+
+            if (userVersion > DatabaseSchemaVersion.Current)
+            {
+                // Stamped by a newer build than this one understands; never rebuild/downgrade it.
+                return LogResult(new DatabaseSchemaState(DatabaseSchemaVersion.Unknown) { NeedsUpgrade = true });
+            }
+
+            // userVersion below Current (0 for every database created before the stamp existed; also any sub-current
+            // stamp): classify structurally below (to distinguish v1/v2-unsupported and Unknown from rebuildable v3/v4),
+            // then flag for rebuild unconditionally - an unstamped/stale database is never canonical even when its columns
+            // already match the current shape (and a future Current bump correctly rebuilds old stamped databases).
+            string? messagesType = null;
+            string? eventsType = null;
+            string? keywordsType = null;
+            string? opcodesType = null;
+            string? tasksType = null;
+            string? parametersType = null;
+            bool hasAnyColumn = false;
+            bool hasParametersColumn = false;
+            bool hasResolvedColumn = false;
+
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = "PRAGMA table_info(\"ProviderDetails\")";
+                using var reader = command.ExecuteReader();
+
+                while (reader.Read())
+                {
+                    hasAnyColumn = true;
+
+                    var columnName = reader["name"]?.ToString();
+                    var columnType = reader["type"]?.ToString();
+
+                    if (string.Equals(columnName, "Messages", StringComparison.Ordinal))
+                    {
+                        messagesType = columnType;
+                    }
+                    else if (string.Equals(columnName, "Events", StringComparison.Ordinal))
+                    {
+                        eventsType = columnType;
+                    }
+                    else if (string.Equals(columnName, "Keywords", StringComparison.Ordinal))
+                    {
+                        keywordsType = columnType;
+                    }
+                    else if (string.Equals(columnName, "Opcodes", StringComparison.Ordinal))
+                    {
+                        opcodesType = columnType;
+                    }
+                    else if (string.Equals(columnName, "Tasks", StringComparison.Ordinal))
+                    {
+                        tasksType = columnType;
+                    }
+                    else if (string.Equals(columnName, "Parameters", StringComparison.Ordinal))
+                    {
+                        parametersType = columnType;
+                        hasParametersColumn = true;
+                    }
+                    else if (string.Equals(columnName,
+                        nameof(Resolution.ProviderDetails.ResolvedFromOwningPublisher),
+                        StringComparison.Ordinal))
+                    {
+                        hasResolvedColumn = true;
+                    }
+                }
+            }
+
+            int currentVersion;
+
+            if (!hasAnyColumn)
+            {
+                currentVersion = DatabaseSchemaVersion.Unknown;
+            }
+            else
+            {
+                var payloadColumnsAllText = IsType(messagesType, "TEXT") &&
+                    IsType(eventsType, "TEXT") &&
+                    IsType(keywordsType, "TEXT") &&
+                    IsType(opcodesType, "TEXT") &&
+                    IsType(tasksType, "TEXT");
+
+                var payloadColumnsAllBlob = IsType(messagesType, "BLOB") &&
+                    IsType(eventsType, "BLOB") &&
+                    IsType(keywordsType, "BLOB") &&
+                    IsType(opcodesType, "BLOB") &&
+                    IsType(tasksType, "BLOB");
+
+                switch (payloadColumnsAllText)
+                {
+                    case true when !hasParametersColumn: currentVersion = 1; break;
+                    case true when IsType(parametersType, "TEXT"): currentVersion = 2; break;
+                    default:
+                        {
+                            if (payloadColumnsAllBlob && IsType(parametersType, "BLOB"))
+                            {
+                                var pkIsNoCase = TryDetectPrimaryKeyNoCaseCollation(connection);
+                                currentVersion = hasResolvedColumn && pkIsNoCase ? 4 : 3;
+                            }
+                            else
+                            {
+                                currentVersion = DatabaseSchemaVersion.Unknown;
+                            }
+
+                            break;
+                        }
+                }
+            }
+
+            return LogResult(new DatabaseSchemaState(currentVersion) { NeedsUpgrade = true });
+
+            DatabaseSchemaState LogResult(DatabaseSchemaState result)
+            {
+                _logger?.Debug(
+                    $"{nameof(ProviderDbContext)}.{nameof(IsUpgradeNeeded)}() for database {Path}. currentVersion: {result.CurrentVersion} needsUpgrade: {result.NeedsUpgrade}");
+
+                return result;
+            }
+        }
+        finally
+        {
+            Database.CloseConnection();
+        }
+    }
+
+    private void PerformUpgradeIfNeededCore()
+    {
+        // Lock-free probe: the whole method already runs under the schema lock (held by PerformUpgradeIfNeeded), and the
+        // file lock is not re-entrant, so the public lock-taking IsUpgradeNeeded must not be called here.
+        var state = IsUpgradeNeededCore();
+
+        if (!state.NeedsUpgrade) { return; }
+
+        if (state.CurrentVersion == DatabaseSchemaVersion.Unknown)
+        {
+            throw new DatabaseUpgradeException(
+                Path,
+                SchemaStateMessages.UnrecognizedSchema(SchemaStateMessages.DefaultLabel, Path));
+        }
+
+        if (state.CurrentVersion is 1 or 2)
+        {
+            throw new DatabaseUpgradeException(
+                Path,
+                SchemaStateMessages.UnsupportedV1OrV2Schema(Path, state.CurrentVersion));
+        }
+
+        var size = new FileInfo(Path).Length;
+
+        _logger?.Information(
+            $"ProviderDbContext upgrading database (current v{state.CurrentVersion} → v{DatabaseSchemaVersion.Current}). Size: {size} Path: {Path}");
+
+        var connection = Database.GetDbConnection();
+        Database.OpenConnection();
+
+        var allProviderDetails = new List<ProviderDetails>();
+
+        try
+        {
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = "SELECT * FROM \"ProviderDetails\"";
+
+                using var detailsReader = command.ExecuteReader();
+
+                while (detailsReader.Read())
+                {
+                    var providerName = (string)detailsReader["ProviderName"];
+
+                    var details = ReadCompressedRow(detailsReader, providerName);
+
+                    allProviderDetails.Add(details);
+                }
+            }
+
+            var merged = ProviderDetailsMerger.MergeCaseInsensitiveDuplicates(allProviderDetails, Path);
+
+            using (var dropCommand = connection.CreateCommand())
+            {
+                dropCommand.CommandText = "DROP TABLE \"ProviderDetails\"";
+                dropCommand.ExecuteNonQuery();
+                dropCommand.CommandText = "VACUUM";
+                dropCommand.ExecuteNonQuery();
+            }
+
+            allProviderDetails = merged;
+        }
+        finally
+        {
+            Database.CloseConnection();
+        }
+
+        Database.EnsureCreated();
+
+        foreach (var p in allProviderDetails)
+        {
+            ProviderDetails.Add(p);
+        }
+
+        SaveChanges();
+
+        size = new FileInfo(Path).Length;
+
+        _logger?.Information($"ProviderDbContext upgrade completed. Size: {size} Path: {Path}");
+
+        // The rebuild produced the current model's shape (EnsureCreated above). Stamp the canonical user_version so the
+        // database is recognized as current on the next open.
+        StampCanonicalUserVersion();
+    }
+
+    private void RunUnderSchemaLock(TimeSpan timeout, Action action)
+    {
+        try
+        {
+            _schemaLock.Run(timeout, action);
+        }
+        catch (TimeoutException ex)
+        {
+            // Surface a lock-acquisition timeout as the domain transient exception so every schema entry point
+            // (probe, create, upgrade) fails the same recoverable way instead of leaking a raw TimeoutException.
+            throw new SchemaLockTimeoutException(Path, ex);
+        }
     }
 
     private void StampCanonicalUserVersion()

--- a/src/EventLogExpert.Provider/Schema/SchemaLockTimeoutException.cs
+++ b/src/EventLogExpert.Provider/Schema/SchemaLockTimeoutException.cs
@@ -1,0 +1,22 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Provider.Schema;
+
+/// <summary>
+///     Thrown when a schema probe could not acquire the cross-process schema lock within its timeout - typically
+///     because another process is mid-upgrade. Callers must treat this as transient/retryable (re-probe later), never
+///     mapping it to a definitive classification such as Unknown, UnrecognizedSchema, or NeedsUpgrade.
+/// </summary>
+public sealed class SchemaLockTimeoutException : Exception
+{
+    public SchemaLockTimeoutException(string databasePath)
+        : base($"Timed out acquiring the schema lock for '{databasePath}'; another process may be upgrading it.") =>
+        DatabasePath = databasePath;
+
+    public SchemaLockTimeoutException(string databasePath, Exception innerException)
+        : base($"Timed out acquiring the schema lock for '{databasePath}'; another process may be upgrading it.", innerException) =>
+        DatabasePath = databasePath;
+
+    public string DatabasePath { get; }
+}

--- a/src/EventLogExpert.Runtime/Common/Activation/IActivationDispatcher.cs
+++ b/src/EventLogExpert.Runtime/Common/Activation/IActivationDispatcher.cs
@@ -6,9 +6,9 @@ using EventLogExpert.Eventing.Common.Channels;
 namespace EventLogExpert.Runtime.Common.Activation;
 
 /// <summary>
-///     Buffers Windows shell activation requests (cold-launch, redirected secondary-instance, folder right-click) so
-///     first-activation args delivered before the UI consumer attaches are not lost. <see cref="StartConsumingAsync" /> is
-///     idempotent (guarded by <see cref="Interlocked" />) — safe to call from both <c>MainPage</c>'s constructor and
+///     Buffers Windows shell activation requests (cold-launch, command-line, folder right-click) so first-activation
+///     args delivered before the UI consumer attaches are not lost. <see cref="StartConsumingAsync" /> is idempotent
+///     (guarded by <see cref="Interlocked" />) — safe to call from both <c>MainPage</c>'s constructor and
 ///     <c>BlazorWebViewInitialized</c> so a missing WebView2 runtime does not strand buffered args.
 /// </summary>
 public interface IActivationDispatcher

--- a/src/EventLogExpert.Runtime/Database/DatabaseFileOperations.cs
+++ b/src/EventLogExpert.Runtime/Database/DatabaseFileOperations.cs
@@ -96,6 +96,16 @@ internal static class DatabaseFileOperations
         {
             return !maintenance.CheckSchemaState(fullPath, readOnly: true).NeedsUpgrade;
         }
+        catch (SchemaLockTimeoutException ex)
+        {
+            // Inconclusive, not a failure: a concurrent process holds the schema lock, so the state can't be re-probed
+            // right now. The sole caller is the post-upgrade verify, where treating this as not-ready would roll back a
+            // just-completed upgrade; the entry is re-classified on the next pass instead.
+            SafeLog(() => traceLogger.Warning(
+                $"{nameof(DatabaseFileOperations)}.{nameof(VerifyEntryReady)}: '{fullPath}' schema lock busy during verify: {ex.Message}"));
+
+            return true;
+        }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             SafeLog(() => traceLogger.Warning(

--- a/src/EventLogExpert.Runtime/FilterLibrary/FilterLibrarySqliteStore.cs
+++ b/src/EventLogExpert.Runtime/FilterLibrary/FilterLibrarySqliteStore.cs
@@ -3,6 +3,7 @@
 
 using EventLogExpert.Filtering.Persistence;
 using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Logging.Concurrency;
 using EventLogExpert.Runtime.Banner;
 using Microsoft.Data.Sqlite;
 using System.Collections.Immutable;
@@ -104,11 +105,14 @@ internal sealed class FilterLibrarySqliteStore : IFilterLibraryStore
         ("tags", "TEXT NULL"),
     ];
 
+    private static readonly TimeSpan s_schemaLockTimeout = TimeSpan.FromSeconds(30);
+
     private readonly string _connectionString;
     private readonly string _dbPath;
     private readonly IErrorBannerService? _errorBannerService;
     private readonly ITraceLogger _logger;
 
+    private int _schemaInitialized;
     private int _systemicUnloadableReported;
 
     public FilterLibrarySqliteStore(string dbPath, ITraceLogger logger, IErrorBannerService? errorBannerService = null)
@@ -494,16 +498,16 @@ internal sealed class FilterLibrarySqliteStore : IFilterLibraryStore
         };
     }
 
-    private static async Task EnsureSchemaColumnsAsync(SqliteConnection connection, CancellationToken cancellationToken)
+    private static void EnsureSchemaColumns(SqliteConnection connection)
     {
         var existing = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        await using (var probe = connection.CreateCommand())
+        using (var probe = connection.CreateCommand())
         {
             probe.CommandText = "PRAGMA table_info(library_entries);";
-            await using var reader = await probe.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            using var reader = probe.ExecuteReader();
 
-            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            while (reader.Read())
             {
                 existing.Add(reader.GetString(1));
             }
@@ -513,15 +517,41 @@ internal sealed class FilterLibrarySqliteStore : IFilterLibraryStore
         {
             if (existing.Contains(column)) { continue; }
 
-            await using var alter = connection.CreateCommand();
+            using var alter = connection.CreateCommand();
             alter.CommandText = $"ALTER TABLE library_entries ADD COLUMN {column} {definition};";
-            await alter.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+
+            try
+            {
+                alter.ExecuteNonQuery();
+            }
+            catch (SqliteException ex) when (IsDuplicateColumn(ex))
+            {
+                // Another instance added this column between the probe and the ALTER (reachable only when the
+                // interprocess mutex is degraded); the column now exists, which is the intended end state.
+            }
         }
 
-        await using var indexCmd = connection.CreateCommand();
+        using var indexCmd = connection.CreateCommand();
         indexCmd.CommandText = CreateUniqueIndexSql;
-        await indexCmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        indexCmd.ExecuteNonQuery();
     }
+
+    private static void InitializeSchema(SqliteConnection connection)
+    {
+        using (var schemaCmd = connection.CreateCommand())
+        {
+            schemaCmd.CommandText = CreateTableSql;
+            schemaCmd.ExecuteNonQuery();
+        }
+
+        EnsureSchemaColumns(connection);
+    }
+
+    // SQLITE_ERROR (1) with this message text is the only duplicate-column signal; matching narrowly so real
+    // schema faults (disk full, corruption, locked) still propagate.
+    private static bool IsDuplicateColumn(SqliteException ex) =>
+        ex.SqliteErrorCode == 1 &&
+        ex.Message.Contains("duplicate column name", StringComparison.OrdinalIgnoreCase);
 
     private static LibraryEntryOrigin ParseOrigin(string raw) =>
         Enum.TryParse<LibraryEntryOrigin>(raw, ignoreCase: false, out var parsed)
@@ -582,6 +612,31 @@ internal sealed class FilterLibrarySqliteStore : IFilterLibraryStore
         }
     }
 
+    private void EnsureSchemaInitialized(SqliteConnection connection)
+    {
+        if (Volatile.Read(ref _schemaInitialized) != 0) { return; }
+
+        // Local, once-per-process: the mutex is only contended during the first-open race after an app update adds a
+        // column; every later open short-circuits on the flag without touching the mutex.
+        using var schemaMutex = new InterProcessMutex("FilterLibrarySchema", _dbPath);
+
+        // Prefer the cross-process lock, but the schema DDL is idempotent (CREATE ... IF NOT EXISTS + duplicate-column
+        // tolerance), so if the mutex is unavailable or contended we still initialize - unguarded execution is safe here.
+        var ranUnderLock = schemaMutex.TryRun(s_schemaLockTimeout, () =>
+        {
+            if (Volatile.Read(ref _schemaInitialized) != 0) { return; }
+
+            InitializeSchema(connection);
+        });
+
+        if (!ranUnderLock)
+        {
+            InitializeSchema(connection);
+        }
+
+        Volatile.Write(ref _schemaInitialized, 1);
+    }
+
     private async Task<SqliteConnection> OpenConnectionAsync(CancellationToken cancellationToken)
     {
         var dir = Path.GetDirectoryName(_dbPath);
@@ -595,13 +650,7 @@ internal sealed class FilterLibrarySqliteStore : IFilterLibraryStore
             connection = new SqliteConnection(_connectionString);
             await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
-            await using (var schemaCmd = connection.CreateCommand())
-            {
-                schemaCmd.CommandText = CreateTableSql;
-                await schemaCmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-            }
-
-            await EnsureSchemaColumnsAsync(connection, cancellationToken).ConfigureAwait(false);
+            EnsureSchemaInitialized(connection);
 
             var result = connection;
             connection = null;

--- a/src/EventLogExpert.Runtime/FilterLibrary/FilterLibrarySqliteStore.cs
+++ b/src/EventLogExpert.Runtime/FilterLibrary/FilterLibrarySqliteStore.cs
@@ -612,9 +612,11 @@ internal sealed class FilterLibrarySqliteStore : IFilterLibraryStore
         }
     }
 
-    private void EnsureSchemaInitialized(SqliteConnection connection)
+    private void EnsureSchemaInitialized(SqliteConnection connection, CancellationToken cancellationToken)
     {
         if (Volatile.Read(ref _schemaInitialized) != 0) { return; }
+
+        cancellationToken.ThrowIfCancellationRequested();
 
         // Local, once-per-process: the mutex is only contended during the first-open race after an app update adds a
         // column; every later open short-circuits on the flag without touching the mutex.
@@ -626,11 +628,13 @@ internal sealed class FilterLibrarySqliteStore : IFilterLibraryStore
         {
             if (Volatile.Read(ref _schemaInitialized) != 0) { return; }
 
+            cancellationToken.ThrowIfCancellationRequested();
             InitializeSchema(connection);
         });
 
         if (!ranUnderLock)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             InitializeSchema(connection);
         }
 
@@ -650,7 +654,7 @@ internal sealed class FilterLibrarySqliteStore : IFilterLibraryStore
             connection = new SqliteConnection(_connectionString);
             await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
-            EnsureSchemaInitialized(connection);
+            EnsureSchemaInitialized(connection, cancellationToken);
 
             var result = connection;
             connection = null;

--- a/src/EventLogExpert/EventLogExpert.csproj
+++ b/src/EventLogExpert/EventLogExpert.csproj
@@ -28,9 +28,9 @@
     </PropertyGroup>
 
     <!-- Suppress MAUI's source-generated Windows Main on the Windows TFM so our handwritten
-         Platforms\Windows\Program.cs takes over. Required to intercept activation BEFORE
-         Application.Start() runs (AppInstance single-instance contract). Also embed app.manifest
-         so the exe is long-path-aware (filesystem operations against >MAX_PATH paths). -->
+         Platforms\Windows\Program.cs takes over. Required to capture the shell activation args and
+         seed them BEFORE Application.Start() builds the app. Also embed app.manifest so the exe is
+         long-path-aware (filesystem operations against >MAX_PATH paths). -->
     <PropertyGroup Condition="$(TargetFramework.Contains('-windows'))">
         <DefineConstants>$(DefineConstants);DISABLE_XAML_GENERATED_MAIN</DefineConstants>
         <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/src/EventLogExpert/Platforms/Windows/Activation/ActivationBootstrap.cs
+++ b/src/EventLogExpert/Platforms/Windows/Activation/ActivationBootstrap.cs
@@ -8,10 +8,10 @@ using System.Collections.Concurrent;
 namespace EventLogExpert.Platforms.Windows.Activation;
 
 /// <summary>
-///     Bridges <c>Program.Main</c> (sees cold-launch + <see cref="AppInstance.Activated" /> before DI is built) and
-///     the <see cref="IActivationDispatcher" /> singleton (constructed by MAUI DI). Buffered args live in a thread-safe
-///     queue because <see cref="AppInstance.Activated" /> fires on a background thread while
-///     <see cref="AttachDispatcher" /> runs on the DI construction thread.
+///     Bridges <c>Program.Main</c> (captures the cold-launch activation args before DI is built) and the
+///     <see cref="IActivationDispatcher" /> singleton (constructed by MAUI DI). Seeded args are buffered until
+///     <see cref="AttachDispatcher" /> runs on the DI construction thread and drains them, so args delivered before the UI
+///     consumer exists are not lost.
 /// </summary>
 internal static class ActivationBootstrap
 {
@@ -33,11 +33,6 @@ internal static class ActivationBootstrap
                 dispatcher.Enqueue(args);
             }
         }
-    }
-
-    internal static void EnqueueRedirected(AppActivationArguments? redirected)
-    {
-        EnqueueArgs(ActivationArgsExtractor.Extract(redirected));
     }
 
     internal static void SeedColdLaunch(AppActivationArguments? coldLaunch)

--- a/src/EventLogExpert/Platforms/Windows/Package.appxmanifest
+++ b/src/EventLogExpert/Platforms/Windows/Package.appxmanifest
@@ -59,9 +59,10 @@
               <!-- FTA "Open with EventLogExpert" verb. Surfaces in the Open With submenu; the
                    top-level right-click entry comes from the desktop4:fileExplorerContextMenus
                    block below, not from this verb.
-                   MultiSelectModel="Player" fans a multi-select into one activation — combined
-                   with AppInstance single-instancing in Platforms\Windows\Program.cs, N selected
-                   .evtx files open in one window.
+                   MultiSelectModel="Player" fans a multi-select into a single activation carrying all
+                   selected files, so N selected .evtx files open together in one new window. This is
+                   independent of process instancing (the app is multi-instance): a separate open
+                   launches its own window; only drag-and-drop adds logs to an existing one.
                    MultiSelectModel is unprefixed because the namespaced uap3:MultiSelectModel
                    form fails MSIX deployment schema validation (DEP0700 / 0xC00CE015). -->
               <uap3:Verb Id="open" MultiSelectModel="Player">Open with EventLogExpert</uap3:Verb>

--- a/src/EventLogExpert/Platforms/Windows/Program.cs
+++ b/src/EventLogExpert/Platforms/Windows/Program.cs
@@ -11,34 +11,24 @@ namespace EventLogExpert.WinUI;
 
 /// <summary>
 ///     Handwritten WinUI entry point. Replaces MAUI's source-generated <c>Main</c> (suppressed via
-///     <c>DISABLE_XAML_GENERATED_MAIN</c> in the csproj's Windows TFM) so activation interception can run BEFORE
-///     <see cref="Application.Start(Microsoft.UI.Xaml.ApplicationInitializationCallback)" /> — the only place the
-///     <see cref="AppInstance.FindOrRegisterForKey(string)" /> single-instance contract permits.
+///     <c>DISABLE_XAML_GENERATED_MAIN</c> in the csproj's Windows TFM) so the shell activation args (cold launch, file, or
+///     command line) can be captured via <see cref="AppInstance.GetCurrent" /> and seeded into
+///     <see cref="ActivationBootstrap" /> BEFORE
+///     <see cref="Application.Start(Microsoft.UI.Xaml.ApplicationInitializationCallback)" /> builds the app. Each launch
+///     runs as its own instance and window; the app is intentionally not single-instanced, so a separate open (context
+///     menu, double-click, Open With) always creates a new window while only drag-and-drop adds logs to an existing one.
 /// </summary>
 internal static class Program
 {
     [STAThread]
     private static int Main(string[] args)
     {
-        // Activation args are re-fetched from AppInstance below; the entry-point parameter is unused.
+        // Activation args are fetched from AppInstance below; the entry-point parameter is unused.
         _ = args;
         XamlCheckProcessRequirements();
         ComWrappersSupport.InitializeComWrappers();
 
         var activationArgs = AppInstance.GetCurrent().GetActivatedEventArgs();
-        var keyInstance = AppInstance.FindOrRegisterForKey("eventlogexpert-main");
-
-        if (!keyInstance.IsCurrent)
-        {
-            keyInstance.RedirectActivationToAsync(activationArgs).AsTask().GetAwaiter().GetResult();
-
-            return 0;
-        }
-
-        // Subscribe BEFORE SeedColdLaunch so the gap between FindOrRegisterForKey returning and the
-        // Activated handler being attached is a single statement wide. AppInstance.Activated does
-        // not buffer; redirects landing in the gap would be silently dropped.
-        keyInstance.Activated += (_, eventArgs) => ActivationBootstrap.EnqueueRedirected(eventArgs);
         ActivationBootstrap.SeedColdLaunch(activationArgs);
 
         // Non-static lambda: avoids the static-anonymous-function-cannot-reference-discard

--- a/tests/Unit/EventLogExpert.Logging.Tests/Concurrency/InterProcessFileLockTests.cs
+++ b/tests/Unit/EventLogExpert.Logging.Tests/Concurrency/InterProcessFileLockTests.cs
@@ -70,6 +70,49 @@ public sealed class InterProcessFileLockTests : IDisposable
     }
 
     [Fact]
+    public void TryRun_InfiniteTimeout_WaitsForHeldLockThenAcquires()
+    {
+        var target = TargetPath();
+        var first = new InterProcessFileLock("ProviderDbSchema", target);
+        var second = new InterProcessFileLock("ProviderDbSchema", target);
+
+        using var acquired = new ManualResetEventSlim(false);
+        using var release = new ManualResetEventSlim(false);
+
+        var holder = StartHolder(first, acquired, release, TestContext.Current.CancellationToken);
+
+        Assert.True(acquired.Wait(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken));
+
+        // Release the holder shortly after; an infinite-timeout acquire must WAIT for the release rather than
+        // treating the -1ms TimeSpan as an already-expired deadline and returning false.
+        var releaser = new Thread(() =>
+        {
+            Thread.Sleep(300);
+            release.Set();
+        });
+        releaser.Start();
+
+        var ranAgain = false;
+        Assert.True(second.TryRun(Timeout.InfiniteTimeSpan, () => ranAgain = true));
+        Assert.True(ranAgain);
+
+        holder.Join();
+        releaser.Join();
+    }
+
+    [Theory]
+    [InlineData(-20000)] // -2ms
+    [InlineData(-15000)] // -1.5ms: a naive (long)TotalMilliseconds cast truncates to -1 (== infinite) and slips through.
+    [InlineData(-1)]     // -1 tick: a naive cast truncates to 0 (== try-once) and slips through.
+    public void TryRun_NegativeTimeoutBelowInfinite_ThrowsArgumentOutOfRange(long ticks)
+    {
+        var fileLock = new InterProcessFileLock("ProviderDbSchema", TargetPath());
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => fileLock.TryRun(TimeSpan.FromTicks(ticks), static () => { }));
+    }
+
+    [Fact]
     public void TryRun_TwoInstancesSamePath_SecondBlockedWhileFirstHolds_ThenSucceeds()
     {
         var target = TargetPath();

--- a/tests/Unit/EventLogExpert.Logging.Tests/Concurrency/InterProcessFileLockTests.cs
+++ b/tests/Unit/EventLogExpert.Logging.Tests/Concurrency/InterProcessFileLockTests.cs
@@ -1,0 +1,113 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Logging.Concurrency;
+
+namespace EventLogExpert.Logging.Tests.Concurrency;
+
+public sealed class InterProcessFileLockTests : IDisposable
+{
+    private readonly string _directory =
+        Path.Combine(Path.GetTempPath(), $"elx-filelock-{Guid.NewGuid():N}");
+
+    public InterProcessFileLockTests() => Directory.CreateDirectory(_directory);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_directory, recursive: true); }
+        catch (IOException) { /* best-effort cleanup */ }
+        catch (UnauthorizedAccessException) { /* best-effort cleanup */ }
+    }
+
+    [Fact]
+    public void Run_ReleasesLockBetweenSequentialCalls()
+    {
+        var target = TargetPath();
+        var fileLock = new InterProcessFileLock("ProviderDbSchema", target);
+
+        fileLock.Run(TimeSpan.FromSeconds(5), static () => { });
+
+        // A second sequential acquisition must succeed, proving the handle was released on the first Run's completion.
+        var ranAgain = false;
+        fileLock.Run(TimeSpan.FromSeconds(5), () => ranAgain = true);
+
+        Assert.True(ranAgain);
+    }
+
+    [Fact]
+    public void Run_RunsActionAndLeavesSentinelFileOnDisk()
+    {
+        var target = TargetPath();
+        var lockPath = $"{target}.ProviderDbSchema.lock";
+        var fileLock = new InterProcessFileLock("ProviderDbSchema", target);
+
+        var ran = false;
+        fileLock.Run(TimeSpan.FromSeconds(5), () => ran = true);
+
+        Assert.True(ran);
+
+        // The sentinel is deliberately never deleted (deleting it would open a pending-deletion race).
+        Assert.True(File.Exists(lockPath));
+    }
+
+    [Fact]
+    public void Run_WhenHeldByAnotherInstance_ThrowsOnTimeout()
+    {
+        var target = TargetPath();
+        var first = new InterProcessFileLock("ProviderDbSchema", target);
+        var second = new InterProcessFileLock("ProviderDbSchema", target);
+
+        using var acquired = new ManualResetEventSlim(false);
+        using var release = new ManualResetEventSlim(false);
+
+        var holder = StartHolder(first, acquired, release, TestContext.Current.CancellationToken);
+
+        Assert.True(acquired.Wait(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken));
+        Assert.Throws<TimeoutException>(() => second.Run(TimeSpan.FromMilliseconds(300), static () => { }));
+
+        release.Set();
+        holder.Join();
+    }
+
+    [Fact]
+    public void TryRun_TwoInstancesSamePath_SecondBlockedWhileFirstHolds_ThenSucceeds()
+    {
+        var target = TargetPath();
+        var first = new InterProcessFileLock("ProviderDbSchema", target);
+        var second = new InterProcessFileLock("ProviderDbSchema", target);
+
+        using var acquired = new ManualResetEventSlim(false);
+        using var release = new ManualResetEventSlim(false);
+
+        var holder = StartHolder(first, acquired, release, TestContext.Current.CancellationToken);
+
+        Assert.True(acquired.Wait(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken));
+        Assert.False(second.TryRun(TimeSpan.FromMilliseconds(300), static () => { }));
+
+        release.Set();
+        holder.Join();
+
+        // The lock is released when the holder's stream is disposed, so the second instance can now acquire it.
+        Assert.True(second.TryRun(TimeSpan.FromSeconds(10), static () => { }));
+    }
+
+    private static Thread StartHolder(
+        InterProcessFileLock fileLock,
+        ManualResetEventSlim acquired,
+        ManualResetEventSlim release,
+        CancellationToken cancellationToken)
+    {
+        var holder = new Thread(() => fileLock.Run(TimeSpan.FromSeconds(10), () =>
+        {
+            acquired.Set();
+            release.Wait(TimeSpan.FromSeconds(10), cancellationToken);
+        }));
+
+        holder.Start();
+
+        return holder;
+    }
+
+    private string TargetPath() =>
+        Path.Combine(_directory, $"{Guid.NewGuid():N}.db");
+}

--- a/tests/Unit/EventLogExpert.Logging.Tests/Concurrency/InterProcessMutexTests.cs
+++ b/tests/Unit/EventLogExpert.Logging.Tests/Concurrency/InterProcessMutexTests.cs
@@ -1,0 +1,132 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Logging.Concurrency;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace EventLogExpert.Logging.Tests.Concurrency;
+
+public sealed class InterProcessMutexTests
+{
+    [Fact]
+    public void DeriveName_DebugLogScope_MatchesLegacyFileLogSinkFormat()
+    {
+        var path = @"C:\Logs\EventLogExpert\debug.log";
+
+        var canonical = Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var expectedHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(canonical.ToUpperInvariant())), 0, 8);
+        var expected = $"Local\\EventLogExpert.DebugLog.{expectedHash}";
+
+        Assert.Equal(expected, InterProcessMutex.DeriveName("DebugLog", path));
+    }
+
+    [Fact]
+    public void DeriveName_DifferentScopes_ProduceDifferentNames()
+    {
+        var first = InterProcessMutex.DeriveName("ScopeA", @"C:\a\b");
+        var second = InterProcessMutex.DeriveName("ScopeB", @"C:\a\b");
+
+        Assert.NotEqual(first, second);
+    }
+
+    [Fact]
+    public void DeriveName_EquivalentPaths_ProduceSameName()
+    {
+        var withoutSeparator = InterProcessMutex.DeriveName("Scope", @"C:\a\b");
+        var withSeparator = InterProcessMutex.DeriveName("Scope", @"C:\a\b\");
+
+        Assert.Equal(withoutSeparator, withSeparator);
+    }
+
+    [Fact]
+    public void Run_WhenHeldByAnotherInstance_ThrowsOnTimeout()
+    {
+        var key = UniqueKey();
+
+        using var first = new InterProcessMutex("MutexScope", key);
+        using var second = new InterProcessMutex("MutexScope", key);
+        using var acquired = new ManualResetEventSlim(false);
+        using var release = new ManualResetEventSlim(false);
+
+        var holder = StartHolder(first, acquired, release, TestContext.Current.CancellationToken);
+
+        Assert.True(acquired.Wait(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken));
+        Assert.Throws<TimeoutException>(() => second.Run(TimeSpan.FromMilliseconds(300), static () => { }));
+
+        release.Set();
+        holder.Join();
+    }
+
+    [Fact]
+    public void TryRun_AfterMutexAbandonedByDeadThread_Recovers()
+    {
+        var key = UniqueKey();
+        var name = InterProcessMutex.DeriveName("AbandonScope", key);
+
+        // Keep the named object alive across the owning thread's death so the abandoned state (not object destruction)
+        // is what the next acquirer observes.
+        using var keepAlive = new Mutex(false, name);
+
+        var owningThread = new Thread(() =>
+        {
+            var owner = new Mutex(false, name);
+            owner.WaitOne();
+
+            // Exit while still owning -> Windows marks the mutex abandoned.
+        });
+
+        owningThread.Start();
+        owningThread.Join();
+
+        using var mutex = new InterProcessMutex("AbandonScope", key);
+        var ran = false;
+
+        Assert.True(mutex.TryRun(TimeSpan.FromSeconds(5), () => ran = true));
+        Assert.True(ran);
+    }
+
+    [Fact]
+    public void TryRun_TwoInstancesSameName_SecondBlockedWhileFirstHolds_ThenSucceeds()
+    {
+        var key = UniqueKey();
+
+        using var first = new InterProcessMutex("MutexScope", key);
+        using var second = new InterProcessMutex("MutexScope", key);
+        using var acquired = new ManualResetEventSlim(false);
+        using var release = new ManualResetEventSlim(false);
+
+        var holder = StartHolder(first, acquired, release, TestContext.Current.CancellationToken);
+
+        Assert.True(acquired.Wait(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken));
+
+        // Separate handle to the same named kernel object cannot acquire while the first holds it - proving true
+        // interprocess coordination rather than an in-process lock.
+        Assert.False(second.TryRun(TimeSpan.FromMilliseconds(300), static () => { }));
+
+        release.Set();
+        holder.Join();
+
+        Assert.True(second.TryRun(TimeSpan.FromSeconds(10), static () => { }));
+    }
+
+    private static Thread StartHolder(
+        InterProcessMutex mutex,
+        ManualResetEventSlim acquired,
+        ManualResetEventSlim release,
+        CancellationToken cancellationToken)
+    {
+        var holder = new Thread(() => mutex.Run(TimeSpan.FromSeconds(10), () =>
+        {
+            acquired.Set();
+            release.Wait(TimeSpan.FromSeconds(10), cancellationToken);
+        }));
+
+        holder.Start();
+
+        return holder;
+    }
+
+    private static string UniqueKey() =>
+        Path.Combine(Path.GetTempPath(), $"elx-mutex-{Guid.NewGuid():N}");
+}


### PR DESCRIPTION
## Summary

Fixes a regression where the app could no longer open more than one instance, and hardens the database schema-migration paths that concurrent instances can now reach.

### Part 1: Multi-instance launching
The handwritten WinUI entry point (`Program.Main`) was registering the process as single-instance via `AppInstance.FindOrRegisterForKey` and redirecting every subsequent launch into the first instance. Removing that restores per-launch windows:
- A separate right-click / double-click / "Open With" launches a **new** window.
- A multi-select right-click still opens the selection together in **one** new window (the shell extension already batches the selection into a single launch).
- Drag-and-drop remains the only path that adds logs to an existing window.

### Part 2: Cross-process schema-migration guards
With concurrent instances now possible, the SQLite schema paths needed cross-process coordination. Two primitives were added in `EventLogExpert.Logging.Concurrency`:
- `InterProcessMutex` - a named mutex for same-user (medium-integrity) coordination. `FileLogSink` is refactored onto it, and it guards the filter-library schema DDL.
- `InterProcessFileLock` - a sentinel-file lock that works across integrity levels (governed by file DACLs, not the mandatory integrity label), so a medium-IL app instance and the high-IL elevated helper coordinate on provider-database schema create/upgrade.

`ProviderDbContext` splits its upgrade probe into a lock-free core (used inside the held upgrade lock) and a public lock-taking probe (external readers), routes every schema entry point through the file lock, and refuses to recreate tables over a crashed mid-upgrade backup. A transient lock-timeout surfaces as `SchemaLockTimeoutException`, handled as a retryable/skip outcome by every caller rather than misclassifying the database.

### Testing
- 5 new unit tests for the concurrency primitives (log-mutex name byte-parity, cross-instance exclusion, abandoned-mutex recovery, timeout semantics, never-deleted sentinel).
- Full existing suite green: 2000+ tests across Logging, Eventing, Provider(.Database), Runtime, DatabaseTools, and the ElevationHelper integration tests (which exercise the file lock through a genuinely separate elevated process). MAUI head compiles.
