### PR TITLE
Resolve the event User column to an offline account identity with a unified SID/name filter

### DIFF
--- a/docs/Filtering.md
+++ b/docs/Filtering.md
@@ -47,7 +47,7 @@ Pick a property, pick an operator, then enter or pick a comparison value. Option
 | `Task Category` | resolved task name |
 | `Process ID` | process id |
 | `Thread ID` | thread id |
-| `User ID` | SID string |
+| `User` | The event's user identity, matched against EITHER the resolved account name shown in the User column (`DOMAIN\user`, a well-known-SID name like `NT AUTHORITY\SYSTEM`) OR the raw SID; the multi-select set offers the account names seen in the active logs. Events with no user identity are not matched by a `User` predicate (including its negation). |
 | `Description` | resolved description text |
 | `Xml` | raw XML (forces eager XML resolution; see caveat) |
 
@@ -88,7 +88,8 @@ Available properties:
 | `TaskCategory` | `string` | |
 | `ProcessId` | `int?` | |
 | `ThreadId` | `int?` | |
-| `UserId` | `SecurityIdentifier?` | Use `.ToString()` to compare. |
+| `UserId` | `SecurityIdentifier?` | SID-exact match of the System &lt;Security UserID&gt; (advanced only; usually empty on Security-audit events). The Basic editor offers `User` instead, which matches the SID or the resolved name. |
+| `UserDisplayName` (alias `User`) | `string` | The merged "User" filter: matches the resolved account name shown in the User column (a well-known-SID name, else the Subject/Target account `DOMAIN\user`) OR the raw SID. `User.Contains("alice")` matches the name; `User == "S-1-5-18"` matches the SID. A row with no user identity is never matched by a value comparison (presence-required, including negated value comparisons) — unlike plain string fields; compare against `null` (`User == null` / `User != null`) to select rows by identity absence or presence. |
 | `TimeCreated` | `DateTime` | The raw `ResolvedEvent` value — the table and Details pane render it in the configured time zone, but expressions see the underlying value. |
 | `LogName` | `string` | Source log channel as reported by the event reader. |
 | `OwningLog` | `string` | The file path or live-channel name as displayed in the tab strip. |

--- a/docs/Viewing-Events.md
+++ b/docs/Viewing-Events.md
@@ -27,6 +27,8 @@ See [Performance](Performance.md) for how the virtualized table, the segmented s
 
 The current sort indicator (a caret) appears in the active column header; clicking it flips between ascending and descending.
 
+The `User` column shows the best-available account identity, resolved offline (no directory lookup): a well-known-SID name (e.g. `NT AUTHORITY\SYSTEM`), otherwise the acting or target account carried in the event's data (`DOMAIN\user`), otherwise the raw SID, and blank only when the event carries no user identity at all. Sorting, grouping, and cell-filtering on `User` all use this displayed name.
+
 **Column reordering.** Drag a column header sideways to drop it before or after another column. The new order persists across sessions until `Reset Column Defaults` (in the column menu) restores it.
 
 **Column sizing.** Drag a column-header edge to resize. Sizes persist across sessions; `Reset Column Defaults` restores the built-in widths along with visibility, ordering, and sort.
@@ -39,7 +41,7 @@ The current sort indicator (a caret) appears in the active column header; clicki
 
 - `Copy Selected` / `Copy Selected (Simple)` / `Copy Selected (XML)` / `Copy Selected (Full)` — same four formats as the `Edit` menu.
 - `Exclude Events Before` / `Exclude Events After` — sets a date filter using the right-clicked event's timestamp as the boundary.
-- `Include` and `Exclude` submenus — each lists the field comparisons applicable to a single right-clicked event. Picking one creates a new basic filter (or exclusion) for that field equal to the right-clicked event's value. `Description` and `Xml` are not present in the submenu. Today this works for `Event ID`, `Activity ID`, `Level`, `Keywords`, `Source`, and `Task Category`; the `Process ID`, `Thread ID`, and `User ID` items are present in the menu but produce empty filter values, so they currently no-op.
+- `Include` and `Exclude` submenus — each lists the field comparisons applicable to a single right-clicked event; a field is enabled only when the event carries a value for it (otherwise it is shown disabled with a reason). Picking an enabled one creates a new basic filter (or exclusion) for that field equal to the right-clicked event's value. `Description`, `Xml`, and the advanced-only `User ID` are not offered; the fields that can produce a filter are `Event ID`, `Activity ID`, `Level`, `Keywords`, `Source`, `Task Category`, `Process ID`, `Thread ID`, `User` (the resolved account name, or the raw SID when that is all the event carries), and `Log Name`.
 
 ### Grouping
 

--- a/src/EventLogExpert.Eventing/Common/Events/EventColumnChunk.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/EventColumnChunk.cs
@@ -25,7 +25,8 @@ internal enum EventColumnField : byte
     TaskCategory,
     Xml,
     UserId,
-    Opcode
+    Opcode,
+    UserDisplayName
 }
 
 /// <summary>
@@ -114,6 +115,7 @@ internal sealed class EventColumnChunk
     private readonly int[] _userDataValue;
     private readonly int[] _userDataValuesCount;
     private readonly int[] _userDataValuesOffset;
+    private readonly int[] _userDisplayName;
     private readonly int[] _userId;
     private readonly int[] _xml;
 
@@ -130,6 +132,7 @@ internal sealed class EventColumnChunk
         _taskCategory = builder.TaskCategory;
         _xml = builder.Xml;
         _userId = builder.UserId;
+        _userDisplayName = builder.UserDisplayName;
         _opcode = builder.Opcode;
 
         _id = builder.Id;
@@ -232,6 +235,7 @@ internal sealed class EventColumnChunk
         EventColumnField.Xml => _xml,
         EventColumnField.UserId => _userId,
         EventColumnField.Opcode => _opcode,
+        EventColumnField.UserDisplayName => _userDisplayName,
         _ => throw new ArgumentOutOfRangeException(nameof(column), column, null)
     };
 
@@ -278,6 +282,7 @@ internal sealed class EventColumnChunk
         EventColumnField.Xml => _xml[row],
         EventColumnField.UserId => _userId[row],
         EventColumnField.Opcode => _opcode[row],
+        EventColumnField.UserDisplayName => _userDisplayName[row],
         _ => throw new ArgumentOutOfRangeException(nameof(column), column, null)
     };
 
@@ -409,6 +414,7 @@ internal sealed class EventColumnChunk
         internal readonly List<int> UserDataValue = [];
         internal readonly List<int> UserDataValuesCount = [];
         internal readonly List<int> UserDataValuesOffset = [];
+        internal readonly int[] UserDisplayName;
         internal readonly int[] UserId;
         internal readonly int[] Xml;
 
@@ -425,6 +431,7 @@ internal sealed class EventColumnChunk
             TaskCategory = new int[count];
             Xml = new int[count];
             UserId = new int[count];
+            UserDisplayName = new int[count];
             Opcode = new int[count];
 
             Id = new int[count];
@@ -469,6 +476,7 @@ internal sealed class EventColumnChunk
             TaskCategory[row] = pool.Intern(resolvedEvent.TaskCategory);
             Xml[row] = pool.Intern(resolvedEvent.Xml);
             UserId[row] = pool.Intern(resolvedEvent.UserId?.Value);
+            UserDisplayName[row] = pool.Intern(resolvedEvent.UserDisplayName.Length == 0 ? null : resolvedEvent.UserDisplayName);
             Opcode[row] = pool.Intern(resolvedEvent.Opcode);
 
             Id[row] = resolvedEvent.Id;
@@ -476,15 +484,35 @@ internal sealed class EventColumnChunk
             LogPathType[row] = (byte)resolvedEvent.LogPathType;
             UserDataIncomplete[row] = resolvedEvent.UserDataIncomplete;
 
-            if (resolvedEvent.RecordId is { } recordId) { RecordId[row] = recordId; RecordIdHas[row] = true; }
+            if (resolvedEvent.RecordId is { } recordId)
+            {
+                RecordId[row] = recordId;
+                RecordIdHas[row] = true;
+            }
 
-            if (resolvedEvent.ActivityId is { } activityId) { ActivityId[row] = activityId; ActivityIdHas[row] = true; }
+            if (resolvedEvent.ActivityId is { } activityId)
+            {
+                ActivityId[row] = activityId;
+                ActivityIdHas[row] = true;
+            }
 
-            if (resolvedEvent.RelatedActivityId is { } relatedActivityId) { RelatedActivityId[row] = relatedActivityId; RelatedActivityIdHas[row] = true; }
+            if (resolvedEvent.RelatedActivityId is { } relatedActivityId)
+            {
+                RelatedActivityId[row] = relatedActivityId;
+                RelatedActivityIdHas[row] = true;
+            }
 
-            if (resolvedEvent.ProcessId is { } processId) { ProcessId[row] = processId; ProcessIdHas[row] = true; }
+            if (resolvedEvent.ProcessId is { } processId)
+            {
+                ProcessId[row] = processId;
+                ProcessIdHas[row] = true;
+            }
 
-            if (resolvedEvent.ThreadId is { } threadId) { ThreadId[row] = threadId; ThreadIdHas[row] = true; }
+            if (resolvedEvent.ThreadId is { } threadId)
+            {
+                ThreadId[row] = threadId;
+                ThreadIdHas[row] = true;
+            }
 
             AddKeywords(row, resolvedEvent, pool);
             AddUserData(row, resolvedEvent, pool);

--- a/src/EventLogExpert.Eventing/Common/Events/EventColumnStore.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/EventColumnStore.cs
@@ -1778,6 +1778,7 @@ public sealed class EventColumnStore
         EventColumnField.LogName => pending.LogName,
         EventColumnField.ComputerName => pending.ComputerName,
         EventColumnField.OwningLog => pending.OwningLog,
+        EventColumnField.UserDisplayName => pending.UserDisplayName,
         _ => throw new ArgumentOutOfRangeException(nameof(field), field, "Field is not a supported group-by dimension.")
     };
 
@@ -1968,6 +1969,7 @@ public sealed class EventColumnStore
             Source = PoolGet(chunk.RowPoolIndex(EventColumnField.Source, row)) ?? string.Empty,
             TaskCategory = PoolGet(chunk.RowPoolIndex(EventColumnField.TaskCategory, row)) ?? string.Empty,
             UserId = userIdPoolIndex < 0 ? null : new SecurityIdentifier(PoolGet(userIdPoolIndex)!),
+            UserDisplayName = PoolGet(chunk.RowPoolIndex(EventColumnField.UserDisplayName, row)) ?? string.Empty,
             RecordId = hasRecordId ? recordId : null,
             ActivityId = hasActivityId ? activityId : null,
             RelatedActivityId = hasRelatedActivityId ? relatedActivityId : null,

--- a/src/EventLogExpert.Eventing/Common/Events/EventColumnStoreReader.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/EventColumnStoreReader.cs
@@ -578,6 +578,10 @@ internal sealed class EventColumnStoreReader : IEventColumnReader
             }
             case EventFieldId.UserId:
                 return UserIdField(index);
+            case EventFieldId.UserDisplayName:
+                return PooledField(EventColumnField.UserDisplayName, index);
+            case EventFieldId.UserIdSddl:
+                return UserIdSddlField(index);
             case EventFieldId.Description:
                 return PooledField(EventColumnField.Description, index);
             case EventFieldId.Xml:
@@ -703,6 +707,7 @@ internal sealed class EventColumnStoreReader : IEventColumnReader
         EventColumnField.Xml => pending.Xml,
         EventColumnField.UserId => pending.UserId?.Value,
         EventColumnField.Opcode => pending.Opcode,
+        EventColumnField.UserDisplayName => pending.UserDisplayName,
         _ => throw new ArgumentOutOfRangeException(nameof(column), column, null)
     };
 
@@ -718,6 +723,7 @@ internal sealed class EventColumnStoreReader : IEventColumnReader
         EventFieldId.Xml => EventColumnField.Xml,
         EventFieldId.OwningLog => EventColumnField.OwningLog,
         EventFieldId.Opcode => EventColumnField.Opcode,
+        EventFieldId.UserDisplayName => EventColumnField.UserDisplayName,
         _ => throw new ArgumentOutOfRangeException(nameof(field), field, "Not a single pooled string column.")
     };
 
@@ -738,6 +744,7 @@ internal sealed class EventColumnStoreReader : IEventColumnReader
             AddPendingValue(pending.TaskCategory, indexByValue, extras);
             AddPendingValue(pending.Xml, indexByValue, extras);
             AddPendingValue(pending.UserId?.Value, indexByValue, extras);
+            AddPendingValue(pending.UserDisplayName, indexByValue, extras);
             AddPendingValue(pending.Opcode, indexByValue, extras);
         }
 
@@ -815,6 +822,15 @@ internal sealed class EventColumnStoreReader : IEventColumnReader
         SecurityIdentifier? userId = poolIndex < 0 ? null : new SecurityIdentifier(_store.PoolGet(poolIndex)!);
 
         return EventFieldValue.FromProperty(userId);
+    }
+
+    // The raw interned SID string (SDDL), allocation-free (no SecurityIdentifier) for the match-both "User" filter's
+    // SID disjunct. Absent (Kind==Null) when the row carries no UserId, matching the pending path.
+    private EventFieldValue UserIdSddlField(int index)
+    {
+        int poolIndex = _store.RawPoolIndex(EventColumnField.UserId, index);
+
+        return poolIndex < 0 ? ResolvedEventFieldReader.Absent : EventFieldValue.FromProperty(_store.PoolGet(poolIndex)!);
     }
 
     // The pending-tail pooled strings that the sealed pool does not already index, addressed as

--- a/src/EventLogExpert.Eventing/Common/Events/EventFieldId.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/EventFieldId.cs
@@ -22,5 +22,7 @@ public enum EventFieldId
     Xml,
     OwningLog,
     Opcode,
-    RelatedActivityId
+    RelatedActivityId,
+    UserDisplayName,
+    UserIdSddl
 }

--- a/src/EventLogExpert.Eventing/Common/Events/ResolvedEvent.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/ResolvedEvent.cs
@@ -54,6 +54,8 @@ public sealed record ResolvedEvent(
 
     public SecurityIdentifier? UserId { get; init; }
 
+    public string UserDisplayName { get; init; } = string.Empty;
+
     /// <summary>
     ///     Pre-rendered XML for the event. Populated by <c>EventLogReader</c> only when the log is opened with
     ///     <c>renderXml: true</c> (currently driven by the presence of an applied filter that references this property). When

--- a/src/EventLogExpert.Eventing/Common/Events/ResolvedEventFieldReader.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/ResolvedEventFieldReader.cs
@@ -26,13 +26,14 @@ internal static class ResolvedEventFieldReader
             EventFieldId.ProcessId => resolvedEvent.ProcessId is { } processId ? EventFieldValue.FromProperty(processId) : Absent,
             EventFieldId.ThreadId => resolvedEvent.ThreadId is { } threadId ? EventFieldValue.FromProperty(threadId) : Absent,
             EventFieldId.UserId => EventFieldValue.FromProperty(resolvedEvent.UserId),
+            EventFieldId.UserDisplayName => EventFieldValue.FromProperty(resolvedEvent.UserDisplayName),
+            EventFieldId.UserIdSddl => resolvedEvent.UserId is { } userIdSddl ? EventFieldValue.FromProperty(userIdSddl.Value) : Absent,
             EventFieldId.Description => EventFieldValue.FromProperty(resolvedEvent.Description),
             EventFieldId.Xml => EventFieldValue.FromProperty(resolvedEvent.Xml),
             EventFieldId.OwningLog => EventFieldValue.FromProperty(resolvedEvent.OwningLog),
             EventFieldId.Opcode => EventFieldValue.FromProperty(resolvedEvent.Opcode),
-            EventFieldId.RelatedActivityId => resolvedEvent.RelatedActivityId is { } relatedActivityId
-                ? EventFieldValue.FromProperty(relatedActivityId)
-                : Absent,
+            EventFieldId.RelatedActivityId => resolvedEvent.RelatedActivityId is { } relatedActivityId ?
+                EventFieldValue.FromProperty(relatedActivityId) : Absent,
             _ => Absent
         };
     }

--- a/src/EventLogExpert.Eventing/Common/Events/UserDisplayNameResolver.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/UserDisplayNameResolver.cs
@@ -1,0 +1,84 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Security.Principal;
+
+namespace EventLogExpert.Eventing.Common.Events;
+
+/// <summary>
+///     Resolves the best-available user identity for an event's User column, offline (no <c>LookupAccountSid</c>):
+///     the System <c>&lt;Security UserID&gt;</c> mapped through <see cref="WellKnownSids" />, otherwise the Subject/Target
+///     account names the event already carries in its &lt;EventData&gt;. Computed once at resolve time and stored on
+///     <see cref="ResolvedEvent.UserDisplayName" />.
+/// </summary>
+internal static class UserDisplayNameResolver
+{
+    internal static string Resolve(SecurityIdentifier? userId, EventDataView eventData)
+    {
+        if (userId is not null)
+        {
+            string sid = userId.Value;
+
+            if (WellKnownSids.TryGetName(sid, out string? knownName)) { return knownName; }
+
+            // A populated but non-well-known SID is almost always a raw user SID with no offline name; prefer an
+            // EventData-carried account name when one exists, else fall back to the SID (today's behavior).
+            return TryDeriveFromEventData(eventData) ?? sid;
+        }
+
+        return TryDeriveFromEventData(eventData) ?? string.Empty;
+    }
+
+    private static string Format(string name, string? domain) => domain is null ? name : domain + "\\" + name;
+
+    private static bool IsInformative(string name) =>
+        !name.EndsWith('$') &&
+        !string.Equals(name, "SYSTEM", StringComparison.OrdinalIgnoreCase) &&
+        !string.Equals(name, "LOCAL SERVICE", StringComparison.OrdinalIgnoreCase) &&
+        !string.Equals(name, "NETWORK SERVICE", StringComparison.OrdinalIgnoreCase) &&
+        !string.Equals(name, "ANONYMOUS LOGON", StringComparison.OrdinalIgnoreCase);
+
+    // Mirrors EventColumnStore.IsUsableRawValue: Windows writes "-" (or empty) for an absent name/domain.
+    private static bool IsUsable(string? value) => !string.IsNullOrWhiteSpace(value) && value != "-";
+
+    private static string? TryDeriveFromEventData(EventDataView eventData)
+    {
+        if (eventData.Kind == EventDataKind.None) { return null; }
+
+        (string Name, string? Domain)? subject = TryReadAccount(eventData, "Subject");
+        (string Name, string? Domain)? target = TryReadAccount(eventData, "Target");
+
+        // Prefer the Subject only when it names a real principal (not SYSTEM / a service / a machine account), so
+        // logon/auth events surface the logged-on Target rather than the reporting SYSTEM/MACHINE$ subject.
+        if (subject is { } informativeSubject && IsInformative(informativeSubject.Name))
+        {
+            return Format(informativeSubject.Name, informativeSubject.Domain);
+        }
+
+        if (target is { } presentTarget) { return Format(presentTarget.Name, presentTarget.Domain); }
+
+        if (subject is { } fallbackSubject) { return Format(fallbackSubject.Name, fallbackSubject.Domain); }
+
+        return null;
+    }
+
+    private static (string Name, string? Domain)? TryReadAccount(EventDataView eventData, string prefix)
+    {
+        if (!eventData.TryGetValue(prefix + "UserName", out EventFieldValue nameValue)) { return null; }
+
+        string name = nameValue.AsString();
+
+        if (!IsUsable(name)) { return null; }
+
+        string? domain = null;
+
+        if (eventData.TryGetValue(prefix + "DomainName", out EventFieldValue domainValue))
+        {
+            string domainText = domainValue.AsString();
+
+            if (IsUsable(domainText)) { domain = domainText; }
+        }
+
+        return (name, domain);
+    }
+}

--- a/src/EventLogExpert.Eventing/Common/Events/WellKnownSids.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/WellKnownSids.cs
@@ -1,0 +1,29 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace EventLogExpert.Eventing.Common.Events;
+
+internal static class WellKnownSids
+{
+    private static readonly Dictionary<string, string> s_namesBySid = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["S-1-0-0"] = "NULL SID",
+        ["S-1-1-0"] = "Everyone",
+        ["S-1-5-7"] = @"NT AUTHORITY\ANONYMOUS LOGON",
+        ["S-1-5-11"] = @"NT AUTHORITY\Authenticated Users",
+        ["S-1-5-18"] = @"NT AUTHORITY\SYSTEM",
+        ["S-1-5-19"] = @"NT AUTHORITY\LOCAL SERVICE",
+        ["S-1-5-20"] = @"NT AUTHORITY\NETWORK SERVICE",
+        ["S-1-5-32-544"] = @"BUILTIN\Administrators",
+        ["S-1-5-32-545"] = @"BUILTIN\Users",
+        ["S-1-5-32-546"] = @"BUILTIN\Guests",
+        ["S-1-5-32-547"] = @"BUILTIN\Power Users",
+        ["S-1-5-32-555"] = @"BUILTIN\Remote Desktop Users",
+        ["S-1-5-32-568"] = @"BUILTIN\IIS_IUSRS"
+    };
+
+    /// <summary>Returns the canonical display name for a well-known <paramref name="sid" /> (SDDL form), if known.</summary>
+    internal static bool TryGetName(string sid, [NotNullWhen(true)] out string? name) => s_namesBySid.TryGetValue(sid, out name);
+}

--- a/src/EventLogExpert.Eventing/Resolvers/EventResolverBase.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/EventResolverBase.cs
@@ -141,6 +141,7 @@ public class EventResolverBase : IDisposable
         TemplateInfo? primaryInfo = modernEvent?.Template is { } template ? _templates.GetTemplateInfo(template) : null;
 
         var (eventDataValues, eventDataSchema) = BuildEventData(eventRecord, primaryInfo);
+        var userId = _cache?.GetOrAddSid(eventRecord.UserId) ?? eventRecord.UserId;
 
         return new(eventRecord.PathName, eventRecord.LogPathType)
         {
@@ -161,7 +162,8 @@ public class EventResolverBase : IDisposable
             TaskCategory = _taskKeywords.ResolveTaskName(eventRecord, details, modernEvent, supplemental, supplementalModernEvent),
             ThreadId = eventRecord.ThreadId,
             TimeCreated = eventRecord.TimeCreated,
-            UserId = _cache?.GetOrAddSid(eventRecord.UserId) ?? eventRecord.UserId,
+            UserId = userId,
+            UserDisplayName = UserDisplayNameResolver.Resolve(userId, new EventDataView(eventDataValues, eventDataSchema)),
             Xml = eventRecord.Xml ?? string.Empty,
             UserData = InternUserData(eventRecord.UserData),
             UserDataIncomplete = eventRecord.UserDataIncomplete

--- a/src/EventLogExpert.Filtering/Basic/BasicFilterDecomposer.cs
+++ b/src/EventLogExpert.Filtering/Basic/BasicFilterDecomposer.cs
@@ -22,12 +22,9 @@ internal static class BasicFilterDecomposer
             return false;
         }
 
-        if (!Tokenizer.TryTokenize(filterText, out var tokens, out _)
-            || !Parser.TryParse(tokens, out var syntax, out _)
-            || !Lowerer.TryLower(syntax!, out var filterNode, out _))
-        {
-            return false;
-        }
+        if (!Tokenizer.TryTokenize(filterText, out var tokens, out _) ||
+            !Parser.TryParse(tokens, out var syntax, out _) ||
+            !Lowerer.TryLower(syntax!, out var filterNode, out _)) { return false; }
 
         return TryDecomposeRoot(filterNode!, out structured);
     }
@@ -309,6 +306,7 @@ internal static class BasicFilterDecomposer
             case ResolvedEventField.ProcessId: property = EventProperty.ProcessId; return true;
             case ResolvedEventField.ThreadId: property = EventProperty.ThreadId; return true;
             case ResolvedEventField.UserId: property = EventProperty.UserId; return true;
+            case ResolvedEventField.UserDisplayName: property = EventProperty.UserDisplayName; return true;
             case ResolvedEventField.Description: property = EventProperty.Description; return true;
             case ResolvedEventField.Xml: property = EventProperty.Xml; return true;
             case ResolvedEventField.LogName: property = EventProperty.LogName; return true;

--- a/src/EventLogExpert.Filtering/Common/Filtering/EventProperty.cs
+++ b/src/EventLogExpert.Filtering/Common/Filtering/EventProperty.cs
@@ -22,5 +22,6 @@ public enum EventProperty
     [EnumMember(Value = "Event Data")] EventData,
     [EnumMember(Value = "User Data")] UserData,
     Opcode,
-    [EnumMember(Value = "Related Activity ID")] RelatedActivityId
+    [EnumMember(Value = "Related Activity ID")] RelatedActivityId,
+    [EnumMember(Value = "User")] UserDisplayName
 }

--- a/src/EventLogExpert.Filtering/Common/Filtering/FilterPropertyConstraints.cs
+++ b/src/EventLogExpert.Filtering/Common/Filtering/FilterPropertyConstraints.cs
@@ -5,6 +5,9 @@ namespace EventLogExpert.Filtering.Common.Filtering;
 
 public static class FilterPropertyConstraints
 {
+    public static bool IsGuidValued(EventProperty property) =>
+        property is EventProperty.ActivityId or EventProperty.RelatedActivityId;
+
     public static bool IsTextOnly(EventProperty property) =>
         property is EventProperty.Description or EventProperty.Xml;
 
@@ -24,9 +27,6 @@ public static class FilterPropertyConstraints
     public static bool SupportsNoneOfMany(EventProperty property) =>
         IsScalarStringManyField(property);
 
-    public static bool IsGuidValued(EventProperty property) =>
-        property is EventProperty.ActivityId or EventProperty.RelatedActivityId;
-
     /// <summary>
     ///     The scalar string properties whose multi-select supports the full operator set (Contains-any and the negated
     ///     Is-none-of / Contains-none). EventData/UserData and everything else are handled separately below.
@@ -37,5 +37,6 @@ public static class FilterPropertyConstraints
             or EventProperty.LogName
             or EventProperty.TaskCategory
             or EventProperty.UserId
+            or EventProperty.UserDisplayName
             or EventProperty.Opcode;
 }

--- a/src/EventLogExpert.Filtering/Emit/ColumnEmitter.cs
+++ b/src/EventLogExpert.Filtering/Emit/ColumnEmitter.cs
@@ -46,6 +46,9 @@ internal static class ColumnEmitter
         }
     }
 
+    private static bool ColumnUserHasIdentity(string userDisplayName, EventFieldValue sid) =>
+        userDisplayName.Length != 0 || sid.Kind != EventFieldValueKind.Null;
+
     private static EventFieldId ContainsFieldId(ResolvedEventField field) =>
         field switch
         {
@@ -61,6 +64,7 @@ internal static class ColumnEmitter
             ResolvedEventField.Level => EventFieldId.Level,
             ResolvedEventField.LogName => EventFieldId.LogName,
             ResolvedEventField.Source => EventFieldId.Source,
+            ResolvedEventField.UserDisplayName => EventFieldId.UserDisplayName,
             ResolvedEventField.TaskCategory => EventFieldId.TaskCategory,
             ResolvedEventField.Opcode => EventFieldId.Opcode,
             ResolvedEventField.Xml => EventFieldId.Xml,
@@ -114,6 +118,12 @@ internal static class ColumnEmitter
     {
         var needle = node.Needle;
         var comparison = node.IgnoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+        if (node.Field == ResolvedEventField.UserDisplayName)
+        {
+            return EmitUserContains(needle, comparison, negated: false);
+        }
+
         var field = ContainsFieldId(node.Field);
 
         return (reader, locator) =>
@@ -313,6 +323,11 @@ internal static class ColumnEmitter
             return EmitMultiContainsUserId(node.Values, comparison, node.Negated);
         }
 
+        if (node.Field == ResolvedEventField.UserDisplayName)
+        {
+            return EmitMultiContainsUser(node.Values, comparison, node.Negated);
+        }
+
         var fieldId = ContainsFieldId(node.Field);
         var needles = CompileTimeLiterals.Snapshot(node.Values);
         var negated = node.Negated;
@@ -325,6 +340,38 @@ internal static class ColumnEmitter
             for (var i = 0; i < needles.Length; i++)
             {
                 if (actual.Contains(needles[i], comparison))
+                {
+                    matched = true;
+
+                    break;
+                }
+            }
+
+            return (negated ? !matched : matched) ? FilterMatch.Match : FilterMatch.NoMatch;
+        };
+    }
+
+    private static Func<IEventColumnReader, EventLocator, FilterMatch> EmitMultiContainsUser(
+        IReadOnlyList<string> values,
+        StringComparison comparison,
+        bool negated)
+    {
+        var needles = CompileTimeLiterals.Snapshot(values);
+
+        return (reader, locator) =>
+        {
+            var udn = reader.GetField(locator, EventFieldId.UserDisplayName).AsString();
+            var sid = reader.GetField(locator, EventFieldId.UserIdSddl);
+
+            if (!ColumnUserHasIdentity(udn, sid)) { return FilterMatch.NoMatch; }
+
+            var sidValue = sid.Kind != EventFieldValueKind.Null ? sid.AsString() : null;
+            var matched = false;
+
+            for (var i = 0; i < needles.Length; i++)
+            {
+                if (udn.Contains(needles[i], comparison) ||
+                    (sidValue is not null && sidValue.Contains(needles[i], comparison)))
                 {
                     matched = true;
 
@@ -374,6 +421,11 @@ internal static class ColumnEmitter
         if (node.Field == ResolvedEventField.UserId)
         {
             return EmitMultiEqualsUserId(node.Values, node.Negated);
+        }
+
+        if (node.Field == ResolvedEventField.UserDisplayName)
+        {
+            return EmitMultiEqualsUser(node.Values, node.Negated);
         }
 
         Func<IEventColumnReader, EventLocator, FilterMatch> positive = node.Field switch
@@ -488,6 +540,35 @@ internal static class ColumnEmitter
         };
     }
 
+    private static Func<IEventColumnReader, EventLocator, FilterMatch> EmitMultiEqualsUser(IReadOnlyList<string> values, bool negated)
+    {
+        var snapshot = CompileTimeLiterals.Snapshot(values);
+
+        return (reader, locator) =>
+        {
+            var udn = reader.GetField(locator, EventFieldId.UserDisplayName).AsString();
+            var sid = reader.GetField(locator, EventFieldId.UserIdSddl);
+
+            if (!ColumnUserHasIdentity(udn, sid)) { return FilterMatch.NoMatch; }
+
+            var sidValue = sid.Kind != EventFieldValueKind.Null ? sid.AsString() : null;
+            var matched = false;
+
+            for (var i = 0; i < snapshot.Length; i++)
+            {
+                if (string.Equals(udn, snapshot[i], StringComparison.Ordinal) ||
+                    (sidValue is not null && string.Equals(sidValue, snapshot[i], StringComparison.Ordinal)))
+                {
+                    matched = true;
+
+                    break;
+                }
+            }
+
+            return (negated ? !matched : matched) ? FilterMatch.Match : FilterMatch.NoMatch;
+        };
+    }
+
     private static Func<IEventColumnReader, EventLocator, FilterMatch> EmitMultiEqualsUserId(
         IReadOnlyList<string> values,
         bool negated)
@@ -544,6 +625,16 @@ internal static class ColumnEmitter
 
     private static Func<IEventColumnReader, EventLocator, FilterMatch> EmitNot(NotNode node)
     {
+        // SPECIAL: NOT(User.Contains) is presence-gated + match-both (name OR SID), NOT the naive !inner.
+        if (node.Operand is ContainsNode { Field: ResolvedEventField.UserDisplayName } userContains)
+        {
+            var userComparison = userContains.IgnoreCase ?
+                StringComparison.OrdinalIgnoreCase :
+                StringComparison.Ordinal;
+
+            return EmitUserContains(userContains.Needle, userComparison, negated: true);
+        }
+
         // SPECIAL: NOT(UserId.Contains) is presence-required - an absent UserId is NoMatch, NOT the
         // naive !inner. Mirrors Emitter.EmitNot.
         if (node.Operand is ContainsNode { Field: ResolvedEventField.UserId } userIdContains)
@@ -570,23 +661,6 @@ internal static class ColumnEmitter
         return (reader, locator) => Negate(inner(reader, locator));
     }
 
-    private static Func<IEventColumnReader, EventLocator, FilterMatch> EmitNullableNullCheck(
-        EventFieldId field,
-        FilterBinaryOperator op) =>
-        op switch
-        {
-            // == null is true (Match) when the field is absent; != null is true when present.
-            FilterBinaryOperator.Equal => (reader, locator) =>
-                reader.GetField(locator, field).Kind == EventFieldValueKind.Null
-                    ? FilterMatch.Match
-                    : FilterMatch.NoMatch,
-            FilterBinaryOperator.NotEqual => (reader, locator) =>
-                reader.GetField(locator, field).Kind == EventFieldValueKind.Null
-                    ? FilterMatch.NoMatch
-                    : FilterMatch.Match,
-            _ => throw new EmitException($"Operator '{op}' is not supported against null.")
-        };
-
     private static Func<IEventColumnReader, EventLocator, FilterMatch> EmitNullComparison(
         ResolvedEventField field,
         FilterBinaryOperator op)
@@ -605,6 +679,8 @@ internal static class ColumnEmitter
                 return EmitNullableNullCheck(EventFieldId.RelatedActivityId, op);
             case ResolvedEventField.UserId:
                 return EmitNullableNullCheck(EventFieldId.UserId, op);
+            case ResolvedEventField.UserDisplayName:
+                return EmitUserNullCheck(op);
             case ResolvedEventField.Id:
             case ResolvedEventField.TimeCreated:
                 return EmitConstantNullComparison(op);
@@ -626,6 +702,23 @@ internal static class ColumnEmitter
         }
     }
 
+    private static Func<IEventColumnReader, EventLocator, FilterMatch> EmitNullableNullCheck(
+        EventFieldId field,
+        FilterBinaryOperator op) =>
+        op switch
+        {
+            // == null is true (Match) when the field is absent; != null is true when present.
+            FilterBinaryOperator.Equal => (reader, locator) =>
+                reader.GetField(locator, field).Kind == EventFieldValueKind.Null ?
+                    FilterMatch.Match :
+                    FilterMatch.NoMatch,
+            FilterBinaryOperator.NotEqual => (reader, locator) =>
+                reader.GetField(locator, field).Kind == EventFieldValueKind.Null ?
+                    FilterMatch.NoMatch :
+                    FilterMatch.Match,
+            _ => throw new EmitException($"Operator '{op}' is not supported against null.")
+        };
+
     private static Func<IEventColumnReader, EventLocator, FilterMatch> EmitOr(OrNode node)
     {
         var parts = FilterNodeMetadata.FlattenOrChain(node).Select(EmitNode).ToArray();
@@ -644,6 +737,7 @@ internal static class ColumnEmitter
             ResolvedEventField.Level => FilterCompare.StringOrdinal(EventFieldId.Level, op, value),
             ResolvedEventField.LogName => FilterCompare.StringOrdinal(EventFieldId.LogName, op, value),
             ResolvedEventField.Source => FilterCompare.StringOrdinal(EventFieldId.Source, op, value),
+            ResolvedEventField.UserDisplayName => EmitUserStringCompare(op, value),
             ResolvedEventField.TaskCategory => FilterCompare.StringOrdinal(EventFieldId.TaskCategory, op, value),
             ResolvedEventField.Opcode => FilterCompare.StringOrdinal(EventFieldId.Opcode, op, value),
             ResolvedEventField.Xml => FilterCompare.StringOrdinal(EventFieldId.Xml, op, value),
@@ -659,6 +753,23 @@ internal static class ColumnEmitter
             ResolvedEventField.Keywords => throw new EmitException(
                 "Keywords cannot be compared directly; use Keywords.Any."),
             _ => throw new EmitException($"Unsupported field '{field}' for string comparison.")
+        };
+
+    private static Func<IEventColumnReader, EventLocator, FilterMatch> EmitUserContains(string needle, StringComparison comparison, bool negated) =>
+        (reader, locator) =>
+        {
+            var udn = reader.GetField(locator, EventFieldId.UserDisplayName).AsString();
+            var sid = reader.GetField(locator, EventFieldId.UserIdSddl);
+
+            if (!ColumnUserHasIdentity(udn, sid)) { return FilterMatch.NoMatch; }
+
+            var sidPresent = sid.Kind != EventFieldValueKind.Null;
+
+            var matched = negated ?
+                !udn.Contains(needle, comparison) && (!sidPresent || !sid.AsString().Contains(needle, comparison)) :
+                udn.Contains(needle, comparison) || (sidPresent && sid.AsString().Contains(needle, comparison));
+
+            return matched ? FilterMatch.Match : FilterMatch.NoMatch;
         };
 
     private static Func<IEventColumnReader, EventLocator, FilterMatch> EmitUserData(
@@ -699,6 +810,50 @@ internal static class ColumnEmitter
             return result == FilterMatch.NoMatch && incomplete ? FilterMatch.Unknown : result;
         };
     }
+
+    private static Func<IEventColumnReader, EventLocator, FilterMatch> EmitUserNullCheck(FilterBinaryOperator op) =>
+        op switch
+        {
+            FilterBinaryOperator.Equal => (reader, locator) =>
+                ColumnUserHasIdentity(reader.GetField(locator, EventFieldId.UserDisplayName).AsString(),
+                    reader.GetField(locator, EventFieldId.UserIdSddl)) ?
+                        FilterMatch.NoMatch : FilterMatch.Match,
+            FilterBinaryOperator.NotEqual => (reader, locator) =>
+                ColumnUserHasIdentity(reader.GetField(locator, EventFieldId.UserDisplayName).AsString(),
+                    reader.GetField(locator, EventFieldId.UserIdSddl)) ?
+                        FilterMatch.Match : FilterMatch.NoMatch,
+            _ => throw new EmitException($"Operator '{op}' is not supported against null.")
+        };
+
+    private static Func<IEventColumnReader, EventLocator, FilterMatch> EmitUserStringCompare(FilterBinaryOperator op, string value) =>
+        op switch
+        {
+            FilterBinaryOperator.Equal => (reader, locator) =>
+            {
+                var udn = reader.GetField(locator, EventFieldId.UserDisplayName).AsString();
+                var sid = reader.GetField(locator, EventFieldId.UserIdSddl);
+
+                if (!ColumnUserHasIdentity(udn, sid)) { return FilterMatch.NoMatch; }
+
+                return string.Equals(udn, value, StringComparison.Ordinal) ||
+                    (sid.Kind != EventFieldValueKind.Null && string.Equals(sid.AsString(), value, StringComparison.Ordinal)) ?
+                        FilterMatch.Match :
+                        FilterMatch.NoMatch;
+            },
+            FilterBinaryOperator.NotEqual => (reader, locator) =>
+            {
+                var udn = reader.GetField(locator, EventFieldId.UserDisplayName).AsString();
+                var sid = reader.GetField(locator, EventFieldId.UserIdSddl);
+
+                if (!ColumnUserHasIdentity(udn, sid)) { return FilterMatch.NoMatch; }
+
+                return !string.Equals(udn, value, StringComparison.Ordinal) &&
+                    (sid.Kind == EventFieldValueKind.Null || !string.Equals(sid.AsString(), value, StringComparison.Ordinal)) ?
+                        FilterMatch.Match :
+                        FilterMatch.NoMatch;
+            },
+            _ => throw new EmitException($"Operator '{op}' is not supported on User.")
+        };
 
     // Evaluates part[index] against the per-event reader and locator carried in a by-value named tuple, so the And/Or
     // combine stays closure-free (a cached static method group, no per-event allocation).

--- a/src/EventLogExpert.Filtering/Emit/Emitter.cs
+++ b/src/EventLogExpert.Filtering/Emit/Emitter.cs
@@ -185,6 +185,7 @@ internal static class Emitter
             ResolvedEventField.Level => resolvedEvent => resolvedEvent.Level.Contains(needle, comparison),
             ResolvedEventField.LogName => resolvedEvent => resolvedEvent.LogName.Contains(needle, comparison),
             ResolvedEventField.Source => resolvedEvent => resolvedEvent.Source.Contains(needle, comparison),
+            ResolvedEventField.UserDisplayName => EmitUserContains(needle, comparison, negated: false),
             ResolvedEventField.TaskCategory => resolvedEvent => resolvedEvent.TaskCategory.Contains(needle, comparison),
             ResolvedEventField.Opcode => resolvedEvent => resolvedEvent.Opcode.Contains(needle, comparison),
             ResolvedEventField.Xml => resolvedEvent => resolvedEvent.Xml.Contains(needle, comparison),
@@ -408,6 +409,11 @@ internal static class Emitter
             return EmitMultiContainsUserId(node.Values, comparison, node.Negated);
         }
 
+        if (node.Field == ResolvedEventField.UserDisplayName)
+        {
+            return EmitMultiContainsUser(node.Values, comparison, node.Negated);
+        }
+
         Func<ResolvedEvent, string> getter = node.Field switch
         {
             ResolvedEventField.ComputerName => static resolvedEvent => resolvedEvent.ComputerName,
@@ -432,6 +438,32 @@ internal static class Emitter
             for (var i = 0; i < needles.Length; i++)
             {
                 if (actual.Contains(needles[i], comparison))
+                {
+                    matched = true;
+
+                    break;
+                }
+            }
+
+            return negated ? !matched : matched;
+        };
+    }
+
+    private static Func<ResolvedEvent, bool> EmitMultiContainsUser(IReadOnlyList<string> values, StringComparison comparison, bool negated)
+    {
+        var needles = CompileTimeLiterals.Snapshot(values);
+
+        return resolvedEvent =>
+        {
+            if (!UserFilterHasIdentity(resolvedEvent)) { return false; }
+
+            var sddl = resolvedEvent.UserId?.Value;
+            var matched = false;
+
+            for (var i = 0; i < needles.Length; i++)
+            {
+                if (resolvedEvent.UserDisplayName.Contains(needles[i], comparison) ||
+                    (sddl is not null && sddl.Contains(needles[i], comparison)))
                 {
                     matched = true;
 
@@ -479,6 +511,11 @@ internal static class Emitter
         if (node.Field == ResolvedEventField.UserId)
         {
             return EmitMultiEqualsUserId(node.Values, node.Negated);
+        }
+
+        if (node.Field == ResolvedEventField.UserDisplayName)
+        {
+            return EmitMultiEqualsUser(node.Values, node.Negated);
         }
 
         Func<ResolvedEvent, bool> positive = node.Field switch
@@ -604,6 +641,32 @@ internal static class Emitter
         };
     }
 
+    private static Func<ResolvedEvent, bool> EmitMultiEqualsUser(IReadOnlyList<string> values, bool negated)
+    {
+        var snapshot = CompileTimeLiterals.Snapshot(values);
+
+        return resolvedEvent =>
+        {
+            if (!UserFilterHasIdentity(resolvedEvent)) { return false; }
+
+            var sddl = resolvedEvent.UserId?.Value;
+            var matched = false;
+
+            for (var i = 0; i < snapshot.Length; i++)
+            {
+                if (string.Equals(resolvedEvent.UserDisplayName, snapshot[i], StringComparison.Ordinal)
+                    || (sddl is not null && string.Equals(sddl, snapshot[i], StringComparison.Ordinal)))
+                {
+                    matched = true;
+
+                    break;
+                }
+            }
+
+            return negated ? !matched : matched;
+        };
+    }
+
     private static Func<ResolvedEvent, bool> EmitMultiEqualsUserId(IReadOnlyList<string> values, bool negated)
     {
         var snapshot = CompileTimeLiterals.Snapshot(values);
@@ -652,13 +715,24 @@ internal static class Emitter
 
     private static Func<ResolvedEvent, bool> EmitNot(NotNode node)
     {
+        if (node.Operand is ContainsNode { Field: ResolvedEventField.UserDisplayName } userContains)
+        {
+            var userNeedle = userContains.Needle;
+
+            var userComparison = userContains.IgnoreCase ?
+                StringComparison.OrdinalIgnoreCase :
+                StringComparison.Ordinal;
+
+            return EmitUserContains(userNeedle, userComparison, negated: true);
+        }
+
         if (node.Operand is ContainsNode { Field: ResolvedEventField.UserId } userIdContains)
         {
             var needle = userIdContains.Needle;
 
-            var comparison = userIdContains.IgnoreCase
-                ? StringComparison.OrdinalIgnoreCase
-                : StringComparison.Ordinal;
+            var comparison = userIdContains.IgnoreCase ?
+                StringComparison.OrdinalIgnoreCase :
+                StringComparison.Ordinal;
 
             return resolvedEvent => resolvedEvent.UserId is not null && !resolvedEvent.UserId.Value.Contains(needle, comparison);
         }
@@ -666,6 +740,56 @@ internal static class Emitter
         var inner = EmitNode(node.Operand);
 
         return resolvedEvent => !inner(resolvedEvent);
+    }
+
+    private static Func<ResolvedEvent, bool> EmitNullComparison(ResolvedEventField field, FilterBinaryOperator op)
+    {
+        switch (field)
+        {
+            case ResolvedEventField.ProcessId:
+                return EmitNullableNullCheck(static resolvedEvent => resolvedEvent.ProcessId.HasValue, op);
+            case ResolvedEventField.ThreadId:
+                return EmitNullableNullCheck(static resolvedEvent => resolvedEvent.ThreadId.HasValue, op);
+            case ResolvedEventField.RecordId:
+                return EmitNullableNullCheck(static resolvedEvent => resolvedEvent.RecordId.HasValue, op);
+            case ResolvedEventField.ActivityId:
+                return EmitNullableNullCheck(static resolvedEvent => resolvedEvent.ActivityId.HasValue, op);
+            case ResolvedEventField.RelatedActivityId:
+                return EmitNullableNullCheck(static resolvedEvent => resolvedEvent.RelatedActivityId.HasValue, op);
+            case ResolvedEventField.UserId:
+                return EmitNullableNullCheck(static resolvedEvent => resolvedEvent.UserId is not null, op);
+            case ResolvedEventField.UserDisplayName:
+                // Presence check over the merged identity (name OR SID): `!= null` iff the row has any User identity.
+                return EmitNullableNullCheck(
+                    static resolvedEvent => resolvedEvent.UserDisplayName.Length != 0 || resolvedEvent.UserId is not null, op);
+            case ResolvedEventField.Id:
+            case ResolvedEventField.TimeCreated:
+                return op switch
+                {
+                    FilterBinaryOperator.Equal => static _ => false,
+                    FilterBinaryOperator.NotEqual => static _ => true,
+                    _ => throw new EmitException($"Operator '{op}' is not supported against null.")
+                };
+            case ResolvedEventField.ComputerName:
+            case ResolvedEventField.Description:
+            case ResolvedEventField.Level:
+            case ResolvedEventField.LogName:
+            case ResolvedEventField.Source:
+            case ResolvedEventField.TaskCategory:
+            case ResolvedEventField.Opcode:
+            case ResolvedEventField.Xml:
+                // ResolvedEvent string properties default to string.Empty and writer paths never assign null.
+                return op switch
+                {
+                    FilterBinaryOperator.Equal => static _ => false,
+                    FilterBinaryOperator.NotEqual => static _ => true,
+                    _ => throw new EmitException($"Operator '{op}' is not supported against null.")
+                };
+            case ResolvedEventField.Keywords:
+                throw new EmitException("Keywords cannot be compared directly; use Keywords.Any.");
+            default:
+                throw new EmitException($"Unsupported field '{field}' for null comparison.");
+        }
     }
 
     private static Func<ResolvedEvent, bool> EmitNullableGuidComparison(
@@ -719,52 +843,6 @@ internal static class Emitter
             _ => throw new EmitException($"Operator '{op}' is not supported against null.")
         };
 
-    private static Func<ResolvedEvent, bool> EmitNullComparison(ResolvedEventField field, FilterBinaryOperator op)
-    {
-        switch (field)
-        {
-            case ResolvedEventField.ProcessId:
-                return EmitNullableNullCheck(static resolvedEvent => resolvedEvent.ProcessId.HasValue, op);
-            case ResolvedEventField.ThreadId:
-                return EmitNullableNullCheck(static resolvedEvent => resolvedEvent.ThreadId.HasValue, op);
-            case ResolvedEventField.RecordId:
-                return EmitNullableNullCheck(static resolvedEvent => resolvedEvent.RecordId.HasValue, op);
-            case ResolvedEventField.ActivityId:
-                return EmitNullableNullCheck(static resolvedEvent => resolvedEvent.ActivityId.HasValue, op);
-            case ResolvedEventField.RelatedActivityId:
-                return EmitNullableNullCheck(static resolvedEvent => resolvedEvent.RelatedActivityId.HasValue, op);
-            case ResolvedEventField.UserId:
-                return EmitNullableNullCheck(static resolvedEvent => resolvedEvent.UserId is not null, op);
-            case ResolvedEventField.Id:
-            case ResolvedEventField.TimeCreated:
-                return op switch
-                {
-                    FilterBinaryOperator.Equal => static _ => false,
-                    FilterBinaryOperator.NotEqual => static _ => true,
-                    _ => throw new EmitException($"Operator '{op}' is not supported against null.")
-                };
-            case ResolvedEventField.ComputerName:
-            case ResolvedEventField.Description:
-            case ResolvedEventField.Level:
-            case ResolvedEventField.LogName:
-            case ResolvedEventField.Source:
-            case ResolvedEventField.TaskCategory:
-            case ResolvedEventField.Opcode:
-            case ResolvedEventField.Xml:
-                // ResolvedEvent string properties default to string.Empty and writer paths never assign null.
-                return op switch
-                {
-                    FilterBinaryOperator.Equal => static _ => false,
-                    FilterBinaryOperator.NotEqual => static _ => true,
-                    _ => throw new EmitException($"Operator '{op}' is not supported against null.")
-                };
-            case ResolvedEventField.Keywords:
-                throw new EmitException("Keywords cannot be compared directly; use Keywords.Any.");
-            default:
-                throw new EmitException($"Unsupported field '{field}' for null comparison.");
-        }
-    }
-
     private static Func<ResolvedEvent, bool> EmitOr(OrNode node)
     {
         var conditions = FilterNodeMetadata.FlattenOrChain(node).Select(EmitNode).ToArray();
@@ -796,6 +874,7 @@ internal static class Emitter
             ResolvedEventField.Level => EmitDirectStringCompare(static resolvedEvent => resolvedEvent.Level, op, value),
             ResolvedEventField.LogName => EmitDirectStringCompare(static resolvedEvent => resolvedEvent.LogName, op, value),
             ResolvedEventField.Source => EmitDirectStringCompare(static resolvedEvent => resolvedEvent.Source, op, value),
+            ResolvedEventField.UserDisplayName => EmitUserStringCompare(op, value),
             ResolvedEventField.TaskCategory => EmitDirectStringCompare(static resolvedEvent => resolvedEvent.TaskCategory, op, value),
             ResolvedEventField.Opcode => EmitDirectStringCompare(static resolvedEvent => resolvedEvent.Opcode, op, value),
             ResolvedEventField.Xml => EmitDirectStringCompare(static resolvedEvent => resolvedEvent.Xml, op, value),
@@ -876,6 +955,15 @@ internal static class Emitter
         }
     }
 
+    private static Func<ResolvedEvent, bool> EmitUserContains(string needle, StringComparison comparison, bool negated) =>
+        negated ?
+            resolvedEvent => UserFilterHasIdentity(resolvedEvent) &&
+                !resolvedEvent.UserDisplayName.Contains(needle, comparison) &&
+                (resolvedEvent.UserId is null || !resolvedEvent.UserId.Value.Contains(needle, comparison)) :
+            resolvedEvent => UserFilterHasIdentity(resolvedEvent) &&
+                (resolvedEvent.UserDisplayName.Contains(needle, comparison) ||
+                    (resolvedEvent.UserId is not null && resolvedEvent.UserId.Value.Contains(needle, comparison)));
+
     private static Func<ResolvedEvent, FilterMatch> EmitUserDataFieldMatcher(
         string canonicalPath,
         Func<StructuredFieldResult, FilterMatch> evaluate)
@@ -907,6 +995,18 @@ internal static class Emitter
             _ => throw new EmitException($"Operator '{op}' is not supported on UserId.")
         };
 
+    private static Func<ResolvedEvent, bool> EmitUserStringCompare(FilterBinaryOperator op, string value) =>
+        op switch
+        {
+            FilterBinaryOperator.Equal => resolvedEvent => UserFilterHasIdentity(resolvedEvent) &&
+                (string.Equals(resolvedEvent.UserDisplayName, value, StringComparison.Ordinal) ||
+                    (resolvedEvent.UserId is not null && string.Equals(resolvedEvent.UserId.Value, value, StringComparison.Ordinal))),
+            FilterBinaryOperator.NotEqual => resolvedEvent => UserFilterHasIdentity(resolvedEvent) &&
+                !string.Equals(resolvedEvent.UserDisplayName, value, StringComparison.Ordinal) &&
+                (resolvedEvent.UserId is null || !string.Equals(resolvedEvent.UserId.Value, value, StringComparison.Ordinal)),
+            _ => throw new EmitException($"Operator '{op}' is not supported on User.")
+        };
+
     private static FilterMatch EvaluateUserDataGlob(
         ResolvedEvent @event,
         Func<string, bool> matchesPath,
@@ -936,4 +1036,7 @@ internal static class Emitter
         // the glob at all) becomes keep-visible Unknown.
         return result == FilterMatch.NoMatch && @event.UserDataIncomplete ? FilterMatch.Unknown : result;
     }
+
+    private static bool UserFilterHasIdentity(ResolvedEvent resolvedEvent) =>
+        resolvedEvent.UserDisplayName.Length != 0 || resolvedEvent.UserId is not null;
 }

--- a/src/EventLogExpert.Filtering/EventData/EventLogDataQueryExtensions.cs
+++ b/src/EventLogExpert.Filtering/EventData/EventLogDataQueryExtensions.cs
@@ -58,6 +58,7 @@ internal static class EventLogDataQueryExtensions
                 EventProperty.Source => events.Select(e => e.Source).Distinct(),
                 EventProperty.TaskCategory => events.Select(e => e.TaskCategory).Distinct(),
                 EventProperty.Opcode => events.Select(e => e.Opcode).Distinct(),
+                EventProperty.UserDisplayName => events.Select(e => e.UserDisplayName).Where(name => name.Length != 0).Distinct(),
                 EventProperty.LogName => events.Select(e => e.LogName).Distinct(),
                 _ => [],
             };

--- a/src/EventLogExpert.Filtering/EventData/EventPropertyValuesCache.cs
+++ b/src/EventLogExpert.Filtering/EventData/EventPropertyValuesCache.cs
@@ -168,5 +168,6 @@ public static class EventPropertyValuesCache
         EventProperty.Source or
         EventProperty.TaskCategory or
         EventProperty.Opcode or
+        EventProperty.UserDisplayName or
         EventProperty.LogName;
 }

--- a/src/EventLogExpert.Filtering/Lowering/Lowerer.cs
+++ b/src/EventLogExpert.Filtering/Lowering/Lowerer.cs
@@ -109,6 +109,19 @@ internal static class Lowerer
             _ => false
         };
 
+    private static bool ContainsUserFilterNode(FilterNode node) =>
+        node switch
+        {
+            ComparisonNode { Field: ResolvedEventField.UserDisplayName } => true,
+            ContainsNode { Field: ResolvedEventField.UserDisplayName } => true,
+            MultiEqualsNode { Field: ResolvedEventField.UserDisplayName } => true,
+            MultiContainsNode { Field: ResolvedEventField.UserDisplayName } => true,
+            AndNode and => ContainsUserFilterNode(and.Left) || ContainsUserFilterNode(and.Right),
+            OrNode or => ContainsUserFilterNode(or.Left) || ContainsUserFilterNode(or.Right),
+            NotNode not => ContainsUserFilterNode(not.Operand),
+            _ => false
+        };
+
     private static IReadOnlyList<string> ExtractStringArray(ArrayCreationSyntax array, int position)
     {
         if (array.Elements.Count == 0)
@@ -186,6 +199,7 @@ internal static class Lowerer
             or ResolvedEventField.Source
             or ResolvedEventField.TaskCategory
             or ResolvedEventField.UserId
+            or ResolvedEventField.UserDisplayName
             or ResolvedEventField.Xml;
 
     private static bool IsNullCheckOnIdentifier(BinarySyntax bin, string identifier)
@@ -567,6 +581,19 @@ internal static class Lowerer
                     multiContains.Values,
                     multiContains.IgnoreCase,
                     !multiContains.Negated);
+            case ComparisonNode { Field: ResolvedEventField.UserDisplayName, Op: FilterBinaryOperator.Equal or FilterBinaryOperator.NotEqual } userComparison:
+                // The merged "User" field is presence-gated, so a negated equality must lower to the gated inverse
+                // operator, NOT a generic NotNode wrap: `!inner` would flip the gate and let a no-identity row match
+                // `!(User == x)`, contradicting `User != x`. Only Equal/NotEqual invert; any other operator falls
+                // through so the emitter reports it as unsupported on User (rather than being silently rewritten).
+                return new ComparisonNode(
+                    userComparison.Field,
+                    userComparison.Op == FilterBinaryOperator.Equal ? FilterBinaryOperator.NotEqual : FilterBinaryOperator.Equal,
+                    userComparison.Literal);
+            case NotNode { Operand: ContainsNode { Field: ResolvedEventField.UserDisplayName } } doubleNegatedUserContains:
+                // `!!User.Contains(...)` == `User.Contains(...)`. Collapsing only the presence-gated User leaf keeps it
+                // out of a NotNode whose generic `!inner` would flip its gate, without changing general `!!` handling.
+                return doubleNegatedUserContains.Operand;
             default:
                 if (ContainsEventDataNode(inner))
                 {
@@ -578,6 +605,15 @@ internal static class Lowerer
                 {
                     throw new LowerException(
                         $"Negating a group that contains UserData conditions is not supported; negate each UserData condition individually (position {neg.Position}).");
+                }
+
+                if (inner is AndNode or OrNode && ContainsUserFilterNode(inner))
+                {
+                    // The merged "User" field is presence-gated; distributing the negation through a group would flip
+                    // the gate for no-identity rows (like EventData/UserData). Reject so the user negates each User
+                    // condition individually or uses `User is none of (...)` (a gated multi-equals).
+                    throw new LowerException(
+                        $"Negating a group that contains a User condition is not supported; negate each User condition individually, or use `User is none of (...)` (position {neg.Position}).");
                 }
 
                 return new NotNode(inner);

--- a/src/EventLogExpert.Filtering/Lowering/PropertyResolver.cs
+++ b/src/EventLogExpert.Filtering/Lowering/PropertyResolver.cs
@@ -16,7 +16,7 @@ internal static class PropertyResolver
     ///     Returns the <see cref="ResolvedEventField" /> matching <paramref name="identifier" /> (case-insensitive), plus
     ///     the literal kind a comparison literal must coerce to.
     /// </summary>
-    public static bool TryResolve(string identifier, out ResolvedEventField field, out TypedLiteralKind literalKind)
+    public static bool TryResolve(string? identifier, out ResolvedEventField field, out TypedLiteralKind literalKind)
     {
         field = default;
         literalKind = default;
@@ -102,6 +102,12 @@ internal static class PropertyResolver
                 return true;
             case "USERID":
                 field = ResolvedEventField.UserId;
+                literalKind = TypedLiteralKind.String;
+
+                return true;
+            case "USER":
+            case "USERDISPLAYNAME":
+                field = ResolvedEventField.UserDisplayName;
                 literalKind = TypedLiteralKind.String;
 
                 return true;

--- a/src/EventLogExpert.Filtering/Lowering/ResolvedEventField.cs
+++ b/src/EventLogExpert.Filtering/Lowering/ResolvedEventField.cs
@@ -29,5 +29,6 @@ internal enum ResolvedEventField
     ThreadId,
     TimeCreated,
     UserId,
+    UserDisplayName,
     Xml
 }

--- a/src/EventLogExpert.Runtime/Common/Clipboard/EventCopyFormatter.cs
+++ b/src/EventLogExpert.Runtime/Common/Clipboard/EventCopyFormatter.cs
@@ -141,7 +141,7 @@ internal sealed class EventCopyFormatter(IEventDetailResolver detailResolver, IE
                             builder.Append($"\"{@event.ThreadId}\" ");
                             break;
                         case ColumnName.User:
-                            builder.Append($"\"{@event.UserId}\" ");
+                            builder.Append($"\"{@event.UserDisplayName}\" ");
                             break;
                     }
                 }
@@ -168,7 +168,13 @@ internal sealed class EventCopyFormatter(IEventDetailResolver detailResolver, IE
                 builder.AppendLine($"Task Category: {@event.TaskCategory}");
                 builder.AppendLine($"Level: {@event.Level}");
                 builder.AppendLine($"Keywords: {@event.KeywordsDisplayName}");
-                builder.AppendLine($"User: {@event.UserId}");
+                builder.AppendLine($"User: {@event.UserDisplayName}");
+
+                if (@event.UserId is { } userId && !string.Equals(userId.Value, @event.UserDisplayName, StringComparison.Ordinal))
+                {
+                    builder.AppendLine($"User SID: {userId.Value}");
+                }
+
                 builder.AppendLine($"Computer: {@event.ComputerName}");
                 builder.AppendLine("Description:");
                 builder.AppendLine(@event.Description);

--- a/src/EventLogExpert.Runtime/DetailsPane/DetailsReaderFormatter.cs
+++ b/src/EventLogExpert.Runtime/DetailsPane/DetailsReaderFormatter.cs
@@ -193,8 +193,14 @@ public static class DetailsReaderFormatter
 
         if (@event.RelatedActivityId is { } relatedActivityId) { properties.Add(new DetailsProperty("Related Activity ID", relatedActivityId.ToString())); }
 
-        // Raw SID by design; account-name resolution is a separate task.
-        if (@event.UserId is { } userId) { properties.Add(new DetailsProperty("User", userId.Value)); }
+        // The best-available user identity (well-known-SID name or EventData Subject/Target account), resolved offline.
+        if (@event.UserDisplayName.Length > 0) { properties.Add(new DetailsProperty("User", @event.UserDisplayName)); }
+
+        // The raw System <Security UserID> SID, shown only when it adds information beyond the resolved name.
+        if (@event.UserId is { } userId && !string.Equals(userId.Value, @event.UserDisplayName, StringComparison.Ordinal))
+        {
+            properties.Add(new DetailsProperty("User SID", userId.Value));
+        }
 
         return properties;
     }

--- a/src/EventLogExpert.Runtime/LogTable/ColumnFieldMap.cs
+++ b/src/EventLogExpert.Runtime/LogTable/ColumnFieldMap.cs
@@ -23,7 +23,7 @@ internal static class ColumnFieldMap
             ColumnName.Keywords => EventFieldId.KeywordsDisplay,
             ColumnName.ProcessId => EventFieldId.ProcessId,
             ColumnName.ThreadId => EventFieldId.ThreadId,
-            ColumnName.User => EventFieldId.UserId,
+            ColumnName.User => EventFieldId.UserDisplayName,
             _ => throw new ArgumentOutOfRangeException(nameof(column), column, "No field mapping for column.")
         };
 }

--- a/src/EventLogExpert.Runtime/LogTable/EventTableColumnFormatter.cs
+++ b/src/EventLogExpert.Runtime/LogTable/EventTableColumnFormatter.cs
@@ -27,21 +27,21 @@ public static class EventTableColumnFormatter
             ColumnName.Keywords => @event.KeywordsDisplayName,
             ColumnName.ProcessId => @event.ProcessId?.ToString() ?? string.Empty,
             ColumnName.ThreadId => @event.ThreadId?.ToString() ?? string.Empty,
-            ColumnName.User => @event.UserId?.ToString() ?? string.Empty,
+            ColumnName.User => @event.UserDisplayName,
             _ => string.Empty
         };
 
     public static string GetColumnHeader(ColumnName column, TimeZoneInfo timeZone) =>
-        column == ColumnName.DateAndTime && !timeZone.Equals(TimeZoneInfo.Local)
-            ? $"Date and Time {timeZone.DisplayName.Split(' ').First()}"
-            : column.ToFullString();
+        column == ColumnName.DateAndTime && !timeZone.Equals(TimeZoneInfo.Local) ?
+            $"Date and Time {timeZone.DisplayName.Split(' ').First()}" :
+            column.ToFullString();
 
     private static string FormatTimeCreated(DateTime timeCreated, TimeZoneInfo timeZone, string? dateTimeFormat)
     {
         DateTime converted = timeCreated.ConvertTimeZone(timeZone);
 
-        return dateTimeFormat is null
-            ? converted.ToString()
-            : converted.ToString(dateTimeFormat, CultureInfo.InvariantCulture);
+        return dateTimeFormat is null ?
+            converted.ToString() :
+            converted.ToString(dateTimeFormat, CultureInfo.InvariantCulture);
     }
 }

--- a/src/EventLogExpert.UI/FilterEditor/Comparison/FilterComparisonEditor.razor
+++ b/src/EventLogExpert.UI/FilterEditor/Comparison/FilterComparisonEditor.razor
@@ -1,10 +1,12 @@
 <ValueSelect AriaLabel="@(PropertyAriaLabelledBy is null ? "Property" : null)"
     AriaLabelledBy="@PropertyAriaLabelledBy"
-    @bind-Value="PropertyBinding"
     CssClass="input filter-dropdown"
     T="EventProperty"
-    ToStringFunc="x => x.ToFullString()">
-    @foreach (var item in Enum.GetValues<EventProperty>().OrderBy(p => p.ToFullString(), StringComparer.CurrentCulture))
+    ToStringFunc="x => x.ToFullString()"
+    @bind-Value="PropertyBinding">
+    @foreach (var item in Enum.GetValues<EventProperty>()
+        .Where(p => p != EventProperty.UserId || Comparison.Property == EventProperty.UserId)
+        .OrderBy(p => p.ToFullString(), StringComparer.CurrentCulture))
     {
         <ValueSelectItem T="EventProperty" Value="item" />
     }
@@ -49,8 +51,8 @@
     MatchMode="Comparison.MatchMode"
     OnChanged="HandleOperatorChanged"
     Operator="Comparison.Operator"
-    SupportsMany="!IsTextOnlyProperty(Comparison.Property)"
     SupportsContainsMany="FilterPropertyConstraints.SupportsContainsMany(Comparison.Property)"
+    SupportsMany="!IsTextOnlyProperty(Comparison.Property)"
     SupportsNoneOfMany="FilterPropertyConstraints.SupportsNoneOfMany(Comparison.Property)" />
 
 <label class="visually-hidden" id="@($"{Id}_Value")">Value</label>

--- a/src/EventLogExpert.UI/LogTable/CellFilterBuilder.cs
+++ b/src/EventLogExpert.UI/LogTable/CellFilterBuilder.cs
@@ -24,7 +24,7 @@ internal static class CellFilterBuilder
             ColumnName.TaskCategory => EventProperty.TaskCategory,
             ColumnName.ProcessId => EventProperty.ProcessId,
             ColumnName.ThreadId => EventProperty.ThreadId,
-            ColumnName.User => EventProperty.UserId,
+            ColumnName.User => EventProperty.UserDisplayName,
             _ => null
         };
 
@@ -64,7 +64,7 @@ internal static class CellFilterBuilder
             EventProperty.TaskCategory => @event.TaskCategory,
             EventProperty.ProcessId => @event.ProcessId?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
             EventProperty.ThreadId => @event.ThreadId?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
-            EventProperty.UserId => @event.UserId?.Value ?? string.Empty,
+            EventProperty.UserDisplayName => @event.UserDisplayName,
             EventProperty.LogName => @event.LogName,
             _ => string.Empty
         };

--- a/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
@@ -673,7 +673,7 @@ public sealed partial class LogTablePane
             ColumnName.Keywords => representative.KeywordsDisplayName,
             ColumnName.ProcessId => representative.ProcessId?.ToString(),
             ColumnName.ThreadId => representative.ThreadId?.ToString(),
-            ColumnName.User => representative.UserId?.ToString(),
+            ColumnName.User => representative.UserDisplayName,
             _ => null
         };
 
@@ -1511,7 +1511,7 @@ public sealed partial class LogTablePane
 
         foreach (EventProperty property in Enum.GetValues<EventProperty>())
         {
-            if (property is EventProperty.Description or EventProperty.Xml) { continue; }
+            if (property is EventProperty.Description or EventProperty.Xml or EventProperty.UserId) { continue; }
 
             var capturedProperty = property;
             bool hasValue = CellFilterBuilder.TryGetDisplayValue(selectedEvent, property, out _);

--- a/tests/Shared/EventLogExpert.Filtering.TestUtils/FilterEventBuilder.cs
+++ b/tests/Shared/EventLogExpert.Filtering.TestUtils/FilterEventBuilder.cs
@@ -24,6 +24,7 @@ public static class FilterEventBuilder
         int? processId = null,
         int? threadId = null,
         SecurityIdentifier? userId = null,
+        string? userDisplayName = null,
         IReadOnlyList<string>? keywords = null,
         string owningLog = "TestLog") =>
         new(owningLog, LogPathType.Channel)
@@ -42,6 +43,7 @@ public static class FilterEventBuilder
             ProcessId = processId,
             ThreadId = threadId,
             UserId = userId,
+            UserDisplayName = userDisplayName ?? userId?.Value ?? string.Empty,
             Keywords = keywords ?? []
         };
 }

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Common/Events/EventColumnRehydrationTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Common/Events/EventColumnRehydrationTests.cs
@@ -18,6 +18,37 @@ public sealed class EventColumnRehydrationTests
     private const int ChunkSize = 4096;
 
     [Fact]
+    public void GetDetailLean_PendingRow_ReturnsSamePendingEvent()
+    {
+        ResolvedEvent pending = BuildRichEvent();
+        EventColumnStore store = EventColumnStore.Build([], generation: 1, contentVersion: 1).Append([pending]);
+
+        Assert.True(store.IsPending(0));
+
+        // R1: a pending lean read is O(1) and leaves the fully materialized detail fields intact.
+        ResolvedEvent lean = store.GetDetailLean(0);
+        Assert.Same(pending, lean);
+    }
+
+    [Fact]
+    public void GetDetailLean_SealedRow_GridMatchesDetailWithEmptyDetailFields()
+    {
+        ResolvedEvent source = BuildRichEvent();
+        EventColumnStore store = EventColumnStore.Build([source], generation: 1, contentVersion: 1);
+        Assert.False(store.IsPending(0));
+
+        ResolvedEvent full = store.GetDetail(0);
+        ResolvedEvent lean = store.GetDetailLean(0);
+
+        AssertGridParity(full, lean);
+
+        // Detail-only fields are best-effort empty on the sealed lean projection.
+        Assert.True(lean.UserData.IsDefaultOrEmpty);
+        Assert.Equal(string.Empty, lean.Xml);
+        Assert.Equal(EventDataKind.None, lean.EventData.Kind);
+    }
+
+    [Fact]
     public void GetDetail_PendingRow_ReturnsSamePendingEvent()
     {
         ResolvedEvent pending = BuildRichEvent();
@@ -310,34 +341,32 @@ public sealed class EventColumnRehydrationTests
     }
 
     [Fact]
-    public void GetDetailLean_PendingRow_ReturnsSamePendingEvent()
+    public void SealedRow_EmptyUserDisplayName_ReconstructsAsEmpty()
     {
-        ResolvedEvent pending = BuildRichEvent();
-        EventColumnStore store = EventColumnStore.Build([], generation: 1, contentVersion: 1).Append([pending]);
+        ResolvedEvent source = new("live", LogPathType.Channel) { Id = 1 };
 
-        Assert.True(store.IsPending(0));
-
-        // R1: a pending lean read is O(1) and leaves the fully materialized detail fields intact.
-        ResolvedEvent lean = store.GetDetailLean(0);
-        Assert.Same(pending, lean);
-    }
-
-    [Fact]
-    public void GetDetailLean_SealedRow_GridMatchesDetailWithEmptyDetailFields()
-    {
-        ResolvedEvent source = BuildRichEvent();
         EventColumnStore store = EventColumnStore.Build([source], generation: 1, contentVersion: 1);
         Assert.False(store.IsPending(0));
 
-        ResolvedEvent full = store.GetDetail(0);
-        ResolvedEvent lean = store.GetDetailLean(0);
+        Assert.Equal(string.Empty, store.GetDetailLean(0).UserDisplayName);
+        Assert.Equal(string.Empty, store.GetDetail(0).UserDisplayName);
+    }
 
-        AssertGridParity(full, lean);
+    [Fact]
+    public void SealedRow_LeanAndDetail_CarryResolvedUserDisplayName()
+    {
+        ResolvedEvent source = new("live", LogPathType.Channel)
+        {
+            Id = 4624,
+            UserId = null,
+            UserDisplayName = @"CONTOSO\alice"
+        };
 
-        // Detail-only fields are best-effort empty on the sealed lean projection.
-        Assert.True(lean.UserData.IsDefaultOrEmpty);
-        Assert.Equal(string.Empty, lean.Xml);
-        Assert.Equal(EventDataKind.None, lean.EventData.Kind);
+        EventColumnStore store = EventColumnStore.Build([source], generation: 1, contentVersion: 1);
+        Assert.False(store.IsPending(0));
+
+        Assert.Equal(@"CONTOSO\alice", store.GetDetailLean(0).UserDisplayName);
+        Assert.Equal(@"CONTOSO\alice", store.GetDetail(0).UserDisplayName);
     }
 
     private static void AssertEnumerationParity(EventDataView expected, EventDataView actual)
@@ -417,6 +446,7 @@ public sealed class EventColumnRehydrationTests
         Assert.Equal(expected.ProcessId, actual.ProcessId);
         Assert.Equal(expected.ThreadId, actual.ThreadId);
         Assert.Equal(expected.UserId, actual.UserId);
+        Assert.Equal(expected.UserDisplayName, actual.UserDisplayName);
         Assert.Equal(expected.UserDataIncomplete, actual.UserDataIncomplete);
 
         Assert.Equal(expected.Keywords.ToArray(), actual.Keywords.ToArray());
@@ -445,6 +475,7 @@ public sealed class EventColumnRehydrationTests
         Assert.Equal(full.ProcessId, lean.ProcessId);
         Assert.Equal(full.ThreadId, lean.ThreadId);
         Assert.Equal(full.UserId, lean.UserId);
+        Assert.Equal(full.UserDisplayName, lean.UserDisplayName);
         Assert.Equal(full.UserDataIncomplete, lean.UserDataIncomplete);
         Assert.Equal(full.Keywords.ToArray(), lean.Keywords.ToArray());
         Assert.Equal(full.KeywordsDisplayName, lean.KeywordsDisplayName);
@@ -570,6 +601,7 @@ public sealed class EventColumnRehydrationTests
             TaskCategory = "Logon",
             Xml = "<Event><System /></Event>",
             UserId = new SecurityIdentifier("S-1-5-18"),
+            UserDisplayName = @"NT AUTHORITY\SYSTEM",
             RecordId = 99L,
             ActivityId = Guid.Parse("33333333-3333-3333-3333-333333333333"),
             RelatedActivityId = Guid.Parse("44444444-4444-4444-4444-444444444444"),

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Common/Events/UserDisplayNameResolverTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Common/Events/UserDisplayNameResolverTests.cs
@@ -1,0 +1,143 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Eventing.Readers;
+using EventLogExpert.Eventing.Resolvers;
+using System.Collections.Immutable;
+using System.Security.Principal;
+
+namespace EventLogExpert.Eventing.Tests.Common.Events;
+
+public sealed class UserDisplayNameResolverTests
+{
+    private static readonly SecurityIdentifier s_userSid = new("S-1-5-21-1111111111-2222222222-3333333333-1105");
+
+    [Fact]
+    public void Resolve_EmptyUserId_OnlyTargetPair_ReturnsTarget()
+    {
+        // 4768/4769-shaped: only Target identity present.
+        EventDataView data = EventData(
+            ("TargetUserName", "bob"),
+            ("TargetDomainName", "CONTOSO"));
+
+        Assert.Equal(@"CONTOSO\bob", UserDisplayNameResolver.Resolve(null, data));
+    }
+
+    [Fact]
+    public void Resolve_EmptyUserId_SubjectNoDomain_ReturnsNameOnly()
+    {
+        EventDataView data = EventData(("SubjectUserName", "alice"));
+
+        Assert.Equal("alice", UserDisplayNameResolver.Resolve(null, data));
+    }
+
+    [Fact]
+    public void Resolve_EmptyUserId_SubjectPair_ReturnsDomainUser()
+    {
+        EventDataView data = EventData(
+            ("SubjectUserName", "alice"),
+            ("SubjectDomainName", "CONTOSO"));
+
+        Assert.Equal(@"CONTOSO\alice", UserDisplayNameResolver.Resolve(null, data));
+    }
+
+    [Fact]
+    public void Resolve_InformativeSubject_PreferredOverTarget()
+    {
+        EventDataView data = EventData(
+            ("SubjectUserName", "alice"),
+            ("SubjectDomainName", "CONTOSO"),
+            ("TargetUserName", "bob"),
+            ("TargetDomainName", "FABRIKAM"));
+
+        Assert.Equal(@"CONTOSO\alice", UserDisplayNameResolver.Resolve(null, data));
+    }
+
+    [Fact]
+    public void Resolve_NoIdentityFields_ReturnsEmpty()
+    {
+        EventDataView data = EventData(("SomeOtherField", "x"), ("Param1", "y"));
+
+        Assert.Equal(string.Empty, UserDisplayNameResolver.Resolve(null, data));
+    }
+
+    [Fact]
+    public void Resolve_NonWellKnownUserId_NoEventData_ReturnsRawSid() =>
+        Assert.Equal(s_userSid.Value, UserDisplayNameResolver.Resolve(s_userSid, EventDataView.Empty));
+
+    [Fact]
+    public void Resolve_NonWellKnownUserId_WithSubjectPair_PrefersDerivedName()
+    {
+        EventDataView data = EventData(
+            ("SubjectUserSid", s_userSid.Value),
+            ("SubjectUserName", "alice"),
+            ("SubjectDomainName", "CONTOSO"));
+
+        Assert.Equal(@"CONTOSO\alice", UserDisplayNameResolver.Resolve(s_userSid, data));
+    }
+
+    [Fact]
+    public void Resolve_NullUserId_NoEventData_ReturnsEmpty() =>
+        Assert.Equal(string.Empty, UserDisplayNameResolver.Resolve(null, EventDataView.Empty));
+
+    [Fact]
+    public void Resolve_PlaceholderDashSubject_SkippedForTarget()
+    {
+        EventDataView data = EventData(
+            ("SubjectUserName", "-"),
+            ("SubjectDomainName", "-"),
+            ("TargetUserName", "bob"),
+            ("TargetDomainName", "CONTOSO"));
+
+        Assert.Equal(@"CONTOSO\bob", UserDisplayNameResolver.Resolve(null, data));
+    }
+
+    [Theory]
+    [InlineData("SYSTEM", "NT AUTHORITY")]
+    [InlineData("LOCAL SERVICE", "NT AUTHORITY")]
+    [InlineData("DC01$", "CONTOSO")]
+    public void Resolve_SubjectIsSystemOrMachine_FallsBackToTarget(string subjectName, string subjectDomain)
+    {
+        // The reporting SYSTEM / machine subject on a logon event should yield to the logged-on Target user.
+        EventDataView data = EventData(
+            ("SubjectUserName", subjectName),
+            ("SubjectDomainName", subjectDomain),
+            ("TargetUserName", "bob"),
+            ("TargetDomainName", "CONTOSO"));
+
+        Assert.Equal(@"CONTOSO\bob", UserDisplayNameResolver.Resolve(null, data));
+    }
+
+    [Fact]
+    public void Resolve_SubjectIsSystem_NoTarget_ShowsSubject()
+    {
+        // A process genuinely running as SYSTEM (no Target) legitimately displays the Subject.
+        EventDataView data = EventData(
+            ("SubjectUserName", "SYSTEM"),
+            ("SubjectDomainName", "NT AUTHORITY"));
+
+        Assert.Equal(@"NT AUTHORITY\SYSTEM", UserDisplayNameResolver.Resolve(null, data));
+    }
+
+    [Theory]
+    [InlineData("S-1-5-18", @"NT AUTHORITY\SYSTEM")]
+    [InlineData("S-1-5-19", @"NT AUTHORITY\LOCAL SERVICE")]
+    [InlineData("S-1-5-20", @"NT AUTHORITY\NETWORK SERVICE")]
+    [InlineData("S-1-0-0", "NULL SID")]
+    [InlineData("S-1-5-32-544", @"BUILTIN\Administrators")]
+    public void Resolve_WellKnownUserId_ReturnsMappedName(string sid, string expected) =>
+        Assert.Equal(expected, UserDisplayNameResolver.Resolve(new SecurityIdentifier(sid), EventDataView.Empty));
+
+    private static EventDataView EventData(params (string Name, string Value)[] fields)
+    {
+        string template = "<template>" +
+            string.Concat(fields.Select(field => $"<data name=\"{field.Name}\"/>")) +
+            "</template>";
+
+        TemplateFieldSchema schema = new TemplateAnalyzer().GetTemplateInfo(template).Schema;
+        ImmutableArray<EventProperty> values = [.. fields.Select(field => (EventProperty)field.Value)];
+
+        return new EventDataView(values, schema);
+    }
+}

--- a/tests/Unit/EventLogExpert.Filtering.Tests/Basic/BasicFilterDecomposerTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/Basic/BasicFilterDecomposerTests.cs
@@ -504,6 +504,7 @@ public sealed class BasicFilterDecomposerTests
             EventProperty.ProcessId => ["4", "8"],
             EventProperty.ThreadId => ["8", "16"],
             EventProperty.UserId => ["S-1-5-18", "S-1-5-19"],
+            EventProperty.UserDisplayName => [@"CONTOSO\alice", @"NT AUTHORITY\SYSTEM"],
             EventProperty.LogName => ["Application", "System"],
             _ => null
         };
@@ -522,6 +523,7 @@ public sealed class BasicFilterDecomposerTests
             EventProperty.ProcessId => "4",
             EventProperty.ThreadId => "8",
             EventProperty.UserId => "S-1-5-18",
+            EventProperty.UserDisplayName => @"CONTOSO\alice",
             EventProperty.Description => "An error occurred",
             EventProperty.Xml => "<x/>",
             EventProperty.LogName => "Application",

--- a/tests/Unit/EventLogExpert.Filtering.Tests/Basic/FilterComparisonJsonConverterTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/Basic/FilterComparisonJsonConverterTests.cs
@@ -11,8 +11,8 @@ public sealed class FilterComparisonJsonConverterTests
     [Fact]
     public void EventProperty_MemberCount_IsFrozenForWireCompatibility()
     {
-        // Members are appended at the end (UserData=14, Opcode=15, RelatedActivityId=16); appending is JSON-by-name wire-safe.
-        Assert.Equal(16, Enum.GetValues<EventProperty>().Length);
+        // Members are appended at the end (Opcode=15, RelatedActivityId=16, UserDisplayName=17); appending is JSON-by-name wire-safe.
+        Assert.Equal(17, Enum.GetValues<EventProperty>().Length);
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Filtering.Tests/Emit/ColumnEmitterParityTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/Emit/ColumnEmitterParityTests.cs
@@ -8,6 +8,7 @@ using EventLogExpert.Eventing.Structured;
 using EventLogExpert.Eventing.TestUtils;
 using EventLogExpert.Filtering.Parsing;
 using EventLogExpert.Filtering.Tests.TestUtils;
+using System.Security.Principal;
 
 namespace EventLogExpert.Filtering.Tests.Emit;
 
@@ -22,7 +23,6 @@ public sealed class ColumnEmitterParityTests
         ("Path", @"C:\Windows\System32\cmd.exe"),
         ("Dup", "first"),
         ("Dup", "second"));
-
     private static readonly ResolvedEvent s_readerEnablerEvent = new("TestLog", LogPathType.Channel)
     {
         Id = 700,
@@ -431,6 +431,39 @@ public sealed class ColumnEmitterParityTests
     }
 
     [Fact]
+    public void UserDisplayName_MultiValueOperators_MatchInBothBackends()
+    {
+        ResolvedEvent alice = new("TestLog", LogPathType.Channel) { Id = 1, UserDisplayName = @"CONTOSO\alice" };
+        ResolvedEvent bob = new("TestLog", LogPathType.Channel) { Id = 2, UserDisplayName = @"CONTOSO\bob" };
+
+        // Multi-equals ("is any of").
+        AssertBothBackends(@"(new[] {""CONTOSO\\alice"", ""CONTOSO\\carol""}).Contains(UserDisplayName)", alice, FilterMatch.Match);
+        AssertBothBackends(@"(new[] {""CONTOSO\\alice"", ""CONTOSO\\carol""}).Contains(UserDisplayName)", bob, FilterMatch.NoMatch);
+
+        // Multi-contains ("contains any of") + its negation.
+        AssertBothBackends(@"(new[] {""alice"", ""carol""}).Any(e => UserDisplayName.Contains(e, StringComparison.OrdinalIgnoreCase))", alice, FilterMatch.Match);
+        AssertBothBackends(@"(new[] {""alice"", ""carol""}).Any(e => UserDisplayName.Contains(e, StringComparison.OrdinalIgnoreCase))", bob, FilterMatch.NoMatch);
+        AssertBothBackends(@"!(new[] {""alice""}).Any(e => UserDisplayName.Contains(e, StringComparison.OrdinalIgnoreCase))", bob, FilterMatch.Match);
+    }
+
+    [Fact]
+    public void UserDisplayName_ResolvedName_MatchesExactAndContains_InBothBackends()
+    {
+        ResolvedEvent alice = new("TestLog", LogPathType.Channel) { Id = 1, UserDisplayName = @"CONTOSO\alice" };
+        ResolvedEvent bob = new("TestLog", LogPathType.Channel) { Id = 2, UserDisplayName = @"CONTOSO\bob" };
+        ResolvedEvent noUser = new("TestLog", LogPathType.Channel) { Id = 3 };
+
+        AssertBothBackends(@"UserDisplayName == ""CONTOSO\\alice""", alice, FilterMatch.Match);
+        AssertBothBackends(@"UserDisplayName == ""CONTOSO\\alice""", bob, FilterMatch.NoMatch);
+        AssertBothBackends(@"UserDisplayName == ""CONTOSO\\alice""", noUser, FilterMatch.NoMatch);
+        AssertBothBackends(@"UserDisplayName.Contains(""alice"", StringComparison.OrdinalIgnoreCase)", alice, FilterMatch.Match);
+
+        // The `User` grammar alias resolves to the same UserDisplayName field.
+        AssertBothBackends(@"User.Contains(""alice"", StringComparison.OrdinalIgnoreCase)", alice, FilterMatch.Match);
+        AssertBothBackends(@"User.Contains(""alice"", StringComparison.OrdinalIgnoreCase)", bob, FilterMatch.NoMatch);
+    }
+
+    [Fact]
     public void UserIdEquals_OverNullUserId_IsNoMatch()
     {
         AssertBothBackends(
@@ -455,6 +488,119 @@ public sealed class ColumnEmitterParityTests
             "UserId != null && UserId.Value != \"S-1-5-18\"",
             FilterTestFixtures.NoNullables,
             FilterMatch.NoMatch);
+    }
+
+    [Fact]
+    public void UserIdSddl_MultiRowSealed_ReadsCorrectSidPerRow()
+    {
+        // A repeated SID interns once, so its pool index differs from later rows' physical indices — guards the
+        // allocation-free reader against confusing the row index with the SID pool index.
+        var sidA = new SecurityIdentifier("S-1-5-21-1-2-3-1001");
+        var sidB = new SecurityIdentifier("S-1-5-21-1-2-3-1002");
+        ResolvedEvent[] events =
+        [
+            new("live", LogPathType.Channel) { Id = 1, UserId = sidA },
+            new("live", LogPathType.Channel) { Id = 2, UserId = sidB },
+            new("live", LogPathType.Channel) { Id = 3, UserId = sidA },
+            new("live", LogPathType.Channel) { Id = 4 }
+        ];
+
+        var reader = EventColumnStore.Build(events, generation: 1, contentVersion: 1).CreateReader(EventLogId.Create());
+
+        Assert.Equal(sidA.Value, reader.GetField(reader.LocatorAt(0), EventFieldId.UserIdSddl).AsString());
+        Assert.Equal(sidB.Value, reader.GetField(reader.LocatorAt(1), EventFieldId.UserIdSddl).AsString());
+        Assert.Equal(sidA.Value, reader.GetField(reader.LocatorAt(2), EventFieldId.UserIdSddl).AsString());
+        Assert.Equal(EventFieldValueKind.Null, reader.GetField(reader.LocatorAt(3), EventFieldId.UserIdSddl).Kind);
+    }
+
+    [Fact]
+    public void User_MatchesSidOrName_InBothBackends()
+    {
+        // Well-known: System UserID present (SID) AND a resolved name that differs from the SID.
+        ResolvedEvent wellKnown = new("TestLog", LogPathType.Channel)
+        {
+            Id = 1,
+            UserId = new SecurityIdentifier("S-1-5-18"),
+            UserDisplayName = @"NT AUTHORITY\SYSTEM"
+        };
+        // Derived: no System UserID; identity came from EventData (name only).
+        ResolvedEvent derived = new("TestLog", LogPathType.Channel) { Id = 2, UserDisplayName = @"CONTOSO\alice" };
+        ResolvedEvent noIdentity = new("TestLog", LogPathType.Channel) { Id = 3 };
+
+        // A SID query matches the well-known row via the SID disjunct; a name query matches via the display name.
+        AssertBothBackends(@"User == ""S-1-5-18""", wellKnown, FilterMatch.Match);
+        AssertBothBackends(@"User.Contains(""SYSTEM"", StringComparison.OrdinalIgnoreCase)", wellKnown, FilterMatch.Match);
+        AssertBothBackends(@"User == ""CONTOSO\\alice""", derived, FilterMatch.Match);
+        AssertBothBackends(@"User == ""S-1-5-18""", derived, FilterMatch.NoMatch);
+        // A no-identity row never matches a value query (presence gate), incl. the degenerate empty value.
+        AssertBothBackends(@"User == ""S-1-5-18""", noIdentity, FilterMatch.NoMatch);
+        AssertBothBackends(@"User == """"", noIdentity, FilterMatch.NoMatch);
+    }
+
+    [Fact]
+    public void User_NegatedComparison_RespectsPresenceGate_InBothBackends()
+    {
+        ResolvedEvent derived = new("TestLog", LogPathType.Channel) { Id = 1, UserDisplayName = @"CONTOSO\alice" };
+        ResolvedEvent noIdentity = new("TestLog", LogPathType.Channel) { Id = 2 };
+
+        // `!(User == x)` must behave exactly like `User != x` (gated), NOT a generic !inner that flips the gate.
+        AssertBothBackends(@"!(User == ""bob"")", derived, FilterMatch.Match);
+        AssertBothBackends(@"!(User == ""bob"")", noIdentity, FilterMatch.NoMatch);
+        // `!(User != x)` must behave like `User == x`.
+        AssertBothBackends(@"!(User != ""CONTOSO\\alice"")", derived, FilterMatch.Match);
+        AssertBothBackends(@"!(User != ""bob"")", noIdentity, FilterMatch.NoMatch);
+        // Double-negated contains collapses to the gated positive.
+        AssertBothBackends(@"!!User.Contains(""alice"", StringComparison.OrdinalIgnoreCase)", derived, FilterMatch.Match);
+        AssertBothBackends(@"!!User.Contains(""alice"", StringComparison.OrdinalIgnoreCase)", noIdentity, FilterMatch.NoMatch);
+    }
+
+    [Fact]
+    public void User_NegativeOperators_GateAndDeMorgan_InBothBackends()
+    {
+        ResolvedEvent wellKnown = new("TestLog", LogPathType.Channel)
+        {
+            Id = 1,
+            UserId = new SecurityIdentifier("S-1-5-18"),
+            UserDisplayName = @"NT AUTHORITY\SYSTEM"
+        };
+        ResolvedEvent derived = new("TestLog", LogPathType.Channel) { Id = 2, UserDisplayName = @"CONTOSO\alice" };
+        ResolvedEvent noIdentity = new("TestLog", LogPathType.Channel) { Id = 3 };
+
+        // DERIVED (null UserId) rows MUST participate in the negatives via the absent-SID=>TRUE De Morgan disjunct.
+        AssertBothBackends(@"User != ""bob""", derived, FilterMatch.Match);
+        AssertBothBackends(@"!User.Contains(""zzz"", StringComparison.OrdinalIgnoreCase)", derived, FilterMatch.Match);
+        AssertBothBackends(@"!(new[] {""bob""}).Any(e => User.Contains(e, StringComparison.OrdinalIgnoreCase))", derived, FilterMatch.Match);
+        // A well-known row won't satisfy `!= its own SID`.
+        AssertBothBackends(@"User != ""S-1-5-18""", wellKnown, FilterMatch.NoMatch);
+        // A true no-identity row is gated OUT of the negatives too (presence-required, like the old User ID field).
+        AssertBothBackends(@"User != ""x""", noIdentity, FilterMatch.NoMatch);
+        AssertBothBackends(@"!User.Contains(""x"", StringComparison.OrdinalIgnoreCase)", noIdentity, FilterMatch.NoMatch);
+    }
+
+    [Fact]
+    public void User_NullComparison_IsPresenceCheck_InBothBackends()
+    {
+        ResolvedEvent derived = new("TestLog", LogPathType.Channel) { Id = 1, UserDisplayName = @"CONTOSO\alice" };
+        ResolvedEvent noIdentity = new("TestLog", LogPathType.Channel) { Id = 2 };
+
+        AssertBothBackends("User != null", derived, FilterMatch.Match);
+        AssertBothBackends("User == null", derived, FilterMatch.NoMatch);
+        AssertBothBackends("User != null", noIdentity, FilterMatch.NoMatch);
+        AssertBothBackends("User == null", noIdentity, FilterMatch.Match);
+    }
+
+    [Fact]
+    public void User_UnsupportedNegatedForms_AreRejectedNotSilentlyRewritten()
+    {
+        // A relational operator isn't supported on User; `!(User < x)` must NOT be silently rewritten to `User == x`.
+        Assert.False(FilterParser.TryCompile(@"!(User < ""x"")", out _, out _));
+        // Negating a GROUP that contains a User condition is rejected (distributing the negation would flip the gate).
+        Assert.False(FilterParser.TryCompile(@"!(User == ""a"" || User == ""b"")", out _, out _));
+        Assert.False(FilterParser.TryCompile(@"!(User == ""a"" && Level == ""Error"")", out _, out _));
+
+        // The gated alternative (negated any-of) compiles and stays presence-gated.
+        ResolvedEvent noIdentity = new("TestLog", LogPathType.Channel) { Id = 1 };
+        AssertBothBackends(@"!(new[] {""a"", ""b""}).Contains(User)", noIdentity, FilterMatch.NoMatch);
     }
 
     private static void AssertBothBackends(string expression, ResolvedEvent resolvedEvent, FilterMatch expected)

--- a/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventPropertyValuesCacheTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/EventData/EventPropertyValuesCacheTests.cs
@@ -132,13 +132,32 @@ public sealed class EventPropertyValuesCacheTests : IDisposable
         Assert.Empty(items);
     }
 
+    [Fact]
+    public void GetValues_UserDisplayNameField_ExcludesNoIdentityRowsFromThePicker()
+    {
+        // No-identity rows carry an empty UserDisplayName; the merged "User" filter is presence-gated, so an
+        // empty selectable value could never match a row — the picker must not offer it.
+        var events = new List<ResolvedEvent>
+        {
+            CreateTestEvent(100, userDisplayName: @"NT AUTHORITY\SYSTEM"),
+            CreateTestEvent(200, userDisplayName: "S-1-5-21-1-2-3-4"),
+            CreateTestEvent(300, userDisplayName: "")
+        };
+
+        var users = EventPropertyValuesCache.GetValues(new object(), events, EventProperty.UserDisplayName);
+
+        Assert.Equal([@"NT AUTHORITY\SYSTEM", "S-1-5-21-1-2-3-4"], users);
+        Assert.DoesNotContain(string.Empty, users);
+    }
+
     private static ResolvedEvent CreateTestEvent(
         int id = 1,
         string source = "TestSource",
         string logName = "Application",
         string owningLog = Constants.LogNameTestLog,
         string opcode = "",
-        Guid? relatedActivityId = null) =>
+        Guid? relatedActivityId = null,
+        string userDisplayName = "") =>
         new(owningLog, LogPathType.Channel)
         {
             Id = id,
@@ -151,6 +170,7 @@ public sealed class EventPropertyValuesCacheTests : IDisposable
             RelatedActivityId = relatedActivityId,
             LogName = logName,
             TimeCreated = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc),
+            UserDisplayName = userDisplayName,
             Keywords = []
         };
 }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Common/Clipboard/EventCopyFormatterTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Common/Clipboard/EventCopyFormatterTests.cs
@@ -10,6 +10,7 @@ using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.Runtime.LogTable;
 using NSubstitute;
 using System.Collections.Immutable;
+using System.Security.Principal;
 
 namespace EventLogExpert.Runtime.Tests.Common.Clipboard;
 
@@ -99,6 +100,67 @@ public sealed class EventCopyFormatterTests
 
         Assert.Contains("FocusProvider", result);
         Assert.Contains("FocusedDescription", result);
+    }
+
+    [Fact]
+    public async Task FormatAsync_FullFormat_IncludesUserSidWhenItDiffersFromResolvedName()
+    {
+        var locator = new EventLocator(s_logId, 0, 0);
+        var @event = new ResolvedEvent("Application", LogPathType.Channel)
+        {
+            RecordId = 1,
+            Id = 4000,
+            Level = "Information",
+            Source = "ProviderA",
+            Description = "Alpha",
+            TimeCreated = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            UserDisplayName = @"NT AUTHORITY\SYSTEM",
+            UserId = new SecurityIdentifier("S-1-5-18")
+        };
+
+        var detailResolver = Substitute.For<IEventDetailResolver>();
+        detailResolver.TryResolve(locator, out Arg.Any<ResolvedEvent?>())
+            .Returns(call => { call[1] = @event; return true; });
+
+        var formatter = new EventCopyFormatter(detailResolver, Substitute.For<IEventXmlResolver>());
+
+        string result = await formatter.FormatAsync(
+            Request([Entry(locator)], focus: null, EventCopyFormat.Full),
+            TestContext.Current.CancellationToken);
+
+        Assert.Contains(@"User: NT AUTHORITY\SYSTEM", result);
+        Assert.Contains("User SID: S-1-5-18", result);
+    }
+
+    [Fact]
+    public async Task FormatAsync_FullFormat_OmitsUserSidWhenResolvedNameIsTheRawSid()
+    {
+        // Raw-SID fallback: the resolved name already IS the SID, so a separate "User SID" line would just duplicate it.
+        var locator = new EventLocator(s_logId, 0, 0);
+        var @event = new ResolvedEvent("Application", LogPathType.Channel)
+        {
+            RecordId = 1,
+            Id = 4000,
+            Level = "Information",
+            Source = "ProviderA",
+            Description = "Alpha",
+            TimeCreated = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            UserDisplayName = "S-1-5-21-1-2-3-4",
+            UserId = new SecurityIdentifier("S-1-5-21-1-2-3-4")
+        };
+
+        var detailResolver = Substitute.For<IEventDetailResolver>();
+        detailResolver.TryResolve(locator, out Arg.Any<ResolvedEvent?>())
+            .Returns(call => { call[1] = @event; return true; });
+
+        var formatter = new EventCopyFormatter(detailResolver, Substitute.For<IEventXmlResolver>());
+
+        string result = await formatter.FormatAsync(
+            Request([Entry(locator)], focus: null, EventCopyFormat.Full),
+            TestContext.Current.CancellationToken);
+
+        Assert.Contains("User: S-1-5-21-1-2-3-4", result);
+        Assert.DoesNotContain("User SID:", result);
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Common/Display/FilterPropertyDisplayOrderTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Common/Display/FilterPropertyDisplayOrderTests.cs
@@ -42,6 +42,7 @@ public sealed class FilterPropertyDisplayOrderTests
                 "Source",
                 "Task Category",
                 "Thread ID",
+                "User",
                 "User Data",
                 "User ID",
                 "Xml"

--- a/tests/Unit/EventLogExpert.Runtime.Tests/DetailsPane/DetailsReaderFormatterTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/DetailsPane/DetailsReaderFormatterTests.cs
@@ -114,6 +114,19 @@ public sealed class DetailsReaderFormatterTests
     }
 
     [Fact]
+    public void BuildModel_DerivedIdentity_RendersUserDisplayNameOnly()
+    {
+        // Security-audit event: no System <Security UserID>, name derived from EventData. The Subject/Target SID is
+        // shown in the EventData section, so no "User SID" row is hoisted here.
+        ResolvedEvent @event = new ResolvedEvent("TestLog", LogPathType.Channel) with { UserDisplayName = @"CONTOSO\alice" };
+
+        DetailsProperty user = Assert.Single(Model(@event).SystemProperties, property => property.Label == "User");
+
+        Assert.Equal(@"CONTOSO\alice", user.Value);
+        Assert.DoesNotContain(Model(@event).SystemProperties, property => property.Label == "User SID");
+    }
+
+    [Fact]
     public void BuildModel_EmptyStringValue_IsMutedButCopiesRealValue()
     {
         DetailsField field = Assert.Single(Model(EventDataTestFactory.CreateEventWithData(("SubjectUserName", ""))).EventData);
@@ -271,6 +284,20 @@ public sealed class DetailsReaderFormatterTests
     }
 
     [Fact]
+    public void BuildModel_UnresolvedUser_RendersSidOnceWithoutDuplicateSidRow()
+    {
+        // A populated but non-well-known SID that resolves to nothing: UserDisplayName == the SID, so the "User SID"
+        // row is suppressed to avoid showing the SID twice.
+        ResolvedEvent @event = new ResolvedEvent("TestLog", LogPathType.Channel)
+            with { UserId = new SecurityIdentifier("S-1-5-21-1-2-3-1105"), UserDisplayName = "S-1-5-21-1-2-3-1105" };
+
+        DetailsProperty user = Assert.Single(Model(@event).SystemProperties, property => property.Label == "User");
+
+        Assert.Equal("S-1-5-21-1-2-3-1105", user.Value);
+        Assert.DoesNotContain(Model(@event).SystemProperties, property => property.Label == "User SID");
+    }
+
+    [Fact]
     public void BuildModel_UserData_RendersPathAndFlagsIncompleteExtraction()
     {
         ResolvedEvent @event = new ResolvedEvent("TestLog", LogPathType.Channel) with
@@ -288,13 +315,16 @@ public sealed class DetailsReaderFormatterTests
     }
 
     [Fact]
-    public void BuildModel_UserId_RendersRawSid()
+    public void BuildModel_WellKnownUser_RendersBothNameAndSid()
     {
-        ResolvedEvent @event = new ResolvedEvent("TestLog", LogPathType.Channel) with { UserId = new SecurityIdentifier("S-1-5-18") };
+        ResolvedEvent @event = new ResolvedEvent("TestLog", LogPathType.Channel)
+            with { UserId = new SecurityIdentifier("S-1-5-18"), UserDisplayName = @"NT AUTHORITY\SYSTEM" };
 
         DetailsProperty user = Assert.Single(Model(@event).SystemProperties, property => property.Label == "User");
+        DetailsProperty userSid = Assert.Single(Model(@event).SystemProperties, property => property.Label == "User SID");
 
-        Assert.Equal("S-1-5-18", user.Value);
+        Assert.Equal(@"NT AUTHORITY\SYSTEM", user.Value);
+        Assert.Equal("S-1-5-18", userSid.Value);
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/EventTableColumnFormatterTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/EventTableColumnFormatterTests.cs
@@ -22,7 +22,8 @@ public sealed class EventTableColumnFormatterTests
         ProcessId = 1234,
         ThreadId = 56,
         Keywords = ["Audit Success"],
-        UserId = new SecurityIdentifier("S-1-5-18")
+        UserId = new SecurityIdentifier("S-1-5-18"),
+        UserDisplayName = @"NT AUTHORITY\SYSTEM"
     };
     private static readonly TimeZoneInfo s_plusTwo =
         TimeZoneInfo.CreateCustomTimeZone("UnitTest+2", TimeSpan.FromHours(2), "UnitTest+2", "UnitTest+2");
@@ -74,9 +75,9 @@ public sealed class EventTableColumnFormatterTests
     }
 
     [Fact]
-    public void GetCellText_User_ReturnsSidValue()
+    public void GetCellText_User_ReturnsUserDisplayName()
     {
-        Assert.Equal("S-1-5-18", EventTableColumnFormatter.GetCellText(s_event, ColumnName.User, s_plusTwo));
+        Assert.Equal(@"NT AUTHORITY\SYSTEM", EventTableColumnFormatter.GetCellText(s_event, ColumnName.User, s_plusTwo));
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/TestSupport/AosReferenceGroupKey.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/TestSupport/AosReferenceGroupKey.cs
@@ -30,7 +30,7 @@ internal static class AosReferenceGroupKey
             ColumnName.Keywords => @event.KeywordsDisplayName ?? string.Empty,
             ColumnName.ProcessId => @event.ProcessId?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
             ColumnName.ThreadId => @event.ThreadId?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
-            ColumnName.User => @event.UserId?.Value ?? string.Empty,
+            ColumnName.User => @event.UserDisplayName,
             _ => string.Empty
         };
 }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/TestSupport/AosReferenceOrdering.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/TestSupport/AosReferenceOrdering.cs
@@ -32,7 +32,7 @@ internal static class AosReferenceOrdering
     private static readonly Comparison<ResolvedEvent> s_ascByThreadId =
         (a, b) => WithTieBreaker(Nullable.Compare(a.ThreadId, b.ThreadId), a, b);
     private static readonly Comparison<ResolvedEvent> s_ascByUser =
-        (a, b) => WithTieBreaker(CompareText(a.UserId?.Value, b.UserId?.Value), a, b);
+        (a, b) => WithTieBreaker(CompareText(a.UserDisplayName, b.UserDisplayName), a, b);
     private static readonly Comparison<ResolvedEvent> s_ascByRecordId =
         (a, b) => WithTieBreaker(Nullable.Compare(a.RecordId, b.RecordId), a, b);
     private static readonly Comparison<ResolvedEvent> s_ascByDefault =
@@ -128,7 +128,7 @@ internal static class AosReferenceOrdering
             ColumnName.Keywords => CompareText(a.KeywordsDisplayName, b.KeywordsDisplayName),
             ColumnName.ProcessId => Nullable.Compare(a.ProcessId, b.ProcessId),
             ColumnName.ThreadId => Nullable.Compare(a.ThreadId, b.ThreadId),
-            ColumnName.User => CompareText(a.UserId?.Value, b.UserId?.Value),
+            ColumnName.User => CompareText(a.UserDisplayName, b.UserDisplayName),
             _ => 0
         };
 

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterEditor/FilterPredicateEditorAccessibilityTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterEditor/FilterPredicateEditorAccessibilityTests.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using Bunit;
+using EventLogExpert.Filtering.Common.Filtering;
 using EventLogExpert.Filtering.Drafts;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.UI.Common;
@@ -52,5 +53,36 @@ public sealed class FilterPredicateEditorAccessibilityTests : BunitContext
         {
             Assert.DoesNotContain(' ', element.GetAttribute("id")!);
         }
+    }
+
+    [Fact]
+    public void PropertyPicker_LegacyUserIdComparison_KeepsUserIdSelectable()
+    {
+        // A saved filter whose property is the retired "User ID" must keep the option so its bound <select> is not
+        // silently rebound to another property.
+        var predicate = new FilterPredicateDraft { Comparison = { Property = EventProperty.UserId } };
+
+        var component = Render<FilterPredicateEditor>(parameters => parameters
+            .Add(editor => editor.Value, predicate)
+            .Add(editor => editor.IsEditing, true));
+
+        var options = component.FindAll("[role=option]").Select(option => option.TextContent.Trim()).ToList();
+
+        Assert.Contains("User ID", options);
+    }
+
+    [Fact]
+    public void PropertyPicker_NewComparison_OffersUser_AndHidesUserId()
+    {
+        var predicate = new FilterPredicateDraft();
+
+        var component = Render<FilterPredicateEditor>(parameters => parameters
+            .Add(editor => editor.Value, predicate)
+            .Add(editor => editor.IsEditing, true));
+
+        var options = component.FindAll("[role=option]").Select(option => option.TextContent.Trim()).ToList();
+
+        Assert.Contains("User", options);
+        Assert.DoesNotContain("User ID", options);
     }
 }

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/CellFilterBuilderTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/CellFilterBuilderTests.cs
@@ -24,7 +24,7 @@ public sealed class CellFilterBuilderTests
     [InlineData(ColumnName.TaskCategory, EventProperty.TaskCategory)]
     [InlineData(ColumnName.ProcessId, EventProperty.ProcessId)]
     [InlineData(ColumnName.ThreadId, EventProperty.ThreadId)]
-    [InlineData(ColumnName.User, EventProperty.UserId)]
+    [InlineData(ColumnName.User, EventProperty.UserDisplayName)]
     public void MapColumn_SupportedColumn_ReturnsProperty(ColumnName column, EventProperty expected) =>
         Assert.Equal(expected, CellFilterBuilder.MapColumn(column));
 
@@ -65,7 +65,7 @@ public sealed class CellFilterBuilderTests
     [InlineData(EventProperty.TaskCategory)]
     [InlineData(EventProperty.ProcessId)]
     [InlineData(EventProperty.ThreadId)]
-    [InlineData(EventProperty.UserId)]
+    [InlineData(EventProperty.UserDisplayName)]
     public void TryBuild_IncludeFilter_MatchesSourceEvent(EventProperty property)
     {
         var sourceEvent = FullEvent();
@@ -130,19 +130,19 @@ public sealed class CellFilterBuilderTests
     }
 
     [Fact]
-    public void TryBuild_UserId_MatchesSameSidButNotDifferentSid()
+    public void TryBuild_UserDisplayName_MatchesSameNameButNotDifferentName()
     {
         var sourceEvent = FullEvent();
-        var otherEvent = FullEvent() with { UserId = new SecurityIdentifier("S-1-5-18") };
+        var otherEvent = FullEvent() with { UserDisplayName = @"CONTOSO\bob" };
 
-        Assert.True(CellFilterBuilder.TryBuild(sourceEvent, EventProperty.UserId, exclude: false, out var filter));
+        Assert.True(CellFilterBuilder.TryBuild(sourceEvent, EventProperty.UserDisplayName, exclude: false, out var filter));
         Assert.True(filter.Compiled!.Predicate(sourceEvent));
         Assert.False(filter.Compiled!.Predicate(otherEvent));
     }
 
     [Theory]
     [InlineData(EventProperty.ActivityId)]
-    [InlineData(EventProperty.UserId)]
+    [InlineData(EventProperty.UserDisplayName)]
     [InlineData(EventProperty.ProcessId)]
     [InlineData(EventProperty.ThreadId)]
     [InlineData(EventProperty.Level)]
@@ -164,7 +164,7 @@ public sealed class CellFilterBuilderTests
     [Theory]
     [InlineData(EventProperty.ProcessId)]
     [InlineData(EventProperty.ThreadId)]
-    [InlineData(EventProperty.UserId)]
+    [InlineData(EventProperty.UserDisplayName)]
     public void TryGetDisplayValue_PreviouslyUnmappedProperties_ReturnNonEmptyValue(EventProperty property)
     {
         Assert.True(CellFilterBuilder.TryGetDisplayValue(FullEvent(), property, out var value));
@@ -175,7 +175,7 @@ public sealed class CellFilterBuilderTests
         property switch
         {
             EventProperty.ActivityId => FullEvent() with { ActivityId = null },
-            EventProperty.UserId => FullEvent() with { UserId = null },
+            EventProperty.UserDisplayName => FullEvent() with { UserDisplayName = string.Empty },
             EventProperty.ProcessId => FullEvent() with { ProcessId = null },
             EventProperty.ThreadId => FullEvent() with { ThreadId = null },
             EventProperty.Level => FullEvent() with { Level = string.Empty },
@@ -195,6 +195,7 @@ public sealed class CellFilterBuilderTests
             ProcessId = 111,
             ThreadId = 222,
             UserId = s_userSid,
+            UserDisplayName = @"CONTOSO\alice",
             ComputerName = "TEST-PC",
             Description = "test description"
         };

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneSelectionTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneSelectionTests.cs
@@ -104,6 +104,7 @@ public sealed class LogTablePaneSelectionTests : BunitContext
             ProcessId = 111,
             ThreadId = 222,
             UserId = userId,
+            UserDisplayName = @"NT AUTHORITY\SYSTEM",
             Description = "test description"
         };
 
@@ -122,7 +123,7 @@ public sealed class LogTablePaneSelectionTests : BunitContext
         Assert.Equal("AuditKeyword", Cell(row, 9).TextContent.Trim());
         Assert.Equal("111", Cell(row, 10).TextContent.Trim());
         Assert.Equal("222", Cell(row, 11).TextContent.Trim());
-        Assert.Equal(userId.ToString(), Cell(row, 12).TextContent.Trim());
+        Assert.Equal(@"NT AUTHORITY\SYSTEM", Cell(row, 12).TextContent.Trim());
         Assert.Equal("test description", Cell(row, 13).TextContent.Trim());
     }
 


### PR DESCRIPTION
## Summary
Resolves the event **User** column from a raw SID to a friendly account identity, computed
**offline** (no `LookupAccountSid`). When no resolved name is available it falls back to the raw
SID (today's behavior), so nothing regresses.

## What changed
- **Offline identity resolution** (`UserDisplayNameResolver`, `WellKnownSids`, both `internal` to the
  Eventing assembly): maps well-known SIDs (SYSTEM, LOCAL/NETWORK SERVICE, Everyone, BUILTIN\*, ...) and,
  for Security-audit events whose `<Security UserID>` is empty, derives the best-available identity from
  the account names the event already carries in `<EventData>` -- the Subject when it names a real
  principal, else the Target. Computed once at resolve time and stored on `ResolvedEvent.UserDisplayName`.
- **Details pane** shows both **User** (resolved name) and **User SID** (raw SID, only when it differs);
  the event clipboard copy mirrors the same name+SID pair.
- **Unified "User" filter**: a single predicate matching either the SID **or** the resolved name,
  presence-gated and mirrored across both filter backends (row + column emitters) with allocation-free
  SID access. Advanced `User == null` / `User != null` test identity absence/presence.
- Column sort/group, right-click cell-filter (Include/Exclude), and the filter-picker surfaces updated;
  docs updated (`Filtering.md`, `Viewing-Events.md`).

## Testing
- Release build clean; all `tests/Unit` projects pass (7155 tests), including new coverage for the
  resolver matrix, both filter backends' match-both / negation / null-compare parity, the value-picker,
  and the clipboard name+SID formatting. Integration suites run in CI (`EVENTLOG_CONTAINER`).

## Notes
- Unresolved rows reuse the SID pool slot, so they cost no extra memory.
