### PR TITLE
Add WinGet auto-publish workflow

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,57 @@
+name: Publish to WinGet
+
+# Submits the multi-architecture (x64 + arm64) .msixbundle to the Windows Package
+# Manager community repo (microsoft/winget-pkgs) using Microsoft's wingetcreate tool.
+on:
+  # Fires when a draft release is manually published as a full (stable) release.
+  # Pre-releases do not raise this event, so they are never pushed to WinGet.
+  release:
+    types: [released]
+  # Manual run: submit a specific version on demand (blank input = latest release).
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to submit, e.g. 26.7.10.1209 (blank = latest release)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  # wingetcreate reads this token to fork winget-pkgs and open the pull request.
+  # Store a classic PAT with the public_repo scope as the WINGET_TOKEN repo secret.
+  # See https://aka.ms/winget-create-token
+  WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_TOKEN }}
+
+jobs:
+  publish:
+    name: Submit Microsoft.EventLogExpert to WinGet
+    runs-on: windows-latest # wingetcreate runs on Windows only
+    steps:
+      - name: Submit updated manifest
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          # Resolve the version: a manual input wins; otherwise use the release tag;
+          # otherwise fall back to the latest published release.
+          $version = '${{ inputs.version }}'.Trim()
+          if (-not $version) {
+            $version = ('${{ github.event.release.tag_name }}'.Trim()) -replace '^v', ''
+          }
+          if (-not $version) {
+            $headers = @{ 'User-Agent' = 'eventlogexpert-winget'; 'Authorization' = "Bearer $env:WINGET_CREATE_GITHUB_TOKEN" }
+            $latest = Invoke-RestMethod -Headers $headers 'https://api.github.com/repos/microsoft/EventLogExpert/releases/latest'
+            $version = ($latest.tag_name) -replace '^v', ''
+          }
+          if (-not $version) { throw 'Could not determine a version to submit.' }
+
+          Write-Host "Submitting Microsoft.EventLogExpert $version to WinGet"
+
+          # One self-contained multi-arch bundle; wingetcreate reads both the x64 and
+          # arm64 packages from it and updates the matching installer nodes.
+          $bundleUrl = "https://github.com/microsoft/EventLogExpert/releases/download/v$version/EventLogExpert_$version.msixbundle"
+
+          curl.exe -JLO https://aka.ms/wingetcreate/latest
+          .\wingetcreate.exe update Microsoft.EventLogExpert --submit --version $version --urls $bundleUrl

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -48,7 +48,7 @@ jobs:
           }
           if (-not $version) {
             $headers = @{ 'User-Agent' = 'eventlogexpert-winget' }
-            if ($env:WINGET_CREATE_GITHUB_TOKEN) { $headers['Authorization'] = "Bearer $env:WINGET_CREATE_GITHUB_TOKEN" }
+            if ($env:WINGET_CREATE_GITHUB_TOKEN) { $headers['Authorization'] = "token $env:WINGET_CREATE_GITHUB_TOKEN" }
             $latest = Invoke-RestMethod -Headers $headers 'https://api.github.com/repos/${{ github.repository }}/releases/latest'
             $version = ($latest.tag_name) -replace '^v', ''
           }

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -27,6 +27,8 @@ env:
 jobs:
   publish:
     name: Submit Microsoft.EventLogExpert to WinGet
+    # Stable releases only: manual dispatch runs on demand; release events run only for non-prereleases.
+    if: ${{ github.event_name != 'release' || github.event.release.prerelease == false }}
     runs-on: windows-latest # wingetcreate runs on Windows only
     steps:
       - name: Submit updated manifest
@@ -58,9 +60,11 @@ jobs:
           $bundleUrl = "https://github.com/${{ github.repository }}/releases/download/v$version/EventLogExpert_$version.msixbundle"
 
           # Download Microsoft's wingetcreate and verify its Authenticode signature before running it.
-          curl.exe -sSL -o wingetcreate.exe https://aka.ms/wingetcreate/latest
+          curl.exe -fsSL -o wingetcreate.exe https://aka.ms/wingetcreate/latest
+          if ($LASTEXITCODE -ne 0) { throw "Failed to download wingetcreate.exe (curl exit $LASTEXITCODE)." }
           $signature = Get-AuthenticodeSignature .\wingetcreate.exe
           if ($signature.Status -ne 'Valid' -or $signature.SignerCertificate.Subject -notlike '*Microsoft Corporation*') {
             throw "wingetcreate.exe failed Authenticode verification (status: $($signature.Status); signer: $($signature.SignerCertificate.Subject))."
           }
           .\wingetcreate.exe update Microsoft.EventLogExpert --submit --version $version --urls $bundleUrl
+          if ($LASTEXITCODE -ne 0) { throw "wingetcreate update failed (exit $LASTEXITCODE)." }

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -3,8 +3,8 @@ name: Publish to WinGet
 # Submits the multi-architecture (x64 + arm64) .msixbundle to the Windows Package
 # Manager community repo (microsoft/winget-pkgs) using Microsoft's wingetcreate tool.
 on:
-  # Fires when a draft release is manually published as a full (stable) release.
-  # Pre-releases do not raise this event, so they are never pushed to WinGet.
+  # Fires when a draft release is published as a full (stable) release. `released`
+  # does not fire for pre-releases; the job-level guard below also enforces stable-only.
   release:
     types: [released]
   # Manual run: submit a specific version on demand (blank input = latest release).
@@ -35,6 +35,10 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
+
+          if (-not $env:WINGET_CREATE_GITHUB_TOKEN) {
+            throw 'The WINGET_TOKEN secret is not set. Add a classic PAT with the public_repo scope as the WINGET_TOKEN repository secret.'
+          }
 
           # Resolve the version: a manual input wins; otherwise use the release tag;
           # otherwise fall back to the latest published release.

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -29,10 +29,13 @@ jobs:
     name: Submit Microsoft.EventLogExpert to WinGet
     # Stable releases only: manual dispatch runs on demand; release events run only for non-prereleases.
     if: ${{ github.event_name != 'release' || github.event.release.prerelease == false }}
-    runs-on: windows-latest # wingetcreate runs on Windows only
+    runs-on: windows-2022 # pinned like the repo's other workflows; wingetcreate runs on Windows only
     steps:
       - name: Submit updated manifest
         shell: pwsh
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           $ErrorActionPreference = 'Stop'
 
@@ -41,10 +44,11 @@ jobs:
           }
 
           # Resolve the version: a manual input wins; otherwise use the release tag;
-          # otherwise fall back to the latest published release.
-          $version = ('${{ github.event.inputs.version }}'.Trim()) -replace '^v', ''
+          # otherwise fall back to the latest published release. Event-supplied values
+          # are read from env vars (not inlined) to avoid script injection.
+          $version = ("$env:INPUT_VERSION".Trim()) -replace '^v', ''
           if (-not $version) {
-            $version = ('${{ github.event.release.tag_name }}'.Trim()) -replace '^v', ''
+            $version = ("$env:RELEASE_TAG".Trim()) -replace '^v', ''
           }
           if (-not $version) {
             $headers = @{ 'User-Agent' = 'eventlogexpert-winget' }

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -36,12 +36,13 @@ jobs:
 
           # Resolve the version: a manual input wins; otherwise use the release tag;
           # otherwise fall back to the latest published release.
-          $version = '${{ inputs.version }}'.Trim()
+          $version = ('${{ inputs.version }}'.Trim()) -replace '^v', ''
           if (-not $version) {
             $version = ('${{ github.event.release.tag_name }}'.Trim()) -replace '^v', ''
           }
           if (-not $version) {
-            $headers = @{ 'User-Agent' = 'eventlogexpert-winget'; 'Authorization' = "Bearer $env:WINGET_CREATE_GITHUB_TOKEN" }
+            $headers = @{ 'User-Agent' = 'eventlogexpert-winget' }
+            if ($env:WINGET_CREATE_GITHUB_TOKEN) { $headers['Authorization'] = "Bearer $env:WINGET_CREATE_GITHUB_TOKEN" }
             $latest = Invoke-RestMethod -Headers $headers 'https://api.github.com/repos/microsoft/EventLogExpert/releases/latest'
             $version = ($latest.tag_name) -replace '^v', ''
           }
@@ -53,5 +54,10 @@ jobs:
           # arm64 packages from it and updates the matching installer nodes.
           $bundleUrl = "https://github.com/microsoft/EventLogExpert/releases/download/v$version/EventLogExpert_$version.msixbundle"
 
-          curl.exe -JLO https://aka.ms/wingetcreate/latest
+          # Download Microsoft's wingetcreate and verify its Authenticode signature before running it.
+          curl.exe -sSL -o wingetcreate.exe https://aka.ms/wingetcreate/latest
+          $signature = Get-AuthenticodeSignature .\wingetcreate.exe
+          if ($signature.Status -ne 'Valid' -or $signature.SignerCertificate.Subject -notlike '*Microsoft Corporation*') {
+            throw "wingetcreate.exe failed Authenticode verification (status: $($signature.Status); signer: $($signature.SignerCertificate.Subject))."
+          }
           .\wingetcreate.exe update Microsoft.EventLogExpert --submit --version $version --urls $bundleUrl

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -61,8 +61,8 @@ jobs:
             $version = ($latest.tag_name) -replace '^v', ''
           }
           if (-not $version) { throw 'Could not determine a version to submit.' }
-          if ($version -notmatch '^\d+(\.\d+){1,3}$') {
-            throw "Resolved version '$version' is not a valid dotted-numeric version (e.g. 26.7.10.1209)."
+          if ($version -notmatch '^\d+(\.\d+){3}$') {
+            throw "Resolved version '$version' is not a valid four-part version (e.g. 26.7.10.1209)."
           }
 
           Write-Host "Submitting Microsoft.EventLogExpert $version to WinGet"

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -28,7 +28,7 @@ jobs:
   publish:
     name: Submit Microsoft.EventLogExpert to WinGet
     # Stable releases only: manual dispatch runs on demand; release events run only for non-prereleases.
-    if: ${{ github.event_name != 'release' || github.event.release.prerelease == false }}
+    if: ${{ github.event_name != 'release' || github.event.release.prerelease != true }}
     runs-on: windows-2022 # pinned like the repo's other workflows; wingetcreate runs on Windows only
     steps:
       - name: Submit updated manifest
@@ -36,6 +36,9 @@ jobs:
         env:
           INPUT_VERSION: ${{ github.event.inputs.version }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
+          # Least privilege: the ephemeral job token (contents: read) is used for the
+          # Releases API lookup; the WINGET_TOKEN PAT is reserved for wingetcreate.
+          GH_API_TOKEN: ${{ github.token }}
         run: |
           $ErrorActionPreference = 'Stop'
 
@@ -44,15 +47,16 @@ jobs:
           }
 
           # Resolve the version: a manual input wins; otherwise use the release tag;
-          # otherwise fall back to the latest published release. Event-supplied values
-          # are read from env vars (not inlined) to avoid script injection.
+          # otherwise fall back to the latest published release. The event-supplied
+          # version values are read from env vars (not inlined) to avoid script injection;
+          # github.repository below is a trusted, non-user-controlled context value.
           $version = ("$env:INPUT_VERSION".Trim()) -replace '^v', ''
           if (-not $version) {
             $version = ("$env:RELEASE_TAG".Trim()) -replace '^v', ''
           }
           if (-not $version) {
             $headers = @{ 'User-Agent' = 'eventlogexpert-winget' }
-            if ($env:WINGET_CREATE_GITHUB_TOKEN) { $headers['Authorization'] = "token $env:WINGET_CREATE_GITHUB_TOKEN" }
+            if ($env:GH_API_TOKEN) { $headers['Authorization'] = "Bearer $env:GH_API_TOKEN" }
             $latest = Invoke-RestMethod -Headers $headers 'https://api.github.com/repos/${{ github.repository }}/releases/latest'
             $version = ($latest.tag_name) -replace '^v', ''
           }

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -36,23 +36,26 @@ jobs:
 
           # Resolve the version: a manual input wins; otherwise use the release tag;
           # otherwise fall back to the latest published release.
-          $version = ('${{ inputs.version }}'.Trim()) -replace '^v', ''
+          $version = ('${{ github.event.inputs.version }}'.Trim()) -replace '^v', ''
           if (-not $version) {
             $version = ('${{ github.event.release.tag_name }}'.Trim()) -replace '^v', ''
           }
           if (-not $version) {
             $headers = @{ 'User-Agent' = 'eventlogexpert-winget' }
             if ($env:WINGET_CREATE_GITHUB_TOKEN) { $headers['Authorization'] = "Bearer $env:WINGET_CREATE_GITHUB_TOKEN" }
-            $latest = Invoke-RestMethod -Headers $headers 'https://api.github.com/repos/microsoft/EventLogExpert/releases/latest'
+            $latest = Invoke-RestMethod -Headers $headers 'https://api.github.com/repos/${{ github.repository }}/releases/latest'
             $version = ($latest.tag_name) -replace '^v', ''
           }
           if (-not $version) { throw 'Could not determine a version to submit.' }
+          if ($version -notmatch '^\d+(\.\d+){1,3}$') {
+            throw "Resolved version '$version' is not a valid dotted-numeric version (e.g. 26.7.10.1209)."
+          }
 
           Write-Host "Submitting Microsoft.EventLogExpert $version to WinGet"
 
           # One self-contained multi-arch bundle; wingetcreate reads both the x64 and
           # arm64 packages from it and updates the matching installer nodes.
-          $bundleUrl = "https://github.com/microsoft/EventLogExpert/releases/download/v$version/EventLogExpert_$version.msixbundle"
+          $bundleUrl = "https://github.com/${{ github.repository }}/releases/download/v$version/EventLogExpert_$version.msixbundle"
 
           # Download Microsoft's wingetcreate and verify its Authenticode signature before running it.
           curl.exe -sSL -o wingetcreate.exe https://aka.ms/wingetcreate/latest


### PR DESCRIPTION
Adds a GitHub Actions workflow that publishes new releases to the Windows Package Manager (winget) using Microsoft's wingetcreate tool.

- Triggers on `release: [released]` (fires when a draft is published as a full stable release) plus `workflow_dispatch` for manual runs.
- Submits the single multi-architecture `.msixbundle`; wingetcreate reads both the x64 and arm64 packages from the one file.
- Reads the `WINGET_TOKEN` repo secret via `WINGET_CREATE_GITHUB_TOKEN`.

Mirrors the pattern in microsoft/terminal's `.github/workflows/winget.yml`.