### PR TITLE
Harden ordered-view bulk index builds: memory budget, cancellable sort, bounded tail replay

### DIFF
--- a/src/EventLogExpert.Runtime/Concurrency/CooperativeCancellation.cs
+++ b/src/EventLogExpert.Runtime/Concurrency/CooperativeCancellation.cs
@@ -1,0 +1,10 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Concurrency;
+
+internal static class CooperativeCancellation
+{
+    internal const int CancellationCheckMask = CancellationCheckStride - 1;
+    internal const int CancellationCheckStride = 8192;
+}

--- a/src/EventLogExpert.Runtime/LogTable/ColumnDirectSort.cs
+++ b/src/EventLogExpert.Runtime/LogTable/ColumnDirectSort.cs
@@ -2,11 +2,35 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Eventing.Common.Events;
+using static EventLogExpert.Runtime.Concurrency.CooperativeCancellation;
 
 namespace EventLogExpert.Runtime.LogTable;
 
 internal static class ColumnDirectSort
 {
+    private const int IntrosortSizeThreshold = 16;
+
+    internal static void CancellableSort(int[] keys, Comparison<int> comparison, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(keys);
+        ArgumentNullException.ThrowIfNull(comparison);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (keys.Length < 2) { return; }
+
+        IntroSort(keys, 0, keys.Length - 1, 2 * FloorLog2(keys.Length), comparison, cancellationToken);
+    }
+
+    internal static void HeapSortForTest(int[] keys, Comparison<int> comparison, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(keys);
+        ArgumentNullException.ThrowIfNull(comparison);
+
+        if (keys.Length < 2) { return; }
+
+        HeapSort(keys, 0, keys.Length - 1, comparison, cancellationToken);
+    }
+
     internal static int[] SortColumnDirect(
         IEventColumnReader reader,
         ReadOnlySpan<int> survivors,
@@ -24,11 +48,165 @@ internal static class ColumnDirectSort
 
         var keys = ColumnDirectKeys.Materialize(reader, orderBy, groupBy, cancellationToken);
         Comparison<int> comparison = keys.BuildComparison(orderBy, isDescending, groupBy, isGroupDescending);
-        cancellationToken.ThrowIfCancellationRequested();
-        Array.Sort(result, comparison);
-        cancellationToken.ThrowIfCancellationRequested();
+        CancellableSort(result, comparison, cancellationToken);
 
         return result;
+    }
+
+    private static void DownHeap(int[] keys, int position, int count, int low, Comparison<int> comparison)
+    {
+        int value = keys[low + position - 1];
+
+        while (position <= count / 2)
+        {
+            int child = 2 * position;
+
+            if (child < count && comparison(keys[low + child - 1], keys[low + child]) < 0) { child++; }
+
+            if (comparison(value, keys[low + child - 1]) >= 0) { break; }
+
+            keys[low + position - 1] = keys[low + child - 1];
+            position = child;
+        }
+
+        keys[low + position - 1] = value;
+    }
+
+    private static int FloorLog2(int value)
+    {
+        int result = 0;
+
+        while (value >= 2)
+        {
+            value >>= 1;
+            result++;
+        }
+
+        return result;
+    }
+
+    private static void HeapSort(int[] keys, int low, int high, Comparison<int> comparison, CancellationToken cancellationToken)
+    {
+        int count = high - low + 1;
+        int sinceCheck = 0;
+
+        for (int parent = count / 2; parent >= 1; parent--)
+        {
+            if ((sinceCheck++ & CancellationCheckMask) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
+
+            DownHeap(keys, parent, count, low, comparison);
+        }
+
+        for (int remaining = count; remaining > 1; remaining--)
+        {
+            if ((sinceCheck++ & CancellationCheckMask) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
+
+            Swap(keys, low, low + remaining - 1);
+            DownHeap(keys, 1, remaining - 1, low, comparison);
+        }
+    }
+
+    private static void InsertionSort(int[] keys, int low, int high, Comparison<int> comparison, CancellationToken cancellationToken)
+    {
+        for (int index = low; index < high; index++)
+        {
+            if ((index & CancellationCheckMask) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
+
+            int current = keys[index + 1];
+            int position = index;
+
+            while (position >= low && comparison(current, keys[position]) < 0)
+            {
+                keys[position + 1] = keys[position];
+                position--;
+            }
+
+            keys[position + 1] = current;
+        }
+    }
+
+    private static void IntroSort(
+        int[] keys, int low, int high, int depthLimit, Comparison<int> comparison, CancellationToken cancellationToken)
+    {
+        while (high > low)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            int partitionSize = high - low + 1;
+
+            if (partitionSize <= IntrosortSizeThreshold)
+            {
+                InsertionSort(keys, low, high, comparison, cancellationToken);
+
+                return;
+            }
+
+            if (depthLimit == 0)
+            {
+                HeapSort(keys, low, high, comparison, cancellationToken);
+
+                return;
+            }
+
+            depthLimit--;
+            int pivotPosition = PickPivotAndPartition(keys, low, high, comparison, cancellationToken);
+            IntroSort(keys, pivotPosition + 1, high, depthLimit, comparison, cancellationToken);
+            high = pivotPosition - 1;
+        }
+    }
+
+    private static int PickPivotAndPartition(
+        int[] keys, int low, int high, Comparison<int> comparison, CancellationToken cancellationToken)
+    {
+        int middle = low + ((high - low) >> 1);
+
+        SwapIfGreater(keys, comparison, low, middle);
+        SwapIfGreater(keys, comparison, low, high);
+        SwapIfGreater(keys, comparison, middle, high);
+
+        int pivot = keys[middle];
+        Swap(keys, middle, high - 1);
+        int left = low;
+        int right = high - 1;
+        int sinceCheck = 0;
+
+        while (left < right)
+        {
+            if ((sinceCheck++ & CancellationCheckMask) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
+
+            while (comparison(keys[++left], pivot) < 0)
+            {
+                if ((sinceCheck++ & CancellationCheckMask) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
+            }
+
+            while (comparison(pivot, keys[--right]) < 0)
+            {
+                if ((sinceCheck++ & CancellationCheckMask) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
+            }
+
+            if (left >= right) { break; }
+
+            Swap(keys, left, right);
+        }
+
+        Swap(keys, left, high - 1);
+
+        return left;
+    }
+
+    private static void Swap(int[] keys, int first, int second)
+    {
+        if (first == second) { return; }
+
+        (keys[first], keys[second]) = (keys[second], keys[first]);
+    }
+
+    private static void SwapIfGreater(int[] keys, Comparison<int> comparison, int first, int second)
+    {
+        if (first != second && comparison(keys[first], keys[second]) > 0)
+        {
+            (keys[first], keys[second]) = (keys[second], keys[first]);
+        }
     }
 
     private sealed class ColumnDirectKeys
@@ -114,7 +292,7 @@ internal static class ColumnDirectSort
 
             foreach (int poolIndex in rawPoolIndices)
             {
-                if ((scanned++ & 8191) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
+                if ((scanned++ & CancellationCheckMask) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
 
                 if (poolIndex >= 0 && !seen[poolIndex])
                 {
@@ -133,21 +311,19 @@ internal static class ColumnDirectSort
 
             for (int index = 0; index < length; index++)
             {
-                if ((index & 8191) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
+                if ((index & CancellationCheckMask) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
 
                 order[index] = index;
             }
 
-            cancellationToken.ThrowIfCancellationRequested();
-            Array.Sort(order, (x, y) => string.Compare(values[x], values[y], StringComparison.Ordinal));
-            cancellationToken.ThrowIfCancellationRequested();
+            CancellableSort(order, (x, y) => string.Compare(values[x], values[y], StringComparison.Ordinal), cancellationToken);
 
             int rank = 0;
             rankByPosition[order[0]] = 0;
 
             for (int position = 1; position < length; position++)
             {
-                if ((position & 8191) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
+                if ((position & CancellationCheckMask) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
 
                 if (!string.Equals(values[order[position]], values[order[position - 1]], StringComparison.Ordinal))
                 {
@@ -276,7 +452,7 @@ internal static class ColumnDirectSort
 
             for (int index = 0; index < Count; index++)
             {
-                if ((index & 8191) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
+                if ((index & CancellationCheckMask) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
 
                 values[index] = reader.GetField(reader.LocatorAt(index), EventFieldId.KeywordsDisplay).AsString();
             }
@@ -321,7 +497,7 @@ internal static class ColumnDirectSort
         {
             for (int index = 0; index < poolIndices.Length; index++)
             {
-                if ((index & 8191) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
+                if ((index & CancellationCheckMask) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
 
                 int poolIndex = poolIndices[index];
                 rankByRow[index] = poolIndex < 0 ? _nullRank : _rankByPoolIndex[poolIndex];
@@ -350,7 +526,7 @@ internal static class ColumnDirectSort
 
                 for (int index = 0; index < used.Count; index++)
                 {
-                    if ((index & 8191) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
+                    if ((index & CancellationCheckMask) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
 
                     usedStrings[index] = pool[used[index]] ?? string.Empty;
                 }
@@ -360,7 +536,7 @@ internal static class ColumnDirectSort
 
                 for (int index = 0; index < used.Count; index++)
                 {
-                    if ((index & 8191) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
+                    if ((index & CancellationCheckMask) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
 
                     _rankByPoolIndex[used[index]] = rankByPosition[index];
                 }

--- a/src/EventLogExpert.Runtime/LogTable/OrderedView/ChunkedOrderIndex.cs
+++ b/src/EventLogExpert.Runtime/LogTable/OrderedView/ChunkedOrderIndex.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Eventing.Common.Events;
+using static EventLogExpert.Runtime.Concurrency.CooperativeCancellation;
 
 namespace EventLogExpert.Runtime.LogTable.OrderedView;
 
@@ -118,7 +119,7 @@ internal sealed class ChunkedOrderIndex
 
         for (int position = 0; position < sortedOrder.Length; position++)
         {
-            if ((position & 8191) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
+            if ((position & CancellationCheckMask) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
 
             var generationKey = new LogGeneration(sortedOrder[position].Locator.LogId, sortedOrder[position].Locator.Generation);
             int index = sortedOrder[position].Locator.Index;
@@ -134,7 +135,7 @@ internal sealed class ChunkedOrderIndex
 
         for (int position = 0; position < sortedOrder.Length; position++)
         {
-            if ((position & 8191) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
+            if ((position & CancellationCheckMask) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
 
             EventLocator locator = sortedOrder[position].Locator;
             var generationKey = new LogGeneration(locator.LogId, locator.Generation);

--- a/src/EventLogExpert.Runtime/LogTable/OrderedView/OrderedViewState.cs
+++ b/src/EventLogExpert.Runtime/LogTable/OrderedView/OrderedViewState.cs
@@ -21,6 +21,13 @@ internal sealed record RebuildRequest(
     long ScopeVersion,
     EventLogId? SingleLog);
 
+internal enum AdoptOutcome
+{
+    Adopted,
+    DroppedStale,
+    AbandonedTail
+}
+
 internal sealed class OrderedViewState
 {
     internal const int DefaultBulkBuildThreshold = 50_000;
@@ -237,9 +244,16 @@ internal sealed class OrderedViewState
 
     public void SupersedeInFlight() => Interlocked.Increment(ref _generation);
 
-    public bool TryAdoptRebuild(RebuildRequest request, ChunkedOrderIndex rebuilt)
+    public AdoptOutcome TryAdoptRebuild(RebuildRequest request, ChunkedOrderIndex rebuilt, long tailBudget, bool allowAbandon)
     {
-        if (Volatile.Read(ref _generation) != request.Generation) { return false; }
+        if (Volatile.Read(ref _generation) != request.Generation) { return AdoptOutcome.DroppedStale; }
+
+        if (allowAbandon && MeasureTail(request) > tailBudget)
+        {
+            _holdIngest = false;
+
+            return AdoptOutcome.AbandonedTail;
+        }
 
         IReaderResolver commitResolver = FreezeReaders();
         rebuilt.RebindInsertComparer(OrderKeyComparerFactory.Create(request.Context, commitResolver));
@@ -292,8 +306,11 @@ internal sealed class OrderedViewState
         _index.RebindInsertComparer(OrderKeyComparerFactory.Create(_activeContext, _liveResolver));
         PublishWith(FreezeReaders());
 
-        return true;
+        return AdoptOutcome.Adopted;
     }
+
+    public bool TryAdoptRebuild(RebuildRequest request, ChunkedOrderIndex rebuilt) =>
+        TryAdoptRebuild(request, rebuilt, long.MaxValue, allowAbandon: false) == AdoptOutcome.Adopted;
 
     public bool TrySetActiveScope(IReadOnlyCollection<EventLogId> scopeLogs, long scopeVersion)
     {
@@ -606,6 +623,22 @@ internal sealed class OrderedViewState
 
     private FrozenReaderResolver FreezeReaders() =>
         new(new Dictionary<LogGeneration, IEventColumnReader>(_latestReaders));
+
+    private long MeasureTail(RebuildRequest request)
+    {
+        long tail = 0;
+
+        foreach (LogGeneration key in _scopeState.Keys)
+        {
+            if (!request.Scope.Includes(key.LogId)) { continue; }
+
+            if (!IsCurrent(key, _requestedGeneration)) { continue; }
+
+            tail += _scopeState.Coverage(key) - request.Coverage.CoverageOf(key);
+        }
+
+        return tail;
+    }
 
     private void PruneReleasedReaders()
     {

--- a/src/EventLogExpert.Runtime/LogTable/OrderedView/OrderedViewState.cs
+++ b/src/EventLogExpert.Runtime/LogTable/OrderedView/OrderedViewState.cs
@@ -23,6 +23,14 @@ internal sealed record RebuildRequest(
 internal sealed class OrderedViewState
 {
     internal const int DefaultBulkBuildThreshold = 50_000;
+
+    // Conservative weights for the bulk peak-memory estimate; over-estimating only falls back to the delegating path
+    // sooner (safe). OrderKey wraps EventLocator (24 B); an SoA lane is bounded by Guid[16]+bool[1]; a pooled-rank
+    // entry is int[4]+bool[1].
+    private const int BulkOrderKeyBytes = 24;
+    private const int BulkPooledRankBytesPerEntry = 5;
+    private const int BulkSoaLaneBytesPerRow = 17;
+
     private readonly Dictionary<EventLogId, int> _activeGeneration = [];
     private readonly Dictionary<LogGeneration, IEventColumnReader> _latestReaders = [];
     private readonly LiveReaderResolver _liveResolver;
@@ -65,7 +73,7 @@ internal sealed class OrderedViewState
     public static ChunkedOrderIndex BuildIndex(RebuildRequest request) => BuildIndex(request, CancellationToken.None);
 
     public static ChunkedOrderIndex BuildIndex(RebuildRequest request, CancellationToken cancellationToken) =>
-        BuildIndex(request, cancellationToken, DefaultBulkBuildThreshold);
+        BuildIndex(request, cancellationToken, DefaultBulkBuildThreshold, DefaultMemoryBudgetBytes());
 
     public RebuildRequest BeginRebuild(Func<EventLocator, IEventColumnReader, bool> newPredicate, SortContext newContext, bool? hold = null)
     {
@@ -295,9 +303,16 @@ internal sealed class OrderedViewState
         return true;
     }
 
-    internal static ChunkedOrderIndex BuildIndex(RebuildRequest request, CancellationToken cancellationToken, int bulkThreshold)
+    internal static ChunkedOrderIndex BuildIndex(RebuildRequest request, CancellationToken cancellationToken, int bulkThreshold) =>
+        BuildIndex(request, cancellationToken, bulkThreshold, DefaultMemoryBudgetBytes());
+
+    internal static ChunkedOrderIndex BuildIndex(
+        RebuildRequest request,
+        CancellationToken cancellationToken,
+        int bulkThreshold,
+        long memoryBudgetBytes)
     {
-        if (TryBuildBulk(request, cancellationToken, bulkThreshold) is { } bulk) { return bulk; }
+        if (TryBuildBulk(request, cancellationToken, bulkThreshold, memoryBudgetBytes) is { } bulk) { return bulk; }
 
         var rebuilt = new ChunkedOrderIndex(OrderKeyComparerFactory.Create(request.Context, request.BeginResolver));
         int examined = 0;
@@ -322,6 +337,17 @@ internal sealed class OrderedViewState
         }
 
         return rebuilt;
+    }
+
+    // Half the currently-free heap headroom: total available minus the bytes currently allocated (which include the
+    // live old published index and the raw event store), so the estimate is measured against real remaining room.
+    // GC.GetTotalMemory reflects allocations since the last GC, unlike GCMemoryInfo.HeapSizeBytes (a last-GC snapshot).
+    internal static long DefaultMemoryBudgetBytes()
+    {
+        long available = GC.GetGCMemoryInfo().TotalAvailableMemoryBytes;
+        long headroom = available - GC.GetTotalMemory(forceFullCollection: false);
+
+        return headroom > 0 ? headroom / 2 : 0;
     }
 
     private static ChunkedOrderIndex BuildCombinedBulk(
@@ -410,6 +436,44 @@ internal sealed class OrderedViewState
         return keys;
     }
 
+    // Peak estimate. The SoA columns + the whole-pool rank arrays are materialized one log at a time, so their peak is
+    // the largest single log; the two coexisting OrderKey[] sets, the permutation, and the survivor lists all live
+    // across the whole merge. (Keyword order/group never reaches here - TryBuildBulk routes it to the delegating path.)
+    private static long EstimateBulkPeakBytes(
+        RebuildRequest request,
+        List<(LogGeneration Key, int Covered)> keys,
+        long totalCovered)
+    {
+        checked
+        {
+            SortContext context = request.Context;
+
+            int lanes = 2; // RecordId + OwningLog are always materialized.
+
+            if (context.GroupBy is not null || context.OrderBy is null) { lanes++; } // DateAndTime
+
+            if (context.OrderBy is not null) { lanes++; }
+
+            if (context.GroupBy is not null) { lanes++; }
+
+            long soaBytesPerRow = (long)lanes * BulkSoaLaneBytesPerRow;
+            long soaPeak = 0;
+
+            foreach ((LogGeneration key, int covered) in keys)
+            {
+                IEventColumnReader reader = request.BeginResolver.Resolve(new EventLocator(key.LogId, key.Generation, 0));
+                long perLog = (covered * soaBytesPerRow) + ((long)reader.Pool.Count * BulkPooledRankBytesPerEntry);
+
+                if (perLog > soaPeak) { soaPeak = perLog; }
+            }
+
+            long orderKeyPeak = 2L * BulkOrderKeyBytes * totalCovered;
+            long scratch = 2L * sizeof(int) * totalCovered; // the int[] permutation + the survivor int lists
+
+            return soaPeak + orderKeyPeak + scratch;
+        }
+    }
+
     private static OrderKey HeadKey(LogGeneration key, int[] run, int cursor) =>
         new(new EventLocator(key.LogId, key.Generation, run[cursor]));
 
@@ -440,7 +504,11 @@ internal sealed class OrderedViewState
             cancellationToken);
     }
 
-    private static ChunkedOrderIndex? TryBuildBulk(RebuildRequest request, CancellationToken cancellationToken, int bulkThreshold)
+    private static ChunkedOrderIndex? TryBuildBulk(
+        RebuildRequest request,
+        CancellationToken cancellationToken,
+        int bulkThreshold,
+        long memoryBudgetBytes)
     {
         List<(LogGeneration Key, int Covered)> keys = CollectInScopeCurrentKeys(request, cancellationToken);
 
@@ -455,6 +523,15 @@ internal sealed class OrderedViewState
         }
 
         if (totalCovered < bulkThreshold) { return null; }
+
+        // Keyword order/group joins arbitrary-length strings per row, so its bake memory cannot be bounded - always
+        // delegate. Otherwise fall back when the estimated transient peak would exceed the budget.
+        if (request.Context.OrderBy is ColumnName.Keywords || request.Context.GroupBy is ColumnName.Keywords)
+        {
+            return null;
+        }
+
+        if (EstimateBulkPeakBytes(request, keys, totalCovered) > memoryBudgetBytes) { return null; }
 
         IComparer<OrderKey> comparer = OrderKeyComparerFactory.Create(request.Context, request.BeginResolver);
 

--- a/src/EventLogExpert.Runtime/LogTable/OrderedView/OrderedViewState.cs
+++ b/src/EventLogExpert.Runtime/LogTable/OrderedView/OrderedViewState.cs
@@ -5,6 +5,7 @@ using EventLogExpert.Eventing.Common.EventLogs;
 using EventLogExpert.Eventing.Common.Events;
 using System.Collections.Immutable;
 using System.Runtime.InteropServices;
+using static EventLogExpert.Runtime.Concurrency.CooperativeCancellation;
 
 namespace EventLogExpert.Runtime.LogTable.OrderedView;
 
@@ -325,7 +326,7 @@ internal sealed class OrderedViewState
 
             for (int index = 0; index < covered; index++)
             {
-                if ((examined++ & 8191) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
+                if ((examined++ & CancellationCheckMask) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
 
                 var locator = new EventLocator(key.LogId, key.Generation, index);
 
@@ -378,7 +379,7 @@ internal sealed class OrderedViewState
 
         for (int run = 0; run < runs.Count; run++)
         {
-            if ((run & 8191) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
+            if ((run & CancellationCheckMask) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
 
             queue.Enqueue(run, HeadKey(runKeys[run], runs[run], 0));
         }
@@ -387,7 +388,7 @@ internal sealed class OrderedViewState
 
         while (queue.TryDequeue(out int run, out OrderKey head))
         {
-            if ((emitted & 8191) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
+            if ((emitted & CancellationCheckMask) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
 
             merged[emitted++] = head;
             int next = ++cursors[run];
@@ -408,7 +409,7 @@ internal sealed class OrderedViewState
 
         for (int display = 0; display < sortedIndices.Length; display++)
         {
-            if ((display & 8191) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
+            if ((display & CancellationCheckMask) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
 
             sortedOrder[display] = new OrderKey(new EventLocator(key.LogId, key.Generation, sortedIndices[display]));
         }
@@ -424,7 +425,7 @@ internal sealed class OrderedViewState
 
         foreach ((LogGeneration key, int covered) in request.Coverage.Entries)
         {
-            if ((scanned++ & 8191) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
+            if ((scanned++ & CancellationCheckMask) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
 
             if (!request.Scope.Includes(key.LogId)) { continue; }
 
@@ -487,7 +488,7 @@ internal sealed class OrderedViewState
 
         for (int index = 0; index < covered; index++)
         {
-            if ((index & 8191) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
+            if ((index & CancellationCheckMask) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
 
             var locator = new EventLocator(key.LogId, key.Generation, index);
 
@@ -517,7 +518,7 @@ internal sealed class OrderedViewState
 
         foreach ((LogGeneration _, int covered) in keys)
         {
-            if ((summed++ & 8191) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
+            if ((summed++ & CancellationCheckMask) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
 
             totalCovered += covered;
         }

--- a/src/EventLogExpert.Runtime/LogTable/OrderedView/OrderedViewWriter.cs
+++ b/src/EventLogExpert.Runtime/LogTable/OrderedView/OrderedViewWriter.cs
@@ -11,6 +11,9 @@ namespace EventLogExpert.Runtime.LogTable.OrderedView;
 
 internal sealed class OrderedViewWriter : IAsyncDisposable
 {
+    private const int DefaultTailBreachLimit = 3;
+    private const int DefaultTailReplayBudget = 50_000;
+
     private readonly Task? _cadence;
     private readonly Channel<Command> _commandChannel;
     private readonly Task _owner;
@@ -18,6 +21,8 @@ internal sealed class OrderedViewWriter : IAsyncDisposable
     private readonly int _publishEvery;
     private readonly CancellationTokenSource _shutdown = new();
     private readonly OrderedViewState _state = new();
+    private readonly int _tailBreachLimit;
+    private readonly long _tailReplayBudget;
 
     private SortContext _adoptedConfig;
     private Filter _adoptedFilter;
@@ -54,10 +59,17 @@ internal sealed class OrderedViewWriter : IAsyncDisposable
 
     private ImmutableHashSet<LogGeneration>? _singleLogInScope;
     private LogGeneration? _singleLogInScopeKey;
+    private int _tailBreaches;
 
-    public OrderedViewWriter(int publishEvery = 256, int publishIntervalMs = 16)
+    public OrderedViewWriter(
+        int publishEvery = 256,
+        int publishIntervalMs = 16,
+        long tailReplayBudget = DefaultTailReplayBudget,
+        int tailBreachLimit = DefaultTailBreachLimit)
     {
         _publishEvery = Math.Max(1, publishEvery);
+        _tailReplayBudget = Math.Max(0, tailReplayBudget);
+        _tailBreachLimit = Math.Max(1, tailBreachLimit);
         _commandChannel = Channel.CreateUnbounded<Command>(new UnboundedChannelOptions { SingleReader = true });
         _owner = Task.Run(RunAsync);
 
@@ -315,37 +327,52 @@ internal sealed class OrderedViewWriter : IAsyncDisposable
                 _rebuildRequired = false;
                 _faultAnnounced = false;
                 _seededRowsAwaitingBuild = false;
+                _tailBreaches = 0;
 
                 break;
             case CommandKind.Adopt:
                 try
                 {
-                    if (command.Request is { } request && command.Rebuilt is { } rebuilt && _state.TryAdoptRebuild(request, rebuilt))
+                    AdoptOutcome outcome = AdoptOutcome.DroppedStale;
+
+                    if (command is { Request: { } request, Rebuilt: { } rebuilt })
                     {
-                        _dirty = false;
-                        _sincePublish = 0;
+                        outcome = _state.TryAdoptRebuild(request, rebuilt, _tailReplayBudget, _tailBreaches < _tailBreachLimit);
 
-                        _adoptedLog = request.SingleLog;
-                        _adoptedScopeLogCount = request.Scope.LogCount;
-
-                        _adoptedGeneration = _adoptedLog is { } adoptedLog ?
-                            request.RequestedGeneration.GetValueOrDefault(adoptedLog) : 0;
-
-                        _adoptedConfig = request.Context;
-                        _adoptedFilter = _pendingFilter;
-
-                        if (_pending is { } adopting && adopting.EngineGeneration == request.Generation)
+                        if (outcome == AdoptOutcome.Adopted)
                         {
-                            _adoptedIdentity = adopting.Identity;
-                            _adoptedSequence = adopting.Sequence;
-                            _pending = null;
-                        }
+                            _tailBreaches = 0;
+                            _dirty = false;
+                            _sincePublish = 0;
 
-                        _rebuildRequired = false;
-                        _faultAnnounced = false;
-                        _seededRowsAwaitingBuild = false;
+                            _adoptedLog = request.SingleLog;
+                            _adoptedScopeLogCount = request.Scope.LogCount;
+
+                            _adoptedGeneration = _adoptedLog is { } adoptedLog ?
+                                request.RequestedGeneration.GetValueOrDefault(adoptedLog) : 0;
+
+                            _adoptedConfig = request.Context;
+                            _adoptedFilter = _pendingFilter;
+
+                            if (_pending is { } adopting && adopting.EngineGeneration == request.Generation)
+                            {
+                                _adoptedIdentity = adopting.Identity;
+                                _adoptedSequence = adopting.Sequence;
+                                _pending = null;
+                            }
+
+                            _rebuildRequired = false;
+                            _faultAnnounced = false;
+                            _seededRowsAwaitingBuild = false;
+                        }
                     }
-                    else if (_seededRowsAwaitingBuild)
+
+                    if (outcome == AdoptOutcome.AbandonedTail)
+                    {
+                        _tailBreaches++;
+                        RebindAndStart(_state.CaptureScopeReseed());
+                    }
+                    else if (outcome != AdoptOutcome.Adopted && _seededRowsAwaitingBuild)
                     {
                         // rows a retag seeded onto it, exactly as a throwing one would.
                         RequireRebuild();
@@ -460,6 +487,7 @@ internal sealed class OrderedViewWriter : IAsyncDisposable
             CancelRunningBuild();
             _desiredBuild = null;
             _pending = null;
+            _tailBreaches = 0;
 
             _state.RestoreRequestedFromAdopted();
             _pendingFilter = _adoptedFilter;
@@ -476,6 +504,7 @@ internal sealed class OrderedViewWriter : IAsyncDisposable
 
         RebuildRequest rebuild = _state.BeginRebuild(request.Predicate, request.Context, request.Hold);
 
+        _tailBreaches = 0;
         _pending = new PendingBuild(request.Identity, request.Sequence, rebuild.Generation);
         StartRebuild(rebuild);
     }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/CancellableSortTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/CancellableSortTests.cs
@@ -1,0 +1,214 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.LogTable;
+
+namespace EventLogExpert.Runtime.Tests.LogTable;
+
+public sealed class CancellableSortTests
+{
+    [Fact]
+    public void CancellableSort_CanceledMidSort_ObservesCancellationWithinCheckStride_OnSortedInput()
+    {
+        const int Count = 200_000;
+        const int CancelAtComparison = 5_000;
+        Comparison<int> inner = StrictOrderByValue([.. Enumerable.Range(0, Count)]);
+        int[] keys = [.. Enumerable.Range(0, Count)];
+        using var cancellation = new CancellationTokenSource();
+
+        int comparisons = 0;
+        Comparison<int> counting = (first, second) =>
+        {
+            if (++comparisons == CancelAtComparison) { cancellation.Cancel(); }
+
+            return inner(first, second);
+        };
+
+        Assert.Throws<OperationCanceledException>(() =>
+            ColumnDirectSort.CancellableSort(keys, counting, cancellation.Token));
+
+        Assert.True(
+            comparisons - CancelAtComparison <= 16_384,
+            $"cancellation observed after {comparisons - CancelAtComparison} comparisons, exceeding the check stride");
+    }
+
+    [Fact]
+    public void CancellableSort_CanceledMidSort_PermutationShape_Throws()
+    {
+        const int Count = 200_000;
+        int[] keys = ShuffledIndices(Count, seed: 11);
+        Comparison<int> inner = StrictOrderByValue(RandomValues(Count, seed: 11, modulo: 65_536));
+        using var cancellation = new CancellationTokenSource();
+
+        int comparisons = 0;
+        Comparison<int> canceling = (first, second) =>
+        {
+            if (++comparisons == 5_000) { cancellation.Cancel(); }
+
+            return inner(first, second);
+        };
+
+        Assert.Throws<OperationCanceledException>(() =>
+            ColumnDirectSort.CancellableSort(keys, canceling, cancellation.Token));
+    }
+
+    [Fact]
+    public void CancellableSort_CanceledMidSort_StringCompareShape_Throws()
+    {
+        const int Count = 200_000;
+        var values = new string[Count];
+
+        for (int index = 0; index < Count; index++)
+        {
+            values[index] = "row-" + (index * 2_654_435_761u % 50_000);
+        }
+
+        int[] order = ShuffledIndices(Count, seed: 5);
+        using var cancellation = new CancellationTokenSource();
+
+        int comparisons = 0;
+        Comparison<int> canceling = (first, second) =>
+        {
+            if (++comparisons == 5_000) { cancellation.Cancel(); }
+
+            return string.Compare(values[first], values[second], StringComparison.Ordinal);
+        };
+
+        Assert.Throws<OperationCanceledException>(() =>
+            ColumnDirectSort.CancellableSort(order, canceling, cancellation.Token));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(15)]
+    [InlineData(16)]
+    [InlineData(17)]
+    [InlineData(1_000)]
+    [InlineData(100_000)]
+    public void CancellableSort_MatchesArraySortPermutation_AcrossDistributions(int count)
+    {
+        foreach (int[] values in Distributions(count))
+        {
+            Comparison<int> comparison = StrictOrderByValue(values);
+            int[] keys = ShuffledIndices(count, seed: 20260813);
+
+            int[] expected = (int[])keys.Clone();
+            Array.Sort(expected, comparison);
+
+            int[] actual = (int[])keys.Clone();
+            ColumnDirectSort.CancellableSort(actual, comparison, TestContext.Current.CancellationToken);
+
+            Assert.Equal(expected, actual);
+        }
+    }
+
+    [Fact]
+    public void CancellableSort_PreCanceledToken_Throws()
+    {
+        int[] keys = ShuffledIndices(1_000, seed: 3);
+        Comparison<int> comparison = StrictOrderByValue(RandomValues(1_000, seed: 3, modulo: 256));
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        Assert.Throws<OperationCanceledException>(() =>
+            ColumnDirectSort.CancellableSort(keys, comparison, cancellation.Token));
+    }
+
+    [Fact]
+    public void HeapSortForTest_CanceledMidSort_Throws()
+    {
+        const int Count = 40_000;
+        Comparison<int> inner = StrictOrderByValue(RandomValues(Count, seed: 21, modulo: 20_000));
+        int[] keys = ShuffledIndices(Count, seed: 21);
+        using var cancellation = new CancellationTokenSource();
+
+        int comparisons = 0;
+        Comparison<int> canceling = (first, second) =>
+        {
+            if (++comparisons == 5_000) { cancellation.Cancel(); }
+
+            return inner(first, second);
+        };
+
+        Assert.Throws<OperationCanceledException>(() =>
+            ColumnDirectSort.HeapSortForTest(keys, canceling, cancellation.Token));
+    }
+
+    [Fact]
+    public void HeapSortForTest_MatchesArraySortPermutation_OnLargeInput()
+    {
+        const int Count = 20_000;
+        int[] values = RandomValues(Count, seed: 99, modulo: 4_096);
+        Comparison<int> comparison = StrictOrderByValue(values);
+        int[] keys = ShuffledIndices(Count, seed: 7);
+
+        int[] expected = (int[])keys.Clone();
+        Array.Sort(expected, comparison);
+
+        int[] actual = (int[])keys.Clone();
+        ColumnDirectSort.HeapSortForTest(actual, comparison, TestContext.Current.CancellationToken);
+
+        Assert.Equal(expected, actual);
+    }
+
+    private static IEnumerable<int[]> Distributions(int count)
+    {
+        yield return RandomValues(count, seed: 42, modulo: Math.Max(1, count));
+        yield return [.. Enumerable.Range(0, count)];
+        yield return [.. Enumerable.Range(0, count).Reverse()];
+        yield return new int[count];
+        yield return DuplicateHeavy(count);
+        yield return OrganPipe(count);
+    }
+
+    private static int[] DuplicateHeavy(int count)
+    {
+        int[] values = new int[count];
+
+        for (int index = 0; index < count; index++) { values[index] = index % 4; }
+
+        return values;
+    }
+
+    private static int[] OrganPipe(int count)
+    {
+        int[] values = new int[count];
+
+        for (int index = 0; index < count; index++) { values[index] = Math.Min(index, count - 1 - index); }
+
+        return values;
+    }
+
+    private static int[] RandomValues(int count, int seed, int modulo)
+    {
+        var random = new Random(seed);
+        int[] values = new int[count];
+
+        for (int index = 0; index < count; index++) { values[index] = random.Next(modulo); }
+
+        return values;
+    }
+
+    private static int[] ShuffledIndices(int count, int seed)
+    {
+        int[] indices = [.. Enumerable.Range(0, count)];
+        var random = new Random(seed);
+
+        for (int index = count - 1; index > 0; index--)
+        {
+            int swap = random.Next(index + 1);
+            (indices[index], indices[swap]) = (indices[swap], indices[index]);
+        }
+
+        return indices;
+    }
+
+    private static Comparison<int> StrictOrderByValue(int[] values) => (first, second) =>
+    {
+        int byValue = values[first].CompareTo(values[second]);
+
+        return byValue != 0 ? byValue : first.CompareTo(second);
+    };
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/OrderedView/OrderedViewBulkBuildTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/OrderedView/OrderedViewBulkBuildTests.cs
@@ -369,6 +369,34 @@ public sealed class OrderedViewBulkBuildTests
         }
     }
 
+    [Theory]
+    [InlineData(303)]
+    [InlineData(1717)]
+    public void MemoryBudget_ForcesDelegatingFallback_WithIdenticalOrder(int seed)
+    {
+        // A tiny budget makes EstimateBulkPeakBytes exceed it, so TryBuildBulk returns null and BuildIndex falls back
+        // to the bounded-memory delegating path. That fallback must be order-identical to the (huge-budget) bulk path.
+        var sample = new OrderedViewSample(seed, logCount: 1);
+        sample.SeedInterleaved(totalEvents: 400);
+        IEventColumnReader reader = sample.Reader(0);
+        EventLogId logId = sample.LogId(0);
+
+        foreach (SortContext context in AllContexts())
+        {
+            var state = new OrderedViewState();
+            state.ReconcileLog(logId, reader);
+            RebuildRequest request = state.BeginRebuild(static (_, _) => true, context);
+
+            ChunkedOrderIndex bulk = OrderedViewState.BuildIndex(
+                request, CancellationToken.None, bulkThreshold: 0, memoryBudgetBytes: long.MaxValue);
+            ChunkedOrderIndex fallback = OrderedViewState.BuildIndex(
+                request, CancellationToken.None, bulkThreshold: 0, memoryBudgetBytes: 1);
+
+            IComparer<OrderKey> comparer = OrderKeyComparerFactory.Create(context, request.BeginResolver);
+            AssertSnapshotsEqual(bulk.Publish(comparer, 0), fallback.Publish(comparer, 0), $"seed={seed} {Describe(context)}");
+        }
+    }
+
     private static OrderedViewSnapshot AdoptCombinedWithTailReplay(OrderedViewSample sample, SortContext context, int bulkThreshold)
     {
         var state = new OrderedViewState();

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/OrderedView/OrderedViewTailReplayTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/OrderedView/OrderedViewTailReplayTests.cs
@@ -1,0 +1,207 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.Runtime.LogTable.OrderedView;
+using EventLogExpert.Runtime.Tests.LogTable.TestSupport;
+
+namespace EventLogExpert.Runtime.Tests.LogTable.OrderedView;
+
+public sealed class OrderedViewTailReplayTests
+{
+    private static readonly SortContext s_context = new(ColumnName.RecordId, false, null, false);
+    private static readonly Filter s_emptyFilter = new(null, []);
+
+    [Fact]
+    public void TryAdoptRebuild_AbandonHeldTail_ReleasesHold_SoLiveIngestResumes()
+    {
+        EventLogId logId = EventLogId.Create();
+        var state = new OrderedViewState();
+
+        state.ReconcileLog(logId, Reader(logId, 50));
+        RebuildRequest first = state.BeginRebuild(static (_, _) => true, s_context);
+        Assert.True(state.TryAdoptRebuild(first, OrderedViewState.BuildIndex(first, CancellationToken.None)));
+        Assert.Equal(50, state.Current.Count);
+
+        RebuildRequest held = state.BeginRebuild(static (_, _) => true, s_context, hold: true);
+        state.ReconcileLog(logId, Reader(logId, 400));
+
+        AdoptOutcome outcome = state.TryAdoptRebuild(
+            held, OrderedViewState.BuildIndex(held, CancellationToken.None), tailBudget: 5, allowAbandon: true);
+
+        Assert.Equal(AdoptOutcome.AbandonedTail, outcome);
+
+        state.ReconcileLog(logId, Reader(logId, 500));
+        OrderedViewSnapshot resumed = state.Publish();
+
+        Assert.True(resumed.Count > 50, "abandoning a held tail must release the hold so live ingest resumes");
+    }
+
+    [Fact]
+    public void TryAdoptRebuild_AbandonsOverBudgetTail_WithoutAdopting_ThenForcedReplayAdoptsFullTail()
+    {
+        EventLogId logId = EventLogId.Create();
+        var state = new OrderedViewState();
+
+        state.ReconcileLog(logId, Reader(logId, 50));
+        RebuildRequest request = state.BeginRebuild(static (_, _) => true, s_context);
+        state.ReconcileLog(logId, Reader(logId, 200));
+
+        AdoptOutcome abandoned = state.TryAdoptRebuild(
+            request, OrderedViewState.BuildIndex(request, CancellationToken.None), tailBudget: 10, allowAbandon: true);
+
+        Assert.Equal(AdoptOutcome.AbandonedTail, abandoned);
+        Assert.Equal(0, state.Current.Count);
+
+        AdoptOutcome adopted = state.TryAdoptRebuild(
+            request, OrderedViewState.BuildIndex(request, CancellationToken.None), tailBudget: 10, allowAbandon: false);
+
+        Assert.Equal(AdoptOutcome.Adopted, adopted);
+        Assert.Equal(200, state.Current.Count);
+    }
+
+    [Fact]
+    public void TryAdoptRebuild_ReplaysTail_WhenWithinBudget_EvenWhenAbandonAllowed()
+    {
+        EventLogId logId = EventLogId.Create();
+        var state = new OrderedViewState();
+
+        state.ReconcileLog(logId, Reader(logId, 50));
+        RebuildRequest request = state.BeginRebuild(static (_, _) => true, s_context);
+        state.ReconcileLog(logId, Reader(logId, 60));
+
+        AdoptOutcome outcome = state.TryAdoptRebuild(
+            request, OrderedViewState.BuildIndex(request, CancellationToken.None), tailBudget: 50, allowAbandon: true);
+
+        Assert.Equal(AdoptOutcome.Adopted, outcome);
+        Assert.Equal(60, state.Current.Count);
+    }
+
+    [Fact]
+    public void TryAdoptRebuild_StaleGeneration_DropsWithoutAbandoning()
+    {
+        EventLogId logId = EventLogId.Create();
+        var state = new OrderedViewState();
+
+        state.ReconcileLog(logId, Reader(logId, 50));
+        RebuildRequest request = state.BeginRebuild(static (_, _) => true, s_context);
+        ChunkedOrderIndex candidate = OrderedViewState.BuildIndex(request, CancellationToken.None);
+
+        state.ReconcileLog(logId, Reader(logId, 400));
+        state.BeginRebuild(static (_, _) => true, s_context);
+
+        AdoptOutcome outcome = state.TryAdoptRebuild(request, candidate, tailBudget: 10, allowAbandon: true);
+
+        Assert.Equal(AdoptOutcome.DroppedStale, outcome);
+        Assert.Equal(0, state.Current.Count);
+    }
+
+    [Fact]
+    public async Task Writer_OverBudgetTail_AbandonsAndReschedules_ThenConvergesToFullCount()
+    {
+        EventLogId logId = EventLogId.Create();
+        IEventColumnReader initialReader = Reader(logId, 50);
+        IEventColumnReader grownReader = Reader(logId, 400);
+
+        using var entered = new ManualResetEventSlim(false);
+        using var blocking = new ManualResetEventSlim(false);
+        int gateArmed = 1;
+
+        await using var writer = new OrderedViewWriter(
+            publishEvery: 16, publishIntervalMs: 0, tailReplayBudget: 5, tailBreachLimit: 3);
+
+        writer.EnqueueReconcile(logId, initialReader);
+        writer.EnqueueViewRequest(ViewRequests.For(s_context, s_emptyFilter, [logId], Predicate));
+
+        Assert.True(entered.Wait(OrderedViewTestTimeouts.Default, TestContext.Current.CancellationToken));
+
+        writer.EnqueueReconcile(logId, grownReader);
+        blocking.Set();
+
+        OrderedViewSnapshot snapshot = await writer.DrainAsync();
+
+        Assert.Null(writer.Faulted);
+        Assert.Equal(400, snapshot.Count);
+        Assert.True(writer.BuildsStarted >= 2, $"expected a reschedule after the abandon, saw {writer.BuildsStarted} builds");
+        return;
+
+        bool Predicate(EventLocator locator, IEventColumnReader columnReader)
+        {
+            if (Interlocked.Exchange(ref gateArmed, 0) == 1)
+            {
+                entered.Set();
+                blocking.Wait(OrderedViewTestTimeouts.Default);
+            }
+
+            return true;
+        }
+    }
+
+    [Fact]
+    public async Task Writer_SustainedTail_ReachesForcedReplayAfterBreachLimit_AndConverges()
+    {
+        EventLogId logId = EventLogId.Create();
+        using var buildEntered = new SemaphoreSlim(0);
+        using var buildRelease = new SemaphoreSlim(0);
+
+        await using var writer = new OrderedViewWriter(
+            publishEvery: 16, publishIntervalMs: 0, tailReplayBudget: 5, tailBreachLimit: 2);
+
+        writer.EnqueueReconcile(logId, Reader(logId, 50));
+        writer.EnqueueViewRequest(ViewRequests.For(s_context, s_emptyFilter, [logId], Predicate));
+
+        Assert.True(buildEntered.Wait(OrderedViewTestTimeouts.Default, TestContext.Current.CancellationToken));
+        writer.EnqueueReconcile(logId, Reader(logId, 200));
+        buildRelease.Release();
+
+        Assert.True(buildEntered.Wait(OrderedViewTestTimeouts.Default, TestContext.Current.CancellationToken));
+        writer.EnqueueReconcile(logId, Reader(logId, 400));
+        buildRelease.Release();
+
+        Assert.True(buildEntered.Wait(OrderedViewTestTimeouts.Default, TestContext.Current.CancellationToken));
+        writer.EnqueueReconcile(logId, Reader(logId, 600));
+        buildRelease.Release();
+
+        OrderedViewSnapshot snapshot = await writer.DrainAsync();
+
+        Assert.Null(writer.Faulted);
+        Assert.Equal(600, snapshot.Count);
+        Assert.Equal(3, writer.BuildsStarted);
+        return;
+
+        bool Predicate(EventLocator locator, IEventColumnReader columnReader)
+        {
+            if (locator.Index == 0)
+            {
+                buildEntered.Release();
+                buildRelease.Wait(OrderedViewTestTimeouts.Default);
+            }
+
+            return true;
+        }
+    }
+
+    private static IEventColumnReader Reader(EventLogId logId, int count)
+    {
+        var clock = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var events = new List<ResolvedEvent>(count);
+
+        for (int index = 0; index < count; index++)
+        {
+            events.Add(new ResolvedEvent("Log", LogPathType.Channel)
+            {
+                RecordId = index,
+                TimeCreated = clock.AddMilliseconds(index),
+                Id = 1000,
+                Level = "Information",
+                Source = "Provider.A",
+                LogName = "Channel"
+            });
+        }
+
+        return EventColumnStore.Build(events, generation: 0, contentVersion: 0).CreateReader(logId);
+    }
+}


### PR DESCRIPTION
Hardens the ordered-view bulk index build path for the large-log extreme, in three independent, order/rank-preserving changes (no public API change):

**Memory-bounded bulk build** - `OrderedViewState.BuildIndex` estimates peak transient bytes and falls back to the bounded-memory delegating insert path when a build would exceed available heap headroom (and always for unbounded Keyword joins), so a large rebuild can't OOM.

**Cancellable sort** - replaces `Array.Sort` in `ColumnDirectSort` (both the permutation sort and the dense-rank string sort) with a token-checking introsort that throws on cancellation (never returns a partial array), so a superseded build stops promptly instead of running an uncancellable multi-second sort. Consolidates the repeated cancellation-check stride into `Concurrency.CooperativeCancellation`.

**Bounded tail replay + forward progress** - `OrderedViewState.TryAdoptRebuild` abandons an over-budget owner-thread tail replay and reschedules; a breach counter forces a bounded owner-thread replay after repeated abandons, preventing both owner-thread stalls and a sustained-append livelock.

**Tests** - +3 files (~26 tests): identical-permutation parity across 756 sort configs, mid-sort cancellation at both sort sites, the memory-budget fallback, and the tail-replay abandon / forced-fallback / hold-clear paths (deterministic concurrency tests; key ones verified to fail under their target regression). Before/after benchmark is perf-neutral with identical allocation.
