### PR TITLE
Add integration test guarding event-log reducer registration

### DIFF
--- a/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EventLogReducerRegistrationTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EventLogReducerRegistrationTests.cs
@@ -1,0 +1,48 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Filtering.TestUtils;
+using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.Tests.TestUtils.Constants;
+using Fluxor;
+using Fluxor.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using System.Collections.Immutable;
+
+namespace EventLogExpert.Runtime.Tests.EventLog;
+
+public sealed class EventLogReducerRegistrationTests
+{
+    [Fact]
+    public void RegisteredReducers_AddThenConsumeEvents_UpdateNewEventBuffer()
+    {
+        using ServiceProvider provider = new ServiceCollection()
+            .AddFluxor(options => options.RegisterStateLibrary().WithLifetime(StoreLifetime.Singleton))
+            .BuildServiceProvider();
+
+        var feature = provider.GetRequiredService<IFeature<EventLogState>>();
+
+        feature.RestoreState(feature.State with
+        {
+            ContinuouslyUpdate = false,
+            OpenLogs = ImmutableDictionary<string, OpenLogInfo>.Empty
+                .Add(Constants.LogNameTestLog, new OpenLogInfo(EventLogId.Create(), LogPathType.Channel))
+        });
+
+        var first = FilterEventBuilder.CreateTestEvent(100, owningLog: Constants.LogNameTestLog);
+        var second = FilterEventBuilder.CreateTestEvent(200, owningLog: Constants.LogNameTestLog);
+
+        feature.ReceiveDispatchNotificationFromStore(new AddEventAction(first));
+        feature.ReceiveDispatchNotificationFromStore(new AddEventAction(second));
+
+        Assert.Equal(2, feature.State.NewEventBuffer.Count);
+        Assert.Same(second, feature.State.NewEventBuffer[0]);
+        Assert.Same(first, feature.State.NewEventBuffer[1]);
+
+        feature.ReceiveDispatchNotificationFromStore(new NewEventBufferConsumedAction([first, second]));
+
+        Assert.Empty(feature.State.NewEventBuffer);
+    }
+}


### PR DESCRIPTION
## Summary
Adds a Runtime.Tests integration test that exercises the real Fluxor reducer registration for the EventLog feature, so a dropped `[ReducerMethod]` attribute or a broken `RegisterStateLibrary()` assembly scan is caught.

## Why
The existing `EventLogStoreTests` call `Reducers.ReduceAddEvent(...)` (and the other reducers) directly as static methods, so they stay green even if a reducer is no longer registered with the store - the silent-break class behind live-tail "Load New Events" not rendering. This test resolves `IFeature<EventLogState>` from a real `AddFluxor(o => o.RegisterStateLibrary())` container and applies `AddEventAction` + `NewEventBufferConsumedAction` through the registered reducer path (`ReceiveDispatchNotificationFromStore`), asserting the buffer fills newest-first then drains.

## Verification
- Stripping `[ReducerMethod]` from `ReduceAddEvent` fails this test while the 52 existing direct-call reducer tests stay green (the gap it fills).
- Runtime.Tests: 2031/2031 pass (baseline 2030 + this test).
- Test-only; no production code changed.
