### PR TITLE
Add a reversible filter lens stack with Show Related by Activity ID

### DIFF
--- a/src/EventLogExpert.Runtime/DependencyInjection/RuntimeServiceCollectionExtensions.cs
+++ b/src/EventLogExpert.Runtime/DependencyInjection/RuntimeServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ using EventLogExpert.Runtime.DatabaseTools.Elevation;
 using EventLogExpert.Runtime.DebugLog;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.Runtime.Export;
+using EventLogExpert.Runtime.FilterLenses;
 using EventLogExpert.Runtime.FilterLibrary;
 using EventLogExpert.Runtime.FilterPane;
 using EventLogExpert.Runtime.LogTable;
@@ -163,6 +164,7 @@ public static class RuntimeServiceCollectionExtensions
 
             // Command facades.
             services.AddSingleton<IEventLogCommands, EventLogCommands>();
+            services.AddSingleton<IFilterLensCommands, FilterLensCommands>();
             services.AddSingleton<IFilterLibraryCommands, FilterLibraryCommands>();
             services.AddSingleton<IFilterPaneCommands, FilterPaneCommands>();
             services.AddSingleton<ILogTableCommands, LogTableCommands>();

--- a/src/EventLogExpert.Runtime/EventLog/EventLogCommands.cs
+++ b/src/EventLogExpert.Runtime/EventLog/EventLogCommands.cs
@@ -13,7 +13,13 @@ internal sealed class EventLogCommands(IDispatcher dispatcher) : IEventLogComman
 
     public void CloseAllLogs() => _dispatcher.Dispatch(new CloseAllLogsAction());
 
-    public void CloseLog(EventLogId logId, string logName) => _dispatcher.Dispatch(new CloseLogAction(logId, logName));
+    // Emits the user-close discriminator alongside the close so lens lifecycle (and any other user-close-only subscriber)
+    // can distinguish a genuine tab close from a filter-driven reload, which dispatches CloseLogAction directly.
+    public void CloseLog(EventLogId logId, string logName)
+    {
+        _dispatcher.Dispatch(new CloseLogAction(logId, logName));
+        _dispatcher.Dispatch(new LogClosedByUserAction(logId, logName));
+    }
 
     public void LoadNewEvents() => _dispatcher.Dispatch(new LoadNewEventsAction());
 

--- a/src/EventLogExpert.Runtime/EventLog/LogClosedByUserAction.cs
+++ b/src/EventLogExpert.Runtime/EventLog/LogClosedByUserAction.cs
@@ -1,0 +1,8 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.EventLogs;
+
+namespace EventLogExpert.Runtime.EventLog;
+
+internal sealed record LogClosedByUserAction(EventLogId LogId, string LogName);

--- a/src/EventLogExpert.Runtime/FilterLenses/ClearFilterLensesAction.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/ClearFilterLensesAction.cs
@@ -1,0 +1,6 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.FilterLenses;
+
+internal sealed record ClearFilterLensesAction;

--- a/src/EventLogExpert.Runtime/FilterLenses/EffectiveFilterBuilder.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/EffectiveFilterBuilder.cs
@@ -1,0 +1,64 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Evaluation;
+
+namespace EventLogExpert.Runtime.FilterLenses;
+
+/// <summary>
+///     The single source of truth for building the effective applied filter from a persistent base filter plus the
+///     active transient lens stack. It is the ONLY place lens composition happens - both the FilterLens push/pop effect
+///     and the FilterPane apply path call it, so the two dispatch sites cannot diverge. A property lens contributes
+///     exclude criteria that are appended (AND-narrowing); a time-window lens intersects the date filter. The base filter
+///     is never mutated.
+/// </summary>
+internal static class EffectiveFilterBuilder
+{
+    public static Filter Build(Filter baseFilter, IReadOnlyList<FilterLens> lenses)
+    {
+        if (lenses.Count == 0) { return baseFilter; }
+
+        var filters = baseFilter.Filters;
+        DateFilter? date = baseFilter.DateFilter;
+
+        foreach (var lens in lenses)
+        {
+            if (!lens.ExcludeFilters.IsEmpty)
+            {
+                filters = filters.AddRange(lens.ExcludeFilters);
+            }
+
+            if (lens.Window is { IsEnabled: true } window)
+            {
+                date = IntersectWindow(date, window);
+            }
+        }
+
+        return new Filter(date, filters);
+    }
+
+    private static DateTime Earlier(DateTime first, DateTime second) => first <= second ? first : second;
+
+    /// <summary>
+    ///     Intersects <paramref name="window" /> into <paramref name="baseDate" />, producing a two-sided, enabled
+    ///     <see cref="DateFilter" />. A null or disabled base imposes no gate (treated as unbounded); any null bound (base or
+    ///     lens) is treated as -/+ infinity so the result never carries a null bound - an enabled date filter with a null
+    ///     bound matches nothing. An empty overlap (After > Before) intentionally yields an empty view.
+    /// </summary>
+    private static DateFilter IntersectWindow(DateFilter? baseDate, DateFilter window)
+    {
+        var baseActive = baseDate is { IsEnabled: true };
+
+        var after = Later(
+            baseActive ? baseDate!.After ?? DateTime.MinValue : DateTime.MinValue,
+            window.After ?? DateTime.MinValue);
+
+        var before = Earlier(
+            baseActive ? baseDate!.Before ?? DateTime.MaxValue : DateTime.MaxValue,
+            window.Before ?? DateTime.MaxValue);
+
+        return new DateFilter { After = after, Before = before, IsEnabled = true };
+    }
+
+    private static DateTime Later(DateTime first, DateTime second) => first >= second ? first : second;
+}

--- a/src/EventLogExpert.Runtime/FilterLenses/Effects.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/Effects.cs
@@ -1,0 +1,68 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.FilterPane;
+using Fluxor;
+
+namespace EventLogExpert.Runtime.FilterLenses;
+
+/// <summary>
+///     Re-narrows the view whenever the lens stack changes by recomposing the effective filter from the current base
+///     (<see cref="FilterPaneState" />) and the lens stack, then dispatching <c>ApplyFilterAction</c>. Composition rides
+///     the existing apply/concurrency path (last dispatch wins via the filter token); lenses are never written back into
+///     the persistent <see cref="FilterPaneState" />.
+/// </summary>
+internal sealed class Effects(IState<FilterLensState> lensState, IState<FilterPaneState> filterPaneState)
+{
+    private readonly IState<FilterPaneState> _filterPaneState = filterPaneState;
+    private readonly IState<FilterLensState> _lensState = lensState;
+
+    [EffectMethod(typeof(ClearFilterLensesAction))]
+    public Task HandleClear(IDispatcher dispatcher) => Reapply(dispatcher);
+
+    // Close-all clears every lens. A single-log close only drops the lenses that originated from that log: the user close
+    // (tab button / tab menu) routes through EventLogCommands.CloseLog, which emits LogClosedByUserAction, whereas a
+    // filter-driven reload dispatches CloseLogAction directly and never emits it - so this never wipes a live lens
+    // mid-reload. Lenses with a null origin (or from a still-open log) persist and clear only on close-all.
+    [EffectMethod(typeof(CloseAllLogsAction))]
+    public Task HandleCloseAllLogs(IDispatcher dispatcher)
+    {
+        if (!_lensState.Value.Lenses.IsEmpty)
+        {
+            dispatcher.Dispatch(new ClearFilterLensesAction());
+        }
+
+        return Task.CompletedTask;
+    }
+
+    [EffectMethod]
+    public Task HandleLogClosedByUser(LogClosedByUserAction action, IDispatcher dispatcher)
+    {
+        if (_lensState.Value.Lenses.Any(lens => string.Equals(lens.OriginLog, action.LogName, StringComparison.Ordinal)))
+        {
+            dispatcher.Dispatch(new RemoveLensesForLogAction(action.LogName));
+        }
+
+        return Task.CompletedTask;
+    }
+
+    [EffectMethod]
+    public Task HandlePush(PushFilterLensAction action, IDispatcher dispatcher) => Reapply(dispatcher);
+
+    [EffectMethod]
+    public Task HandleRemove(RemoveFilterLensAction action, IDispatcher dispatcher) => Reapply(dispatcher);
+
+    [EffectMethod]
+    public Task HandleRemoveForLog(RemoveLensesForLogAction action, IDispatcher dispatcher) => Reapply(dispatcher);
+
+    private Task Reapply(IDispatcher dispatcher)
+    {
+        var baseFilter = FilterPaneFilterBuilder.Build(_filterPaneState.Value);
+        var effective = EffectiveFilterBuilder.Build(baseFilter, _lensState.Value.Lenses);
+
+        dispatcher.Dispatch(new ApplyFilterAction(effective));
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/EventLogExpert.Runtime/FilterLenses/FilterLens.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/FilterLens.cs
@@ -1,0 +1,38 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Evaluation;
+using EventLogExpert.Filtering.Persistence;
+using System.Collections.Immutable;
+
+namespace EventLogExpert.Runtime.FilterLenses;
+
+/// <summary>
+///     A transient, reversible narrowing "lens" pushed on top of the persistent filter. A lens NEVER mutates the
+///     saved/base filter; it contributes exclude-of-complement <see cref="SavedFilter" /> criteria and/or a time-window
+///     <see cref="DateFilter" /> that <see cref="EffectiveFilterBuilder" /> folds into the effective applied filter.
+/// </summary>
+public sealed record FilterLens
+{
+    public FilterLensId Id { get; init; } = FilterLensId.Create();
+
+    public required string Label { get; init; }
+
+    public required LensKind Kind { get; init; }
+
+    /// <summary>
+    ///     Exclude criteria whose "hide everything else" arm is decisive (Match) for an absent field value, so the lens
+    ///     narrows to exactly the intended rows without leaking absent-field rows. Only <see cref="FilterLensFactory" /> may
+    ///     produce these, which is what enforces the total-operator invariant.
+    /// </summary>
+    public ImmutableList<SavedFilter> ExcludeFilters { get; init; } = [];
+
+    public DateFilter? Window { get; init; }
+
+    /// <summary>
+    ///     The owning log the lens originated from - the source event's <c>OwningLog</c> (the app's internal log name,
+    ///     which is also the name carried by a user-initiated log close). Used only for lifecycle: the lens is dropped when
+    ///     that log is closed by the user. A null origin clears only on close-all.
+    /// </summary>
+    public string? OriginLog { get; init; }
+}

--- a/src/EventLogExpert.Runtime/FilterLenses/FilterLensCommands.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/FilterLensCommands.cs
@@ -1,0 +1,25 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Fluxor;
+
+namespace EventLogExpert.Runtime.FilterLenses;
+
+internal sealed class FilterLensCommands(IDispatcher dispatcher) : IFilterLensCommands
+{
+    private readonly IDispatcher _dispatcher = dispatcher;
+
+    public void ClearLenses() => _dispatcher.Dispatch(new ClearFilterLensesAction());
+
+    public void RemoveLens(FilterLens lens) => _dispatcher.Dispatch(new RemoveFilterLensAction(lens));
+
+    public void ShowRelatedByActivityId(Guid? activityId, string? originLog = null)
+    {
+        if (activityId is not { } id) { return; }
+
+        if (FilterLensFactory.ForActivityId(id, originLog) is { } lens)
+        {
+            _dispatcher.Dispatch(new PushFilterLensAction(lens));
+        }
+    }
+}

--- a/src/EventLogExpert.Runtime/FilterLenses/FilterLensFactory.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/FilterLensFactory.cs
@@ -1,0 +1,58 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Basic;
+using EventLogExpert.Filtering.Common.Filtering;
+using EventLogExpert.Filtering.Evaluation;
+using EventLogExpert.Filtering.Persistence;
+
+namespace EventLogExpert.Runtime.FilterLenses;
+
+internal static class FilterLensFactory
+{
+    /// <summary>
+    ///     Builds a "Show Related by Activity ID" lens: keep only rows whose ActivityId equals
+    ///     <paramref name="activityId" />, hiding every other row including those with no ActivityId. Because the base's
+    ///     include filters are OR-combined an appended include would broaden, so the complement is excluded (
+    ///     <c>ActivityId != X</c>, <see cref="SavedFilter.IsExcluded" />) to AND-narrow to exactly <c>ActivityId == X</c>.
+    ///     <c>NotEqual</c> on the nullable-Guid column is total (a decisive Match for an absent value), so the exclude hides
+    ///     absent-ActivityId rows rather than leaking them. Returns <see langword="null" /> only if the criterion fails to
+    ///     format or compile.
+    /// </summary>
+    public static FilterLens? ForActivityId(Guid activityId, string? originLog = null)
+    {
+        if (!TryFormatNotEqual(EventProperty.ActivityId, activityId.ToString(), out var comparisonText))
+        {
+            return null;
+        }
+
+        var complement = SavedFilter.TryCreate(
+            comparisonText,
+            isExcluded: true,
+            isEnabled: true,
+            mode: FilterMode.Advanced);
+
+        if (complement?.Compiled is null) { return null; }
+
+        return new FilterLens
+        {
+            Label = $"Activity ID = {activityId}",
+            Kind = LensKind.Property,
+            ExcludeFilters = [complement],
+            OriginLog = originLog
+        };
+    }
+
+    private static bool TryFormatNotEqual(EventProperty property, string value, out string comparisonText)
+    {
+        var comparison = new FilterComparison
+        {
+            Property = property,
+            Operator = ComparisonOperator.NotEqual,
+            MatchMode = MatchMode.Single,
+            Value = value
+        };
+
+        return BasicFilterFormatter.TryFormat(new BasicFilter(comparison, []), out comparisonText);
+    }
+}

--- a/src/EventLogExpert.Runtime/FilterLenses/FilterLensId.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/FilterLensId.cs
@@ -1,0 +1,9 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.FilterLenses;
+
+public readonly record struct FilterLensId(Guid Value)
+{
+    public static FilterLensId Create() => new(Guid.NewGuid());
+}

--- a/src/EventLogExpert.Runtime/FilterLenses/FilterLensState.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/FilterLensState.cs
@@ -1,0 +1,18 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Fluxor;
+using System.Collections.Immutable;
+
+namespace EventLogExpert.Runtime.FilterLenses;
+
+/// <summary>
+///     The active transient lens stack layered over the persistent filter. Oldest first; the last entry is the top of
+///     the stack (most recently pushed). Lenses live only here and in the derived applied filter - never in the persistent
+///     <c>FilterPaneState</c> - so they cannot contaminate saved filters.
+/// </summary>
+[FeatureState]
+public sealed record FilterLensState
+{
+    public ImmutableList<FilterLens> Lenses { get; init; } = [];
+}

--- a/src/EventLogExpert.Runtime/FilterLenses/IFilterLensCommands.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/IFilterLensCommands.cs
@@ -1,0 +1,21 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+
+namespace EventLogExpert.Runtime.FilterLenses;
+
+public interface IFilterLensCommands
+{
+    void ClearLenses();
+
+    void RemoveLens(FilterLens lens);
+
+    /// <summary>
+    ///     Pushes a "Show Related by Activity ID" lens narrowing the view to events sharing
+    ///     <paramref name="activityId" />. A null id is a no-op, so callers may pass an event's nullable ActivityId directly.
+    ///     <paramref name="originLog" /> is the source event's <see cref="ResolvedEvent.OwningLog" /> so the lens auto-clears
+    ///     when that log is closed.
+    /// </summary>
+    void ShowRelatedByActivityId(Guid? activityId, string? originLog = null);
+}

--- a/src/EventLogExpert.Runtime/FilterLenses/LensKind.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/LensKind.cs
@@ -1,0 +1,11 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.FilterLenses;
+
+public enum LensKind
+{
+    Property,
+
+    TimeWindow
+}

--- a/src/EventLogExpert.Runtime/FilterLenses/PushFilterLensAction.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/PushFilterLensAction.cs
@@ -1,0 +1,6 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.FilterLenses;
+
+internal sealed record PushFilterLensAction(FilterLens Lens);

--- a/src/EventLogExpert.Runtime/FilterLenses/Reducers.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/Reducers.cs
@@ -1,0 +1,34 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Fluxor;
+
+namespace EventLogExpert.Runtime.FilterLenses;
+
+internal sealed class Reducers
+{
+    [ReducerMethod(typeof(ClearFilterLensesAction))]
+    public static FilterLensState ReduceClear(FilterLensState state) =>
+        state.Lenses.IsEmpty ? state : new FilterLensState();
+
+    [ReducerMethod]
+    public static FilterLensState ReducePush(FilterLensState state, PushFilterLensAction action) =>
+        state with { Lenses = state.Lenses.Add(action.Lens) };
+
+    [ReducerMethod]
+    public static FilterLensState ReduceRemove(FilterLensState state, RemoveFilterLensAction action)
+    {
+        var updated = state.Lenses.RemoveAll(lens => lens.Id == action.Lens.Id);
+
+        return updated.Count == state.Lenses.Count ? state : state with { Lenses = updated };
+    }
+
+    [ReducerMethod]
+    public static FilterLensState ReduceRemoveForLog(FilterLensState state, RemoveLensesForLogAction action)
+    {
+        var updated = state.Lenses.RemoveAll(
+            lens => string.Equals(lens.OriginLog, action.LogName, StringComparison.Ordinal));
+
+        return updated.Count == state.Lenses.Count ? state : state with { Lenses = updated };
+    }
+}

--- a/src/EventLogExpert.Runtime/FilterLenses/RemoveFilterLensAction.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/RemoveFilterLensAction.cs
@@ -1,0 +1,6 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.FilterLenses;
+
+internal sealed record RemoveFilterLensAction(FilterLens Lens);

--- a/src/EventLogExpert.Runtime/FilterLenses/RemoveLensesForLogAction.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/RemoveLensesForLogAction.cs
@@ -1,0 +1,6 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.FilterLenses;
+
+internal sealed record RemoveLensesForLogAction(string LogName);

--- a/src/EventLogExpert.Runtime/FilterPane/Effects.cs
+++ b/src/EventLogExpert.Runtime/FilterPane/Effects.cs
@@ -4,6 +4,7 @@
 using EventLogExpert.Eventing.Common.EventLogs;
 using EventLogExpert.Filtering.Evaluation;
 using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.FilterLenses;
 using EventLogExpert.Runtime.FilterLibrary;
 using EventLogExpert.Runtime.LogTable;
 using Fluxor;
@@ -14,16 +15,19 @@ internal sealed class Effects
 {
     private readonly IStateSelection<EventLogState, Filter> _appliedFilter;
     private readonly IState<FilterPaneState> _filterPaneState;
+    private readonly IState<FilterLensState> _lensState;
     private readonly IState<RawEventStoreState> _rawEventStore;
 
     public Effects(
         IStateSelection<EventLogState, Filter> appliedFilter,
         IState<RawEventStoreState> rawEventStore,
-        IState<FilterPaneState> filterPaneState)
+        IState<FilterPaneState> filterPaneState,
+        IState<FilterLensState> lensState)
     {
         _appliedFilter = appliedFilter;
         _rawEventStore = rawEventStore;
         _filterPaneState = filterPaneState;
+        _lensState = lensState;
 
         _appliedFilter.Select(static s => s.AppliedFilter);
     }
@@ -171,16 +175,14 @@ internal sealed class Effects
         return Task.CompletedTask;
     }
 
-    private static Filter GetFilter(FilterPaneState filterPaneState) =>
-        new(filterPaneState.FilteredDateRange, [.. filterPaneState.Filters.Where(f => f.IsEnabled)]);
-
     private void UpdateEventTableFilters(FilterPaneState filterPaneState, IDispatcher dispatcher)
     {
-        var candidate = filterPaneState.IsEnabled
-            ? GetFilter(filterPaneState)
-            : new Filter(
-                filterPaneState.FilteredDateRange,
-                [.. filterPaneState.Filters.Where(filter => filter.IsExcluded)]);
+        // Build the effective filter by layering any active transient lenses onto the base through the single shared
+        // EffectiveFilterBuilder, so the FilterPane apply path and the FilterLens push/pop path can never diverge.
+        // FilterPaneFilterBuilder handles both the enabled and the excluded-only (pane-disabled) branch, so lenses narrow in both.
+        var candidate = EffectiveFilterBuilder.Build(
+            FilterPaneFilterBuilder.Build(filterPaneState),
+            _lensState.Value.Lenses);
 
         if (!candidate.HasFilteringChangedFrom(_appliedFilter.Value))
         {

--- a/src/EventLogExpert.Runtime/FilterPane/FilterPaneFilterBuilder.cs
+++ b/src/EventLogExpert.Runtime/FilterPane/FilterPaneFilterBuilder.cs
@@ -1,0 +1,20 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Evaluation;
+
+namespace EventLogExpert.Runtime.FilterPane;
+
+/// <summary>
+///     Builds the base (lens-free) <see cref="Filter" /> from the current <see cref="FilterPaneState" />. Shared by
+///     the FilterPane apply effect and the FilterLens effect so both compose lenses onto an identical base. When filtering
+///     is disabled only exclusion filters (plus the date range) apply, matching the historical
+///     <c>UpdateEventTableFilters</c> branch.
+/// </summary>
+internal static class FilterPaneFilterBuilder
+{
+    public static Filter Build(FilterPaneState state) =>
+        state.IsEnabled
+            ? new Filter(state.FilteredDateRange, [.. state.Filters.Where(filter => filter.IsEnabled)])
+            : new Filter(state.FilteredDateRange, [.. state.Filters.Where(filter => filter.IsExcluded)]);
+}

--- a/src/EventLogExpert.UI/FilterLenses/LensBreadcrumb.razor
+++ b/src/EventLogExpert.UI/FilterLenses/LensBreadcrumb.razor
@@ -1,0 +1,33 @@
+@inherits FluxorComponent
+
+@{
+    var lenses = LensState.Value.Lenses;
+}
+
+@if (!lenses.IsEmpty)
+{
+    <div aria-label="Active filter lenses"
+        class="lens-breadcrumb"
+        @onkeydown="HandleKeyDown"
+        @onkeydown:stopPropagation="true"
+        role="region"
+        tabindex="0">
+        <span class="lens-breadcrumb-label">Lenses</span>
+
+        @foreach (var lens in lenses)
+        {
+            var captured = lens;
+            <span class="lens-chip">
+                <span class="lens-chip-label" title="@lens.Label">@lens.Label</span>
+                <button aria-label="@($"Remove lens: {lens.Label}")"
+                    class="lens-chip-remove"
+                    @onclick="@(() => Commands.RemoveLens(captured))"
+                    type="button">
+                    &times;
+                </button>
+            </span>
+        }
+
+        <button class="lens-clear" @onclick="Commands.ClearLenses" type="button">Clear all</button>
+    </div>
+}

--- a/src/EventLogExpert.UI/FilterLenses/LensBreadcrumb.razor.cs
+++ b/src/EventLogExpert.UI/FilterLenses/LensBreadcrumb.razor.cs
@@ -1,0 +1,31 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.FilterLenses;
+using Fluxor;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+
+namespace EventLogExpert.UI.FilterLenses;
+
+public sealed partial class LensBreadcrumb
+{
+    [Inject] private IFilterLensCommands Commands { get; init; } = null!;
+
+    [Inject] private IState<FilterLensState> LensState { get; init; } = null!;
+
+    private void HandleKeyDown(KeyboardEventArgs args)
+    {
+        if (args.Key != "Escape") { return; }
+
+        var lenses = LensState.Value.Lenses;
+
+        // Escape scoped to the breadcrumb pops the most recently pushed lens, and stopPropagation keeps it from reaching
+        // the event table's own Escape handler (which clears the selection). The breadcrumb only renders when a lens is
+        // active, so a plain table Escape is unaffected.
+        if (!lenses.IsEmpty)
+        {
+            Commands.RemoveLens(lenses[^1]);
+        }
+    }
+}

--- a/src/EventLogExpert.UI/FilterLenses/LensBreadcrumb.razor.css
+++ b/src/EventLogExpert.UI/FilterLenses/LensBreadcrumb.razor.css
@@ -1,0 +1,58 @@
+.lens-breadcrumb {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+    padding: 0.25rem 0.5rem;
+    border-bottom: 1px solid var(--border-divider);
+}
+
+.lens-breadcrumb-label {
+    color: var(--text-secondary);
+    font-size: 0.85em;
+    margin-right: 0.25rem;
+}
+
+.lens-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    max-width: 22rem;
+    padding: 0.1rem 0.25rem 0.1rem 0.5rem;
+    border: 1px solid var(--clr-lightblue);
+    border-radius: 1rem;
+    color: var(--text-primary);
+    font-size: 0.85em;
+}
+
+.lens-chip-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.lens-chip-remove,
+.lens-clear {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 0 0.25rem;
+    line-height: 1;
+    color: var(--text-secondary);
+}
+
+.lens-clear {
+    color: var(--clr-lightblue);
+    font-size: 0.85em;
+}
+
+.lens-chip-remove:hover,
+.lens-clear:hover {
+    color: var(--clr-red);
+}
+
+.lens-breadcrumb:focus-visible,
+.lens-chip-remove:focus-visible,
+.lens-clear:focus-visible {
+    outline: 2px solid var(--toggle-accent);
+}

--- a/src/EventLogExpert.UI/Layout/MainContent.razor
+++ b/src/EventLogExpert.UI/Layout/MainContent.razor
@@ -3,6 +3,7 @@
 @if (HasActiveLogs.Value)
 {
     <FilterPane />
+    <LensBreadcrumb />
     <LogTablePane />
     <DetailsPane />
 }

--- a/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
@@ -11,6 +11,7 @@ using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Runtime.Common.Clipboard;
 using EventLogExpert.Runtime.Common.Display;
 using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.FilterLenses;
 using EventLogExpert.Runtime.FilterPane;
 using EventLogExpert.Runtime.LogTable;
 using EventLogExpert.Runtime.Menu;
@@ -80,6 +81,8 @@ public sealed partial class LogTablePane
     [Inject] private ILogTableColumnDefaultsProvider ColumnDefaults { get; init; } = null!;
 
     [Inject] private IEventLogCommands EventLogCommands { get; init; } = null!;
+
+    [Inject] private IFilterLensCommands FilterLensCommands { get; init; } = null!;
 
     [Inject] private IFilterPaneCommands FilterPaneCommands { get; init; } = null!;
 
@@ -1319,6 +1322,12 @@ public sealed partial class LogTablePane
             MenuItem.Item("Exclude Events After", () =>
                 FilterPaneCommands.SetFilterDateRange(
                     new DateFilter { After = selectedEvent.TimeCreated })),
+            MenuItem.Separator(),
+            MenuItem.Item(
+                "Show Related by Activity ID",
+                () => FilterLensCommands.ShowRelatedByActivityId(selectedEvent.ActivityId, selectedEvent.OwningLog),
+                isEnabled: selectedEvent.ActivityId.HasValue,
+                disabledReason: selectedEvent.ActivityId.HasValue ? null : "This event has no Activity ID."),
             MenuItem.Separator(),
             MenuItem.SubMenu(
                 "More Fields",

--- a/src/EventLogExpert.UI/_Imports.razor
+++ b/src/EventLogExpert.UI/_Imports.razor
@@ -33,6 +33,7 @@
 @using EventLogExpert.UI.FilterEditor.Comparison
 @using EventLogExpert.UI.FilterEditor.Editing
 @using EventLogExpert.UI.FilterEditor.Rows
+@using EventLogExpert.UI.FilterLenses
 @using EventLogExpert.UI.FilterLibrary
 @using EventLogExpert.UI.FilterPane
 @using EventLogExpert.UI.Inputs

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/EffectiveFilterBuilderTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/EffectiveFilterBuilderTests.cs
@@ -1,0 +1,153 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Compilation;
+using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Filtering.TestUtils;
+using EventLogExpert.Runtime.FilterLenses;
+
+namespace EventLogExpert.Runtime.Tests.FilterLenses;
+
+public sealed class EffectiveFilterBuilderTests
+{
+    private static readonly FilterService s_filterService = new();
+    private static readonly Guid s_other = new("99999999-8888-7777-6666-555555555555");
+    private static readonly Guid s_target = new("11111111-2222-3333-4444-555555555555");
+
+    [Fact]
+    public void Build_MultipleActivityLenses_AndTogether()
+    {
+        var matchBoth = FilterEventBuilder.CreateTestEvent(id: 1, activityId: s_target);
+        var matchFirstOnly = FilterEventBuilder.CreateTestEvent(id: 2, activityId: s_target);
+
+        // Two lenses for different Activity IDs AND together -> no event can match both distinct GUIDs -> empty.
+        var composed = EffectiveFilterBuilder.Build(
+            new Filter(null, []),
+            [FilterLensFactory.ForActivityId(s_target)!, FilterLensFactory.ForActivityId(s_other)!]);
+
+        var result = s_filterService.GetFilteredEvents([matchBoth, matchFirstOnly], composed);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Build_NoLenses_ReturnsBaseUnchanged()
+    {
+        var baseFilter = new Filter(null, []);
+
+        var composed = EffectiveFilterBuilder.Build(baseFilter, []);
+
+        Assert.Equal(baseFilter, composed);
+    }
+
+    [Fact]
+    public void Build_TimeWindowLens_IntersectsWithBaseDate_TwoSidedEnabled()
+    {
+        // Arrange - base date [10:00, 14:00]; lens window [12:00, 16:00]; intersection [12:00, 14:00].
+        var inside = FilterEventBuilder.CreateTestEvent(id: 1, timeCreated: At(13));
+        var beforeWindow = FilterEventBuilder.CreateTestEvent(id: 2, timeCreated: At(11));
+        var afterBase = FilterEventBuilder.CreateTestEvent(id: 3, timeCreated: At(15));
+
+        var baseFilter = new Filter(new DateFilter { After = At(10), Before = At(14), IsEnabled = true }, []);
+        var windowLens = new FilterLens
+        {
+            Label = "window",
+            Kind = LensKind.TimeWindow,
+            Window = new DateFilter { After = At(12), Before = At(16), IsEnabled = true }
+        };
+
+        var composed = EffectiveFilterBuilder.Build(baseFilter, [windowLens]);
+
+        Assert.NotNull(composed.DateFilter);
+        Assert.True(composed.DateFilter!.IsEnabled);
+        Assert.Equal(At(12), composed.DateFilter.After);
+        Assert.Equal(At(14), composed.DateFilter.Before);
+
+        var result = s_filterService.GetFilteredEvents([inside, beforeWindow, afterBase], composed);
+        Assert.Equal([1], result.Select(e => e.Id).OrderBy(id => id));
+    }
+
+    [Fact]
+    public void Build_TimeWindowLens_NullOrDisabledBase_UsesWindowVerbatim()
+    {
+        var windowLens = new FilterLens
+        {
+            Label = "window",
+            Kind = LensKind.TimeWindow,
+            Window = new DateFilter { After = At(12), Before = At(16), IsEnabled = true }
+        };
+
+        var nullBase = EffectiveFilterBuilder.Build(new Filter(null, []), [windowLens]);
+        Assert.NotNull(nullBase.DateFilter);
+        Assert.True(nullBase.DateFilter!.IsEnabled);
+        Assert.Equal(At(12), nullBase.DateFilter.After);
+        Assert.Equal(At(16), nullBase.DateFilter.Before);
+
+        // Disabled base date is treated as unbounded, so the window applies verbatim.
+        var disabledBase = EffectiveFilterBuilder.Build(
+            new Filter(new DateFilter { After = At(1), Before = At(23), IsEnabled = false }, []),
+            [windowLens]);
+        Assert.Equal(At(12), disabledBase.DateFilter!.After);
+        Assert.Equal(At(16), disabledBase.DateFilter.Before);
+    }
+
+    [Fact]
+    public void Build_WithActivityIdLensOnBaseInclude_NarrowsToIntersection()
+    {
+        // Arrange - base includes Level == Error (OR-combined include list); the lens must AND-narrow, so only the
+        // Error event that ALSO matches the ActivityId survives - not every Error, and not the matching-Activity Info.
+        var errorMatch = FilterEventBuilder.CreateTestEvent(id: 1, level: "Error", activityId: s_target);
+        var errorOther = FilterEventBuilder.CreateTestEvent(id: 2, level: "Error", activityId: s_other);
+        var infoMatch = FilterEventBuilder.CreateTestEvent(id: 3, level: "Information", activityId: s_target);
+
+        var levelInclude = SavedFilterFor("Level == \"Error\"");
+        var baseFilter = new Filter(null, [levelInclude]);
+
+        var composed = EffectiveFilterBuilder.Build(baseFilter, [FilterLensFactory.ForActivityId(s_target)!]);
+
+        var result = s_filterService.GetFilteredEvents([errorMatch, errorOther, infoMatch], composed);
+
+        Assert.Equal([1], result.Select(e => e.Id).OrderBy(id => id));
+    }
+
+    [Fact]
+    public void Build_WithActivityIdLensOnEmptyBase_KeepsOnlyMatchingActivityId_HidesOtherAndAbsent()
+    {
+        // Arrange - the load-bearing behavior: exclude-of-complement (ActivityId != target) narrows to exactly
+        // ActivityId == target, and because NotEqual on the nullable Guid is total (Match-for-null) the absent-ActivityId
+        // event is HIDDEN, not leaked.
+        var matching = FilterEventBuilder.CreateTestEvent(id: 1, activityId: s_target);
+        var other = FilterEventBuilder.CreateTestEvent(id: 2, activityId: s_other);
+        var absent = FilterEventBuilder.CreateTestEvent(id: 3, activityId: null);
+
+        var lens = FilterLensFactory.ForActivityId(s_target);
+        Assert.NotNull(lens);
+
+        var composed = EffectiveFilterBuilder.Build(new Filter(null, []), [lens]);
+
+        var result = s_filterService.GetFilteredEvents([matching, other, absent], composed);
+
+        Assert.Equal([1], result.Select(e => e.Id).OrderBy(id => id));
+    }
+
+    [Fact]
+    public void Build_DisabledWindowLens_DoesNotApplyDateFilter()
+    {
+        var disabledWindowLens = new FilterLens
+        {
+            Label = "window",
+            Kind = LensKind.TimeWindow,
+            Window = new DateFilter { After = At(12), Before = At(16), IsEnabled = false }
+        };
+
+        var composed = EffectiveFilterBuilder.Build(new Filter(null, []), [disabledWindowLens]);
+
+        Assert.Null(composed.DateFilter);
+    }
+
+    private static DateTime At(int hourUtc) => new(2024, 1, 1, hourUtc, 0, 0, DateTimeKind.Utc);
+
+    private static SavedFilter SavedFilterFor(string comparisonText) =>
+        SavedFilter.TryCreate(comparisonText, isEnabled: true)
+        ?? throw new InvalidOperationException($"test filter failed to compile: {comparisonText}");
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensCommandsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensCommandsTests.cs
@@ -1,0 +1,66 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.FilterLenses;
+using Fluxor;
+using NSubstitute;
+
+namespace EventLogExpert.Runtime.Tests.FilterLenses;
+
+public sealed class FilterLensCommandsTests
+{
+    [Fact]
+    public void ClearLenses_DispatchesClear()
+    {
+        var dispatcher = Substitute.For<IDispatcher>();
+
+        new FilterLensCommands(dispatcher).ClearLenses();
+
+        dispatcher.Received(1).Dispatch(Arg.Any<ClearFilterLensesAction>());
+    }
+
+    [Fact]
+    public void RemoveLens_DispatchesRemove()
+    {
+        var dispatcher = Substitute.For<IDispatcher>();
+        var lens = new FilterLens { Label = "x", Kind = LensKind.Property };
+
+        new FilterLensCommands(dispatcher).RemoveLens(lens);
+
+        dispatcher.Received(1).Dispatch(Arg.Is<RemoveFilterLensAction>(action => action.Lens == lens));
+    }
+
+    [Fact]
+    public void ShowRelatedByActivityId_Guid_DispatchesPushWithCompiledExcludeLens()
+    {
+        var dispatcher = Substitute.For<IDispatcher>();
+
+        new FilterLensCommands(dispatcher).ShowRelatedByActivityId(Guid.NewGuid());
+
+        dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action =>
+            action.Lens.Kind == LensKind.Property &&
+            action.Lens.ExcludeFilters.Count == 1 &&
+            action.Lens.ExcludeFilters[0].IsExcluded &&
+            action.Lens.ExcludeFilters[0].Compiled != null));
+    }
+
+    [Fact]
+    public void ShowRelatedByActivityId_NullId_DoesNotDispatch()
+    {
+        var dispatcher = Substitute.For<IDispatcher>();
+
+        new FilterLensCommands(dispatcher).ShowRelatedByActivityId(null);
+
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<PushFilterLensAction>());
+    }
+
+    [Fact]
+    public void ShowRelatedByActivityId_WithOriginLog_TagsLensWithThatLog()
+    {
+        var dispatcher = Substitute.For<IDispatcher>();
+
+        new FilterLensCommands(dispatcher).ShowRelatedByActivityId(Guid.NewGuid(), "LogA");
+
+        dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action => action.Lens.OriginLog == "LogA"));
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensEffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensEffectsTests.cs
@@ -1,0 +1,101 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.FilterLenses;
+using EventLogExpert.Runtime.FilterPane;
+using Fluxor;
+using NSubstitute;
+using LensEffects = EventLogExpert.Runtime.FilterLenses.Effects;
+
+namespace EventLogExpert.Runtime.Tests.FilterLenses;
+
+public sealed class FilterLensEffectsTests
+{
+    [Fact]
+    public async Task HandleCloseAllLogs_NoLenses_DoesNothing()
+    {
+        var (effects, dispatcher) = CreateEffects(new FilterLensState(), new FilterPaneState());
+
+        await effects.HandleCloseAllLogs(dispatcher);
+
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<ClearFilterLensesAction>());
+    }
+
+    [Fact]
+    public async Task HandleCloseAllLogs_WithActiveLenses_DispatchesClear()
+    {
+        var lens = FilterLensFactory.ForActivityId(Guid.NewGuid())!;
+        var (effects, dispatcher) = CreateEffects(new FilterLensState { Lenses = [lens] }, new FilterPaneState());
+
+        await effects.HandleCloseAllLogs(dispatcher);
+
+        dispatcher.Received(1).Dispatch(Arg.Any<ClearFilterLensesAction>());
+    }
+
+    [Fact]
+    public async Task HandleLogClosedByUser_LensFromThatLog_DispatchesRemoveForLog()
+    {
+        var lens = FilterLensFactory.ForActivityId(Guid.NewGuid(), "LogA")!;
+        var (effects, dispatcher) = CreateEffects(new FilterLensState { Lenses = [lens] }, new FilterPaneState());
+
+        await effects.HandleLogClosedByUser(new LogClosedByUserAction(EventLogId.Create(), "LogA"), dispatcher);
+
+        dispatcher.Received(1).Dispatch(Arg.Is<RemoveLensesForLogAction>(action => action.LogName == "LogA"));
+    }
+
+    [Fact]
+    public async Task HandleLogClosedByUser_NoLensFromThatLog_DoesNothing()
+    {
+        var lens = FilterLensFactory.ForActivityId(Guid.NewGuid(), "LogA")!;
+        var (effects, dispatcher) = CreateEffects(new FilterLensState { Lenses = [lens] }, new FilterPaneState());
+
+        await effects.HandleLogClosedByUser(new LogClosedByUserAction(EventLogId.Create(), "LogB"), dispatcher);
+
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<RemoveLensesForLogAction>());
+    }
+
+    [Fact]
+    public async Task HandlePush_ComposesLensOntoBase_DispatchesApplyFilter_WithoutTouchingBase()
+    {
+        // The base is a single include (Level == Error). Pushing an ActivityId lens must dispatch an effective filter
+        // that is base-include + lens-exclude, and must NOT write anything back into the persistent FilterPaneState.
+        var baseInclude = Compile("Level == \"Error\"");
+        var paneState = new FilterPaneState { Filters = [baseInclude] };
+        var lens = FilterLensFactory.ForActivityId(Guid.NewGuid())!;
+
+        var (effects, dispatcher) = CreateEffects(new FilterLensState { Lenses = [lens] }, paneState);
+
+        await effects.HandlePush(new PushFilterLensAction(lens), dispatcher);
+
+        dispatcher.Received(1).Dispatch(Arg.Is<ApplyFilterAction>(action =>
+            action.Filter.Filters.Count == 2 &&
+            action.Filter.Filters.Count(filter => filter.IsExcluded) == 1 &&
+            action.Filter.Filters.Count(filter => !filter.IsExcluded) == 1));
+
+        // No round-trip: no FilterPane-mutating action fires, and the base pane state is unchanged.
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<AddFilterAction>());
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<SetFilterAction>());
+        Assert.Single(paneState.Filters);
+        Assert.False(paneState.Filters[0].IsExcluded);
+    }
+
+    private static SavedFilter Compile(string text) =>
+        SavedFilter.TryCreate(text, isEnabled: true)
+        ?? throw new InvalidOperationException($"test filter failed to compile: {text}");
+
+    private static (LensEffects Effects, IDispatcher Dispatcher) CreateEffects(
+        FilterLensState lensState,
+        FilterPaneState paneState)
+    {
+        var lens = Substitute.For<IState<FilterLensState>>();
+        lens.Value.Returns(lensState);
+
+        var pane = Substitute.For<IState<FilterPaneState>>();
+        pane.Value.Returns(paneState);
+
+        return (new LensEffects(lens, pane), Substitute.For<IDispatcher>());
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensReducerTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensReducerTests.cs
@@ -1,0 +1,110 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.FilterLenses;
+
+namespace EventLogExpert.Runtime.Tests.FilterLenses;
+
+public sealed class FilterLensReducerTests
+{
+    [Fact]
+    public void Clear_AlreadyEmpty_ReturnsSameStateInstance()
+    {
+        var state = new FilterLensState();
+
+        var result = Reducers.ReduceClear(state);
+
+        Assert.Same(state, result);
+    }
+
+    [Fact]
+    public void Clear_EmptiesStack()
+    {
+        var state = new FilterLensState { Lenses = [Lens("a"), Lens("b")] };
+
+        var result = Reducers.ReduceClear(state);
+
+        Assert.Empty(result.Lenses);
+    }
+
+    [Fact]
+    public void Push_AddsLensToTopOfStack()
+    {
+        var a = Lens("a");
+        var b = Lens("b");
+        var state = new FilterLensState { Lenses = [a] };
+
+        var result = Reducers.ReducePush(state, new PushFilterLensAction(b));
+
+        Assert.Equal(2, result.Lenses.Count);
+        Assert.Same(a, result.Lenses[0]);
+        Assert.Same(b, result.Lenses[1]);
+    }
+
+    [Fact]
+    public void Remove_DuplicateContentLenses_RemovesOnlyTargetedInstance()
+    {
+        var first = Lens("duplicate");
+        var second = Lens("duplicate");
+        Assert.NotEqual(first.Id, second.Id);
+        var state = new FilterLensState { Lenses = [first, second] };
+
+        var result = Reducers.ReduceRemove(state, new RemoveFilterLensAction(second));
+
+        Assert.Single(result.Lenses);
+        Assert.Same(first, result.Lenses[0]);
+    }
+
+    [Fact]
+    public void Remove_RemovesSpecificLens()
+    {
+        var a = Lens("a");
+        var b = Lens("b");
+        var state = new FilterLensState { Lenses = [a, b] };
+
+        var result = Reducers.ReduceRemove(state, new RemoveFilterLensAction(a));
+
+        Assert.Single(result.Lenses);
+        Assert.Same(b, result.Lenses[0]);
+    }
+
+    [Fact]
+    public void Remove_UnknownLens_ReturnsSameStateInstance()
+    {
+        var state = new FilterLensState { Lenses = [Lens("a")] };
+
+        var result = Reducers.ReduceRemove(state, new RemoveFilterLensAction(Lens("other")));
+
+        Assert.Same(state, result);
+    }
+
+    [Fact]
+    public void RemoveForLog_NoMatch_ReturnsSameStateInstance()
+    {
+        var state = new FilterLensState { Lenses = [LensFromLog("a", "LogA")] };
+
+        var result = Reducers.ReduceRemoveForLog(state, new RemoveLensesForLogAction("LogB"));
+
+        Assert.Same(state, result);
+    }
+
+    [Fact]
+    public void RemoveForLog_RemovesOnlyLensesFromThatLog()
+    {
+        var fromA1 = LensFromLog("a1", "LogA");
+        var fromB = LensFromLog("b", "LogB");
+        var fromA2 = LensFromLog("a2", "LogA");
+        var state = new FilterLensState { Lenses = [fromA1, fromB, fromA2] };
+
+        var result = Reducers.ReduceRemoveForLog(state, new RemoveLensesForLogAction("LogA"));
+
+        Assert.Single(result.Lenses);
+        Assert.Same(fromB, result.Lenses[0]);
+    }
+
+    private static FilterLens Lens(string label) =>
+        new() { Label = label, Kind = LensKind.Property, ExcludeFilters = [] };
+
+    private static FilterLens LensFromLog(string label, string originLog) =>
+        new() { Label = label, Kind = LensKind.Property, OriginLog = originLog };
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterPane/EffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterPane/EffectsTests.cs
@@ -8,6 +8,7 @@ using EventLogExpert.Filtering.Persistence;
 using EventLogExpert.Filtering.TestUtils;
 using EventLogExpert.Filtering.TestUtils.Constants;
 using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.FilterLenses;
 using EventLogExpert.Runtime.FilterLibrary;
 using EventLogExpert.Runtime.FilterPane;
 using EventLogExpert.Runtime.FilterProgress;
@@ -572,7 +573,10 @@ public sealed class EffectsTests
         var mockRawEventStore = Substitute.For<IState<RawEventStoreState>>();
         mockRawEventStore.Value.Returns(rawStore);
 
-        var effects = new Effects(mockAppliedFilter, mockRawEventStore, mockFilterPaneState);
+        var mockLensState = Substitute.For<IState<FilterLensState>>();
+        mockLensState.Value.Returns(new FilterLensState());
+
+        var effects = new Effects(mockAppliedFilter, mockRawEventStore, mockFilterPaneState, mockLensState);
         var mockDispatcher = Substitute.For<IDispatcher>();
 
         return (effects, mockDispatcher);

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterPane/ReplaceFiltersTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterPane/ReplaceFiltersTests.cs
@@ -4,6 +4,7 @@
 using EventLogExpert.Filtering.Persistence;
 using EventLogExpert.Filtering.TestUtils;
 using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.FilterLenses;
 using EventLogExpert.Runtime.FilterPane;
 using EventLogExpert.Runtime.LogTable;
 using Fluxor;
@@ -103,7 +104,10 @@ public sealed class ReplaceFiltersTests
         var mockRawEventStore = Substitute.For<IState<RawEventStoreState>>();
         mockRawEventStore.Value.Returns(new RawEventStoreState());
 
-        var effects = new Effects(mockAppliedFilter, mockRawEventStore, mockFilterPaneState);
+        var mockLensState = Substitute.For<IState<FilterLensState>>();
+        mockLensState.Value.Returns(new FilterLensState());
+
+        var effects = new Effects(mockAppliedFilter, mockRawEventStore, mockFilterPaneState, mockLensState);
         var dispatcher = Substitute.For<IDispatcher>();
 
         return (effects, dispatcher);

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterPane/RestoreFilterPaneStateTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterPane/RestoreFilterPaneStateTests.cs
@@ -4,6 +4,7 @@
 using EventLogExpert.Filtering.Persistence;
 using EventLogExpert.Filtering.TestUtils;
 using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.FilterLenses;
 using EventLogExpert.Runtime.FilterPane;
 using EventLogExpert.Runtime.LogTable;
 using Fluxor;
@@ -61,7 +62,10 @@ public sealed class RestoreFilterPaneStateTests
         var rawEventStore = Substitute.For<IState<RawEventStoreState>>();
         rawEventStore.Value.Returns(new RawEventStoreState());
 
-        var effects = new Effects(appliedFilter, rawEventStore, filterPaneState);
+        var lensState = Substitute.For<IState<FilterLensState>>();
+        lensState.Value.Returns(new FilterLensState());
+
+        var effects = new Effects(appliedFilter, rawEventStore, filterPaneState, lensState);
 
         return (effects, Substitute.For<IDispatcher>());
     }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/ScenarioApplyIntegrationTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/ScenarioApplyIntegrationTests.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.FilterLenses;
 using EventLogExpert.Runtime.FilterPane;
 using EventLogExpert.Runtime.LogTable;
 using Fluxor;
@@ -47,7 +48,10 @@ public sealed class ScenarioApplyIntegrationTests
         var rawEventStore = Substitute.For<IState<RawEventStoreState>>();
         rawEventStore.Value.Returns(new RawEventStoreState());
 
-        var effects = new FilterPaneEffects(appliedFilter, rawEventStore, paneStateAccessor);
+        var lensState = Substitute.For<IState<FilterLensState>>();
+        lensState.Value.Returns(new FilterLensState());
+
+        var effects = new FilterPaneEffects(appliedFilter, rawEventStore, paneStateAccessor, lensState);
         var dispatcher = Substitute.For<IDispatcher>();
 
         ApplyFilterAction? captured = null;

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterLenses/LensBreadcrumbTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterLenses/LensBreadcrumbTests.cs
@@ -1,0 +1,79 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using EventLogExpert.Runtime.FilterLenses;
+using EventLogExpert.UI.FilterLenses;
+using Fluxor;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace EventLogExpert.UI.Tests.FilterLenses;
+
+public sealed class LensBreadcrumbTests : BunitContext
+{
+    private readonly IFilterLensCommands _commands = Substitute.For<IFilterLensCommands>();
+    private readonly IState<FilterLensState> _lensState = Substitute.For<IState<FilterLensState>>();
+
+    public LensBreadcrumbTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddSingleton(_commands);
+        Services.AddSingleton(_lensState);
+        Services.AddFluxor(options => options.ScanAssemblies(typeof(LensBreadcrumb).Assembly));
+    }
+
+    [Fact]
+    public void ClearAllButton_DispatchesClearLenses()
+    {
+        _lensState.Value.Returns(new FilterLensState { Lenses = [Lens("x")] });
+
+        var cut = Render<LensBreadcrumb>();
+
+        cut.Find(".lens-clear").Click();
+
+        _commands.Received(1).ClearLenses();
+    }
+
+    [Fact]
+    public void Escape_WithinBreadcrumb_PopsTopLens()
+    {
+        var older = Lens("older");
+        var top = Lens("top");
+        _lensState.Value.Returns(new FilterLensState { Lenses = [older, top] });
+
+        var cut = Render<LensBreadcrumb>();
+
+        cut.Find(".lens-breadcrumb").KeyDown(new KeyboardEventArgs { Key = "Escape" });
+
+        _commands.Received(1).RemoveLens(top);
+    }
+
+    [Fact]
+    public void NoLenses_RendersNothing()
+    {
+        _lensState.Value.Returns(new FilterLensState());
+
+        var cut = Render<LensBreadcrumb>();
+
+        Assert.Empty(cut.FindAll(".lens-breadcrumb"));
+    }
+
+    [Fact]
+    public void WithLens_RendersChip_AndRemoveButtonDispatchesRemoveLens()
+    {
+        var lens = Lens("Activity ID = abc");
+        _lensState.Value.Returns(new FilterLensState { Lenses = [lens] });
+
+        var cut = Render<LensBreadcrumb>();
+
+        Assert.Contains("Activity ID = abc", cut.Markup);
+
+        cut.Find(".lens-chip-remove").Click();
+
+        _commands.Received(1).RemoveLens(lens);
+    }
+
+    private static FilterLens Lens(string label) => new() { Label = label, Kind = LensKind.Property };
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/Layout/MainContentTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Layout/MainContentTests.cs
@@ -5,6 +5,7 @@ using Bunit;
 using Bunit.TestDoubles;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.UI.Dashboard;
+using EventLogExpert.UI.FilterLenses;
 using EventLogExpert.UI.Layout;
 using EventLogExpert.UI.LogTable;
 using Fluxor;
@@ -27,6 +28,7 @@ public sealed class MainContentTests : BunitContext
         JSInterop.Mode = JSRuntimeMode.Loose;
 
         ComponentFactories.AddStub<FilterPaneComponent>();
+        ComponentFactories.AddStub<LensBreadcrumb>();
         ComponentFactories.AddStub<LogTablePane>();
         ComponentFactories.AddStub<DetailsPaneComponent>();
         ComponentFactories.AddStub<EmptyStateDashboard>();

--- a/tests/Unit/EventLogExpert.UI.Tests/TestUtils/LogTablePaneDependenciesExtensions.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/TestUtils/LogTablePaneDependenciesExtensions.cs
@@ -5,6 +5,7 @@ using EventLogExpert.Filtering.Compilation;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Runtime.Alerts;
 using EventLogExpert.Runtime.Common.Clipboard;
+using EventLogExpert.Runtime.FilterLenses;
 using EventLogExpert.Runtime.FilterPane;
 using EventLogExpert.Runtime.LogTable;
 using EventLogExpert.Runtime.Menu;
@@ -21,6 +22,7 @@ internal static class LogTablePaneDependenciesExtensions
         {
             services.AddSingleton(Substitute.For<IAlertDialogService>());
             services.AddSingleton(Substitute.For<IClipboardService>());
+            services.AddSingleton(Substitute.For<IFilterLensCommands>());
             services.AddSingleton(Substitute.For<IFilterPaneCommands>());
             services.AddSingleton(Substitute.For<IFilterService>());
             services.AddSingleton(Substitute.For<ILogTableCommands>());


### PR DESCRIPTION
## What

Adds a "filter lens" stack: transient, reversible narrowing layers applied on top of the persistent filter without mutating saved filters or exports. The first lens is **Show Related by Activity ID** - from an event's context menu, narrow the event view to only events sharing that Activity ID. Events with no Activity ID are correctly hidden (not leaked), because the lens is encoded as an exclude of `ActivityId != X` and `NotEqual` on the nullable-Guid column is total.

## Components

- `FilterLens` / `FilterLensId` / `FilterLensState` - transient lens records and the Fluxor feature state. Lenses live only in derived state, never in `FilterPaneState`, so they cannot contaminate saved filters.
- `EffectiveFilterBuilder.Build(baseFilter, lenses)` - the single composition site, called by both the FilterPane apply path and the lens push/pop effect so they cannot diverge. Pairs with the existing `FilterPaneFilterBuilder`.
- `FilterLensFactory.ForActivityId(...)` - builds the Show-Related lens.
- `IFilterLensCommands` - push/remove/clear facade injected into the UI.
- `LensBreadcrumb` - UI showing active lenses with per-lens remove chips, a "Clear all" action, and scoped Escape-to-pop.
- Lifecycle: a lens auto-clears when the user closes its originating log (tab close button or tab menu) and on close-all; filter-driven reloads never clear it.

## Tests

Adds Filter Stack unit tests across the builder, factory, reducers (including duplicate-identity removal), effects (including owning-log lifecycle), commands, and the breadcrumb component. All unit suites green: Runtime 1678, UI 1038. Release build clean (0 warnings/0 errors).
