### PR TITLE
Add a Details Pane reader view with decoded fields and severity

### DIFF
--- a/src/EventLogExpert.Eventing/Common/Events/EventFieldValue.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/EventFieldValue.cs
@@ -108,6 +108,20 @@ public readonly struct EventFieldValue
         return false;
     }
 
+    public bool TryGetBytes([NotNullWhen(true)] out byte[]? value)
+    {
+        if (_kind == EventFieldValueKind.Bytes && _reference is byte[] bytes)
+        {
+            value = bytes;
+
+            return true;
+        }
+
+        value = null;
+
+        return false;
+    }
+
     public bool TryGetStringArray([NotNullWhen(true)] out string[]? values)
     {
         if (_kind == EventFieldValueKind.StringArray && _reference is string[] array)
@@ -118,6 +132,20 @@ public readonly struct EventFieldValue
         }
 
         values = null;
+
+        return false;
+    }
+
+    public bool TryGetArray([NotNullWhen(true)] out Array? value)
+    {
+        if (_kind == EventFieldValueKind.Array && _reference is Array array)
+        {
+            value = array;
+
+            return true;
+        }
+
+        value = null;
 
         return false;
     }

--- a/src/EventLogExpert.Eventing/Common/Events/LevelSeverity.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/LevelSeverity.cs
@@ -1,0 +1,17 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Eventing.Common.Events;
+
+public static class LevelSeverity
+{
+    public static SeverityLevel? FromLevelName(string? level) => level switch
+    {
+        nameof(SeverityLevel.Critical) => SeverityLevel.Critical,
+        nameof(SeverityLevel.Error) => SeverityLevel.Error,
+        nameof(SeverityLevel.Warning) => SeverityLevel.Warning,
+        nameof(SeverityLevel.Information) => SeverityLevel.Information,
+        nameof(SeverityLevel.Verbose) => SeverityLevel.Verbose,
+        _ => null
+    };
+}

--- a/src/EventLogExpert.Runtime/DetailsPane/DetailsField.cs
+++ b/src/EventLogExpert.Runtime/DetailsPane/DetailsField.cs
@@ -1,0 +1,27 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.DetailsPane;
+
+public sealed record DetailsField
+{
+    public required string Label { get; init; }
+
+    public required IReadOnlyList<string> PreviewLines { get; init; }
+
+    public required IReadOnlyList<string> FullLines { get; init; }
+
+    public required string CopyValue { get; init; }
+
+    public bool IsTruncated { get; init; }
+
+    public bool IsMuted { get; init; }
+
+    public bool IsMonospace { get; init; }
+
+    public string? DecodedLabel { get; init; }
+
+    public string? Description { get; init; }
+
+    public bool PreferFullWidth => PreviewLines.Count > 1 || IsTruncated || Description is not null;
+}

--- a/src/EventLogExpert.Runtime/DetailsPane/DetailsProperty.cs
+++ b/src/EventLogExpert.Runtime/DetailsPane/DetailsProperty.cs
@@ -1,0 +1,7 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.DetailsPane;
+
+/// <summary>A single label / value row in the reader view's identity header or system-details section.</summary>
+public readonly record struct DetailsProperty(string Label, string Value);

--- a/src/EventLogExpert.Runtime/DetailsPane/DetailsReaderFormatter.cs
+++ b/src/EventLogExpert.Runtime/DetailsPane/DetailsReaderFormatter.cs
@@ -1,0 +1,331 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Eventing.Structured;
+using EventLogExpert.Runtime.Common.Display;
+using System.Globalization;
+using System.Text;
+
+namespace EventLogExpert.Runtime.DetailsPane;
+
+/// <summary>
+///     Projects a <see cref="ResolvedEvent" /> into the <see cref="DetailsReaderModel" /> the details pane renders,
+///     and builds the clipboard text for the whole event and for each section. All display strings are pre-rendered here
+///     so the component retains no transient <see cref="EventFieldValue" />, and the copy builders reuse the projection so
+///     displayed and copied text cannot drift. EventData fields render their names (or a positional <c>[i]</c> when
+///     unnamed) with one line per array item, a hex preview for binary values, muted placeholders for empty values, and
+///     any inline explanation from <see cref="EventFieldExplainer" />; UserData fields are never run through the explainer
+///     because their leaf paths lack the provider / event context the glossary keys on.
+/// </summary>
+public static class DetailsReaderFormatter
+{
+    private const int BytesPreviewByteCount = 64;
+    private const string EmptyArrayPlaceholder = "(no values)";
+    private const string EmptyStringPlaceholder = "(empty)";
+    private const int LongTextPreviewLength = 500;
+    private const string NullValuePlaceholder = "(none)";
+
+    public static string BuildEventCopyText(DetailsReaderModel model)
+    {
+        StringBuilder builder = new();
+
+        builder.AppendLine($"Event ID: {model.EventId}");
+
+        if (!string.IsNullOrEmpty(model.Level)) { builder.AppendLine($"Level: {model.Level}"); }
+
+        foreach (DetailsProperty property in model.Header)
+        {
+            builder.AppendLine($"{property.Label}: {property.Value}");
+        }
+
+        foreach (DetailsProperty property in model.SystemProperties)
+        {
+            builder.AppendLine($"{property.Label}: {property.Value}");
+        }
+
+        if (model.HasMessage)
+        {
+            builder.AppendLine();
+            builder.AppendLine("Message:");
+            builder.AppendLine(model.Message);
+        }
+
+        AppendFieldsSection(builder, "Event Data:", model.EventData);
+        AppendFieldsSection(builder, "User Data:", model.UserData);
+
+        return builder.ToString().TrimEnd();
+    }
+
+    public static string BuildFieldsCopyText(IReadOnlyList<DetailsField> fields)
+    {
+        StringBuilder builder = new();
+
+        foreach (DetailsField field in fields)
+        {
+            AppendFieldCopyText(builder, field);
+        }
+
+        return builder.ToString().TrimEnd();
+    }
+
+    public static DetailsReaderModel BuildModel(ResolvedEvent @event, TimeZoneInfo timeZone) =>
+        new()
+        {
+            EventId = @event.Id.ToString(CultureInfo.InvariantCulture),
+            Level = @event.Level,
+            Severity = LevelSeverity.FromLevelName(@event.Level),
+            Header = BuildHeader(@event, timeZone),
+            SystemProperties = BuildSystemProperties(@event),
+            EventData = BuildEventDataFields(@event, timeZone),
+            UserData = BuildUserDataFields(@event),
+            Message = @event.Description,
+            HasMessage = !string.IsNullOrEmpty(@event.Description),
+            UserDataIncomplete = @event.UserDataIncomplete
+        };
+
+    public static string BuildPropertiesCopyText(IReadOnlyList<DetailsProperty> properties)
+    {
+        StringBuilder builder = new();
+
+        foreach (DetailsProperty property in properties)
+        {
+            builder.AppendLine($"{property.Label}: {property.Value}");
+        }
+
+        return builder.ToString().TrimEnd();
+    }
+
+    private static void AddIfPresent(List<DetailsProperty> properties, string label, string value)
+    {
+        if (!string.IsNullOrEmpty(value)) { properties.Add(new DetailsProperty(label, value)); }
+    }
+
+    private static void AppendFieldCopyText(StringBuilder builder, DetailsField field)
+    {
+        if (field.CopyValue.Contains('\n'))
+        {
+            builder.AppendLine($"{field.Label}:");
+
+            foreach (string line in field.CopyValue.Split('\n'))
+            {
+                builder.AppendLine($"    {line}");
+            }
+
+            return;
+        }
+
+        builder.Append(field.Label).Append(": ").Append(field.CopyValue);
+
+        if (field.DecodedLabel is { } decoded)
+        {
+            builder.Append(" (").Append(decoded).Append(')');
+        }
+
+        builder.AppendLine();
+    }
+
+    private static void AppendFieldsSection(StringBuilder builder, string heading, IReadOnlyList<DetailsField> fields)
+    {
+        if (fields.Count == 0) { return; }
+
+        builder.AppendLine();
+        builder.AppendLine(heading);
+
+        foreach (DetailsField field in fields)
+        {
+            AppendFieldCopyText(builder, field);
+        }
+    }
+
+    private static IReadOnlyList<DetailsField> BuildEventDataFields(ResolvedEvent @event, TimeZoneInfo timeZone)
+    {
+        List<DetailsField> fields = [];
+        int index = 0;
+
+        foreach (EventDataView.Field field in @event.EventData)
+        {
+            string label = string.IsNullOrEmpty(field.Name)
+                ? $"[{index}]"
+                : field.Name;
+
+            EventFieldExplanation explanation =
+                EventFieldExplainer.TryExplain(@event.Source, @event.Id, field.Name, field.Value, out EventFieldExplanation resolved)
+                    ? resolved
+                    : default;
+
+            fields.Add(ToField(label, RenderValue(field.Value, timeZone), explanation));
+            index++;
+        }
+
+        return fields;
+    }
+
+    private static IReadOnlyList<DetailsProperty> BuildHeader(ResolvedEvent @event, TimeZoneInfo timeZone)
+    {
+        // Event ID + Level are projected as typed summary fields (with the severity bucket) and rendered separately, so
+        // they are intentionally not in this list; BuildEventCopyText re-emits them first to keep the clipboard order.
+        List<DetailsProperty> properties = [];
+
+        AddIfPresent(properties, "Source", @event.Source);
+        properties.Add(new DetailsProperty("Date and Time", @event.TimeCreated.ConvertTimeZone(timeZone).ToString(CultureInfo.CurrentCulture)));
+        AddIfPresent(properties, "Computer", @event.ComputerName);
+        AddIfPresent(properties, "Log Name", @event.LogName);
+
+        return properties;
+    }
+
+    private static IReadOnlyList<DetailsProperty> BuildSystemProperties(ResolvedEvent @event)
+    {
+        List<DetailsProperty> properties = [];
+
+        AddIfPresent(properties, "Task Category", @event.TaskCategory);
+        AddIfPresent(properties, "Opcode", @event.Opcode);
+        AddIfPresent(properties, "Keywords", @event.KeywordsDisplayName);
+
+        if (@event.RecordId is { } recordId) { properties.Add(new DetailsProperty("Record ID", recordId.ToString(CultureInfo.InvariantCulture))); }
+
+        if (@event.ProcessId is { } processId) { properties.Add(new DetailsProperty("Process ID", processId.ToString(CultureInfo.InvariantCulture))); }
+
+        if (@event.ThreadId is { } threadId) { properties.Add(new DetailsProperty("Thread ID", threadId.ToString(CultureInfo.InvariantCulture))); }
+
+        if (@event.ActivityId is { } activityId) { properties.Add(new DetailsProperty("Activity ID", activityId.ToString())); }
+
+        if (@event.RelatedActivityId is { } relatedActivityId) { properties.Add(new DetailsProperty("Related Activity ID", relatedActivityId.ToString())); }
+
+        // Raw SID by design; account-name resolution is a separate task.
+        if (@event.UserId is { } userId) { properties.Add(new DetailsProperty("User", userId.Value)); }
+
+        return properties;
+    }
+
+    private static IReadOnlyList<DetailsField> BuildUserDataFields(ResolvedEvent @event)
+    {
+        if (@event.UserData.IsDefaultOrEmpty) { return []; }
+
+        List<DetailsField> fields = [];
+
+        foreach (UserDataField field in @event.UserData)
+        {
+            string[] values = field.Values.IsDefaultOrEmpty ? [] : [.. field.Values];
+
+            fields.Add(ToField(field.Path, RenderArray(values), default));
+        }
+
+        return fields;
+    }
+
+    private static string GroupHex(byte[] bytes, int count)
+    {
+        StringBuilder builder = new(count * 3);
+
+        for (int i = 0; i < count; i++)
+        {
+            if (i > 0) { builder.Append(' '); }
+
+            builder.Append(bytes[i].ToString("X2", CultureInfo.InvariantCulture));
+        }
+
+        return builder.ToString();
+    }
+
+    private static RenderedValue Placeholder(string text)
+    {
+        string[] lines = [text];
+
+        return new RenderedValue(lines, lines, string.Empty, IsTruncated: false, IsMuted: true);
+    }
+
+    private static RenderedValue RenderArray(string[] items) =>
+        items.Length == 0 ?
+            Placeholder(EmptyArrayPlaceholder) :
+            new RenderedValue(items, items, string.Join('\n', items), IsTruncated: false, IsMuted: false);
+
+    private static RenderedValue RenderBytes(byte[] bytes)
+    {
+        if (bytes.Length == 0) { return Placeholder(EmptyStringPlaceholder); }
+
+        string copyValue = Convert.ToHexString(bytes);
+        string full = GroupHex(bytes, bytes.Length);
+
+        if (bytes.Length > BytesPreviewByteCount)
+        {
+            return new RenderedValue([$"{GroupHex(bytes, BytesPreviewByteCount)} ..."], [full], copyValue, IsTruncated: true, IsMuted: false, IsMonospace: true);
+        }
+
+        string[] lines = [full];
+
+        return new RenderedValue(lines, lines, copyValue, IsTruncated: false, IsMuted: false, IsMonospace: true);
+    }
+
+    private static RenderedValue RenderScalarText(string text)
+    {
+        if (text.Length == 0) { return Placeholder(EmptyStringPlaceholder); }
+
+        if (text.Length > LongTextPreviewLength)
+        {
+            return new RenderedValue([$"{text[..LongTextPreviewLength]}..."], [text], text, IsTruncated: true, IsMuted: false);
+        }
+
+        string[] lines = [text];
+
+        return new RenderedValue(lines, lines, text, IsTruncated: false, IsMuted: false);
+    }
+
+    private static RenderedValue RenderValue(in EventFieldValue value, TimeZoneInfo timeZone)
+    {
+        if (value.TryGetStringArray(out string[]? strings)) { return RenderArray(strings); }
+
+        if (value.TryGetArray(out Array? array)) { return RenderArray(ToStringItems(array)); }
+
+        if (value.TryGetBytes(out byte[]? bytes)) { return RenderBytes(bytes); }
+
+        if (value.TryGetDateTime(out DateTime timestamp))
+        {
+            return RenderScalarText(timestamp.ConvertTimeZone(timeZone).ToString(CultureInfo.CurrentCulture));
+        }
+
+        if (value.Kind == EventFieldValueKind.Null) { return Placeholder(NullValuePlaceholder); }
+
+        RenderedValue scalar = RenderScalarText(value.AsString());
+
+        // GUIDs and SIDs scan better fixed-width; general strings and numbers keep the app's sans-serif.
+        return value.Kind is EventFieldValueKind.Guid or EventFieldValueKind.Sid
+            ? scalar with { IsMonospace = true }
+            : scalar;
+    }
+
+    private static DetailsField ToField(string label, RenderedValue rendered, EventFieldExplanation explanation) =>
+        new()
+        {
+            Label = label,
+            PreviewLines = rendered.PreviewLines,
+            FullLines = rendered.FullLines,
+            CopyValue = rendered.CopyValue,
+            IsTruncated = rendered.IsTruncated,
+            IsMuted = rendered.IsMuted,
+            IsMonospace = rendered.IsMonospace,
+            DecodedLabel = explanation.DecodedLabel,
+            Description = explanation.Description
+        };
+
+    private static string[] ToStringItems(Array array)
+    {
+        string[] items = new string[array.Length];
+
+        for (int i = 0; i < array.Length; i++)
+        {
+            items[i] = Convert.ToString(array.GetValue(i), CultureInfo.InvariantCulture) ?? string.Empty;
+        }
+
+        return items;
+    }
+
+    private readonly record struct RenderedValue(
+        IReadOnlyList<string> PreviewLines,
+        IReadOnlyList<string> FullLines,
+        string CopyValue,
+        bool IsTruncated,
+        bool IsMuted,
+        bool IsMonospace = false);
+}

--- a/src/EventLogExpert.Runtime/DetailsPane/DetailsReaderModel.cs
+++ b/src/EventLogExpert.Runtime/DetailsPane/DetailsReaderModel.cs
@@ -1,0 +1,31 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+
+namespace EventLogExpert.Runtime.DetailsPane;
+
+public sealed record DetailsReaderModel
+{
+    public required string EventId { get; init; }
+
+    public required string Level { get; init; }
+
+    public SeverityLevel? Severity { get; init; }
+
+    public required IReadOnlyList<DetailsProperty> Header { get; init; }
+
+    public required IReadOnlyList<DetailsProperty> SystemProperties { get; init; }
+
+    public required IReadOnlyList<DetailsField> EventData { get; init; }
+
+    public required IReadOnlyList<DetailsField> UserData { get; init; }
+
+    public required string Message { get; init; }
+
+    public bool HasMessage { get; init; }
+
+    public bool UserDataIncomplete { get; init; }
+
+    public bool HasNamedEventData => EventData.Count > 0;
+}

--- a/src/EventLogExpert.Runtime/DetailsPane/EventFieldExplainer.cs
+++ b/src/EventLogExpert.Runtime/DetailsPane/EventFieldExplainer.cs
@@ -1,0 +1,164 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+using System.Collections.Frozen;
+using System.Globalization;
+
+namespace EventLogExpert.Runtime.DetailsPane;
+
+/// <summary>
+///     Resolves optional inline explanations for structured EventData fields: a small curated glossary (what a field
+///     means) plus a bounded set of value decoders (what a specific value means, e.g. a logon type). Both are fail-closed
+///     - an unrecognized field or value yields no text rather than a guess. Glossary lookups follow a most-specific-wins
+///     order (provider + event id + field, then provider + field, then a small allowlist of provider-agnostic field
+///     names); decoders and the glossary resolve independently, so a value decode is never suppressed by a glossary match
+///     or vice versa.
+/// </summary>
+public static class EventFieldExplainer
+{
+    private const string SecurityAuditing = "Microsoft-Windows-Security-Auditing";
+
+    // Field names whose meaning is too provider-specific to explain from a bare name. They are only ever explained
+    // through a provider- or event-scoped rule, never the provider-agnostic allowlist.
+    private static readonly FrozenSet<string> s_ambiguousFieldNames =
+        new[] { "Status", "Type", "Name", "Id", "Subject", "Data" }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+    private static readonly GlossaryEntry[] s_glossary =
+    [
+        // Provider + event scoped (most specific).
+        new(SecurityAuditing, 4624, "TargetUserName", "The account that was logged on."),
+        new(SecurityAuditing, 4624, "SubjectUserName", "The account that requested the logon."),
+        new(SecurityAuditing, 4625, "TargetUserName", "The account that failed to log on."),
+
+        // Provider scoped (any event from this provider).
+        new(SecurityAuditing, null, "AuthenticationPackageName", "The authentication package (e.g. NTLM, Kerberos) that handled the logon."),
+        new(SecurityAuditing, null, "LogonProcessName", "The trusted process that submitted the logon request."),
+
+        // Provider-agnostic allowlist (field names whose meaning is stable across providers).
+        new(null, null, "LogonType", "How the logon was initiated; see the decoded value for the specific type."),
+        new(null, null, "IpAddress", "The source network address associated with the event."),
+        new(null, null, "IpPort", "The source network port associated with the event."),
+        new(null, null, "ProcessName", "The full path of the process associated with the event."),
+        new(null, null, "CommandLine", "The command line used to start the process."),
+        new(null, null, "WorkstationName", "The name of the workstation from which the action originated.")
+    ];
+
+    private static readonly FrozenDictionary<string, Func<EventFieldValue, string?>> s_valueDecoders =
+        new Dictionary<string, Func<EventFieldValue, string?>>
+        {
+            ["LogonType"] = DecodeLogonType
+        }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    ///     Produces an <see cref="EventFieldExplanation" /> for the given field, resolving a value decode and a glossary
+    ///     description independently. Returns <c>false</c> (and an empty explanation) when neither applies.
+    /// </summary>
+    public static bool TryExplain(
+        string providerName,
+        int eventId,
+        string fieldName,
+        in EventFieldValue value,
+        out EventFieldExplanation explanation)
+    {
+        string? decodedLabel = TryDecodeValue(fieldName, value);
+        string? description = ResolveDescription(providerName, eventId, fieldName);
+
+        explanation = new EventFieldExplanation(decodedLabel, description);
+
+        return explanation.HasValue;
+    }
+
+    private static string? DecodeLogonType(EventFieldValue value)
+    {
+        if (!TryReadWholeNumber(value, out ulong logonType)) { return null; }
+
+        return logonType switch
+        {
+            0 => "System",
+            2 => "Interactive",
+            3 => "Network",
+            4 => "Batch",
+            5 => "Service",
+            7 => "Unlock",
+            8 => "NetworkCleartext",
+            9 => "NewCredentials",
+            10 => "RemoteInteractive",
+            11 => "CachedInteractive",
+            12 => "CachedRemoteInteractive",
+            13 => "CachedUnlock",
+            _ => null
+        };
+    }
+
+    private static string? ResolveDescription(string providerName, int eventId, string fieldName)
+    {
+        // Most specific: provider + event id + field.
+        foreach (GlossaryEntry entry in s_glossary)
+        {
+            if (entry.EventId == eventId
+                && entry.Provider is { } scopedProvider
+                && string.Equals(scopedProvider, providerName, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(entry.Field, fieldName, StringComparison.OrdinalIgnoreCase))
+            {
+                return entry.Description;
+            }
+        }
+
+        // Provider + field (any event from that provider).
+        foreach (GlossaryEntry entry in s_glossary)
+        {
+            if (entry.EventId is null
+                && entry.Provider is { } scopedProvider
+                && string.Equals(scopedProvider, providerName, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(entry.Field, fieldName, StringComparison.OrdinalIgnoreCase))
+            {
+                return entry.Description;
+            }
+        }
+
+        // Provider-agnostic allowlist, never applied to an ambiguous bare name.
+        if (s_ambiguousFieldNames.Contains(fieldName)) { return null; }
+
+        foreach (GlossaryEntry entry in s_glossary)
+        {
+            if (entry is { Provider: null, EventId: null }
+                && string.Equals(entry.Field, fieldName, StringComparison.OrdinalIgnoreCase))
+            {
+                return entry.Description;
+            }
+        }
+
+        return null;
+    }
+
+    private static string? TryDecodeValue(string fieldName, in EventFieldValue value) =>
+        s_valueDecoders.TryGetValue(fieldName, out Func<EventFieldValue, string?>? decoder)
+            ? decoder(value)
+            : null;
+
+    private static bool TryReadWholeNumber(in EventFieldValue value, out ulong number)
+    {
+        if (value.TryGetUInt64(out number)) { return true; }
+
+        if (value.TryGetInt64(out long signed) && signed >= 0)
+        {
+            number = (ulong)signed;
+
+            return true;
+        }
+
+        // Strict parse only for a string-typed value: no sign, whitespace, or fractional part.
+        if (value.Kind == EventFieldValueKind.String
+            && ulong.TryParse(value.AsString(), NumberStyles.None, CultureInfo.InvariantCulture, out number))
+        {
+            return true;
+        }
+
+        number = 0;
+
+        return false;
+    }
+
+    private sealed record GlossaryEntry(string? Provider, int? EventId, string Field, string Description);
+}

--- a/src/EventLogExpert.Runtime/DetailsPane/EventFieldExplanation.cs
+++ b/src/EventLogExpert.Runtime/DetailsPane/EventFieldExplanation.cs
@@ -1,0 +1,15 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.DetailsPane;
+
+/// <summary>
+///     An inline explanation for a single EventData field. <see cref="DecodedLabel" /> is a human reading of the
+///     field's value (e.g. a logon type of <c>3</c> to "Network") shown beside the raw value and included in copy;
+///     <see cref="Description" /> is glossary prose about what the field means, shown as a muted note and excluded from
+///     copy. The two resolve independently, so a field may carry one, both, or neither.
+/// </summary>
+public readonly record struct EventFieldExplanation(string? DecodedLabel, string? Description)
+{
+    public bool HasValue => DecodedLabel is not null || Description is not null;
+}

--- a/src/EventLogExpert.Runtime/FilterPane/FilterPaneState.cs
+++ b/src/EventLogExpert.Runtime/FilterPane/FilterPaneState.cs
@@ -17,7 +17,20 @@ public sealed record FilterPaneState
 
     public bool IsEnabled { get; init; } = true;
 
-    public bool IsFilteringEnabled =>
-        FilteredDateRange?.IsEnabled is true ||
-        (IsEnabled ? Filters.Any(filter => filter.IsEnabled) : Filters.Any(filter => filter.IsExcluded));
+    public bool IsFilteringEnabled
+    {
+        get
+        {
+            if (FilteredDateRange?.IsEnabled is true) { return true; }
+
+            // foreach over the typed ImmutableList uses its struct enumerator; Filters.Any(predicate) would box the
+            // enumerator via IEnumerable, allocating on this frequently-evaluated render / state-selection path.
+            foreach (var filter in Filters)
+            {
+                if (IsEnabled ? filter.IsEnabled : filter.IsExcluded) { return true; }
+            }
+
+            return false;
+        }
+    }
 }

--- a/src/EventLogExpert.UI/DetailsPane/DetailsFieldRow.razor
+++ b/src/EventLogExpert.UI/DetailsPane/DetailsFieldRow.razor
@@ -1,0 +1,48 @@
+<div class="details-field @(Field.IsMuted ? "is-muted" : null) @(Field.PreferFullWidth ? "is-wide" : null)">
+    <div class="details-field-name">
+        <span>@Field.Label</span>
+        <button aria-label="@($"Copy value for {Field.Label}")" class="details-copy" @onclick="OnCopy" type="button">
+            <i class="bi bi-clipboard"></i>
+        </button>
+    </div>
+    <div class="details-field-value">
+        @if (Field.DecodedLabel is { } decoded)
+        {
+            <div class="details-value-line @(Field.IsMonospace ? "is-mono" : null)">@Field.PreviewLines[0]<span class="details-decoded"> (@decoded)</span></div>
+        }
+        else
+        {
+            @foreach (string line in (IsExpanded ? Field.FullLines : Field.PreviewLines))
+            {
+                <div class="details-value-line @(Field.IsMonospace ? "is-mono" : null)">@line</div>
+            }
+
+            @if (Field.IsTruncated)
+            {
+                <button aria-expanded="@(IsExpanded ? "true" : "false")" class="details-show-more" @onclick="OnToggleExpand" type="button">
+                    @(IsExpanded ? "Show less" : "Show more")
+                </button>
+            }
+        }
+
+        @if (Field.Description is { } description)
+        {
+            <div class="details-explain">@description</div>
+        }
+    </div>
+</div>
+
+@code {
+    [Parameter]
+    [EditorRequired]
+    public DetailsField Field { get; set; } = null!;
+
+    [Parameter]
+    public bool IsExpanded { get; set; }
+
+    [Parameter]
+    public EventCallback OnCopy { get; set; }
+
+    [Parameter]
+    public EventCallback OnToggleExpand { get; set; }
+}

--- a/src/EventLogExpert.UI/DetailsPane/DetailsFieldRow.razor.css
+++ b/src/EventLogExpert.UI/DetailsPane/DetailsFieldRow.razor.css
@@ -1,0 +1,116 @@
+.details-field {
+    padding: 0.3rem 0;
+    border-bottom: 1px solid var(--border-divider);
+
+    /* is-wide fields (arrays, hex, long scalars, explained fields) span every column of the parent EventData grid so
+       their value block gets the full payload width instead of a single packed card. */
+    &.is-wide {
+        grid-column: 1 / -1;
+    }
+
+    &.is-muted .details-field-value {
+        color: var(--text-secondary);
+    }
+
+    &:last-child {
+        border-bottom: 0;
+    }
+}
+
+/* Stacked: the field name (+ hover copy button) sits on its own line above a full-width value block, so even long
+   Security/Sysmon field names get the whole card width and never truncate. */
+.details-field-name {
+    display: flex;
+    align-items: baseline;
+    gap: 4px;
+    min-width: 0;
+}
+
+.details-field-name > span {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    color: var(--text-secondary);
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1.3;
+}
+
+.details-field-value {
+    min-width: 0;
+    margin-top: 0.1rem;
+    color: var(--text-primary);
+    overflow-wrap: anywhere;
+}
+
+.details-value-line {
+    font-size: 13px;
+    line-height: 1.35;
+}
+
+.details-value-line.is-mono {
+    font-family: ui-monospace, "Cascadia Mono", Consolas, monospace;
+    font-size: 13px;
+}
+
+.details-decoded {
+    display: inline-block;
+    margin-left: 0.35rem;
+    padding: 0 0.4rem;
+    border: 1px solid var(--border-divider);
+    border-radius: 999px;
+    color: var(--text-primary);
+    background: var(--surface-inset);
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1.4;
+}
+
+.details-explain {
+    max-width: 90ch;
+    margin-top: 0.15rem;
+    color: var(--text-secondary);
+    font-size: 12px;
+    line-height: 1.35;
+}
+
+.details-show-more {
+    appearance: none;
+    margin-top: 2px;
+    padding: 0;
+    border: 0;
+    font: inherit;
+    font-size: 12px;
+    color: var(--text-secondary);
+    text-decoration: underline;
+    background: none;
+    cursor: pointer;
+
+    &:hover,
+    &:focus-visible {
+        color: var(--text-primary);
+    }
+}
+
+.details-copy {
+    appearance: none;
+    display: inline-flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    margin-left: auto;
+    padding: 0;
+    border: 0;
+    border-radius: 4px;
+    color: var(--text-secondary);
+    background: none;
+    opacity: 0.5;
+    cursor: pointer;
+}
+
+.details-field:hover .details-copy,
+.details-copy:focus-visible {
+    color: var(--text-primary);
+    opacity: 1;
+}

--- a/src/EventLogExpert.UI/DetailsPane/DetailsPane.razor
+++ b/src/EventLogExpert.UI/DetailsPane/DetailsPane.razor
@@ -1,64 +1,235 @@
 @inherits FluxorComponent
 
-<div class="details-pane" data-toggle="@IsVisible" hidden="@(_selectedEvent is null)">
+<div class="details-pane" data-toggle="@IsExpanded" hidden="@(_selectedEvent is null)">
     <div class="details-resizer"></div>
 
-    <ChromelessButton aria-expanded="@_isVisible.ToString().ToLower()"
-        aria-label="@(_isVisible ? "Details Expanded" : "Details Collapsed")"
+    <ChromelessButton aria-expanded="@IsExpanded"
+        aria-label="@(_isExpanded ? "Collapse details" : "Expand details")"
         CssClass="flex-space-between"
         id="details-header"
         OnClick="ToggleMenu">
         <span>Details</span>
 
-        <span class="menu-toggle" data-rotate="@IsVisible">
+        <span class="menu-toggle" data-rotate="@IsExpanded">
             <i class="bi bi-caret-up"></i>
         </span>
     </ChromelessButton>
 
-    @if (_selectedEvent is not null)
-    {
-        <div class="details-group" data-toggle="@_isXmlVisible.ToString().ToLower()">
-            <div class="d-flex flex-row">
-                <div>Log Name: @_selectedEvent.LogName</div>
-                <div>Source: @_selectedEvent.Source</div>
-                <div>Event Id: @_selectedEvent.Id</div>
-                <div>Level: @_selectedEvent.Level</div>
-                @if (_selectedEvent.Keywords.Any())
-                {
-                    <div>Keywords: @_selectedEvent.KeywordsDisplayName</div>
-                }
-                <div>Date and Time: @_selectedEvent.TimeCreated.ConvertTimeZone(Settings.TimeZoneInfo)</div>
+    <div class="details-body">
+        @if (_model is not null)
+        {
+            <div aria-label="Event detail views" class="details-tabs" role="tablist">
+                <button aria-controls="details-tabpanel-reader"
+                    aria-selected="@(_activeTab == DetailsTab.Reader ? "true" : "false")"
+                    class="details-tab"
+                    data-active="@(_activeTab == DetailsTab.Reader ? "true" : "false")"
+                    id="details-tab-reader"
+                    @onclick="() => SetTab(DetailsTab.Reader)"
+                    role="tab"
+                    type="button">
+                    Reader
+                </button>
+                <button aria-controls="details-tabpanel-xml"
+                    aria-selected="@(_activeTab == DetailsTab.Xml ? "true" : "false")"
+                    class="details-tab"
+                    data-active="@(_activeTab == DetailsTab.Xml ? "true" : "false")"
+                    id="details-tab-xml"
+                    @onclick="() => SetTab(DetailsTab.Xml)"
+                    role="tab"
+                    type="button">
+                    XML
+                </button>
+
+                <button aria-label="Copy event to clipboard" class="details-copy-event" @onclick="CopyEventAsync" type="button">
+                    <i class="bi bi-clipboard"></i>
+                    <span class="details-copy-event-label">Copy event</span>
+                </button>
             </div>
 
-            <div>Description:</div>
-            <p class="details-description">@_selectedEvent.Description</p>
-        </div>
+            <div aria-labelledby="details-tab-reader" class="details-reader" hidden="@(_activeTab != DetailsTab.Reader)" id="details-tabpanel-reader" role="tabpanel">
+                @if (_activeTab == DetailsTab.Reader)
+                {
+                    <div class="details-reader-layout">
+                        <div class="reader-rail">
+                            <div class="details-summary">
+                                <span class="details-summary-id">Event ID @_model.EventId</span>
+                                @if (!string.IsNullOrEmpty(_model.Level))
+                                {
+                                    <span class="details-summary-level">
+                                        @if (SeverityDot(_model.Severity) is { } severity)
+                                        {
+                                            <span aria-hidden="true" class="details-severity-dot" data-severity="@severity" title="@($"Severity: {_model.Level}")"></span>
+                                        }
+                                        @_model.Level
+                                    </span>
+                                }
+                            </div>
 
-        <hr />
+                            @if (_model.Header.Count > 0)
+                            {
+                                <dl class="details-grid">
+                                    @foreach (DetailsProperty property in _model.Header)
+                                    {
+                                        <dt>@property.Label</dt>
+                                        <dd>@property.Value</dd>
+                                    }
+                                </dl>
+                            }
 
-        <ChromelessButton aria-expanded="@_isXmlVisible.ToString().ToLower()"
-            aria-label="@(_isXmlVisible ? "XML Expanded" : "XML Collapsed")"
-            CssClass="details-row-xml flex-space-between"
-            OnClick="ToggleXml">
-            <span>XML</span>
-            <span class="menu-toggle" data-rotate="@_isXmlVisible.ToString().ToLower()">
-                <i class="bi bi-caret-up"></i>
-            </span>
-        </ChromelessButton>
+                            @* Capture the render-time non-null event so the button closures act on the event that was
+                               displayed when clicked, never on a newer/null selection read from the mutable field. *@
+                            @if (_selectedEvent is { } correlationEvent && (correlationEvent.ActivityId.HasValue || correlationEvent.RelatedActivityId.HasValue))
+                            {
+                                <section class="details-correlation">
+                                    <h3>Correlation</h3>
+                                    <div class="details-correlation-actions">
+                                        @if (correlationEvent.ActivityId.HasValue)
+                                        {
+                                            <button class="button details-correlation-action"
+                                                @onclick="() => FilterLensCommands.ShowRelatedByActivityId(correlationEvent.ActivityId, correlationEvent.OwningLog)"
+                                                type="button">
+                                                Show related events
+                                            </button>
+                                        }
+                                        @if (correlationEvent.RelatedActivityId.HasValue)
+                                        {
+                                            <button class="button details-correlation-action"
+                                                @onclick="() => FilterLensCommands.ShowParentActivity(correlationEvent.RelatedActivityId, correlationEvent.OwningLog)"
+                                                type="button">
+                                                Show parent activity
+                                            </button>
+                                        }
+                                    </div>
+                                </section>
+                            }
 
-        <p class="details-xml" data-toggle="@_isXmlVisible.ToString().ToLower()">
-            @if (_resolvedXml is null)
-            {
-                <text>Resolving XML...</text>
-            }
-            else if (_resolvedXml.Length > 0)
-            {
-                @GetXmlForDisplay()
-            }
-            else
-            {
-                <text>No XML available for this event.</text>
-            }
-        </p>
-    }
+                            @if (_model.SystemProperties.Count > 0)
+                            {
+                                <details class="details-section" open>
+                                    <summary>
+                                        <span>System details</span>
+                                        <button aria-label="Copy system details to clipboard"
+                                            class="details-copy-section"
+                                            @onclick="() => CopyPropertiesAsync(_model.SystemProperties)"
+                                            @onclick:preventDefault="true"
+                                            @onclick:stopPropagation="true"
+                                            type="button">
+                                            <i class="bi bi-clipboard"></i>
+                                        </button>
+                                    </summary>
+                                    <dl class="details-grid">
+                                        @foreach (DetailsProperty property in _model.SystemProperties)
+                                        {
+                                            <dt>@property.Label</dt>
+                                            <dd>@property.Value</dd>
+                                        }
+                                    </dl>
+                                </details>
+                            }
+                        </div>
+
+                        <div class="reader-payload">
+                            <section class="details-section">
+                                <h3>Message</h3>
+                                @if (_model.HasMessage)
+                                {
+                                    <p class="details-message">@_model.Message</p>
+                                }
+                                else
+                                {
+                                    <p class="details-muted">No provider-formatted message is available for this event.</p>
+                                }
+                            </section>
+
+                            <section class="details-section">
+                                <div class="details-section-head">
+                                    <h3>Event Data</h3>
+                                    @if (_model.HasNamedEventData)
+                                    {
+                                        <button aria-label="Copy event data to clipboard"
+                                            class="details-copy-section"
+                                            @onclick="() => CopyFieldsAsync(_model.EventData)"
+                                            type="button">
+                                            <i class="bi bi-clipboard"></i>
+                                        </button>
+                                    }
+                                </div>
+
+                                @if (_model.HasNamedEventData)
+                                {
+                                    <div class="details-fields">
+                                        @for (int i = 0; i < _model.EventData.Count; i++)
+                                        {
+                                            int index = i;
+                                            DetailsField field = _model.EventData[index];
+
+                                            <DetailsFieldRow Field="field"
+                                                IsExpanded="IsFieldExpanded(index)"
+                                                OnCopy="() => CopyValueAsync(field)"
+                                                OnToggleExpand="() => ToggleFieldExpansion(index)" />
+                                        }
+                                    </div>
+                                }
+                                else
+                                {
+                                    <p class="details-muted">This event has no named data fields. See the message above or the XML view.</p>
+                                }
+                            </section>
+
+                            @if (_model.UserData.Count > 0)
+                            {
+                                <section class="details-section">
+                                    <div class="details-section-head">
+                                        <h3>User Data</h3>
+                                        <button aria-label="Copy user data to clipboard"
+                                            class="details-copy-section"
+                                            @onclick="() => CopyFieldsAsync(_model.UserData)"
+                                            type="button">
+                                            <i class="bi bi-clipboard"></i>
+                                        </button>
+                                    </div>
+
+                                    @if (_model.UserDataIncomplete)
+                                    {
+                                        <p class="details-warn">Some user-data fields may be missing; extraction reached its limit. See the XML view for the full payload.</p>
+                                    }
+
+                                    <div class="details-fields-userdata">
+                                        @for (int j = 0; j < _model.UserData.Count; j++)
+                                        {
+                                            int index = _model.EventData.Count + j;
+                                            DetailsField field = _model.UserData[j];
+
+                                            <DetailsFieldRow Field="field"
+                                                IsExpanded="IsFieldExpanded(index)"
+                                                OnCopy="() => CopyValueAsync(field)"
+                                                OnToggleExpand="() => ToggleFieldExpansion(index)" />
+                                        }
+                                    </div>
+                                </section>
+                            }
+                        </div>
+                    </div>
+                }
+                </div>
+
+                <p aria-labelledby="details-tab-xml" class="details-xml" hidden="@(_activeTab != DetailsTab.Xml)" id="details-tabpanel-xml" role="tabpanel">
+                    @if (_activeTab == DetailsTab.Xml)
+                    {
+                        @if (_resolvedXml is null)
+                        {
+                            <text>Resolving XML...</text>
+                        }
+                        else if (_resolvedXml.Length > 0)
+                        {
+                            @GetXmlForDisplay()
+                        }
+                        else
+                        {
+                            <text>No XML available for this event.</text>
+                        }
+                    }
+                </p>
+        }
+    </div>
 </div>

--- a/src/EventLogExpert.UI/DetailsPane/DetailsPane.razor.cs
+++ b/src/EventLogExpert.UI/DetailsPane/DetailsPane.razor.cs
@@ -1,11 +1,14 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Eventing.Common.EventLogs;
 using EventLogExpert.Eventing.Common.Events;
 using EventLogExpert.Eventing.Resolvers;
 using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.Common.Clipboard;
 using EventLogExpert.Runtime.DetailsPane;
 using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.FilterLenses;
 using EventLogExpert.Runtime.LogTable;
 using EventLogExpert.Runtime.Settings;
 using EventLogExpert.UI.Common.Interop;
@@ -19,11 +22,14 @@ namespace EventLogExpert.UI.DetailsPane;
 
 public sealed partial class DetailsPane
 {
+    private readonly HashSet<int> _expandedFields = [];
+
+    private DetailsTab _activeTab = DetailsTab.Reader;
     private IJSObjectReference? _detailsPaneModule;
     private DotNetObjectReference<DetailsPane>? _dotNetRef;
     private bool _hasOpened;
-    private bool _isVisible;
-    private bool _isXmlVisible;
+    private bool _isExpanded;
+    private DetailsReaderModel? _model;
     private string? _resolvedXml;
     private ResolvedEvent? _selectedEvent;
     /// <summary>
@@ -34,11 +40,23 @@ public sealed partial class DetailsPane
     /// <summary>Cancels any in-flight XML resolution when the selection changes again before completion.</summary>
     private CancellationTokenSource? _xmlResolveCts;
 
+    private enum DetailsTab
+    {
+        Reader,
+        Xml
+    }
+
+    [Inject] private IStateSelection<LogTableState, EventLogId?> ActiveLog { get; init; } = null!;
+
+    [Inject] private IClipboardService Clipboard { get; init; } = null!;
+
     [Inject] private IEventXmlResolver EventXmlResolver { get; init; } = null!;
+
+    [Inject] private IFilterLensCommands FilterLensCommands { get; init; } = null!;
 
     [Inject] private IStateSelection<EventLogState, SelectionEntry?> Focus { get; init; } = null!;
 
-    private string IsVisible => (_selectedEvent is not null && _isVisible).ToString().ToLower();
+    private string IsExpanded => _isExpanded.ToString().ToLowerInvariant();
 
     [Inject] private IJSRuntime JSRuntime { get; init; } = null!;
 
@@ -64,6 +82,8 @@ public sealed partial class DetailsPane
         if (disposing)
         {
             Focus.SelectedValueChanged -= OnFocusChanged;
+            ActiveLog.SelectedValueChanged -= OnActiveLogChanged;
+            Settings.TimeZoneChanged -= OnTimeZoneChanged;
 
             try { _xmlResolveCts?.Cancel(); } catch (ObjectDisposedException) { /* CTS already disposed; cancel is moot. */ }
 
@@ -103,11 +123,18 @@ public sealed partial class DetailsPane
     protected override void OnInitialized()
     {
         Focus.Select(s => s.Focus);
-
         Focus.SelectedValueChanged += OnFocusChanged;
 
+        // The active tab / log is the reset signal for the view tab (NOT the selected event's member log, which varies
+        // per selection inside a combined view).
+        ActiveLog.Select(s => s.ActiveEventLogId);
+        ActiveLog.SelectedValueChanged += OnActiveLogChanged;
+
+        // The reader model pre-renders timestamps in the configured zone, so a zone change must rebuild it.
+        Settings.TimeZoneChanged += OnTimeZoneChanged;
+
         // Seed from the current store value so the pane reflects an existing focus (e.g., a restore that completed
-        // before this component subscribed) instead of staying hidden until the next change event.
+        // before this component subscribed) instead of staying empty until the next change event.
         if (Focus.Value is not null)
         {
             OnFocusChanged(this, Focus.Value);
@@ -115,6 +142,31 @@ public sealed partial class DetailsPane
 
         base.OnInitialized();
     }
+
+    // Only Error/Warning get a coloured severity dot, mirroring the log table's level colouring exactly (LevelSeverity +
+    // GetLevelClass); Critical/Information/Verbose/unknown show no dot, matching the table's neutral treatment there.
+    private static string? SeverityDot(SeverityLevel? severity) => severity switch
+    {
+        SeverityLevel.Error => "error",
+        SeverityLevel.Warning => "warning",
+        _ => null
+    };
+
+    private async Task CopyEventAsync()
+    {
+        if (_model is { } model)
+        {
+            await Clipboard.CopyTextAsync(DetailsReaderFormatter.BuildEventCopyText(model));
+        }
+    }
+
+    private async Task CopyFieldsAsync(IReadOnlyList<DetailsField> fields) =>
+        await Clipboard.CopyTextAsync(DetailsReaderFormatter.BuildFieldsCopyText(fields));
+
+    private async Task CopyPropertiesAsync(IReadOnlyList<DetailsProperty> properties) =>
+        await Clipboard.CopyTextAsync(DetailsReaderFormatter.BuildPropertiesCopyText(properties));
+
+    private async Task CopyValueAsync(DetailsField field) => await Clipboard.CopyTextAsync(field.CopyValue);
 
     private string GetXmlForDisplay()
     {
@@ -126,9 +178,25 @@ public sealed partial class DetailsPane
         }
         catch (XmlException ex)
         {
-            TraceLogger.Trace($"DetailsPane: failed to parse XML for display, falling back to raw text: {ex.Message}");
+            TraceLogger.Trace($"{nameof(DetailsPane)}: failed to parse XML for display, falling back to raw text: {ex.Message}");
 
             return _resolvedXml;
+        }
+    }
+
+    private bool IsFieldExpanded(int index) => _expandedFields.Contains(index);
+
+    private async void OnActiveLogChanged(object? sender, EventLogId? activeLog)
+    {
+        try
+        {
+            _activeTab = DetailsTab.Reader;
+
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (Exception ex)
+        {
+            TraceLogger.Error($"{nameof(DetailsPane)}: failed to handle active-log change: {ex}");
         }
     }
 
@@ -139,8 +207,8 @@ public sealed partial class DetailsPane
             var handle = focus?.CurrentHandle;
             _selectedHandle = handle;
 
-            // A null CurrentHandle (a selection whose row could not be re-resolved after a reload) resolves to nothing
-            // and hides the pane.
+            // A null CurrentHandle (a selection whose row could not be re-resolved after a reload) resolves to nothing,
+            // leaving _selectedEvent/_model null so the pane hides.
             ResolvedEvent? selectedEvent = null;
 
             if (handle is { } locator
@@ -150,6 +218,8 @@ public sealed partial class DetailsPane
             }
 
             _selectedEvent = selectedEvent;
+            _model = selectedEvent is { } resolved ? DetailsReaderFormatter.BuildModel(resolved, Settings.TimeZoneInfo) : null;
+            _expandedFields.Clear();
 
             // Cancel any in-flight resolution from a prior selection so a stale fetch
             // can't overwrite the resolved XML for the now-current selection.
@@ -167,7 +237,10 @@ public sealed partial class DetailsPane
                 return;
             }
 
-            if (!_hasOpened || PreferencesProvider.DisplayPaneSelectionPreference) { _isVisible = true; }
+            // The pane stays closed until the user opens something: auto-expand on the FIRST selection, but after the
+            // user has toggled it (_hasOpened) respect their choice on later selections unless the preference opts into
+            // always-expand-on-select.
+            if (!_hasOpened || PreferencesProvider.DisplayPaneSelectionPreference) { _isExpanded = true; }
 
             // Short-circuit: live-watcher events arrive with XML already pre-rendered. Skip the
             // resolver round-trip (and the "Resolving XML..." flicker) when we already have it.
@@ -202,7 +275,7 @@ public sealed partial class DetailsPane
                 }
                 catch (Exception ex)
                 {
-                    TraceLogger.Error($"DetailsPane: XML resolution failed for selected event: {ex}");
+                    TraceLogger.Error($"{nameof(DetailsPane)}: XML resolution failed for selected event: {ex}");
 
                     // Only surface the failure if we're still the current selection; otherwise a newer selection owns
                     // _resolvedXml. A re-resolve mints a new event instance, so compare the stable locator, not object identity.
@@ -238,16 +311,37 @@ public sealed partial class DetailsPane
         }
         catch (Exception e)
         {
-            TraceLogger.Error($"Failed to handle selected event change: {e}");
+            TraceLogger.Error($"{nameof(DetailsPane)}: failed to handle selected event change: {e}");
         }
+    }
+
+    private async void OnTimeZoneChanged(object? sender, TimeZoneInfo timeZone)
+    {
+        try
+        {
+            if (_selectedEvent is { } detail)
+            {
+                _model = DetailsReaderFormatter.BuildModel(detail, timeZone);
+            }
+
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (Exception ex)
+        {
+            TraceLogger.Error($"{nameof(DetailsPane)}: failed to handle time-zone change: {ex}");
+        }
+    }
+
+    private void SetTab(DetailsTab tab) => _activeTab = tab;
+
+    private void ToggleFieldExpansion(int index)
+    {
+        if (!_expandedFields.Add(index)) { _expandedFields.Remove(index); }
     }
 
     private void ToggleMenu()
     {
-        if (!_hasOpened) { _hasOpened = true; }
-
-        _isVisible = !_isVisible;
+        _hasOpened = true;
+        _isExpanded = !_isExpanded;
     }
-
-    private void ToggleXml() => _isXmlVisible = !_isXmlVisible;
 }

--- a/src/EventLogExpert.UI/DetailsPane/DetailsPane.razor.css
+++ b/src/EventLogExpert.UI/DetailsPane/DetailsPane.razor.css
@@ -1,15 +1,13 @@
-﻿.details-pane {
+.details-pane {
+    position: relative;
     display: flex;
     flex-direction: column;
     flex: 0 0 auto;
-    position: relative;
-
-    margin: 0 5px;
     height: var(--details-pane-height, 30%);
     min-height: 20%;
-    overflow: hidden;
-
+    margin: 0 5px;
     border-top: solid var(--background-darkgray);
+    overflow: hidden;
 
     &[data-toggle="false"] {
         height: auto;
@@ -20,67 +18,312 @@
 .details-pane[data-toggle="false"] ::deep > :not(#details-header) { display: none; }
 
 .details-resizer {
-    height: 10px;
-    width: 100%;
-    margin: 0;
-    padding: 0;
-    user-select: none;
     position: absolute;
     top: -6px;
     left: 0;
     z-index: var(--z-base);
-
+    width: 100%;
+    height: 10px;
+    margin: 0;
+    padding: 0;
+    user-select: none;
     cursor: n-resize;
 }
 
 .details-pane ::deep #details-header {
     appearance: none;
-    background: none;
-    border: 0;
     padding: 0;
-    color: inherit;
+    border: 0;
     font: inherit;
     text-align: left;
+    color: inherit;
+    background: none;
     user-select: none;
     cursor: pointer;
 }
 
-.details-group { display: contents; }
-
-    .details-group[data-toggle="true"] { display: none; }
-
-.flex-row > div { padding-right: 5rem; }
-
-.details-description {
+.details-body {
+    display: flex;
+    flex-direction: column;
     height: 100%;
-    overflow-y: auto;
+    overflow: hidden;
+}
+
+.details-tabs {
+    display: flex;
+    flex: 0 0 auto;
+    align-items: center;
+    gap: 2px;
+    padding: 0 0.5rem;
+    border-bottom: 1px solid var(--border-divider);
+}
+
+.details-tab {
+    appearance: none;
+    padding: 5px 12px;
+    border: 0;
+    border-bottom: 2px solid transparent;
+    font: inherit;
+    color: var(--text-secondary);
+    background: none;
+    cursor: pointer;
+
+    &[data-active="true"] {
+        color: var(--text-primary);
+        border-bottom-color: var(--clr-lightblue);
+        font-weight: 600;
+    }
+}
+
+/* The reader is the SOLE scrollport (keeps overflow-y:auto). The split grid lives on the descendant
+   .details-reader-layout, which - unlike .details-reader itself - can respond to this container query. */
+.details-reader {
+    container: details-reader / inline-size;
+    flex: 1 1 auto;
+    min-height: 0;
+    padding: 0.6rem 0.85rem 1rem;
+    line-height: 1.35;
     overflow-x: hidden;
+    overflow-y: auto;
+}
+
+.details-reader-layout {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.75rem;
+}
+
+.reader-rail {
+    min-width: 0;
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid var(--border-divider);
+}
+
+.reader-payload {
+    container: reader-payload / inline-size;
+    min-width: 0;
+}
+
+/* Wide-short pane: metadata rail beside the payload, filling the horizontal space. One scrollport still (the reader);
+   grid cells stretch so the rail divider runs full height. */
+@container details-reader (min-width: 46rem) {
+    .details-reader-layout {
+        grid-template-columns: minmax(16rem, 20rem) minmax(0, 1fr);
+        column-gap: 1.25rem;
+    }
+
+    .reader-rail {
+        padding-bottom: 0;
+        padding-right: 1.25rem;
+        border-bottom: 0;
+        border-right: 1px solid var(--border-divider);
+    }
+}
+
+.details-summary {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.35rem 0.9rem;
+    margin-bottom: 0.5rem;
+}
+
+.details-summary-id {
+    color: var(--text-primary);
+    font-size: 13px;
+    font-weight: 600;
+}
+
+.details-summary-level {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    color: var(--text-secondary);
+    font-size: 13px;
+}
+
+.details-severity-dot {
+    width: 8px;
+    height: 8px;
+    flex: 0 0 auto;
+    border-radius: 50%;
+    background: var(--text-secondary);
+}
+
+.details-severity-dot[data-severity="error"] { background: var(--clr-red); }
+
+.details-severity-dot[data-severity="warning"] { background: var(--clr-yellow); }
+
+.details-grid {
+    display: grid;
+    grid-template-columns: minmax(6rem, max-content) minmax(0, 1fr);
+    align-items: baseline;
+    gap: 0.3rem 1rem;
+    margin: 0 0 0.25rem;
+
+    & dt {
+        margin: 0;
+        color: var(--text-secondary);
+        font-size: 12px;
+        font-weight: 600;
+    }
+
+    & dd {
+        margin: 0;
+        color: var(--text-primary);
+        font-size: 13px;
+        overflow-wrap: anywhere;
+    }
+}
+
+.details-section {
+    margin: 0;
+    padding: 0.6rem 0;
+    border-top: 1px solid var(--border-divider);
+}
+
+.reader-payload > .details-section:first-child {
+    padding-top: 0;
+    border-top: 0;
+}
+
+.details-section-head {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.35rem;
+}
+
+.details-reader h3,
+.details-section > summary {
+    margin: 0 0 0.35rem;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--text-secondary);
+}
+
+.details-section-head h3 { margin: 0; }
+
+.details-section > summary {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    user-select: none;
+    cursor: pointer;
+}
+
+.details-correlation {
+    margin: 0;
+    padding: 0.6rem 0;
+    border-top: 1px solid var(--border-divider);
+}
+
+.details-correlation-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+}
+
+.details-correlation-action {
+    font-size: 12px;
+}
+
+.details-message {
+    margin: 0;
+    max-width: 90ch;
+    color: var(--text-primary);
+    font-size: 13px;
+    line-height: 1.4;
     overflow-wrap: anywhere;
     white-space: pre-wrap;
 }
 
-.details-pane ::deep .details-row-xml {
+.details-muted {
+    margin: 0.25rem 0;
+    color: var(--text-secondary);
+    font-size: 12px;
+}
+
+.details-warn {
+    margin: 0.25rem 0;
+    color: var(--clr-yellow);
+    font-size: 12px;
+    font-weight: 600;
+}
+
+/* EventData packs into at most three columns; the tiers are keyed on the payload width and raised so each card stays
+   >= ~22rem (a starved narrow card would truncate long field names - stacked rows already give the name full width). */
+.details-fields {
+    display: grid;
+    grid-template-columns: 1fr;
+    column-gap: 1.25rem;
+}
+
+@container reader-payload (min-width: 46rem) {
+    .details-fields { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+@container reader-payload (min-width: 70rem) {
+    .details-fields { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+}
+
+/* UserData stays single-column (path-like values want full width regardless of the field's line count). */
+.details-fields-userdata {
+    display: grid;
+    grid-template-columns: 1fr;
+}
+
+.details-copy-event {
     appearance: none;
-    background: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    height: 24px;
+    margin-left: auto;
+    padding: 0 0.55rem;
     border: 0;
-    padding: 0;
-    color: inherit;
-    font: inherit;
-    text-align: left;
-    user-select: none;
+    border-radius: 4px;
+    color: var(--text-secondary);
+    background: none;
     cursor: pointer;
 }
 
+.details-copy-event-label { font-size: 12px; }
+
+.details-copy-section {
+    appearance: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    margin-left: auto;
+    padding: 0;
+    border: 0;
+    border-radius: 4px;
+    color: var(--text-secondary);
+    background: none;
+    cursor: pointer;
+}
+
+.details-copy-event:hover,
+.details-copy-event:focus-visible,
+.details-copy-section:hover,
+.details-copy-section:focus-visible {
+    color: var(--text-primary);
+}
+
 .details-xml {
+    flex: 1 1 auto;
+    min-height: 0;
     margin: 0;
-    height: 100%;
-    overflow-y: auto;
+    padding: 0.5rem 0.85rem;
+    font-family: ui-monospace, "Cascadia Mono", Consolas, monospace;
     overflow-x: hidden;
+    overflow-y: auto;
     overflow-wrap: anywhere;
     text-wrap: pretty;
     white-space: pre-wrap;
 }
-
-    .details-xml[data-toggle="false"] { display: none; }
-
-hr { margin: 1px 0; }

--- a/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
@@ -143,6 +143,15 @@ public sealed partial class LogTablePane
         return new ItemsProviderResult<DisplayRow>(window, totalCount);
     }
 
+    internal static string GetLevelClass(string level) =>
+        LevelSeverity.FromLevelName(level) switch
+        {
+            SeverityLevel.Error => "bi bi-exclamation-circle error",
+            SeverityLevel.Warning => "bi bi-exclamation-triangle warning",
+            SeverityLevel.Information => "bi bi-info-circle",
+            _ => string.Empty,
+        };
+
     protected override async ValueTask DisposeAsyncCore(bool disposing)
     {
         if (disposing)
@@ -355,15 +364,6 @@ public sealed partial class LogTablePane
     // after a reload (null for a null-RecordId row, which cannot be re-resolved).
     private static SelectionEntry EntryFor(DisplayRow row) =>
         new(row.Loc, row.Loc, ValueKey.TryCreate(row.Lean, out var key) ? key : null);
-
-    private static string GetLevelClass(string level) =>
-        level switch
-        {
-            nameof(SeverityLevel.Error) => "bi bi-exclamation-circle error",
-            nameof(SeverityLevel.Warning) => "bi bi-exclamation-triangle warning",
-            nameof(SeverityLevel.Information) => "bi bi-info-circle",
-            _ => string.Empty,
-        };
 
     private static string TruncateForMenu(string value)
     {

--- a/src/EventLogExpert.UI/_Imports.razor
+++ b/src/EventLogExpert.UI/_Imports.razor
@@ -18,6 +18,7 @@
 @using EventLogExpert.Runtime.Banner
 @using EventLogExpert.Runtime.Common.Display
 @using EventLogExpert.Runtime.Database
+@using EventLogExpert.Runtime.DetailsPane
 @using EventLogExpert.Runtime.FilterLibrary
 @using EventLogExpert.Runtime.LogTable
 @using EventLogExpert.Runtime.Settings

--- a/tests/Shared/EventLogExpert.Eventing.TestUtils/EventDataTestFactory.cs
+++ b/tests/Shared/EventLogExpert.Eventing.TestUtils/EventDataTestFactory.cs
@@ -22,6 +22,24 @@ public static class EventDataTestFactory
     public static ResolvedEvent CreateEventWithData(params (string Name, object? Value)[] fields) =>
         new ResolvedEvent("TestLog", LogPathType.Channel).WithEventData(fields);
 
+    // Produces an event whose EventData carries values but no aligned field-name schema, so Kind is EventData and Count
+    // is non-zero while the enumerator yields nothing - the template/values mismatch the reader view must fall back on.
+    public static ResolvedEvent CreateEventWithUnalignedData(params object?[] values)
+    {
+        var builder = ImmutableArray.CreateBuilder<EventProperty>(values.Length);
+
+        foreach (object? value in values)
+        {
+            builder.Add(ToEventProperty(value));
+        }
+
+        return new ResolvedEvent("TestLog", LogPathType.Channel) with
+        {
+            EventDataValues = builder.MoveToImmutable(),
+            EventDataSchema = null
+        };
+    }
+
     public static ResolvedEvent WithEventData(this ResolvedEvent source, params (string Name, object? Value)[] fields)
     {
         var template = "<template>"
@@ -57,6 +75,7 @@ public static class EventDataTestFactory
             SecurityIdentifier sid => sid,
             byte[] bytes => bytes,
             string[] strings => strings,
+            Array array => EventProperty.FromReference(array),
             _ => value.ToString() ?? string.Empty
         };
 }

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Common/Events/EventFieldValueTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Common/Events/EventFieldValueTests.cs
@@ -170,6 +170,45 @@ public sealed class EventFieldValueTests
     }
 
     [Fact]
+    public void TryGetArray_ReturnsFalse_ForStringArrayKind()
+    {
+        EventFieldValue value = EventFieldValue.FromProperty((EventProperty)(string[])["a", "b"]);
+
+        Assert.Equal(EventFieldValueKind.StringArray, value.Kind);
+        Assert.False(value.TryGetArray(out Array? array));
+        Assert.Null(array);
+    }
+
+    [Fact]
+    public void TryGetArray_ReturnsStoredArray_ForArrayKind()
+    {
+        EventFieldValue value = EventFieldValue.FromProperty(EventProperty.FromReference(new uint[] { 1, 2, 3 }));
+
+        Assert.Equal(EventFieldValueKind.Array, value.Kind);
+        Assert.True(value.TryGetArray(out Array? array));
+        Assert.Equal(new uint[] { 1, 2, 3 }, array);
+    }
+
+    [Fact]
+    public void TryGetBytes_ReturnsFalse_ForNonBytesKind()
+    {
+        EventFieldValue value = EventFieldValue.FromProperty((EventProperty)"not-bytes");
+
+        Assert.False(value.TryGetBytes(out byte[]? bytes));
+        Assert.Null(bytes);
+    }
+
+    [Fact]
+    public void TryGetBytes_ReturnsStoredBytes_ForBytesKind()
+    {
+        EventFieldValue value = EventFieldValue.FromProperty((EventProperty)(byte[])[1, 2, 3]);
+
+        Assert.Equal(EventFieldValueKind.Bytes, value.Kind);
+        Assert.True(value.TryGetBytes(out byte[]? bytes));
+        Assert.Equal((byte[])[1, 2, 3], bytes);
+    }
+
+    [Fact]
     public void TryGetGuid_ReturnsStoredValue()
     {
         var guid = Guid.NewGuid();

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Common/Events/LevelSeverityTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Common/Events/LevelSeverityTests.cs
@@ -1,0 +1,27 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+
+namespace EventLogExpert.Eventing.Tests.Common.Events;
+
+public sealed class LevelSeverityTests
+{
+    [Theory]
+    [InlineData("Critical", SeverityLevel.Critical)]
+    [InlineData("Error", SeverityLevel.Error)]
+    [InlineData("Warning", SeverityLevel.Warning)]
+    [InlineData("Information", SeverityLevel.Information)]
+    [InlineData("Verbose", SeverityLevel.Verbose)]
+    public void FromLevelName_MapsInvariantEnumNames(string level, SeverityLevel expected) =>
+        Assert.Equal(expected, LevelSeverity.FromLevelName(level));
+
+    [Theory]
+    [InlineData("error")]
+    [InlineData("WARNING")]
+    [InlineData("")]
+    [InlineData("Audit Success")]
+    [InlineData(null)]
+    public void FromLevelName_ReturnsNullForUnrecognizedOrMiscasedNames(string? level) =>
+        Assert.Null(LevelSeverity.FromLevelName(level));
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/DetailsPane/DetailsReaderFormatterTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/DetailsPane/DetailsReaderFormatterTests.cs
@@ -1,0 +1,323 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Eventing.Structured;
+using EventLogExpert.Eventing.TestUtils;
+using EventLogExpert.Runtime.DetailsPane;
+using System.Security.Principal;
+
+namespace EventLogExpert.Runtime.Tests.DetailsPane;
+
+public sealed class DetailsReaderFormatterTests
+{
+    private const string SecurityAuditing = "Microsoft-Windows-Security-Auditing";
+
+    [Fact]
+    public void BuildEventCopyText_EmitsEventIdThenLevelThenHeader()
+    {
+        ResolvedEvent @event = new ResolvedEvent("TestLog", LogPathType.Channel) with { Id = 4624, Level = "Warning", Source = "Contoso" };
+
+        string[] lines = DetailsReaderFormatter.BuildEventCopyText(Model(@event)).Split(Environment.NewLine);
+
+        Assert.Equal("Event ID: 4624", lines[0]);
+        Assert.Equal("Level: Warning", lines[1]);
+        Assert.Equal("Source: Contoso", lines[2]);
+    }
+
+    [Fact]
+    public void BuildEventCopyText_ExcludesXml()
+    {
+        ResolvedEvent @event = EventDataTestFactory.CreateEventWithData(("LogonType", 3)) with { Xml = "<Event>secret</Event>" };
+
+        string copy = DetailsReaderFormatter.BuildEventCopyText(Model(@event));
+
+        Assert.DoesNotContain("<Event", copy);
+    }
+
+    [Fact]
+    public void BuildEventCopyText_IncludesDecodedLabelExcludesDescriptionProse()
+    {
+        ResolvedEvent @event = EventDataTestFactory.CreateEventWithData(("LogonType", 3)) with { Source = SecurityAuditing, Id = 4624 };
+
+        string copy = DetailsReaderFormatter.BuildEventCopyText(Model(@event));
+
+        Assert.Contains("LogonType: 3 (Network)", copy);
+        Assert.DoesNotContain("How the logon", copy);
+    }
+
+    [Fact]
+    public void BuildEventCopyText_MultiValueFieldIndentsItems()
+    {
+        ResolvedEvent @event = EventDataTestFactory.CreateEventWithData(("Privileges", (string[])["SeDebugPrivilege", "SeBackupPrivilege"]));
+
+        string copy = DetailsReaderFormatter.BuildEventCopyText(Model(@event));
+
+        Assert.Contains("Privileges:", copy);
+        Assert.Contains("    SeDebugPrivilege", copy);
+        Assert.Contains("    SeBackupPrivilege", copy);
+    }
+
+    [Fact]
+    public void BuildEventCopyText_OmitsLevelLineWhenLevelEmpty()
+    {
+        ResolvedEvent @event = new ResolvedEvent("TestLog", LogPathType.Channel) with { Id = 4624, Source = "Contoso" };
+
+        string[] lines = DetailsReaderFormatter.BuildEventCopyText(Model(@event)).Split(Environment.NewLine);
+
+        Assert.Equal("Event ID: 4624", lines[0]);
+        Assert.Equal("Source: Contoso", lines[1]);
+    }
+
+    [Fact]
+    public void BuildEventCopyText_SectionsAppearInStableOrder()
+    {
+        ResolvedEvent @event = EventDataTestFactory.CreateEventWithData(("Field1", "v1")) with
+        {
+            Id = 4624,
+            Level = "Warning",
+            Source = "Contoso",
+            ProcessId = 42,
+            Description = "A message.",
+            UserData = [new UserDataField("Config/Setting", ["u1"], false)]
+        };
+
+        string copy = DetailsReaderFormatter.BuildEventCopyText(Model(@event));
+
+        int eventId = copy.IndexOf("Event ID:", StringComparison.Ordinal);
+        int level = copy.IndexOf("Level:", StringComparison.Ordinal);
+        int source = copy.IndexOf("Source:", StringComparison.Ordinal);
+        int processId = copy.IndexOf("Process ID:", StringComparison.Ordinal);
+        int message = copy.IndexOf("Message:", StringComparison.Ordinal);
+        int eventData = copy.IndexOf("Event Data:", StringComparison.Ordinal);
+        int userData = copy.IndexOf("User Data:", StringComparison.Ordinal);
+
+        // Pins the full section order (identity -> System -> Message -> Event Data -> User Data), not just the first
+        // lines, so moving any later section is caught.
+        Assert.True(
+            eventId >= 0 && level > eventId && source > level && processId > source &&
+            message > processId && eventData > message && userData > eventData,
+            $"Unexpected copy section order:{Environment.NewLine}{copy}");
+    }
+
+    [Fact]
+    public void BuildModel_CorrelationIds_RemainInSystemPropertiesAndCopyText()
+    {
+        var activityId = Guid.NewGuid();
+        ResolvedEvent @event = new ResolvedEvent("TestLog", LogPathType.Channel) with { ActivityId = activityId };
+
+        DetailsReaderModel model = Model(@event);
+
+        Assert.Contains(model.SystemProperties, property => property.Label == "Activity ID" && property.Value == activityId.ToString());
+        Assert.Contains(activityId.ToString(), DetailsReaderFormatter.BuildEventCopyText(model));
+    }
+
+    [Fact]
+    public void BuildModel_EmptyStringValue_IsMutedButCopiesRealValue()
+    {
+        DetailsField field = Assert.Single(Model(EventDataTestFactory.CreateEventWithData(("SubjectUserName", ""))).EventData);
+
+        Assert.True(field.IsMuted);
+        Assert.Equal("(empty)", Assert.Single(field.PreviewLines));
+        Assert.Equal(string.Empty, field.CopyValue);
+    }
+
+    [Fact]
+    public void BuildModel_GeneralArray_RendersOneLinePerItem()
+    {
+        DetailsField field = Assert.Single(Model(EventDataTestFactory.CreateEventWithData(("Ports", new uint[] { 80, 443 }))).EventData);
+
+        Assert.Equal(new[] { "80", "443" }, field.FullLines);
+    }
+
+    [Fact]
+    public void BuildModel_HeaderExcludesEventIdAndLevel()
+    {
+        ResolvedEvent @event = new ResolvedEvent("TestLog", LogPathType.Channel) with { Id = 4624, Level = "Warning" };
+
+        DetailsReaderModel model = Model(@event);
+
+        Assert.DoesNotContain(model.Header, property => property.Label == "Event ID");
+        Assert.DoesNotContain(model.Header, property => property.Label == "Level");
+    }
+
+    [Fact]
+    public void BuildModel_LargeByteArray_TruncatesPreviewKeepsFullHexCopy()
+    {
+        DetailsField field = Assert.Single(Model(EventDataTestFactory.CreateEventWithData(("Binary", new byte[100]))).EventData);
+
+        Assert.True(field.IsTruncated);
+        Assert.Equal(200, field.CopyValue.Length);
+        Assert.NotEqual(field.PreviewLines[0], field.FullLines[0]);
+    }
+
+    [Fact]
+    public void BuildModel_LegacyEventWithNoEventData_HasNoNamedEventData()
+    {
+        DetailsReaderModel model = Model(new ResolvedEvent("TestLog", LogPathType.Channel));
+
+        Assert.False(model.HasNamedEventData);
+        Assert.Empty(model.EventData);
+    }
+
+    [Fact]
+    public void BuildModel_LongScalar_TruncatesPreviewKeepsFullCopy()
+    {
+        string longValue = new('a', 600);
+
+        DetailsField field = Assert.Single(Model(EventDataTestFactory.CreateEventWithData(("CommandLine", longValue))).EventData);
+
+        Assert.True(field.IsTruncated);
+        Assert.Equal(longValue, field.CopyValue);
+        Assert.Equal(longValue, field.FullLines[0]);
+    }
+
+    [Fact]
+    public void BuildModel_NullValue_IsMuted()
+    {
+        DetailsField field = Assert.Single(Model(EventDataTestFactory.CreateEventWithData(("SubjectUserSid", null))).EventData);
+
+        Assert.True(field.IsMuted);
+        Assert.Equal("(none)", Assert.Single(field.PreviewLines));
+    }
+
+    [Fact]
+    public void BuildModel_OmitsEmptySystemProperties()
+    {
+        ResolvedEvent @event = new ResolvedEvent("TestLog", LogPathType.Channel) with { Opcode = "", TaskCategory = "", ProcessId = 42 };
+
+        DetailsReaderModel model = Model(@event);
+
+        Assert.DoesNotContain(model.SystemProperties, property => property.Label == "Opcode");
+        Assert.Contains(model.SystemProperties, property => property.Label == "Process ID");
+    }
+
+    [Fact]
+    public void BuildModel_SchemaMisalignment_HasNoNamedEventDataDespiteNonZeroCount()
+    {
+        ResolvedEvent @event = EventDataTestFactory.CreateEventWithUnalignedData("a", "b");
+
+        Assert.Equal(2, @event.EventData.Count);
+
+        DetailsReaderModel model = Model(@event);
+
+        Assert.False(model.HasNamedEventData);
+        Assert.Empty(model.EventData);
+    }
+
+    [Fact]
+    public void BuildModel_SetsEventIdLevelAndSeverity()
+    {
+        ResolvedEvent @event = new ResolvedEvent("TestLog", LogPathType.Channel) with { Id = 4624, Level = "Warning" };
+
+        DetailsReaderModel model = Model(@event);
+
+        Assert.Equal("4624", model.EventId);
+        Assert.Equal("Warning", model.Level);
+        Assert.Equal(SeverityLevel.Warning, model.Severity);
+    }
+
+    [Fact]
+    public void BuildModel_StringArray_PreservesEmbeddedCommasOnePerLine()
+    {
+        DetailsField field = Assert.Single(Model(EventDataTestFactory.CreateEventWithData(("Groups", (string[])["a,b", "c"]))).EventData);
+
+        Assert.Equal(new[] { "a,b", "c" }, field.FullLines);
+        Assert.Equal("a,b\nc", field.CopyValue);
+    }
+
+    [Fact]
+    public void BuildModel_StructuredTokenFields_AreMonospaced()
+    {
+        DetailsReaderModel model = Model(EventDataTestFactory.CreateEventWithData(
+            ("Id", Guid.NewGuid()),
+            ("Sid", new SecurityIdentifier("S-1-5-18")),
+            ("Blob", new byte[] { 1, 2 }),
+            ("Name", "plain")));
+
+        Assert.True(model.EventData[0].IsMonospace);
+        Assert.True(model.EventData[1].IsMonospace);
+        Assert.True(model.EventData[2].IsMonospace);
+        Assert.False(model.EventData[3].IsMonospace);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("warning")]
+    [InlineData("Custom")]
+    public void BuildModel_UnknownOrLowercaseLevel_HasNullSeverity(string level)
+    {
+        ResolvedEvent @event = new ResolvedEvent("TestLog", LogPathType.Channel) with { Level = level };
+
+        Assert.Null(Model(@event).Severity);
+    }
+
+    [Fact]
+    public void BuildModel_UnnamedField_UsesPositionalLabel()
+    {
+        DetailsField field = Assert.Single(Model(EventDataTestFactory.CreateEventWithData(("", "value"))).EventData);
+
+        Assert.Equal("[0]", field.Label);
+    }
+
+    [Fact]
+    public void BuildModel_UserData_RendersPathAndFlagsIncompleteExtraction()
+    {
+        ResolvedEvent @event = new ResolvedEvent("TestLog", LogPathType.Channel) with
+        {
+            UserData = [new UserDataField("Config/Setting", ["v1"], false)],
+            UserDataIncomplete = true
+        };
+
+        DetailsReaderModel model = Model(@event);
+        DetailsField field = Assert.Single(model.UserData);
+
+        Assert.True(model.UserDataIncomplete);
+        Assert.Equal("Config/Setting", field.Label);
+        Assert.Equal("v1", Assert.Single(field.FullLines));
+    }
+
+    [Fact]
+    public void BuildModel_UserId_RendersRawSid()
+    {
+        ResolvedEvent @event = new ResolvedEvent("TestLog", LogPathType.Channel) with { UserId = new SecurityIdentifier("S-1-5-18") };
+
+        DetailsProperty user = Assert.Single(Model(@event).SystemProperties, property => property.Label == "User");
+
+        Assert.Equal("S-1-5-18", user.Value);
+    }
+
+    [Fact]
+    public void PreferFullWidth_TrueForExplainedField()
+    {
+        ResolvedEvent @event = EventDataTestFactory.CreateEventWithData(("LogonType", 3)) with { Source = SecurityAuditing, Id = 4624 };
+
+        DetailsField field = Assert.Single(Model(@event).EventData);
+
+        Assert.NotNull(field.Description);
+        Assert.True(field.PreferFullWidth);
+    }
+
+    [Fact]
+    public void PreferFullWidth_TrueForMultiItemArray_FalseForSingleElementArray()
+    {
+        DetailsField multi = Assert.Single(Model(EventDataTestFactory.CreateEventWithData(("Groups", (string[])["a", "b"]))).EventData);
+        DetailsField single = Assert.Single(Model(EventDataTestFactory.CreateEventWithData(("Groups", (string[])["only"]))).EventData);
+
+        Assert.True(multi.PreferFullWidth);
+        Assert.False(single.PreferFullWidth);
+    }
+
+    [Fact]
+    public void PreferFullWidth_TrueForTruncatedScalar_FalseForShortScalar()
+    {
+        DetailsField longField = Assert.Single(Model(EventDataTestFactory.CreateEventWithData(("CommandLine", new string('a', 600)))).EventData);
+        DetailsField shortField = Assert.Single(Model(EventDataTestFactory.CreateEventWithData(("Name", "plain"))).EventData);
+
+        Assert.True(longField.PreferFullWidth);
+        Assert.False(shortField.PreferFullWidth);
+    }
+
+    private static DetailsReaderModel Model(ResolvedEvent @event) => DetailsReaderFormatter.BuildModel(@event, TimeZoneInfo.Utc);
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/DetailsPane/EventFieldExplainerTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/DetailsPane/EventFieldExplainerTests.cs
@@ -1,0 +1,135 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Eventing.TestUtils;
+using EventLogExpert.Runtime.DetailsPane;
+
+namespace EventLogExpert.Runtime.Tests.DetailsPane;
+
+public sealed class EventFieldExplainerTests
+{
+    private const string SecurityAuditing = "Microsoft-Windows-Security-Auditing";
+
+    [Fact]
+    public void Explain_AmbiguousBareName_IsNotExplained()
+    {
+        Assert.False(EventFieldExplainer.TryExplain("Contoso-Provider", 1, "Status", ValueOf("0x0"), out EventFieldExplanation explanation));
+        Assert.False(explanation.HasValue);
+    }
+
+    [Fact]
+    public void Explain_DecoderAndGlossaryResolveIndependently()
+    {
+        Assert.True(EventFieldExplainer.TryExplain("Contoso-Provider", 1, "LogonType", ValueOf(3), out EventFieldExplanation explanation));
+
+        Assert.Equal("Network", explanation.DecodedLabel);
+        Assert.NotNull(explanation.Description);
+    }
+
+    [Fact]
+    public void Explain_GenericField_AppliesAcrossProviders()
+    {
+        Assert.True(EventFieldExplainer.TryExplain("Contoso-Provider", 42, "IpAddress", ValueOf("10.0.0.1"), out EventFieldExplanation explanation));
+        Assert.NotNull(explanation.Description);
+    }
+
+    [Fact]
+    public void Explain_ProviderMismatch_DropsScopedDescription()
+    {
+        Assert.False(EventFieldExplainer.TryExplain("Contoso-Provider", 4624, "TargetUserName", ValueOf("SYSTEM"), out EventFieldExplanation explanation));
+        Assert.Null(explanation.Description);
+    }
+
+    [Fact]
+    public void Explain_ProviderScopedField_AppliesToAnyEvent()
+    {
+        Assert.True(EventFieldExplainer.TryExplain(SecurityAuditing, 9999, "AuthenticationPackageName", ValueOf("NTLM"), out EventFieldExplanation explanation));
+        Assert.NotNull(explanation.Description);
+    }
+
+    [Fact]
+    public void Explain_ScopedField_IsEventSpecific()
+    {
+        Assert.True(EventFieldExplainer.TryExplain(SecurityAuditing, 4624, "TargetUserName", ValueOf("SYSTEM"), out EventFieldExplanation logon));
+        Assert.True(EventFieldExplainer.TryExplain(SecurityAuditing, 4625, "TargetUserName", ValueOf("SYSTEM"), out EventFieldExplanation failure));
+
+        Assert.NotNull(logon.Description);
+        Assert.NotNull(failure.Description);
+        Assert.NotEqual(logon.Description, failure.Description);
+    }
+
+    [Fact]
+    public void Explain_UnknownField_ReturnsFalse()
+    {
+        Assert.False(EventFieldExplainer.TryExplain("Contoso-Provider", 1, "SomeUnknownField", ValueOf("x"), out EventFieldExplanation explanation));
+        Assert.False(explanation.HasValue);
+    }
+
+    [Theory]
+    [InlineData(0, "System")]
+    [InlineData(2, "Interactive")]
+    [InlineData(3, "Network")]
+    [InlineData(5, "Service")]
+    [InlineData(10, "RemoteInteractive")]
+    [InlineData(12, "CachedRemoteInteractive")]
+    [InlineData(13, "CachedUnlock")]
+    public void LogonType_DecodesKnownNumericValue(int logonType, string expected)
+    {
+        Assert.True(EventFieldExplainer.TryExplain("Contoso-Provider", 1, "LogonType", ValueOf(logonType), out EventFieldExplanation explanation));
+        Assert.Equal(expected, explanation.DecodedLabel);
+    }
+
+    [Fact]
+    public void LogonType_DecodesStringValue()
+    {
+        Assert.True(EventFieldExplainer.TryExplain("Contoso-Provider", 1, "LogonType", ValueOf("3"), out EventFieldExplanation explanation));
+        Assert.Equal("Network", explanation.DecodedLabel);
+    }
+
+    [Fact]
+    public void LogonType_DecodesUnsignedValue()
+    {
+        // A real Security-Auditing LogonType materializes as UInt32 -> EventFieldValueKind.UInt64, exercising the
+        // TryGetUInt64 branch the int-typed cases above never reach.
+        Assert.True(EventFieldExplainer.TryExplain("Contoso-Provider", 1, "LogonType", ValueOf(3u), out EventFieldExplanation explanation));
+        Assert.Equal("Network", explanation.DecodedLabel);
+    }
+
+    [Fact]
+    public void LogonType_NegativeInteger_IsNotDecoded()
+    {
+        Assert.True(EventFieldExplainer.TryExplain("Contoso-Provider", 1, "LogonType", ValueOf(-3), out EventFieldExplanation explanation));
+        Assert.Null(explanation.DecodedLabel);
+    }
+
+    [Theory]
+    [InlineData(" 3 ")]
+    [InlineData("-3")]
+    [InlineData("3.0")]
+    [InlineData("three")]
+    public void LogonType_NonCanonicalString_IsNotDecoded(string raw)
+    {
+        Assert.True(EventFieldExplainer.TryExplain("Contoso-Provider", 1, "LogonType", ValueOf(raw), out EventFieldExplanation explanation));
+        Assert.Null(explanation.DecodedLabel);
+    }
+
+    [Fact]
+    public void LogonType_UnknownValue_HasNoDecodedLabel()
+    {
+        Assert.True(EventFieldExplainer.TryExplain("Contoso-Provider", 1, "LogonType", ValueOf(99), out EventFieldExplanation explanation));
+
+        Assert.Null(explanation.DecodedLabel);
+        Assert.NotNull(explanation.Description);
+    }
+
+    private static EventFieldValue ValueOf(object? raw)
+    {
+        foreach (EventDataView.Field field in EventDataTestFactory.CreateEventWithData(("Field", raw)).EventData)
+        {
+            return field.Value;
+        }
+
+        throw new InvalidOperationException("Test factory produced no EventData field.");
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/DetailsPane/DetailsPaneTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/DetailsPane/DetailsPaneTests.cs
@@ -1,0 +1,357 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using AngleSharp.Dom;
+using Bunit;
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Eventing.Resolvers;
+using EventLogExpert.Eventing.Structured;
+using EventLogExpert.Eventing.TestUtils;
+using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.Common.Clipboard;
+using EventLogExpert.Runtime.DetailsPane;
+using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.FilterLenses;
+using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.Runtime.Settings;
+using Fluxor;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using DetailsPaneComponent = EventLogExpert.UI.DetailsPane.DetailsPane;
+
+namespace EventLogExpert.UI.Tests.DetailsPane;
+
+public sealed class DetailsPaneTests : BunitContext
+{
+    private readonly IStateSelection<LogTableState, EventLogId?> _activeLog = Substitute.For<IStateSelection<LogTableState, EventLogId?>>();
+    private readonly IClipboardService _clipboard = Substitute.For<IClipboardService>();
+    private readonly IFilterLensCommands _filterLensCommands = Substitute.For<IFilterLensCommands>();
+    private readonly IStateSelection<EventLogState, SelectionEntry?> _focus = Substitute.For<IStateSelection<EventLogState, SelectionEntry?>>();
+    private readonly EventLogId _logId = EventLogId.Create();
+    private readonly IState<LogTableState> _logTableState = Substitute.For<IState<LogTableState>>();
+    private readonly IDetailsPanePreferencesProvider _preferences = Substitute.For<IDetailsPanePreferencesProvider>();
+    private readonly ISettingsService _settings = Substitute.For<ISettingsService>();
+    private readonly ITraceLogger _traceLogger = Substitute.For<ITraceLogger>();
+    private readonly IEventXmlResolver _xmlResolver = Substitute.For<IEventXmlResolver>();
+
+    public DetailsPaneTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        JSInterop.SetupModule("./_content/EventLogExpert.UI/DetailsPane/DetailsPane.razor.js");
+
+        _settings.TimeZoneInfo.Returns(TimeZoneInfo.Utc);
+        _focus.Value.Returns((SelectionEntry?)null);
+
+        Services.AddSingleton(_activeLog);
+        Services.AddSingleton(_clipboard);
+        Services.AddSingleton(_filterLensCommands);
+        Services.AddSingleton(_focus);
+        Services.AddSingleton(_logTableState);
+        Services.AddSingleton(_preferences);
+        Services.AddSingleton(_settings);
+        Services.AddSingleton(_traceLogger);
+        Services.AddSingleton(_xmlResolver);
+        Services.AddFluxor(options => options.ScanAssemblies(typeof(DetailsPaneComponent).Assembly));
+    }
+
+    [Fact]
+    public void CollapsedPane_ReopensOnNextSelection_WhenPreferenceOn()
+    {
+        _preferences.DisplayPaneSelectionPreference.Returns(true);
+        var @event = EventWithData(("LogonType", 3));
+        var cut = SelectAndRender(@event);
+
+        cut.Find("#details-header").Click();
+        Assert.Equal("false", cut.Find(".details-pane").GetAttribute("data-toggle"));
+
+        RaiseFocusChanged(@event);
+
+        cut.WaitForAssertion(() => Assert.Equal("true", cut.Find(".details-pane").GetAttribute("data-toggle")));
+    }
+
+    [Fact]
+    public void CollapsedPane_StaysCollapsedOnNextSelection_WhenPreferenceOff()
+    {
+        _preferences.DisplayPaneSelectionPreference.Returns(false);
+        var @event = EventWithData(("LogonType", 3));
+        var cut = SelectAndRender(@event);
+
+        // User collapses the pane, then a later selection arrives: it must respect the collapse.
+        cut.Find("#details-header").Click();
+        Assert.Equal("false", cut.Find(".details-pane").GetAttribute("data-toggle"));
+
+        RaiseFocusChanged(@event);
+
+        cut.WaitForAssertion(() => Assert.Equal("false", cut.Find(".details-pane").GetAttribute("data-toggle")));
+    }
+
+    [Fact]
+    public void CopyEventButton_HasVisibleLabel()
+    {
+        var cut = SelectAndRender(EventWithData(("LogonType", 3)));
+
+        Assert.Contains("Copy event", cut.Find(".details-copy-event").TextContent);
+    }
+
+    [Fact]
+    public void CopyEventButton_InvokesClipboardWithEventText()
+    {
+        var cut = SelectAndRender(EventWithData(("LogonType", 3)));
+
+        cut.Find(".details-copy-event").Click();
+
+        _clipboard.Received(1).CopyTextAsync(Arg.Is<string>(text => text.Contains("LogonType: 3 (Network)")));
+    }
+
+    [Fact]
+    public void CorrelationButtons_DispatchLensCommandsForSelectedEventAndOwningLog()
+    {
+        var activityId = Guid.NewGuid();
+        var relatedActivityId = Guid.NewGuid();
+        ResolvedEvent @event = BaseEvent() with { ActivityId = activityId, RelatedActivityId = relatedActivityId };
+
+        var cut = SelectAndRender(@event);
+
+        Assert.Equal(2, cut.FindAll(".details-correlation-action").Count);
+
+        // Re-issue FindAll before each click: the first click re-renders, which invalidates handler ids captured earlier.
+        cut.FindAll(".details-correlation-action")[0].Click();
+        cut.FindAll(".details-correlation-action")[1].Click();
+
+        _filterLensCommands.Received(1).ShowRelatedByActivityId(activityId, "Application");
+        _filterLensCommands.Received(1).ShowParentActivity(relatedActivityId, "Application");
+    }
+
+    [Fact]
+    public void CorrelationSection_HiddenWhenNoActivityIds()
+    {
+        var cut = SelectAndRender(EventWithData(("LogonType", 3)));
+
+        Assert.Empty(cut.FindAll(".details-correlation"));
+    }
+
+    [Fact]
+    public void CorrelationSection_ShownForGuidEmptyActivityId_MirroringContextMenu()
+    {
+        // The log-table context menu enables its lens items on Guid?.HasValue (so a zero-Guid still enables); the pane
+        // mirrors that, keeping the two surfaces consistent.
+        ResolvedEvent @event = BaseEvent() with { ActivityId = Guid.Empty };
+
+        var cut = SelectAndRender(@event);
+        var button = Assert.Single(cut.FindAll(".details-correlation-action"));
+
+        Assert.Contains("Show related events", button.TextContent);
+    }
+
+    [Fact]
+    public void CorrelationSection_ShowsOnlyParentButton_WhenOnlyRelatedActivityIdPresent()
+    {
+        ResolvedEvent @event = BaseEvent() with { RelatedActivityId = Guid.NewGuid() };
+
+        var cut = SelectAndRender(@event);
+        var button = Assert.Single(cut.FindAll(".details-correlation-action"));
+
+        Assert.Contains("Show parent activity", button.TextContent);
+    }
+
+    [Fact]
+    public void CorrelationSection_ShowsOnlyRelatedButton_WhenOnlyActivityIdPresent()
+    {
+        ResolvedEvent @event = BaseEvent() with { ActivityId = Guid.NewGuid() };
+
+        var cut = SelectAndRender(@event);
+        var button = Assert.Single(cut.FindAll(".details-correlation-action"));
+
+        Assert.Contains("Show related events", button.TextContent);
+    }
+
+    [Fact]
+    public void LegacyEvent_ShowsNoNamedFieldsFallback()
+    {
+        var cut = SelectAndRender(BaseEvent());
+
+        Assert.Contains("no named data fields", cut.Markup);
+        Assert.Empty(cut.FindAll(".details-field"));
+    }
+
+    [Fact]
+    public void NoSelection_PaneIsHiddenUntilAnEventIsClicked()
+    {
+        var cut = Render<DetailsPaneComponent>();
+
+        Assert.True(cut.Find(".details-pane").HasAttribute("hidden"));
+        Assert.Empty(cut.FindAll(".details-tabs"));
+    }
+
+    [Fact]
+    public void OpenPane_CollapsesViaHeaderToggle()
+    {
+        var cut = SelectAndRender(EventWithData(("LogonType", 3)));
+
+        cut.Find("#details-header").Click();
+
+        Assert.Equal("false", cut.Find(".details-pane").GetAttribute("data-toggle"));
+        Assert.False(cut.Find(".details-pane").HasAttribute("hidden"));
+    }
+
+    [Fact]
+    public void PerFieldCopy_UsesTheClickedFieldsValue()
+    {
+        var cut = SelectAndRender(EventWithData(("SubjectUserName", "SYSTEM"), ("TargetUserName", "ADMIN")));
+
+        cut.FindAll(".details-copy")[0].Click();
+        cut.FindAll(".details-copy")[1].Click();
+
+        // A shared-variable closure capture would make every field's button emit the last field's value, so asserting
+        // each row copies its OWN value discriminates that regression.
+        _clipboard.Received(1).CopyTextAsync("SYSTEM");
+        _clipboard.Received(1).CopyTextAsync("ADMIN");
+    }
+
+    [Fact]
+    public void SelectedEvent_DefaultsToReaderTab()
+    {
+        var cut = SelectAndRender(EventWithData(("LogonType", 3)));
+
+        Assert.Equal("true", ReaderTab(cut).GetAttribute("aria-selected"));
+        Assert.NotNull(cut.Find(".details-reader"));
+        Assert.Contains("Event ID", cut.Markup);
+        Assert.NotEmpty(cut.FindAll(".details-field"));
+        Assert.Contains("Network", cut.Markup);
+    }
+
+    [Fact]
+    public void SelectingEvent_OpensThePane()
+    {
+        var cut = SelectAndRender(EventWithData(("LogonType", 3)));
+
+        Assert.False(cut.Find(".details-pane").HasAttribute("hidden"));
+        Assert.Equal("true", cut.Find(".details-pane").GetAttribute("data-toggle"));
+    }
+
+    [Theory]
+    [InlineData("Critical")]
+    [InlineData("Information")]
+    [InlineData("Verbose")]
+    [InlineData("Audit Success")]
+    public void SeverityDot_AbsentForNonErrorWarningLevels(string level)
+    {
+        var cut = SelectAndRender(BaseEvent() with { Level = level });
+
+        Assert.Empty(cut.FindAll(".details-severity-dot"));
+    }
+
+    [Theory]
+    [InlineData("Error", "error")]
+    [InlineData("Warning", "warning")]
+    public void SeverityDot_ColoredForErrorAndWarning(string level, string expected)
+    {
+        var cut = SelectAndRender(BaseEvent() with { Level = level });
+
+        Assert.Equal(expected, cut.Find(".details-severity-dot").GetAttribute("data-severity"));
+    }
+
+    [Fact]
+    public void ShowMoreToggle_ExposesExpandedStateToAssistiveTech()
+    {
+        // A 600-char scalar exceeds the preview length, so the field renders the Show more / Show less toggle.
+        var cut = SelectAndRender(EventWithData(("CommandLine", new string('a', 600))));
+
+        IElement toggle = cut.Find(".details-show-more");
+        Assert.Equal("false", toggle.GetAttribute("aria-expanded"));
+
+        toggle.Click();
+
+        Assert.Equal("true", cut.Find(".details-show-more").GetAttribute("aria-expanded"));
+    }
+
+    [Fact]
+    public void SwitchingToXmlTab_ShowsXmlAndDeselectsReader()
+    {
+        var cut = SelectAndRender(EventWithData(("LogonType", 3)));
+
+        XmlTab(cut).Click();
+
+        Assert.Equal("true", XmlTab(cut).GetAttribute("aria-selected"));
+        Assert.Equal("false", ReaderTab(cut).GetAttribute("aria-selected"));
+        Assert.True(cut.Find("#details-tabpanel-reader").HasAttribute("hidden"));
+        Assert.False(cut.Find("#details-tabpanel-xml").HasAttribute("hidden"));
+    }
+
+    [Fact]
+    public void TabResetsToReader_WhenActiveLogChanges()
+    {
+        var cut = SelectAndRender(EventWithData(("LogonType", 3)));
+        XmlTab(cut).Click();
+
+        _activeLog.SelectedValueChanged += Raise.Event<EventHandler<EventLogId?>>(_activeLog, (EventLogId?)EventLogId.Create());
+
+        cut.WaitForAssertion(() => Assert.Equal("true", ReaderTab(cut).GetAttribute("aria-selected")));
+    }
+
+    [Fact]
+    public void Tabs_AreLinkedToTheirPanelsViaAria()
+    {
+        var cut = SelectAndRender(EventWithData(("LogonType", 3)));
+
+        // Both tabpanels stay mounted (only hidden toggles), so every tab's aria-controls resolves to a panel that is
+        // actually in the DOM, and each panel points back at its controlling tab.
+        Assert.Equal("details-tabpanel-reader", cut.Find("#details-tab-reader").GetAttribute("aria-controls"));
+        Assert.Equal("details-tab-reader", cut.Find("#details-tabpanel-reader").GetAttribute("aria-labelledby"));
+        Assert.Equal("details-tabpanel-xml", cut.Find("#details-tab-xml").GetAttribute("aria-controls"));
+        Assert.Equal("details-tab-xml", cut.Find("#details-tabpanel-xml").GetAttribute("aria-labelledby"));
+    }
+
+    [Fact]
+    public void UserDataIncomplete_ShowsWarning()
+    {
+        ResolvedEvent @event = BaseEvent() with
+        {
+            UserData = [new UserDataField("Config/Setting", ["v1"], false)],
+            UserDataIncomplete = true
+        };
+
+        var cut = SelectAndRender(@event);
+
+        Assert.NotEmpty(cut.FindAll(".details-warn"));
+    }
+
+    private static ResolvedEvent BaseEvent() =>
+        new("Application", LogPathType.Channel)
+        {
+            Id = 4624,
+            RecordId = 1,
+            Level = "Information",
+            Source = "Microsoft-Windows-Security-Auditing",
+            TimeCreated = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            Description = "A logon occurred.",
+            Xml = "<Event/>"
+        };
+
+    private static ResolvedEvent EventWithData(params (string Name, object? Value)[] fields) =>
+        BaseEvent().WithEventData(fields);
+
+    private static IElement ReaderTab(IRenderedComponent<DetailsPaneComponent> cut) => cut.FindAll(".details-tab")[0];
+
+    private static IElement XmlTab(IRenderedComponent<DetailsPaneComponent> cut) => cut.FindAll(".details-tab")[1];
+
+    private void RaiseFocusChanged(ResolvedEvent @event)
+    {
+        var handle = new EventLocator(_logId, 0, 0);
+        ValueKey.TryCreate(@event, out var reloadKey);
+        _focus.SelectedValueChanged += Raise.Event<EventHandler<SelectionEntry?>>(_focus, new SelectionEntry(handle, handle, reloadKey));
+    }
+
+    private IRenderedComponent<DetailsPaneComponent> SelectAndRender(ResolvedEvent @event)
+    {
+        _logTableState.Value.Returns(new LogTableState { ActiveEventLogId = _logId }.WithLogEvents(_logId, @event));
+
+        var handle = new EventLocator(_logId, 0, 0);
+        ValueKey.TryCreate(@event, out var reloadKey);
+        _focus.Value.Returns(new SelectionEntry(handle, handle, reloadKey));
+
+        return Render<DetailsPaneComponent>();
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/EventLogExpert.UI.Tests.csproj
+++ b/tests/Unit/EventLogExpert.UI.Tests/EventLogExpert.UI.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\EventLogExpert.Eventing.OfflineImaging\EventLogExpert.Eventing.OfflineImaging.csproj" />
+    <ProjectReference Include="..\..\Shared\EventLogExpert.Eventing.TestUtils\EventLogExpert.Eventing.TestUtils.csproj" />
     <ProjectReference Include="..\..\..\src\EventLogExpert.UI\EventLogExpert.UI.csproj" />
   </ItemGroup>
 

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneLevelClassTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneLevelClassTests.cs
@@ -1,0 +1,24 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.UI.LogTable;
+
+namespace EventLogExpert.UI.Tests.LogTable;
+
+public sealed class LogTablePaneLevelClassTests
+{
+    // Pins the level -> icon/colour class mapping after it was refactored to consume the shared
+    // LevelSeverity.FromLevelName parse: Error/Warning keep their colour class, Information is icon-only, and
+    // Critical/Verbose/miscased/unknown fall through to "" exactly as the pre-refactor case-sensitive switch did.
+    [Theory]
+    [InlineData("Error", "bi bi-exclamation-circle error")]
+    [InlineData("Warning", "bi bi-exclamation-triangle warning")]
+    [InlineData("Information", "bi bi-info-circle")]
+    [InlineData("Critical", "")]
+    [InlineData("Verbose", "")]
+    [InlineData("error", "")]
+    [InlineData("Audit Success", "")]
+    [InlineData("", "")]
+    public void GetLevelClass_ReturnsExpectedClassString(string level, string expected) =>
+        Assert.Equal(expected, LogTablePane.GetLevelClass(level));
+}


### PR DESCRIPTION
## Summary

Adds a structured **reader view** to the Details Pane and redesigns its layout (ADO 62704693).

- **Reader view** - a `Reader | XML` tab strip. The Reader decodes structured EventData/UserData (named fields, arrays one-per-line, hex preview for binary, muted placeholders for empty/null), with optional inline explanations (a LogonType value decoder + a small curated Security-Auditing glossary) and per-field / per-section / whole-event copy.
- **Two-region layout** - the wide-short pane splits into a metadata rail (identity + Level severity + a correlation block + collapsible System) beside a payload region (Message + multi-column Event Data + User Data), collapsing to one column when narrow. Uniform two-size typography; stacked field rows so long field names never truncate; EventData packs into at most three columns.
- **Level severity** - a small coloured dot on Error/Warning that mirrors the log table exactly, via a new shared `LevelSeverity.FromLevelName` parse that the log table's `GetLevelClass` now consumes too (single source, no drift).
- **Correlation lenses** - "Show related events" / "Show parent activity" buttons that reuse the existing `IFilterLensCommands` (the same commands the row context menu drives).
- The pane stays **closed until an event is clicked** (restored the prior committed behaviour).

## Validation

- Test suites all green: Eventing **639**, Runtime **1753**, UI **1070**. Every touched project builds with **0 warnings / 0 errors**.
- Governance: pre-implementation multi-model panel **5/5 DESIGN_READY**, post-code panel **5/5 CODE_REVIEW_READY**, plus a **5/5** delta review on the closed-until-clicked fix.

## Manual acceptance still needed (WebView2)

Visual outcomes automated tests can't verify - please check in the running app:

- Split boundary around 46rem and the single-column fallback at half-window.
- Payload column tiers (2 cols >= 46rem, 3 cols >= 70rem payload; caps at 3; field names do not truncate).
- Pane dragged to min-height (20%); 125% / 150% OS text scaling.
- A very long provider message (stays elastic, no nested scroller) and a dense EventData + UserData event.
