### PR TITLE
Dependency security updates and NSubstitute 6.0 upgrade

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,28 +13,39 @@
              dotnet list package, include-transitive) so the ExplorerExtension companion exe and
              the MAUI head share a single Microsoft.WindowsAppSDK version. -->
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.9" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.10" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
     <!-- TEMPORARY security override for CVE-2025-6965 (GHSA-2m69-gcr7-jv3q, High).
-         Microsoft.Data.Sqlite / Microsoft.EntityFrameworkCore.Sqlite 10.0.9 transitively pull
+         Microsoft.Data.Sqlite / Microsoft.EntityFrameworkCore.Sqlite 10.0.10 transitively pull
          SQLitePCLRaw.bundle_e_sqlite3 2.1.11 -> SQLitePCLRaw.lib.e_sqlite3 2.1.11 (SQLite < 3.50.2).
-         There is no 2.1.x patch; lib.e_sqlite3 3.50.3 is a native-only package (no managed deps) that
-         satisfies the bundle's [2.1.11, ) range, so this swaps in the SQLite 3.50.3 binary while keeping
-         the SQLitePCLRaw 2.x managed core. Remove once Microsoft.Data.Sqlite ships the upstream fix
+         The upstream fix (SQLitePCLRaw 3.x) ships only in the 11.0.0-preview line; latest stable
+         Microsoft.Data.Sqlite 10.0.10 still references the vulnerable bundle 2.1.11. lib.e_sqlite3
+         3.53.3 is a native-only package (no managed deps) that satisfies the bundle's [2.1.11, )
+         range, so this swaps in the patched SQLite 3.53.3 binary while keeping the SQLitePCLRaw 2.x
+         managed core. Remove once Microsoft.Data.Sqlite ships the fix on a stable channel
          (dotnet/efcore PR 38402, milestone 11.0-preview6). Tracked by:
          https://github.com/microsoft/EventLogExpert/issues/604 -->
-    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
-    <PackageVersion Include="Fluxor.Blazor.Web" Version="6.9.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.53.3" />
+    <PackageVersion Include="Fluxor.Blazor.Web" Version="6.10.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="xunit.v3.mtp-off" Version="3.2.2" />
     <PackageVersion Include="bunit" Version="2.7.2" />
+    <!-- Security override for CVE-2026-54570 (GHSA-pgww-w46g-26qg, moderate).
+         bunit 2.7.2 (test-only) transitively resolves AngleSharp 1.4.0, which mis-parses
+         MathML annotation-xml HTML integration points and does not escape &lt; or &gt; when
+         serializing attribute values (a mutation-XSS vector that can bypass sanitizers built
+         on AngleSharp). The fix first shipped in AngleSharp 1.5.0 and there is no 1.4.x patch,
+         so this pins the transitively-resolved core package to 1.5.2 (latest 1.5.x stable).
+         The sibling AngleSharp.Css / AngleSharp.Diffing packages are not covered by the
+         advisory. Remove once bunit ships an AngleSharp reference >= 1.5.0. -->
+    <PackageVersion Include="AngleSharp" Version="1.5.2" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,7 +32,7 @@
     <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.53.3" />
     <PackageVersion Include="Fluxor.Blazor.Web" Version="6.10.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="NSubstitute" Version="6.0.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />

--- a/tests/Integration/EventLogExpert.Runtime.IntegrationTests/Database/DatabaseServiceTests.cs
+++ b/tests/Integration/EventLogExpert.Runtime.IntegrationTests/Database/DatabaseServiceTests.cs
@@ -878,7 +878,7 @@ public sealed class DatabaseServiceTests : IDisposable
         Assert.Equal(DatabaseStatus.Ready, entry.Status);
 
         preferences.Received().DisabledDatabasesPreference =
-            Arg.Is<List<string>>(disabled => disabled.Contains(Constants.TestDb1, StringComparer.OrdinalIgnoreCase));
+            Arg.Is<List<string>>(disabled => disabled != null && disabled.Contains(Constants.TestDb1, StringComparer.OrdinalIgnoreCase));
     }
 
     [Fact]
@@ -914,7 +914,7 @@ public sealed class DatabaseServiceTests : IDisposable
         Assert.True(entry.IsEnabled);
 
         preferences.DidNotReceive().DisabledDatabasesPreference =
-            Arg.Is<List<string>>(disabled => disabled.Contains(Constants.TestDb1, StringComparer.OrdinalIgnoreCase));
+            Arg.Is<List<string>>(disabled => disabled != null && disabled.Contains(Constants.TestDb1, StringComparer.OrdinalIgnoreCase));
     }
 
     [Fact]
@@ -952,7 +952,7 @@ public sealed class DatabaseServiceTests : IDisposable
         Assert.Equal(DatabaseStatus.Ready, entry.Status);
 
         preferences.DidNotReceive().DisabledDatabasesPreference =
-            Arg.Is<List<string>>(disabled => disabled.Contains(Constants.TestDb1, StringComparer.OrdinalIgnoreCase));
+            Arg.Is<List<string>>(disabled => disabled != null && disabled.Contains(Constants.TestDb1, StringComparer.OrdinalIgnoreCase));
     }
 
     [Fact]
@@ -2040,7 +2040,7 @@ public sealed class DatabaseServiceTests : IDisposable
         Assert.False(service.Entries[0].IsEnabled);
 
         preferences.Received(1).DisabledDatabasesPreference =
-            Arg.Is<IEnumerable<string>>(disabled => disabled.Contains(Constants.TestDb1));
+            Arg.Is<IEnumerable<string>>(disabled => disabled != null && disabled.Contains(Constants.TestDb1));
     }
 
     [Fact]

--- a/tests/Integration/EventLogExpert.Runtime.IntegrationTests/FilterLibrary/FilterLibraryMigrationIntegrationTests.cs
+++ b/tests/Integration/EventLogExpert.Runtime.IntegrationTests/FilterLibrary/FilterLibraryMigrationIntegrationTests.cs
@@ -63,7 +63,7 @@ public sealed class FilterLibraryMigrationIntegrationTests : IDisposable
         Assert.Empty(await realStore.LoadAllAsync(TestContext.Current.CancellationToken));
         Assert.True(prefs.ContainsKey(FavoriteFiltersKey));
         Assert.False(prefs.ContainsKey(MigrationSectionsKey));
-        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a.Entries.IsEmpty));
+        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a != null && a.Entries.IsEmpty));
         dispatcher.DidNotReceive().Dispatch(Arg.Any<LoadLibraryFailureAction>());
     }
 
@@ -198,7 +198,7 @@ public sealed class FilterLibraryMigrationIntegrationTests : IDisposable
         Assert.Equal(2, filterSet.Filters.Count);
         Assert.Equal(LibraryEntryOrigin.UserSaved, filterSet.Origin);
 
-        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a.Entries.Count == 3));
+        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a != null && a.Entries.Count == 3));
         dispatcher.DidNotReceive().Dispatch(Arg.Any<LoadLibraryFailureAction>());
 
         Assert.True(prefs.ContainsKey(FavoriteFiltersKey));

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Alerts/AlertDialogServiceTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Alerts/AlertDialogServiceTests.cs
@@ -40,7 +40,7 @@ public sealed class ModalAlertDialogServiceTests
         // Assert
         Assert.Equal("typed-value", result);
         await host.Received(1).ShowInlineAlertAsync(
-            Arg.Is<InlineAlertRequest>(r => r.IsPrompt && r.Title == "Rename" && r.Message == "Enter new name"),
+            Arg.Is<InlineAlertRequest>(r => r != null && r.IsPrompt && r.Title == "Rename" && r.Message == "Enter new name"),
             Arg.Any<CancellationToken>());
     }
 
@@ -133,7 +133,7 @@ public sealed class ModalAlertDialogServiceTests
 
         var mainThread = Substitute.For<IMainThreadService>();
         mainThread.InvokeOnMainThreadAsync(Arg.Any<Func<Task>>())
-            .Returns(call => ((Func<Task>)call[0])());
+            .Returns(call => call.ArgAt<Func<Task>>(0)());
 
         var sut = new AlertDialogService(
             coordinator,
@@ -415,6 +415,7 @@ public sealed class ModalAlertDialogServiceTests
         Assert.False(standaloneCalled);
         await host.Received(1).ShowInlineAlertAsync(
             Arg.Is<InlineAlertRequest>(r =>
+                r != null &&
                 r.Title == "Confirm" &&
                 r.Message == "Are you sure?" &&
                 r.AcceptLabel == "Yes" &&

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Database/DatabaseOperationCoordinatorTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Database/DatabaseOperationCoordinatorTests.cs
@@ -65,8 +65,8 @@ public sealed class DatabaseOperationCoordinatorTests
         _databases.Received(1).Toggle("c.db");
         _databases.Received(1).Toggle("d.db");
         _databases.Received(1).Toggle("e.db");
-        _errorBanners.Received(1).ReportError("Failed to Update Database", Arg.Is<string>(m => m.Contains("c.db", StringComparison.Ordinal)));
-        _errorBanners.Received(1).ReportError("Failed to Update Database", Arg.Is<string>(m => m.Contains("e.db", StringComparison.Ordinal)));
+        _errorBanners.Received(1).ReportError("Failed to Update Database", Arg.Is<string>(m => m != null && m.Contains("c.db", StringComparison.Ordinal)));
+        _errorBanners.Received(1).ReportError("Failed to Update Database", Arg.Is<string>(m => m != null && m.Contains("e.db", StringComparison.Ordinal)));
         _errorBanners.Received(2).ReportError("Failed to Update Database", Arg.Any<string>());
     }
 
@@ -136,7 +136,7 @@ public sealed class DatabaseOperationCoordinatorTests
 
         await _databases.Received(1).ImportAsync(
             Arg.Any<IEnumerable<string>>(),
-            Arg.Is<IReadOnlySet<string>>(s => !s.Contains("exists.db")),
+            Arg.Is<IReadOnlySet<string>>(s => s != null && !s.Contains("exists.db")),
             Arg.Any<CancellationToken>());
     }
 
@@ -158,7 +158,7 @@ public sealed class DatabaseOperationCoordinatorTests
         // Conflict defaults to Skip because overwriting is riskier than importing nothing.
         await _databases.Received(1).ImportAsync(
             Arg.Any<IEnumerable<string>>(),
-            Arg.Is<IReadOnlySet<string>>(s => s.Contains("exists.db")),
+            Arg.Is<IReadOnlySet<string>>(s => s != null && s.Contains("exists.db")),
             Arg.Any<CancellationToken>());
         _errorBanners.DidNotReceiveWithAnyArgs().ReportError(null!, null!);
     }
@@ -175,7 +175,7 @@ public sealed class DatabaseOperationCoordinatorTests
         var sut = CreateSut();
         var outcome = await sut.ImportAsync(cancellationToken: Ct);
 
-        _errorBanners.Received(1).ReportError("Import Failed", Arg.Is<string>(m => m.Contains("boom", StringComparison.Ordinal)));
+        _errorBanners.Received(1).ReportError("Import Failed", Arg.Is<string>(m => m != null && m.Contains("boom", StringComparison.Ordinal)));
         _infoBanners.DidNotReceiveWithAnyArgs().ReportInfoBanner(null!, null!, default);
         Assert.Equal(ImportOutcome.None, outcome);
     }
@@ -218,7 +218,7 @@ public sealed class DatabaseOperationCoordinatorTests
 
         _infoBanners.Received(1).ReportInfoBanner(
             "Import Successful",
-            Arg.Is<string>(m => m.Contains("1 database has successfully been imported", StringComparison.Ordinal)),
+            Arg.Is<string>(m => m != null && m.Contains("1 database has successfully been imported", StringComparison.Ordinal)),
             BannerSeverity.Info);
         Assert.Equal(1, outcome.ImportedCount);
     }
@@ -253,7 +253,7 @@ public sealed class DatabaseOperationCoordinatorTests
 
         await _databases.Received(1).ImportAsync(
             Arg.Any<IEnumerable<string>>(),
-            Arg.Is<IReadOnlySet<string>>(s => s.Contains("exists.db")),
+            Arg.Is<IReadOnlySet<string>>(s => s != null && s.Contains("exists.db")),
             Arg.Any<CancellationToken>());
     }
 
@@ -306,7 +306,7 @@ public sealed class DatabaseOperationCoordinatorTests
 
         await _databases.Received(1).ImportAsync(
             Arg.Any<IEnumerable<string>>(),
-            Arg.Is<IReadOnlySet<string>>(skipFileNames => skipFileNames.Contains("A.db")),
+            Arg.Is<IReadOnlySet<string>>(skipFileNames => skipFileNames != null && skipFileNames.Contains("A.db")),
             Arg.Any<CancellationToken>());
     }
 
@@ -379,7 +379,7 @@ public sealed class DatabaseOperationCoordinatorTests
         var sut = CreateSut();
         var outcome = await sut.ImportAsync(cancellationToken: Ct);
 
-        _errorBanners.Received(1).ReportError("Import Failed", Arg.Is<string>(m => m.Contains("A.db (bad)", StringComparison.Ordinal)));
+        _errorBanners.Received(1).ReportError("Import Failed", Arg.Is<string>(m => m != null && m.Contains("A.db (bad)", StringComparison.Ordinal)));
         _infoBanners.DidNotReceiveWithAnyArgs().ReportInfoBanner(null!, null!, default);
         Assert.Equal(0, outcome.ImportedCount);
         Assert.False(outcome.DatabaseStateChanged);
@@ -398,7 +398,7 @@ public sealed class DatabaseOperationCoordinatorTests
         Assert.Equal(1, outcome.ImportedCount);
         await _filePicker.DidNotReceiveWithAnyArgs().PickMultipleAsync(null!, null!);
         await _databases.Received(1).ImportAsync(
-            Arg.Is<IEnumerable<string>>(paths => paths.SequenceEqual(new[] { @"C:\out\A.db" })),
+            Arg.Is<IEnumerable<string>>(paths => paths != null && paths.SequenceEqual(new[] { @"C:\out\A.db" })),
             Arg.Any<IReadOnlySet<string>>(),
             Arg.Any<CancellationToken>());
         _databases.DidNotReceiveWithAnyArgs().Toggle(null!);
@@ -462,7 +462,7 @@ public sealed class DatabaseOperationCoordinatorTests
         _logReload.Received(1).ReopenAfterDatabaseRemoval(Arg.Any<IReadOnlyList<LogReopenInfo>>());
         _errorBanners.Received(1).ReportError(
             "Failed to Remove Database",
-            Arg.Is<string>(m => m.Contains("removal failed mid-flight", StringComparison.Ordinal)));
+            Arg.Is<string>(m => m != null && m.Contains("removal failed mid-flight", StringComparison.Ordinal)));
     }
 
     [Fact]
@@ -601,7 +601,7 @@ public sealed class DatabaseOperationCoordinatorTests
         Assert.True(outcome.Removed);
         Assert.True(outcome.LogsReopened);
         _logReload.Received(1).ReopenAfterDatabaseRemoval(
-            Arg.Is<IReadOnlyList<LogReopenInfo>>(l => l.Count == 1 && l[0].Name == "Application"));
+            Arg.Is<IReadOnlyList<LogReopenInfo>>(l => l != null && l.Count == 1 && l[0].Name == "Application"));
         _errorBanners.DidNotReceiveWithAnyArgs().ReportError(null!, null!);
     }
 
@@ -644,7 +644,7 @@ public sealed class DatabaseOperationCoordinatorTests
         Assert.Equal(2, stateChangeCount);
         _errorBanners.Received(1).ReportError(
             "Database Upgrade Failed",
-            Arg.Is<string>(m => m.Contains("upgrade body failed", StringComparison.Ordinal)));
+            Arg.Is<string>(m => m != null && m.Contains("upgrade body failed", StringComparison.Ordinal)));
     }
 
     [Fact]
@@ -691,8 +691,8 @@ public sealed class DatabaseOperationCoordinatorTests
         var sut = CreateSut();
         await sut.UpgradeDatabaseAsync("a.db", cancellationToken: Ct);
 
-        _errorBanners.Received(1).ReportError("Database Upgrade Failed", Arg.Is<string>(m => m.Contains("a.db", StringComparison.Ordinal) && m.Contains("schema-mismatch", StringComparison.Ordinal)));
-        _errorBanners.Received(1).ReportError("Database Upgrade Failed", Arg.Is<string>(m => m.Contains("b.db", StringComparison.Ordinal) && m.Contains("io-error", StringComparison.Ordinal)));
+        _errorBanners.Received(1).ReportError("Database Upgrade Failed", Arg.Is<string>(m => m != null && m.Contains("a.db", StringComparison.Ordinal) && m.Contains("schema-mismatch", StringComparison.Ordinal)));
+        _errorBanners.Received(1).ReportError("Database Upgrade Failed", Arg.Is<string>(m => m != null && m.Contains("b.db", StringComparison.Ordinal) && m.Contains("io-error", StringComparison.Ordinal)));
     }
 
     [Theory]
@@ -735,7 +735,7 @@ public sealed class DatabaseOperationCoordinatorTests
         Assert.False(sut.IsAnyUpgradeInFlight);
         Assert.False(sut.IsUpgradeInFlight("a.db"));
         await _databases.Received(1).UpgradeBatchAsync(
-            Arg.Is<IReadOnlyList<string>>(l => l.Count == 1 && l[0] == "a.db"),
+            Arg.Is<IReadOnlyList<string>>(l => l != null && l.Count == 1 && l[0] == "a.db"),
             Arg.Any<UpgradeProgressScope>(),
             Arg.Any<CancellationToken>());
     }
@@ -769,7 +769,7 @@ public sealed class DatabaseOperationCoordinatorTests
         Assert.False(wasInFlightDuringExit, "Exit event should fire after file is removed");
         Assert.False(sut.IsAnyUpgradeInFlight);
         await _databases.Received(1).UpgradeBatchAsync(
-            Arg.Is<IReadOnlyList<string>>(l => l.Count == 1 && l[0] == "a.db"),
+            Arg.Is<IReadOnlyList<string>>(l => l != null && l.Count == 1 && l[0] == "a.db"),
             UpgradeProgressScope.ManageDatabasesTriggered,
             Arg.Any<CancellationToken>());
     }
@@ -842,8 +842,8 @@ public sealed class DatabaseOperationCoordinatorTests
         var actual = await sut.UpgradeDatabasesAsync(["a.db", "b.db", "c.db"], UpgradeProgressScope.ManageDatabasesTriggered, Ct);
 
         Assert.Same(result, actual);
-        _errorBanners.Received(1).ReportError("Database Upgrade Failed", Arg.Is<string>(s => s.Contains("b.db") && s.Contains("schema mismatch")));
-        _errorBanners.Received(1).ReportError("Database Upgrade Failed", Arg.Is<string>(s => s.Contains("c.db") && s.Contains("io error")));
+        _errorBanners.Received(1).ReportError("Database Upgrade Failed", Arg.Is<string>(s => s != null && s.Contains("b.db") && s.Contains("schema mismatch")));
+        _errorBanners.Received(1).ReportError("Database Upgrade Failed", Arg.Is<string>(s => s != null && s.Contains("c.db") && s.Contains("io error")));
     }
 
     [Fact]
@@ -893,7 +893,7 @@ public sealed class DatabaseOperationCoordinatorTests
         Assert.NotNull(result);
         Assert.Empty(result.Succeeded);
         Assert.False(sut.IsAnyUpgradeInFlight);
-        _errorBanners.Received(1).ReportError("Database Upgrade Failed", Arg.Is<string>(s => s.Contains("disk full")));
+        _errorBanners.Received(1).ReportError("Database Upgrade Failed", Arg.Is<string>(s => s != null && s.Contains("disk full")));
     }
 
     private static DatabaseEntry CreateEntry(

--- a/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/DatabaseCoordinationEffectsReloadTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/DatabaseCoordinationEffectsReloadTests.cs
@@ -71,7 +71,7 @@ public sealed class DatabaseCoordinationEffectsReloadTests
         using var cts = new CancellationTokenSource();
         _dispatcher.When(d => d.Dispatch(Arg.Any<CloseLogAction>())).Do(call =>
         {
-            var action = (CloseLogAction)call.Args()[0];
+            var action = call.ArgAt<CloseLogAction>(0);
 
             if (action.LogName == "Application")
             {
@@ -103,7 +103,7 @@ public sealed class DatabaseCoordinationEffectsReloadTests
 
         _dispatcher.When(d => d.Dispatch(Arg.Any<CloseLogAction>())).Do(call =>
         {
-            var action = (CloseLogAction)call.Args()[0];
+            var action = call.ArgAt<CloseLogAction>(0);
             _closeCoordinator.CompleteCloseFor(action.LogId);
         });
 
@@ -165,7 +165,7 @@ public sealed class DatabaseCoordinationEffectsReloadTests
                 return;
             }
 
-            var action = (CloseLogAction)call.Args()[0];
+            var action = call.ArgAt<CloseLogAction>(0);
             _closeCoordinator.CompleteCloseFor(action.LogId);
         });
 
@@ -203,15 +203,15 @@ public sealed class DatabaseCoordinationEffectsReloadTests
 
         _dispatcher.When(d => d.Dispatch(Arg.Any<CloseLogAction>())).Do(call =>
         {
-            var action = (CloseLogAction)call.Args()[0];
+            var action = call.ArgAt<CloseLogAction>(0);
             _closeCoordinator.CompleteCloseFor(action.LogId);
         });
 
         var sut = CreateSut();
         await sut.ReloadAllActiveLogsAsync(Ct);
 
-        _dispatcher.Received(1).Dispatch(Arg.Is<CloseLogAction>(a => a.LogName == "Application"));
-        _dispatcher.Received(1).Dispatch(Arg.Is<CloseLogAction>(a => a.LogName == "C:/path/security.evtx"));
+        _dispatcher.Received(1).Dispatch(Arg.Is<CloseLogAction>(a => a != null && a.LogName == "Application"));
+        _dispatcher.Received(1).Dispatch(Arg.Is<CloseLogAction>(a => a != null && a.LogName == "C:/path/security.evtx"));
         _dispatcher.DidNotReceive().Dispatch(Arg.Any<CloseAllLogsAction>());
         _eventLogCommands.Received(1).OpenLog("Application", LogPathType.Channel, Arg.Any<CancellationToken>());
         _eventLogCommands.Received(1).OpenLog("C:/path/security.evtx", LogPathType.File, Arg.Any<CancellationToken>());

--- a/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EffectsTests.cs
@@ -48,7 +48,7 @@ public sealed class EffectsTests
 
         // Assert
         mockDispatcher.Received(1)
-            .Dispatch(Arg.Is<EventBufferedAction>(a =>
+            .Dispatch(Arg.Is<EventBufferedAction>(a => a != null &&
                 a.IsFull == true && a.UpdatedBuffer.Count == EventLogState.MaxNewEvents));
     }
 
@@ -71,7 +71,7 @@ public sealed class EffectsTests
 
         // Assert
         mockDispatcher.Received(1)
-            .Dispatch(Arg.Is<EventBufferedAction>(a =>
+            .Dispatch(Arg.Is<EventBufferedAction>(a => a != null &&
                 a.UpdatedBuffer.Count == 1 && a.UpdatedBuffer[0] == newEvent));
     }
 
@@ -118,7 +118,7 @@ public sealed class EffectsTests
         await effects.HandleAddEvent(new AddEventAction(newEvent), mockDispatcher);
 
         // Assert: raw is ingested unconditionally (Prepend) even though the filtered display append is skipped.
-        mockDispatcher.Received(1).Dispatch(Arg.Is<IngestRawEventsAction>(a =>
+        mockDispatcher.Received(1).Dispatch(Arg.Is<IngestRawEventsAction>(a => a != null &&
             a.Mode == RawIngestMode.Prepend && a.EventsByLog.ContainsKey(logData.Id)));
         mockDispatcher.DidNotReceive().Dispatch(Arg.Any<AppendTableEventsAction>());
     }
@@ -149,7 +149,7 @@ public sealed class EffectsTests
         // post-ingest store is visible when HandleAddEvent rebuilds the display view over it.
         mockDispatcher
             .When(d => d.Dispatch(Arg.Any<IngestRawEventsAction>()))
-            .Do(callInfo => rawState = RawEventStoreReducers.ReduceIngestRawEvents(rawState, callInfo.Arg<IngestRawEventsAction>()));
+            .Do(callInfo => rawState = RawEventStoreReducers.ReduceIngestRawEvents(rawState, callInfo.ArgAt<IngestRawEventsAction>(0)));
 
         var newEvent = FilterEventBuilder.CreateTestEvent(100, logName: Constants.LogNameTestLog);
         var action = new AddEventAction(newEvent);
@@ -158,11 +158,11 @@ public sealed class EffectsTests
         await effects.HandleAddEvent(action, mockDispatcher);
 
         // Assert
-        mockDispatcher.Received(1).Dispatch(Arg.Is<IngestRawEventsAction>(a =>
+        mockDispatcher.Received(1).Dispatch(Arg.Is<IngestRawEventsAction>(a => a != null &&
             a.Mode == RawIngestMode.Prepend && a.EventsByLog.ContainsKey(logData.Id)));
 
         mockDispatcher.Received(1)
-            .Dispatch(Arg.Is<AppendTableEventsAction>(a =>
+            .Dispatch(Arg.Is<AppendTableEventsAction>(a => a != null &&
                 a.LogId == logData.Id && a.View != null && a.View.Count == 1 && a.View.EnumerateDetail().First().Id == newEvent.Id));
 
         mockDispatcher.DidNotReceive().Dispatch(Arg.Any<DisplayReadyAction>());
@@ -198,9 +198,9 @@ public sealed class EffectsTests
 
         Received.InOrder(() =>
         {
-            mockDispatcher.Dispatch(Arg.Is<SetFilterProgressAction>(a => a.IsLoading));
+            mockDispatcher.Dispatch(Arg.Is<SetFilterProgressAction>(a => a != null && a.IsLoading));
             mockDispatcher.Dispatch(Arg.Any<DisplayReadyAction>());
-            mockDispatcher.Dispatch(Arg.Is<SetFilterProgressAction>(a => !a.IsLoading));
+            mockDispatcher.Dispatch(Arg.Is<SetFilterProgressAction>(a => a != null && !a.IsLoading));
         });
     }
 
@@ -244,8 +244,8 @@ public sealed class EffectsTests
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => effects.HandleApplyFilter(action, mockDispatcher));
 
-        mockDispatcher.Received(1).Dispatch(Arg.Is<SetFilterProgressAction>(a => a.IsLoading));
-        mockDispatcher.Received(1).Dispatch(Arg.Is<SetFilterProgressAction>(a => !a.IsLoading));
+        mockDispatcher.Received(1).Dispatch(Arg.Is<SetFilterProgressAction>(a => a != null && a.IsLoading));
+        mockDispatcher.Received(1).Dispatch(Arg.Is<SetFilterProgressAction>(a => a != null && !a.IsLoading));
         mockDispatcher.DidNotReceive().Dispatch(Arg.Any<DisplayReadyAction>());
     }
 
@@ -287,7 +287,7 @@ public sealed class EffectsTests
         // The pass-1 snapshot saw only event 200 at ContentVersion 0; the post-build re-check saw the
         // finalize rebuild at ContentVersion 1 and refiltered, so the published view reflects all three.
         mockDispatcher.Received(1)
-            .Dispatch(Arg.Is<DisplayReadyAction>(a =>
+            .Dispatch(Arg.Is<DisplayReadyAction>(a => a != null &&
                 a.Views.ContainsKey(snapshotData.Id) &&
                 a.Views[snapshotData.Id].Count == finalizedRaw.Count &&
                 a.Views[snapshotData.Id].EnumerateDetail().Any(e => e.Id == 202)));
@@ -330,7 +330,7 @@ public sealed class EffectsTests
         // The pass-1 snapshot saw only event 100 at ContentVersion 0; the post-build re-check saw the
         // live-tail append at ContentVersion 1 and refiltered, so the published view includes event 101.
         mockDispatcher.Received(1)
-            .Dispatch(Arg.Is<DisplayReadyAction>(a =>
+            .Dispatch(Arg.Is<DisplayReadyAction>(a => a != null &&
                 a.Views.ContainsKey(snapshotData.Id) &&
                 a.Views[snapshotData.Id].Count == liveTailRaw.Count &&
                 a.Views[snapshotData.Id].EnumerateDetail().Any(e => e.Id == 101)));
@@ -373,7 +373,7 @@ public sealed class EffectsTests
         // Assert: the raw store dropped the log during the off-thread build (the post-snapshot reads
         // return an empty store), so the post-build re-check finds it gone and DisplayReady omits its slice.
         mockDispatcher.Received(1)
-            .Dispatch(Arg.Is<DisplayReadyAction>(a => !a.Views.ContainsKey(snapshotData.Id)));
+            .Dispatch(Arg.Is<DisplayReadyAction>(a => a != null && !a.Views.ContainsKey(snapshotData.Id)));
     }
 
     [Fact]
@@ -427,7 +427,7 @@ public sealed class EffectsTests
         // the live-tail rebuild at ContentVersion 1 and refiltered from current state, so the published view
         // reflects the updated row set (event 101), not the stale pass-1 rows.
         mockDispatcher.Received(1)
-            .Dispatch(Arg.Is<DisplayReadyAction>(a =>
+            .Dispatch(Arg.Is<DisplayReadyAction>(a => a != null &&
                 a.Views.ContainsKey(snapshotData.Id) &&
                 a.Views[snapshotData.Id].Count == liveTailRaw.Count &&
                 a.Views[snapshotData.Id].EnumerateDetail().Any(e => e.Id == 101)));
@@ -487,12 +487,12 @@ public sealed class EffectsTests
         // so the slice is still stale and omitted, and a convergence pass is scheduled while the progress
         // spinner stays on (cleared later by the converging pass).
         mockDispatcher.Received(1)
-            .Dispatch(Arg.Is<DisplayReadyAction>(a => !a.Views.ContainsKey(snapshotData.Id)));
+            .Dispatch(Arg.Is<DisplayReadyAction>(a => a != null && !a.Views.ContainsKey(snapshotData.Id)));
 
         mockDispatcher.Received(1)
-            .Dispatch(Arg.Is<ConvergeFilterAction>(a => a.StaleIds.Contains(snapshotData.Id)));
+            .Dispatch(Arg.Is<ConvergeFilterAction>(a => a != null && a.StaleIds.Contains(snapshotData.Id)));
 
-        mockDispatcher.DidNotReceive().Dispatch(Arg.Is<SetFilterProgressAction>(a => !a.IsLoading));
+        mockDispatcher.DidNotReceive().Dispatch(Arg.Is<SetFilterProgressAction>(a => a != null && !a.IsLoading));
     }
 
     [Fact]
@@ -524,7 +524,7 @@ public sealed class EffectsTests
         var superseded = 0;
 
         mockDispatcher
-            .When(d => d.Dispatch(Arg.Is<SetFilterProgressAction>(a => a.IsLoading)))
+            .When(d => d.Dispatch(Arg.Is<SetFilterProgressAction>(a => a != null && a.IsLoading)))
             .Do(_ =>
             {
                 if (Interlocked.Exchange(ref superseded, 1) == 0)
@@ -542,10 +542,10 @@ public sealed class EffectsTests
         await effects.HandleApplyFilter(new ApplyFilterAction(new Filter(null, [])), mockDispatcher);
 
         mockDispatcher.Received(1)
-            .Dispatch(Arg.Is<DisplayReadyAction>(a => a.Views[logData.Id].EnumerateDetail().Any(e => e.Id == 100)));
+            .Dispatch(Arg.Is<DisplayReadyAction>(a => a != null && a.Views[logData.Id].EnumerateDetail().Any(e => e.Id == 100)));
 
         // The stale run's finally was suppressed by the token guard, so only the fresh run cleared the spinner.
-        mockDispatcher.Received(1).Dispatch(Arg.Is<SetFilterProgressAction>(a => !a.IsLoading));
+        mockDispatcher.Received(1).Dispatch(Arg.Is<SetFilterProgressAction>(a => a != null && !a.IsLoading));
     }
 
     [Fact]
@@ -569,7 +569,7 @@ public sealed class EffectsTests
             .When(d => d.Dispatch(Arg.Any<CloseLogAction>()))
             .Do(callInfo =>
             {
-                closeTasks.Add(effects.HandleCloseLog(callInfo.Arg<CloseLogAction>(), mockDispatcher));
+                closeTasks.Add(effects.HandleCloseLog(callInfo.ArgAt<CloseLogAction>(0), mockDispatcher));
             });
 
         var xmlFilter = FilterBuilder.CreateTestFilter(FilterTestConstants.FilterXmlContainsData, isEnabled: true);
@@ -578,8 +578,8 @@ public sealed class EffectsTests
         await effects.HandleApplyFilter(action, mockDispatcher);
 
         Assert.True(action.Filter.RequiresXml);
-        mockDispatcher.Received(1).Dispatch(Arg.Is<SetFilterProgressAction>(a => !a.IsLoading));
-        mockDispatcher.DidNotReceive().Dispatch(Arg.Is<SetFilterProgressAction>(a => a.IsLoading));
+        mockDispatcher.Received(1).Dispatch(Arg.Is<SetFilterProgressAction>(a => a != null && !a.IsLoading));
+        mockDispatcher.DidNotReceive().Dispatch(Arg.Is<SetFilterProgressAction>(a => a != null && a.IsLoading));
 
         // Surface any HandleCloseLog faults before exiting the test.
         await Task.WhenAll(closeTasks);
@@ -637,7 +637,7 @@ public sealed class EffectsTests
             .When(d => d.Dispatch(Arg.Any<CloseLogAction>()))
             .Do(callInfo =>
             {
-                closeTasks.Add(effects.HandleCloseLog(callInfo.Arg<CloseLogAction>(), mockDispatcher));
+                closeTasks.Add(effects.HandleCloseLog(callInfo.ArgAt<CloseLogAction>(0), mockDispatcher));
             });
 
         // Hook the FIRST OpenLogAction dispatch to land CloseAll synchronously, which bumps
@@ -671,7 +671,7 @@ public sealed class EffectsTests
         mockDispatcher.Received(1).Dispatch(Arg.Any<OpenLogAction>());
 
         // The cleanup CloseLog targets the log we already reopened (Log1).
-        mockDispatcher.Received().Dispatch(Arg.Is<CloseLogAction>(a => a.LogName == Constants.LogNameLog1));
+        mockDispatcher.Received().Dispatch(Arg.Is<CloseLogAction>(a => a != null && a.LogName == Constants.LogNameLog1));
 
         // Surface any HandleCloseLog faults before exiting the test.
         await Task.WhenAll(closeTasks);
@@ -734,7 +734,7 @@ public sealed class EffectsTests
             .When(d => d.Dispatch(Arg.Any<CloseLogAction>()))
             .Do(callInfo =>
             {
-                closeTasks.Add(effects.HandleCloseLog(callInfo.Arg<CloseLogAction>(), mockDispatcher));
+                closeTasks.Add(effects.HandleCloseLog(callInfo.ArgAt<CloseLogAction>(0), mockDispatcher));
             });
 
         var xmlFilter = FilterBuilder.CreateTestFilter(FilterTestConstants.FilterXmlContainsData, isEnabled: true);
@@ -789,7 +789,7 @@ public sealed class EffectsTests
             .When(d => d.Dispatch(Arg.Any<CloseLogAction>()))
             .Do(callInfo =>
             {
-                closeTasks.Add(effects.HandleCloseLog(callInfo.Arg<CloseLogAction>(), mockDispatcher));
+                closeTasks.Add(effects.HandleCloseLog(callInfo.ArgAt<CloseLogAction>(0), mockDispatcher));
             });
 
         var xmlFilter = FilterBuilder.CreateTestFilter(FilterTestConstants.FilterXmlContainsData, isEnabled: true);
@@ -869,7 +869,7 @@ public sealed class EffectsTests
             .When(d => d.Dispatch(Arg.Any<CloseLogAction>()))
             .Do(callInfo =>
             {
-                closeTasks.Add(effects.HandleCloseLog(callInfo.Arg<CloseLogAction>(), mockDispatcher));
+                closeTasks.Add(effects.HandleCloseLog(callInfo.ArgAt<CloseLogAction>(0), mockDispatcher));
             });
 
         var xmlFilter = FilterBuilder.CreateTestFilter(FilterTestConstants.FilterXmlContainsData, isEnabled: true);
@@ -891,7 +891,7 @@ public sealed class EffectsTests
 
         // OpenLog should now have been dispatched (only happens after the close await).
         mockDispatcher.Received(1)
-            .Dispatch(Arg.Is<OpenLogAction>(a =>
+            .Dispatch(Arg.Is<OpenLogAction>(a => a != null &&
                 a.LogName == Constants.LogNameTestLog && a.LogPathType == LogPathType.Channel));
 
         // Surface any HandleCloseLog faults before exiting the test.
@@ -936,7 +936,7 @@ public sealed class EffectsTests
         var mockFilterService = Substitute.For<IFilterService>();
 
         mockFilterService.GetFilteredEvents(Arg.Any<IEnumerable<ResolvedEvent>>(), Arg.Any<Filter>())
-            .Returns(callInfo => callInfo.Arg<IEnumerable<ResolvedEvent>>().ToList());
+            .Returns(callInfo => callInfo.ArgAt<IEnumerable<ResolvedEvent>>(0).ToList());
 
         var mockServiceScopeFactory = Substitute.For<IServiceScopeFactory>();
         var mockServiceScope = Substitute.For<IServiceScope>();
@@ -972,7 +972,7 @@ public sealed class EffectsTests
             .When(d => d.Dispatch(Arg.Any<CloseLogAction>()))
             .Do(callInfo =>
             {
-                closeTasks.Add(effects.HandleCloseLog(callInfo.Arg<CloseLogAction>(), mockDispatcher));
+                closeTasks.Add(effects.HandleCloseLog(callInfo.ArgAt<CloseLogAction>(0), mockDispatcher));
             });
 
         var xmlFilter = FilterBuilder.CreateTestFilter(FilterTestConstants.FilterXmlContainsData, isEnabled: true);
@@ -987,7 +987,7 @@ public sealed class EffectsTests
 
         // Assert: SetSelectedEvents dispatched with exactly the restored event (RecordId=42).
         mockDispatcher.Received(1)
-            .Dispatch(Arg.Is<SetSelectedEventsAction>(a =>
+            .Dispatch(Arg.Is<SetSelectedEventsAction>(a => a != null &&
                 a.Selection.Count() == 1 && a.Selection.First().ReloadKey!.Value.RecordId == 42));
 
         // Surface any HandleCloseLog faults before exiting the test.
@@ -1013,7 +1013,7 @@ public sealed class EffectsTests
             .When(d => d.Dispatch(Arg.Any<CloseLogAction>()))
             .Do(callInfo =>
             {
-                closeTasks.Add(effects.HandleCloseLog(callInfo.Arg<CloseLogAction>(), mockDispatcher));
+                closeTasks.Add(effects.HandleCloseLog(callInfo.ArgAt<CloseLogAction>(0), mockDispatcher));
             });
 
         var xmlFilter = FilterBuilder.CreateTestFilter(FilterTestConstants.FilterXmlContainsData, isEnabled: true);
@@ -1027,11 +1027,11 @@ public sealed class EffectsTests
         Assert.True(filter.RequiresXml);
 
         mockDispatcher.Received(1)
-            .Dispatch(Arg.Is<CloseLogAction>(a =>
+            .Dispatch(Arg.Is<CloseLogAction>(a => a != null &&
                 a.LogName == Constants.LogNameTestLog && a.LogId == logData.Id));
 
         mockDispatcher.Received(1)
-            .Dispatch(Arg.Is<OpenLogAction>(a =>
+            .Dispatch(Arg.Is<OpenLogAction>(a => a != null &&
                 a.LogName == Constants.LogNameTestLog && a.LogPathType == LogPathType.Channel));
 
         // Reload path returns early; no DisplayReady until LoadEvents fires.
@@ -1065,7 +1065,7 @@ public sealed class EffectsTests
             .When(d => d.Dispatch(Arg.Any<CloseLogAction>()))
             .Do(callInfo =>
             {
-                closeTasks.Add(effects.HandleCloseLog(callInfo.Arg<CloseLogAction>(), mockDispatcher));
+                closeTasks.Add(effects.HandleCloseLog(callInfo.ArgAt<CloseLogAction>(0), mockDispatcher));
             });
 
         var xmlFilter1 = FilterBuilder.CreateTestFilter(FilterTestConstants.FilterXmlContainsData, isEnabled: true);
@@ -1094,7 +1094,7 @@ public sealed class EffectsTests
         // would not have happened if the round-2 guard had treated filter2's filter token
         // bump as supersession).
         mockDispatcher.Received(1)
-            .Dispatch(Arg.Is<OpenLogAction>(a =>
+            .Dispatch(Arg.Is<OpenLogAction>(a => a != null &&
                 a.LogName == Constants.LogNameTestLog && a.LogPathType == LogPathType.Channel));
 
         // Surface any HandleCloseLog faults before exiting the test.
@@ -1137,7 +1137,7 @@ public sealed class EffectsTests
         var superseded = 0;
 
         mockDispatcher
-            .When(d => d.Dispatch(Arg.Is<SetFilterProgressAction>(a => a.IsLoading)))
+            .When(d => d.Dispatch(Arg.Is<SetFilterProgressAction>(a => a != null && a.IsLoading)))
             .Do(_ =>
             {
                 if (Interlocked.Exchange(ref superseded, 1) == 0)
@@ -1153,7 +1153,7 @@ public sealed class EffectsTests
 
         // The stale filter-only run must NOT have dispatched its DisplayReady for id 999.
         mockDispatcher.DidNotReceive()
-            .Dispatch(Arg.Is<DisplayReadyAction>(a =>
+            .Dispatch(Arg.Is<DisplayReadyAction>(a => a != null &&
                 a.Views.ContainsKey(logData.Id) && a.Views[logData.Id].EnumerateDetail().Any(e => e.Id == 999)));
     }
 
@@ -1321,7 +1321,7 @@ public sealed class EffectsTests
         await mockLogWatcher.Received(1).RemoveLogAsync(Constants.LogNameTestLog);
 
         mockDispatcher.Received(1)
-            .Dispatch(Arg.Is<Runtime.LogTable.CloseLogAction>(a =>
+            .Dispatch(Arg.Is<Runtime.LogTable.CloseLogAction>(a => a != null &&
                 a.LogId == logId));
     }
 
@@ -1396,9 +1396,9 @@ public sealed class EffectsTests
 
         // Assert: converged slice published, progress cleared, no further convergence scheduled.
         mockDispatcher.Received(1)
-            .Dispatch(Arg.Is<DisplayReadyAction>(a => a.Views.ContainsKey(logData.Id)));
+            .Dispatch(Arg.Is<DisplayReadyAction>(a => a != null && a.Views.ContainsKey(logData.Id)));
 
-        mockDispatcher.Received(1).Dispatch(Arg.Is<SetFilterProgressAction>(a => !a.IsLoading));
+        mockDispatcher.Received(1).Dispatch(Arg.Is<SetFilterProgressAction>(a => a != null && !a.IsLoading));
 
         mockDispatcher.DidNotReceive().Dispatch(Arg.Any<ConvergeFilterAction>());
     }
@@ -1488,7 +1488,7 @@ public sealed class EffectsTests
 
         mockDispatcher.DidNotReceive().Dispatch(Arg.Any<DisplayReadyAction>());
         mockDispatcher.DidNotReceive().Dispatch(Arg.Any<ConvergeFilterAction>());
-        mockDispatcher.Received(1).Dispatch(Arg.Is<SetFilterProgressAction>(a => !a.IsLoading));
+        mockDispatcher.Received(1).Dispatch(Arg.Is<SetFilterProgressAction>(a => a != null && !a.IsLoading));
     }
 
     [Fact]
@@ -1531,7 +1531,7 @@ public sealed class EffectsTests
         await effects.HandleLoadEvents(action, mockDispatcher);
 
         // Assert: a pre-built display view for the finalized log is handed to the reducer.
-        mockDispatcher.Received(1).Dispatch(Arg.Is<UpdateTableAction>(a =>
+        mockDispatcher.Received(1).Dispatch(Arg.Is<UpdateTableAction>(a => a != null &&
             a.LogId == logData.Id && a.View != null && a.View.Count == 2));
     }
 
@@ -1548,7 +1548,7 @@ public sealed class EffectsTests
 
         await effects.HandleLoadNewEvents(mockDispatcher);
 
-        mockDispatcher.Received(1).Dispatch(Arg.Is<IngestRawEventsAction>(a =>
+        mockDispatcher.Received(1).Dispatch(Arg.Is<IngestRawEventsAction>(a => a != null &&
             a.Mode == RawIngestMode.Prepend && a.EventsByLog.ContainsKey(logData.Id)));
     }
 
@@ -1584,14 +1584,14 @@ public sealed class EffectsTests
         // visible in the store when the batch view is built.
         mockDispatcher
             .When(d => d.Dispatch(Arg.Any<IngestRawEventsAction>()))
-            .Do(callInfo => rawState = RawEventStoreReducers.ReduceIngestRawEvents(rawState, callInfo.Arg<IngestRawEventsAction>()));
+            .Do(callInfo => rawState = RawEventStoreReducers.ReduceIngestRawEvents(rawState, callInfo.ArgAt<IngestRawEventsAction>(0)));
 
         // Act
         await effects.HandleLoadNewEvents(mockDispatcher);
 
         // Assert
         mockDispatcher.Received(1)
-            .Dispatch(Arg.Is<AppendTableEventsBatchAction>(a =>
+            .Dispatch(Arg.Is<AppendTableEventsBatchAction>(a => a != null &&
                 a.ViewsByLog.Count == 1 &&
                 a.ViewsByLog.ContainsKey(logData.Id) &&
                 a.ViewsByLog[logData.Id].Count == 2));
@@ -1599,7 +1599,7 @@ public sealed class EffectsTests
         mockDispatcher.DidNotReceive().Dispatch(Arg.Any<DisplayReadyAction>());
 
         mockDispatcher.Received(1)
-            .Dispatch(Arg.Is<EventBufferedAction>(a =>
+            .Dispatch(Arg.Is<EventBufferedAction>(a => a != null &&
                 a.UpdatedBuffer.Count == 0 && a.IsFull == false));
     }
 
@@ -1628,7 +1628,7 @@ public sealed class EffectsTests
         mockDispatcher.DidNotReceive().Dispatch(Arg.Any<AppendTableEventsBatchAction>());
 
         mockDispatcher.Received(1)
-            .Dispatch(Arg.Is<EventBufferedAction>(a =>
+            .Dispatch(Arg.Is<EventBufferedAction>(a => a != null &&
                 a.UpdatedBuffer.Count == 0 && a.IsFull == false));
     }
 
@@ -1670,13 +1670,13 @@ public sealed class EffectsTests
         // single batch view is built.
         mockDispatcher
             .When(d => d.Dispatch(Arg.Any<IngestRawEventsAction>()))
-            .Do(callInfo => rawState = RawEventStoreReducers.ReduceIngestRawEvents(rawState, callInfo.Arg<IngestRawEventsAction>()));
+            .Do(callInfo => rawState = RawEventStoreReducers.ReduceIngestRawEvents(rawState, callInfo.ArgAt<IngestRawEventsAction>(0)));
 
         AppendTableEventsBatchAction? captured = null;
 
         mockDispatcher
             .When(dispatcher => dispatcher.Dispatch(Arg.Any<AppendTableEventsBatchAction>()))
-            .Do(call => captured = (AppendTableEventsBatchAction)call.Args()[0]);
+            .Do(call => captured = call.ArgAt<AppendTableEventsBatchAction>(0));
 
         // Act
         await effects.HandleLoadNewEvents(mockDispatcher);
@@ -2028,7 +2028,7 @@ public sealed class EffectsTests
         await openLog.HandleOpenLog(new OpenLogAction(Constants.LogNameApplication, LogPathType.Channel), dispatcher);
 
         // A log that fails to open surfaces an error instead of a misleading empty final load, and never seeds the watcher.
-        dispatcher.Received().Dispatch(Arg.Is<SetResolverStatusAction>(a =>
+        dispatcher.Received().Dispatch(Arg.Is<SetResolverStatusAction>(a => a != null &&
             a.ResolverStatus.Contains("Error") && a.ResolverStatus.Contains(Constants.LogNameApplication)));
         Assert.Empty(dispatcher.ReceivedCalls().Select(call => call.GetArguments()[0]).OfType<LoadEventsAction>());
         watcher.DidNotReceive().AddLog(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
@@ -2049,7 +2049,7 @@ public sealed class EffectsTests
         await openLog.HandleOpenLog(new OpenLogAction(Constants.LogNameApplication, LogPathType.Channel), dispatcher);
 
         // A read that stops on a Win32 error is surfaced as a failure, not dispatched as a successful final load.
-        dispatcher.Received().Dispatch(Arg.Is<SetResolverStatusAction>(a =>
+        dispatcher.Received().Dispatch(Arg.Is<SetResolverStatusAction>(a => a != null &&
             a.ResolverStatus.Contains("Error") && a.ResolverStatus.Contains(Constants.LogNameApplication)));
         Assert.Empty(dispatcher.ReceivedCalls().Select(call => call.GetArguments()[0]).OfType<LoadEventsAction>());
     }
@@ -2071,8 +2071,8 @@ public sealed class EffectsTests
 
         await effects.HandleOpenLog(action, mockDispatcher);
 
-        mockDispatcher.Received(1).Dispatch(Arg.Is<AddTableAction>(a => a.LogData.Id == logData.Id));
-        mockDispatcher.Received().Dispatch(Arg.Is<CloseLogAction>(a => a.LogId == logData.Id));
+        mockDispatcher.Received(1).Dispatch(Arg.Is<AddTableAction>(a => a != null && a.LogData.Id == logData.Id));
+        mockDispatcher.Received().Dispatch(Arg.Is<CloseLogAction>(a => a != null && a.LogId == logData.Id));
     }
 
     [Fact]
@@ -2111,7 +2111,7 @@ public sealed class EffectsTests
 
         // Assert
         mockDispatcher.Received(1)
-            .Dispatch(Arg.Is<SetResolverStatusAction>(a =>
+            .Dispatch(Arg.Is<SetResolverStatusAction>(a => a != null &&
                 a.ResolverStatus.Contains("Error") && a.ResolverStatus.Contains(Constants.LogNameTestLog)));
     }
 
@@ -2133,7 +2133,7 @@ public sealed class EffectsTests
 
         // Assert
         mockDispatcher.Received(1)
-            .Dispatch(Arg.Is<SetResolverStatusAction>(a =>
+            .Dispatch(Arg.Is<SetResolverStatusAction>(a => a != null &&
                 a.ResolverStatus.Contains("Error")));
     }
 
@@ -2219,7 +2219,7 @@ public sealed class EffectsTests
 
         await effects.Filtering.HandleSetOrderBy(new SetOrderByAction(ColumnName.Source), mockDispatcher);
 
-        mockDispatcher.Received(1).Dispatch(Arg.Is<DisplayReadyAction>(a =>
+        mockDispatcher.Received(1).Dispatch(Arg.Is<DisplayReadyAction>(a => a != null &&
             a.Version == 7 &&
             a.Views.ContainsKey(logData.Id) &&
             a.Views[logData.Id].HasContext(new SortContext(ColumnName.Source, true, null, false))));
@@ -2326,7 +2326,7 @@ public sealed class EffectsTests
 
         await effects.Filtering.HandleUpdateTable(mockDispatcher);
 
-        mockDispatcher.Received(1).Dispatch(Arg.Is<DisplayReadyAction>(a =>
+        mockDispatcher.Received(1).Dispatch(Arg.Is<DisplayReadyAction>(a => a != null &&
             a.Version == 7 &&
             a.Views.ContainsKey(logData.Id) &&
             a.Views[logData.Id].HasContext(new SortContext(ColumnName.Source, true, null, false))));
@@ -2370,7 +2370,7 @@ public sealed class EffectsTests
         await effects.Filtering.HandleUpdateTable(mockDispatcher);
 
         var requested = new SortContext(ColumnName.Source, true, null, false);
-        mockDispatcher.Received(1).Dispatch(Arg.Is<DisplayReadyAction>(a =>
+        mockDispatcher.Received(1).Dispatch(Arg.Is<DisplayReadyAction>(a => a != null &&
             a.Version == 3 &&
             a.Views.ContainsKey(logA.Id) && a.Views[logA.Id].HasContext(requested) &&
             a.Views.ContainsKey(logB.Id) && a.Views[logB.Id].HasContext(requested)));
@@ -2394,11 +2394,11 @@ public sealed class EffectsTests
 
         // Assert
         mockDispatcher.Received(1)
-            .Dispatch(Arg.Is<OpenLogAction>(a =>
+            .Dispatch(Arg.Is<OpenLogAction>(a => a != null &&
                 a.LogName == Constants.LogNameLog1 && a.LogPathType == LogPathType.Channel));
 
         mockDispatcher.Received(1)
-            .Dispatch(Arg.Is<OpenLogAction>(a =>
+            .Dispatch(Arg.Is<OpenLogAction>(a => a != null &&
                 a.LogName == Constants.LogNameLog2 && a.LogPathType == LogPathType.File));
     }
 
@@ -2561,7 +2561,7 @@ public sealed class EffectsTests
         var resolver = Substitute.For<IEventResolver>();
         resolver.ResolveEvent(Arg.Any<EventRecord>()).Returns(callInfo =>
         {
-            var record = callInfo.Arg<EventRecord>();
+            var record = callInfo.ArgAt<EventRecord>(0);
 
             if (resolveDelayMs is not null)
             {
@@ -2639,7 +2639,7 @@ public sealed class EffectsTests
             .Returns(new Dictionary<EventLogId, IReadOnlyList<ResolvedEvent>>());
 
         mockFilterService.GetFilteredEvents(Arg.Any<IEnumerable<ResolvedEvent>>(), Arg.Any<Filter>())
-            .Returns(callInfo => callInfo.Arg<IEnumerable<ResolvedEvent>>().ToList());
+            .Returns(callInfo => callInfo.ArgAt<IEnumerable<ResolvedEvent>>(0).ToList());
 
         var mockLogger = Substitute.For<ITraceLogger>();
         var mockLogWatcherService = Substitute.For<ILogWatcherService>();
@@ -2762,7 +2762,7 @@ public sealed class EffectsTests
             .Returns(new Dictionary<EventLogId, IReadOnlyList<ResolvedEvent>>());
 
         mockFilterService.GetFilteredEvents(Arg.Any<IEnumerable<ResolvedEvent>>(), Arg.Any<Filter>())
-            .Returns(callInfo => callInfo.Arg<IEnumerable<ResolvedEvent>>().ToList());
+            .Returns(callInfo => callInfo.ArgAt<IEnumerable<ResolvedEvent>>(0).ToList());
 
         var mockLogger = Substitute.For<ITraceLogger>();
         var mockLogWatcherService = Substitute.For<ILogWatcherService>();
@@ -2825,7 +2825,7 @@ public sealed class EffectsTests
             .Returns(new Dictionary<EventLogId, IReadOnlyList<ResolvedEvent>>());
 
         mockFilterService.GetFilteredEvents(Arg.Any<IEnumerable<ResolvedEvent>>(), Arg.Any<Filter>())
-            .Returns(callInfo => callInfo.Arg<IEnumerable<ResolvedEvent>>().ToList());
+            .Returns(callInfo => callInfo.ArgAt<IEnumerable<ResolvedEvent>>(0).ToList());
 
         var mockLogger = Substitute.For<ITraceLogger>();
         var mockLogWatcherService = Substitute.For<ILogWatcherService>();

--- a/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/PartialLoadCoordinatorTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/PartialLoadCoordinatorTests.cs
@@ -185,7 +185,7 @@ public sealed class PartialLoadCoordinatorTests
     {
         var dispatched = new List<object>();
         var dispatcher = Substitute.For<IDispatcher>();
-        dispatcher.When(d => d.Dispatch(Arg.Any<object>())).Do(call => dispatched.Add(call.Arg<object>()));
+        dispatcher.When(d => d.Dispatch(Arg.Any<object>())).Do(call => dispatched.Add(call.ArgAt<object>(0)));
 
         var storeHolder = new StoreHolder();
         var rawState = Substitute.For<IState<RawEventStoreState>>();

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensCommandsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensCommandsTests.cs
@@ -27,7 +27,8 @@ public sealed class FilterLensCommandsTests
 
         new FilterLensCommands(dispatcher).RemoveLens(lens);
 
-        dispatcher.Received(1).Dispatch(Arg.Is<RemoveFilterLensAction>(action => action.Lens == lens));
+        dispatcher.Received(1).Dispatch(Arg.Is<RemoveFilterLensAction>(action =>
+            action != null && action.Lens == lens));
     }
 
     [Theory]
@@ -44,6 +45,7 @@ public sealed class FilterLensCommandsTests
             new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc), TimeSpan.FromSeconds(seconds), TimeZoneInfo.Utc);
 
         dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action =>
+            action != null &&
             action.Lens.Label.EndsWith(expectedSuffix, StringComparison.Ordinal)));
     }
 
@@ -56,6 +58,7 @@ public sealed class FilterLensCommandsTests
         new FilterLensCommands(dispatcher).ShowEventsNearTime(anchor, TimeSpan.FromMinutes(5), TimeZoneInfo.Utc);
 
         dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action =>
+            action != null &&
             action.Lens.Kind == LensKind.TimeWindow &&
             action.Lens.Window != null &&
             action.Lens.Window.IsEnabled &&
@@ -73,6 +76,7 @@ public sealed class FilterLensCommandsTests
             new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc), TimeSpan.FromSeconds(90), TimeZoneInfo.Utc);
 
         dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action =>
+            action != null &&
             action.Lens.Label.EndsWith("\u00b190s", StringComparison.Ordinal)));
     }
 
@@ -89,6 +93,7 @@ public sealed class FilterLensCommandsTests
         // Built with the same culture-sensitive ":T" the production label uses, so the assertion holds under any ambient
         // culture; the anchor renders in the +5 display zone (17:00:00), not UTC (12:00:00).
         dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action =>
+            action != null &&
             action.Lens.Label == $"Near {expectedAnchor:T} \u00b15m"));
     }
 
@@ -103,6 +108,7 @@ public sealed class FilterLensCommandsTests
             DateTime.MinValue, TimeSpan.FromSeconds(30), TimeZoneInfo.Utc);
 
         dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action =>
+            action != null &&
             action.Lens.Window!.After == DateTime.MinValue &&
             action.Lens.Window.Before == DateTime.MinValue.AddSeconds(30)));
     }
@@ -158,7 +164,8 @@ public sealed class FilterLensCommandsTests
         new FilterLensCommands(dispatcher).ShowEventsNearTime(
             new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc), TimeSpan.FromMinutes(5), TimeZoneInfo.Utc, "LogA");
 
-        dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action => action.Lens.OriginLog == "LogA"));
+        dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action =>
+            action != null && action.Lens.OriginLog == "LogA"));
     }
 
     [Fact]
@@ -170,6 +177,7 @@ public sealed class FilterLensCommandsTests
         new FilterLensCommands(dispatcher).ShowParentActivity(relatedActivityId);
 
         dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action =>
+            action != null &&
             action.Lens.Label == $"Parent Activity = {relatedActivityId}" &&
             action.Lens.ExcludeFilters.Count == 1 &&
             action.Lens.ExcludeFilters[0].Compiled != null &&
@@ -194,7 +202,8 @@ public sealed class FilterLensCommandsTests
 
         new FilterLensCommands(dispatcher).ShowParentActivity(Guid.NewGuid(), "LogA");
 
-        dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action => action.Lens.OriginLog == "LogA"));
+        dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action =>
+            action != null && action.Lens.OriginLog == "LogA"));
     }
 
     [Fact]
@@ -205,6 +214,7 @@ public sealed class FilterLensCommandsTests
         new FilterLensCommands(dispatcher).ShowRelatedByActivityId(Guid.NewGuid());
 
         dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action =>
+            action != null &&
             action.Lens.Kind == LensKind.Property &&
             action.Lens.ExcludeFilters.Count == 1 &&
             action.Lens.ExcludeFilters[0].IsExcluded &&
@@ -228,7 +238,8 @@ public sealed class FilterLensCommandsTests
 
         new FilterLensCommands(dispatcher).ShowRelatedByActivityId(Guid.NewGuid(), "LogA");
 
-        dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action => action.Lens.OriginLog == "LogA"));
+        dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action =>
+            action != null && action.Lens.OriginLog == "LogA"));
     }
 
     [Fact]
@@ -240,6 +251,7 @@ public sealed class FilterLensCommandsTests
         new FilterLensCommands(dispatcher).ShowRelatedByRelatedActivityId(id);
 
         dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action =>
+            action != null &&
             action.Lens.Label == $"Related Activity ID = {id}" &&
             action.Lens.ExcludeFilters.Count == 1 &&
             action.Lens.ExcludeFilters[0].IsExcluded &&
@@ -264,7 +276,8 @@ public sealed class FilterLensCommandsTests
 
         new FilterLensCommands(dispatcher).ShowRelatedByRelatedActivityId(Guid.NewGuid(), "LogA");
 
-        dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action => action.Lens.OriginLog == "LogA"));
+        dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action =>
+            action != null && action.Lens.OriginLog == "LogA"));
     }
 
     [Fact]
@@ -277,6 +290,7 @@ public sealed class FilterLensCommandsTests
         new FilterLensCommands(dispatcher).ShowTimeRange(start, end, TimeZoneInfo.Utc);
 
         dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action =>
+            action != null &&
             action.Lens.Kind == LensKind.TimeWindow &&
             action.Lens.Window != null &&
             action.Lens.Window.IsEnabled &&
@@ -294,6 +308,7 @@ public sealed class FilterLensCommandsTests
         new FilterLensCommands(dispatcher).ShowTimeRange(later, earlier, TimeZoneInfo.Utc);
 
         dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action =>
+            action != null &&
             action.Lens.Window!.After == earlier &&
             action.Lens.Window.Before == later));
     }
@@ -309,6 +324,7 @@ public sealed class FilterLensCommandsTests
             TimeZoneInfo.Utc,
             "LogA");
 
-        dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action => action.Lens.OriginLog == "LogA"));
+        dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action =>
+            action != null && action.Lens.OriginLog == "LogA"));
     }
 }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensEffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensEffectsTests.cs
@@ -43,7 +43,8 @@ public sealed class FilterLensEffectsTests
 
         await effects.HandleLogClosedByUser(new LogClosedByUserAction(EventLogId.Create(), "LogA"), dispatcher);
 
-        dispatcher.Received(1).Dispatch(Arg.Is<RemoveLensesForLogAction>(action => action.LogName == "LogA"));
+        dispatcher.Received(1).Dispatch(Arg.Is<RemoveLensesForLogAction>(action =>
+            action != null && action.LogName == "LogA"));
     }
 
     [Fact]
@@ -71,6 +72,7 @@ public sealed class FilterLensEffectsTests
         await effects.HandlePush(new PushFilterLensAction(lens), dispatcher);
 
         dispatcher.Received(1).Dispatch(Arg.Is<ApplyFilterAction>(action =>
+            action != null &&
             action.Filter.Filters.Count == 2 &&
             action.Filter.Filters.Count(filter => filter.IsExcluded) == 1 &&
             action.Filter.Filters.Count(filter => !filter.IsExcluded) == 1));

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLibrary/FilterLibraryCommandsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLibrary/FilterLibraryCommandsTests.cs
@@ -20,7 +20,7 @@ public sealed class FilterLibraryCommandsTests
 
         sut.AddEntry(entry);
 
-        dispatcher.Received(1).Dispatch(Arg.Is<AddLibraryEntryAction>(a => ReferenceEquals(a.Entry, entry)));
+        dispatcher.Received(1).Dispatch(Arg.Is<AddLibraryEntryAction>(a => a != null && ReferenceEquals(a.Entry, entry)));
     }
 
     [Fact]
@@ -35,7 +35,7 @@ public sealed class FilterLibraryCommandsTests
 
         sut.AddFilterToExistingFilterSet(filterSetId, filter, source);
 
-        dispatcher.Received(1).Dispatch(Arg.Is<AddFilterToExistingFilterSetAction>(a =>
+        dispatcher.Received(1).Dispatch(Arg.Is<AddFilterToExistingFilterSetAction>(a => a != null &&
             a.FilterSetId == filterSetId && a.SourceEntryId == source && ReferenceEquals(a.Filter, filter)));
     }
 
@@ -49,7 +49,7 @@ public sealed class FilterLibraryCommandsTests
 
         sut.AddFilterToNewFilterSet("New", filter, sourceEntryId: null);
 
-        dispatcher.Received(1).Dispatch(Arg.Is<AddFilterToNewFilterSetAction>(a =>
+        dispatcher.Received(1).Dispatch(Arg.Is<AddFilterToNewFilterSetAction>(a => a != null &&
             a.NewFilterSetName == "New" && a.SourceEntryId == null && ReferenceEquals(a.Filter, filter)));
     }
 
@@ -62,7 +62,7 @@ public sealed class FilterLibraryCommandsTests
 
         sut.ApplyEntry(id);
 
-        dispatcher.Received(1).Dispatch(Arg.Is<ApplyLibraryEntryAction>(a => a.EntryId == id));
+        dispatcher.Received(1).Dispatch(Arg.Is<ApplyLibraryEntryAction>(a => a != null && a.EntryId == id));
     }
 
     [Fact]
@@ -74,7 +74,7 @@ public sealed class FilterLibraryCommandsTests
 
         sut.DeleteEntry(id);
 
-        dispatcher.Received(1).Dispatch(Arg.Is<DeleteLibraryEntryAction>(a => a.EntryId == id));
+        dispatcher.Received(1).Dispatch(Arg.Is<DeleteLibraryEntryAction>(a => a != null && a.EntryId == id));
     }
 
     [Fact]
@@ -101,7 +101,7 @@ public sealed class FilterLibraryCommandsTests
 
         sut.RecordFilterApplied(filter);
 
-        dispatcher.Received(1).Dispatch(Arg.Is<RecordFilterAppliedAction>(a => ReferenceEquals(a.Filter, filter)));
+        dispatcher.Received(1).Dispatch(Arg.Is<RecordFilterAppliedAction>(a => a != null && ReferenceEquals(a.Filter, filter)));
     }
 
     [Fact]
@@ -113,7 +113,7 @@ public sealed class FilterLibraryCommandsTests
 
         sut.ReplaceWithEntry(id);
 
-        dispatcher.Received(1).Dispatch(Arg.Is<ReplaceWithLibraryEntryAction>(a => a.EntryId == id));
+        dispatcher.Received(1).Dispatch(Arg.Is<ReplaceWithLibraryEntryAction>(a => a != null && a.EntryId == id));
     }
 
     [Fact]
@@ -125,7 +125,7 @@ public sealed class FilterLibraryCommandsTests
 
         sut.SaveEntry(id);
 
-        dispatcher.Received(1).Dispatch(Arg.Is<SaveEntryAction>(a => a.EntryId == id));
+        dispatcher.Received(1).Dispatch(Arg.Is<SaveEntryAction>(a => a != null && a.EntryId == id));
     }
 
     [Fact]
@@ -139,7 +139,7 @@ public sealed class FilterLibraryCommandsTests
 
         sut.SaveFilterSet("My Preset", filters);
 
-        dispatcher.Received(1).Dispatch(Arg.Is<SaveFilterSetAction>(a => a.Name == "My Preset" && a.Filters == filters));
+        dispatcher.Received(1).Dispatch(Arg.Is<SaveFilterSetAction>(a => a != null && a.Name == "My Preset" && a.Filters == filters));
     }
 
     [Fact]
@@ -150,7 +150,7 @@ public sealed class FilterLibraryCommandsTests
 
         sut.SavePaneAsFilterSet("My Preset");
 
-        dispatcher.Received(1).Dispatch(Arg.Is<SavePaneAsFilterSetAction>(a => a.Name == "My Preset"));
+        dispatcher.Received(1).Dispatch(Arg.Is<SavePaneAsFilterSetAction>(a => a != null && a.Name == "My Preset"));
     }
 
     [Fact]
@@ -162,7 +162,7 @@ public sealed class FilterLibraryCommandsTests
 
         sut.SetIsFavorite(id, isFavorite: true);
 
-        dispatcher.Received(1).Dispatch(Arg.Is<SetIsFavoriteAction>(a => a.EntryId == id && a.IsFavorite));
+        dispatcher.Received(1).Dispatch(Arg.Is<SetIsFavoriteAction>(a => a != null && a.EntryId == id && a.IsFavorite));
     }
 
     [Fact]
@@ -174,7 +174,7 @@ public sealed class FilterLibraryCommandsTests
 
         sut.UpdateEntry(entry);
 
-        dispatcher.Received(1).Dispatch(Arg.Is<UpdateLibraryEntryAction>(a => ReferenceEquals(a.Entry, entry)));
+        dispatcher.Received(1).Dispatch(Arg.Is<UpdateLibraryEntryAction>(a => a != null && ReferenceEquals(a.Entry, entry)));
     }
 
     [Fact]
@@ -185,7 +185,7 @@ public sealed class FilterLibraryCommandsTests
 
         sut.RenameTag("bug", "defect");
 
-        dispatcher.Received(1).Dispatch(Arg.Is<RenameTagAction>(a => a.OldName == "bug" && a.NewName == "defect"));
+        dispatcher.Received(1).Dispatch(Arg.Is<RenameTagAction>(a => a != null && a.OldName == "bug" && a.NewName == "defect"));
     }
 
     [Fact]
@@ -196,7 +196,7 @@ public sealed class FilterLibraryCommandsTests
 
         sut.DeleteTag("bug");
 
-        dispatcher.Received(1).Dispatch(Arg.Is<DeleteTagAction>(a => a.Name == "bug"));
+        dispatcher.Received(1).Dispatch(Arg.Is<DeleteTagAction>(a => a != null && a.Name == "bug"));
     }
 
     private static LibraryEntry BuildEntry()

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLibrary/FilterLibraryEffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLibrary/FilterLibraryEffectsTests.cs
@@ -34,7 +34,7 @@ public sealed class FilterLibraryEffectsTests
                 bulkCalls++;
                 if (bulkCalls == 1)
                 {
-                    var list = (IReadOnlyList<LibraryEntry>)call[0];
+                    var list = call.ArgAt<IReadOnlyList<LibraryEntry>>(0);
                     return Task.FromResult<IReadOnlyList<LibraryEntryId>>(list.Select(e => e.Id).ToList());
                 }
 
@@ -94,9 +94,9 @@ public sealed class FilterLibraryEffectsTests
             dispatcher);
 
         // Did NOT update the filter set (duplicate).
-        await store.DidNotReceive().UpdateAsync(Arg.Is<LibraryEntry>(e => e.Id == filterSet.Id), Arg.Any<CancellationToken>());
+        await store.DidNotReceive().UpdateAsync(Arg.Is<LibraryEntry>(e => e != null && e.Id == filterSet.Id), Arg.Any<CancellationToken>());
         // But DID promote the source.
-        await store.Received(1).UpdateAsync(Arg.Is<LibraryEntry>(e => e.Id == source.Id && e.Origin == LibraryEntryOrigin.UserSaved), Arg.Any<CancellationToken>());
+        await store.Received(1).UpdateAsync(Arg.Is<LibraryEntry>(e => e != null && e.Id == source.Id && e.Origin == LibraryEntryOrigin.UserSaved), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -147,7 +147,7 @@ public sealed class FilterLibraryEffectsTests
             new AddFilterToExistingFilterSetAction(filterSet.Id, basic, SourceEntryId: null),
             Substitute.For<IDispatcher>());
 
-        await store.Received(1).UpdateAsync(Arg.Is<LibraryEntry>(e => e.GetType() == typeof(LibraryEntryFilterSet)
+        await store.Received(1).UpdateAsync(Arg.Is<LibraryEntry>(e => e != null && e.GetType() == typeof(LibraryEntryFilterSet)
             && ((LibraryEntryFilterSet)e).Id == filterSet.Id
             && ((LibraryEntryFilterSet)e).Filters.Count == 2
             && ((LibraryEntryFilterSet)e).Filters.Any(f => f.Mode == FilterMode.Advanced)
@@ -177,7 +177,7 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleAddFilterToNewFilterSet(new AddFilterToNewFilterSetAction("New", filter, SourceEntryId: null), dispatcher);
 
-        await store.Received(1).AddAsync(Arg.Is<LibraryEntry>(e => e.GetType() == typeof(LibraryEntryFilterSet)
+        await store.Received(1).AddAsync(Arg.Is<LibraryEntry>(e => e != null && e.GetType() == typeof(LibraryEntryFilterSet)
             && ((LibraryEntryFilterSet)e).Name == "New"
             && ((LibraryEntryFilterSet)e).Filters.Count == 1
             && ((LibraryEntryFilterSet)e).Filters[0].Id != filter.Id), Arg.Any<CancellationToken>());
@@ -193,7 +193,7 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleAddFilterToNewFilterSet(new AddFilterToNewFilterSetAction("New", filter, source.Id), dispatcher);
 
-        await store.Received(1).UpdateAsync(Arg.Is<LibraryEntry>(e =>
+        await store.Received(1).UpdateAsync(Arg.Is<LibraryEntry>(e => e != null &&
             e.Id == source.Id && e.Origin == LibraryEntryOrigin.UserSaved), Arg.Any<CancellationToken>());
     }
 
@@ -218,7 +218,7 @@ public sealed class FilterLibraryEffectsTests
         await effects.HandleAddLibraryEntry(new AddLibraryEntryAction(entry), dispatcher);
 
         await store.Received(1).AddAsync(Arg.Is(entry), Arg.Any<CancellationToken>());
-        dispatcher.Received(1).Dispatch(Arg.Is<AddLibraryEntrySuccessAction>(a => ReferenceEquals(a.Entry, entry)));
+        dispatcher.Received(1).Dispatch(Arg.Is<AddLibraryEntrySuccessAction>(a => a != null && ReferenceEquals(a.Entry, entry)));
     }
 
     [Fact]
@@ -252,8 +252,8 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleApplyLibraryEntry(new ApplyLibraryEntryAction(filterSet.Id), dispatcher);
 
-        dispatcher.Received(1).Dispatch(Arg.Is<MergeFiltersAction>(a => a.Filters.Count == 2));
-        dispatcher.Received(1).Dispatch(Arg.Is<RecordEntryAppliedAction>(a => a.EntryId == filterSet.Id));
+        dispatcher.Received(1).Dispatch(Arg.Is<MergeFiltersAction>(a => a != null && a.Filters.Count == 2));
+        dispatcher.Received(1).Dispatch(Arg.Is<RecordEntryAppliedAction>(a => a != null && a.EntryId == filterSet.Id));
         dispatcher.DidNotReceive().Dispatch(Arg.Any<ReplaceFiltersAction>());
     }
 
@@ -265,8 +265,8 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleApplyLibraryEntry(new ApplyLibraryEntryAction(entry.Id), dispatcher);
 
-        dispatcher.Received(1).Dispatch(Arg.Is<MergeFiltersAction>(a => a.Filters.Count == 1));
-        dispatcher.Received(1).Dispatch(Arg.Is<RecordEntryAppliedAction>(a => a.EntryId == entry.Id));
+        dispatcher.Received(1).Dispatch(Arg.Is<MergeFiltersAction>(a => a != null && a.Filters.Count == 1));
+        dispatcher.Received(1).Dispatch(Arg.Is<RecordEntryAppliedAction>(a => a != null && a.EntryId == entry.Id));
         dispatcher.DidNotReceive().Dispatch(Arg.Any<ReplaceFiltersAction>());
     }
 
@@ -304,7 +304,7 @@ public sealed class FilterLibraryEffectsTests
         await effects.HandleDeleteLibraryEntry(new DeleteLibraryEntryAction(id), dispatcher);
 
         await store.Received(1).DeleteAsync(Arg.Is(id), Arg.Any<CancellationToken>());
-        dispatcher.Received(1).Dispatch(Arg.Is<DeleteLibraryEntrySuccessAction>(a => a.EntryId == id));
+        dispatcher.Received(1).Dispatch(Arg.Is<DeleteLibraryEntrySuccessAction>(a => a != null && a.EntryId == id));
     }
 
     [Fact]
@@ -338,7 +338,7 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleDeleteTag(new DeleteTagAction("bug"), dispatcher);
 
-        await store.Received(1).UpdateRangeAsync(Arg.Is<IReadOnlyList<LibraryEntry>>(list =>
+        await store.Received(1).UpdateRangeAsync(Arg.Is<IReadOnlyList<LibraryEntry>>(list => list != null &&
             list.Count == 1 && list[0].Tags.SequenceEqual(new[] { "perf" })), Arg.Any<CancellationToken>());
     }
 
@@ -366,7 +366,7 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleDeleteTag(new DeleteTagAction("BUG"), dispatcher);
 
-        await store.Received(1).UpdateRangeAsync(Arg.Is<IReadOnlyList<LibraryEntry>>(list =>
+        await store.Received(1).UpdateRangeAsync(Arg.Is<IReadOnlyList<LibraryEntry>>(list => list != null &&
             list.Count == 2 &&
             list.Any(e => e.Id == a.Id && e.Tags.SequenceEqual(new[] { "perf" })) &&
             list.Any(e => e.Id == b.Id && e.Tags.IsEmpty) &&
@@ -402,8 +402,8 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleDeleteTag(new DeleteTagAction("bug"), dispatcher);
 
-        dispatcher.Received(1).Dispatch(Arg.Is<UpdateLibraryEntrySuccessAction>(s => s.Entry.Id == a.Id));
-        dispatcher.DidNotReceive().Dispatch(Arg.Is<UpdateLibraryEntrySuccessAction>(s => s.Entry.Id == b.Id));
+        dispatcher.Received(1).Dispatch(Arg.Is<UpdateLibraryEntrySuccessAction>(s => s != null && s.Entry.Id == a.Id));
+        dispatcher.DidNotReceive().Dispatch(Arg.Is<UpdateLibraryEntrySuccessAction>(s => s != null && s.Entry.Id == b.Id));
         dispatcher.Received(1).Dispatch(Arg.Any<LoadLibraryAction>());
         announcer.Received(1).Announce("Removed tag 'bug' from 1 entry");
     }
@@ -466,7 +466,7 @@ public sealed class FilterLibraryEffectsTests
         await effects.HandleLoadLibrary(dispatcher);
 
         backslashMigrator.Received(1).BuildMigrationPlan(Arg.Any<IReadOnlyList<LibraryEntry>>());
-        await store.Received(1).UpdateAsync(Arg.Is<LibraryEntry>(e => e.Name == "DNS"), Arg.Any<CancellationToken>());
+        await store.Received(1).UpdateAsync(Arg.Is<LibraryEntry>(e => e != null && e.Name == "DNS"), Arg.Any<CancellationToken>());
         backslashMigrator.Received(1).MarkMigrationCompleted();
         dispatcher.Received(1).Dispatch(Arg.Any<LoadLibrarySuccessAction>());
     }
@@ -507,7 +507,7 @@ public sealed class FilterLibraryEffectsTests
         await effects.HandleLoadLibrary(dispatcher);
 
         dispatcher.Received(1).Dispatch(Arg.Any<LoadLibraryFailureAction>());
-        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a.Entries.IsEmpty));
+        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a != null && a.Entries.IsEmpty));
         logger.ReceivedWithAnyArgs(1).Warning(default);
     }
 
@@ -609,7 +609,7 @@ public sealed class FilterLibraryEffectsTests
         await effects.HandleLoadLibrary(dispatcher);
 
         dispatcher.Received(1).Dispatch(Arg.Any<LoadLibraryStartedAction>());
-        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a.Entries.Count == 1 && a.Entries[0].Id == entry.Id));
+        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a != null && a.Entries.Count == 1 && a.Entries[0].Id == entry.Id));
     }
 
     [Fact]
@@ -634,7 +634,7 @@ public sealed class FilterLibraryEffectsTests
         await effects.HandleLoadLibrary(dispatcher);
 
         await store.Received(1).AddRangeAsync(Arg.Any<IEnumerable<LibraryEntry>>(), Arg.Any<CancellationToken>());
-        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a.Entries.Count == 1 && a.Entries[0].Id == migratedEntry.Id));
+        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a != null && a.Entries.Count == 1 && a.Entries[0].Id == migratedEntry.Id));
         dispatcher.DidNotReceive().Dispatch(Arg.Any<LoadLibraryFailureAction>());
         migrator.Received(1).MarkMigrationCompleted(sections);
         logger.ReceivedWithAnyArgs(1).Warning(default);
@@ -656,7 +656,7 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleLoadLibrary(dispatcher);
 
-        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a.Entries.IsEmpty));
+        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a != null && a.Entries.IsEmpty));
         dispatcher.DidNotReceive().Dispatch(Arg.Any<LoadLibraryFailureAction>());
         migrator.DidNotReceive().MarkMigrationCompleted(Arg.Any<LegacyMigrationSections>());
         logger.ReceivedWithAnyArgs(1).Warning(default);
@@ -674,7 +674,7 @@ public sealed class FilterLibraryEffectsTests
         await effects.HandleLoadLibrary(dispatcher);
 
         await store.DidNotReceive().AddRangeAsync(Arg.Any<IEnumerable<LibraryEntry>>(), Arg.Any<CancellationToken>());
-        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a.Entries.IsEmpty));
+        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a != null && a.Entries.IsEmpty));
         dispatcher.DidNotReceive().Dispatch(Arg.Any<LoadLibraryFailureAction>());
         migrator.Received(1).MarkMigrationCompleted(sections);
     }
@@ -694,9 +694,9 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleLoadLibrary(dispatcher);
 
-        await store.Received(1).AddRangeAsync(Arg.Is<IEnumerable<LibraryEntry>>(e => e.Count() == 1), Arg.Any<CancellationToken>());
+        await store.Received(1).AddRangeAsync(Arg.Is<IEnumerable<LibraryEntry>>(e => e != null && e.Count() == 1), Arg.Any<CancellationToken>());
         await store.Received(2).LoadAllAsync(Arg.Any<CancellationToken>());
-        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a.Entries.Count == 1 && a.Entries[0].Id == migratedEntry.Id));
+        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a != null && a.Entries.Count == 1 && a.Entries[0].Id == migratedEntry.Id));
         dispatcher.DidNotReceive().Dispatch(Arg.Any<LoadLibraryFailureAction>());
         migrator.Received(1).MarkMigrationCompleted(sections);
     }
@@ -709,7 +709,7 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleLoadLibrary(dispatcher);
 
-        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a.Entries.IsEmpty));
+        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a != null && a.Entries.IsEmpty));
         await store.DidNotReceive().AddRangeAsync(Arg.Any<IEnumerable<LibraryEntry>>(), Arg.Any<CancellationToken>());
         migrator.Received(1).MarkMigrationCompleted(Arg.Any<LegacyMigrationSections>());
     }
@@ -728,7 +728,7 @@ public sealed class FilterLibraryEffectsTests
         migrator.DidNotReceive().BuildEntriesFromLegacy();
         migrator.DidNotReceive().MarkMigrationCompleted(Arg.Any<LegacyMigrationSections>());
         await store.DidNotReceive().AddRangeAsync(Arg.Any<IEnumerable<LibraryEntry>>(), Arg.Any<CancellationToken>());
-        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a.Entries.IsEmpty));
+        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a != null && a.Entries.IsEmpty));
     }
 
     [Fact]
@@ -764,9 +764,9 @@ public sealed class FilterLibraryEffectsTests
         await effects.HandleLoadLibrary(dispatcher);
 
         // Distinct filter content → migrated filter set is NOT deduped → AddRange called with it.
-        await store.Received(1).AddRangeAsync(Arg.Is<IEnumerable<LibraryEntry>>(e => e.Count() == 1 && e.First() is LibraryEntryFilterSet), Arg.Any<CancellationToken>());
+        await store.Received(1).AddRangeAsync(Arg.Is<IEnumerable<LibraryEntry>>(e => e != null && e.Count() == 1 && e.First() is LibraryEntryFilterSet), Arg.Any<CancellationToken>());
         migrator.Received(1).MarkMigrationCompleted(sections);
-        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a.Entries.Count == 2));
+        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a != null && a.Entries.Count == 2));
     }
 
     [Fact]
@@ -796,7 +796,7 @@ public sealed class FilterLibraryEffectsTests
         // Bitmask still advances - the section is "complete" from the persistence perspective.
         migrator.Received(1).MarkMigrationCompleted(sections);
         // Loaded entries reflect the existing store (no duplicates).
-        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a.Entries.Count == 2));
+        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a != null && a.Entries.Count == 2));
     }
 
     [Fact]
@@ -817,9 +817,9 @@ public sealed class FilterLibraryEffectsTests
         await effects.HandleLoadLibrary(dispatcher);
 
         // Only the non-overlapping entry is inserted.
-        await store.Received(1).AddRangeAsync(Arg.Is<IEnumerable<LibraryEntry>>(e => e.Count() == 1 && e.First().Id == newEntry.Id), Arg.Any<CancellationToken>());
+        await store.Received(1).AddRangeAsync(Arg.Is<IEnumerable<LibraryEntry>>(e => e != null && e.Count() == 1 && e.First().Id == newEntry.Id), Arg.Any<CancellationToken>());
         migrator.Received(1).MarkMigrationCompleted(sections);
-        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a.Entries.Count == 2));
+        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a != null && a.Entries.Count == 2));
     }
 
     [Fact]
@@ -841,7 +841,7 @@ public sealed class FilterLibraryEffectsTests
         await effects.HandleLoadLibrary(dispatcher);
 
         migrator.DidNotReceive().MarkMigrationCompleted(Arg.Any<LegacyMigrationSections>());
-        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a.Entries.Count == 1 && a.Entries[0].Id == existingEntry.Id));
+        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a != null && a.Entries.Count == 1 && a.Entries[0].Id == existingEntry.Id));
         dispatcher.DidNotReceive().Dispatch(Arg.Any<LoadLibraryFailureAction>());
     }
 
@@ -860,7 +860,7 @@ public sealed class FilterLibraryEffectsTests
         migrator.DidNotReceive().BuildEntriesFromLegacy();
         await store.DidNotReceive().AddRangeAsync(Arg.Any<IEnumerable<LibraryEntry>>(), Arg.Any<CancellationToken>());
         migrator.DidNotReceive().MarkMigrationCompleted(Arg.Any<LegacyMigrationSections>());
-        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a.Entries.Count == 1));
+        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a != null && a.Entries.Count == 1));
     }
 
     [Fact]
@@ -879,7 +879,7 @@ public sealed class FilterLibraryEffectsTests
         migrator.Received(1).BuildEntriesFromLegacy();
         await store.DidNotReceive().AddRangeAsync(Arg.Any<IEnumerable<LibraryEntry>>(), Arg.Any<CancellationToken>());
         migrator.Received(1).MarkMigrationCompleted(Arg.Any<LegacyMigrationSections>());
-        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a.Entries.Count == 1));
+        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a != null && a.Entries.Count == 1));
     }
 
     [Fact]
@@ -900,9 +900,9 @@ public sealed class FilterLibraryEffectsTests
 
         migrator.Received(1).ShouldRunMigration();
         migrator.Received(1).BuildEntriesFromLegacy();
-        await store.Received(1).AddRangeAsync(Arg.Is<IEnumerable<LibraryEntry>>(e => e.Count() == 1), Arg.Any<CancellationToken>());
+        await store.Received(1).AddRangeAsync(Arg.Is<IEnumerable<LibraryEntry>>(e => e != null && e.Count() == 1), Arg.Any<CancellationToken>());
         migrator.Received(1).MarkMigrationCompleted(sections);
-        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a.Entries.Count == 2));
+        dispatcher.Received(1).Dispatch(Arg.Is<LoadLibrarySuccessAction>(a => a != null && a.Entries.Count == 2));
     }
 
     [Fact]
@@ -968,7 +968,7 @@ public sealed class FilterLibraryEffectsTests
         await effects.HandleRecordEntryApplied(new RecordEntryAppliedAction(entry.Id), dispatcher);
 
         await store.Received(1).TryBumpLastUsedIfNotFavoriteAsync(entry.Id, Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
-        dispatcher.Received(1).Dispatch(Arg.Is<UpdateLibraryEntrySuccessAction>(a =>
+        dispatcher.Received(1).Dispatch(Arg.Is<UpdateLibraryEntrySuccessAction>(a => a != null &&
             a.Entry.Id == entry.Id && a.Entry.LastUsedUtc != null));
     }
 
@@ -1052,7 +1052,7 @@ public sealed class FilterLibraryEffectsTests
 
         // SQL-guarded delete no-ops if the row was concurrently promoted/favorited.
         await store.Received(1).TryDeleteAutoTrackedIfNotFavoriteAsync(Arg.Is(oldestId), Arg.Any<CancellationToken>());
-        dispatcher.Received(1).Dispatch(Arg.Is<DeleteLibraryEntrySuccessAction>(a => a.EntryId == oldestId));
+        dispatcher.Received(1).Dispatch(Arg.Is<DeleteLibraryEntrySuccessAction>(a => a != null && a.EntryId == oldestId));
     }
 
     [Fact]
@@ -1088,7 +1088,7 @@ public sealed class FilterLibraryEffectsTests
 
         await store.Received(1).AddOrReturnExistingFilterAsync(Arg.Any<LibraryEntrySavedFilter>(), Arg.Any<CancellationToken>());
         await store.Received(1).TryBumpLastUsedIfNotFavoriteAsync(existing.Id, Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
-        dispatcher.Received(1).Dispatch(Arg.Is<AddLibraryEntrySuccessAction>(a =>
+        dispatcher.Received(1).Dispatch(Arg.Is<AddLibraryEntrySuccessAction>(a => a != null &&
             a.Entry.Id == existing.Id && a.Entry.LastUsedUtc != existing.LastUsedUtc));
     }
 
@@ -1159,7 +1159,7 @@ public sealed class FilterLibraryEffectsTests
         await store.DidNotReceive().TryDeleteAutoTrackedIfNotFavoriteAsync(Arg.Any<LibraryEntryId>(), Arg.Any<CancellationToken>());
         dispatcher.DidNotReceive().Dispatch(Arg.Any<DeleteLibraryEntrySuccessAction>());
         // Bump + AddSuccess dispatch still happen as part of the collision-bump path.
-        dispatcher.Received(1).Dispatch(Arg.Is<AddLibraryEntrySuccessAction>(a => a.Entry.Id == alreadyInState.Id));
+        dispatcher.Received(1).Dispatch(Arg.Is<AddLibraryEntrySuccessAction>(a => a != null && a.Entry.Id == alreadyInState.Id));
     }
 
     [Fact]
@@ -1179,7 +1179,7 @@ public sealed class FilterLibraryEffectsTests
         };
         var (effects, store, dispatcher, _, _) = CreateEffects(state: new FilterLibraryState { Entries = [existing] });
         store.AddOrReturnExistingFilterAsync(Arg.Any<LibraryEntrySavedFilter>(), Arg.Any<CancellationToken>())
-            .Returns(call => (call.Arg<LibraryEntrySavedFilter>(), true));
+            .Returns(call => (call.ArgAt<LibraryEntrySavedFilter>(0), true));
 
         await effects.HandleRecordFilterApplied(new RecordFilterAppliedAction(basic), dispatcher);
 
@@ -1225,7 +1225,7 @@ public sealed class FilterLibraryEffectsTests
         store.AddOrReturnExistingFilterAsync(Arg.Any<LibraryEntrySavedFilter>(), Arg.Any<CancellationToken>())
             .Returns(call =>
             {
-                var candidate = call.Arg<LibraryEntrySavedFilter>();
+                var candidate = call.ArgAt<LibraryEntrySavedFilter>(0);
                 return (candidate, true);
             });
         var filter = SavedFilter.TryCreate("Level == 4");
@@ -1234,7 +1234,7 @@ public sealed class FilterLibraryEffectsTests
         await effects.HandleRecordFilterApplied(new RecordFilterAppliedAction(filter), dispatcher);
 
         await store.Received(1).AddOrReturnExistingFilterAsync(Arg.Any<LibraryEntrySavedFilter>(), Arg.Any<CancellationToken>());
-        dispatcher.Received(1).Dispatch(Arg.Is<AddLibraryEntrySuccessAction>(a =>
+        dispatcher.Received(1).Dispatch(Arg.Is<AddLibraryEntrySuccessAction>(a => a != null &&
             a.Entry.GetType() == typeof(LibraryEntrySavedFilter)
                 && ((LibraryEntrySavedFilter)a.Entry).Origin == LibraryEntryOrigin.AutoTracked
                 && ((LibraryEntrySavedFilter)a.Entry).LastUsedUtc != null
@@ -1267,14 +1267,14 @@ public sealed class FilterLibraryEffectsTests
 
         var (effects, store, dispatcher, _, _) = CreateEffects(state: new FilterLibraryState { Entries = [.. entries] });
         store.AddOrReturnExistingFilterAsync(Arg.Any<LibraryEntrySavedFilter>(), Arg.Any<CancellationToken>())
-            .Returns(call => (call.Arg<LibraryEntrySavedFilter>(), true));
+            .Returns(call => (call.ArgAt<LibraryEntrySavedFilter>(0), true));
         store.TryDeleteAutoTrackedIfNotFavoriteAsync(Arg.Any<LibraryEntryId>(), Arg.Any<CancellationToken>()).Returns(true);
 
         await effects.HandleRecordFilterApplied(new RecordFilterAppliedAction(newFilter), dispatcher);
 
         await store.Received(1).AddOrReturnExistingFilterAsync(Arg.Any<LibraryEntrySavedFilter>(), Arg.Any<CancellationToken>());
         await store.Received(1).TryDeleteAutoTrackedIfNotFavoriteAsync(Arg.Is(oldestId), Arg.Any<CancellationToken>());
-        dispatcher.Received(1).Dispatch(Arg.Is<DeleteLibraryEntrySuccessAction>(a => a.EntryId == oldestId));
+        dispatcher.Received(1).Dispatch(Arg.Is<DeleteLibraryEntrySuccessAction>(a => a != null && a.EntryId == oldestId));
     }
 
     [Fact]
@@ -1317,7 +1317,7 @@ public sealed class FilterLibraryEffectsTests
         await effects.HandleRecordFilterApplied(new RecordFilterAppliedAction(filter), dispatcher);
 
         await store.Received(1).TryBumpLastUsedIfNotFavoriteAsync(existing.Id, Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
-        dispatcher.Received(1).Dispatch(Arg.Is<UpdateLibraryEntrySuccessAction>(a =>
+        dispatcher.Received(1).Dispatch(Arg.Is<UpdateLibraryEntrySuccessAction>(a => a != null &&
             a.Entry.Id == existing.Id && a.Entry.LastUsedUtc != existing.LastUsedUtc));
         await store.DidNotReceive().AddOrReturnExistingFilterAsync(Arg.Any<LibraryEntrySavedFilter>(), Arg.Any<CancellationToken>());
     }
@@ -1343,7 +1343,7 @@ public sealed class FilterLibraryEffectsTests
 
         await store.Received(1).TryBumpLastUsedIfNotFavoriteAsync(existing.Id, Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
         await store.DidNotReceive().AddOrReturnExistingFilterAsync(Arg.Any<LibraryEntrySavedFilter>(), Arg.Any<CancellationToken>());
-        dispatcher.Received(1).Dispatch(Arg.Is<UpdateLibraryEntrySuccessAction>(a => a.Entry.Id == existing.Id));
+        dispatcher.Received(1).Dispatch(Arg.Is<UpdateLibraryEntrySuccessAction>(a => a != null && a.Entry.Id == existing.Id));
     }
 
     [Fact]
@@ -1354,7 +1354,7 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleRenameTag(new RenameTagAction("bug", "defect"), dispatcher);
 
-        await store.Received(1).UpdateRangeAsync(Arg.Is<IReadOnlyList<LibraryEntry>>(list =>
+        await store.Received(1).UpdateRangeAsync(Arg.Is<IReadOnlyList<LibraryEntry>>(list => list != null &&
             list.Count == 1 && list[0].Tags.SequenceEqual(new[] { "defect" })), Arg.Any<CancellationToken>());
     }
 
@@ -1385,7 +1385,7 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleRenameTag(new RenameTagAction("bug", "defect"), dispatcher);
 
-        await store.Received(1).UpdateRangeAsync(Arg.Is<IReadOnlyList<LibraryEntry>>(list =>
+        await store.Received(1).UpdateRangeAsync(Arg.Is<IReadOnlyList<LibraryEntry>>(list => list != null &&
             list.Count == 1 && list[0] is LibraryEntryFilterSet && list[0].Tags.SequenceEqual(new[] { "defect" })), Arg.Any<CancellationToken>());
     }
 
@@ -1397,7 +1397,7 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleRenameTag(new RenameTagAction("bug", "defect"), dispatcher);
 
-        await store.Received(1).UpdateRangeAsync(Arg.Is<IReadOnlyList<LibraryEntry>>(list =>
+        await store.Received(1).UpdateRangeAsync(Arg.Is<IReadOnlyList<LibraryEntry>>(list => list != null &&
             list.Count == 1 && list[0].Tags.SequenceEqual(new[] { "defect" })), Arg.Any<CancellationToken>());
         dispatcher.Received(1).Dispatch(Arg.Any<UpdateLibraryEntrySuccessAction>());
     }
@@ -1422,7 +1422,7 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleRenameTag(new RenameTagAction("  BUG  ", "Defect "), dispatcher);
 
-        await store.Received(1).UpdateRangeAsync(Arg.Is<IReadOnlyList<LibraryEntry>>(list =>
+        await store.Received(1).UpdateRangeAsync(Arg.Is<IReadOnlyList<LibraryEntry>>(list => list != null &&
             list.Count == 1 && list[0].Tags.SequenceEqual(new[] { "defect" })), Arg.Any<CancellationToken>());
     }
 
@@ -1436,7 +1436,7 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleRenameTag(new RenameTagAction("bug", "defect"), dispatcher);
 
-        await store.Received(1).UpdateRangeAsync(Arg.Is<IReadOnlyList<LibraryEntry>>(list =>
+        await store.Received(1).UpdateRangeAsync(Arg.Is<IReadOnlyList<LibraryEntry>>(list => list != null &&
             list.Count == 2 &&
             list.Any(e => e.Id == a.Id && e.Tags.SequenceEqual(new[] { "defect", "perf" })) &&
             list.Any(e => e.Id == b.Id && e.Tags.SequenceEqual(new[] { "defect" })) &&
@@ -1453,7 +1453,7 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleRenameTag(new RenameTagAction("bug", "defect"), dispatcher);
 
-        await store.Received(1).UpdateRangeAsync(Arg.Is<IReadOnlyList<LibraryEntry>>(list =>
+        await store.Received(1).UpdateRangeAsync(Arg.Is<IReadOnlyList<LibraryEntry>>(list => list != null &&
             list.Count == 1 && list[0].Id == withTag.Id), Arg.Any<CancellationToken>());
     }
 
@@ -1469,8 +1469,8 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleRenameTag(new RenameTagAction("bug", "defect"), dispatcher);
 
-        dispatcher.Received(1).Dispatch(Arg.Is<UpdateLibraryEntrySuccessAction>(s => s.Entry.Id == a.Id));
-        dispatcher.DidNotReceive().Dispatch(Arg.Is<UpdateLibraryEntrySuccessAction>(s => s.Entry.Id == b.Id));
+        dispatcher.Received(1).Dispatch(Arg.Is<UpdateLibraryEntrySuccessAction>(s => s != null && s.Entry.Id == a.Id));
+        dispatcher.DidNotReceive().Dispatch(Arg.Is<UpdateLibraryEntrySuccessAction>(s => s != null && s.Entry.Id == b.Id));
         dispatcher.Received(1).Dispatch(Arg.Any<LoadLibraryAction>());
         announcer.Received(1).Announce("Renamed tag 'bug' to 'defect' in 1 entry");
     }
@@ -1526,8 +1526,8 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleReplaceWithLibraryEntry(new ReplaceWithLibraryEntryAction(filterSet.Id), dispatcher);
 
-        dispatcher.Received(1).Dispatch(Arg.Is<ReplaceFiltersAction>(a => a.Filters.Count == 2));
-        dispatcher.Received(1).Dispatch(Arg.Is<RecordEntryAppliedAction>(a => a.EntryId == filterSet.Id));
+        dispatcher.Received(1).Dispatch(Arg.Is<ReplaceFiltersAction>(a => a != null && a.Filters.Count == 2));
+        dispatcher.Received(1).Dispatch(Arg.Is<RecordEntryAppliedAction>(a => a != null && a.EntryId == filterSet.Id));
         dispatcher.DidNotReceive().Dispatch(Arg.Any<MergeFiltersAction>());
     }
 
@@ -1539,8 +1539,8 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleReplaceWithLibraryEntry(new ReplaceWithLibraryEntryAction(entry.Id), dispatcher);
 
-        dispatcher.Received(1).Dispatch(Arg.Is<ReplaceFiltersAction>(a => a.Filters.Count == 1));
-        dispatcher.Received(1).Dispatch(Arg.Is<RecordEntryAppliedAction>(a => a.EntryId == entry.Id));
+        dispatcher.Received(1).Dispatch(Arg.Is<ReplaceFiltersAction>(a => a != null && a.Filters.Count == 1));
+        dispatcher.Received(1).Dispatch(Arg.Is<RecordEntryAppliedAction>(a => a != null && a.EntryId == entry.Id));
     }
 
     [Fact]
@@ -1587,7 +1587,7 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleSaveEntry(new SaveEntryAction(entry.Id), dispatcher);
 
-        await store.Received(1).UpdateAsync(Arg.Is<LibraryEntry>(e =>
+        await store.Received(1).UpdateAsync(Arg.Is<LibraryEntry>(e => e != null &&
             e.Id == entry.Id && e.Origin == LibraryEntryOrigin.UserSaved), Arg.Any<CancellationToken>());
     }
 
@@ -1604,7 +1604,7 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleSaveEntry(new SaveEntryAction(staleEntry.Id), dispatcher);
 
-        dispatcher.Received(1).Dispatch(Arg.Is<UpdateLibraryEntrySuccessAction>(a =>
+        dispatcher.Received(1).Dispatch(Arg.Is<UpdateLibraryEntrySuccessAction>(a => a != null &&
             a.Entry.Id == staleEntry.Id &&
             a.Entry.Name == "NewName" &&
             a.Entry.Origin == LibraryEntryOrigin.UserSaved));
@@ -1633,7 +1633,7 @@ public sealed class FilterLibraryEffectsTests
         await effects.HandleSaveEntry(new SaveEntryAction(entry.Id), dispatcher);
 
         await store.Received(1).UpdateAsync(
-            Arg.Is<LibraryEntry>(e => e.Id == entry.Id && e.Origin == LibraryEntryOrigin.UserSaved),
+            Arg.Is<LibraryEntry>(e => e != null && e.Id == entry.Id && e.Origin == LibraryEntryOrigin.UserSaved),
             Arg.Any<CancellationToken>());
         dispatcher.DidNotReceive().Dispatch(Arg.Any<UpdateLibraryEntrySuccessAction>());
     }
@@ -1650,13 +1650,13 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleSaveFilterSet(new SaveFilterSetAction("My Preset", [f1, f2]), dispatcher);
 
-        await store.Received(1).AddAsync(Arg.Is<LibraryEntry>(e => e.GetType() == typeof(LibraryEntryFilterSet)
+        await store.Received(1).AddAsync(Arg.Is<LibraryEntry>(e => e != null && e.GetType() == typeof(LibraryEntryFilterSet)
             && ((LibraryEntryFilterSet)e).Name == "My Preset"
             && ((LibraryEntryFilterSet)e).Origin == LibraryEntryOrigin.UserSaved
             && ((LibraryEntryFilterSet)e).Filters.Count == 2
             && ((LibraryEntryFilterSet)e).Filters.All(f => !originalIds.Contains(f.Id))
             && ((LibraryEntryFilterSet)e).Filters.All(f => !f.IsEnabled)), Arg.Any<CancellationToken>());
-        dispatcher.Received(1).Dispatch(Arg.Is<AddLibraryEntrySuccessAction>(a => a.Entry.GetType() == typeof(LibraryEntryFilterSet)));
+        dispatcher.Received(1).Dispatch(Arg.Is<AddLibraryEntrySuccessAction>(a => a != null && a.Entry.GetType() == typeof(LibraryEntryFilterSet)));
     }
 
     [Fact]
@@ -1702,7 +1702,7 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleSavePaneAsFilterSet(new SavePaneAsFilterSetAction("Pane Preset"), dispatcher);
 
-        dispatcher.Received(1).Dispatch(Arg.Is<SaveFilterSetAction>(a =>
+        dispatcher.Received(1).Dispatch(Arg.Is<SaveFilterSetAction>(a => a != null &&
             a.Name == "Pane Preset" && a.Filters.Count == 1 && a.Filters[0] == f1));
     }
 
@@ -1738,7 +1738,7 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleSetIsFavorite(new SetIsFavoriteAction(filter.Id, IsFavorite: false), dispatcher);
 
-        await store.Received(1).UpdateAsync(Arg.Is<LibraryEntry>(e =>
+        await store.Received(1).UpdateAsync(Arg.Is<LibraryEntry>(e => e != null &&
             e.Id == filter.Id && !e.IsFavorite && e.LastUsedUtc != null), Arg.Any<CancellationToken>());
     }
 
@@ -1758,7 +1758,7 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleSetIsFavorite(new SetIsFavoriteAction(filterSet.Id, IsFavorite: false), dispatcher);
 
-        await store.Received(1).UpdateAsync(Arg.Is<LibraryEntry>(e => e.Id == filterSet.Id && !e.IsFavorite && e.LastUsedUtc == null), Arg.Any<CancellationToken>());
+        await store.Received(1).UpdateAsync(Arg.Is<LibraryEntry>(e => e != null && e.Id == filterSet.Id && !e.IsFavorite && e.LastUsedUtc == null), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -1773,9 +1773,9 @@ public sealed class FilterLibraryEffectsTests
 
         await effects.HandleSetIsFavorite(new SetIsFavoriteAction(entry.Id, IsFavorite: true), dispatcher);
 
-        await store.Received(1).UpdateAsync(Arg.Is<LibraryEntry>(e =>
+        await store.Received(1).UpdateAsync(Arg.Is<LibraryEntry>(e => e != null &&
             e.Id == entry.Id && e.IsFavorite && e.LastUsedUtc == null && e.Origin == LibraryEntryOrigin.UserSaved), Arg.Any<CancellationToken>());
-        dispatcher.Received(1).Dispatch(Arg.Is<UpdateLibraryEntrySuccessAction>(a =>
+        dispatcher.Received(1).Dispatch(Arg.Is<UpdateLibraryEntrySuccessAction>(a => a != null &&
             a.Entry.IsFavorite && a.Entry.LastUsedUtc == null && a.Entry.Origin == LibraryEntryOrigin.UserSaved));
     }
 
@@ -1799,7 +1799,7 @@ public sealed class FilterLibraryEffectsTests
         await effects.HandleUpdateLibraryEntry(new UpdateLibraryEntryAction(entry), dispatcher);
 
         await store.Received(1).UpdateAsync(Arg.Is(entry), Arg.Any<CancellationToken>());
-        dispatcher.Received(1).Dispatch(Arg.Is<UpdateLibraryEntrySuccessAction>(a => ReferenceEquals(a.Entry, entry)));
+        dispatcher.Received(1).Dispatch(Arg.Is<UpdateLibraryEntrySuccessAction>(a => a != null && ReferenceEquals(a.Entry, entry)));
     }
 
     [Fact]
@@ -1940,7 +1940,7 @@ public sealed class FilterLibraryEffectsTests
         if (!storeWasSupplied)
         {
             store.LoadAllAsync(Arg.Any<CancellationToken>()).Returns([]);
-            store.UpdateRangeAsync(Arg.Any<IReadOnlyList<LibraryEntry>>(), Arg.Any<CancellationToken>()).ReturnsForAnyArgs(ci => ((IReadOnlyList<LibraryEntry>)ci[0]).Select(e => e.Id).ToList());
+            store.UpdateRangeAsync(Arg.Any<IReadOnlyList<LibraryEntry>>(), Arg.Any<CancellationToken>()).ReturnsForAnyArgs(ci => ci.ArgAt<IReadOnlyList<LibraryEntry>>(0).Select(e => e.Id).ToList());
         }
 
         var stateMock = Substitute.For<IState<FilterLibraryState>>();

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterPane/EffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterPane/EffectsTests.cs
@@ -75,6 +75,7 @@ public sealed class EffectsTests
 
         // Assert
         mockDispatcher.Received(1).Dispatch(Arg.Is<RecordFilterAppliedAction>(x =>
+            x != null &&
             x.Filter.ComparisonText == FilterTestConstants.FilterIdEquals100));
     }
 
@@ -92,6 +93,7 @@ public sealed class EffectsTests
 
         // Assert
         mockDispatcher.Received(1).Dispatch(Arg.Is<RecordFilterAppliedAction>(x =>
+            x != null &&
             x.Filter.ComparisonText == FilterTestConstants.FilterIdEquals100));
     }
 
@@ -165,6 +167,7 @@ public sealed class EffectsTests
 
         // Assert
         mockDispatcher.Received(1).Dispatch(Arg.Is<RecordFilterAppliedAction>(x =>
+            x != null &&
             x.Filter.ComparisonText == FilterTestConstants.FilterIdEquals100));
     }
 
@@ -182,6 +185,7 @@ public sealed class EffectsTests
 
         // Assert
         mockDispatcher.Received(1).Dispatch(Arg.Is<RecordFilterAppliedAction>(x =>
+            x != null &&
             x.Filter.ComparisonText == FilterTestConstants.FilterIdEquals100));
     }
 
@@ -210,6 +214,7 @@ public sealed class EffectsTests
         // Assert
         var expectedAfter = new DateTime(2024, 1, 1, 8, 0, 0, DateTimeKind.Utc);
         mockDispatcher.Received(1).Dispatch(Arg.Is<SetFilterDateRangeSuccessAction>(x =>
+            x != null &&
             x.DateFilter != null &&
             x.DateFilter.After == expectedAfter &&
             x.DateFilter.Before == unrelatedBefore));
@@ -240,6 +245,7 @@ public sealed class EffectsTests
         // Assert
         var expectedBefore = new DateTime(2024, 1, 1, 15, 0, 0, DateTimeKind.Utc);
         mockDispatcher.Received(1).Dispatch(Arg.Is<SetFilterDateRangeSuccessAction>(x =>
+            x != null &&
             x.DateFilter != null &&
             x.DateFilter.After == unrelatedAfter &&
             x.DateFilter.Before == expectedBefore));
@@ -281,6 +287,7 @@ public sealed class EffectsTests
 
         // Assert
         mockDispatcher.Received(1).Dispatch(Arg.Is<SetFilterDateRangeSuccessAction>(x =>
+            x != null &&
             x.DateFilter != null &&
             x.DateFilter.After == new DateTime(2024, 1, 1, 4, 0, 0, DateTimeKind.Utc) &&
             x.DateFilter.Before == new DateTime(2024, 1, 5, 22, 0, 0, DateTimeKind.Utc)));
@@ -301,6 +308,7 @@ public sealed class EffectsTests
 
         // Assert
         mockDispatcher.Received(1).Dispatch(Arg.Is<SetFilterDateRangeSuccessAction>(x =>
+            x != null &&
             x.DateFilter != null &&
             x.DateFilter.After == after &&
             x.DateFilter.Before == before));
@@ -323,6 +331,7 @@ public sealed class EffectsTests
 
         // Assert
         mockDispatcher.Received(1).Dispatch(Arg.Is<SetFilterDateRangeSuccessAction>(x =>
+            x != null &&
             x.DateFilter != null &&
             x.DateFilter.After == existingAfter &&
             x.DateFilter.Before == newBefore));
@@ -345,6 +354,7 @@ public sealed class EffectsTests
 
         // Assert
         mockDispatcher.Received(1).Dispatch(Arg.Is<SetFilterDateRangeSuccessAction>(x =>
+            x != null &&
             x.DateFilter != null &&
             x.DateFilter.After == newAfter &&
             x.DateFilter.Before == existingBefore));
@@ -362,6 +372,7 @@ public sealed class EffectsTests
 
         // Assert
         mockDispatcher.Received(1).Dispatch(Arg.Is<SetFilterDateRangeSuccessAction>(x =>
+            x != null &&
             x.DateFilter == null));
     }
 
@@ -482,6 +493,7 @@ public sealed class EffectsTests
 
         // Assert
         mockDispatcher.Received(1).Dispatch(Arg.Is<ApplyFilterAction>(x =>
+            x != null &&
             x.Filter.Filters.Count == 1 &&
             x.Filter.Filters[0].IsExcluded));
     }
@@ -505,6 +517,7 @@ public sealed class EffectsTests
 
         // Assert
         mockDispatcher.Received(1).Dispatch(Arg.Is<ApplyFilterAction>(x =>
+            x != null &&
             x.Filter.Filters.Count == 1 &&
             x.Filter.Filters[0].ComparisonText == FilterTestConstants.FilterIdEquals100));
     }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/EffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/EffectsTests.cs
@@ -30,6 +30,7 @@ public sealed class EffectsTests
 
         // Assert
         mockDispatcher.Received(1).Dispatch(Arg.Is<LoadColumnsCompletedAction>(action =>
+            action != null &&
             action.LoadedColumns.Count == Enum.GetValues<ColumnName>().Length));
     }
 
@@ -51,6 +52,7 @@ public sealed class EffectsTests
 
         // Assert
         mockDispatcher.Received(1).Dispatch(Arg.Is<LoadColumnsCompletedAction>(action =>
+            action != null &&
             action.ColumnWidths[ColumnName.Level] == 150));
     }
 
@@ -70,6 +72,7 @@ public sealed class EffectsTests
 
         // Assert
         mockDispatcher.Received(1).Dispatch(Arg.Is<LoadColumnsCompletedAction>(action =>
+            action != null &&
             action.LoadedColumns[ColumnName.Source] == false &&
             action.LoadedColumns[ColumnName.EventId] == false));
     }
@@ -91,6 +94,7 @@ public sealed class EffectsTests
 
         // Assert
         mockDispatcher.Received(1).Dispatch(Arg.Is<LoadColumnsCompletedAction>(action =>
+            action != null &&
             action.LoadedColumns[ColumnName.Level] == true &&
             action.LoadedColumns[ColumnName.DateAndTime] == true));
     }
@@ -108,6 +112,7 @@ public sealed class EffectsTests
 
         // Assert
         mockDispatcher.Received(1).Dispatch(Arg.Is<LoadColumnsCompletedAction>(action =>
+            action != null &&
             action.ColumnOrder.SequenceEqual(s_columnDefaults.ColumnOrder)));
     }
 
@@ -124,6 +129,7 @@ public sealed class EffectsTests
 
         // Assert
         mockDispatcher.Received(1).Dispatch(Arg.Is<LoadColumnsCompletedAction>(action =>
+            action != null &&
             action.ColumnWidths[ColumnName.Level] == s_columnDefaults.GetColumnWidth(ColumnName.Level)));
     }
 
@@ -142,6 +148,7 @@ public sealed class EffectsTests
 
         // Assert
         mockDispatcher.Received(1).Dispatch(Arg.Is<LoadColumnsCompletedAction>(action =>
+            action != null &&
             action.ColumnOrder[0] == ColumnName.Source &&
             action.ColumnOrder[1] == ColumnName.Level));
     }
@@ -159,6 +166,7 @@ public sealed class EffectsTests
 
         // Assert
         mockDispatcher.Received(1).Dispatch(Arg.Is<LoadColumnsCompletedAction>(action =>
+            action != null &&
             action.LoadedColumns.All(kvp => kvp.Value == false)));
     }
 
@@ -180,7 +188,7 @@ public sealed class EffectsTests
 
         // Assert
         _ = mockPreferencesProvider.Received(1).ColumnOrderPreference =
-            Arg.Is<IEnumerable<ColumnName>>(order => order.First() == ColumnName.Source);
+            Arg.Is<IEnumerable<ColumnName>>(order => order != null && order.First() == ColumnName.Source);
     }
 
     [Fact]
@@ -195,15 +203,17 @@ public sealed class EffectsTests
 
         // Assert
         _ = mockPreferencesProvider.Received(1).EnabledEventTableColumnsPreference =
-            Arg.Is<IEnumerable<ColumnName>>(c => c.SequenceEqual(s_columnDefaults.EnabledColumns));
+            Arg.Is<IEnumerable<ColumnName>>(columns =>
+                columns != null && columns.SequenceEqual(s_columnDefaults.EnabledColumns));
         _ = mockPreferencesProvider.Received(1).ColumnWidthsPreference =
-            Arg.Is<IDictionary<ColumnName, int>>(w => w.Count == 0);
+            Arg.Is<IDictionary<ColumnName, int>>(widths => widths != null && widths.Count == 0);
         _ = mockPreferencesProvider.Received(1).ColumnOrderPreference =
-            Arg.Is<IEnumerable<ColumnName>>(o => !o.Any());
+            Arg.Is<IEnumerable<ColumnName>>(order => order != null && !order.Any());
 
         var expectedWidths = s_columnDefaults.ColumnWidths.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
         mockDispatcher.Received(1).Dispatch(Arg.Is<LoadColumnsCompletedAction>(action =>
+            action != null &&
             action.ColumnWidths.Count == expectedWidths.Count &&
             action.ColumnWidths.All(kvp =>
                 expectedWidths.ContainsKey(kvp.Key) && expectedWidths[kvp.Key] == kvp.Value) &&
@@ -237,7 +247,7 @@ public sealed class EffectsTests
 
         // Assert
         _ = mockPreferencesProvider.Received(1).ColumnWidthsPreference =
-            Arg.Is<IDictionary<ColumnName, int>>(width => width[ColumnName.Level] == 200);
+            Arg.Is<IDictionary<ColumnName, int>>(width => width != null && width[ColumnName.Level] == 200);
     }
 
     [Fact]
@@ -260,6 +270,7 @@ public sealed class EffectsTests
 
         // Assert
         mockDispatcher.Received(1).Dispatch(Arg.Is<LoadColumnsCompletedAction>(action =>
+            action != null &&
             action.LoadedColumns[ColumnName.Level] == true &&
             action.LoadedColumns[ColumnName.DateAndTime] == false &&
             action.LoadedColumns[ColumnName.Source] == true &&
@@ -285,6 +296,7 @@ public sealed class EffectsTests
         // Assert
         _ = mockPreferencesProvider.Received(1).EnabledEventTableColumnsPreference =
             Arg.Is<IEnumerable<ColumnName>>(columns =>
+                columns != null &&
                 columns.Contains(ColumnName.Source));
     }
 
@@ -306,6 +318,7 @@ public sealed class EffectsTests
 
         // Assert
         mockDispatcher.Received(1).Dispatch(Arg.Is<LoadColumnsCompletedAction>(action =>
+            action != null &&
             action.LoadedColumns[ColumnName.Level] == true &&
             action.LoadedColumns[ColumnName.DateAndTime] == true &&
             action.LoadedColumns[ColumnName.Source] == true));
@@ -330,6 +343,7 @@ public sealed class EffectsTests
 
         // Assert
         mockDispatcher.Received(1).Dispatch(Arg.Is<LoadColumnsCompletedAction>(action =>
+            action != null &&
             action.LoadedColumns[ColumnName.Level] == false &&
             action.LoadedColumns[ColumnName.DateAndTime] == true &&
             action.LoadedColumns[ColumnName.Source] == true));
@@ -355,6 +369,7 @@ public sealed class EffectsTests
         // Assert
         var _ = mockPreferencesProvider.Received(1).EnabledEventTableColumnsPreference =
             Arg.Is<IEnumerable<ColumnName>>(columns =>
+                columns != null &&
                 columns.Contains(ColumnName.Level) &&
                 columns.Contains(ColumnName.DateAndTime) &&
                 !columns.Contains(ColumnName.Source) &&
@@ -379,6 +394,7 @@ public sealed class EffectsTests
         // Assert
         _ = mockPreferencesProvider.Received(1).EnabledEventTableColumnsPreference =
             Arg.Is<IEnumerable<ColumnName>>(columns =>
+                columns != null &&
                 columns.Contains(ColumnName.Level) &&
                 columns.Contains(ColumnName.Source) &&
                 columns.Count() == 2);

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/Favorites/EffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/Favorites/EffectsTests.cs
@@ -41,6 +41,7 @@ public sealed class EffectsTests
         await sut.HandleLoadScenarioFavorites(_dispatcher);
 
         _dispatcher.Received(1).Dispatch(Arg.Is<LoadScenarioFavoritesSuccessAction>(action =>
+            action != null &&
             action.FavoriteScenarioIds.Contains("application-crashes") &&
             action.FavoriteScenarioIds.Contains("failed-services-at-boot")));
     }
@@ -69,7 +70,7 @@ public sealed class EffectsTests
         await _store.Received(1).AddAsync("application-crashes", Arg.Any<CancellationToken>());
         _announcer.Received(1).Announce("Added Application crashes to favorites");
         _dispatcher.Received(1).Dispatch(Arg.Is<SetScenarioFavoriteSuccessAction>(action =>
-            action.ScenarioId == "application-crashes" && action.IsFavorite));
+            action != null && action.ScenarioId == "application-crashes" && action.IsFavorite));
     }
 
     [Fact]
@@ -112,6 +113,6 @@ public sealed class EffectsTests
 
         await _store.Received(1).DeleteAsync("application-crashes", Arg.Any<CancellationToken>());
         _announcer.Received(1).Announce("Removed Application crashes from favorites");
-        _dispatcher.Received(1).Dispatch(Arg.Is<SetScenarioFavoriteSuccessAction>(action => !action.IsFavorite));
+        _dispatcher.Received(1).Dispatch(Arg.Is<SetScenarioFavoriteSuccessAction>(action => action != null && !action.IsFavorite));
     }
 }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/Favorites/ScenarioFavoriteCommandsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/Favorites/ScenarioFavoriteCommandsTests.cs
@@ -29,6 +29,7 @@ public sealed class ScenarioFavoriteCommandsTests
         sut.SetFavorite("application-crashes", "Application crashes", isFavorite: true);
 
         dispatcher.Received(1).Dispatch(Arg.Is<SetScenarioFavoriteAction>(action =>
+            action != null &&
             action.ScenarioId == "application-crashes" &&
             action.ScenarioName == "Application crashes" &&
             action.IsFavorite));
@@ -43,6 +44,6 @@ public sealed class ScenarioFavoriteCommandsTests
         sut.SetFavorite("application-crashes", "Application crashes", isFavorite: false);
 
         dispatcher.Received(1).Dispatch(Arg.Is<SetScenarioFavoriteAction>(action =>
-            action.ScenarioId == "application-crashes" && !action.IsFavorite));
+            action != null && action.ScenarioId == "application-crashes" && !action.IsFavorite));
     }
 }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/ScenarioApplyIntegrationTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/ScenarioApplyIntegrationTests.cs
@@ -56,7 +56,7 @@ public sealed class ScenarioApplyIntegrationTests
 
         ApplyFilterAction? captured = null;
         dispatcher.When(target => target.Dispatch(Arg.Any<ApplyFilterAction>()))
-            .Do(call => captured = (ApplyFilterAction)call[0]);
+            .Do(call => captured = call.ArgAt<ApplyFilterAction>(0));
 
         await effects.HandleReplaceFilters(dispatcher);
 

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/ScenarioApplyServiceTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/ScenarioApplyServiceTests.cs
@@ -24,7 +24,8 @@ public sealed class ScenarioApplyServiceTests
         service.ApplyInApp(scenario, replace: false);
 
         dispatcher.Received(1).Dispatch(Arg.Is<MergeFiltersAction>(action =>
-            action.Filters.Count == expected.Count
+            action != null
+            && action.Filters.Count == expected.Count
             && action.Filters[0].ComparisonText == expected[0].ComparisonText));
         dispatcher.DidNotReceive().Dispatch(Arg.Any<ReplaceFiltersAction>());
     }
@@ -39,7 +40,7 @@ public sealed class ScenarioApplyServiceTests
 
         MergeFiltersAction? captured = null;
         dispatcher.When(target => target.Dispatch(Arg.Any<MergeFiltersAction>()))
-            .Do(call => captured = (MergeFiltersAction)call[0]);
+            .Do(call => captured = call.ArgAt<MergeFiltersAction>(0));
 
         service.ApplyInApp(scenario, replace: false);
 
@@ -74,7 +75,8 @@ public sealed class ScenarioApplyServiceTests
         service.ApplyInApp(scenario, replace: true);
 
         dispatcher.Received(1).Dispatch(Arg.Is<ReplaceFiltersAction>(action =>
-            action.Filters.Count == expected.Count
+            action != null
+            && action.Filters.Count == expected.Count
             && action.Filters[0].ComparisonText == expected[0].ComparisonText));
         dispatcher.DidNotReceive().Dispatch(Arg.Any<MergeFiltersAction>());
     }
@@ -89,7 +91,7 @@ public sealed class ScenarioApplyServiceTests
 
         ReplaceFiltersAction? captured = null;
         dispatcher.When(target => target.Dispatch(Arg.Any<ReplaceFiltersAction>()))
-            .Do(call => captured = (ReplaceFiltersAction)call[0]);
+            .Do(call => captured = call.ArgAt<ReplaceFiltersAction>(0));
 
         var seeded = FilterPaneReducers.ReduceMergeFilters(
             new FilterPaneState(),

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/ScenarioLaunchServiceTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/ScenarioLaunchServiceTests.cs
@@ -37,7 +37,7 @@ public sealed class ScenarioLaunchServiceTests
 
         await service.LaunchAsync(scenario, dateWindow: null);
 
-        dispatcher.Received().Dispatch(Arg.Is<SetFilterDateRangeAction>(action => action.DateFilter == null));
+        dispatcher.Received().Dispatch(Arg.Is<SetFilterDateRangeAction>(action => action != null && action.DateFilter == null));
     }
 
     [Fact]
@@ -141,7 +141,7 @@ public sealed class ScenarioLaunchServiceTests
         await service.LaunchAsync(scenario, dateWindow: null);
 
         dispatcher.Received(1)
-            .Dispatch(Arg.Is<RestoreFilterPaneStateAction>(action => ReferenceEquals(action.State, priorState)));
+            .Dispatch(Arg.Is<RestoreFilterPaneStateAction>(action => action != null && ReferenceEquals(action.State, priorState)));
     }
 
     private static (IScenarioLaunchService Service, IDispatcher Dispatcher, IMenuActionService Menu, ScenarioDefinition Scenario)

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Update/Deployment/DeploymentServiceTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Update/Deployment/DeploymentServiceTests.cs
@@ -77,8 +77,8 @@ public sealed class DeploymentServiceTests
         // NSubstitute's Received() doesn't reliably return configured values for IAsyncOperationWithProgress
         _ = mockPackageDeploymentService.Received(1)
             .AddPackageAsync(
-                Arg.Is<Uri>(uri => uri.LocalPath == Constants.DownloadPath),
-                Arg.Is<PackageDeploymentOptions>(opt =>
+                Arg.Is<Uri>(uri => uri != null && uri.LocalPath == Constants.DownloadPath),
+                Arg.Is<PackageDeploymentOptions>(opt => opt != null &&
                     opt.ForceUpdateFromAnyVersion == true &&
                     opt.ForceTargetAppShutdown == true &&
                     opt.DeferRegistrationWhenPackagesAreInUse == false));
@@ -133,11 +133,11 @@ public sealed class DeploymentServiceTests
 
         mockMainThreadService.InvokeOnMainThread(Arg.Any<Action>()).Returns(callInfo =>
         {
-            callInfo.Arg<Action>().Invoke();
+            callInfo.ArgAt<Action>(0).Invoke();
             return Task.CompletedTask;
         });
 
-        mockMainThreadService.InvokeOnMainThreadAsync(Arg.Any<Func<Task>>()).Returns(callInfo => callInfo.Arg<Func<Task>>()());
+        mockMainThreadService.InvokeOnMainThreadAsync(Arg.Any<Func<Task>>()).Returns(callInfo => callInfo.ArgAt<Func<Task>>(0)());
 
         var deploymentService = CreateDeploymentService(
             appTitleService: mockAppTitleService,
@@ -173,11 +173,11 @@ public sealed class DeploymentServiceTests
 
         mockMainThreadService.InvokeOnMainThread(Arg.Any<Action>()).Returns(callInfo =>
         {
-            callInfo.Arg<Action>().Invoke();
+            callInfo.ArgAt<Action>(0).Invoke();
             return Task.CompletedTask;
         });
 
-        mockMainThreadService.InvokeOnMainThreadAsync(Arg.Any<Func<Task>>()).Returns(callInfo => callInfo.Arg<Func<Task>>()());
+        mockMainThreadService.InvokeOnMainThreadAsync(Arg.Any<Func<Task>>()).Returns(callInfo => callInfo.ArgAt<Func<Task>>(0)());
 
         var deploymentService = CreateDeploymentService(
             appTitleService: mockAppTitleService,
@@ -215,11 +215,11 @@ public sealed class DeploymentServiceTests
 
         mockMainThreadService.InvokeOnMainThread(Arg.Any<Action>()).Returns(callInfo =>
         {
-            callInfo.Arg<Action>().Invoke();
+            callInfo.ArgAt<Action>(0).Invoke();
             return Task.CompletedTask;
         });
 
-        mockMainThreadService.InvokeOnMainThreadAsync(Arg.Any<Func<Task>>()).Returns(callInfo => callInfo.Arg<Func<Task>>()());
+        mockMainThreadService.InvokeOnMainThreadAsync(Arg.Any<Func<Task>>()).Returns(callInfo => callInfo.ArgAt<Func<Task>>(0)());
 
         var deploymentService = CreateDeploymentService(
             appTitleService: mockAppTitleService,
@@ -236,7 +236,7 @@ public sealed class DeploymentServiceTests
         await mockMainThreadService.Received(1).InvokeOnMainThreadAsync(Arg.Any<Func<Task>>());
         await mockAlertDialogService.Received(1).ShowAlert(
             Constants.UpdateFailureTitle,
-            Arg.Is<string>(msg => msg.Contains(testException.ToString())),
+            Arg.Is<string>(msg => msg != null && msg.Contains(testException.ToString())),
             Constants.UpdateFailureOk);
 
         mockAppTitleService.Received(1).SetProgressString(null);
@@ -263,11 +263,11 @@ public sealed class DeploymentServiceTests
 
         mockMainThreadService.InvokeOnMainThread(Arg.Any<Action>()).Returns(callInfo =>
         {
-            callInfo.Arg<Action>().Invoke();
+            callInfo.ArgAt<Action>(0).Invoke();
             return Task.CompletedTask;
         });
 
-        mockMainThreadService.InvokeOnMainThreadAsync(Arg.Any<Func<Task>>()).Returns(callInfo => callInfo.Arg<Func<Task>>()());
+        mockMainThreadService.InvokeOnMainThreadAsync(Arg.Any<Func<Task>>()).Returns(callInfo => callInfo.ArgAt<Func<Task>>(0)());
 
         var deploymentService = CreateDeploymentService(
             appTitleService: mockAppTitleService,
@@ -308,11 +308,11 @@ public sealed class DeploymentServiceTests
 
         mockMainThreadService.InvokeOnMainThread(Arg.Any<Action>()).Returns(callInfo =>
         {
-            callInfo.Arg<Action>().Invoke();
+            callInfo.ArgAt<Action>(0).Invoke();
             return Task.CompletedTask;
         });
 
-        mockMainThreadService.InvokeOnMainThreadAsync(Arg.Any<Func<Task>>()).Returns(callInfo => callInfo.Arg<Func<Task>>()());
+        mockMainThreadService.InvokeOnMainThreadAsync(Arg.Any<Func<Task>>()).Returns(callInfo => callInfo.ArgAt<Func<Task>>(0)());
 
         var deploymentService = CreateDeploymentService(
             appTitleService: mockAppTitleService,
@@ -349,8 +349,8 @@ public sealed class DeploymentServiceTests
         // NSubstitute's Received() doesn't reliably return configured values for IAsyncOperationWithProgress
         _ = mockPackageDeploymentService.Received(1)
             .AddPackageAsync(
-                Arg.Is<Uri>(uri => uri.LocalPath == Constants.DownloadPath),
-                Arg.Is<PackageDeploymentOptions>(opt =>
+                Arg.Is<Uri>(uri => uri != null && uri.LocalPath == Constants.DownloadPath),
+                Arg.Is<PackageDeploymentOptions>(opt => opt != null &&
                     opt.ForceUpdateFromAnyVersion == true &&
                     opt.ForceTargetAppShutdown == false &&
                     opt.DeferRegistrationWhenPackagesAreInUse == true));
@@ -420,11 +420,11 @@ public sealed class DeploymentServiceTests
 
         mockMainThreadService.InvokeOnMainThread(Arg.Any<Action>()).Returns(callInfo =>
         {
-            callInfo.Arg<Action>().Invoke();
+            callInfo.ArgAt<Action>(0).Invoke();
             return Task.CompletedTask;
         });
 
-        mockMainThreadService.InvokeOnMainThreadAsync(Arg.Any<Func<Task>>()).Returns(callInfo => callInfo.Arg<Func<Task>>()());
+        mockMainThreadService.InvokeOnMainThreadAsync(Arg.Any<Func<Task>>()).Returns(callInfo => callInfo.ArgAt<Func<Task>>(0)());
 
         var deploymentService = CreateDeploymentService(
             appTitleService: mockAppTitleService,
@@ -458,11 +458,11 @@ public sealed class DeploymentServiceTests
 
         mockMainThreadService.InvokeOnMainThread(Arg.Any<Action>()).Returns(callInfo =>
         {
-            callInfo.Arg<Action>().Invoke();
+            callInfo.ArgAt<Action>(0).Invoke();
             return Task.CompletedTask;
         });
 
-        mockMainThreadService.InvokeOnMainThreadAsync(Arg.Any<Func<Task>>()).Returns(callInfo => callInfo.Arg<Func<Task>>()());
+        mockMainThreadService.InvokeOnMainThreadAsync(Arg.Any<Func<Task>>()).Returns(callInfo => callInfo.ArgAt<Func<Task>>(0)());
 
         var deploymentService = CreateDeploymentService(
             appTitleService: mockAppTitleService,
@@ -478,7 +478,7 @@ public sealed class DeploymentServiceTests
         await mockMainThreadService.Received(1).InvokeOnMainThreadAsync(Arg.Any<Func<Task>>());
         await mockAlertDialogService.Received(1).ShowAlert(
             Constants.UpdateFailureTitle,
-            Arg.Is<string>(msg => msg.Contains(testException.ToString())),
+            Arg.Is<string>(msg => msg != null && msg.Contains(testException.ToString())),
             Constants.UpdateFailureOk);
 
         mockAppTitleService.Received(1).SetProgressString(null);
@@ -502,11 +502,11 @@ public sealed class DeploymentServiceTests
 
         mockMainThreadService.InvokeOnMainThread(Arg.Any<Action>()).Returns(callInfo =>
         {
-            callInfo.Arg<Action>().Invoke();
+            callInfo.ArgAt<Action>(0).Invoke();
             return Task.CompletedTask;
         });
 
-        mockMainThreadService.InvokeOnMainThreadAsync(Arg.Any<Func<Task>>()).Returns(callInfo => callInfo.Arg<Func<Task>>()());
+        mockMainThreadService.InvokeOnMainThreadAsync(Arg.Any<Func<Task>>()).Returns(callInfo => callInfo.ArgAt<Func<Task>>(0)());
 
         var deploymentService = CreateDeploymentService(
             appTitleService: mockAppTitleService,
@@ -543,11 +543,11 @@ public sealed class DeploymentServiceTests
 
         mockMainThreadService.InvokeOnMainThread(Arg.Any<Action>()).Returns(callInfo =>
         {
-            callInfo.Arg<Action>().Invoke();
+            callInfo.ArgAt<Action>(0).Invoke();
             return Task.CompletedTask;
         });
 
-        mockMainThreadService.InvokeOnMainThreadAsync(Arg.Any<Func<Task>>()).Returns(callInfo => callInfo.Arg<Func<Task>>()());
+        mockMainThreadService.InvokeOnMainThreadAsync(Arg.Any<Func<Task>>()).Returns(callInfo => callInfo.ArgAt<Func<Task>>(0)());
 
         var deploymentService = CreateDeploymentService(
             appTitleService: mockAppTitleService,
@@ -583,11 +583,11 @@ public sealed class DeploymentServiceTests
 
         mockMainThreadService.InvokeOnMainThread(Arg.Any<Action>()).Returns(callInfo =>
         {
-            callInfo.Arg<Action>().Invoke();
+            callInfo.ArgAt<Action>(0).Invoke();
             return Task.CompletedTask;
         });
 
-        mockMainThreadService.InvokeOnMainThreadAsync(Arg.Any<Func<Task>>()).Returns(callInfo => callInfo.Arg<Func<Task>>()());
+        mockMainThreadService.InvokeOnMainThreadAsync(Arg.Any<Func<Task>>()).Returns(callInfo => callInfo.ArgAt<Func<Task>>(0)());
 
         var deploymentService = CreateDeploymentService(
             appTitleService: mockAppTitleService,

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Update/UpdateServiceTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Update/UpdateServiceTests.cs
@@ -97,7 +97,7 @@ public sealed class UpdateServiceTests
 
         // Assert
         await mockAlertDialogService.Received(1)
-            .ShowAlert("Update Failure", Arg.Is<string>(s => s.Contains("Deployment failed")), "OK");
+            .ShowAlert("Update Failure", Arg.Is<string>(s => s != null && s.Contains("Deployment failed")), "OK");
     }
 
     [Fact]
@@ -217,7 +217,7 @@ public sealed class UpdateServiceTests
 
         // Assert
         await mockAlertDialogService.Received(1)
-            .ShowAlert("Update Failure", Arg.Is<string>(s => s.Contains("Network error")), "OK");
+            .ShowAlert("Update Failure", Arg.Is<string>(s => s != null && s.Contains("Network error")), "OK");
 
         mockDeploymentService.DidNotReceive().RestartNowAndUpdate(Arg.Any<string>(), Arg.Any<bool>());
         mockDeploymentService.DidNotReceive().UpdateOnNextRestart(Arg.Any<string>(), Arg.Any<bool>());
@@ -447,7 +447,7 @@ public sealed class UpdateServiceTests
         mockDeploymentService.DidNotReceive().UpdateOnNextRestart(Arg.Any<string>(), Arg.Any<bool>());
 
         await mockAlertDialogService.Received(1)
-            .ShowAlert("Update Failure", Arg.Is<string>(s => s.Contains("No releases available")), "OK");
+            .ShowAlert("Update Failure", Arg.Is<string>(s => s != null && s.Contains("No releases available")), "OK");
     }
 
     [Fact]
@@ -807,7 +807,7 @@ public sealed class UpdateServiceTests
 
         // Assert
         await mockAlertDialogService.Received(1)
-            .ShowAlert(Arg.Is<string>(s => s.Contains("Release Notes")), Arg.Is<string>(s => s.Contains("Failed to get release notes")), "OK");
+            .ShowAlert(Arg.Is<string>(s => s != null && s.Contains("Release Notes")), Arg.Is<string>(s => s != null && s.Contains("Failed to get release notes")), "OK");
         Assert.Null(result);
     }
 

--- a/tests/Unit/EventLogExpert.UI.Tests/Banner/AttentionBannerTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Banner/AttentionBannerTests.cs
@@ -76,7 +76,7 @@ public sealed class AttentionBannerTests : BunitContext
 
         _attentionBannerService.Received(1).DismissAttention();
         _errorBannerService.Received(1)
-            .ReportError("Databases", Arg.Is<string>(s => s.Contains("Failed to open databases")));
+            .ReportError("Databases", Arg.Is<string>(s => s != null && s.Contains("Failed to open databases")));
         Assert.NotNull(captured);
         Assert.Equal(BannerView.Error, captured.View);
     }
@@ -113,7 +113,7 @@ public sealed class AttentionBannerTests : BunitContext
 
         _attentionBannerService.Received(1).DismissAttention();
         _errorBannerService.Received(1)
-            .ReportError("Databases", Arg.Is<string>(s => s.Contains("modal boom")));
+            .ReportError("Databases", Arg.Is<string>(s => s != null && s.Contains("modal boom")));
         _traceLogger.Received(1).Error(Arg.Is<ErrorLogHandler>(h =>
             h.ToString().Contains(nameof(AttentionBanner)) && h.ToString().Contains("modal boom")));
         Assert.NotNull(captured);

--- a/tests/Unit/EventLogExpert.UI.Tests/Banner/CriticalBannerTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Banner/CriticalBannerTests.cs
@@ -44,7 +44,7 @@ public sealed class CriticalBannerTests : BunitContext
         component.Find("aside.banner-critical .banner-actions button:contains('Copy details')").Click();
 
         await _clipboardService.Received(1)
-            .CopyTextAsync(Arg.Is<string>(s => s.Contains("InvalidOperationException") && s.Contains("kaboom")));
+            .CopyTextAsync(Arg.Is<string>(s => s != null && s.Contains("InvalidOperationException") && s.Contains("kaboom")));
 
         Assert.Single(component.FindAll("aside.banner-critical .banner-feedback .banner-chip"));
     }

--- a/tests/Unit/EventLogExpert.UI.Tests/Dashboard/EmptyStateDashboardTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Dashboard/EmptyStateDashboardTests.cs
@@ -118,7 +118,7 @@ public sealed class EmptyStateDashboardTests : BunitContext
         cut.WaitForAssertion(() =>
         {
             _scenarioLaunch.Received(1)
-                .LaunchAsync(Arg.Is<ScenarioDefinition>(scenario => scenario.Id == "application-crashes"), null);
+                .LaunchAsync(Arg.Is<ScenarioDefinition>(scenario => scenario != null && scenario.Id == "application-crashes"), null);
             _announcer.Received(1).Announce(Arg.Any<string>());
         });
     }
@@ -136,7 +136,7 @@ public sealed class EmptyStateDashboardTests : BunitContext
         cut.Find(ActiveDetailLaunch).Click();
 
         cut.WaitForAssertion(() =>
-            _announcer.Received(1).Announce(Arg.Is<string>(message => message.Contains("No channels"))));
+            _announcer.Received(1).Announce(Arg.Is<string>(message => message != null && message.Contains("No channels"))));
     }
 
     [Fact]
@@ -205,7 +205,7 @@ public sealed class EmptyStateDashboardTests : BunitContext
         FindLaunch(cut, "Open Application + System (live)").Click();
 
         cut.WaitForAssertion(() => _actions.Received(1).OpenLiveLogsAsync(
-            Arg.Is<IEnumerable<string>>(channels => channels.SequenceEqual(new[] { "Application", "System" })),
+            Arg.Is<IEnumerable<string>>(channels => channels != null && channels.SequenceEqual(new[] { "Application", "System" })),
             false));
     }
 

--- a/tests/Unit/EventLogExpert.UI.Tests/Database/DatabaseEntryRowTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Database/DatabaseEntryRowTests.cs
@@ -114,7 +114,7 @@ public sealed class DatabaseEntryRowTests : BunitContext
         await component.Find(".db-entry-row").TriggerEventAsync("oncontextmenu",
             new MouseEventArgs { ClientX = 100, ClientY = 200 });
 
-        _menuService.Received(1).OpenAt(100, 200, Arg.Is<IReadOnlyList<MenuItem>>(items => items.Count == 1));
+        _menuService.Received(1).OpenAt(100, 200, Arg.Is<IReadOnlyList<MenuItem>>(items => items != null && items.Count == 1));
     }
 
     [Fact]
@@ -143,7 +143,7 @@ public sealed class DatabaseEntryRowTests : BunitContext
         var entry = MakeEntry(DatabaseStatus.Ready, "MyProvider.db");
         IReadOnlyList<MenuItem>? capturedItems = null;
         _menuService.When(s => s.OpenAt(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<IReadOnlyList<MenuItem>>(), Arg.Any<bool>(), Arg.Any<bool>()))
-            .Do(call => capturedItems = call.Arg<IReadOnlyList<MenuItem>>());
+            .Do(call => capturedItems = call.ArgAt<IReadOnlyList<MenuItem>>(2));
 
         var component = RenderRow(entry);
         await component.Find(".db-entry-row").TriggerEventAsync("oncontextmenu", new MouseEventArgs());

--- a/tests/Unit/EventLogExpert.UI.Tests/Database/DatabaseRecoveryHostTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Database/DatabaseRecoveryHostTests.cs
@@ -41,14 +41,14 @@ public sealed class DatabaseRecoveryHostTests
         _mainThreadService.InvokeOnMainThread(Arg.Any<Action>())
             .Returns(call =>
             {
-                ((Action)call[0])();
+                call.ArgAt<Action>(0)();
                 return Task.CompletedTask;
             });
 
         _mainThreadService.InvokeOnMainThreadAsync(Arg.Any<Func<Task>>())
             .Returns(async call =>
             {
-                await ((Func<Task>)call[0])();
+                await call.ArgAt<Func<Task>>(0)();
             });
     }
 
@@ -273,7 +273,7 @@ public sealed class DatabaseRecoveryHostTests
                     return Task.FromException(dispatchFailure);
                 }
 
-                ((Action)call[0])();
+                call.ArgAt<Action>(0)();
                 return Task.CompletedTask;
             });
 

--- a/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/Tabs/CreateDatabaseTabTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/Tabs/CreateDatabaseTabTests.cs
@@ -374,7 +374,7 @@ public sealed class CreateDatabaseTabTests : BunitContext
             .CreateAsync(default!, default!, default, default)
             .ReturnsForAnyArgs(callInfo =>
             {
-                var targetPath = callInfo.Arg<CreateDatabaseRequest>().TargetPath;
+                var targetPath = callInfo.ArgAt<CreateDatabaseRequest>(0).TargetPath;
                 File.WriteAllText(targetPath, string.Empty);
                 writtenDatabasePaths.Add(targetPath);
                 return Task.FromResult(new DatabaseToolsResult(DatabaseToolsOutcome.Succeeded, null, TimeSpan.Zero));

--- a/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/Tabs/ManageDatabasesTabTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/DatabaseTools/Tabs/ManageDatabasesTabTests.cs
@@ -126,7 +126,7 @@ public sealed class ManageDatabasesTabTests : BunitContext
             .Returns(new RemoveOutcome(RemoveOutcomeStatus.Confirmed, true, false));
         var alertSurface = new FakeInlineAlertSurface { Result = new InlineAlertResult(true, null) };
         var component = RenderWithAlertSurface(alertSurface);
-
+
         await EnterSelectionModeAsync(component);
         var checkboxes = component.FindAll(".db-entry-row input[type='checkbox']");
         await component.InvokeAsync(() => checkboxes[0].ChangeAsync(new ChangeEventArgs { Value = true }));
@@ -153,7 +153,7 @@ public sealed class ManageDatabasesTabTests : BunitContext
             Entry("b.db", isEnabled: false, status: DatabaseStatus.Ready)];
         var alertSurface = new FakeInlineAlertSurface { Result = new InlineAlertResult(false, null) };
         var component = RenderWithAlertSurface(alertSurface);
-
+
         await EnterSelectionModeAsync(component);
         var checkboxes = component.FindAll(".db-entry-row input[type='checkbox']");
         await component.InvokeAsync(() => checkboxes[0].ChangeAsync(new ChangeEventArgs { Value = true }));
@@ -181,7 +181,7 @@ public sealed class ManageDatabasesTabTests : BunitContext
 
         var alertSurface = new FakeInlineAlertSurface { Result = new InlineAlertResult(false, null) };
         var component = RenderWithAlertSurface(alertSurface);
-
+
         await EnterSelectionModeAsync(component);
         await component.InvokeAsync(() => component.Find(".db-entry-row input[type='checkbox']").ChangeAsync(new ChangeEventArgs { Value = true }));
         var bulkRemove = component.Find(".manage-databases-bulk-strip .button-red");
@@ -264,7 +264,7 @@ public sealed class ManageDatabasesTabTests : BunitContext
             .Returns(new RemoveOutcome(RemoveOutcomeStatus.Confirmed, true, false));
         var alertSurface = new FakeInlineAlertSurface { Result = new InlineAlertResult(true, null) };
         var component = RenderWithAlertSurface(alertSurface);
-
+
         await EnterSelectionModeAsync(component);
         var checkboxes = component.FindAll(".db-entry-row input[type='checkbox']");
         await component.InvokeAsync(() => checkboxes[0].ChangeAsync(new ChangeEventArgs { Value = true }));
@@ -273,7 +273,7 @@ public sealed class ManageDatabasesTabTests : BunitContext
         var bulkRemove = component.Find(".manage-databases-bulk-strip .button-red");
         await component.InvokeAsync(() => bulkRemove.Click());
 
-        _announcementService.Received().Announce(Arg.Is<string>(s => s.Contains("a.db") && s.Contains("disk full")));
+        _announcementService.Received().Announce(Arg.Is<string>(s => s != null && s.Contains("a.db") && s.Contains("disk full")));
     }
 
     [Fact]
@@ -298,7 +298,7 @@ public sealed class ManageDatabasesTabTests : BunitContext
         await component.InvokeAsync(() => upgradeBtn.Click());
 
         await _coordinator.Received(1).UpgradeDatabasesAsync(
-            Arg.Is<IReadOnlyList<string>>(l => l.Count == 2 && l.Contains("a.db") && l.Contains("b.db")),
+            Arg.Is<IReadOnlyList<string>>(l => l != null && l.Count == 2 && l.Contains("a.db") && l.Contains("b.db")),
             UpgradeProgressScope.ManageDatabasesTriggered,
             Arg.Any<CancellationToken>());
     }
@@ -440,7 +440,7 @@ public sealed class ManageDatabasesTabTests : BunitContext
         Assert.Equal("Upgrade 1", prompt.AcceptLabel);
 
         await _coordinator.Received(1).UpgradeDatabasesAsync(
-            Arg.Is<IReadOnlyList<string>>(l => l.Count == 1 && l.Contains("a.db")),
+            Arg.Is<IReadOnlyList<string>>(l => l != null && l.Count == 1 && l.Contains("a.db")),
             UpgradeProgressScope.ManageDatabasesTriggered,
             Arg.Any<CancellationToken>());
     }
@@ -1124,8 +1124,8 @@ public sealed class ManageDatabasesTabTests : BunitContext
 
         Assert.Equal(1, _databaseService.RestoreFromBackupCalls);
         Assert.False(component.Instance.HasDatabaseStateChanged);
-        _announcementService.Received(1).Announce(Arg.Is<string>(s => s.Contains("Could not restore")));
-        _announcementService.DidNotReceive().Announce(Arg.Is<string>(s => s.StartsWith("Restored ")));
+        _announcementService.Received(1).Announce(Arg.Is<string>(s => s != null && s.Contains("Could not restore")));
+        _announcementService.DidNotReceive().Announce(Arg.Is<string>(s => s != null && s.StartsWith("Restored ")));
     }
 
     [Fact]
@@ -1142,7 +1142,7 @@ public sealed class ManageDatabasesTabTests : BunitContext
 
         Assert.Equal(1, _databaseService.RestoreFromBackupCalls);
         Assert.True(component.Instance.HasDatabaseStateChanged);
-        _announcementService.Received(1).Announce(Arg.Is<string>(s => s.StartsWith("Restored ")));
+        _announcementService.Received(1).Announce(Arg.Is<string>(s => s != null && s.StartsWith("Restored ")));
     }
 
     [Fact]
@@ -1160,7 +1160,7 @@ public sealed class ManageDatabasesTabTests : BunitContext
                 .Invoke(component.Instance, [_databaseService.Entries[0]])!));
 
         Assert.Equal(0, _databaseService.RestoreFromBackupCalls);
-        _announcementService.Received(1).Announce(Arg.Is<string>(s => s.Contains("Cannot restore")));
+        _announcementService.Received(1).Announce(Arg.Is<string>(s => s != null && s.Contains("Cannot restore")));
     }
 
     [Fact]
@@ -1258,7 +1258,7 @@ public sealed class ManageDatabasesTabTests : BunitContext
     {
         _databaseService.Entries = [Entry("a.db", isEnabled: false, status: DatabaseStatus.Ready)];
         var component = Render<ManageDatabasesTab>();
-
+
         await EnterSelectionModeAsync(component);
         await component.InvokeAsync(() => component.Find(".db-entry-row input[type='checkbox']").ChangeAsync(new ChangeEventArgs { Value = true }));
 
@@ -1274,7 +1274,7 @@ public sealed class ManageDatabasesTabTests : BunitContext
             Entry("a.db", isEnabled: false, status: DatabaseStatus.Ready),
             Entry("b.db", isEnabled: false, status: DatabaseStatus.Ready)];
         var component = Render<ManageDatabasesTab>();
-
+
         await EnterSelectionModeAsync(component);
         var checkboxes = component.FindAll(".db-entry-row input[type='checkbox']");
         await component.InvokeAsync(() => checkboxes[0].ChangeAsync(new ChangeEventArgs { Value = true }));
@@ -1294,7 +1294,7 @@ public sealed class ManageDatabasesTabTests : BunitContext
     {
         _databaseService.Entries = [Entry("a.db", isEnabled: false, status: DatabaseStatus.Ready)];
         var component = Render<ManageDatabasesTab>();
-
+
         await EnterSelectionModeAsync(component);
         await component.InvokeAsync(() => component.Find(".db-entry-row input[type='checkbox']").ChangeAsync(new ChangeEventArgs { Value = true }));
         Assert.True(component.Instance.HasBulkSelection);

--- a/tests/Unit/EventLogExpert.UI.Tests/DetailsPane/DetailsPaneTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/DetailsPane/DetailsPaneTests.cs
@@ -102,7 +102,7 @@ public sealed class DetailsPaneTests : BunitContext
 
         cut.Find(".details-copy-event").Click();
 
-        _clipboard.Received(1).CopyTextAsync(Arg.Is<string>(text => text.Contains("LogonType: 3 (Network)")));
+        _clipboard.Received(1).CopyTextAsync(Arg.Is<string>(text => text != null && text.Contains("LogonType: 3 (Network)")));
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterEditor/ScenarioClipboardExporterTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterEditor/ScenarioClipboardExporterTests.cs
@@ -35,7 +35,7 @@ public sealed class ScenarioClipboardExporterTests
 
         await _alertDialog.Received(1).ShowAlert(
             "Scenario JSON exported with warnings",
-            Arg.Is<string>(message => message.Contains("single-row color guardrail")),
+            Arg.Is<string>(message => message != null && message.Contains("single-row color guardrail")),
             "OK");
         _announcements.DidNotReceive().Announce(Arg.Any<string>());
     }

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterLibrary/FilterLibraryModalTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterLibrary/FilterLibraryModalTests.cs
@@ -80,7 +80,7 @@ public sealed class FilterLibraryModalTests : BunitContext
         var existing = BuildSavedFilter("Existing");
         var incoming = BuildSavedFilter("Incoming") with { Id = existing.Id, Tags = [" Alpha ", "alpha", "Beta"] };
         LibraryEntry? added = null;
-        _commands.When(c => c.AddEntry(Arg.Any<LibraryEntry>())).Do(call => added = call.Arg<LibraryEntry>());
+        _commands.When(c => c.AddEntry(Arg.Any<LibraryEntry>())).Do(call => added = call.ArgAt<LibraryEntry>(0));
         var preflight = new ImportPreflight(
             [],
             [],
@@ -114,7 +114,7 @@ public sealed class FilterLibraryModalTests : BunitContext
             Tags = [" Alpha ", "alpha", "Beta"],
         };
         LibraryEntry? updated = null;
-        _commands.When(c => c.UpdateEntry(Arg.Any<LibraryEntry>())).Do(call => updated = call.Arg<LibraryEntry>());
+        _commands.When(c => c.UpdateEntry(Arg.Any<LibraryEntry>())).Do(call => updated = call.ArgAt<LibraryEntry>(0));
         var preflight = new ImportPreflight(
             [],
             [(existing, incoming)],
@@ -140,7 +140,7 @@ public sealed class FilterLibraryModalTests : BunitContext
         var incomingA = BuildSavedFilter("IncomingA") with { Tags = [" Alpha "] };
         var incomingB = BuildSavedFilter("IncomingB") with { Tags = ["Beta"] };
         LibraryEntry? updated = null;
-        _commands.When(c => c.UpdateEntry(Arg.Any<LibraryEntry>())).Do(call => updated = call.Arg<LibraryEntry>());
+        _commands.When(c => c.UpdateEntry(Arg.Any<LibraryEntry>())).Do(call => updated = call.ArgAt<LibraryEntry>(0));
         var preflight = new ImportPreflight(
             [],
             [],
@@ -266,7 +266,7 @@ public sealed class FilterLibraryModalTests : BunitContext
 
         var component = Render<FilterLibraryModal>();
 
-        _modalCoordinator.Received().RegisterModal(Arg.Is<ModalRegistration>(r => r.InlineAlertHost == component.Instance));
+        _modalCoordinator.Received().RegisterModal(Arg.Is<ModalRegistration>(r => r != null && r.InlineAlertHost == component.Instance));
     }
 
     [Fact]
@@ -307,7 +307,7 @@ public sealed class FilterLibraryModalTests : BunitContext
         var component = Render<FilterLibraryModal>();
 
         _modalCoordinator.Received(1).RegisterModal(Arg.Is<ModalRegistration>(r =>
-            r.InlineAlertHost == component.Instance));
+            r != null && r.InlineAlertHost == component.Instance));
     }
 
     [Fact]
@@ -699,7 +699,7 @@ public sealed class FilterLibraryModalTests : BunitContext
         await bar.KeyDownAsync(new KeyboardEventArgs { Key = "Escape" });
 
         Assert.Equal(2, component.Find("[role='tabpanel'].active").QuerySelectorAll(".library-entry").Length);
-        _announcements.Received().Announce(Arg.Is<string>(s => s.Contains("Tag filters cleared")));
+        _announcements.Received().Announce(Arg.Is<string>(s => s != null && s.Contains("Tag filters cleared")));
     }
 
     [Fact]
@@ -712,7 +712,7 @@ public sealed class FilterLibraryModalTests : BunitContext
         var bar = component.Find(".library-tag-filter-bar");
         await bar.KeyDownAsync(new KeyboardEventArgs { Key = "Escape" });
 
-        _announcements.DidNotReceive().Announce(Arg.Is<string>(s => s.Contains("Tag filters cleared")));
+        _announcements.DidNotReceive().Announce(Arg.Is<string>(s => s != null && s.Contains("Tag filters cleared")));
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterLibrary/LibraryEntryRowTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterLibrary/LibraryEntryRowTests.cs
@@ -117,7 +117,7 @@ public sealed class LibraryEntryRowTests : BunitContext
         var items = await CapturedMoreMenuItemsAsync(component);
         await items.First(i => i.Label == "Delete").OnClickAsync!.Invoke();
 
-        await _alerts.Received(1).ShowAlert("Delete from library?", Arg.Is<string>(m => m.Contains("filter set 'P' with 2 filters")), "Delete", "Cancel");
+        await _alerts.Received(1).ShowAlert("Delete from library?", Arg.Is<string>(m => m != null && m.Contains("filter set 'P' with 2 filters")), "Delete", "Cancel");
     }
 
     [Fact]
@@ -226,7 +226,7 @@ public sealed class LibraryEntryRowTests : BunitContext
         Assert.NotNull(captured);
         Assert.Equal(entry.Id, captured.EntryId);
         Assert.True(captured.NewIsFavorite);
-        _announcements.Received(1).Announce(Arg.Is<string>(s => s.Contains("Marked X as favorite")));
+        _announcements.Received(1).Announce(Arg.Is<string>(s => s != null && s.Contains("Marked X as favorite")));
     }
 
     [Fact]
@@ -392,7 +392,7 @@ public sealed class LibraryEntryRowTests : BunitContext
         await component.Find("button[aria-label='Remove tag bug']").ClickAsync(new MouseEventArgs());
 
         _commands.Received(1).SetEntryTags(entry.Id, Arg.Is<ImmutableList<string>>(
-            tags => tags.SequenceEqual(new[] { "perf" })));
+            tags => tags != null && tags.SequenceEqual(new[] { "perf" })));
         _announcements.Received(1).Announce("Removed tag 'bug' from X");
     }
 
@@ -459,7 +459,7 @@ public sealed class LibraryEntryRowTests : BunitContext
         await items.First(i => i.Label == "Save to Library").OnClickAsync!.Invoke();
 
         Assert.True(invoked);
-        _announcements.Received(1).Announce(Arg.Is<string>(s => s.Contains("Saved X to library")));
+        _announcements.Received(1).Announce(Arg.Is<string>(s => s != null && s.Contains("Saved X to library")));
     }
 
     [Fact]
@@ -526,7 +526,7 @@ public sealed class LibraryEntryRowTests : BunitContext
     {
         IReadOnlyList<MenuItem>? captured = null;
         _menuService.WhenForAnyArgs(s => s.OpenAt(0, 0, null!, false, false))
-            .Do(call => captured = (IReadOnlyList<MenuItem>)call[2]!);
+            .Do(call => captured = call.ArgAt<IReadOnlyList<MenuItem>>(2));
         await component.Find("button[aria-label^='More actions for']").ClickAsync(new MouseEventArgs());
         Assert.NotNull(captured);
         return captured;

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterLibrary/LibrarySavedTabHeaderTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterLibrary/LibrarySavedTabHeaderTests.cs
@@ -145,7 +145,7 @@ public sealed class LibrarySavedTabHeaderTests : BunitContext
         Assert.NotNull(captured);
         Assert.Equal("My New", captured.Name);
         Assert.Equal(LibraryEntryOrigin.UserSaved, captured.Origin);
-        _announcements.Received().Announce(Arg.Is<string>(s => s.Contains("My New")));
+        _announcements.Received().Announce(Arg.Is<string>(s => s != null && s.Contains("My New")));
         Assert.NotNull(component.Find(".library-saved-tab-new-button"));
     }
 

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterPane/FilterPaneTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterPane/FilterPaneTests.cs
@@ -323,7 +323,7 @@ public sealed class FilterPaneTests : BunitContext
         await copyButton.ClickAsync(new MouseEventArgs());
 
         authoring.Received(1).ExportRows(
-            Arg.Is<IReadOnlyList<SavedFilter>>(rows => rows.Count == 1 && rows[0].IsEnabled),
+            Arg.Is<IReadOnlyList<SavedFilter>>(rows => rows != null && rows.Count == 1 && rows[0].IsEnabled),
             Arg.Any<IReadOnlyList<string>>());
     }
 

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneGroupingTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneGroupingTests.cs
@@ -174,7 +174,7 @@ public sealed class LogTablePaneGroupingTests : BunitContext
             .When(m => m.OpenAt(
                 Arg.Any<double>(), Arg.Any<double>(), Arg.Any<IReadOnlyList<MenuItem>>(),
                 Arg.Any<bool>(), Arg.Any<bool>()))
-            .Do(call => items = call.Arg<IReadOnlyList<MenuItem>>());
+            .Do(call => items = call.ArgAt<IReadOnlyList<MenuItem>>(2));
 
         var cut = RenderGrouped(Collapsed(), Event(1, "Alpha"));
         cut.Find("tr.group-header-row").TriggerEvent("oncontextmenu", new MouseEventArgs());
@@ -192,7 +192,7 @@ public sealed class LogTablePaneGroupingTests : BunitContext
             .When(m => m.OpenAt(
                 Arg.Any<double>(), Arg.Any<double>(), Arg.Any<IReadOnlyList<MenuItem>>(),
                 Arg.Any<bool>(), Arg.Any<bool>()))
-            .Do(call => items = call.Arg<IReadOnlyList<MenuItem>>());
+            .Do(call => items = call.ArgAt<IReadOnlyList<MenuItem>>(2));
 
         var cut = RenderGrouped(Collapsed(), Event(1, "Alpha"), Event(2, "Alpha"), Event(3, "Beta"));
         cut.Find("tr.group-header-row").TriggerEvent("oncontextmenu", new MouseEventArgs());
@@ -200,7 +200,7 @@ public sealed class LogTablePaneGroupingTests : BunitContext
         await items!.First(item => item.Label == "Select Group").OnClickAsync!();
 
         _eventLogCommands.Received(1).SetSelectedEvents(
-            Arg.Is<IReadOnlyCollection<SelectionEntry>>(c => c.Count == 2),
+            Arg.Is<IReadOnlyCollection<SelectionEntry>>(c => c != null && c.Count == 2),
             Arg.Any<SelectionEntry?>());
     }
 
@@ -353,7 +353,7 @@ public sealed class LogTablePaneGroupingTests : BunitContext
         Press(cut, "PageDown"); // clamps to the last visible row (event 2)
 
         _eventLogCommands.Received(1).SetSelectedEvents(
-            Arg.Is<IReadOnlyCollection<SelectionEntry>>(c => c.Count == 1),
+            Arg.Is<IReadOnlyCollection<SelectionEntry>>(c => c != null && c.Count == 1),
             Arg.Any<SelectionEntry?>());
         Assert.Equal(3, LastFocusedRow());
     }
@@ -368,7 +368,7 @@ public sealed class LogTablePaneGroupingTests : BunitContext
         Press(cut, "ArrowDown"); // land on the first event
 
         _eventLogCommands.Received(1).SetSelectedEvents(
-            Arg.Is<IReadOnlyCollection<SelectionEntry>>(c => c.Count == 1),
+            Arg.Is<IReadOnlyCollection<SelectionEntry>>(c => c != null && c.Count == 1),
             Arg.Any<SelectionEntry?>());
     }
 
@@ -452,7 +452,7 @@ public sealed class LogTablePaneGroupingTests : BunitContext
             .When(m => m.OpenAt(
                 Arg.Any<double>(), Arg.Any<double>(), Arg.Any<IReadOnlyList<MenuItem>>(),
                 Arg.Any<bool>(), Arg.Any<bool>()))
-            .Do(call => items = call.Arg<IReadOnlyList<MenuItem>>());
+            .Do(call => items = call.ArgAt<IReadOnlyList<MenuItem>>(2));
 
         var cut = RenderGrouped(Collapsed(), Event(1, "Alpha"), Event(2, "Alpha"));
         cut.Find("tr.group-header-row").TriggerEvent("oncontextmenu", new MouseEventArgs());
@@ -485,7 +485,7 @@ public sealed class LogTablePaneGroupingTests : BunitContext
         Press(cut, "ArrowRight"); // focus + select first child
 
         _eventLogCommands.Received(1).SetSelectedEvents(
-            Arg.Is<IReadOnlyCollection<SelectionEntry>>(c => c.Count == 1),
+            Arg.Is<IReadOnlyCollection<SelectionEntry>>(c => c != null && c.Count == 1),
             Arg.Any<SelectionEntry?>());
         _logTableCommands.DidNotReceive().ToggleGroupCollapsed(Arg.Any<string>());
     }
@@ -503,7 +503,7 @@ public sealed class LogTablePaneGroupingTests : BunitContext
         Press(cut, "ArrowDown", shift: true); // skips the collapsed Beta header to event 4
 
         _eventLogCommands.Received(1).SetSelectedEvents(
-            Arg.Is<IReadOnlyCollection<SelectionEntry>>(c => c.Count == 4),
+            Arg.Is<IReadOnlyCollection<SelectionEntry>>(c => c != null && c.Count == 4),
             Arg.Any<SelectionEntry?>());
     }
 
@@ -519,7 +519,7 @@ public sealed class LogTablePaneGroupingTests : BunitContext
         Press(cut, "ArrowUp", shift: true); // skips the collapsed Beta header to event 1
 
         _eventLogCommands.Received(1).SetSelectedEvents(
-            Arg.Is<IReadOnlyCollection<SelectionEntry>>(c => c.Count == 4),
+            Arg.Is<IReadOnlyCollection<SelectionEntry>>(c => c != null && c.Count == 4),
             Arg.Any<SelectionEntry?>());
     }
 
@@ -558,7 +558,7 @@ public sealed class LogTablePaneGroupingTests : BunitContext
         Press(cut, "ArrowDown");
 
         _eventLogCommands.Received(1).SetSelectedEvents(
-            Arg.Is<IReadOnlyCollection<SelectionEntry>>(c => c.Count == 1 && c.Any(entry => entry.ReloadKey!.Value.RecordId == alpha.RecordId)),
+            Arg.Is<IReadOnlyCollection<SelectionEntry>>(c => c != null && c.Count == 1 && c.Any(entry => entry.ReloadKey!.Value.RecordId == alpha.RecordId)),
             Arg.Any<SelectionEntry?>());
     }
 
@@ -682,7 +682,7 @@ public sealed class LogTablePaneGroupingTests : BunitContext
         Press(cut, "ArrowDown"); // selects the next event
 
         _eventLogCommands.Received(1).SetSelectedEvents(
-            Arg.Is<IReadOnlyCollection<SelectionEntry>>(c => c.Count == 1),
+            Arg.Is<IReadOnlyCollection<SelectionEntry>>(c => c != null && c.Count == 1),
             Arg.Any<SelectionEntry?>());
     }
 

--- a/tests/Unit/EventLogExpert.Windows.Tests/ActivationDispatcherTests.cs
+++ b/tests/Unit/EventLogExpert.Windows.Tests/ActivationDispatcherTests.cs
@@ -58,7 +58,7 @@ public sealed class ActivationDispatcherTests
         var dialogService = Substitute.For<IAlertDialogService>();
         var mainThread = Substitute.For<IMainThreadService>();
         mainThread.InvokeOnMainThreadAsync(Arg.Any<Func<Task>>())
-            .Returns(callInfo => callInfo.Arg<Func<Task>>().Invoke());
+            .Returns(callInfo => callInfo.ArgAt<Func<Task>>(0).Invoke());
 
         var (dispatcher, channel) = CreateDispatcher(dialogService: dialogService, mainThread: mainThread);
         var alertOrderedBeforeOpen = false;
@@ -94,7 +94,7 @@ public sealed class ActivationDispatcherTests
     {
         var mainThread = Substitute.For<IMainThreadService>();
         mainThread.InvokeOnMainThreadAsync(Arg.Any<Func<Task>>())
-            .Returns(callInfo => callInfo.Arg<Func<Task>>().Invoke());
+            .Returns(callInfo => callInfo.ArgAt<Func<Task>>(0).Invoke());
 
         var (dispatcher, channel) = CreateDispatcher(mainThread: mainThread);
         var openBatchInvoked = false;
@@ -123,7 +123,7 @@ public sealed class ActivationDispatcherTests
     {
         var mainThread = Substitute.For<IMainThreadService>();
         mainThread.InvokeOnMainThreadAsync(Arg.Any<Func<Task>>())
-            .Returns(callInfo => callInfo.Arg<Func<Task>>().Invoke());
+            .Returns(callInfo => callInfo.ArgAt<Func<Task>>(0).Invoke());
 
         var (dispatcher, channel) = CreateDispatcher(mainThread: mainThread);
         IEnumerable<(string Path, LogPathType Type)>? capturedPaths = null;
@@ -244,7 +244,7 @@ public sealed class ActivationDispatcherTests
         {
             // Default: run on-thread to keep tests deterministic.
             resolvedMainThread.InvokeOnMainThreadAsync(Arg.Any<Func<Task>>())
-                .Returns(callInfo => callInfo.Arg<Func<Task>>().Invoke());
+                .Returns(callInfo => callInfo.ArgAt<Func<Task>>(0).Invoke());
         }
 
         var dispatcher = new ActivationDispatcher(


### PR DESCRIPTION
## Summary

Dependency security updates plus the NSubstitute 6.0 test-framework upgrade, split into two commits so the urgent security fix can be reviewed and reverted independently of the test migration.

### Commit 1 - Bump dependencies and refresh security pins
- **AngleSharp -> 1.5.2 (new transitive pin)** - fixes **CVE-2026-54570** (GHSA-pgww-w46g-26qg, mutation XSS). AngleSharp 1.4.0 came transitively through bUnit 2.7.2 (test-only). The advisory was tripping NuGetAudit (NU1902) as an error and breaking the build.
- **SQLitePCLRaw.lib.e_sqlite3 3.50.3 -> 3.53.3** - refreshes the existing **CVE-2025-6965** (GHSA-2m69-gcr7-jv3q) override. Latest stable Microsoft.Data.Sqlite 10.0.10 still references the vulnerable bundle 2.1.11; the upstream fix (SQLitePCLRaw 3.x) is only in 11.0-preview, so the pin stays (#604).
- Routine bumps: Microsoft.Extensions.{DependencyInjection, .Abstractions, Logging.Abstractions} 10.0.9 -> 10.0.10; Microsoft.Data.Sqlite / EntityFrameworkCore.Sqlite 10.0.9 -> 10.0.10; System.CommandLine 2.0.9 -> 2.0.10; Fluxor.Blazor.Web 6.9.0 -> 6.10.0; Microsoft.NET.Test.Sdk 18.6.0 -> 18.8.1.
- **Held:** Microsoft.Maui.Controls (`$(MauiVersion)`) and Microsoft.WindowsAppSDK 2.2.0 - WindowsAppSDK tracks the MAUI head transitive resolution and cannot be validated locally.

### Commit 2 - Upgrade NSubstitute to 6.0.0 and migrate test matchers
NSubstitute 6.0 enables nullable-reference annotations on its public API, breaking compilation under TreatWarningsAsErrors across 33 test files (~210 matcher guards + ~67 CallInfo accessors). Uniform, behavior-preserving migration:
- `Arg.Is<T>(x => BODY)` dereferencing x -> `Arg.Is<T>(x => x != null && BODY)` (an is-not-null pattern is illegal in an expression tree; `!= null` compiles there and still narrows nullability).
- `callInfo.Arg<T>()` / `((T)callInfo[N])` -> `callInfo.ArgAt<T>(N)` (non-null typed positional accessor).
- Value-type interpolated-string-handler matchers (WarningLogHandler, ErrorLogHandler) need no null guard; their ToString() is non-null.

Includes a test-quality audit of every touched test (remove tautologies / weak-redundant assertions). All touched tests exercise real behavior, so **0 removals**.

## Validation
- Full unit suite green: **6,209 tests, 0 failed / 0 skipped / 0 warnings** (TreatWarningsAsErrors).
- `dotnet list package --vulnerable` -> **35 projects, no vulnerable packages**.
- Reviewed by a 4-model review panel; no blocking issues.

## Notes
- The MAUI head (EventLogExpert.csproj) is not buildable in this local environment (pre-existing nuget.exe prerequisite); CI validates it.