### PR TITLE
Commit a completed events export even if Cancel is clicked late

### DIFF
--- a/src/EventLogExpert/Adapters/Menu/MauiMenuActionService.cs
+++ b/src/EventLogExpert/Adapters/Menu/MauiMenuActionService.cs
@@ -182,7 +182,6 @@ public sealed class MauiMenuActionService(
         }
 
         CancellationTokenSource cancellation = new();
-        bool finished = false;
         string? savedPath = null;
         Exception? failure = null;
         bool canceled = false;
@@ -192,22 +191,22 @@ public sealed class MauiMenuActionService(
             savedPath = await _fileSaveService.SaveStreamingAsync(
                 suggestedFileName,
                 fileTypes,
-                async (stream, token) =>
+                async (stream, _) =>
                 {
-                    // Begin only once the picker has returned a destination and the streaming write is
-                    // starting; dismissing the picker never reaches here, so it stays silent. The finished
-                    // flag turns a late Cancel click into a clean no-op.
+                    // Begin only once the picker has returned a destination and the streaming write is starting;
+                    // dismissing the picker never reaches here, so it stays silent. A Cancel click can race export
+                    // teardown (the CTS is disposed in the finally), so guard the narrow disposed-CTS window.
                     _exportProgress.Begin(
-                        "Exporting events...", () => { if (!Volatile.Read(ref finished)) { cancellation.Cancel(); } });
+                        "Exporting events...",
+                        () => { try { cancellation.Cancel(); } catch (ObjectDisposedException) { /* Teardown disposed the CTS; a late Cancel is a no-op. */ } });
 
+                    // Cancellation gates the WRITE only: ExportAsync throws per-row on Cancel, so AtomicFileWriter
+                    // discards the temp. SaveStreamingAsync gets CancellationToken.None, so once the write completes
+                    // the atomic commit is unconditional - a late Cancel can no longer discard a fully-written export.
                     await _eventTableExporter.ExportAsync(
-                        stream, format, events, columns, timeZone, includeDescription: true, token);
-
-                    // The streaming write is done; stop honoring Cancel before SaveStreamingAsync runs its
-                    // post-write cancel gates, so a late Cancel can't abort an already-written export's commit.
-                    Volatile.Write(ref finished, true);
+                        stream, format, events, columns, timeZone, includeDescription: true, cancellation.Token);
                 },
-                cancellation.Token);
+                CancellationToken.None);
         }
         catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
         {
@@ -219,8 +218,6 @@ public sealed class MauiMenuActionService(
         }
         finally
         {
-            Volatile.Write(ref finished, true);
-
             // End() raises StateChanged; isolate it so a throwing subscriber can never skip the CTS
             // disposal or the in-flight reset, which would otherwise wedge every later export.
             try

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Common/Files/AtomicFileWriterTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Common/Files/AtomicFileWriterTests.cs
@@ -108,6 +108,26 @@ public sealed class AtomicFileWriterTests : IDisposable
             () => AtomicFileWriter.WriteAsync("barefilename.log", WriteText("x"), TestContext.Current.CancellationToken));
 
     [Fact]
+    public async Task WriteAsync_NoneToken_CommitsCompletedWriteEvenWhenASeparateSourceIsCancelled()
+    {
+        // Mirrors ExportEventsAsync: the write is scoped to a caller CTS, but AtomicFileWriter receives None, so a
+        // Cancel that lands after the content is written cannot abort the atomic commit - the completed file is saved.
+        var destination = Destination();
+        using var cancellation = new CancellationTokenSource();
+
+        Func<Stream, CancellationToken, Task> writeThenCancelSeparate = async (stream, _) =>
+        {
+            await stream.WriteAsync(Encoding.UTF8.GetBytes("exported"), TestContext.Current.CancellationToken);
+            await cancellation.CancelAsync();
+        };
+
+        await AtomicFileWriter.WriteAsync(destination, writeThenCancelSeparate, CancellationToken.None);
+
+        Assert.Equal("exported", await File.ReadAllTextAsync(destination, TestContext.Current.CancellationToken));
+        Assert.Empty(LeakedTempFiles());
+    }
+
+    [Fact]
     public async Task WriteAsync_NullWriteContent_ThrowsArgumentNullException() =>
         await Assert.ThrowsAsync<ArgumentNullException>(
             () => AtomicFileWriter.WriteAsync(Destination(), null!, TestContext.Current.CancellationToken));

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Export/EventTableExporterTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Export/EventTableExporterTests.cs
@@ -22,6 +22,21 @@ public sealed class EventTableExporterTests
     private static readonly TimeZoneInfo s_utc = TimeZoneInfo.Utc;
 
     [Fact]
+    public async Task ExportAsync_CancelledToken_ThrowsAndWritesNothing()
+    {
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+        EventTableExporter exporter = new(new TabularExportWriter());
+        using MemoryStream stream = new();
+
+        // A Cancel during the export must throw so AtomicFileWriter discards the temp; nothing is written.
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => exporter.ExportAsync(
+            stream, ExportFormat.Csv, BuildView(s_events), s_columns, s_utc, includeDescription: false, cancellation.Token));
+
+        Assert.Equal(0, stream.Length);
+    }
+
+    [Fact]
     public async Task ExportAsync_Csv_ExcludeDescription_OmitsColumn()
     {
         ResolvedEvent[] events = [new("Log", LogPathType.Channel) { Id = 1, Source = "Alpha", Description = "Ignored" }];


### PR DESCRIPTION
## Summary

`MauiMenuActionService.ExportEventsAsync` passed the export's cancellation token to `SaveStreamingAsync`, so `AtomicFileWriter`'s post-write cancellation gate (a `ThrowIfCancellationRequested` immediately before the atomic commit) could throw in the tiny window between the streaming write finishing and the commit. A Cancel click landing there **discarded a fully written export** and reported it canceled. A `finished` flag tried to disarm the banner Cancel after the write, but it was set a few instructions too late to close the race.

## Fix

Scope cancellation to the **write phase** only:

- Pass the CTS token directly to `EventTableExporter.ExportAsync` — it throws per row on Cancel, so a mid-write Cancel discards the temp file (unchanged behavior).
- Pass **`CancellationToken.None`** to `SaveStreamingAsync`, so once the write completes the atomic commit is **unconditional** — a late Cancel is now a no-op and the completed export is saved.

This matches Windows Event Viewer (a finished export shouldn't be thrown away) and the two other `SaveStreamingAsync` callers (`DebugLogModal`, `DatabaseToolsLogView`), which already pass `None`. The banner Cancel callback now swallows `ObjectDisposedException` (only) to stay safe against the CTS being disposed during teardown, replacing the racy `finished` flag; any other throw still reaches `BannerActionGuard`.

## Behavior

- **Cancel during the write** -> `ExportAsync` throws -> temp discarded, "Export canceled". *(unchanged)*
- **Cancel after the write completes** -> ignored -> the finished export is saved. *(the fix)*
- `AtomicFileWriter` (shared, safety-critical) is **unchanged**; the other callers are unaffected.

## Testing

The MAUI action has no unit-test harness, so the two guarantees are locked at the Runtime layer:

- `EventTableExporterTests.ExportAsync_CancelledToken_ThrowsAndWritesNothing` — a canceled token aborts the export and writes nothing (so `AtomicFileWriter` discards the temp).
- `AtomicFileWriterTests.WriteAsync_NoneToken_CommitsCompletedWriteEvenWhenASeparateSourceIsCancelled` — a completed write commits under `CancellationToken.None` even when a *separate* source is canceled (complements the existing `WriteAsync_CancelledAfterWrite`, which proves the gate fires for a real token).

Full solution builds; Runtime.Tests 2032/2032.
