### PR TITLE
Redesign the status bar with structured counts and scoped aria-live

### DIFF
--- a/src/EventLogExpert.Runtime/FilterPane/FilterPaneState.cs
+++ b/src/EventLogExpert.Runtime/FilterPane/FilterPaneState.cs
@@ -16,4 +16,8 @@ public sealed record FilterPaneState
     public DateFilter? FilteredDateRange { get; init; }
 
     public bool IsEnabled { get; init; } = true;
+
+    public bool IsFilteringEnabled =>
+        FilteredDateRange?.IsEnabled is true ||
+        (IsEnabled ? Filters.Any(filter => filter.IsEnabled) : Filters.Any(filter => filter.IsExcluded));
 }

--- a/src/EventLogExpert.Runtime/StatusBar/StatusBarFormatter.cs
+++ b/src/EventLogExpert.Runtime/StatusBar/StatusBarFormatter.cs
@@ -1,0 +1,108 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.LogTable;
+
+namespace EventLogExpert.Runtime.StatusBar;
+
+/// <summary>
+///     Pure presentation helpers for the status bar: the active-source label, the total/shown/selected count phrase,
+///     the filter-lens indicator tooltip, and the coarse screen-reader activity announcement. Kept free of Fluxor so the
+///     UI component stays thin and the logic is unit-testable in isolation, mirroring <c>EventTableColumnFormatter</c>.
+///     Count formatting uses the current culture (thousands separators); tests pin the culture.
+/// </summary>
+public static class StatusBarFormatter
+{
+    /// <summary>
+    ///     Tooltip for the filter-lens indicator that names the narrowing mechanism the breadcrumb/pane owns the detail
+    ///     of: "Filter active", "N lenses", or "Filter + N lenses". Returns <see langword="null" /> when nothing narrows (the
+    ///     indicator is then hidden).
+    /// </summary>
+    public static string? FilterIndicatorTooltip(bool persistentActive, int lensCount)
+    {
+        var lensText = lensCount switch
+        {
+            <= 0 => null,
+            1 => "1 lens",
+            _ => $"{lensCount} lenses"
+        };
+
+        return (persistentActive, lensText) switch
+        {
+            (true, null) => "Filter active",
+            (true, not null) => $"Filter + {lensText}",
+            (false, not null) => lensText,
+            (false, null) => null
+        };
+    }
+
+    /// <summary>
+    ///     The coarse activity label announced to screen readers (via the single polite status region). It changes only
+    ///     on state transitions, so per-tick loading/buffer counts - which render as silent visual siblings - never announce.
+    ///     Priority puts a load error first: <paramref name="resolverStatus" /> is only ever an error message or empty, so it
+    ///     must surface even while another log is still loading; then buffer-full, then loading, then continuous updating.
+    /// </summary>
+    public static string FormatActivityAnnouncement(
+        bool isLoading,
+        bool bufferFull,
+        bool continuouslyUpdating,
+        string resolverStatus)
+    {
+        if (!string.IsNullOrEmpty(resolverStatus)) { return resolverStatus; }
+
+        if (bufferFull) { return "Buffer full"; }
+
+        if (isLoading) { return "Loading"; }
+
+        return continuouslyUpdating ? "Continuously updating" : string.Empty;
+    }
+
+    /// <summary>
+    ///     "1,234 events" normally, "200 of 1,234 shown" when the effective (base intersect lenses) filter narrows the
+    ///     view, plus " {middot} 3 selected" only for a multi-select (<paramref name="selectedCount" /> &gt;= 2 - a single
+    ///     click already selects one row, so surfacing "1 selected" would be near-omnipresent noise).
+    /// </summary>
+    public static string FormatCounts(int total, int shown, bool isFiltered, int selectedCount)
+    {
+        var head = isFiltered ? $"{shown:N0} of {total:N0} shown" : $"{total:N0} events";
+
+        return selectedCount >= 2 ? $"{head} \u00b7 {selectedCount:N0} selected" : head;
+    }
+
+    /// <summary>
+    ///     The active tab's source label: a channel's <see cref="LogView.LogName" />, an opened file's base name, a named
+    ///     group's name, "All logs (N)" for the implicit all-logs view (N = open per-log tabs), or "Combined (N logs)" for an
+    ///     unnamed group. Remote/computer origin is deliberately omitted (<see cref="LogView.ComputerName" /> is the event's
+    ///     origin machine, not the connection source). Returns "No log open" when there is no active view.
+    /// </summary>
+    public static string FormatSource(
+        LogView? active,
+        IReadOnlyList<LogView> eventTables,
+        IReadOnlyList<LogTabGroup> groups)
+    {
+        if (active is null) { return "No log open"; }
+
+        if (active.GroupId is not { } groupId)
+        {
+            return active.FileName is { } fileName ? Path.GetFileName(fileName) : active.LogName;
+        }
+
+        if (groupId.IsAll)
+        {
+            var openLogs = 0;
+
+            foreach (var table in eventTables)
+            {
+                if (!table.IsCombined) { openLogs++; }
+            }
+
+            return $"All logs ({openLogs})";
+        }
+
+        var group = groups.FirstOrDefault(candidate => candidate.Id == groupId);
+
+        if (group is null) { return "Combined"; }
+
+        return string.IsNullOrEmpty(group.Name) ? $"Combined ({group.MemberIds.Count} logs)" : group.Name;
+    }
+}

--- a/src/EventLogExpert.UI/StatusBar/StatusBar.razor
+++ b/src/EventLogExpert.UI/StatusBar/StatusBar.razor
@@ -1,4 +1,5 @@
 @using EventLogExpert.Eventing.Common.Channels
+@using EventLogExpert.Runtime.StatusBar
 @inherits FluxorComponent
 
 @{
@@ -6,55 +7,78 @@
     var rawCount = RawCountSelection.Value;
     var logTable = LogTableSelection.Value;
     var statusBar = StatusBarSelection.Value;
+
+    var activeTable = logTable.EventTables.FirstOrDefault(table => table.Id == logTable.ActiveEventLogId);
+    var hasChannel = logTable.EventTables.Any(table => table.LogPathType == LogPathType.Channel);
+    var isFiltered = eventLog.AppliedFilter.IsFilteringEnabled;
+    var isLoading = !statusBar.EventsLoading.IsEmpty;
+
+    var source = StatusBarFormatter.FormatSource(activeTable, logTable.EventTables, logTable.Groups);
+    var filterTooltip = StatusBarFormatter.FilterIndicatorTooltip(FilterActiveSelection.Value, LensCountSelection.Value);
+
+    var announcement = StatusBarFormatter.FormatActivityAnnouncement(
+        isLoading,
+        hasChannel && eventLog.NewEventBufferIsFull,
+        hasChannel && eventLog.ContinuouslyUpdate,
+        statusBar.ResolverStatus);
 }
 
-<div aria-atomic="true" aria-live="polite" class="status-bar" role="status">
-    @foreach (var loadingProgress in statusBar.EventsLoading)
-    {
-        <span>Loading: @loadingProgress.Value.Item1</span>
+<div class="status-bar">
+    <div class="status-bar-left">
+        <span class="status-bar-source" title="@(activeTable?.FileName ?? source)">@source</span>
 
-        @if (loadingProgress.Value.Item2 > 0)
+        @if (activeTable is not null)
         {
-            <span>Failed: @loadingProgress.Value.Item2</span>
+            var total = TotalRawCount(activeTable, logTable.Groups, rawCount);
+
+            var shown = activeTable.IsCombined ?
+                logTable.ActiveFilteredViewCount :
+                logTable.EventCountByLog.GetValueOrDefault(activeTable.Id, 0);
+
+            <span aria-hidden="true" class="status-bar-sep">|</span>
+            <span class="status-bar-counts">@StatusBarFormatter.FormatCounts(total, shown, isFiltered, eventLog.SelectionCount)</span>
         }
-    }
 
-    <span>Events Loaded: @rawCount.Total</span>
-
-    @if (logTable.ActiveEventLogId is not null && eventLog.AppliedFilter.IsFilteringEnabled)
-    {
-        var activeTable = logTable.EventTables.FirstOrDefault(table => table.Id == logTable.ActiveEventLogId);
-
-        if (activeTable is null) { return; }
-
-        var totalEvents = TotalRawCount(activeTable, logTable.Groups, rawCount);
-
-        var filteredEvents = activeTable.IsCombined ?
-            logTable.ActiveFilteredViewCount :
-            logTable.EventCountByLog.GetValueOrDefault(activeTable.Id, 0);
-
-        <span>Visible: @(filteredEvents) Hidden by filter: @(totalEvents - filteredEvents)</span>
-    }
-
-    @if (logTable.EventTables.Any(table => table.LogPathType == LogPathType.Channel))
-    {
-        @if (eventLog.ContinuouslyUpdate)
+        @if (isFiltered)
         {
-            <span>Continuously Updating</span>
+            <span aria-hidden="true" class="status-bar-sep">|</span>
+            <span class="status-bar-filter" title="@filterTooltip">Filtered</span>
         }
-        else
-        {
-            <span>New Events: @eventLog.NewEventBuffer.Count</span>
+    </div>
 
-            @if (eventLog.NewEventBufferIsFull)
+    <div class="status-bar-right">
+        <span aria-atomic="true" aria-live="polite" class="status-bar-announce" role="status">@announcement</span>
+
+        @foreach (var loadingProgress in statusBar.EventsLoading)
+        {
+            <span class="status-bar-activity">Loading: @loadingProgress.Value.Item1</span>
+
+            @if (loadingProgress.Value.Item2 > 0)
             {
-                <span>Buffer Full</span>
+                <span class="status-bar-activity status-bar-warn">Failed: @loadingProgress.Value.Item2</span>
             }
         }
-    }
 
-    @if (!string.IsNullOrEmpty(statusBar.ResolverStatus))
-    {
-        <span>@statusBar.ResolverStatus</span>
-    }
+        @if (hasChannel)
+        {
+            @if (eventLog.ContinuouslyUpdate)
+            {
+                <span class="status-bar-activity status-bar-live">Continuously updating</span>
+            }
+            else
+            {
+                <span aria-live="off" class="status-bar-activity">New Events: @eventLog.NewEventBufferCount</span>
+
+                @if (eventLog.NewEventBufferIsFull)
+                {
+                    <span class="status-bar-activity status-bar-warn">Buffer full</span>
+                }
+            }
+        }
+
+        @if (!string.IsNullOrEmpty(statusBar.ResolverStatus))
+        {
+            <span class="status-bar-activity">@statusBar.ResolverStatus</span>
+        }
+    </div>
 </div>

--- a/src/EventLogExpert.UI/StatusBar/StatusBar.razor.cs
+++ b/src/EventLogExpert.UI/StatusBar/StatusBar.razor.cs
@@ -2,9 +2,10 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Eventing.Common.EventLogs;
-using EventLogExpert.Eventing.Common.Events;
 using EventLogExpert.Filtering.Evaluation;
 using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.FilterLenses;
+using EventLogExpert.Runtime.FilterPane;
 using EventLogExpert.Runtime.LogTable;
 using EventLogExpert.Runtime.StatusBar;
 using Fluxor;
@@ -19,9 +20,16 @@ public sealed partial class StatusBar
     private IStateSelection<EventLogState, (
         Filter AppliedFilter,
         bool ContinuouslyUpdate,
-        IReadOnlyList<ResolvedEvent> NewEventBuffer,
-        bool NewEventBufferIsFull)> EventLogSelection
+        int NewEventBufferCount,
+        bool NewEventBufferIsFull,
+        int SelectionCount)> EventLogSelection
     { get; init; } = null!;
+
+    [Inject]
+    private IStateSelection<FilterPaneState, bool> FilterActiveSelection { get; init; } = null!;
+
+    [Inject]
+    private IStateSelection<FilterLensState, int> LensCountSelection { get; init; } = null!;
 
     [Inject]
     private IStateSelection<LogTableState, (
@@ -47,7 +55,7 @@ public sealed partial class StatusBar
     protected override void OnInitialized()
     {
         EventLogSelection.Select(static s =>
-            (s.AppliedFilter, s.ContinuouslyUpdate, s.NewEventBuffer, s.NewEventBufferIsFull));
+            (s.AppliedFilter, s.ContinuouslyUpdate, s.NewEventBuffer.Count, s.NewEventBufferIsFull, s.Selection.Count));
         RawCountSelection.Select(static s => (s.Total, s.ByLog));
         LogTableSelection.Select(static s =>
         {
@@ -61,6 +69,8 @@ public sealed partial class StatusBar
                 s.Groups);
         });
         StatusBarSelection.Select(static s => (s.EventsLoading, s.ResolverStatus));
+        FilterActiveSelection.Select(static s => s.IsFilteringEnabled);
+        LensCountSelection.Select(static s => s.Lenses.Count);
 
         base.OnInitialized();
     }
@@ -72,13 +82,13 @@ public sealed partial class StatusBar
     {
         if (activeTable.GroupId?.IsAll == true) { return rawCount.Total; }
 
-        if (activeTable.GroupId is { } groupId)
+        if (activeTable.GroupId is not { } groupId)
         {
-            var group = groups.FirstOrDefault(candidate => candidate.Id == groupId);
-
-            return group is null ? 0 : group.MemberIds.Sum(id => rawCount.ByLog.GetValueOrDefault(id, 0));
+            return rawCount.ByLog.GetValueOrDefault(activeTable.Id, 0);
         }
 
-        return rawCount.ByLog.GetValueOrDefault(activeTable.Id, 0);
+        var group = groups.FirstOrDefault(candidate => candidate.Id == groupId);
+
+        return group is null ? 0 : group.MemberIds.Sum(id => rawCount.ByLog.GetValueOrDefault(id, 0));
     }
 }

--- a/src/EventLogExpert.UI/StatusBar/StatusBar.razor.css
+++ b/src/EventLogExpert.UI/StatusBar/StatusBar.razor.css
@@ -1,10 +1,63 @@
 ﻿.status-bar {
     flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
     background-color: var(--clr-statusbar);
     color: var(--clr-white);
-    padding-left: 5px;
+    padding: 2px 8px;
 }
 
-.status-bar > span {
-    margin-right: 10px;
+.status-bar-left,
+.status-bar-right {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+}
+
+.status-bar-right {
+    justify-content: flex-end;
+    flex-shrink: 0;
+}
+
+.status-bar-source {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 40ch;
+}
+
+.status-bar-counts,
+.status-bar-activity {
+    white-space: nowrap;
+}
+
+.status-bar-sep {
+    opacity: 0.5;
+}
+
+.status-bar-filter {
+    font-weight: 600;
+}
+
+/* White (inherited) text keeps WCAG AA contrast on the blue status bar; weight distinguishes the state. A color-coded
+   status palette that meets AA on the status-bar fill is deferred to v2. */
+.status-bar-warn,
+.status-bar-live {
+    font-weight: 600;
+}
+
+/* Screen-reader-only region: announces the coarse activity transition without showing a duplicate visual label. */
+.status-bar-announce {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterPane/FilterPaneStateFilteringTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterPane/FilterPaneStateFilteringTests.cs
@@ -1,0 +1,58 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Runtime.FilterPane;
+
+namespace EventLogExpert.Runtime.Tests.FilterPane;
+
+public sealed class FilterPaneStateFilteringTests
+{
+    private static readonly SavedFilter s_include =
+        SavedFilter.TryCreate("Level == 4", isEnabled: true)
+        ?? throw new InvalidOperationException("test filter failed to compile");
+    private static readonly SavedFilter s_disabledInclude = s_include with { IsEnabled = false };
+
+    private static readonly SavedFilter s_exclude = s_include with { IsExcluded = true };
+
+    [Fact]
+    public void IsFilteringEnabled_DisabledDateRangeNoFilters_IsFalse() =>
+        AssertMatchesBuilder(
+            new FilterPaneState { FilteredDateRange = new DateFilter { IsEnabled = false } },
+            expected: false);
+
+    [Fact]
+    public void IsFilteringEnabled_DisabledWithExcludeFilter_IsTrue() =>
+        AssertMatchesBuilder(new FilterPaneState { IsEnabled = false, Filters = [s_exclude] }, expected: true);
+
+    [Fact]
+    public void IsFilteringEnabled_DisabledWithOnlyIncludeFilter_IsFalse() =>
+        AssertMatchesBuilder(new FilterPaneState { IsEnabled = false, Filters = [s_include] }, expected: false);
+
+    [Fact]
+    public void IsFilteringEnabled_Empty_IsFalse() =>
+        AssertMatchesBuilder(new FilterPaneState(), expected: false);
+
+    [Fact]
+    public void IsFilteringEnabled_EnabledDateRange_IsTrue() =>
+        AssertMatchesBuilder(
+            new FilterPaneState { FilteredDateRange = new DateFilter { IsEnabled = true } },
+            expected: true);
+
+    [Fact]
+    public void IsFilteringEnabled_EnabledWithEnabledFilter_IsTrue() =>
+        AssertMatchesBuilder(new FilterPaneState { IsEnabled = true, Filters = [s_include] }, expected: true);
+
+    [Fact]
+    public void IsFilteringEnabled_EnabledWithOnlyDisabledFilter_IsFalse() =>
+        AssertMatchesBuilder(new FilterPaneState { IsEnabled = true, Filters = [s_disabledInclude] }, expected: false);
+
+    // The status bar's persistent-filter indicator selects FilterPaneState.IsFilteringEnabled, which must stay identical
+    // to the composed FilterPaneFilterBuilder.Build(state).IsFilteringEnabled it derives from - locking that here prevents
+    // the two from drifting.
+    private static void AssertMatchesBuilder(FilterPaneState state, bool expected)
+    {
+        Assert.Equal(expected, state.IsFilteringEnabled);
+        Assert.Equal(FilterPaneFilterBuilder.Build(state).IsFilteringEnabled, state.IsFilteringEnabled);
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/StatusBar/StatusBarFormatterTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/StatusBar/StatusBarFormatterTests.cs
@@ -1,0 +1,117 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.Runtime.StatusBar;
+
+namespace EventLogExpert.Runtime.Tests.StatusBar;
+
+public sealed class StatusBarFormatterTests
+{
+    [Theory]
+    [InlineData(1, "1 lens")]
+    [InlineData(3, "3 lenses")]
+    public void FilterIndicatorTooltip_LensesOnly_ReturnsLensCount(int lensCount, string expected) =>
+        Assert.Equal(expected, StatusBarFormatter.FilterIndicatorTooltip(persistentActive: false, lensCount));
+
+    [Fact]
+    public void FilterIndicatorTooltip_NoNarrowing_ReturnsNull() =>
+        Assert.Null(StatusBarFormatter.FilterIndicatorTooltip(persistentActive: false, lensCount: 0));
+
+    [Fact]
+    public void FilterIndicatorTooltip_PersistentAndLenses_CombinesBoth() =>
+        Assert.Equal("Filter + 2 lenses", StatusBarFormatter.FilterIndicatorTooltip(persistentActive: true, lensCount: 2));
+
+    [Fact]
+    public void FilterIndicatorTooltip_PersistentOnly_ReturnsFilterActive() =>
+        Assert.Equal("Filter active", StatusBarFormatter.FilterIndicatorTooltip(persistentActive: true, lensCount: 0));
+
+    [Theory]
+    [InlineData(true, false, false, "Error: Failed to load System", "Error: Failed to load System")]
+    [InlineData(true, false, false, "", "Loading")]
+    [InlineData(false, true, false, "", "Buffer full")]
+    [InlineData(false, false, true, "", "Continuously updating")]
+    [InlineData(false, false, false, "Error: No resolver", "Error: No resolver")]
+    [InlineData(false, false, false, "", "")]
+    public void FormatActivityAnnouncement_SurfacesErrorOverLoading(
+        bool isLoading, bool bufferFull, bool continuouslyUpdating, string resolverStatus, string expected) =>
+        Assert.Equal(
+            expected,
+            StatusBarFormatter.FormatActivityAnnouncement(isLoading, bufferFull, continuouslyUpdating, resolverStatus));
+
+    [Fact]
+    public void FormatCounts_Filtered_ShowsShownOfTotal() =>
+        Assert.Equal(
+            $"{200:N0} of {1234:N0} shown",
+            StatusBarFormatter.FormatCounts(1234, 200, isFiltered: true, selectedCount: 0));
+
+    [Fact]
+    public void FormatCounts_MultiSelect_AppendsSelectedSuffix() =>
+        Assert.Equal(
+            $"{200:N0} of {1234:N0} shown \u00b7 {3:N0} selected",
+            StatusBarFormatter.FormatCounts(1234, 200, isFiltered: true, selectedCount: 3));
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void FormatCounts_SingleOrNoSelection_OmitsSelectedSuffix(int selectedCount) =>
+        Assert.Equal(
+            $"{1234:N0} events",
+            StatusBarFormatter.FormatCounts(1234, 1234, isFiltered: false, selectedCount));
+
+    [Fact]
+    public void FormatCounts_Unfiltered_ShowsTotalEvents() =>
+        Assert.Equal($"{1234:N0} events", StatusBarFormatter.FormatCounts(1234, 1234, isFiltered: false, selectedCount: 0));
+
+    [Fact]
+    public void FormatSource_AllLogs_CountsOnlyStandaloneTabs()
+    {
+        var allLogs = Combined(LogTabGroupId.AllLogs);
+        var eventTables = new[] { Channel("Application"), Channel("System"), allLogs };
+
+        Assert.Equal("All logs (2)", StatusBarFormatter.FormatSource(allLogs, eventTables, []));
+    }
+
+    [Fact]
+    public void FormatSource_Channel_ReturnsLogName() =>
+        Assert.Equal("Application", StatusBarFormatter.FormatSource(Channel("Application"), [], []));
+
+    [Fact]
+    public void FormatSource_NamedGroup_ReturnsGroupName()
+    {
+        var groupId = LogTabGroupId.Create();
+        var active = Combined(groupId);
+        var groups = new[] { new LogTabGroup(groupId, "Incident triage", [EventLogId.Create(), EventLogId.Create()]) };
+
+        Assert.Equal("Incident triage", StatusBarFormatter.FormatSource(active, [active], groups));
+    }
+
+    [Fact]
+    public void FormatSource_NoActiveView_ReturnsNoLogOpen() =>
+        Assert.Equal("No log open", StatusBarFormatter.FormatSource(null, [], []));
+
+    [Fact]
+    public void FormatSource_OpenedFile_ReturnsBaseName() =>
+        Assert.Equal("Security.evtx", StatusBarFormatter.FormatSource(File(@"C:\logs\Security.evtx"), [], []));
+
+    [Fact]
+    public void FormatSource_UnnamedGroup_ReturnsCombinedWithMemberCount()
+    {
+        var groupId = LogTabGroupId.Create();
+        var active = Combined(groupId);
+        var groups = new[] { new LogTabGroup(groupId, string.Empty, [EventLogId.Create(), EventLogId.Create(), EventLogId.Create()]) };
+
+        Assert.Equal("Combined (3 logs)", StatusBarFormatter.FormatSource(active, [active], groups));
+    }
+
+    private static LogView Channel(string name) =>
+        new(EventLogId.Create()) { LogName = name, LogPathType = LogPathType.Channel };
+
+    private static LogView Combined(LogTabGroupId groupId) =>
+        new(EventLogId.Create()) { GroupId = groupId };
+
+    private static LogView File(string path) =>
+        new(EventLogId.Create()) { FileName = path, LogPathType = LogPathType.File };
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/StatusBar/StatusBarTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/StatusBar/StatusBarTests.cs
@@ -1,0 +1,169 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Filtering.Evaluation;
+using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.FilterLenses;
+using EventLogExpert.Runtime.FilterPane;
+using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.Runtime.StatusBar;
+using Fluxor;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using System.Collections.Immutable;
+
+namespace EventLogExpert.UI.Tests.StatusBar;
+
+public sealed class StatusBarTests : BunitContext
+{
+    private readonly IStateSelection<EventLogState, (Filter, bool, int, bool, int)> _eventLog =
+        Substitute.For<IStateSelection<EventLogState, (Filter, bool, int, bool, int)>>();
+
+    private readonly IStateSelection<FilterPaneState, bool> _filterActive =
+        Substitute.For<IStateSelection<FilterPaneState, bool>>();
+
+    private readonly IStateSelection<FilterLensState, int> _lensCount =
+        Substitute.For<IStateSelection<FilterLensState, int>>();
+
+    private readonly IStateSelection<LogTableState, (
+        EventLogId?, ImmutableList<LogView>, int, ImmutableDictionary<EventLogId, int>, ImmutableList<LogTabGroup>)> _logTable =
+        Substitute.For<IStateSelection<LogTableState, (
+            EventLogId?, ImmutableList<LogView>, int, ImmutableDictionary<EventLogId, int>, ImmutableList<LogTabGroup>)>>();
+
+    private readonly IStateSelection<RawEventCountState, (int, ImmutableDictionary<EventLogId, int>)> _rawCount =
+        Substitute.For<IStateSelection<RawEventCountState, (int, ImmutableDictionary<EventLogId, int>)>>();
+
+    private readonly IStateSelection<StatusBarState, (ImmutableDictionary<StatusActivityId, (int, int)>, string)> _statusBar =
+        Substitute.For<IStateSelection<StatusBarState, (ImmutableDictionary<StatusActivityId, (int, int)>, string)>>();
+
+    public StatusBarTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        Services.AddFluxor(options => options.ScanAssemblies(typeof(UI.StatusBar.StatusBar).Assembly));
+        Services.AddSingleton(_eventLog);
+        Services.AddSingleton(_logTable);
+        Services.AddSingleton(_rawCount);
+        Services.AddSingleton(_statusBar);
+        Services.AddSingleton(_filterActive);
+        Services.AddSingleton(_lensCount);
+
+        _eventLog.Value.Returns((Unfiltered, false, 0, false, 0));
+        _logTable.Value.Returns((null, ImmutableList<LogView>.Empty, 0,
+            ImmutableDictionary<EventLogId, int>.Empty, ImmutableList<LogTabGroup>.Empty));
+        _rawCount.Value.Returns((0, ImmutableDictionary<EventLogId, int>.Empty));
+        _statusBar.Value.Returns((ImmutableDictionary<StatusActivityId, (int, int)>.Empty, string.Empty));
+        _filterActive.Value.Returns(false);
+        _lensCount.Value.Returns(0);
+    }
+
+    private static Filter Filtered => new(new DateFilter { IsEnabled = true }, []);
+
+    private static Filter Unfiltered => new(null, []);
+
+    [Fact]
+    public void ChannelNewEventsCounter_IsNotAnnounced()
+    {
+        var id = EventLogId.Create();
+        var channel = new LogView(id) { LogName = "Application", LogPathType = LogPathType.Channel };
+        _logTable.Value.Returns((id, ImmutableList.Create(channel), 0,
+            ImmutableDictionary<EventLogId, int>.Empty.Add(id, 0), ImmutableList<LogTabGroup>.Empty));
+        _rawCount.Value.Returns((0, ImmutableDictionary<EventLogId, int>.Empty.Add(id, 0)));
+        _eventLog.Value.Returns((Unfiltered, false, 42, false, 0));
+
+        var cut = Render<UI.StatusBar.StatusBar>();
+
+        var newEvents = cut.FindAll(".status-bar-activity").Single(node => node.TextContent.Contains("New Events"));
+        Assert.Equal("off", newEvents.GetAttribute("aria-live"));
+    }
+
+    [Fact]
+    public void Filtered_ShowsShownOfTotal_AndFilteredIndicator()
+    {
+        _filterActive.Value.Returns(true);
+        SetActiveLog(total: 1500, shown: 200, filter: Filtered, selected: 0);
+
+        var cut = Render<UI.StatusBar.StatusBar>();
+
+        Assert.Contains($"{200:N0} of {1500:N0} shown", cut.Markup);
+
+        var indicator = cut.Find(".status-bar-filter");
+        Assert.Equal("Filter active", indicator.GetAttribute("title"));
+    }
+
+    [Fact]
+    public void LensOnlyNarrowing_ShowsShown_AndLensTooltip()
+    {
+        // Persistent filter off, but lenses narrow the composed AppliedFilter - the "shown" count and funnel must still
+        // appear (the corrected lens-awareness), and the tooltip names the lens mechanism.
+        _filterActive.Value.Returns(false);
+        _lensCount.Value.Returns(2);
+        SetActiveLog(total: 1500, shown: 300, filter: Filtered, selected: 0);
+
+        var cut = Render<UI.StatusBar.StatusBar>();
+
+        Assert.Contains($"{300:N0} of {1500:N0} shown", cut.Markup);
+        Assert.Equal("2 lenses", cut.Find(".status-bar-filter").GetAttribute("title"));
+    }
+
+    [Fact]
+    public void MultiSelect_ShowsSelectedSuffix_SingleSelectDoesNot()
+    {
+        SetActiveLog(total: 500, shown: 500, filter: Unfiltered, selected: 3);
+        Assert.Contains("3 selected", Render<UI.StatusBar.StatusBar>().Markup);
+
+        _eventLog.Value.Returns((Unfiltered, false, 0, false, 1));
+        Assert.DoesNotContain("selected", Render<UI.StatusBar.StatusBar>().Markup);
+    }
+
+    [Fact]
+    public void NoActiveLog_ShowsNoLogOpen_AndNoCounts()
+    {
+        var cut = Render<UI.StatusBar.StatusBar>();
+
+        Assert.Contains("No log open", cut.Markup);
+        Assert.Empty(cut.FindAll(".status-bar-counts"));
+    }
+
+    [Fact]
+    public void Root_HasNoLiveRegion_ButAnnounceRegionIsPoliteStatus()
+    {
+        SetActiveLog(total: 500, shown: 500, filter: Unfiltered, selected: 0);
+
+        var cut = Render<UI.StatusBar.StatusBar>();
+
+        var root = cut.Find(".status-bar");
+        Assert.False(root.HasAttribute("aria-live"));
+        Assert.False(root.HasAttribute("role"));
+
+        var announce = cut.Find(".status-bar-announce");
+        Assert.Equal("status", announce.GetAttribute("role"));
+        Assert.Equal("polite", announce.GetAttribute("aria-live"));
+    }
+
+    [Fact]
+    public void Unfiltered_ShowsTotalEvents_WithoutFilteredIndicator()
+    {
+        SetActiveLog(total: 1500, shown: 1500, filter: Unfiltered, selected: 0);
+
+        var cut = Render<UI.StatusBar.StatusBar>();
+
+        Assert.Contains($"{1500:N0} events", cut.Markup);
+        Assert.DoesNotContain("shown", cut.Markup);
+        Assert.Empty(cut.FindAll(".status-bar-filter"));
+    }
+
+    private void SetActiveLog(int total, int shown, Filter filter, int selected)
+    {
+        var id = EventLogId.Create();
+        var log = new LogView(id) { LogName = "Application", LogPathType = LogPathType.Channel };
+
+        _logTable.Value.Returns((id, ImmutableList.Create(log), shown,
+            ImmutableDictionary<EventLogId, int>.Empty.Add(id, shown), ImmutableList<LogTabGroup>.Empty));
+        _rawCount.Value.Returns((total, ImmutableDictionary<EventLogId, int>.Empty.Add(id, total)));
+        _eventLog.Value.Returns((filter, false, 0, false, selected));
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the ad-hoc status bar (a flat row of spans in one `aria-live` region) with a **structured left/right layout** and fixes a real screen-reader accessibility defect.

- **Left (persistent, silent):** active **source** (channel name / file base name / "All logs (N)" / group name) - **counts** ("1,234 events", or "200 of 1,234 shown" when narrowed, plus "3 selected" for a multi-select) - a read-only **"Filtered"** indicator whose tooltip names the mechanism ("Filter active" / "N lenses" / "Filter + N lenses").
- **Right (transient):** loading / failed / live-channel / resolver activity.

Tracks ADO 63067058. Base is `main` (independent of the still-open time-window PR #645; no file overlap).

## Design

Shaped by a 5-reviewer UX design panel: left/right split (VS-Code-style persistent-vs-transient), thousands-separated counts, a compact read-only filter indicator (the lens breadcrumb above the table owns the removable chips), source = active tab only, and the accessibility model below.

## Accessibility fix (the core of the ADO)

The old bar was a single `aria-live="polite" aria-atomic="true"` region, so a screen reader **re-announced the entire bar on every count tick** - driven by the unthrottled event-count and per-event live-buffer counters.

- Root region: **no** `aria-live` / `role` / `aria-atomic`. Counts and source update silently.
- A single visually-hidden `role="status" aria-live="polite"` region carries only a **coarse, transition-only** label (load error / buffer full / loading / continuously updating), so it announces on state changes, not on numeric ticks.
- The unthrottled "New Events: N" counter renders outside the live region with `aria-live="off"`.
- A load **error** takes priority over "Loading" so a failure is announced even while another log is still loading.

## Key correctness

- **Lens-aware counts:** the "shown" gate reads the composed `AppliedFilter.IsFilteringEnabled` (base intersect lenses), so a lens-only narrowing correctly shows "M of N shown" - and a new public `FilterPaneState.IsFilteringEnabled` distinguishes the persistent filter for the tooltip (drift-locked to `FilterPaneFilterBuilder.Build`).
- Removed a latent whole-component early `return` that could drop the activity region.
- Dropped remote/computer detection for v1 (`LogView.ComputerName` is the event-origin machine, not the connection source - deferred to v2).

## Implementation

- `FilterPaneState.IsFilteringEnabled` (public computed, allocation-free).
- `StatusBarFormatter` (public static, Runtime, mirrors `EventTableColumnFormatter`): source / counts / filter-tooltip / activity-announcement.
- `StatusBar.razor(.cs/.css)` restructured; new `IStateSelection` projectors for the persistent-filter bool and lens count.

## Tests (34 new)

- `StatusBarFormatterTests` (formatter variants, culture-robust counts, error-over-loading priority).
- `FilterPaneStateFilteringTests` (locks `IsFilteringEnabled` == `Build(state).IsFilteringEnabled` across 7 states).
- `StatusBarTests` (bUnit: root not live / announce region is `role=status`, "No log open", shown-iff-filtered, selected only at N>=2, "New Events" is `aria-live=off`, lens-only narrowing shows counts + "N lenses").

## Validation

Runtime.Tests 1716/1716, UI.Tests 1045/1045, full-solution Release build 0 warnings / 0 errors.

## Deferred to v2

Indicator interactivity (click-to-focus), remote-source indication, a color-coded status palette meeting WCAG AA on the status-bar fill, focused-row position, an explicit "Hidden" count, and aria transition-coalescing.
