### PR TITLE
Fix stale highlight-tie masks and ARIA briefly rendered during async disarm

### DIFF
--- a/src/EventLogExpert.UI/LogTable/Histogram/HistogramPane.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/Histogram/HistogramPane.razor.cs
@@ -369,6 +369,9 @@ public sealed partial class HistogramPane
         return joined.Length == 0 ? joined : char.ToUpperInvariant(joined[0]) + joined[1..];
     }
 
+    private static bool IsCategoricalOther(HistogramData data, int group) =>
+        group < data.Groups.Count && data.Groups[group].ColorClass == "histogram-cat-other";
+
     private static string? SelectActiveOriginLog(LogTableState state)
     {
         var activeTab = state.EventTables.FirstOrDefault(tab => tab.Id == state.ActiveEventLogId);
@@ -534,8 +537,6 @@ public sealed partial class HistogramPane
         return labels;
     }
 
-    private int BarsAreaHeight() => Math.Max(0, _plotHeightPx - AxisReservePx);
-
     private string BarTooltip(HistogramRenderBin bin)
     {
         var start = ToDisplay(new DateTime(bin.StartTicks, DateTimeKind.Utc));
@@ -546,6 +547,8 @@ public sealed partial class HistogramPane
 
         return $"{bin.Total} {_baseData?.EventNoun ?? "events"}{GroupBreakdown(bin)}, {startText} - {endText}";
     }
+
+    private int BarsAreaHeight() => Math.Max(0, _plotHeightPx - AxisReservePx);
 
     private string BinCursorAnnouncement(HistogramRenderBin bin)
     {
@@ -679,9 +682,6 @@ public sealed partial class HistogramPane
 
         return ResolveGroupHighlight(masks[group]).Description;
     }
-
-    private static bool IsCategoricalOther(HistogramData data, int group) =>
-        group < data.Groups.Count && data.Groups[group].ColorClass == "histogram-cat-other";
 
     private void HandleKeyDown(KeyboardEventArgs args)
     {
@@ -827,6 +827,14 @@ public sealed partial class HistogramPane
         if (_render is { } render && _baseData is { } data) { ComputeSegmentHeights(render, data.Groups.Count); }
     }
 
+    // Refresh the cached assertive-region bin readout against the current (post-filter-change) state. The cached string
+    // embeds the highlight description, so it must be re-derived on every highlight change (disarm, plan change, or a
+    // color-only edit that does not rescan) or it can keep announcing a stale highlight after the cursor is dismissed.
+    private void RefreshBinAnnouncement() =>
+        _binAnnouncement = _binCursor is { } cursor && _render is { } render && cursor < render.Bins.Count
+            ? BinCursorAnnouncement(render.Bins[cursor])
+            : string.Empty;
+
     private void RefreshFindTicks() =>
         _findTicks = FindMarkers.Owner == ActiveEventLogId.Value && FindMarkers.Ticks is { Count: > 0 } ticks
             ? [.. ticks]
@@ -847,16 +855,23 @@ public sealed partial class HistogramPane
 
         if (rescanNeeded && rescanOnPredicateChange)
         {
+            // The rescan will republish _baseData, but until it lands the current masks were resolved against the OLD
+            // eligible list. Invalidate them synchronously so a render in the gap does not map stale ordinals through
+            // the new filters (masks are non-null only when the prior state was armed).
+            if (_baseData is { GroupHighlightMasks: not null } data)
+            {
+                _baseData = data with { GroupHighlightMasks = null };
+            }
+
+            RefreshBinAnnouncement();
+            StateHasChanged();
+
             StartScan();
 
             return;
         }
 
-        if (_binCursor is { } cursor && _render is { } render && cursor < render.Bins.Count)
-        {
-            _binAnnouncement = BinCursorAnnouncement(render.Bins[cursor]);
-        }
-
+        RefreshBinAnnouncement();
         StateHasChanged();
     }
 
@@ -915,7 +930,7 @@ public sealed partial class HistogramPane
         {
             await InvokeAsync(() =>
             {
-                if (_disposed || epoch != _scanEpoch || !ReferenceEquals(view, ActiveView.Value)) { return; }
+                if (_disposed || token.IsCancellationRequested || epoch != _scanEpoch || !ReferenceEquals(view, ActiveView.Value)) { return; }
 
                 if (useHighlightTie && tiePlanKey != _tiePlanKey) { return; }
 
@@ -1030,10 +1045,14 @@ public sealed partial class HistogramPane
         _scanCts?.Dispose();
         _scanCts = null;
 
+        // Bump the epoch on every supersede -- even when we bail below for a zero-size viewport -- so a prior scan whose
+        // UI publication is already queued is rejected by RunScanAsync's epoch guard and cannot restore stale data (for
+        // example, re-arm masks that a disarm just cleared).
+        int epoch = ++_scanEpoch;
+
         if (_viewportWidthPx <= 0 || _plotHeightPx <= 0) { return; }
 
         IEventColumnView view = ActiveView.Value;
-        int epoch = ++_scanEpoch;
         HistogramDimension dimension = _dimension;
         SavedFilter[] tieHighlightFilters = _tieHighlightFilters;
         int tiePlanKey = _tiePlanKey;

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/Histogram/HistogramPaneTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/Histogram/HistogramPaneTests.cs
@@ -101,6 +101,78 @@ public sealed class HistogramPaneTests : BunitContext
     }
 
     [Fact]
+    public async Task FilterRefresh_WhenColorOnlyEditWithNoActiveCursor_ClearsStaleBinAnnouncement()
+    {
+        // Red -> blue keeps the tie armed AND the same predicate-plan key (color is excluded from the plan key), so no
+        // rescan occurs. The non-rescan tail must still drop the stale "Light red" announcement when no cursor is active.
+        SavedFilter red = Filter(HighlightColor.LightRed);
+        SavedFilter blue = Filter(HighlightColor.LightBlue);
+        _highlightSelector.Select(Arg.Any<ImmutableList<SavedFilter>>()).Returns([blue]);
+        _highlightSelector.ComputePredicatePlanKey(Arg.Any<ImmutableList<SavedFilter>>()).Returns(7);
+        var cut = Render<HistogramPane>();
+
+        SetPrivateField(cut, "_tieHighlightFilters", new[] { red });
+        SetPrivateField(cut, "_binCursor", null);
+        SetPrivateField(cut, "_binAnnouncement", "2 events (1 Alpha, Light red highlight)");
+        await cut.InvokeAsync(() => { });
+        Assert.Contains("Light red", GetPrivateField<string>(cut, "_binAnnouncement"));
+
+        _filters.SelectedValueChanged +=
+            Raise.Event<EventHandler<ImmutableList<SavedFilter>>>(_filters, ImmutableList.Create(blue));
+        await cut.InvokeAsync(() => { });
+
+        Assert.Equal(string.Empty, GetPrivateField<string>(cut, "_binAnnouncement"));
+    }
+
+    [Fact]
+    public async Task FilterRefresh_WhenDisarmedWithNoActiveCursor_ClearsStaleBinAnnouncement()
+    {
+        SavedFilter red = Filter(HighlightColor.LightRed);
+        _highlightSelector.Select(Arg.Any<ImmutableList<SavedFilter>>()).Returns([]);
+        _highlightSelector.ComputePredicatePlanKey(Arg.Any<ImmutableList<SavedFilter>>()).Returns(7);
+        var cut = Render<HistogramPane>();
+
+        // A prior armed bin readout was cached, then the cursor was dismissed (Escape) which leaves the text behind.
+        SetPrivateField(cut, "_tieHighlightFilters", new[] { red });
+        SetPrivateField(cut, "_binCursor", null);
+        SetPrivateField(cut, "_binAnnouncement", "2 events (1 Alpha, Light red highlight)");
+        await cut.InvokeAsync(() => { });
+        Assert.Contains("highlight", GetPrivateField<string>(cut, "_binAnnouncement"));
+
+        _filters.SelectedValueChanged +=
+            Raise.Event<EventHandler<ImmutableList<SavedFilter>>>(_filters, ImmutableList<SavedFilter>.Empty);
+        await cut.InvokeAsync(() => { });
+
+        Assert.Equal(string.Empty, GetPrivateField<string>(cut, "_binAnnouncement"));
+    }
+
+    [Fact]
+    public async Task FilterRefresh_WhenDisarmed_ClearsGroupHighlightMasksSynchronously()
+    {
+        // Arm on init, disarm on the filter change. Keep the viewport at 0 (never resize) so StartScan no-ops and cannot
+        // publish mask-free data on its own -- the synchronous mask clear in RefreshTieFilters is the only mutation.
+        SavedFilter red = Filter(HighlightColor.LightRed);
+        _highlightSelector.Select(Arg.Any<ImmutableList<SavedFilter>>()).Returns([]);
+        _highlightSelector.ComputePredicatePlanKey(Arg.Any<ImmutableList<SavedFilter>>()).Returns(7);
+        var cut = Render<HistogramPane>();
+
+        SetPrivateField(cut, "_tieHighlightFilters", new[] { red });
+        await PublishBaseDataAsync(cut, ArmedCategoryData());
+
+        // Non-vacuous: the armed legend swatch renders the highlight class.
+        cut.WaitForAssertion(() => Assert.Equal("histogram-cat-hl", AlphaSwatchClass(cut)));
+
+        _filters.SelectedValueChanged +=
+            Raise.Event<EventHandler<ImmutableList<SavedFilter>>>(_filters, ImmutableList<SavedFilter>.Empty);
+        await cut.InvokeAsync(() => { });
+
+        // histogram-cat-hl comes only from GroupHighlightMasks; with no scan publishing (viewport 0), its disappearance
+        // proves the synchronous clear ran.
+        cut.WaitForAssertion(() => Assert.NotEqual("histogram-cat-hl", AlphaSwatchClass(cut)));
+        Assert.Null(GetPrivateField<HistogramData>(cut, "_baseData").GroupHighlightMasks);
+    }
+
+    [Fact]
     public async Task FilterRefresh_WhenOnlyHighlightColorChanges_DoesNotReadActiveViewForScan()
     {
         SavedFilter red = Filter(HighlightColor.LightRed);
@@ -122,23 +194,6 @@ public sealed class HistogramPaneTests : BunitContext
         await cut.InvokeAsync(() => { });
 
         _ = _activeView.DidNotReceive().Value;
-    }
-
-    [Fact]
-    public async Task FilterRefresh_WhenPredicatePlanChanges_ReadsActiveViewForScan()
-    {
-        SavedFilter red = Filter(HighlightColor.LightRed);
-        SavedFilter blue = Filter(HighlightColor.LightBlue);
-        _highlightSelector.Select(Arg.Any<ImmutableList<SavedFilter>>()).Returns([red], [blue]);
-        _highlightSelector.ComputePredicatePlanKey(Arg.Any<ImmutableList<SavedFilter>>()).Returns(7, 8);
-        var cut = Render<HistogramPane>();
-        await cut.InvokeAsync(() => cut.Instance.OnHistogramResized(500, 100));
-        _activeView.ClearReceivedCalls();
-
-        _filters.SelectedValueChanged +=
-            Raise.Event<EventHandler<ImmutableList<SavedFilter>>>(_filters, ImmutableList.Create(blue));
-
-        _ = _activeView.Received().Value;
     }
 
     [Fact]
@@ -164,6 +219,28 @@ public sealed class HistogramPaneTests : BunitContext
         await cut.InvokeAsync(() => { });
 
         _ = _activeView.DidNotReceive().Value;
+    }
+
+    [Fact]
+    public async Task FilterRefresh_WhenPredicatePlanChanges_ReadsActiveViewForScan()
+    {
+        SavedFilter red = Filter(HighlightColor.LightRed);
+        SavedFilter blue = Filter(HighlightColor.LightBlue);
+        _highlightSelector.Select(Arg.Any<ImmutableList<SavedFilter>>()).Returns([red], [blue]);
+        _highlightSelector.ComputePredicatePlanKey(Arg.Any<ImmutableList<SavedFilter>>()).Returns(7, 8);
+        var cut = Render<HistogramPane>();
+        await cut.InvokeAsync(() => cut.Instance.OnHistogramResized(500, 100));
+
+        // Wait for the resize scan's two ActiveView.Value reads (sync StartScan + post-scan continuation) to settle
+        // before clearing, so the continuation's late read is not miscounted against the plan-change rescan under test.
+        cut.WaitForAssertion(() => _ = _activeView.Received(2).Value);
+        _activeView.ClearReceivedCalls();
+
+        _filters.SelectedValueChanged +=
+            Raise.Event<EventHandler<ImmutableList<SavedFilter>>>(_filters, ImmutableList.Create(blue));
+
+        // The plan-change rescan dispatches via InvokeAsync; wait for its ActiveView.Value read rather than checking eagerly.
+        cut.WaitForAssertion(() => _ = _activeView.Received().Value);
     }
 
     [Fact]
@@ -300,6 +377,37 @@ public sealed class HistogramPaneTests : BunitContext
         }
     }
 
+    [Fact]
+    public async Task StartScan_WhenViewportZero_BumpsScanEpochToSupersedeQueuedPublish()
+    {
+        // A zero-size viewport makes StartScan bail without launching a scan, but it must still bump the epoch so a prior
+        // scan whose UI publication is already queued is rejected and cannot restore stale (for example, armed) data.
+        var cut = Render<HistogramPane>();
+        int before = GetPrivateField<int>(cut, "_scanEpoch");
+
+        await cut.InvokeAsync(() => InvokePrivate(cut, "StartScan"));
+
+        Assert.Equal(before + 1, GetPrivateField<int>(cut, "_scanEpoch"));
+    }
+
+    private static string? AlphaSwatchClass(IRenderedComponent<HistogramPane> cut) =>
+        cut.FindAll(".histogram-legend-item")
+            .Single(button => button.TextContent == "Alpha")
+            .QuerySelector("rect")?
+            .GetAttribute("class");
+
+    private static HistogramData ArmedCategoryData() =>
+        new(
+            [1, 1],
+            2,
+            1,
+            new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2024, 1, 1, 1, 0, 0, DateTimeKind.Utc),
+            2,
+            TimeSpan.FromHours(1).Ticks,
+            HistogramGroups.ForCategories(["alpha"], ["Alpha"], "Other"),
+            [1u << 1, 1u << 1]);
+
     private static SavedFilter Filter(HighlightColor color) =>
         new() { Color = color, IsEnabled = true, ComparisonText = "Id == 1", Compiled = null! };
 
@@ -311,6 +419,20 @@ public sealed class HistogramPaneTests : BunitContext
 
         Assert.NotNull(field);
         return Assert.IsType<HistogramDimension>(field.GetValue(cut.Instance));
+    }
+
+    private static T GetPrivateField<T>(IRenderedComponent<HistogramPane> cut, string name)
+    {
+        var field = typeof(HistogramPane).GetField(name, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        return Assert.IsType<T>(field.GetValue(cut.Instance));
+    }
+
+    private static void InvokePrivate(IRenderedComponent<HistogramPane> cut, string name)
+    {
+        var method = typeof(HistogramPane).GetMethod(name, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        method.Invoke(cut.Instance, null);
     }
 
     private static Task PublishBaseDataAsync(IRenderedComponent<HistogramPane> cut, HistogramData data)
@@ -350,5 +472,12 @@ public sealed class HistogramPaneTests : BunitContext
         var select = cut.FindComponent<ValueSelect<HistogramDimension>>();
 
         return cut.InvokeAsync(() => select.Instance.UpdateValue(dimension));
+    }
+
+    private static void SetPrivateField(IRenderedComponent<HistogramPane> cut, string name, object? value)
+    {
+        var field = typeof(HistogramPane).GetField(name, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        field.SetValue(cut.Instance, value);
     }
 }


### PR DESCRIPTION
Closes #659.

## Problem
The scenario histogram's highlight-tie refresh (`HistogramPane.RefreshTieFilters`) reassigns `_tieHighlightFilters` synchronously, but the histogram data (`_baseData`, including `GroupHighlightMasks`) is only replaced when a background scan completes. On a **disarm** transition (the last highlight color is cleared, or the eligible filter count crosses 31), the mask-free scan does not clear `_baseData` synchronously, so a re-render in the gap maps the old **armed** mask ordinals through the new (unarmed) filter list -- briefly flashing stale or mis-mapped group-highlight styling and the corresponding ARIA. Transient, self-healing, visual/accessibility only.

## Fixes
- **Synchronous mask invalidation.** On the `RefreshTieFilters` rescan branch, clear `_baseData.GroupHighlightMasks` immediately (via `with { ... = null }`) so the render is mask-free until the correct masks republish. Covers disarm and an armed reconfigure whose eligible-list reorder remaps the old ordinals.
- **Cached-ARIA refresh.** The assertive live region caches a bin announcement that embeds the highlight description. A shared `RefreshBinAnnouncement()` helper now re-derives it on **every** highlight change (both the rescan and non-rescan paths of `RefreshTieFilters`), so a disarm, plan change, or color-only edit does not leave the live region announcing a stale highlight after the cursor is dismissed.
- **Mask-restore race.** `StartScan` bumped the scan epoch only *after* its zero-viewport early return, so a queued armed-scan publication could restore the just-cleared masks (a color-only disarm keeps the same predicate plan key, so the epoch bump is what supersedes it). The epoch is now bumped before the early return, and the publish path rechecks the cancellation token.

## Testing
bUnit coverage in `HistogramPaneTests`:
- Disarm clears `GroupHighlightMasks` synchronously (viewport pinned to 0 so no background scan can publish and mask the result).
- The cached bin announcement is refreshed on both the rescan (disarm) and non-rescan (color-only edit) paths.
- A zero-viewport `StartScan` still bumps the scan epoch.

Full-solution build: 0 warnings / 0 errors. UI unit tests: 1190/1190.
