### PR TITLE
Add a time-window filter lens (Show Events Near This Time)

### DIFF
--- a/src/EventLogExpert.Runtime/FilterLenses/FilterLensCommands.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/FilterLensCommands.cs
@@ -13,6 +13,9 @@ internal sealed class FilterLensCommands(IDispatcher dispatcher) : IFilterLensCo
 
     public void RemoveLens(FilterLens lens) => _dispatcher.Dispatch(new RemoveFilterLensAction(lens));
 
+    public void ShowEventsNearTime(DateTime timeCreated, TimeSpan radius, TimeZoneInfo displayZone, string? originLog = null) =>
+        PushLens(FilterLensFactory.ForTimeWindow(timeCreated, radius, displayZone, originLog));
+
     public void ShowParentActivity(Guid? relatedActivityId, string? originLog = null)
     {
         if (relatedActivityId is { } id)

--- a/src/EventLogExpert.Runtime/FilterLenses/FilterLensFactory.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/FilterLensFactory.cs
@@ -5,6 +5,7 @@ using EventLogExpert.Filtering.Basic;
 using EventLogExpert.Filtering.Common.Filtering;
 using EventLogExpert.Filtering.Evaluation;
 using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Runtime.Common.Display;
 
 namespace EventLogExpert.Runtime.FilterLenses;
 
@@ -28,6 +29,46 @@ internal static class FilterLensFactory
             relatedActivityId,
             $"Related Activity ID = {relatedActivityId}",
             originLog);
+
+    /// <summary>
+    ///     Builds a transient time-window lens centered on <paramref name="timeCreatedUtc" /> (the source event's UTC
+    ///     timestamp): the effective view is narrowed to the inclusive range [timeCreatedUtc - radius, timeCreatedUtc +
+    ///     radius], so the source event itself always survives. Bounds are clamped to the <see cref="DateTime" /> range
+    ///     because boundary arithmetic throws on overflow - a degenerate near-min/near-max timestamp must not crash the menu
+    ///     handler. The chip label renders the anchor's time of day in <paramref name="displayZone" /> (the grid's display
+    ///     zone) as a compact marker; it is not the grid's full date+time rendering. <paramref name="radius" /> must be within
+    ///     (0, 1 hour] and a whole number of seconds (validated); the suffix renders it to its largest whole unit (for example
+    ///     90s stays "90s").
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///     <paramref name="radius" /> is not within (0, 1 hour], or is not a whole
+    ///     number of seconds.
+    /// </exception>
+    public static FilterLens ForTimeWindow(
+        DateTime timeCreatedUtc,
+        TimeSpan radius,
+        TimeZoneInfo displayZone,
+        string? originLog = null)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(radius, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(radius, TimeSpan.FromHours(1));
+
+        if (radius.Ticks % TimeSpan.TicksPerSecond != 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(radius), radius, "Radius must be a whole number of seconds.");
+        }
+
+        var after = timeCreatedUtc <= DateTime.MinValue + radius ? DateTime.MinValue : timeCreatedUtc - radius;
+        var before = timeCreatedUtc >= DateTime.MaxValue - radius ? DateTime.MaxValue : timeCreatedUtc + radius;
+
+        return new FilterLens
+        {
+            Label = $"Near {timeCreatedUtc.ConvertTimeZone(displayZone):T} \u00b1{FormatRadius(radius)}",
+            Kind = LensKind.TimeWindow,
+            Window = new DateFilter { After = after, Before = before, IsEnabled = true },
+            OriginLog = originLog
+        };
+    }
 
     /// <summary>
     ///     Encodes a nullable-Guid equality narrowing (keep only rows where the field equals <paramref name="value" />)
@@ -60,6 +101,18 @@ internal static class FilterLensFactory
             OriginLog = originLog
         };
     }
+
+    /// <summary>
+    ///     Formats the window radius as a compact chip suffix (for example "30s", "5m", "1h") using the largest whole
+    ///     unit that represents it exactly. Callers are validated to whole-second radii, so every valid radius renders
+    ///     losslessly.
+    /// </summary>
+    private static string FormatRadius(TimeSpan radius) => radius switch
+    {
+        { Minutes: 0, Seconds: 0, Milliseconds: 0 } => $"{radius.TotalHours:0}h",
+        { Seconds: 0, Milliseconds: 0 } => $"{radius.TotalMinutes:0}m",
+        _ => $"{radius.TotalSeconds:0}s"
+    };
 
     private static bool TryFormatNotEqual(EventProperty property, string value, out string comparisonText)
     {

--- a/src/EventLogExpert.Runtime/FilterLenses/IFilterLensCommands.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/IFilterLensCommands.cs
@@ -12,6 +12,15 @@ public interface IFilterLensCommands
     void RemoveLens(FilterLens lens);
 
     /// <summary>
+    ///     Pushes a transient time-window lens centered on <paramref name="timeCreated" /> (the source event's UTC
+    ///     timestamp), narrowing the view to events no more than <paramref name="radius" /> before or after it. The window is
+    ///     inclusive, so the source event always stays in view. <paramref name="displayZone" /> renders the chip's anchor time
+    ///     in the grid's display zone; <paramref name="originLog" /> is the source event's
+    ///     <see cref="ResolvedEvent.OwningLog" /> so the lens auto-clears when that log is closed.
+    /// </summary>
+    void ShowEventsNearTime(DateTime timeCreated, TimeSpan radius, TimeZoneInfo displayZone, string? originLog = null);
+
+    /// <summary>
     ///     Pushes a lens narrowing the view to the parent activity's events - those whose ActivityId equals the source
     ///     event's <paramref name="relatedActivityId" />. A null id is a no-op. <paramref name="originLog" /> is the source
     ///     event's <see cref="ResolvedEvent.OwningLog" /> so the lens auto-clears when that log is closed.

--- a/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
@@ -1338,6 +1338,30 @@ public sealed partial class LogTablePane
                 () => FilterLensCommands.ShowParentActivity(selectedEvent.RelatedActivityId, selectedEvent.OwningLog),
                 isEnabled: selectedEvent.RelatedActivityId.HasValue,
                 disabledReason: selectedEvent.RelatedActivityId.HasValue ? null : "This event has no Related Activity ID."),
+            MenuItem.SubMenu(
+                "Show Events Near This Time",
+                [
+                    MenuItem.Item(
+                        "\u00b130 Seconds",
+                        () => FilterLensCommands.ShowEventsNearTime(
+                            selectedEvent.TimeCreated, TimeSpan.FromSeconds(30), Settings.TimeZoneInfo, selectedEvent.OwningLog)),
+                    MenuItem.Item(
+                        "\u00b11 Minute",
+                        () => FilterLensCommands.ShowEventsNearTime(
+                            selectedEvent.TimeCreated, TimeSpan.FromMinutes(1), Settings.TimeZoneInfo, selectedEvent.OwningLog)),
+                    MenuItem.Item(
+                        "\u00b15 Minutes",
+                        () => FilterLensCommands.ShowEventsNearTime(
+                            selectedEvent.TimeCreated, TimeSpan.FromMinutes(5), Settings.TimeZoneInfo, selectedEvent.OwningLog)),
+                    MenuItem.Item(
+                        "\u00b115 Minutes",
+                        () => FilterLensCommands.ShowEventsNearTime(
+                            selectedEvent.TimeCreated, TimeSpan.FromMinutes(15), Settings.TimeZoneInfo, selectedEvent.OwningLog)),
+                    MenuItem.Item(
+                        "\u00b11 Hour",
+                        () => FilterLensCommands.ShowEventsNearTime(
+                            selectedEvent.TimeCreated, TimeSpan.FromHours(1), Settings.TimeZoneInfo, selectedEvent.OwningLog)),
+                ]),
             MenuItem.Separator(),
             MenuItem.SubMenu(
                 "More Fields",

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/EffectiveFilterBuilderTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/EffectiveFilterBuilderTests.cs
@@ -107,6 +107,27 @@ public sealed class EffectiveFilterBuilderTests
     }
 
     [Fact]
+    public void Build_TimeWindowLensFromFactory_KeepsEventsWithinRadius_IncludingInclusiveBoundsAndSource()
+    {
+        // The factory-built centered window [T-1h, T+1h] keeps the source event at T and neighbors exactly on the
+        // inclusive bounds, and hides anything past them.
+        var anchor = At(12);
+        var source = FilterEventBuilder.CreateTestEvent(id: 1, timeCreated: anchor);
+        var onLowerBound = FilterEventBuilder.CreateTestEvent(id: 2, timeCreated: At(11));
+        var onUpperBound = FilterEventBuilder.CreateTestEvent(id: 3, timeCreated: At(13));
+        var belowWindow = FilterEventBuilder.CreateTestEvent(id: 4, timeCreated: At(10));
+        var aboveWindow = FilterEventBuilder.CreateTestEvent(id: 5, timeCreated: At(14));
+
+        var lens = FilterLensFactory.ForTimeWindow(anchor, TimeSpan.FromHours(1), TimeZoneInfo.Utc);
+        var composed = EffectiveFilterBuilder.Build(new Filter(null, []), [lens]);
+
+        var result = s_filterService.GetFilteredEvents(
+            [source, onLowerBound, onUpperBound, belowWindow, aboveWindow], composed);
+
+        Assert.Equal([1, 2, 3], result.Select(e => e.Id).OrderBy(id => id));
+    }
+
+    [Fact]
     public void Build_WithActivityIdLensOnBaseInclude_NarrowsToIntersection()
     {
         // Arrange - base includes Level == Error (OR-combined include list); the lens must AND-narrow, so only the

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensCommandsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensCommandsTests.cs
@@ -30,6 +30,121 @@ public sealed class FilterLensCommandsTests
         dispatcher.Received(1).Dispatch(Arg.Is<RemoveFilterLensAction>(action => action.Lens == lens));
     }
 
+    [Theory]
+    [InlineData(30, "\u00b130s")]
+    [InlineData(60, "\u00b11m")]
+    [InlineData(300, "\u00b15m")]
+    [InlineData(900, "\u00b115m")]
+    [InlineData(3600, "\u00b11h")]
+    public void ShowEventsNearTime_ChipSuffixMatchesOfferedDurations(int seconds, string expectedSuffix)
+    {
+        var dispatcher = Substitute.For<IDispatcher>();
+
+        new FilterLensCommands(dispatcher).ShowEventsNearTime(
+            new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc), TimeSpan.FromSeconds(seconds), TimeZoneInfo.Utc);
+
+        dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action =>
+            action.Lens.Label.EndsWith(expectedSuffix, StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public void ShowEventsNearTime_DispatchesPushWithCenteredEnabledWindow()
+    {
+        var dispatcher = Substitute.For<IDispatcher>();
+        var anchor = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        new FilterLensCommands(dispatcher).ShowEventsNearTime(anchor, TimeSpan.FromMinutes(5), TimeZoneInfo.Utc);
+
+        dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action =>
+            action.Lens.Kind == LensKind.TimeWindow &&
+            action.Lens.Window != null &&
+            action.Lens.Window.IsEnabled &&
+            action.Lens.Window.After == anchor.AddMinutes(-5) &&
+            action.Lens.Window.Before == anchor.AddMinutes(5)));
+    }
+
+    [Fact]
+    public void ShowEventsNearTime_InRangeNonStandardRadius_RendersLosslessChipSuffix()
+    {
+        var dispatcher = Substitute.For<IDispatcher>();
+
+        // 90s is within (0, 1h] but not an offered duration; the suffix renders it losslessly as "90s", not a rounded "2m".
+        new FilterLensCommands(dispatcher).ShowEventsNearTime(
+            new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc), TimeSpan.FromSeconds(90), TimeZoneInfo.Utc);
+
+        dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action =>
+            action.Lens.Label.EndsWith("\u00b190s", StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public void ShowEventsNearTime_LabelRendersAnchorInDisplayZone()
+    {
+        var dispatcher = Substitute.For<IDispatcher>();
+        var anchor = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        var displayZone = TimeZoneInfo.CreateCustomTimeZone("test+5", TimeSpan.FromHours(5), "test+5", "test+5");
+        var expectedAnchor = TimeZoneInfo.ConvertTimeFromUtc(anchor, displayZone);
+
+        new FilterLensCommands(dispatcher).ShowEventsNearTime(anchor, TimeSpan.FromMinutes(5), displayZone);
+
+        // Built with the same culture-sensitive ":T" the production label uses, so the assertion holds under any ambient
+        // culture; the anchor renders in the +5 display zone (17:00:00), not UTC (12:00:00).
+        dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action =>
+            action.Lens.Label == $"Near {expectedAnchor:T} \u00b15m"));
+    }
+
+    [Fact]
+    public void ShowEventsNearTime_MinValueAnchor_ClampsLowerBoundWithoutThrowing()
+    {
+        var dispatcher = Substitute.For<IDispatcher>();
+
+        // A degenerate default(DateTime) anchor must not throw - DateTime boundary arithmetic throws on underflow; the
+        // lower bound clamps to DateTime.MinValue.
+        new FilterLensCommands(dispatcher).ShowEventsNearTime(
+            DateTime.MinValue, TimeSpan.FromSeconds(30), TimeZoneInfo.Utc);
+
+        dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action =>
+            action.Lens.Window!.After == DateTime.MinValue &&
+            action.Lens.Window.Before == DateTime.MinValue.AddSeconds(30)));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-30)]
+    [InlineData(3601)]
+    public void ShowEventsNearTime_RadiusOutsideSupportedRange_ThrowsAndDoesNotDispatch(int seconds)
+    {
+        var dispatcher = Substitute.For<IDispatcher>();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => new FilterLensCommands(dispatcher).ShowEventsNearTime(
+            new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc), TimeSpan.FromSeconds(seconds), TimeZoneInfo.Utc));
+
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<PushFilterLensAction>());
+    }
+
+    [Fact]
+    public void ShowEventsNearTime_SubSecondRadius_ThrowsAndDoesNotDispatch()
+    {
+        var dispatcher = Substitute.For<IDispatcher>();
+
+        // The window is whole-second granularity; a sub-second radius (which the compact suffix cannot render losslessly)
+        // is rejected rather than silently rounded.
+        Assert.Throws<ArgumentOutOfRangeException>(() => new FilterLensCommands(dispatcher).ShowEventsNearTime(
+            new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc), TimeSpan.FromMilliseconds(500), TimeZoneInfo.Utc));
+
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<PushFilterLensAction>());
+    }
+
+    [Fact]
+    public void ShowEventsNearTime_WithOriginLog_TagsLensWithThatLog()
+    {
+        var dispatcher = Substitute.For<IDispatcher>();
+
+        new FilterLensCommands(dispatcher).ShowEventsNearTime(
+            new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc), TimeSpan.FromMinutes(5), TimeZoneInfo.Utc, "LogA");
+
+        dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action => action.Lens.OriginLog == "LogA"));
+    }
+
     [Fact]
     public void ShowParentActivity_Guid_DispatchesActivityIdExcludeLensWithParentLabel()
     {

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensCommandsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensCommandsTests.cs
@@ -135,6 +135,22 @@ public sealed class FilterLensCommandsTests
     }
 
     [Fact]
+    public void ShowEventsNearTime_MinValueAnchorWithNegativeOffsetZone_RendersLabelWithoutThrowing()
+    {
+        var dispatcher = Substitute.For<IDispatcher>();
+        var westOfUtc = TimeZoneInfo.CreateCustomTimeZone("test-5", TimeSpan.FromHours(-5), "test-5", "test-5");
+
+        // Guards the chip-label conversion for a degenerate default(DateTime) anchor against a non-UTC display zone: on
+        // net10 TimeZoneInfo.ConvertTimeFromUtc clamps an out-of-range result to DateTime.MinValue instead of throwing, so
+        // the label renders without crashing the context-menu handler. (Legacy .NET Framework threw for this exact case; a
+        // future retarget that reintroduced the throw would fail this test rather than crashing at runtime.)
+        new FilterLensCommands(dispatcher).ShowEventsNearTime(
+            DateTime.MinValue, TimeSpan.FromSeconds(30), westOfUtc);
+
+        dispatcher.Received(1).Dispatch(Arg.Any<PushFilterLensAction>());
+    }
+
+    [Fact]
     public void ShowEventsNearTime_WithOriginLog_TagsLensWithThatLog()
     {
         var dispatcher = Substitute.For<IDispatcher>();


### PR DESCRIPTION
## Summary

Adds a transient, reversible **time-window filter lens** surfaced as a **"Show Events Near This Time"** context-menu submenu on an event row. Selecting a duration pushes a lens that narrows the event table to a centered window `[TimeCreated - d, TimeCreated + d]` and drops a removable breadcrumb chip (for example `Near 2:03:22 PM +/-5m`). Like the other lenses it never mutates the saved/persistent filter and pops off cleanly.

This completes the Wave-2 lens set alongside the merged Filter Stack (#643) and Related Activity ID lenses (#644). It is a genuinely new "zoom into the time neighborhood of an event, look around, then pop back" gesture, distinct from the existing **persistent** "Exclude Events Before/After" items.

Tracks ADO 62704670.

## Durations

Five fixed centered windows: `+/-30s`, `+/-1m`, `+/-5m`, `+/-15m`, `+/-1h` (capped at 1 hour; day-scale browsing remains the persistent date range's job).

## Design

Informed by a 5-reviewer UX design panel:
- **Centered "around" only** - one-sided transient lenses were deferred as they would duplicate/confuse next to the persistent "Exclude Before/After".
- **Menu placement** in the lens "Show..." group, separated from the persistent "Exclude..." group; the "Show" (transient lens) vs "Exclude" (persistent) verb split is the anti-confusion lever.
- **Inclusive bounds** so the clicked event always stays in view.
- **Window math in UTC; chip anchor rendered in the grid's display timezone** so the chip time matches the clicked row.

## Implementation

- `FilterLensFactory.ForTimeWindow` - builds the windowed `FilterLens`; bounds clamped to the `DateTime` range (boundary arithmetic throws on overflow), radius validated to `(0, 1 hour]` and whole seconds, chip suffix rendered losslessly.
- `IFilterLensCommands.ShowEventsNearTime` / `FilterLensCommands` - dispatches the lens via the existing push path.
- `LogTablePane` - the "Show Events Near This Time" submenu (5 durations), no gating (every event has a timestamp).

## Tests

- End-to-end via the composer: inclusive bounds + source-event survival + radius exclusion (below and above the window).
- Command dispatch: centered enabled window bounds, chip-suffix mapping for all five durations, display-zone anchor rendering, origin-log tagging, degenerate `MinValue` anchor clamp (no throw), radius-contract rejection (zero / negative / >1h / sub-second).

## Validation

Runtime.Tests 1702/1702, UI.Tests 1038/1038, full-solution Release build 0 warnings / 0 errors.
