### PR TITLE
Histogram EventData group-by, spike-outline cleanup, and timeline-aware single-log sort

### DIFF
--- a/src/EventLogExpert.Eventing/Common/Events/EventColumnStore.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/EventColumnStore.cs
@@ -75,6 +75,9 @@ internal sealed class EventDataSchemaBuilder
 /// </summary>
 public sealed class EventColumnStore
 {
+    // Per-scan EventData field-index memo sentinels: a schema not yet looked up, and a schema that lacks the field.
+    private const int SchemaFieldAbsent = -1;
+    private const int SchemaFieldUnresolved = -2;
     // Target sealed-chunk size. The pending tail columnarizes into one new chunk each time it reaches this many rows,
     // giving amortized O(1) append with no partially filled columnar chunks.
     private const int TargetChunkSize = 4096;
@@ -225,6 +228,54 @@ public sealed class EventColumnStore
         maxTicks = MaxTimeTicks;
 
         return Count > 0;
+    }
+
+    internal void BucketTimeTicksByEventData(
+        ReadOnlySpan<int> rankByPhysical,
+        long minTicks,
+        long bucketSpanTicks,
+        int bucketCount,
+        string fieldName,
+        long[] targetCodes,
+        int slotCount,
+        int[] slotCounts,
+        CancellationToken cancellationToken)
+    {
+        int otherSlot = targetCodes.Length;
+        int[] fieldIndexBySchema = NewSchemaFieldMemo();
+        int offset = 0;
+
+        foreach (EventColumnChunk chunk in _sealedChunks)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            ReadOnlySpan<long> timeColumn = chunk.TimeTicksColumn;
+
+            for (int row = 0; row < timeColumn.Length; row++)
+            {
+                if (rankByPhysical[offset + row] < 0) { continue; }
+
+                int slot = TryGetSealedEventDataCode(chunk, row, fieldName, fieldIndexBySchema, out long code)
+                    ? SlotForCode(code, targetCodes, otherSlot)
+                    : otherSlot;
+                int bucket = ToBucket(timeColumn[row], minTicks, bucketSpanTicks, bucketCount);
+                slotCounts[(bucket * slotCount) + slot]++;
+            }
+
+            offset += chunk.RowCount;
+        }
+
+        for (int index = _sealedCount; index < Count; index++)
+        {
+            if (rankByPhysical[index] < 0) { continue; }
+
+            ResolvedEvent pending = Pending(index);
+            int slot = TryGetPendingEventDataCode(pending, fieldName, out long code)
+                ? SlotForCode(code, targetCodes, otherSlot)
+                : otherSlot;
+            int bucket = ToBucket(pending.TimeCreated.Ticks, minTicks, bucketSpanTicks, bucketCount);
+            slotCounts[(bucket * slotCount) + slot]++;
+        }
     }
 
     internal void BucketTimeTicksByEventId(
@@ -543,6 +594,41 @@ public sealed class EventColumnStore
         {
             values[index] = Pending(index).TimeCreated.Ticks;
             hasValue[index] = true;
+        }
+    }
+
+    internal void CountEventDataValues(ReadOnlySpan<int> rankByPhysical, string fieldName, IDictionary<long, int> counts, CancellationToken cancellationToken)
+    {
+        int[] fieldIndexBySchema = NewSchemaFieldMemo();
+        int offset = 0;
+
+        foreach (EventColumnChunk chunk in _sealedChunks)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            ReadOnlySpan<long> timeColumn = chunk.TimeTicksColumn;
+
+            for (int row = 0; row < timeColumn.Length; row++)
+            {
+                if (rankByPhysical[offset + row] < 0) { continue; }
+
+                if (TryGetSealedEventDataCode(chunk, row, fieldName, fieldIndexBySchema, out long code))
+                {
+                    counts[code] = counts.TryGetValue(code, out int existing) ? existing + 1 : 1;
+                }
+            }
+
+            offset += chunk.RowCount;
+        }
+
+        for (int index = _sealedCount; index < Count; index++)
+        {
+            if (rankByPhysical[index] < 0) { continue; }
+
+            if (TryGetPendingEventDataCode(Pending(index), fieldName, out long code))
+            {
+                counts[code] = counts.TryGetValue(code, out int existing) ? existing + 1 : 1;
+            }
         }
     }
 
@@ -1052,6 +1138,16 @@ public sealed class EventColumnStore
         _ => throw new ArgumentOutOfRangeException(nameof(field), field, "Field is not a supported group-by dimension.")
     };
 
+    private static int SlotForCode(long value, long[] targets, int otherSlot)
+    {
+        for (int slot = 0; slot < targets.Length; slot++)
+        {
+            if (value == targets[slot]) { return slot; }
+        }
+
+        return otherSlot;
+    }
+
     // Shared by the pooled-field and event-id group-by scans: a pure integer match, so a negative event id still matches its own target; callers resolve absent pooled targets to int.MinValue (not -1) so a null-field row can't collide.
     private static int SlotForIndex(int value, int[] targets, int otherSlot)
     {
@@ -1087,6 +1183,15 @@ public sealed class EventColumnStore
         return bucket < 0 ? 0 : bucket >= bucketCount ? bucketCount - 1 : (int)bucket;
     }
 
+    private static bool TryGetPendingEventDataCode(ResolvedEvent pending, string fieldName, out long code)
+    {
+        if (pending.EventData.TryGetValue(fieldName, out EventFieldValue value)) { return value.TryGetWholeNumber(out code); }
+
+        code = 0;
+
+        return false;
+    }
+
     private (EventColumnChunk Chunk, int Row) Locate(int index)
     {
         int[] prefix = SealedPrefix();
@@ -1099,6 +1204,16 @@ public sealed class EventColumnStore
         (uint)index >= (uint)_sealedCount ? throw new ArgumentOutOfRangeException(nameof(index),
             "The columnar representation exists only for sealed rows; check IsPending first.") :
         Locate(index);
+
+    // A fresh per-scan memo (schemaId -> field index, or Unresolved until first hit), so each distinct schema's field
+    // position is resolved exactly once per scan rather than once per row.
+    private int[] NewSchemaFieldMemo()
+    {
+        int[] memo = new int[_schemas.Length];
+        Array.Fill(memo, SchemaFieldUnresolved);
+
+        return memo;
+    }
 
     private ResolvedEvent Pending(int index) => _pendingTail[index - _sealedCount];
 
@@ -1208,6 +1323,20 @@ public sealed class EventColumnStore
         return fields.MoveToImmutable();
     }
 
+    private int ResolveSchemaFieldIndex(int schemaId, string fieldName)
+    {
+        int[] nameIndices = _schemas[schemaId];
+
+        for (int i = 0; i < nameIndices.Length; i++)
+        {
+            string? name = PoolGet(nameIndices[i]);
+
+            if (!string.IsNullOrEmpty(name) && string.Equals(name, fieldName, StringComparison.Ordinal)) { return i; }
+        }
+
+        return SchemaFieldAbsent;
+    }
+
     private int[] SealedPrefix()
     {
         int[]? prefix = Volatile.Read(ref _sealedPrefix);
@@ -1221,5 +1350,62 @@ public sealed class EventColumnStore
         Volatile.Write(ref _sealedPrefix, prefix);
 
         return prefix;
+    }
+
+    private bool TryGetSealedEventDataCode(EventColumnChunk chunk, int row, string fieldName, int[] fieldIndexBySchema, out long code)
+    {
+        int schemaId = chunk.RowEventDataSchemaId(row);
+
+        if ((uint)schemaId >= (uint)fieldIndexBySchema.Length) { code = 0; return false; }
+
+        int fieldIndex = fieldIndexBySchema[schemaId];
+
+        if (fieldIndex == SchemaFieldUnresolved)
+        {
+            fieldIndex = ResolveSchemaFieldIndex(schemaId, fieldName);
+            fieldIndexBySchema[schemaId] = fieldIndex;
+        }
+
+        if (fieldIndex < 0 || fieldIndex >= chunk.RowEventDataCount(row))
+        {
+            code = 0;
+
+            return false;
+        }
+
+        return TryGetWholeNumberFromRawField(chunk.RowEventDataField(row, fieldIndex), out code);
+    }
+
+    private bool TryGetWholeNumberFromRawField(in RawEventDataField field, out long code)
+    {
+        switch (field.Kind)
+        {
+            case StoredFieldKind.SByte:
+            case StoredFieldKind.Int16:
+            case StoredFieldKind.Int32:
+            case StoredFieldKind.Int64:
+                code = field.Bits;
+
+                return code >= 0;
+            case StoredFieldKind.Byte:
+            case StoredFieldKind.UInt16:
+            case StoredFieldKind.UInt32:
+            case StoredFieldKind.UInt64:
+            case StoredFieldKind.SizeT:
+                ulong unsigned = unchecked((ulong)field.Bits);
+
+                if (unsigned <= long.MaxValue) { code = (long)unsigned; return true; }
+
+                code = 0;
+
+                return false;
+            case StoredFieldKind.String:
+            case StoredFieldKind.StringForm:
+                return EventFieldValue.TryParseWholeNumber(PoolGet(field.RefIndex), out code);
+            default:
+                code = 0;
+
+                return false;
+        }
     }
 }

--- a/src/EventLogExpert.Eventing/Common/Events/EventColumnStoreReader.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/EventColumnStoreReader.cs
@@ -36,6 +36,29 @@ internal sealed class EventColumnStoreReader : IEventColumnReader
 
     public IReadOnlyList<string?> Pool => new PoolView(_store, PendingPool());
 
+    public void BucketTimeTicksByEventData(
+        ReadOnlySpan<int> rankByPhysical,
+        long minTicks,
+        long bucketSpanTicks,
+        int bucketCount,
+        string fieldName,
+        long[] targetCodes,
+        int[] slotCounts,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(fieldName);
+        ArgumentNullException.ThrowIfNull(targetCodes);
+        ArgumentNullException.ThrowIfNull(slotCounts);
+        ArgumentOutOfRangeException.ThrowIfNotEqual(rankByPhysical.Length, Count);
+        ArgumentOutOfRangeException.ThrowIfLessThan(bucketSpanTicks, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(bucketCount, 1);
+
+        int slotCount = targetCodes.Length + 1;
+        ArgumentOutOfRangeException.ThrowIfLessThan(slotCounts.Length, bucketCount * slotCount);
+
+        _store.BucketTimeTicksByEventData(rankByPhysical, minTicks, bucketSpanTicks, bucketCount, fieldName, targetCodes, slotCount, slotCounts, cancellationToken);
+    }
+
     public void BucketTimeTicksByEventId(
         ReadOnlySpan<int> rankByPhysical,
         long minTicks,
@@ -157,6 +180,15 @@ internal sealed class EventColumnStoreReader : IEventColumnReader
             string? value = PendingPoolString(_store.GetPendingEvent(index), column);
             poolIndices[index] = value is null ? -1 : extension.StorePoolCount + extension.IndexOf(value);
         }
+    }
+
+    public void CountEventDataValues(ReadOnlySpan<int> rankByPhysical, string fieldName, IDictionary<long, int> counts, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(fieldName);
+        ArgumentNullException.ThrowIfNull(counts);
+        ArgumentOutOfRangeException.ThrowIfNotEqual(rankByPhysical.Length, Count);
+
+        _store.CountEventDataValues(rankByPhysical, fieldName, counts, cancellationToken);
     }
 
     public void CountEventIds(ReadOnlySpan<int> rankByPhysical, IDictionary<int, int> counts, CancellationToken cancellationToken)

--- a/src/EventLogExpert.Eventing/Common/Events/EventFieldValue.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/EventFieldValue.cs
@@ -63,6 +63,54 @@ public readonly struct EventFieldValue
         return false;
     }
 
+    /// <summary>
+    ///     Reads this value as a non-negative whole number when it is one: a typed integral kind, or a
+    ///     <see cref="EventFieldValueKind.String" /> holding a plain decimal (e.g. "23") or a <c>0x</c>-prefixed hex form
+    ///     (e.g. "0x17"). Decimal and hex spellings of the same code canonicalize to the same value. Allocation-free.
+    /// </summary>
+    public bool TryGetWholeNumber(out long value)
+    {
+        switch (_kind)
+        {
+            case EventFieldValueKind.Int64 when _bits >= 0:
+            case EventFieldValueKind.UInt64 when unchecked((ulong)_bits) <= long.MaxValue:
+                value = _bits;
+
+                return true;
+            case EventFieldValueKind.String:
+                return TryParseWholeNumber(_reference as string, out value);
+            default:
+                value = 0;
+
+                return false;
+        }
+    }
+
+    internal static bool TryParseWholeNumber(string? text, out long value)
+    {
+        value = 0;
+
+        if (string.IsNullOrEmpty(text)) { return false; }
+
+        ReadOnlySpan<char> span = text;
+
+        if (!span.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+        {
+            return long.TryParse(span, NumberStyles.None, CultureInfo.InvariantCulture, out value);
+        }
+
+        // Parse hex as unsigned so a high-bit form (e.g. 0xFFFF...) can't wrap to a negative code, then keep only codes that fit a non-negative long.
+        if (!ulong.TryParse(span[2..], NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out ulong hex) ||
+            hex > long.MaxValue)
+        {
+            return false;
+        }
+
+        value = (long)hex;
+
+        return true;
+    }
+
     public bool TryGetDouble(out double value)
     {
         if (_kind == EventFieldValueKind.Double) { value = BitConverter.Int64BitsToDouble(_bits); return true; }

--- a/src/EventLogExpert.Eventing/Common/Events/IEventColumnReader.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/IEventColumnReader.cs
@@ -22,6 +22,21 @@ public interface IEventColumnReader
     /// </summary>
     IReadOnlyList<string?> Pool { get; }
 
+    /// <summary>
+    ///     Bucket-by-EventData variant of <see cref="BucketTimeTicksByField" />: each survivor lands in its
+    ///     <paramref name="targetCodes" /> slot (matched on the field's whole-number code) else the trailing "other" slot,
+    ///     which also absorbs rows that lack the field; (<paramref name="targetCodes" /> length + 1) slots per bin.
+    /// </summary>
+    void BucketTimeTicksByEventData(
+        ReadOnlySpan<int> rankByPhysical,
+        long minTicks,
+        long bucketSpanTicks,
+        int bucketCount,
+        string fieldName,
+        long[] targetCodes,
+        int[] slotCounts,
+        CancellationToken cancellationToken);
+
     /// <summary>Group-by variant keyed on the numeric event id; (<paramref name="targetIds" /> length + 1) slots per bin.</summary>
     void BucketTimeTicksByEventId(
         ReadOnlySpan<int> rankByPhysical,
@@ -77,6 +92,13 @@ public interface IEventColumnReader
     ///     entry indexes <see cref="Pool" />. KeywordsDisplay is not a single pooled column and is not supported here.
     /// </summary>
     void CopyPoolIndexColumn(EventFieldId field, int[] poolIndices);
+
+    /// <summary>
+    ///     Group-by variant for a named EventData field of allowlisted numeric codes: tallies survivors by the field's
+    ///     whole-number code (decimal and <c>0x</c>-hex spellings canonicalize to one code), so the histogram can split, for
+    ///     example, by LogonType or TicketEncryptionType. Rows that lack the field are omitted.
+    /// </summary>
+    void CountEventDataValues(ReadOnlySpan<int> rankByPhysical, string fieldName, IDictionary<long, int> counts, CancellationToken cancellationToken);
 
     /// <summary>
     ///     Tallies each surviving row by its numeric event id into <paramref name="counts" /> (accumulating across a

--- a/src/EventLogExpert.Runtime/Common/Display/EventDataValueDecoder.cs
+++ b/src/EventLogExpert.Runtime/Common/Display/EventDataValueDecoder.cs
@@ -1,0 +1,55 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Common.Display;
+
+/// <summary>
+///     Decodes the small set of well-known numeric EventData codes the app surfaces in more than one place - the
+///     details-pane field explanation and the timeline group-by labels - to human-readable text, so both stay in sync.
+///     Fail-open: an unrecognized field or code returns <see langword="null" /> and each caller supplies its own fallback
+///     (the details pane shows nothing; the histogram keeps the raw code as a distinct band).
+/// </summary>
+public static class EventDataValueDecoder
+{
+    /// <summary>
+    ///     The friendly label for <paramref name="code" /> under <paramref name="fieldName" /> (e.g. LogonType 3 =&gt;
+    ///     "Network", TicketEncryptionType 23 =&gt; "RC4"), or <see langword="null" /> when the field is not decoded or the
+    ///     code is unrecognized.
+    /// </summary>
+    public static string? TryDecodeLabel(string fieldName, long code)
+    {
+        if (string.Equals(fieldName, "LogonType", StringComparison.OrdinalIgnoreCase)) { return DecodeLogonType(code); }
+
+        return string.Equals(fieldName, "TicketEncryptionType", StringComparison.OrdinalIgnoreCase) ? DecodeTicketEncryptionType(code) : null;
+    }
+
+    private static string? DecodeLogonType(long code) => code switch
+    {
+        0 => "System",
+        2 => "Interactive",
+        3 => "Network",
+        4 => "Batch",
+        5 => "Service",
+        7 => "Unlock",
+        8 => "NetworkCleartext",
+        9 => "NewCredentials",
+        10 => "RemoteInteractive",
+        11 => "CachedInteractive",
+        12 => "CachedRemoteInteractive",
+        13 => "CachedUnlock",
+        _ => null
+    };
+
+    // Kerberos RFC 3961 encryption types as carried by Security 4768/4769/4770 TicketEncryptionType; the triage split is
+    // the weak legacy RC4 (0x17) against modern AES (0x11/0x12).
+    private static string? DecodeTicketEncryptionType(long code) => code switch
+    {
+        1 => "DES-CBC-CRC",
+        3 => "DES-CBC-MD5",
+        17 => "AES128",
+        18 => "AES256",
+        23 => "RC4",
+        24 => "RC4-EXP",
+        _ => null
+    };
+}

--- a/src/EventLogExpert.Runtime/DetailsPane/EventFieldExplainer.cs
+++ b/src/EventLogExpert.Runtime/DetailsPane/EventFieldExplainer.cs
@@ -2,8 +2,8 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Runtime.Common.Display;
 using System.Collections.Frozen;
-using System.Globalization;
 
 namespace EventLogExpert.Runtime.DetailsPane;
 
@@ -44,12 +44,6 @@ public static class EventFieldExplainer
         new(null, null, "WorkstationName", "The name of the workstation from which the action originated.")
     ];
 
-    private static readonly FrozenDictionary<string, Func<EventFieldValue, string?>> s_valueDecoders =
-        new Dictionary<string, Func<EventFieldValue, string?>>
-        {
-            ["LogonType"] = DecodeLogonType
-        }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
-
     /// <summary>
     ///     Produces an <see cref="EventFieldExplanation" /> for the given field, resolving a value decode and a glossary
     ///     description independently. Returns <c>false</c> (and an empty explanation) when neither applies.
@@ -67,28 +61,6 @@ public static class EventFieldExplainer
         explanation = new EventFieldExplanation(decodedLabel, description);
 
         return explanation.HasValue;
-    }
-
-    private static string? DecodeLogonType(EventFieldValue value)
-    {
-        if (!TryReadWholeNumber(value, out ulong logonType)) { return null; }
-
-        return logonType switch
-        {
-            0 => "System",
-            2 => "Interactive",
-            3 => "Network",
-            4 => "Batch",
-            5 => "Service",
-            7 => "Unlock",
-            8 => "NetworkCleartext",
-            9 => "NewCredentials",
-            10 => "RemoteInteractive",
-            11 => "CachedInteractive",
-            12 => "CachedRemoteInteractive",
-            13 => "CachedUnlock",
-            _ => null
-        };
     }
 
     private static string? ResolveDescription(string providerName, int eventId, string fieldName)
@@ -133,32 +105,7 @@ public static class EventFieldExplainer
     }
 
     private static string? TryDecodeValue(string fieldName, in EventFieldValue value) =>
-        s_valueDecoders.TryGetValue(fieldName, out Func<EventFieldValue, string?>? decoder)
-            ? decoder(value)
-            : null;
-
-    private static bool TryReadWholeNumber(in EventFieldValue value, out ulong number)
-    {
-        if (value.TryGetUInt64(out number)) { return true; }
-
-        if (value.TryGetInt64(out long signed) && signed >= 0)
-        {
-            number = (ulong)signed;
-
-            return true;
-        }
-
-        // Strict parse only for a string-typed value: no sign, whitespace, or fractional part.
-        if (value.Kind == EventFieldValueKind.String
-            && ulong.TryParse(value.AsString(), NumberStyles.None, CultureInfo.InvariantCulture, out number))
-        {
-            return true;
-        }
-
-        number = 0;
-
-        return false;
-    }
+        value.TryGetWholeNumber(out long code) ? EventDataValueDecoder.TryDecodeLabel(fieldName, code) : null;
 
     private sealed record GlossaryEntry(string? Provider, int? EventId, string Field, string Description);
 }

--- a/src/EventLogExpert.Runtime/EventLog/FilteringEffects.cs
+++ b/src/EventLogExpert.Runtime/EventLog/FilteringEffects.cs
@@ -8,6 +8,7 @@ using EventLogExpert.Filtering.Compilation;
 using EventLogExpert.Filtering.Evaluation;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Runtime.FilterProgress;
+using EventLogExpert.Runtime.Histogram;
 using EventLogExpert.Runtime.LogTable;
 using Fluxor;
 using Microsoft.Extensions.DependencyInjection;
@@ -207,6 +208,21 @@ internal sealed class FilteringEffects(
     [EffectMethod]
     public async Task HandleSetGroupBy(SetGroupByAction action, IDispatcher dispatcher) =>
         await RepublishForSortAsync(dispatcher);
+
+    [EffectMethod]
+    public async Task HandleSetHistogramVisible(SetHistogramVisibleAction action, IDispatcher dispatcher)
+    {
+        // Timeline visibility only changes the default order of a single log with no explicit sort or grouping; every other
+        // view keeps its order, so skip the rebuild. This predicate matches the reducer's conditional DisplayListVersion bump.
+        var logTable = _logTableState.Value;
+
+        if (logTable.PerLogEvents.Count != 1 || logTable.RequestedOrderBy is not null || logTable.RequestedGroupBy is not null)
+        {
+            return;
+        }
+
+        await RepublishForSortAsync(dispatcher);
+    }
 
     [EffectMethod]
     public async Task HandleSetOrderBy(SetOrderByAction action, IDispatcher dispatcher) =>

--- a/src/EventLogExpert.Runtime/Histogram/HistogramBuilder.cs
+++ b/src/EventLogExpert.Runtime/Histogram/HistogramBuilder.cs
@@ -71,9 +71,10 @@ public static class HistogramBuilder
 
         if (counts.Count == 0)
         {
-            // No row in the view carries this field. Report the true survivor count (view.Count - every survivor falls within
-            // the view's own min/max span) so the accessible region label isn't "0 events" over a non-empty span, and flag the
-            // empty-state so the pane shows a message rather than a lone "Other" band.
+            // No row in the view yields a decodable whole-number value for this field - the field is absent from every row,
+            // or every occurrence is non-numeric or out of range. Report the true survivor count (view.Count - every survivor
+            // falls within the view's own min/max span) so the accessible region label isn't "0 events" over a non-empty span,
+            // and flag the empty-state so the pane shows a message rather than a lone "Other" band.
             return new HistogramData([], 0, bucketCount, minUtc, maxUtc, view.Count, bucketSpanTicks, []) { GroupingFieldAbsent = true };
         }
 

--- a/src/EventLogExpert.Runtime/Histogram/HistogramBuilder.cs
+++ b/src/EventLogExpert.Runtime/Histogram/HistogramBuilder.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Runtime.Common.Display;
 using EventLogExpert.Runtime.LogTable;
 using System.Globalization;
 
@@ -25,6 +26,11 @@ public static class HistogramBuilder
         long bucketSpanTicks = Math.Max(1, (spanTicks + maxBuckets - 1) / maxBuckets);
         int bucketCount = (int)Math.Min((spanTicks + bucketSpanTicks - 1) / bucketSpanTicks, maxBuckets);
 
+        if (dimension is HistogramDimension.LogonType or HistogramDimension.TicketEncryptionType)
+        {
+            return BuildByEventData(view, ToEventDataFieldName(dimension), minTicks, maxTicks, bucketSpanTicks, bucketCount, cancellationToken);
+        }
+
         (int[] slotCounts, int slotCount, IReadOnlyList<HistogramGroup> groups) = dimension switch
         {
             HistogramDimension.Severity => ScanSeverity(view, minTicks, bucketSpanTicks, bucketCount, cancellationToken),
@@ -46,6 +52,61 @@ public static class HistogramBuilder
             total,
             bucketSpanTicks,
             groups);
+    }
+
+    private static HistogramData BuildByEventData(
+        IEventColumnView view,
+        string fieldName,
+        long minTicks,
+        long maxTicks,
+        long bucketSpanTicks,
+        int bucketCount,
+        CancellationToken cancellationToken)
+    {
+        var counts = new Dictionary<long, int>();
+        view.CountEventDataValues(fieldName, counts, cancellationToken);
+
+        var minUtc = new DateTime(minTicks, DateTimeKind.Utc);
+        var maxUtc = new DateTime(maxTicks, DateTimeKind.Utc);
+
+        if (counts.Count == 0)
+        {
+            // No row in the view carries this field. Report the true survivor count (view.Count - every survivor falls within
+            // the view's own min/max span) so the accessible region label isn't "0 events" over a non-empty span, and flag the
+            // empty-state so the pane shows a message rather than a lone "Other" band.
+            return new HistogramData([], 0, bucketCount, minUtc, maxUtc, view.Count, bucketSpanTicks, []) { GroupingFieldAbsent = true };
+        }
+
+        long[] targetCodes = counts
+            .OrderByDescending(pair => pair.Value)
+            .ThenBy(pair => pair.Key)
+            .Take(HistogramConstants.MaxGroupByCategories)
+            .Select(pair => pair.Key)
+            .ToArray();
+
+        int slotCount = targetCodes.Length + 1;
+        int[] slotCounts = new int[bucketCount * slotCount];
+        view.BucketTimeTicksByEventData(minTicks, bucketSpanTicks, bucketCount, fieldName, targetCodes, slotCounts, cancellationToken);
+
+        int total = 0;
+
+        foreach (int count in slotCounts) { total += count; }
+
+        // Key = the raw invariant code (stable toggle key); Label = the friendly decode, or the raw code when unrecognized.
+        string[] keys = Array.ConvertAll(targetCodes, code => code.ToString(CultureInfo.InvariantCulture));
+        string[] labels = Array.ConvertAll(
+            targetCodes,
+            code => EventDataValueDecoder.TryDecodeLabel(fieldName, code) ?? code.ToString(CultureInfo.InvariantCulture));
+
+        return new HistogramData(
+            slotCounts,
+            slotCount,
+            bucketCount,
+            minUtc,
+            maxUtc,
+            total,
+            bucketSpanTicks,
+            HistogramGroups.ForCategories(keys, labels));
     }
 
     private static (int[] SlotCounts, int SlotCount, IReadOnlyList<HistogramGroup> Groups) ScanByEventId(
@@ -114,6 +175,13 @@ public static class HistogramBuilder
 
         return (slotCounts, slotCount, HistogramGroups.Severity);
     }
+
+    private static string ToEventDataFieldName(HistogramDimension dimension) => dimension switch
+    {
+        HistogramDimension.LogonType => "LogonType",
+        HistogramDimension.TicketEncryptionType => "TicketEncryptionType",
+        _ => throw new ArgumentOutOfRangeException(nameof(dimension), dimension, "Dimension is not an EventData field.")
+    };
 
     private static EventFieldId ToFieldId(HistogramDimension dimension) => dimension switch
     {

--- a/src/EventLogExpert.Runtime/Histogram/HistogramData.cs
+++ b/src/EventLogExpert.Runtime/Histogram/HistogramData.cs
@@ -14,7 +14,8 @@ public sealed record HistogramData(
     long BucketSpanTicks,
     IReadOnlyList<HistogramGroup> Groups)
 {
-    // True when the selected group-by dimension is a named EventData field that no row in the view carries, so the pane
-    // shows an explicit empty-state rather than a single, meaningless "Other" band.
+    // True when the selected group-by dimension is a named EventData field for which no row in the view yields a decodable
+    // whole-number value (the field is absent from every row, or every occurrence is non-numeric or out of range), so the
+    // pane shows an explicit empty-state rather than a single, meaningless "Other" band.
     public bool GroupingFieldAbsent { get; init; }
 }

--- a/src/EventLogExpert.Runtime/Histogram/HistogramData.cs
+++ b/src/EventLogExpert.Runtime/Histogram/HistogramData.cs
@@ -12,4 +12,9 @@ public sealed record HistogramData(
     DateTime MaxUtc,
     int Total,
     long BucketSpanTicks,
-    IReadOnlyList<HistogramGroup> Groups);
+    IReadOnlyList<HistogramGroup> Groups)
+{
+    // True when the selected group-by dimension is a named EventData field that no row in the view carries, so the pane
+    // shows an explicit empty-state rather than a single, meaningless "Other" band.
+    public bool GroupingFieldAbsent { get; init; }
+}

--- a/src/EventLogExpert.Runtime/Histogram/HistogramDimension.cs
+++ b/src/EventLogExpert.Runtime/Histogram/HistogramDimension.cs
@@ -10,5 +10,7 @@ public enum HistogramDimension
     EventId,
     TaskCategory,
     Opcode,
-    Log
+    Log,
+    LogonType,
+    TicketEncryptionType
 }

--- a/src/EventLogExpert.Runtime/LogTable/CombinedColumnView.cs
+++ b/src/EventLogExpert.Runtime/LogTable/CombinedColumnView.cs
@@ -58,27 +58,85 @@ internal sealed class CombinedColumnView : IEventColumnView
 
     internal static CombinedColumnView Empty { get; } = new([], new SortContext(null, true, null, false));
 
-    public void BucketTimeTicksByEventId(long minTicks, long bucketSpanTicks, int bucketCount, int[] targetIds, int[] slotCounts, CancellationToken cancellationToken)
+    public void BucketTimeTicksByEventData(
+        long minTicks,
+        long bucketSpanTicks,
+        int bucketCount,
+        string fieldName,
+        long[] targetCodes,
+        int[] slotCounts,
+        CancellationToken cancellationToken)
     {
         foreach (var view in _views)
         {
-            view.BucketTimeTicksByEventId(minTicks, bucketSpanTicks, bucketCount, targetIds, slotCounts, cancellationToken);
+            view.BucketTimeTicksByEventData(minTicks,
+                bucketSpanTicks,
+                bucketCount,
+                fieldName,
+                targetCodes,
+                slotCounts,
+                cancellationToken);
         }
     }
 
-    public void BucketTimeTicksByField(long minTicks, long bucketSpanTicks, int bucketCount, EventFieldId field, string[] targetValues, int[] slotCounts, CancellationToken cancellationToken)
+    public void BucketTimeTicksByEventId(
+        long minTicks,
+        long bucketSpanTicks,
+        int bucketCount,
+        int[] targetIds,
+        int[] slotCounts,
+        CancellationToken cancellationToken)
     {
         foreach (var view in _views)
         {
-            view.BucketTimeTicksByField(minTicks, bucketSpanTicks, bucketCount, field, targetValues, slotCounts, cancellationToken);
+            view.BucketTimeTicksByEventId(minTicks,
+                bucketSpanTicks,
+                bucketCount,
+                targetIds,
+                slotCounts,
+                cancellationToken);
         }
     }
 
-    public void BucketTimeTicksBySeverity(long minTicks, long bucketSpanTicks, int bucketCount, int[] slotCounts, CancellationToken cancellationToken)
+    public void BucketTimeTicksByField(
+        long minTicks,
+        long bucketSpanTicks,
+        int bucketCount,
+        EventFieldId field,
+        string[] targetValues,
+        int[] slotCounts,
+        CancellationToken cancellationToken)
+    {
+        foreach (var view in _views)
+        {
+            view.BucketTimeTicksByField(minTicks,
+                bucketSpanTicks,
+                bucketCount,
+                field,
+                targetValues,
+                slotCounts,
+                cancellationToken);
+        }
+    }
+
+    public void BucketTimeTicksBySeverity(
+        long minTicks,
+        long bucketSpanTicks,
+        int bucketCount,
+        int[] slotCounts,
+        CancellationToken cancellationToken)
     {
         foreach (var view in _views)
         {
             view.BucketTimeTicksBySeverity(minTicks, bucketSpanTicks, bucketCount, slotCounts, cancellationToken);
+        }
+    }
+
+    public void CountEventDataValues(string fieldName, IDictionary<long, int> counts, CancellationToken cancellationToken)
+    {
+        foreach (var view in _views)
+        {
+            view.CountEventDataValues(fieldName, counts, cancellationToken);
         }
     }
 

--- a/src/EventLogExpert.Runtime/LogTable/EventColumnView.cs
+++ b/src/EventLogExpert.Runtime/LogTable/EventColumnView.cs
@@ -33,6 +33,24 @@ internal sealed class EventColumnView : IEventColumnView
     // so the current display order is a valid re-sort input.
     internal ReadOnlySpan<int> Survivors => _order;
 
+    public void BucketTimeTicksByEventData(
+        long minTicks,
+        long bucketSpanTicks,
+        int bucketCount,
+        string fieldName,
+        long[] targetCodes,
+        int[] slotCounts,
+        CancellationToken cancellationToken) =>
+        _reader.BucketTimeTicksByEventData(
+            _rankByPhysical,
+            minTicks,
+            bucketSpanTicks,
+            bucketCount,
+            fieldName,
+            targetCodes,
+            slotCounts,
+            cancellationToken);
+
     public void BucketTimeTicksByEventId(
         long minTicks,
         long bucketSpanTicks,
@@ -77,6 +95,12 @@ internal sealed class EventColumnView : IEventColumnView
             bucketCount,
             slotCounts,
             cancellationToken);
+
+    public void CountEventDataValues(
+        string fieldName,
+        IDictionary<long, int> counts,
+        CancellationToken cancellationToken) =>
+        _reader.CountEventDataValues(_rankByPhysical, fieldName, counts, cancellationToken);
 
     public void CountEventIds(IDictionary<int, int> counts, CancellationToken cancellationToken) =>
         _reader.CountEventIds(_rankByPhysical, counts, cancellationToken);

--- a/src/EventLogExpert.Runtime/LogTable/IEventColumnView.cs
+++ b/src/EventLogExpert.Runtime/LogTable/IEventColumnView.cs
@@ -15,6 +15,19 @@ public interface IEventColumnView
 {
     int Count { get; }
 
+    /// <summary>
+    ///     Group-by variant keyed on a named EventData field's whole-number code; (targetCodes length + 1) slots per bin,
+    ///     with the trailing "other" slot also absorbing rows that lack the field.
+    /// </summary>
+    void BucketTimeTicksByEventData(
+        long minTicks,
+        long bucketSpanTicks,
+        int bucketCount,
+        string fieldName,
+        long[] targetCodes,
+        int[] slotCounts,
+        CancellationToken cancellationToken);
+
     /// <summary>Group-by variant keyed on the numeric event id; (targetIds length + 1) slots per bin.</summary>
     void BucketTimeTicksByEventId(
         long minTicks,
@@ -47,6 +60,12 @@ public interface IEventColumnView
         int bucketCount,
         int[] slotCounts,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Tallies this view's rows by the whole-number code of a named EventData field (accumulating across a combined
+    ///     view, since a numeric code is store-independent); resolves the top-N group-by categories for the histogram.
+    /// </summary>
+    void CountEventDataValues(string fieldName, IDictionary<long, int> counts, CancellationToken cancellationToken);
 
     /// <summary>
     ///     Tallies this view's rows by numeric event id into <paramref name="counts" /> (accumulating across a combined

--- a/src/EventLogExpert.Runtime/LogTable/LogTableState.cs
+++ b/src/EventLogExpert.Runtime/LogTable/LogTableState.cs
@@ -50,6 +50,13 @@ public sealed record LogTableState
 
     public bool IsGroupDescending { get; init; }
 
+    /// <summary>
+    ///     Mirrors the timeline pane's visibility (kept in sync through <c>SetHistogramVisibleAction</c>). A single log
+    ///     with no explicit sort defaults to Date/Time order while the timeline is shown, so the table reads in the same order
+    ///     as the time axis, and to Record ID order while it is hidden. Combined views are unaffected (always Date/Time).
+    /// </summary>
+    public bool TimelineVisible { get; init; }
+
     internal ColumnName? RequestedOrderBy { get; init; }
 
     internal bool RequestedIsDescending { get; init; } = true;
@@ -66,7 +73,7 @@ public sealed record LogTableState
         ImmutableHashSet.Create<string>(StringComparer.Ordinal);
 
     internal SortContext SortContext =>
-        new(ResolvedEventOrdering.ResolveDefaultOrderBy(RequestedOrderBy, RequestedGroupBy, PerLogEvents.Count),
+        new(ResolvedEventOrdering.ResolveDefaultOrderBy(RequestedOrderBy, RequestedGroupBy, PerLogEvents.Count, TimelineVisible),
             RequestedIsDescending,
             RequestedGroupBy,
             RequestedIsGroupDescending);
@@ -219,7 +226,7 @@ public sealed record LogTableState
         int newCount = PerLogEvents.ContainsKey(logId) ? PerLogEvents.Count : PerLogEvents.Count + 1;
 
         var context = new SortContext(
-            ResolvedEventOrdering.ResolveDefaultOrderBy(OrderBy, GroupBy, newCount),
+            ResolvedEventOrdering.ResolveDefaultOrderBy(OrderBy, GroupBy, newCount, TimelineVisible),
             IsDescending,
             GroupBy,
             IsGroupDescending);

--- a/src/EventLogExpert.Runtime/LogTable/Reducers.cs
+++ b/src/EventLogExpert.Runtime/LogTable/Reducers.cs
@@ -4,6 +4,7 @@
 using EventLogExpert.Eventing.Common.Channels;
 using EventLogExpert.Eventing.Common.EventLogs;
 using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.Histogram;
 using Fluxor;
 using System.Collections.Immutable;
 
@@ -75,7 +76,7 @@ internal sealed class Reducers
             state.PerLogEvents.Count + 1;
 
         var context = EffectiveSortContext(
-            state.OrderBy, state.IsDescending, state.GroupBy, state.IsGroupDescending, postCount);
+            state.OrderBy, state.IsDescending, state.GroupBy, state.IsGroupDescending, postCount, state.TimelineVisible);
 
         var perLog = SetLog(state.PerLogEvents, table.Id, view, context);
         perLog = ReconcileToLogCount(perLog, state);
@@ -119,7 +120,7 @@ internal sealed class Reducers
         }
 
         var context = EffectiveSortContext(
-            state.OrderBy, state.IsDescending, state.GroupBy, state.IsGroupDescending, perLog.Count + newLogs);
+            state.OrderBy, state.IsDescending, state.GroupBy, state.IsGroupDescending, perLog.Count + newLogs, state.TimelineVisible);
 
         foreach (var (logId, view) in action.ViewsByLog)
         {
@@ -255,7 +256,7 @@ internal sealed class Reducers
         }
 
         var context = EffectiveSortContext(
-            flipped.OrderBy, flipped.IsDescending, flipped.GroupBy, flipped.IsGroupDescending, postCount);
+            flipped.OrderBy, flipped.IsDescending, flipped.GroupBy, flipped.IsGroupDescending, postCount, flipped.TimelineVisible);
         var perLogBuilder = ImmutableDictionary.CreateBuilder<EventLogId, EventColumnView>();
         var perLogVersion = state.PerLogListVersion;
         var counts = state.EventCountByLog;
@@ -326,7 +327,7 @@ internal sealed class Reducers
                 GroupCollapseOverrides = ImmutableHashSet.Create<string>(StringComparer.Ordinal),
                 PerLogEvents = ResortAllLogs(
                     updated.PerLogEvents,
-                    EffectiveSortContext(updated.OrderBy, updated.IsDescending, null, false, updated.PerLogEvents.Count))
+                    EffectiveSortContext(updated.OrderBy, updated.IsDescending, null, false, updated.PerLogEvents.Count, updated.TimelineVisible))
             };
         }
 
@@ -481,6 +482,25 @@ internal sealed class Reducers
     }
 
     [ReducerMethod]
+    public static LogTableState ReduceSetHistogramVisible(LogTableState state, SetHistogramVisibleAction action)
+    {
+        if (state.TimelineVisible == action.IsVisible) { return state; }
+
+        // A single log with no explicit sort takes its default order from timeline visibility, so bump the display version
+        // only when that republish will actually follow (see FilteringEffects.HandleSetHistogramVisible). Bumping on a
+        // combined or explicitly sorted toggle would reject an in-flight republish carrying the pre-bump version with no replacement.
+        bool willResort = state.PerLogEvents.Count == 1 &&
+            state.RequestedOrderBy is null &&
+            state.RequestedGroupBy is null;
+
+        return state with
+        {
+            TimelineVisible = action.IsVisible,
+            DisplayListVersion = willResort ? state.DisplayListVersion + 1 : state.DisplayListVersion
+        };
+    }
+
+    [ReducerMethod]
     public static LogTableState ReduceSetOrderBy(LogTableState state, SetOrderByAction action) =>
         state.RequestedOrderBy.Equals(action.OrderBy) ?
             state with
@@ -573,7 +593,7 @@ internal sealed class Reducers
             state.PerLogEvents.Count + 1;
 
         var context = EffectiveSortContext(
-            state.OrderBy, state.IsDescending, state.GroupBy, state.IsGroupDescending, postCount);
+            state.OrderBy, state.IsDescending, state.GroupBy, state.IsGroupDescending, postCount, state.TimelineVisible);
 
         // Always store the finalize view: built over the just-rebuilt raw store, its reader (and every locator it hands
         // out) addresses the current generation, so a pre-finalize view would strand selection.
@@ -598,8 +618,9 @@ internal sealed class Reducers
         bool isDescending,
         ColumnName? groupBy,
         bool isGroupDescending,
-        int logCount) =>
-        new(ResolvedEventOrdering.ResolveDefaultOrderBy(orderBy, groupBy, logCount),
+        int logCount,
+        bool timelineVisible) =>
+        new(ResolvedEventOrdering.ResolveDefaultOrderBy(orderBy, groupBy, logCount, timelineVisible),
             isDescending,
             groupBy,
             isGroupDescending);
@@ -613,7 +634,8 @@ internal sealed class Reducers
                 state.IsDescending,
                 state.GroupBy,
                 state.IsGroupDescending,
-                perLog.Count));
+                perLog.Count,
+                state.TimelineVisible));
 
     private static LogTableState RedirectActiveToGroupIfHidden(LogTableState state)
     {

--- a/src/EventLogExpert.Runtime/LogTable/ResolvedEventOrdering.cs
+++ b/src/EventLogExpert.Runtime/LogTable/ResolvedEventOrdering.cs
@@ -7,12 +7,14 @@ namespace EventLogExpert.Runtime.LogTable;
 
 internal static partial class ResolvedEventOrdering
 {
-    // RecordId for one log; timestamp for a combined view of several.
-    internal static ColumnName? ResolveDefaultOrderBy(ColumnName? orderBy, ColumnName? groupBy, int logCount)
+    // RecordId for one log while the timeline is hidden; timestamp for a combined view of several, or for a single log
+    // while the timeline is shown (so the table reads in the same order as the time axis). An explicit sort or grouping
+    // always wins.
+    internal static ColumnName? ResolveDefaultOrderBy(ColumnName? orderBy, ColumnName? groupBy, int logCount, bool timelineVisible)
     {
         if (orderBy is not null || groupBy is not null) { return orderBy; }
 
-        return logCount > 1 ? ColumnName.DateAndTime : null;
+        return logCount > 1 || timelineVisible ? ColumnName.DateAndTime : null;
     }
 
     private static int CompareDateTime(EventFieldValue left, EventFieldValue right)

--- a/src/EventLogExpert.UI/LogTable/Histogram/HistogramPane.razor
+++ b/src/EventLogExpert.UI/LogTable/Histogram/HistogramPane.razor
@@ -14,10 +14,12 @@
                     ValueChanged="OnDimensionSelected">
                     <ValueSelectItem T="HistogramDimension" Value="HistogramDimension.EventId" />
                     <ValueSelectItem T="HistogramDimension" Value="HistogramDimension.Log" />
+                    <ValueSelectItem T="HistogramDimension" Value="HistogramDimension.LogonType" />
                     <ValueSelectItem T="HistogramDimension" Value="HistogramDimension.Opcode" />
                     <ValueSelectItem T="HistogramDimension" Value="HistogramDimension.Severity" />
                     <ValueSelectItem T="HistogramDimension" Value="HistogramDimension.Source" />
                     <ValueSelectItem T="HistogramDimension" Value="HistogramDimension.TaskCategory" />
+                    <ValueSelectItem T="HistogramDimension" Value="HistogramDimension.TicketEncryptionType" />
                 </ValueSelect>
             </div>
             @if (_baseData is { } legendData)
@@ -177,6 +179,10 @@
                 </div>
                 <div class="histogram-selection" hidden></div>
             </div>
+        }
+        else if (_baseData is { GroupingFieldAbsent: true })
+        {
+            <div class="histogram-empty">No @DimensionLabel(_dimension) values in this view.</div>
         }
         else
         {

--- a/src/EventLogExpert.UI/LogTable/Histogram/HistogramPane.razor
+++ b/src/EventLogExpert.UI/LogTable/Histogram/HistogramPane.razor
@@ -127,7 +127,6 @@
                         int slotWidth = Math.Max(1, barRight - barLeft);
                         int barDrawWidth = Math.Max(1, slotWidth - 1);
                         double segmentTop = barsHeight;
-                        int visiblePx = 0;
                         int baseSlot = index * groupCount;
 
                         <g data-tip="@BarTooltip(bin)">
@@ -139,7 +138,6 @@
                                 if (height <= 0 || IsGroupHidden(group)) { continue; }
 
                                 segmentTop -= height;
-                                visiblePx += height;
 
                                 <rect class="@GroupColorClass(group)"
                                     height="@height"
@@ -148,10 +146,6 @@
                                     x="@barLeft"
                                     y="@FormatCoordinate(segmentTop)">
                                 </rect>
-                            }
-                            @if (bin.IsAnomaly && visiblePx > 0)
-                            {
-                                <rect class="histogram-anomaly" height="@visiblePx" width="@barDrawWidth" x="@barLeft" y="@FormatCoordinate(barsHeight - visiblePx)"></rect>
                             }
                             @if (HasFindHit(bin.StartTicks, bin.EndTicks))
                             {

--- a/src/EventLogExpert.UI/LogTable/Histogram/HistogramPane.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/Histogram/HistogramPane.razor.cs
@@ -243,7 +243,9 @@ public sealed partial class HistogramPane
     private static string DimensionLabel(HistogramDimension dimension) => dimension switch
     {
         HistogramDimension.EventId => "Event ID",
+        HistogramDimension.LogonType => "Logon Type",
         HistogramDimension.TaskCategory => "Task Category",
+        HistogramDimension.TicketEncryptionType => "Ticket Encryption Type",
         _ => dimension.ToString()
     };
 
@@ -263,9 +265,17 @@ public sealed partial class HistogramPane
     {
         _binCursor = null;
 
-        if (_baseData is not { } data)
+        if (_baseData is not { } data || data.GroupingFieldAbsent)
         {
             _render = null;
+
+            if (_baseData is { GroupingFieldAbsent: true })
+            {
+                // Match the visible empty-state so a screen reader is told why the timeline is blank, and drop any stale bin readout.
+                _binAnnouncement = string.Empty;
+                _announcement = $"No {DimensionLabel(_dimension)} values in this view.";
+            }
+
             StateHasChanged();
 
             return;
@@ -561,6 +571,10 @@ public sealed partial class HistogramPane
 
         _dimension = dimension;
         _hiddenGroups.Clear();
+
+        // A retained absent-field result would otherwise render its empty-state under the newly-selected dimension's name until the rescan lands.
+        if (_baseData is { GroupingFieldAbsent: true }) { _baseData = null; _render = null; }
+
         RecomputeSegmentHeights();
 
         StartScan();

--- a/src/EventLogExpert.UI/LogTable/Histogram/HistogramPane.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/Histogram/HistogramPane.razor.cs
@@ -572,8 +572,16 @@ public sealed partial class HistogramPane
         _dimension = dimension;
         _hiddenGroups.Clear();
 
-        // A retained absent-field result would otherwise render its empty-state under the newly-selected dimension's name until the rescan lands.
-        if (_baseData is { GroupingFieldAbsent: true }) { _baseData = null; _render = null; }
+        // A retained absent-field result would otherwise render its empty-state under the newly-selected dimension's name
+        // until the rescan lands; clear the live-region status with it so a screen reader isn't left holding the previous
+        // dimension's "no values" message during the gap.
+        if (_baseData is { GroupingFieldAbsent: true })
+        {
+            _baseData = null;
+            _render = null;
+            _announcement = string.Empty;
+            _binAnnouncement = string.Empty;
+        }
 
         RecomputeSegmentHeights();
 

--- a/src/EventLogExpert.UI/LogTable/Histogram/HistogramPane.razor.css
+++ b/src/EventLogExpert.UI/LogTable/Histogram/HistogramPane.razor.css
@@ -243,14 +243,6 @@
     pointer-events: none;
 }
 
-.histogram-anomaly {
-    fill: none;
-    stroke: var(--clr-statusbar);
-    stroke-width: 1.5;
-    vector-effect: non-scaling-stroke;
-    pointer-events: none;
-}
-
 .histogram-marker-selected {
     stroke: var(--toggle-accent);
     stroke-width: 1.5;

--- a/src/EventLogExpert.UI/LogTable/Histogram/HistogramPane.razor.css
+++ b/src/EventLogExpert.UI/LogTable/Histogram/HistogramPane.razor.css
@@ -41,7 +41,7 @@
 .histogram-groupby ::deep .dropdown-input { margin: 0; }
 
 .histogram-groupby ::deep .histogram-dimension-select {
-    width: 8rem;
+    width: 13rem;
     margin: 0;
 }
 

--- a/tests/Shared/EventLogExpert.Eventing.TestUtils/Common/Events/LegacyEventColumnReader.cs
+++ b/tests/Shared/EventLogExpert.Eventing.TestUtils/Common/Events/LegacyEventColumnReader.cs
@@ -36,6 +36,44 @@ public sealed class LegacyEventColumnReader : IEventColumnReader
 
     public IReadOnlyList<string?> Pool => StringPool().Values;
 
+    public void BucketTimeTicksByEventData(
+        ReadOnlySpan<int> rankByPhysical,
+        long minTicks,
+        long bucketSpanTicks,
+        int bucketCount,
+        string fieldName,
+        long[] targetCodes,
+        int[] slotCounts,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(fieldName);
+        ArgumentNullException.ThrowIfNull(targetCodes);
+        ArgumentNullException.ThrowIfNull(slotCounts);
+        ArgumentOutOfRangeException.ThrowIfNotEqual(rankByPhysical.Length, Count);
+
+        int slotCount = targetCodes.Length + 1;
+        int otherSlot = targetCodes.Length;
+
+        for (int index = 0; index < _events.Count; index++)
+        {
+            if (rankByPhysical[index] < 0) { continue; }
+
+            long bucket = (_events[index].TimeCreated.Ticks - minTicks) / bucketSpanTicks;
+            int clamped = bucket < 0 ? 0 : bucket >= bucketCount ? bucketCount - 1 : (int)bucket;
+            int slot = otherSlot;
+
+            if (_events[index].EventData.TryGetValue(fieldName, out EventFieldValue value) && value.TryGetWholeNumber(out long code))
+            {
+                for (int target = 0; target < targetCodes.Length; target++)
+                {
+                    if (targetCodes[target] == code) { slot = target; break; }
+                }
+            }
+
+            slotCounts[(clamped * slotCount) + slot]++;
+        }
+    }
+
     public void BucketTimeTicksByEventId(
         ReadOnlySpan<int> rankByPhysical,
         long minTicks,
@@ -198,6 +236,23 @@ public sealed class LegacyEventColumnReader : IEventColumnReader
         {
             string? value = RawPoolString(_events[index], field);
             poolIndices[index] = value is null ? -1 : pool.IndexOf(value);
+        }
+    }
+
+    public void CountEventDataValues(ReadOnlySpan<int> rankByPhysical, string fieldName, IDictionary<long, int> counts, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(fieldName);
+        ArgumentNullException.ThrowIfNull(counts);
+        ArgumentOutOfRangeException.ThrowIfNotEqual(rankByPhysical.Length, Count);
+
+        for (int index = 0; index < _events.Count; index++)
+        {
+            if (rankByPhysical[index] < 0) { continue; }
+
+            if (_events[index].EventData.TryGetValue(fieldName, out EventFieldValue value) && value.TryGetWholeNumber(out long code))
+            {
+                counts[code] = counts.TryGetValue(code, out int existing) ? existing + 1 : 1;
+            }
         }
     }
 

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Common/Events/EventColumnStoreEventDataTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Common/Events/EventColumnStoreEventDataTests.cs
@@ -1,0 +1,135 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Eventing.TestUtils;
+
+namespace EventLogExpert.Eventing.Tests.Common.Events;
+
+public sealed class EventColumnStoreEventDataTests
+{
+    private static readonly EventLogId s_logId = EventLogId.Create();
+
+    [Fact]
+    public void BucketTimeTicksByEventData_ClassifiesRowsByCodeWithOtherForNonTargets()
+    {
+        IEventColumnReader reader = ReaderFor(
+            Event("LogonType", 3L),
+            Event("LogonType", 3L),
+            Event("LogonType", 10L),
+            Event("LogonType", 7L)); // 7 is not a target -> Other
+
+        long[] targetCodes = [3, 10];
+        int slotCount = targetCodes.Length + 1;
+        int[] slotCounts = new int[slotCount];
+        reader.BucketTimeTicksByEventData(AllSurvive(reader.Count), 0, long.MaxValue, 1, "LogonType", targetCodes, slotCounts, CancellationToken.None);
+
+        Assert.Equal(2, slotCounts[0]); // code 3
+        Assert.Equal(1, slotCounts[1]); // code 10
+        Assert.Equal(1, slotCounts[2]); // Other (code 7)
+    }
+
+    [Fact]
+    public void BucketTimeTicksByEventData_IsAllocationFreeOnSealedRows()
+    {
+        // EventColumnStore.Build seals the whole batch. One schema means the field-index memo resolves once, so the
+        // per-row path performs no allocation; only the fixed per-scan memo array (int[schemaCount]) is charged.
+        var events = new ResolvedEvent[8192];
+
+        for (int index = 0; index < events.Length; index++)
+        {
+            events[index] = Event("LogonType", index % 3 == 0 ? 3L : 10L, index);
+        }
+
+        IEventColumnReader reader = EventColumnStore.Build(events, generation: 0, contentVersion: 0).CreateReader(s_logId);
+        int[] rank = AllSurvive(reader.Count);
+        long[] targetCodes = [3, 10];
+        int[] slotCounts = new int[targetCodes.Length + 1];
+
+        // Warm: first scan resolves the schema and JITs.
+        reader.BucketTimeTicksByEventData(rank, 0, long.MaxValue, 1, "LogonType", targetCodes, slotCounts, CancellationToken.None);
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        reader.BucketTimeTicksByEventData(rank, 0, long.MaxValue, 1, "LogonType", targetCodes, slotCounts, CancellationToken.None);
+        long delta = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        // A single per-row byte would cost 8192; the fixed memo array is a few dozen bytes, so this proves the hot path is allocation-free.
+        Assert.True(delta < 512, $"Per-row allocation detected: {delta} bytes over {events.Length} sealed rows.");
+    }
+
+    [Fact]
+    public void CountEventDataValues_FoldsDecimalAndHexSpellingsOfOneCode()
+    {
+        IEventColumnReader reader = ReaderFor(
+            Event("TicketEncryptionType", 23L),
+            Event("TicketEncryptionType", "0x17"),
+            Event("TicketEncryptionType", 18L));
+
+        var counts = new Dictionary<long, int>();
+        reader.CountEventDataValues(AllSurvive(reader.Count), "TicketEncryptionType", counts, CancellationToken.None);
+
+        Assert.Equal(2, counts.Count);
+        Assert.Equal(2, counts[23]); // decimal 23 and hex "0x17" fold to the same code
+        Assert.Equal(1, counts[18]);
+    }
+
+    [Fact]
+    public void CountEventDataValues_OmitsRowsThatLackTheField()
+    {
+        IEventColumnReader reader = ReaderFor(Event("LogonType", 3L), EventWithoutData());
+
+        var counts = new Dictionary<long, int>();
+        reader.CountEventDataValues(AllSurvive(reader.Count), "LogonType", counts, CancellationToken.None);
+
+        Assert.Single(counts);
+        Assert.Equal(1, counts[3]);
+    }
+
+    [Fact]
+    public void CountEventDataValues_ReadsUnsignedIntegralCodes()
+    {
+        // A UInt32-typed value exercises the unsigned direct-read branch and must fold with the signed Int64 spelling of the same code.
+        IEventColumnReader reader = ReaderFor(Event("LogonType", (uint)3), Event("LogonType", 3L));
+
+        var counts = new Dictionary<long, int>();
+        reader.CountEventDataValues(AllSurvive(reader.Count), "LogonType", counts, CancellationToken.None);
+
+        Assert.Single(counts);
+        Assert.Equal(2, counts[3]);
+    }
+
+    [Fact]
+    public void CountEventDataValues_RejectsHexCodeThatOverflowsALong()
+    {
+        // A high-bit hex form must not wrap to a negative code (-1) and fold with a real code.
+        IEventColumnReader reader = ReaderFor(Event("TicketEncryptionType", "0xFFFFFFFFFFFFFFFF"), Event("TicketEncryptionType", 23L));
+
+        var counts = new Dictionary<long, int>();
+        reader.CountEventDataValues(AllSurvive(reader.Count), "TicketEncryptionType", counts, CancellationToken.None);
+
+        Assert.Single(counts);
+        Assert.Equal(1, counts[23]);
+        Assert.DoesNotContain(-1L, counts.Keys);
+    }
+
+    private static int[] AllSurvive(int count)
+    {
+        int[] rank = new int[count];
+
+        for (int index = 0; index < count; index++) { rank[index] = index; }
+
+        return rank;
+    }
+
+    private static ResolvedEvent Event(string fieldName, object value, int tick = 0) =>
+        new ResolvedEvent("TestLog", LogPathType.Channel) { Id = 4624, TimeCreated = new DateTime(tick, DateTimeKind.Utc) }
+            .WithEventData((fieldName, value));
+
+    private static ResolvedEvent EventWithoutData() =>
+        new("TestLog", LogPathType.Channel) { Id = 4624, TimeCreated = new DateTime(0, DateTimeKind.Utc) };
+
+    private static IEventColumnReader ReaderFor(params ResolvedEvent[] events) =>
+        EventColumnStore.Build(events, generation: 0, contentVersion: 0).CreateReader(s_logId);
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Common/Display/EventDataValueDecoderTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Common/Display/EventDataValueDecoderTests.cs
@@ -1,0 +1,33 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.Common.Display;
+
+namespace EventLogExpert.Runtime.Tests.Common.Display;
+
+public sealed class EventDataValueDecoderTests
+{
+    [Fact]
+    public void TryDecodeLabel_FieldNameIsCaseInsensitive() =>
+        Assert.Equal("Network", EventDataValueDecoder.TryDecodeLabel("logontype", 3));
+
+    [Theory]
+    [InlineData("LogonType", 0, "System")]
+    [InlineData("LogonType", 3, "Network")]
+    [InlineData("LogonType", 10, "RemoteInteractive")]
+    [InlineData("TicketEncryptionType", 17, "AES128")]
+    [InlineData("TicketEncryptionType", 18, "AES256")]
+    [InlineData("TicketEncryptionType", 23, "RC4")]
+    public void TryDecodeLabel_KnownCode_ReturnsFriendlyLabel(string fieldName, long code, string expected) =>
+        Assert.Equal(expected, EventDataValueDecoder.TryDecodeLabel(fieldName, code));
+
+    [Fact]
+    public void TryDecodeLabel_UndecodedField_ReturnsNull() =>
+        Assert.Null(EventDataValueDecoder.TryDecodeLabel("TargetUserName", 3));
+
+    [Theory]
+    [InlineData("LogonType", 99)]
+    [InlineData("TicketEncryptionType", 99)]
+    public void TryDecodeLabel_UnrecognizedCode_ReturnsNull(string fieldName, long code) =>
+        Assert.Null(EventDataValueDecoder.TryDecodeLabel(fieldName, code));
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Histogram/HistogramBuilderTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Histogram/HistogramBuilderTests.cs
@@ -4,6 +4,7 @@
 using EventLogExpert.Eventing.Common.Channels;
 using EventLogExpert.Eventing.Common.EventLogs;
 using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Eventing.TestUtils;
 using EventLogExpert.Runtime.Histogram;
 using EventLogExpert.Runtime.LogTable;
 using EventLogExpert.Runtime.Tests.TestUtils;
@@ -159,6 +160,61 @@ public sealed class HistogramBuilderTests
     }
 
     [Fact]
+    public void Build_GroupByLogonType_FieldAbsentFromView_SignalsEmptyState()
+    {
+        var view = DisplayViewTestFactory.Build(s_logId, EventsAt(0, 100, 200)); // no EventData at all
+
+        HistogramData? data = HistogramBuilder.Build(view, HistogramDimension.LogonType, maxBuckets: 100, CancellationToken.None);
+
+        Assert.NotNull(data);
+        Assert.True(data!.GroupingFieldAbsent);
+        Assert.Empty(data.Groups);
+        Assert.Equal(3, data.Total); // the true survivor count, so the accessible region label isn't "0 events"
+    }
+
+    [Fact]
+    public void Build_GroupByLogonType_RowsWithoutTheFieldFallToOther()
+    {
+        var view = DisplayViewTestFactory.Build(s_logId, EventDataEvents("LogonType", (3, 2), (null, 3)));
+
+        HistogramData? data = HistogramBuilder.Build(view, HistogramDimension.LogonType, maxBuckets: 100, CancellationToken.None);
+
+        Assert.NotNull(data);
+        Assert.Equal(3, GroupTotal(data, 0)); // Other absorbs the 3 field-less rows
+        Assert.Equal("Network", data!.Groups[1].Label);
+        Assert.Equal(2, GroupTotal(data, 1));
+    }
+
+    [Fact]
+    public void Build_GroupByLogonType_SplitsByDecodedLabel()
+    {
+        // LogonType 3 = Network (x3), 10 = RemoteInteractive (x2).
+        var view = DisplayViewTestFactory.Build(s_logId, EventDataEvents("LogonType", (3, 3), (10, 2)));
+
+        HistogramData? data = HistogramBuilder.Build(view, HistogramDimension.LogonType, maxBuckets: 100, CancellationToken.None);
+
+        Assert.NotNull(data);
+        Assert.False(data!.GroupingFieldAbsent);
+        Assert.Equal("Network", data.Groups[1].Label);
+        Assert.Equal("cat:3", data.Groups[1].Key);
+        Assert.Equal(3, GroupTotal(data, 1));
+        Assert.Equal("RemoteInteractive", data.Groups[2].Label);
+        Assert.Equal(2, GroupTotal(data, 2));
+    }
+
+    [Fact]
+    public void Build_GroupByLogonType_UnrecognizedCode_KeepsTheRawCodeAsLabel()
+    {
+        var view = DisplayViewTestFactory.Build(s_logId, EventDataEvents("LogonType", (99, 2)));
+
+        HistogramData? data = HistogramBuilder.Build(view, HistogramDimension.LogonType, maxBuckets: 100, CancellationToken.None);
+
+        Assert.NotNull(data);
+        Assert.Equal("99", data!.Groups[1].Label);
+        Assert.Equal("cat:99", data.Groups[1].Key);
+    }
+
+    [Fact]
     public void Build_GroupBySource_FoldsValuesBeyondTheTopCapIntoOther()
     {
         var events = SourceEvents(("s1", 5), ("s2", 4), ("s3", 3), ("s4", 2), ("s5", 1), ("s6", 1));
@@ -195,6 +251,21 @@ public sealed class HistogramBuilderTests
     }
 
     [Fact]
+    public void Build_GroupByTicketEncryptionType_DecimalAndHexCodesFoldIntoOneBand()
+    {
+        // 0x17 and 23 are the same RC4 etype; the numeric-code scan must fold both spellings into one group.
+        var view = DisplayViewTestFactory.Build(s_logId, EventDataEvents("TicketEncryptionType", (23, 2), ("0x17", 1)));
+
+        HistogramData? data = HistogramBuilder.Build(view, HistogramDimension.TicketEncryptionType, maxBuckets: 100, CancellationToken.None);
+
+        Assert.NotNull(data);
+        Assert.Equal(2, data!.Groups.Count); // Other + a single RC4 band
+        Assert.Equal("RC4", data.Groups[1].Label);
+        Assert.Equal("cat:23", data.Groups[1].Key);
+        Assert.Equal(3, GroupTotal(data, 1));
+    }
+
+    [Fact]
     public void Build_RecordsPerSeverityCountsInTheBaseBuffer()
     {
         var events = new[]
@@ -224,6 +295,28 @@ public sealed class HistogramBuilderTests
             TimeCreated = new DateTime(ticks, DateTimeKind.Utc),
             Level = level
         };
+
+    private static ResolvedEvent[] EventDataEvents(string fieldName, params (object? Value, int Count)[] groups)
+    {
+        var events = new List<ResolvedEvent>();
+        long ticks = 0;
+
+        foreach ((object? value, int count) in groups)
+        {
+            for (int index = 0; index < count; index++)
+            {
+                var @event = new ResolvedEvent("TestLog", LogPathType.Channel)
+                {
+                    Id = 4624,
+                    TimeCreated = new DateTime(ticks++, DateTimeKind.Utc)
+                };
+
+                events.Add(value is null ? @event : @event.WithEventData((fieldName, value)));
+            }
+        }
+
+        return [.. events];
+    }
 
     private static ResolvedEvent[] EventsAt(params long[] ticks)
     {

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/LogTabGroupTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/LogTabGroupTests.cs
@@ -516,7 +516,7 @@ public sealed class LogTabGroupTests
     {
         var oracle = AosReferenceOrdering.OrderedEvents(
             expected,
-            ResolvedEventOrdering.ResolveDefaultOrderBy(state.OrderBy, state.GroupBy, state.PerLogEvents.Count),
+            ResolvedEventOrdering.ResolveDefaultOrderBy(state.OrderBy, state.GroupBy, state.PerLogEvents.Count, state.TimelineVisible),
             state.IsDescending,
             state.GroupBy,
             state.IsGroupDescending);

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/LogTableReducerDifferentialTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/LogTableReducerDifferentialTests.cs
@@ -92,7 +92,7 @@ public sealed class LogTableReducerDifferentialTests
         public LogTableState State { get; private set; } = new();
 
         private ColumnName? EffectiveOrderBy =>
-            ResolvedEventOrdering.ResolveDefaultOrderBy(State.OrderBy, State.GroupBy, OpenLogs().Count);
+            ResolvedEventOrdering.ResolveDefaultOrderBy(State.OrderBy, State.GroupBy, OpenLogs().Count, State.TimelineVisible);
 
         public void AppendToAnyLog()
         {

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/LogTableReducerInvariantTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/LogTableReducerInvariantTests.cs
@@ -210,7 +210,7 @@ public sealed class LogTableReducerInvariantTests
     {
         var oracle = AosReferenceOrdering.OrderedEvents(
             expected,
-            ResolvedEventOrdering.ResolveDefaultOrderBy(state.OrderBy, state.GroupBy, state.PerLogEvents.Count),
+            ResolvedEventOrdering.ResolveDefaultOrderBy(state.OrderBy, state.GroupBy, state.PerLogEvents.Count, state.TimelineVisible),
             state.IsDescending,
             state.GroupBy,
             state.IsGroupDescending);
@@ -230,7 +230,7 @@ public sealed class LogTableReducerInvariantTests
     private static void AssertEveryLogIsOnTheCurrentContext(LogTableState state)
     {
         var displayed = new SortContext(
-            ResolvedEventOrdering.ResolveDefaultOrderBy(state.OrderBy, state.GroupBy, state.PerLogEvents.Count),
+            ResolvedEventOrdering.ResolveDefaultOrderBy(state.OrderBy, state.GroupBy, state.PerLogEvents.Count, state.TimelineVisible),
             state.IsDescending,
             state.GroupBy,
             state.IsGroupDescending);

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/LogTableStoreTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/LogTableStoreTests.cs
@@ -1534,7 +1534,7 @@ public sealed class LogTableStoreTests
         var afterSort = Reducers.ReduceSetOrderBy(state, new SetOrderByAction(ColumnName.EventId));
 
         var displayed = new SortContext(
-            ResolvedEventOrdering.ResolveDefaultOrderBy(afterSort.OrderBy, afterSort.GroupBy, afterSort.PerLogEvents.Count),
+            ResolvedEventOrdering.ResolveDefaultOrderBy(afterSort.OrderBy, afterSort.GroupBy, afterSort.PerLogEvents.Count, afterSort.TimelineVisible),
             afterSort.IsDescending,
             afterSort.GroupBy,
             afterSort.IsGroupDescending);
@@ -2140,9 +2140,9 @@ public sealed class LogTableStoreTests
     {
         var byLog = events.GroupBy(resolved => resolved.OwningLog).ToList();
 
-        // Match the reducers' default: RecordId for one log, else DateAndTime.
+        // Match the reducers' default: RecordId for one log while the timeline is hidden, else DateAndTime.
         var context = new SortContext(
-            ResolvedEventOrdering.ResolveDefaultOrderBy(orderBy, groupBy, byLog.Count),
+            ResolvedEventOrdering.ResolveDefaultOrderBy(orderBy, groupBy, byLog.Count, timelineVisible: false),
             isDescending,
             groupBy,
             isGroupDescending);

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/TestSupport/LegacyEventColumnView.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/TestSupport/LegacyEventColumnView.cs
@@ -21,6 +21,9 @@ internal sealed class LegacyEventColumnView(
 
     public IEventColumnReader Reader => _reader;
 
+    public void BucketTimeTicksByEventData(long minTicks, long bucketSpanTicks, int bucketCount, string fieldName, long[] targetCodes, int[] slotCounts, CancellationToken cancellationToken) =>
+        _reader.BucketTimeTicksByEventData(AllSurvive(), minTicks, bucketSpanTicks, bucketCount, fieldName, targetCodes, slotCounts, cancellationToken);
+
     public void BucketTimeTicksByEventId(long minTicks, long bucketSpanTicks, int bucketCount, int[] targetIds, int[] slotCounts, CancellationToken cancellationToken) =>
         _reader.BucketTimeTicksByEventId(AllSurvive(), minTicks, bucketSpanTicks, bucketCount, targetIds, slotCounts, cancellationToken);
 
@@ -29,6 +32,9 @@ internal sealed class LegacyEventColumnView(
 
     public void BucketTimeTicksBySeverity(long minTicks, long bucketSpanTicks, int bucketCount, int[] slotCounts, CancellationToken cancellationToken) =>
         _reader.BucketTimeTicksBySeverity(AllSurvive(), minTicks, bucketSpanTicks, bucketCount, slotCounts, cancellationToken);
+
+    public void CountEventDataValues(string fieldName, IDictionary<long, int> counts, CancellationToken cancellationToken) =>
+        _reader.CountEventDataValues(AllSurvive(), fieldName, counts, cancellationToken);
 
     public void CountEventIds(IDictionary<int, int> counts, CancellationToken cancellationToken) =>
         _reader.CountEventIds(AllSurvive(), counts, cancellationToken);

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/TimelineDefaultSortTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/TimelineDefaultSortTests.cs
@@ -19,7 +19,7 @@ public sealed class TimelineDefaultSortTests
     {
         // Grouping short-circuits the default, so the timeline flag cannot force a column sort.
         Assert.Null(
-            ResolvedEventOrdering.ResolveDefaultOrderBy(orderBy: null, ColumnName.Source, logCount: 1, timelineVisible: true));
+            ResolvedEventOrdering.ResolveDefaultOrderBy(orderBy: null, groupBy: ColumnName.Source, logCount: 1, timelineVisible: true));
     }
 
     [Fact]
@@ -28,7 +28,7 @@ public sealed class TimelineDefaultSortTests
         // An explicit column sort always wins over the timeline-driven default, even for a single log.
         Assert.Equal(
             ColumnName.EventId,
-            ResolvedEventOrdering.ResolveDefaultOrderBy(ColumnName.EventId, groupBy: null, logCount: 1, timelineVisible: true));
+            ResolvedEventOrdering.ResolveDefaultOrderBy(orderBy: ColumnName.EventId, groupBy: null, logCount: 1, timelineVisible: true));
     }
 
     [Theory]
@@ -41,11 +41,7 @@ public sealed class TimelineDefaultSortTests
         bool timelineVisible,
         ColumnName? expected)
     {
-        var resolved = ResolvedEventOrdering.ResolveDefaultOrderBy(
-            orderBy: null,
-            groupBy: null,
-            logCount,
-            timelineVisible);
+        var resolved = ResolvedEventOrdering.ResolveDefaultOrderBy(null, null, logCount, timelineVisible);
 
         Assert.Equal(expected, resolved);
     }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/TimelineDefaultSortTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/TimelineDefaultSortTests.cs
@@ -1,0 +1,144 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Runtime.Histogram;
+using EventLogExpert.Runtime.LogTable;
+using Reducers = EventLogExpert.Runtime.LogTable.Reducers;
+
+namespace EventLogExpert.Runtime.Tests.LogTable;
+
+public sealed class TimelineDefaultSortTests
+{
+    private static readonly DateTime s_baseTime = new(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void ResolveDefaultOrderBy_WhenGrouped_IgnoresTimeline()
+    {
+        // Grouping short-circuits the default, so the timeline flag cannot force a column sort.
+        Assert.Null(
+            ResolvedEventOrdering.ResolveDefaultOrderBy(orderBy: null, ColumnName.Source, logCount: 1, timelineVisible: true));
+    }
+
+    [Fact]
+    public void ResolveDefaultOrderBy_WithExplicitSort_IgnoresTimeline()
+    {
+        // An explicit column sort always wins over the timeline-driven default, even for a single log.
+        Assert.Equal(
+            ColumnName.EventId,
+            ResolvedEventOrdering.ResolveDefaultOrderBy(ColumnName.EventId, groupBy: null, logCount: 1, timelineVisible: true));
+    }
+
+    [Theory]
+    [InlineData(1, false, null)]                        // one log, timeline hidden -> Record ID (null)
+    [InlineData(1, true, ColumnName.DateAndTime)]       // one log, timeline shown -> Date/Time
+    [InlineData(2, false, ColumnName.DateAndTime)]      // combined view -> Date/Time regardless of the timeline
+    [InlineData(2, true, ColumnName.DateAndTime)]
+    public void ResolveDefaultOrderBy_WithoutExplicitSort_FollowsLogCountAndTimeline(
+        int logCount,
+        bool timelineVisible,
+        ColumnName? expected)
+    {
+        var resolved = ResolvedEventOrdering.ResolveDefaultOrderBy(
+            orderBy: null,
+            groupBy: null,
+            logCount,
+            timelineVisible);
+
+        Assert.Equal(expected, resolved);
+    }
+
+    [Fact]
+    public void SetHistogramVisible_OnCombinedView_FlipsFlagWithoutBumpingDisplayVersion()
+    {
+        var log1 = EventLogId.Create();
+        var log2 = EventLogId.Create();
+        var state = new LogTableState()
+            .WithLogEvents(log1, LogEvents("Log1"))
+            .WithLogEvents(log2, LogEvents("Log2"));
+        int before = state.DisplayListVersion;
+
+        var shown = Reducers.ReduceSetHistogramVisible(state, new SetHistogramVisibleAction(true));
+
+        // A combined view is Date/Time either way, so no republish follows and the version must not move (it would strand
+        // an in-flight republish carrying the pre-bump version).
+        Assert.True(shown.TimelineVisible);
+        Assert.Equal(before, shown.DisplayListVersion);
+    }
+
+    [Fact]
+    public void SetHistogramVisible_OnSingleDefaultLog_FlipsFlagAndBumpsDisplayVersion()
+    {
+        var logId = EventLogId.Create();
+        var state = new LogTableState().WithLogEvents(logId, OutOfRecordOrderEvents());
+        int before = state.DisplayListVersion;
+
+        var shown = Reducers.ReduceSetHistogramVisible(state, new SetHistogramVisibleAction(true));
+
+        Assert.True(shown.TimelineVisible);
+        Assert.Equal(before + 1, shown.DisplayListVersion);
+    }
+
+    [Fact]
+    public void SetHistogramVisible_WhenUnchanged_ReturnsSameState()
+    {
+        var logId = EventLogId.Create();
+        var state = new LogTableState { TimelineVisible = true }.WithLogEvents(logId, OutOfRecordOrderEvents());
+
+        var result = Reducers.ReduceSetHistogramVisible(state, new SetHistogramVisibleAction(true));
+
+        Assert.Same(state, result);
+    }
+
+    [Fact]
+    public void SetHistogramVisible_WithExplicitSort_FlipsFlagWithoutBumpingDisplayVersion()
+    {
+        var logId = EventLogId.Create();
+        var state = new LogTableState { RequestedOrderBy = ColumnName.EventId }
+            .WithLogEvents(logId, OutOfRecordOrderEvents());
+        int before = state.DisplayListVersion;
+
+        var shown = Reducers.ReduceSetHistogramVisible(state, new SetHistogramVisibleAction(true));
+
+        Assert.True(shown.TimelineVisible);
+        Assert.Equal(before, shown.DisplayListVersion);
+    }
+
+    [Fact]
+    public void SingleLog_WithTimelineHidden_OrdersByRecordId()
+    {
+        var logId = EventLogId.Create();
+        var state = new LogTableState { ActiveEventLogId = logId, TimelineVisible = false }
+            .WithLogEvents(logId, OutOfRecordOrderEvents());
+
+        Assert.Null(state.SortContext.OrderBy);
+        Assert.Equal(new long?[] { 3, 2, 1 }, DisplayedRecordIds(state));
+    }
+
+    [Fact]
+    public void SingleLog_WithTimelineVisible_OrdersByDateAndTime()
+    {
+        var logId = EventLogId.Create();
+        var state = new LogTableState { ActiveEventLogId = logId, TimelineVisible = true }
+            .WithLogEvents(logId, OutOfRecordOrderEvents());
+
+        Assert.Equal(ColumnName.DateAndTime, state.SortContext.OrderBy);
+
+        // Record IDs 1/2/3 carry times +3/+1/+2, so Date/Time descending is 1, 3, 2 (not the Record ID order 3, 2, 1).
+        Assert.Equal(new long?[] { 1, 3, 2 }, DisplayedRecordIds(state));
+    }
+
+    private static long?[] DisplayedRecordIds(LogTableState state) =>
+        [.. state.DisplayedEvents.EnumerateDetail().Select(resolved => resolved.RecordId)];
+
+    private static ResolvedEvent[] LogEvents(string owningLog) =>
+    [
+        new(owningLog, LogPathType.Channel) { Id = 10, RecordId = 1, TimeCreated = s_baseTime.AddMinutes(3) },
+        new(owningLog, LogPathType.Channel) { Id = 20, RecordId = 2, TimeCreated = s_baseTime.AddMinutes(1) },
+        new(owningLog, LogPathType.Channel) { Id = 30, RecordId = 3, TimeCreated = s_baseTime.AddMinutes(2) }
+    ];
+
+    private static ResolvedEvent[] OutOfRecordOrderEvents() => LogEvents("TestLog");
+}


### PR DESCRIPTION
## Summary

Three histogram follow-ups on top of the merged event-timeline feature (#650):

1. **EventData group-by dimensions**: adds **Logon Type** and **Ticket Encryption Type** to the timeline's Group by picker, decoded from a curated EventData allowlist.
2. **Removes the spike (anomaly) outline**: the tall bar already signals a volume spike, and the colored outline added no meaning for users unfamiliar with it.
3. **Timeline-aware single-log sort**: a single log's table now defaults to Date/Time order while the timeline is visible (so it reads in the same order as the time axis) and to Record ID order while it is hidden.

## EventData group-by (Logon Type / Ticket Encryption Type)

- A columnar Eventing scan (`CountEventDataValues` / `BucketTimeTicksByEventData`) buckets survivor-scoped time ticks keyed on the canonical numeric code, so a value written as `23`, `0x17`, or a typed integer folds into one band.
- A shared `EventDataValueDecoder` maps the code to a label (for example `2` to Interactive, `23` to AES256), reused by both the histogram and the Details Pane field explainer.
- Always shown, with an empty state ("No {dimension} values in this view.") when the field is absent in the current view; the Group by picker widened to fit the longer label.
- A direct-read path (`TryGetWholeNumberFromRawField`) reads the raw field bits without materializing an event property, keeping the scan allocation-free and O(1) per row.

## Timeline-aware single-log sort

- `ResolvedEventOrdering.ResolveDefaultOrderBy` now factors in timeline visibility: a single log with no explicit sort resolves to Date/Time when the timeline is shown and to Record ID when hidden. Combined views (always Date/Time) and explicit user sorts are unchanged.
- `LogTableState.TimelineVisible` mirrors the histogram's visibility (synced through `SetHistogramVisibleAction`). Toggling the timeline republishes the single-log view through the existing async sort pipeline, and the display-version bump is gated to that same case so it cannot strand an in-flight explicit-sort republish.

## Accessibility

- The removed spike outline keeps its non-visual equivalent: the keyboard bin-cursor still announces ", spike" for a statistically anomalous bin, so screen-reader users retain the cue that the tall bar gives sighted users.
- Follow-up tracked: a polite announcement when a timeline toggle reorders a single-log table (the header `aria-sort` reflects only explicit sorts today, matching the pre-existing default-sort behavior).

## Validation

- Test suites green: Eventing **665**, Runtime **1877**, UI **1121**. Touched projects build **0 warnings / 0 errors**.
- Governance: pre-implementation and post-code multi-model panels reached unanimous convergence on each change.

## Manual acceptance (WebView2)

- Group by **Logon Type** / **Ticket Encryption Type**; confirm the decoded band labels and the empty state on logs without those fields.
- Confirm the timeline no longer draws a colored outline around tall / spike bars.
- With a single log open, toggle **View > Timeline**: the table reorders to Date/Time (shown) versus Record ID (hidden), and an explicit column sort is not overridden.
