### PR TITLE
Fix EventColumnView._byKey unsafe publication; add sort tie-break tests

### DIFF
--- a/src/EventLogExpert.Runtime/LogTable/EventColumnView.cs
+++ b/src/EventLogExpert.Runtime/LogTable/EventColumnView.cs
@@ -60,7 +60,15 @@ internal sealed class EventColumnView : IEventColumnView
 
     public EventLocator? ResolveByKey(ValueKey key)
     {
-        var byKey = _byKey ??= BuildByKey();
+        var byKey = Volatile.Read(ref _byKey);
+
+        if (byKey is null)
+        {
+            byKey = BuildByKey();
+
+            // First writer wins; a racing reader either sees null (and builds its own discarded copy) or a complete map.
+            byKey = Interlocked.CompareExchange(ref _byKey, byKey, null) ?? byKey;
+        }
 
         return byKey.TryGetValue(key, out int physical) ? _reader.LocatorAt(physical) : null;
     }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/ColumnDirectSortKernelTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/ColumnDirectSortKernelTests.cs
@@ -24,7 +24,6 @@ public sealed class ColumnDirectSortKernelTests(ITestOutputHelper output)
     private static readonly ColumnName[] s_allColumns = Enum.GetValues<ColumnName>();
     private static readonly bool[] s_bools = [false, true];
     private static readonly IReadOnlyList<SortConfig> s_allConfigs = BuildAllConfigs();
-
     private static readonly IReadOnlyList<ResolvedEvent> s_edgeCorpus = BuildEdgeCorpus();
     private static readonly IReadOnlyList<ResolvedEvent> s_tieBurstCorpus = BuildTieBurstCorpus();
 
@@ -75,6 +74,61 @@ public sealed class ColumnDirectSortKernelTests(ITestOutputHelper output)
         _ = AosReferenceOrdering.Order(corpus, ColumnName.DateAndTime, isDescending: true).Length;
         baseline.Stop();
         _output.WriteLine($"AosReferenceOrdering.Order (reference baseline, DateAndTime desc): {baseline.ElapsedMilliseconds} ms for {eventCount:N0} events");
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void SortColumnDirect_FullTieCorpus_ReordersToAscendingIndexTieBreak_RegardlessOfDescending(bool isDescending)
+    {
+        // Four byte-identical events with a null RecordId in one OwningLog: the whole chain (RecordId, time, OwningLog)
+        // ties, so only the final physical-index tie-break separates rows. The survivors are handed in DESCENDING index
+        // order, so the expected ascending result can ONLY come from the tie-break actively reordering - the test fails if
+        // WithIndexTieBreak is broken to return 0 (a pre-sorted input would leave it a placebo). That tie-break is ascending
+        // and never negated, so a descending order still lands ascending physical index.
+        var when = new DateTime(2024, 3, 3, 3, 3, 3, DateTimeKind.Utc);
+        IReadOnlyList<ResolvedEvent> corpus =
+        [
+            FilterEventBuilder.CreateTestEvent(id: 9, source: "Same", level: "Same", timeCreated: when, owningLog: "L"),
+            FilterEventBuilder.CreateTestEvent(id: 9, source: "Same", level: "Same", timeCreated: when, owningLog: "L"),
+            FilterEventBuilder.CreateTestEvent(id: 9, source: "Same", level: "Same", timeCreated: when, owningLog: "L"),
+            FilterEventBuilder.CreateTestEvent(id: 9, source: "Same", level: "Same", timeCreated: when, owningLog: "L")
+        ];
+        var reader = NewReader(corpus);
+        int[] survivors = [3, 2, 1, 0];
+
+        int[] order = ResolvedEventOrdering.SortColumnDirect(
+            reader, survivors, ColumnName.DateAndTime, isDescending, groupBy: null, isGroupDescending: false);
+
+        Assert.Equal(new[] { 0, 1, 2, 3 }, order);
+    }
+
+    [Theory]
+    [InlineData(false, false, new[] { 0, 1, 2, 3 })]
+    [InlineData(true, false, new[] { 1, 0, 3, 2 })]
+    [InlineData(false, true, new[] { 2, 3, 0, 1 })]
+    [InlineData(true, true, new[] { 3, 2, 1, 0 })]
+    public void SortColumnDirect_GroupedChain_NegatesGroupAndWithinOrderIndependently(
+        bool isWithinDescending, bool isGroupDescending, int[] expectedOrder)
+    {
+        // Two Source groups (Alpha < Beta ordinally), two distinct RecordIds within each. With groupBy=Source and
+        // orderBy=RecordId the two GroupedChain negations are isolated: the group order flips with isGroupDescending and
+        // the within-group order flips with isDescending, independently. These direct expected orders guard the two
+        // -Math.Sign(...) sites in GroupedChain without routing through the AoS parity oracle.
+        var when = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        IReadOnlyList<ResolvedEvent> corpus =
+        [
+            FilterEventBuilder.CreateTestEvent(id: 1, recordId: 1, source: "Alpha", timeCreated: when, owningLog: "L"),
+            FilterEventBuilder.CreateTestEvent(id: 1, recordId: 2, source: "Alpha", timeCreated: when, owningLog: "L"),
+            FilterEventBuilder.CreateTestEvent(id: 1, recordId: 3, source: "Beta", timeCreated: when, owningLog: "L"),
+            FilterEventBuilder.CreateTestEvent(id: 1, recordId: 4, source: "Beta", timeCreated: when, owningLog: "L")
+        ];
+        var reader = NewReader(corpus);
+
+        int[] order = ResolvedEventOrdering.SortColumnDirect(
+            reader, AllIndices(corpus.Count), ColumnName.RecordId, isWithinDescending, ColumnName.Source, isGroupDescending);
+
+        Assert.Equal(expectedOrder, order);
     }
 
     [Fact]


### PR DESCRIPTION
**What** — Fixes an unsafe-publication data race in `EventColumnView._byKey` and adds two direct sort-kernel regression tests.

**Why** — `ResolveByKey` published the lazily-built `_byKey` dictionary via `_byKey ??= BuildByKey()` with no memory barrier — unlike every sibling M6 cache (`TemplateFieldSchema`, `CombinedColumnView._index`, the column store/pool) which use `Volatile`/`Interlocked`/`Lock`. Under concurrent `ResolveByKey`, a reader could observe the non-null reference before the dictionary's internal writes are visible on a weak-memory CPU (ARM64) — yielding a wrong/absent result or a throw.

**Fix** — Publish via `Volatile.Read` + `Interlocked.CompareExchange(ref _byKey, byKey, null)` (mirrors `TemplateFieldSchema.GetOrBuildIndex`). `BuildByKey` is idempotent over the immutable order, so a benign build-race is harmless.

**Tests** — grouped group/within-order negation (pins the two `-Math.Sign` sites independently of the AoS parity oracle); full-tie corpus with a reversed survivor input, so the ascending physical-index tie-break must actively reorder regardless of descending (mutation-verified: the test fails when `WithIndexTieBreak` is broken).

**Validation** — Full `EventLogExpert.Runtime.Tests`: 1641/1641 pass. Surfaced by a post-release audit of the M6 columnar store; the race is latent today (`ResolveByKey` has no production caller yet — only parity tests).