### PR TITLE
Open Folder: background scan with progress/cancel, and recurse subfolders by default

### DIFF
--- a/docs/Opening-Logs.md
+++ b/docs/Opening-Logs.md
@@ -21,7 +21,7 @@ The newest events paint first (usually within about a second) while the rest str
 
 ### Folder
 
-`File` → `Open` → `Folder` opens a folder picker. Every `.evtx` in the picked folder (top-level only, no recursion) is loaded as a separate log.
+`File` → `Open` → `Folder` opens a folder picker and loads every `.evtx` in the picked folder as a separate log. Subfolders are scanned by default, so nested collections (for example KAPE or triage output) load in one step. To load only the picked folder's top-level `.evtx` files, uncheck **Include subfolders** next to the start page's **Folder...** button or a scenario's **Open from folder** action, or use `File` → `Open` → `Folder (top level only)`. Recursive scans skip subfolders that cannot be read and do not follow reparse points (junctions and symlinks). The scan runs off the UI thread and, on the start page, shows a progress indicator you can cancel.
 
 Use this when you've been handed a folder of `.evtx` exports from one or more machines and want to load the lot in one step.
 

--- a/src/EventLogExpert.Runtime/Menu/FolderOpenPhase.cs
+++ b/src/EventLogExpert.Runtime/Menu/FolderOpenPhase.cs
@@ -1,0 +1,14 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Menu;
+
+/// <summary>
+///     A progress phase reported by <see cref="IMenuActionService.OpenFolderAsync" /> so a caller can surface a
+///     cancellable busy indicator only while cancellation is meaningful.
+/// </summary>
+public enum FolderOpenPhase
+{
+    Scanning,
+    Opening
+}

--- a/src/EventLogExpert.Runtime/Menu/IMenuActionService.cs
+++ b/src/EventLogExpert.Runtime/Menu/IMenuActionService.cs
@@ -26,7 +26,11 @@ public interface IMenuActionService
 
     Task OpenFileAsync(bool combineLog);
 
-    Task OpenFolderAsync(bool combineLog);
+    Task OpenFolderAsync(
+        bool combineLog,
+        bool includeSubfolders = false,
+        CancellationToken cancellationToken = default,
+        Func<FolderOpenPhase, Task>? onPhase = null);
 
     Task OpenIssueAsync();
 

--- a/src/EventLogExpert.Runtime/Scenarios/EvtxFolderScanResult.cs
+++ b/src/EventLogExpert.Runtime/Scenarios/EvtxFolderScanResult.cs
@@ -6,8 +6,8 @@ using System.Collections.Immutable;
 namespace EventLogExpert.Runtime.Scenarios;
 
 /// <summary>
-///     Discriminated result for <see cref="IEvtxFolderEnumerator.EnumerateTopLevel" /> so a folder that cannot be read
-///     is reported distinctly from one that merely holds no <c>.evtx</c> files.
+///     Discriminated result for <see cref="IEvtxFolderEnumerator.Enumerate" /> so a folder that cannot be read is
+///     reported distinctly from one that merely holds no <c>.evtx</c> files.
 /// </summary>
 public abstract record EvtxFolderScanResult
 {

--- a/src/EventLogExpert.Runtime/Scenarios/IEvtxFolderEnumerator.cs
+++ b/src/EventLogExpert.Runtime/Scenarios/IEvtxFolderEnumerator.cs
@@ -3,8 +3,11 @@
 
 namespace EventLogExpert.Runtime.Scenarios;
 
-/// <summary>Lists the top-level <c>.evtx</c> files in a folder, surfacing access and IO failures distinctly.</summary>
+/// <summary>
+///     Lists the <c>.evtx</c> files in a folder (optionally recursing into subfolders), surfacing access and IO
+///     failures distinctly.
+/// </summary>
 public interface IEvtxFolderEnumerator
 {
-    EvtxFolderScanResult EnumerateTopLevel(string folderPath, CancellationToken cancellationToken);
+    EvtxFolderScanResult Enumerate(string folderPath, bool includeSubfolders, CancellationToken cancellationToken);
 }

--- a/src/EventLogExpert.Runtime/Scenarios/IScenarioLaunchService.cs
+++ b/src/EventLogExpert.Runtime/Scenarios/IScenarioLaunchService.cs
@@ -16,11 +16,11 @@ public interface IScenarioLaunchService
     Task<ScenarioLaunchResult> LaunchAsync(ScenarioDefinition scenario, DateFilter? dateWindow, bool combineLog = false);
 
     /// <summary>
-    ///     Prompts for a folder, opens the exported <c>.evtx</c> files whose channel matches the scenario, and applies
-    ///     the scenario's filters to a fresh view. The scenario's filters and channels are read from the definition, so this
-    ///     works even for logs not present on the local host. The folder enumeration and per-file channel probe run off the
-    ///     caller's thread and honor <paramref name="cancellationToken" />, returning
-    ///     <see cref="ScenarioFolderOutcome.Cancelled" /> if the scan is abandoned before any log is opened.
+    ///     Prompts for a folder, opens the exported <c>.evtx</c> files (optionally recursing into subfolders) whose
+    ///     channel matches the scenario, and applies the scenario's filters to a fresh view. The scenario's filters and
+    ///     channels are read from the definition, so this works even for logs not present on the local host. The folder
+    ///     enumeration and per-file channel probe run off the caller's thread and honor <paramref name="cancellationToken" />,
+    ///     returning <see cref="ScenarioFolderOutcome.Cancelled" /> if the scan is abandoned before any log is opened.
     ///     <paramref name="onPhase" />, when supplied, is invoked as the operation crosses each
     ///     <see cref="ScenarioFolderPhase" /> boundary so a caller can show a cancellable busy indicator only while
     ///     cancellation is still meaningful.
@@ -28,6 +28,7 @@ public interface IScenarioLaunchService
     Task<ScenarioFolderLaunchResult> LaunchFromFolderAsync(
         ScenarioDefinition scenario,
         DateFilter? dateWindow,
+        bool includeSubfolders = false,
         CancellationToken cancellationToken = default,
         Func<ScenarioFolderPhase, Task>? onPhase = null);
 }

--- a/src/EventLogExpert.Runtime/Scenarios/ScenarioLaunchService.cs
+++ b/src/EventLogExpert.Runtime/Scenarios/ScenarioLaunchService.cs
@@ -77,6 +77,7 @@ internal sealed class ScenarioLaunchService(
     public async Task<ScenarioFolderLaunchResult> LaunchFromFolderAsync(
         ScenarioDefinition scenario,
         DateFilter? dateWindow,
+        bool includeSubfolders = false,
         CancellationToken cancellationToken = default,
         Func<ScenarioFolderPhase, Task>? onPhase = null)
     {
@@ -104,7 +105,7 @@ internal sealed class ScenarioLaunchService(
         try
         {
             var scan = await Task.Run(
-                () => _folderEnumerator.EnumerateTopLevel(folder, cancellationToken), cancellationToken);
+                () => _folderEnumerator.Enumerate(folder, includeSubfolders, cancellationToken), cancellationToken);
 
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/EventLogExpert.UI/Dashboard/EmptyStateDashboard.razor
+++ b/src/EventLogExpert.UI/Dashboard/EmptyStateDashboard.razor
@@ -10,23 +10,14 @@
             </div>
         </div>
         <div class="empty-dashboard__masthead-actions">
-            @if (_scanningScenario is { } scanning)
+            @if (_folderScanActive)
             {
                 <div class="empty-dashboard__chip empty-dashboard__chip--scanning" role="status">
                     <i aria-hidden="true" class="bi bi-arrow-repeat loader-spin"></i>
-                    @if (_openingLogs)
+                    <span class="empty-dashboard__chip-text">@FolderScanStatusText()</span>
+                    @if (!_openingLogs && !_cancelRequested)
                     {
-                        <span class="empty-dashboard__chip-text">Opening logs for @scanning.Name...</span>
-                    }
-                    else if (_cancelRequested)
-                    {
-                        <span class="empty-dashboard__chip-text">Cancelling folder scan for @scanning.Name...</span>
-                    }
-                    else
-                    {
-                        <span class="empty-dashboard__chip-text">Scanning @scanning.Name folder for logs...</span>
-
-                        <Button OnClick="CancelFolderScan" aria-label="@($"Cancel folder scan for {scanning.Name}")" @ref="_cancelScanButton">Cancel</Button>
+                        <Button OnClick="CancelFolderScan" aria-label="@FolderScanCancelLabel()" @ref="_cancelScanButton">Cancel</Button>
                     }
                 </div>
             }
@@ -95,6 +86,10 @@
             <ChromelessButton CssClass="empty-dashboard__launch" Disabled="@_isBusy" IconClass="bi bi-folder2-open" OnClick="OpenFolderAsync" aria-label="Open Folder...">
                 <span>Folder...</span>
             </ChromelessButton>
+            <label class="empty-dashboard__subfolders">
+                <input type="checkbox" @bind="_includeSubfolders" disabled="@_isBusy" />
+                <span>Include subfolders</span>
+            </label>
         </div>
     </section>
 
@@ -120,7 +115,7 @@
                         IsScenarioDisabled="IsScenarioDisabled"
                         OnEnableChannel="EnableChannelAsync"
                         OnLaunch="LaunchScenarioAsync"
-                        OnLaunchFromFolder="LaunchScenarioFromFolderAsync"
+                        OnLaunchFromFolder="request => LaunchScenarioFromFolderAsync(request.Scenario, request.IncludeSubfolders)"
                         OnSelect="scenario => Select(category, scenario)"
                         OnToggleFavorite="ToggleFavorite"
                         Scenarios="ScenariosFor(category)"

--- a/src/EventLogExpert.UI/Dashboard/EmptyStateDashboard.razor.cs
+++ b/src/EventLogExpert.UI/Dashboard/EmptyStateDashboard.razor.cs
@@ -49,6 +49,9 @@ public sealed partial class EmptyStateDashboard : AppStateComponentBase
     private ElementReference _dashboardRoot;
     private bool _disposed;
     private CancellationTokenSource? _folderLaunchCts;
+    private bool _folderScanActive;
+    private string? _folderScanLabel;
+    private bool _includeSubfolders = true;
     private bool _isBusy;
     private LivePresence _livePresence = new(false, FrozenSet<string>.Empty);
     private bool _openingLogs;
@@ -57,7 +60,6 @@ public sealed partial class EmptyStateDashboard : AppStateComponentBase
     private bool _pendingTabFocus;
     private IReadOnlyDictionary<string, ChannelReadiness> _readinessByChannel =
         new Dictionary<string, ChannelReadiness>(StringComparer.OrdinalIgnoreCase);
-    private ScenarioDefinition? _scanningScenario;
     private SidebarTabs<SplashCategory>? _sidebarTabs;
     private IReadOnlyList<ScenarioDefinition>? _splashScenarios;
     private IReadOnlyList<(SplashCategory Tab, string Label)> _tabs = [];
@@ -325,6 +327,24 @@ public sealed partial class EmptyStateDashboard : AppStateComponentBase
                 .OrderBy(scenario => scenario.Priority)
                 .ThenBy(scenario => scenario.Order);
 
+    private string FolderScanCancelLabel() =>
+        _folderScanLabel is { } label ? $"Cancel folder scan for {label}" : "Cancel folder scan";
+
+    private string FolderScanStatusText()
+    {
+        if (_openingLogs)
+        {
+            return _folderScanLabel is { } openingLabel ? $"Opening logs for {openingLabel}..." : "Opening logs...";
+        }
+
+        if (_cancelRequested)
+        {
+            return _folderScanLabel is { } cancellingLabel ? $"Cancelling folder scan for {cancellingLabel}..." : "Cancelling folder scan...";
+        }
+
+        return _folderScanLabel is { } scanningLabel ? $"Scanning {scanningLabel} folder for logs..." : "Scanning folder for logs...";
+    }
+
     private IReadOnlyList<ChannelReadiness> GetChannelReadiness(ScenarioDefinition scenario) =>
         ReadinessFor(scenario.Channels);
 
@@ -353,7 +373,7 @@ public sealed partial class EmptyStateDashboard : AppStateComponentBase
                     "Launch scenario",
                     message,
                     "Open from folder",
-                    () => LaunchScenarioFromFolderAsync(scenario));
+                    () => LaunchScenarioFromFolderAsync(scenario, includeSubfolders: true));
             }
             else
             {
@@ -361,10 +381,10 @@ public sealed partial class EmptyStateDashboard : AppStateComponentBase
             }
         });
 
-    private Task LaunchScenarioFromFolderAsync(ScenarioDefinition scenario) =>
-        RunGuardedAsync(() => LaunchScenarioFromFolderCoreAsync(scenario));
+    private Task LaunchScenarioFromFolderAsync(ScenarioDefinition scenario, bool includeSubfolders = false) =>
+        RunGuardedAsync(() => LaunchScenarioFromFolderCoreAsync(scenario, includeSubfolders));
 
-    private async Task LaunchScenarioFromFolderCoreAsync(ScenarioDefinition scenario)
+    private async Task LaunchScenarioFromFolderCoreAsync(ScenarioDefinition scenario, bool includeSubfolders)
     {
         var cts = CancellationTokenSource.CreateLinkedTokenSource(_lifetimeCts.Token);
         _folderLaunchCts = cts;
@@ -373,7 +393,7 @@ public sealed partial class EmptyStateDashboard : AppStateComponentBase
 
         try
         {
-            result = await ScenarioLaunch.LaunchFromFolderAsync(scenario, null, cts.Token, OnFolderScanPhaseAsync);
+            result = await ScenarioLaunch.LaunchFromFolderAsync(scenario, null, includeSubfolders, cts.Token, OnFolderScanPhaseAsync);
         }
         finally
         {
@@ -381,9 +401,10 @@ public sealed partial class EmptyStateDashboard : AppStateComponentBase
 
             cts.Dispose();
 
-            if (_scanningScenario is not null)
+            if (_folderScanActive)
             {
-                _scanningScenario = null;
+                _folderScanActive = false;
+                _folderScanLabel = null;
                 _openingLogs = false;
                 _cancelRequested = false;
                 _pendingCancelFocus = false;
@@ -422,7 +443,8 @@ public sealed partial class EmptyStateDashboard : AppStateComponentBase
                 {
                     case ScenarioFolderPhase.Scanning:
                         scanStarted = true;
-                        _scanningScenario = scenario;
+                        _folderScanActive = true;
+                        _folderScanLabel = scenario.Name;
                         _openingLogs = false;
                         _cancelRequested = false;
                         _pendingTabFocus = false;
@@ -464,7 +486,65 @@ public sealed partial class EmptyStateDashboard : AppStateComponentBase
 
     private Task OpenFileAsync() => RunGuardedAsync(() => Actions.OpenFileAsync(false));
 
-    private Task OpenFolderAsync() => RunGuardedAsync(() => Actions.OpenFolderAsync(false));
+    private Task OpenFolderAsync() => RunGuardedAsync(() => OpenFolderCoreAsync(_includeSubfolders));
+
+    private async Task OpenFolderCoreAsync(bool includeSubfolders)
+    {
+        var cts = CancellationTokenSource.CreateLinkedTokenSource(_lifetimeCts.Token);
+        _folderLaunchCts = cts;
+        var scanStarted = false;
+
+        try
+        {
+            await Actions.OpenFolderAsync(false, includeSubfolders, cts.Token, OnFolderOpenPhaseAsync);
+        }
+        finally
+        {
+            if (ReferenceEquals(_folderLaunchCts, cts)) { _folderLaunchCts = null; }
+
+            cts.Dispose();
+
+            if (_folderScanActive)
+            {
+                _folderScanActive = false;
+                _folderScanLabel = null;
+                _openingLogs = false;
+                _cancelRequested = false;
+                _pendingCancelFocus = false;
+                _pendingScanEndFocus = false;
+
+                await SafeInvokeAsync(StateHasChanged);
+            }
+        }
+
+        if (scanStarted) { RestoreFocusAfterScan(); }
+
+        async Task OnFolderOpenPhaseAsync(FolderOpenPhase phase) =>
+            await SafeInvokeAsync(() =>
+            {
+                switch (phase)
+                {
+                    case FolderOpenPhase.Scanning:
+                        scanStarted = true;
+                        _folderScanActive = true;
+                        _folderScanLabel = null;
+                        _openingLogs = false;
+                        _cancelRequested = false;
+                        _pendingTabFocus = false;
+                        _pendingScanEndFocus = false;
+                        _pendingCancelFocus = true;
+                        break;
+                    case FolderOpenPhase.Opening:
+                        _openingLogs = true;
+                        _pendingCancelFocus = false;
+                        _pendingTabFocus = false;
+                        _pendingScanEndFocus = true;
+                        break;
+                }
+
+                StateHasChanged();
+            });
+    }
 
     private Task OpenSecurityAsync() => RunGuardedAsync(() => Actions.OpenLiveLogAsync(LogChannelNames.SecurityLog, false));
 

--- a/src/EventLogExpert.UI/Dashboard/EmptyStateDashboard.razor.css
+++ b/src/EventLogExpert.UI/Dashboard/EmptyStateDashboard.razor.css
@@ -215,6 +215,19 @@
     background-color: var(--border-divider);
 }
 
+.empty-dashboard__subfolders {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    cursor: pointer;
+}
+
+.empty-dashboard__subfolders input {
+    cursor: pointer;
+}
+
 .empty-dashboard__catalog {
     flex: 1 1 0;
     min-height: 0;

--- a/src/EventLogExpert.UI/Dashboard/ScenarioBrowserPanel.razor
+++ b/src/EventLogExpert.UI/Dashboard/ScenarioBrowserPanel.razor
@@ -24,20 +24,20 @@
         </ul>
 
         <div class="scenario-browser__detail">
-            @if (Selected is not null)
+            @if (Selected is { } selected)
             {
                 <ScenarioDetail CanEnableChannels="CanEnableChannels"
-                    ChannelReadiness="GetChannelReadiness(Selected)"
+                    ChannelReadiness="GetChannelReadiness(selected)"
                     IsBusy="IsBusy"
-                    IsDisabled="IsScenarioDisabled(Selected)"
-                    IsFavored="IsFavored(Selected)"
-                    IsLivePresent="IsLivePresent(Selected)"
+                    IsDisabled="IsScenarioDisabled(selected)"
+                    IsFavored="IsFavored(selected)"
+                    IsLivePresent="IsLivePresent(selected)"
                     OnEnableChannel="OnEnableChannel"
-                    OnLaunch="() => OnLaunch.InvokeAsync(Selected)"
-                    OnLaunchFromFolder="() => OnLaunchFromFolder.InvokeAsync(Selected)"
-                    OnToggleFavorite="() => OnToggleFavorite.InvokeAsync(Selected)"
-                    OptionalChannelReadiness="GetOptionalChannelReadiness(Selected)"
-                    Scenario="Selected" />
+                    OnLaunch="() => OnLaunch.InvokeAsync(selected)"
+                    OnLaunchFromFolder="includeSubfolders => OnLaunchFromFolder.InvokeAsync(new ScenarioFolderOpenRequest(selected, includeSubfolders))"
+                    OnToggleFavorite="() => OnToggleFavorite.InvokeAsync(selected)"
+                    OptionalChannelReadiness="GetOptionalChannelReadiness(selected)"
+                    Scenario="selected" />
             }
         </div>
     }

--- a/src/EventLogExpert.UI/Dashboard/ScenarioBrowserPanel.razor.cs
+++ b/src/EventLogExpert.UI/Dashboard/ScenarioBrowserPanel.razor.cs
@@ -38,7 +38,7 @@ public sealed partial class ScenarioBrowserPanel : IAsyncDisposable
 
     [Parameter] public EventCallback<ScenarioDefinition> OnLaunch { get; set; }
 
-    [Parameter] public EventCallback<ScenarioDefinition> OnLaunchFromFolder { get; set; }
+    [Parameter] public EventCallback<ScenarioFolderOpenRequest> OnLaunchFromFolder { get; set; }
 
     [Parameter] public EventCallback<ScenarioDefinition> OnSelect { get; set; }
 

--- a/src/EventLogExpert.UI/Dashboard/ScenarioDetail.razor
+++ b/src/EventLogExpert.UI/Dashboard/ScenarioDetail.razor
@@ -114,5 +114,9 @@
             aria-label="@($"Open {Scenario.Name} from a folder of exported logs")">
             <span>Open from folder</span>
         </ChromelessButton>
+        <label class="scenario-detail__subfolders">
+            <input type="checkbox" @bind="_includeSubfolders" disabled="@IsBusy" />
+            <span>Include subfolders</span>
+        </label>
     </div>
 </div>

--- a/src/EventLogExpert.UI/Dashboard/ScenarioDetail.razor.cs
+++ b/src/EventLogExpert.UI/Dashboard/ScenarioDetail.razor.cs
@@ -16,6 +16,8 @@ public sealed partial class ScenarioDetail
     private readonly string _nameId = ComponentId.NewUnique().Value;
     private readonly string _offlineId = ComponentId.NewUnique().Value;
 
+    private bool _includeSubfolders = true;
+
     [Parameter] public bool CanEnableChannels { get; set; }
 
     [Parameter] public IReadOnlyList<ChannelReadiness> ChannelReadiness { get; set; } = [];
@@ -32,7 +34,7 @@ public sealed partial class ScenarioDetail
 
     [Parameter] public EventCallback OnLaunch { get; set; }
 
-    [Parameter] public EventCallback OnLaunchFromFolder { get; set; }
+    [Parameter] public EventCallback<bool> OnLaunchFromFolder { get; set; }
 
     [Parameter] public EventCallback OnToggleFavorite { get; set; }
 
@@ -111,7 +113,7 @@ public sealed partial class ScenarioDetail
     {
         if (IsBusy) { return; }
 
-        await OnLaunchFromFolder.InvokeAsync();
+        await OnLaunchFromFolder.InvokeAsync(_includeSubfolders);
     }
 
     private readonly record struct FilterLine(string Text, HighlightColor Color);

--- a/src/EventLogExpert.UI/Dashboard/ScenarioDetail.razor.css
+++ b/src/EventLogExpert.UI/Dashboard/ScenarioDetail.razor.css
@@ -269,3 +269,16 @@
     color: var(--text-secondary);
     cursor: default;
 }
+
+.scenario-detail__subfolders {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    cursor: pointer;
+}
+
+.scenario-detail__subfolders input {
+    cursor: pointer;
+}

--- a/src/EventLogExpert.UI/Dashboard/ScenarioFolderOpenRequest.cs
+++ b/src/EventLogExpert.UI/Dashboard/ScenarioFolderOpenRequest.cs
@@ -1,0 +1,8 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Scenarios.Catalog;
+
+namespace EventLogExpert.UI.Dashboard;
+
+public readonly record struct ScenarioFolderOpenRequest(ScenarioDefinition Scenario, bool IncludeSubfolders);

--- a/src/EventLogExpert.UI/Menu/MenuBar.razor.cs
+++ b/src/EventLogExpert.UI/Menu/MenuBar.razor.cs
@@ -179,7 +179,8 @@ public sealed partial class MenuBar
         return
         [
             MenuItem.Item("File", () => Actions.OpenFileAsync(combineLog), combineLog ? null : "Ctrl+O"),
-            MenuItem.Item("Folder", () => Actions.OpenFolderAsync(combineLog)),
+            MenuItem.Item("Folder", () => Actions.OpenFolderAsync(combineLog, includeSubfolders: true)),
+            MenuItem.Item("Folder (top level only)", () => Actions.OpenFolderAsync(combineLog, includeSubfolders: false)),
             MenuItem.SubMenu("Live",
             [
                 MenuItem.Item(LogChannelNames.ApplicationLog,

--- a/src/EventLogExpert.WindowsPlatform/Activation/ActivationDispatcher.cs
+++ b/src/EventLogExpert.WindowsPlatform/Activation/ActivationDispatcher.cs
@@ -100,7 +100,7 @@ public sealed class ActivationDispatcher : IActivationDispatcher
 
         foreach (var folder in args.FolderPaths)
         {
-            var result = EvtxFolderEnumerator.EnumerateEvtxTopLevel(folder);
+            var result = EvtxFolderEnumerator.EnumerateEvtx(folder, includeSubfolders: false);
 
             if (result is EvtxEnumerationResult.Success success)
             {

--- a/src/EventLogExpert.WindowsPlatform/Activation/EvtxEnumerationResult.cs
+++ b/src/EventLogExpert.WindowsPlatform/Activation/EvtxEnumerationResult.cs
@@ -3,10 +3,6 @@
 
 namespace EventLogExpert.WindowsPlatform.Activation;
 
-/// <summary>
-///     Discriminated record hierarchy for <see cref="EvtxFolderEnumerator.EnumerateEvtxTopLevel" /> so callers can
-///     apply distinct UX per failure mode without losing diagnostic detail.
-/// </summary>
 public abstract record EvtxEnumerationResult
 {
     private EvtxEnumerationResult() { }

--- a/src/EventLogExpert.WindowsPlatform/Activation/EvtxFolderEnumerator.cs
+++ b/src/EventLogExpert.WindowsPlatform/Activation/EvtxFolderEnumerator.cs
@@ -8,7 +8,7 @@ public static class EvtxFolderEnumerator
     private const string EvtxSearchPattern = "*.evtx";
     private const string OpenFolderFailedTitle = "Open Folder Failed";
 
-    public static EvtxEnumerationResult EnumerateEvtxTopLevel(string folderPath, CancellationToken cancellationToken = default)
+    public static EvtxEnumerationResult EnumerateEvtx(string folderPath, bool includeSubfolders, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(folderPath);
 
@@ -18,15 +18,33 @@ public static class EvtxFolderEnumerator
 
             var files = new List<string>();
 
-            foreach (var file in Directory.EnumerateFiles(folderPath, EvtxSearchPattern, SearchOption.TopDirectoryOnly))
+            CollectTopLevelEvtx(folderPath, files, cancellationToken);
+
+            if (includeSubfolders)
             {
-                cancellationToken.ThrowIfCancellationRequested();
-                files.Add(file);
+                var pendingDirectories = new Stack<string>();
+                PushSubdirectories(folderPath, pendingDirectories, cancellationToken);
+
+                while (pendingDirectories.Count > 0)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    var directory = pendingDirectories.Pop();
+
+                    try
+                    {
+                        CollectTopLevelEvtx(directory, files, cancellationToken);
+                        PushSubdirectories(directory, pendingDirectories, cancellationToken);
+                    }
+                    catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+                    {
+                        // Skip a descendant that became unreadable mid-scan; only a failure reading the selected root surfaces.
+                    }
+                }
             }
 
-            // A folder that yields no matches never enters the loop body, and Directory.EnumerateFiles has no overload that
-            // observes the token mid-scan, so re-check here: cancellation requested while the directory was being walked is
-            // then surfaced as OperationCanceledException rather than a normal Empty/Success result.
+            // Directory enumeration has no overload that observes the token mid-scan, so re-check: a cancel requested while
+            // an empty directory was walked surfaces here as OperationCanceledException rather than a normal result.
             cancellationToken.ThrowIfCancellationRequested();
 
             if (files.Count == 0)
@@ -56,4 +74,38 @@ public static class EvtxFolderEnumerator
         EvtxEnumerationResult.IoError i => (OpenFolderFailedTitle, i.Message),
         _ => null,
     };
+
+    private static void CollectTopLevelEvtx(string directory, List<string> files, CancellationToken cancellationToken)
+    {
+        foreach (var file in Directory.EnumerateFiles(directory, EvtxSearchPattern, SearchOption.TopDirectoryOnly))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            files.Add(file);
+        }
+    }
+
+    private static void PushSubdirectories(string directory, Stack<string> pendingDirectories, CancellationToken cancellationToken)
+    {
+        foreach (var subdirectory in Directory.EnumerateDirectories(directory))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            bool isReparsePoint;
+
+            try
+            {
+                isReparsePoint = (File.GetAttributes(subdirectory) & FileAttributes.ReparsePoint) != 0;
+            }
+            catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+            {
+                // A child whose attributes cannot be read (denied, or removed mid-scan) is skipped, not fatal to the scan.
+                continue;
+            }
+
+            // Do not descend reparse points (junctions / symlinks): they can escape the selected tree or cycle indefinitely.
+            if (isReparsePoint) { continue; }
+
+            pendingDirectories.Push(subdirectory);
+        }
+    }
 }

--- a/src/EventLogExpert/Adapters/FilePicker/MauiEvtxFolderEnumerator.cs
+++ b/src/EventLogExpert/Adapters/FilePicker/MauiEvtxFolderEnumerator.cs
@@ -9,8 +9,8 @@ namespace EventLogExpert.Adapters.FilePicker;
 /// <summary>MAUI adapter that maps <see cref="EvtxFolderEnumerator" /> onto the Runtime folder-scan contract.</summary>
 internal sealed class MauiEvtxFolderEnumerator : IEvtxFolderEnumerator
 {
-    public EvtxFolderScanResult EnumerateTopLevel(string folderPath, CancellationToken cancellationToken) =>
-        EvtxFolderEnumerator.EnumerateEvtxTopLevel(folderPath, cancellationToken) switch
+    public EvtxFolderScanResult Enumerate(string folderPath, bool includeSubfolders, CancellationToken cancellationToken) =>
+        EvtxFolderEnumerator.EnumerateEvtx(folderPath, includeSubfolders, cancellationToken) switch
         {
             EvtxEnumerationResult.Success success => new EvtxFolderScanResult.Files([.. success.Files]),
             EvtxEnumerationResult.Empty => EvtxFolderScanResult.Empty.Instance,

--- a/src/EventLogExpert/Adapters/Menu/MauiMenuActionService.cs
+++ b/src/EventLogExpert/Adapters/Menu/MauiMenuActionService.cs
@@ -69,6 +69,7 @@ public sealed class MauiMenuActionService(
 
     private CancellationTokenSource _cancellationTokenSource = new();
     private bool _disposed;
+    private bool _folderOpenInProgress;
 
     public async Task CheckForUpdatesAsync()
     {
@@ -149,41 +150,74 @@ public sealed class MauiMenuActionService(
         await OpenLogsBatchAsync(paths.Select(path => (path, LogPathType.File)), combineLog);
     }
 
-    public async Task OpenFolderAsync(bool combineLog)
+    public async Task OpenFolderAsync(
+        bool combineLog,
+        bool includeSubfolders = false,
+        CancellationToken cancellationToken = default,
+        Func<FolderOpenPhase, Task>? onPhase = null)
     {
-        string? folderPath;
+        // Enumeration runs on a background thread, so without this guard a second folder-open (the menu has no busy
+        // guard of its own) could race an in-flight scan and open the wrong folder's logs.
+        if (_folderOpenInProgress) { return; }
+
+        _folderOpenInProgress = true;
 
         try
         {
-            folderPath = await _folderPickerService.PickFolderAsync();
+            string? folderPath;
+
+            try
+            {
+                folderPath = await _folderPickerService.PickFolderAsync();
+            }
+            catch (InvalidOperationException ex)
+            {
+                await _dialogService.ShowAlert("Open Folder Failed", ex.Message, "Ok");
+
+                return;
+            }
+
+            if (folderPath is null || cancellationToken.IsCancellationRequested) { return; }
+
+            if (onPhase is not null) { await onPhase(FolderOpenPhase.Scanning); }
+
+            EvtxEnumerationResult result;
+
+            try
+            {
+                result = await Task.Run(
+                    () => EvtxFolderEnumerator.EnumerateEvtx(folderPath, includeSubfolders, cancellationToken), cancellationToken);
+
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+
+            if (EvtxFolderEnumerator.ToAlertCopy(result) is { } copy)
+            {
+                await _dialogService.ShowAlert(copy.Title, copy.Message, "Ok");
+
+                return;
+            }
+
+            if (result is not EvtxEnumerationResult.Success success || cancellationToken.IsCancellationRequested) { return; }
+
+            if (onPhase is not null) { await onPhase(FolderOpenPhase.Opening); }
+
+            if (cancellationToken.IsCancellationRequested) { return; }
+
+            var files = success.Files
+                .Select(file => (file, LogPathType.File))
+                .ToList();
+
+            await OpenLogsBatchAsync(files, combineLog);
         }
-        catch (InvalidOperationException ex)
+        finally
         {
-            await _dialogService.ShowAlert("Open Folder Failed", ex.Message, "Ok");
-
-            return;
+            _folderOpenInProgress = false;
         }
-
-        if (folderPath is null) { return; }
-
-        var result = EvtxFolderEnumerator.EnumerateEvtxTopLevel(folderPath);
-
-        var alertCopy = EvtxFolderEnumerator.ToAlertCopy(result);
-
-        if (alertCopy is { } copy)
-        {
-            await _dialogService.ShowAlert(copy.Title, copy.Message, "Ok");
-
-            return;
-        }
-
-        if (result is not EvtxEnumerationResult.Success success) { return; }
-
-        var files = success.Files
-            .Select(file => (file, LogPathType.File))
-            .ToList();
-
-        await OpenLogsBatchAsync(files, combineLog);
     }
 
     public Task OpenIssueAsync() => OpenBrowserAsync("https://github.com/microsoft/EventLogExpert/issues/new");

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/ScenarioLaunchServiceTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/ScenarioLaunchServiceTests.cs
@@ -334,11 +334,11 @@ public sealed class ScenarioLaunchServiceTests
         var (service, _, menu, picker, enumerator, reader, scenario) =
             CreateFolder(FolderScenario() with { ActivatesTimeline = true }, timelineVisible: false);
         picker.PickFolderAsync().Returns("C:\\bundle");
-        enumerator.EnumerateTopLevel("C:\\bundle", Arg.Any<CancellationToken>()).Returns(new EvtxFolderScanResult.Files(["C:\\bundle\\System.evtx"]));
+        enumerator.Enumerate("C:\\bundle", Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(new EvtxFolderScanResult.Files(["C:\\bundle\\System.evtx"]));
         reader.ReadChannel("C:\\bundle\\System.evtx").Returns(EvtxChannelReadResult.FromChannel("System"));
         menu.OpenLogFilesAsync(Arg.Any<IEnumerable<string>>(), false, false).Returns(new OpenLogsBatchResult(1, 0, 0, 0, []));
 
-        await service.LaunchFromFolderAsync(scenario, dateWindow: null, TestContext.Current.CancellationToken);
+        await service.LaunchFromFolderAsync(scenario, dateWindow: null, cancellationToken: TestContext.Current.CancellationToken);
 
         menu.Received(1).SetHistogramVisible(true);
     }
@@ -353,11 +353,11 @@ public sealed class ScenarioLaunchServiceTests
                 TimelineDimension = ScenarioTimelineDimension.Log
             });
         picker.PickFolderAsync().Returns("C:\\bundle");
-        enumerator.EnumerateTopLevel("C:\\bundle", Arg.Any<CancellationToken>()).Returns(new EvtxFolderScanResult.Files(["C:\\bundle\\System.evtx"]));
+        enumerator.Enumerate("C:\\bundle", Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(new EvtxFolderScanResult.Files(["C:\\bundle\\System.evtx"]));
         reader.ReadChannel("C:\\bundle\\System.evtx").Returns(EvtxChannelReadResult.FromChannel("System"));
         menu.OpenLogFilesAsync(Arg.Any<IEnumerable<string>>(), false, false).Returns(new OpenLogsBatchResult(1, 0, 0, 0, []));
 
-        await service.LaunchFromFolderAsync(scenario, dateWindow: null, TestContext.Current.CancellationToken);
+        await service.LaunchFromFolderAsync(scenario, dateWindow: null, cancellationToken: TestContext.Current.CancellationToken);
 
         dispatcher.Received(1).Dispatch(
             Arg.Is<RequestHistogramDimensionAction>(action => action != null && action.Dimension == HistogramDimension.Log));
@@ -375,11 +375,11 @@ public sealed class ScenarioLaunchServiceTests
                 },
                 timelineVisible: true);
         picker.PickFolderAsync().Returns("C:\\bundle");
-        enumerator.EnumerateTopLevel("C:\\bundle", Arg.Any<CancellationToken>()).Returns(new EvtxFolderScanResult.Files(["C:\\bundle\\System.evtx"]));
+        enumerator.Enumerate("C:\\bundle", Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(new EvtxFolderScanResult.Files(["C:\\bundle\\System.evtx"]));
         reader.ReadChannel("C:\\bundle\\System.evtx").Returns(EvtxChannelReadResult.FromChannel("System"));
         menu.OpenLogFilesAsync(Arg.Any<IEnumerable<string>>(), false, false).Returns(new OpenLogsBatchResult(1, 0, 0, 0, []));
 
-        await service.LaunchFromFolderAsync(scenario, dateWindow: null, TestContext.Current.CancellationToken);
+        await service.LaunchFromFolderAsync(scenario, dateWindow: null, cancellationToken: TestContext.Current.CancellationToken);
 
         dispatcher.Received(1).Dispatch(
             Arg.Is<RequestHistogramDimensionAction>(action => action != null && action.Dimension == HistogramDimension.Source));
@@ -391,11 +391,11 @@ public sealed class ScenarioLaunchServiceTests
         var (service, dispatcher, menu, picker, enumerator, reader, scenario) =
             CreateFolder(FolderScenario() with { ActivatesTimeline = true });
         picker.PickFolderAsync().Returns("C:\\bundle");
-        enumerator.EnumerateTopLevel("C:\\bundle", Arg.Any<CancellationToken>()).Returns(new EvtxFolderScanResult.Files(["C:\\bundle\\System.evtx"]));
+        enumerator.Enumerate("C:\\bundle", Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(new EvtxFolderScanResult.Files(["C:\\bundle\\System.evtx"]));
         reader.ReadChannel("C:\\bundle\\System.evtx").Returns(EvtxChannelReadResult.FromChannel("System"));
         menu.OpenLogFilesAsync(Arg.Any<IEnumerable<string>>(), false, false).Returns(new OpenLogsBatchResult(1, 0, 0, 0, []));
 
-        await service.LaunchFromFolderAsync(scenario, dateWindow: null, TestContext.Current.CancellationToken);
+        await service.LaunchFromFolderAsync(scenario, dateWindow: null, cancellationToken: TestContext.Current.CancellationToken);
 
         dispatcher.DidNotReceive().Dispatch(Arg.Any<RequestHistogramDimensionAction>());
     }
@@ -406,7 +406,7 @@ public sealed class ScenarioLaunchServiceTests
         var (service, _, _, picker, enumerator, _, scenario) = CreateFolder(FolderScenario());
         using var cts = new CancellationTokenSource();
         picker.PickFolderAsync().Returns("C:\\bundle");
-        enumerator.EnumerateTopLevel("C:\\bundle", Arg.Any<CancellationToken>())
+        enumerator.Enumerate("C:\\bundle", Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(_ =>
             {
                 cts.Cancel();
@@ -416,7 +416,7 @@ public sealed class ScenarioLaunchServiceTests
         var phases = new List<ScenarioFolderPhase>();
 
         var result = await service.LaunchFromFolderAsync(
-            scenario, dateWindow: null, cts.Token, phase => { phases.Add(phase); return Task.CompletedTask; });
+            scenario, dateWindow: null, cancellationToken: cts.Token, onPhase: phase => { phases.Add(phase); return Task.CompletedTask; });
 
         // Scanning is emitted before enumeration, so a mid-scan cancellation leaves it already reported; Opening is not.
         Assert.Equal(ScenarioFolderOutcome.Cancelled, result.Outcome);
@@ -432,7 +432,7 @@ public sealed class ScenarioLaunchServiceTests
 
         // The enumerator observes cancellation mid-scan and returns a normal (non-throwing) Empty result; the service must
         // re-check the token after the off-thread enumeration and report Cancelled instead of opening logs or alerting.
-        enumerator.EnumerateTopLevel("C:\\bundle", Arg.Any<CancellationToken>())
+        enumerator.Enumerate("C:\\bundle", Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(_ =>
             {
                 cts.Cancel();
@@ -440,7 +440,7 @@ public sealed class ScenarioLaunchServiceTests
                 return EvtxFolderScanResult.Empty.Instance;
             });
 
-        var result = await service.LaunchFromFolderAsync(scenario, dateWindow: null, cts.Token);
+        var result = await service.LaunchFromFolderAsync(scenario, dateWindow: null, cancellationToken: cts.Token);
 
         Assert.Equal(ScenarioFolderOutcome.Cancelled, result.Outcome);
         await menu.DidNotReceive().OpenLogFilesAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<bool>());
@@ -453,7 +453,7 @@ public sealed class ScenarioLaunchServiceTests
         var (service, dispatcher, menu, picker, enumerator, reader, scenario) = CreateFolder(FolderScenario());
         using var cts = new CancellationTokenSource();
         picker.PickFolderAsync().Returns("C:\\bundle");
-        enumerator.EnumerateTopLevel("C:\\bundle", Arg.Any<CancellationToken>())
+        enumerator.Enumerate("C:\\bundle", Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(new EvtxFolderScanResult.Files(["C:\\bundle\\System.evtx"]));
 
         // The per-file probe observes cancellation as it completes; the parallel loop still produces a match, so the
@@ -465,7 +465,7 @@ public sealed class ScenarioLaunchServiceTests
             return EvtxChannelReadResult.FromChannel("System");
         });
 
-        var result = await service.LaunchFromFolderAsync(scenario, dateWindow: null, cts.Token);
+        var result = await service.LaunchFromFolderAsync(scenario, dateWindow: null, cancellationToken: cts.Token);
 
         Assert.Equal(ScenarioFolderOutcome.Cancelled, result.Outcome);
         await menu.DidNotReceive().OpenLogFilesAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<bool>());
@@ -479,10 +479,10 @@ public sealed class ScenarioLaunchServiceTests
         using var cts = new CancellationTokenSource();
         cts.Cancel();
         picker.PickFolderAsync().Returns("C:\\bundle");
-        enumerator.EnumerateTopLevel("C:\\bundle", Arg.Any<CancellationToken>())
+        enumerator.Enumerate("C:\\bundle", Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(new EvtxFolderScanResult.Files(["C:\\bundle\\System.evtx"]));
 
-        var result = await service.LaunchFromFolderAsync(scenario, dateWindow: null, cts.Token);
+        var result = await service.LaunchFromFolderAsync(scenario, dateWindow: null, cancellationToken: cts.Token);
 
         Assert.Equal(ScenarioFolderOutcome.Cancelled, result.Outcome);
         await menu.DidNotReceive().OpenLogFilesAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<bool>());
@@ -494,13 +494,13 @@ public sealed class ScenarioLaunchServiceTests
     {
         var (service, _, menu, picker, enumerator, reader, scenario) = CreateFolder(FolderScenario());
         picker.PickFolderAsync().Returns("C:\\bundle");
-        enumerator.EnumerateTopLevel("C:\\bundle", Arg.Any<CancellationToken>())
+        enumerator.Enumerate("C:\\bundle", Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(new EvtxFolderScanResult.Files(["C:\\bundle\\System.evtx", "C:\\bundle\\bad.evtx"]));
         reader.ReadChannel("C:\\bundle\\System.evtx").Returns(EvtxChannelReadResult.FromChannel("System"));
         reader.ReadChannel("C:\\bundle\\bad.evtx").Returns(EvtxChannelReadResult.Unreadable);
         menu.OpenLogFilesAsync(Arg.Any<IEnumerable<string>>(), false, false).Returns(new OpenLogsBatchResult(1, 0, 0, 0, []));
 
-        var result = await service.LaunchFromFolderAsync(scenario, dateWindow: null, TestContext.Current.CancellationToken);
+        var result = await service.LaunchFromFolderAsync(scenario, dateWindow: null, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(ScenarioFolderOutcome.Completed, result.Outcome);
         Assert.Equal(1, result.Matched);
@@ -512,9 +512,9 @@ public sealed class ScenarioLaunchServiceTests
     {
         var (service, _, menu, picker, enumerator, _, scenario) = CreateFolder(FolderScenario());
         picker.PickFolderAsync().Returns("C:\\bundle");
-        enumerator.EnumerateTopLevel("C:\\bundle", Arg.Any<CancellationToken>()).Returns(EvtxFolderScanResult.Empty.Instance);
+        enumerator.Enumerate("C:\\bundle", Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(EvtxFolderScanResult.Empty.Instance);
 
-        var result = await service.LaunchFromFolderAsync(scenario, dateWindow: null, TestContext.Current.CancellationToken);
+        var result = await service.LaunchFromFolderAsync(scenario, dateWindow: null, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(ScenarioFolderOutcome.NoMatchingLogs, result.Outcome);
         await menu.DidNotReceive().OpenLogFilesAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<bool>(), Arg.Any<bool>());
@@ -525,12 +525,25 @@ public sealed class ScenarioLaunchServiceTests
     {
         var (service, _, _, picker, enumerator, _, scenario) = CreateFolder(FolderScenario());
         picker.PickFolderAsync().Returns("C:\\bundle");
-        enumerator.EnumerateTopLevel("C:\\bundle", Arg.Any<CancellationToken>()).Returns(new EvtxFolderScanResult.AccessDenied("access denied"));
+        enumerator.Enumerate("C:\\bundle", Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(new EvtxFolderScanResult.AccessDenied("access denied"));
 
-        var result = await service.LaunchFromFolderAsync(scenario, dateWindow: null, TestContext.Current.CancellationToken);
+        var result = await service.LaunchFromFolderAsync(scenario, dateWindow: null, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(ScenarioFolderOutcome.Error, result.Outcome);
         Assert.Equal("access denied", result.Message);
+    }
+
+    [Fact]
+    public async Task LaunchFromFolderAsync_ForwardsIncludeSubfoldersToEnumerator()
+    {
+        var (service, _, _, picker, enumerator, _, scenario) = CreateFolder(FolderScenario());
+        picker.PickFolderAsync().Returns("C:\\bundle");
+        enumerator.Enumerate("C:\\bundle", true, Arg.Any<CancellationToken>()).Returns(EvtxFolderScanResult.Empty.Instance);
+
+        await service.LaunchFromFolderAsync(
+            scenario, dateWindow: null, includeSubfolders: true, cancellationToken: TestContext.Current.CancellationToken);
+
+        enumerator.Received(1).Enumerate("C:\\bundle", true, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -538,11 +551,11 @@ public sealed class ScenarioLaunchServiceTests
     {
         var (service, dispatcher, menu, picker, enumerator, reader, scenario) = CreateFolder(FolderScenario());
         picker.PickFolderAsync().Returns("C:\\bundle");
-        enumerator.EnumerateTopLevel("C:\\bundle", Arg.Any<CancellationToken>()).Returns(new EvtxFolderScanResult.Files(["C:\\bundle\\System.evtx"]));
+        enumerator.Enumerate("C:\\bundle", Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(new EvtxFolderScanResult.Files(["C:\\bundle\\System.evtx"]));
         reader.ReadChannel("C:\\bundle\\System.evtx").Returns(EvtxChannelReadResult.FromChannel("System"));
         menu.OpenLogFilesAsync(Arg.Any<IEnumerable<string>>(), false, false).Returns(new OpenLogsBatchResult(1, 0, 0, 0, []));
 
-        var result = await service.LaunchFromFolderAsync(scenario, dateWindow: null, TestContext.Current.CancellationToken);
+        var result = await service.LaunchFromFolderAsync(scenario, dateWindow: null, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(ScenarioFolderOutcome.Completed, result.Outcome);
         Assert.Equal(1, result.Opened);
@@ -565,11 +578,11 @@ public sealed class ScenarioLaunchServiceTests
     {
         var (service, dispatcher, menu, picker, enumerator, reader, scenario) = CreateFolder(FolderScenario());
         picker.PickFolderAsync().Returns("C:\\bundle");
-        enumerator.EnumerateTopLevel("C:\\bundle", Arg.Any<CancellationToken>()).Returns(new EvtxFolderScanResult.Files(["C:\\bundle\\System.evtx"]));
+        enumerator.Enumerate("C:\\bundle", Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(new EvtxFolderScanResult.Files(["C:\\bundle\\System.evtx"]));
         reader.ReadChannel("C:\\bundle\\System.evtx").Returns(EvtxChannelReadResult.FromChannel("System"));
         menu.OpenLogFilesAsync(Arg.Any<IEnumerable<string>>(), false, false).Returns(new OpenLogsBatchResult(0, 1, 0, 0, []));
 
-        var result = await service.LaunchFromFolderAsync(scenario, dateWindow: null, TestContext.Current.CancellationToken);
+        var result = await service.LaunchFromFolderAsync(scenario, dateWindow: null, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(ScenarioFolderOutcome.NoLogsOpened, result.Outcome);
         Assert.Equal(1, result.Empty);
@@ -582,10 +595,10 @@ public sealed class ScenarioLaunchServiceTests
     {
         var (service, _, menu, picker, enumerator, reader, scenario) = CreateFolder(FolderScenario());
         picker.PickFolderAsync().Returns("C:\\bundle");
-        enumerator.EnumerateTopLevel("C:\\bundle", Arg.Any<CancellationToken>()).Returns(new EvtxFolderScanResult.Files(["C:\\bundle\\other.evtx"]));
+        enumerator.Enumerate("C:\\bundle", Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(new EvtxFolderScanResult.Files(["C:\\bundle\\other.evtx"]));
         reader.ReadChannel("C:\\bundle\\other.evtx").Returns(EvtxChannelReadResult.FromChannel("Application"));
 
-        var result = await service.LaunchFromFolderAsync(scenario, dateWindow: null, TestContext.Current.CancellationToken);
+        var result = await service.LaunchFromFolderAsync(scenario, dateWindow: null, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(ScenarioFolderOutcome.NoMatchingLogs, result.Outcome);
         Assert.Contains("System", result.MissingChannels);
@@ -597,10 +610,10 @@ public sealed class ScenarioLaunchServiceTests
     {
         var (service, _, _, picker, enumerator, reader, scenario) = CreateFolder(FolderScenario());
         picker.PickFolderAsync().Returns("C:\\bundle");
-        enumerator.EnumerateTopLevel("C:\\bundle", Arg.Any<CancellationToken>()).Returns(new EvtxFolderScanResult.Files(["C:\\bundle\\corrupt.evtx"]));
+        enumerator.Enumerate("C:\\bundle", Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(new EvtxFolderScanResult.Files(["C:\\bundle\\corrupt.evtx"]));
         reader.ReadChannel("C:\\bundle\\corrupt.evtx").Returns(EvtxChannelReadResult.Unreadable);
 
-        var result = await service.LaunchFromFolderAsync(scenario, dateWindow: null, TestContext.Current.CancellationToken);
+        var result = await service.LaunchFromFolderAsync(scenario, dateWindow: null, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(ScenarioFolderOutcome.Error, result.Outcome);
         Assert.Equal(1, result.Unreadable);
@@ -612,7 +625,7 @@ public sealed class ScenarioLaunchServiceTests
         var (service, dispatcher, menu, picker, _, _, scenario) = CreateFolder(FolderScenario());
         picker.PickFolderAsync().Returns((string?)null);
 
-        var result = await service.LaunchFromFolderAsync(scenario, dateWindow: null, TestContext.Current.CancellationToken);
+        var result = await service.LaunchFromFolderAsync(scenario, dateWindow: null, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(ScenarioFolderOutcome.Cancelled, result.Outcome);
         await menu.DidNotReceive().OpenLogFilesAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<bool>(), Arg.Any<bool>());
@@ -625,7 +638,7 @@ public sealed class ScenarioLaunchServiceTests
         var (service, _, _, picker, _, _, scenario) = CreateFolder(FolderScenario());
         picker.PickFolderAsync().ThrowsAsync(new InvalidOperationException("picker boom"));
 
-        var result = await service.LaunchFromFolderAsync(scenario, dateWindow: null, TestContext.Current.CancellationToken);
+        var result = await service.LaunchFromFolderAsync(scenario, dateWindow: null, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(ScenarioFolderOutcome.Error, result.Outcome);
         Assert.Equal("picker boom", result.Message);
@@ -637,7 +650,7 @@ public sealed class ScenarioLaunchServiceTests
         var (service, dispatcher, menu, picker, enumerator, reader, scenario) = CreateFolder(FolderScenario());
         using var cts = new CancellationTokenSource();
         picker.PickFolderAsync().Returns("C:\\bundle");
-        enumerator.EnumerateTopLevel("C:\\bundle", Arg.Any<CancellationToken>()).Returns(new EvtxFolderScanResult.Files(["C:\\bundle\\System.evtx"]));
+        enumerator.Enumerate("C:\\bundle", Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(new EvtxFolderScanResult.Files(["C:\\bundle\\System.evtx"]));
         reader.ReadChannel("C:\\bundle\\System.evtx").Returns(EvtxChannelReadResult.FromChannel("System"));
         menu.OpenLogFilesAsync(Arg.Any<IEnumerable<string>>(), false, false).Returns(new OpenLogsBatchResult(1, 0, 0, 0, []));
 
@@ -646,8 +659,8 @@ public sealed class ScenarioLaunchServiceTests
         var result = await service.LaunchFromFolderAsync(
             scenario,
             dateWindow: null,
-            cts.Token,
-            phase =>
+            cancellationToken: cts.Token,
+            onPhase: phase =>
             {
                 if (phase == ScenarioFolderPhase.Opening) { cts.Cancel(); }
 
@@ -664,12 +677,12 @@ public sealed class ScenarioLaunchServiceTests
     {
         var (service, _, _, picker, enumerator, reader, scenario) = CreateFolder(FolderScenario());
         picker.PickFolderAsync().Returns("C:\\bundle");
-        enumerator.EnumerateTopLevel("C:\\bundle", Arg.Any<CancellationToken>()).Returns(new EvtxFolderScanResult.Files(["C:\\bundle\\other.evtx"]));
+        enumerator.Enumerate("C:\\bundle", Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(new EvtxFolderScanResult.Files(["C:\\bundle\\other.evtx"]));
         reader.ReadChannel("C:\\bundle\\other.evtx").Returns(EvtxChannelReadResult.FromChannel("Application"));
         var phases = new List<ScenarioFolderPhase>();
 
         var result = await service.LaunchFromFolderAsync(
-            scenario, dateWindow: null, TestContext.Current.CancellationToken, phase => { phases.Add(phase); return Task.CompletedTask; });
+            scenario, dateWindow: null, cancellationToken: TestContext.Current.CancellationToken, onPhase: phase => { phases.Add(phase); return Task.CompletedTask; });
 
         // Zero matched paths never open anything, so Opening (gated on a nonempty match) is never reported.
         Assert.Equal(ScenarioFolderOutcome.NoMatchingLogs, result.Outcome);
@@ -684,7 +697,7 @@ public sealed class ScenarioLaunchServiceTests
         var phases = new List<ScenarioFolderPhase>();
 
         await service.LaunchFromFolderAsync(
-            scenario, dateWindow: null, TestContext.Current.CancellationToken, phase => { phases.Add(phase); return Task.CompletedTask; });
+            scenario, dateWindow: null, cancellationToken: TestContext.Current.CancellationToken, onPhase: phase => { phases.Add(phase); return Task.CompletedTask; });
 
         Assert.Empty(phases);
     }
@@ -694,13 +707,13 @@ public sealed class ScenarioLaunchServiceTests
     {
         var (service, _, menu, picker, enumerator, reader, scenario) = CreateFolder(FolderScenario());
         picker.PickFolderAsync().Returns("C:\\bundle");
-        enumerator.EnumerateTopLevel("C:\\bundle", Arg.Any<CancellationToken>()).Returns(new EvtxFolderScanResult.Files(["C:\\bundle\\System.evtx"]));
+        enumerator.Enumerate("C:\\bundle", Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(new EvtxFolderScanResult.Files(["C:\\bundle\\System.evtx"]));
         reader.ReadChannel("C:\\bundle\\System.evtx").Returns(EvtxChannelReadResult.FromChannel("System"));
         menu.OpenLogFilesAsync(Arg.Any<IEnumerable<string>>(), false, false).Returns(new OpenLogsBatchResult(1, 0, 0, 0, []));
         var phases = new List<ScenarioFolderPhase>();
 
         var result = await service.LaunchFromFolderAsync(
-            scenario, dateWindow: null, TestContext.Current.CancellationToken, phase => { phases.Add(phase); return Task.CompletedTask; });
+            scenario, dateWindow: null, cancellationToken: TestContext.Current.CancellationToken, onPhase: phase => { phases.Add(phase); return Task.CompletedTask; });
 
         Assert.Equal(ScenarioFolderOutcome.Completed, result.Outcome);
         Assert.Equal([ScenarioFolderPhase.Scanning, ScenarioFolderPhase.Opening], phases);

--- a/tests/Unit/EventLogExpert.UI.Tests/Dashboard/EmptyStateDashboardTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Dashboard/EmptyStateDashboardTests.cs
@@ -301,9 +301,24 @@ public sealed class EmptyStateDashboardTests : BunitContext
     }
 
     [Fact]
+    public void DetailOpenFromFolder_ByDefault_ScansSubfolders()
+    {
+        _scenarioLaunch.LaunchFromFolderAsync(Arg.Any<ScenarioDefinition>(), Arg.Any<DateFilter?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>(), Arg.Any<Func<ScenarioFolderPhase, Task>?>())
+            .Returns(new ScenarioFolderLaunchResult { Outcome = ScenarioFolderOutcome.Completed, Opened = 1, Matched = 1 });
+        _scenarioQuery.GetSplashScenarios().Returns([Scenario("application-crashes", "Application crashes")]);
+
+        var cut = Render<EmptyStateDashboard>();
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(ActiveDetailOpenFolder)));
+        cut.Find(ActiveDetailOpenFolder).Click();
+
+        cut.WaitForAssertion(() => _scenarioLaunch.Received(1).LaunchFromFolderAsync(
+            Arg.Any<ScenarioDefinition>(), Arg.Any<DateFilter?>(), true, Arg.Any<CancellationToken>(), Arg.Any<Func<ScenarioFolderPhase, Task>?>()));
+    }
+
+    [Fact]
     public void DetailOpenFromFolder_WhenCompleted_AnnouncesWithoutAlert()
     {
-        _scenarioLaunch.LaunchFromFolderAsync(Arg.Any<ScenarioDefinition>(), Arg.Any<DateFilter?>(), Arg.Any<CancellationToken>(), Arg.Any<Func<ScenarioFolderPhase, Task>?>())
+        _scenarioLaunch.LaunchFromFolderAsync(Arg.Any<ScenarioDefinition>(), Arg.Any<DateFilter?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>(), Arg.Any<Func<ScenarioFolderPhase, Task>?>())
             .Returns(new ScenarioFolderLaunchResult { Outcome = ScenarioFolderOutcome.Completed, Opened = 1, Matched = 1 });
         _scenarioQuery.GetSplashScenarios().Returns([Scenario("application-crashes", "Application crashes")]);
 
@@ -322,7 +337,7 @@ public sealed class EmptyStateDashboardTests : BunitContext
     [Fact]
     public void DetailOpenFromFolder_WhenError_ShowsErrorAlert()
     {
-        _scenarioLaunch.LaunchFromFolderAsync(Arg.Any<ScenarioDefinition>(), Arg.Any<DateFilter?>(), Arg.Any<CancellationToken>(), Arg.Any<Func<ScenarioFolderPhase, Task>?>())
+        _scenarioLaunch.LaunchFromFolderAsync(Arg.Any<ScenarioDefinition>(), Arg.Any<DateFilter?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>(), Arg.Any<Func<ScenarioFolderPhase, Task>?>())
             .Returns(ScenarioFolderLaunchResult.Error("access denied"));
         _scenarioQuery.GetSplashScenarios().Returns([Scenario("application-crashes", "Application crashes")]);
 
@@ -337,7 +352,7 @@ public sealed class EmptyStateDashboardTests : BunitContext
     [Fact]
     public void DetailOpenFromFolder_WhenNoMatchingLogs_ShowsVisibleAlert()
     {
-        _scenarioLaunch.LaunchFromFolderAsync(Arg.Any<ScenarioDefinition>(), Arg.Any<DateFilter?>(), Arg.Any<CancellationToken>(), Arg.Any<Func<ScenarioFolderPhase, Task>?>())
+        _scenarioLaunch.LaunchFromFolderAsync(Arg.Any<ScenarioDefinition>(), Arg.Any<DateFilter?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>(), Arg.Any<Func<ScenarioFolderPhase, Task>?>())
             .Returns(new ScenarioFolderLaunchResult { Outcome = ScenarioFolderOutcome.NoMatchingLogs });
         _scenarioQuery.GetSplashScenarios().Returns([Scenario("application-crashes", "Application crashes")]);
 
@@ -347,6 +362,22 @@ public sealed class EmptyStateDashboardTests : BunitContext
         cut.Find(ActiveDetailOpenFolder).Click();
 
         cut.WaitForAssertion(() => _alertDialog.Received(1).ShowAlert("Open from folder", Arg.Any<string>(), "OK"));
+    }
+
+    [Fact]
+    public void DetailOpenFromFolder_WhenSubfoldersUnchecked_ScansTopLevelOnly()
+    {
+        _scenarioLaunch.LaunchFromFolderAsync(Arg.Any<ScenarioDefinition>(), Arg.Any<DateFilter?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>(), Arg.Any<Func<ScenarioFolderPhase, Task>?>())
+            .Returns(new ScenarioFolderLaunchResult { Outcome = ScenarioFolderOutcome.Completed, Opened = 1, Matched = 1 });
+        _scenarioQuery.GetSplashScenarios().Returns([Scenario("application-crashes", "Application crashes")]);
+
+        var cut = Render<EmptyStateDashboard>();
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(ActiveDetailOpenFolder)));
+        cut.Find(".sidebar-tabs-tabpanel.active .scenario-detail__subfolders input").Change(false);
+        cut.Find(ActiveDetailOpenFolder).Click();
+
+        cut.WaitForAssertion(() => _scenarioLaunch.Received(1).LaunchFromFolderAsync(
+            Arg.Any<ScenarioDefinition>(), Arg.Any<DateFilter?>(), false, Arg.Any<CancellationToken>(), Arg.Any<Func<ScenarioFolderPhase, Task>?>()));
     }
 
     [Fact]
@@ -492,7 +523,7 @@ public sealed class EmptyStateDashboardTests : BunitContext
         var release = new TaskCompletionSource<ScenarioFolderLaunchResult>();
         CancellationToken captured = default;
         _scenarioLaunch
-            .LaunchFromFolderAsync(Arg.Any<ScenarioDefinition>(), Arg.Any<DateFilter?>(), Arg.Any<CancellationToken>(), Arg.Any<Func<ScenarioFolderPhase, Task>?>())
+            .LaunchFromFolderAsync(Arg.Any<ScenarioDefinition>(), Arg.Any<DateFilter?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>(), Arg.Any<Func<ScenarioFolderPhase, Task>?>())
             .Returns(async ci =>
             {
                 captured = ci.Arg<CancellationToken>();
@@ -544,7 +575,7 @@ public sealed class EmptyStateDashboardTests : BunitContext
         var pickerGate = new TaskCompletionSource();
         var release = new TaskCompletionSource<ScenarioFolderLaunchResult>();
         _scenarioLaunch
-            .LaunchFromFolderAsync(Arg.Any<ScenarioDefinition>(), Arg.Any<DateFilter?>(), Arg.Any<CancellationToken>(), Arg.Any<Func<ScenarioFolderPhase, Task>?>())
+            .LaunchFromFolderAsync(Arg.Any<ScenarioDefinition>(), Arg.Any<DateFilter?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>(), Arg.Any<Func<ScenarioFolderPhase, Task>?>())
             .Returns(async ci =>
             {
                 await pickerGate.Task;
@@ -590,7 +621,7 @@ public sealed class EmptyStateDashboardTests : BunitContext
     {
         var release = new TaskCompletionSource<ScenarioFolderLaunchResult>();
         _scenarioLaunch
-            .LaunchFromFolderAsync(Arg.Any<ScenarioDefinition>(), Arg.Any<DateFilter?>(), Arg.Any<CancellationToken>(), Arg.Any<Func<ScenarioFolderPhase, Task>?>())
+            .LaunchFromFolderAsync(Arg.Any<ScenarioDefinition>(), Arg.Any<DateFilter?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>(), Arg.Any<Func<ScenarioFolderPhase, Task>?>())
             .Returns(async ci =>
             {
                 var onPhase = ci.Arg<Func<ScenarioFolderPhase, Task>>()!;
@@ -620,7 +651,7 @@ public sealed class EmptyStateDashboardTests : BunitContext
     {
         var release = new TaskCompletionSource<ScenarioFolderLaunchResult>();
         _scenarioLaunch
-            .LaunchFromFolderAsync(Arg.Any<ScenarioDefinition>(), Arg.Any<DateFilter?>(), Arg.Any<CancellationToken>(), Arg.Any<Func<ScenarioFolderPhase, Task>?>())
+            .LaunchFromFolderAsync(Arg.Any<ScenarioDefinition>(), Arg.Any<DateFilter?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>(), Arg.Any<Func<ScenarioFolderPhase, Task>?>())
             .Returns(async ci =>
             {
                 await ci.Arg<Func<ScenarioFolderPhase, Task>>()!(ScenarioFolderPhase.Scanning);
@@ -651,7 +682,7 @@ public sealed class EmptyStateDashboardTests : BunitContext
     {
         var release = new TaskCompletionSource<ScenarioFolderLaunchResult>();
         _scenarioLaunch
-            .LaunchFromFolderAsync(Arg.Any<ScenarioDefinition>(), Arg.Any<DateFilter?>(), Arg.Any<CancellationToken>(), Arg.Any<Func<ScenarioFolderPhase, Task>?>())
+            .LaunchFromFolderAsync(Arg.Any<ScenarioDefinition>(), Arg.Any<DateFilter?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>(), Arg.Any<Func<ScenarioFolderPhase, Task>?>())
             .Returns(async ci =>
             {
                 await ci.Arg<Func<ScenarioFolderPhase, Task>>()!(ScenarioFolderPhase.Scanning);
@@ -700,6 +731,114 @@ public sealed class EmptyStateDashboardTests : BunitContext
         var cut = Render<EmptyStateDashboard>();
 
         Assert.NotEmpty(cut.FindAll(".empty-dashboard__brand-mark .bi-journal-text"));
+    }
+
+    [Fact]
+    public void OpenFolder_ByDefault_ScansSubfolders()
+    {
+        _actions.OpenFolderAsync(Arg.Is(false), Arg.Any<bool>(), Arg.Any<CancellationToken>(), Arg.Any<Func<FolderOpenPhase, Task>?>())
+            .Returns(Task.CompletedTask);
+
+        var cut = Render<EmptyStateDashboard>();
+        FindLaunch(cut, "Open Folder...").Click();
+
+        cut.WaitForAssertion(() => _actions.Received(1).OpenFolderAsync(
+            false, true, Arg.Any<CancellationToken>(), Arg.Any<Func<FolderOpenPhase, Task>?>()));
+    }
+
+    [Fact]
+    public void OpenFolder_WhenCancelClicked_CancelsTokenAndShowsCancelling()
+    {
+        var release = new TaskCompletionSource();
+        CancellationToken captured = default;
+        _actions.OpenFolderAsync(Arg.Is(false), Arg.Any<bool>(), Arg.Any<CancellationToken>(), Arg.Any<Func<FolderOpenPhase, Task>?>())
+            .Returns(async ci =>
+            {
+                captured = ci.Arg<CancellationToken>();
+                await ci.Arg<Func<FolderOpenPhase, Task>>()!(FolderOpenPhase.Scanning);
+                await release.Task;
+            });
+
+        var cut = Render<EmptyStateDashboard>();
+        FindLaunch(cut, "Open Folder...").Click();
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".empty-dashboard__chip--scanning button")));
+
+        cut.Find(".empty-dashboard__chip--scanning button").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Cancelling", cut.Find(".empty-dashboard__chip--scanning").TextContent);
+            Assert.Empty(cut.FindAll(".empty-dashboard__chip--scanning button"));
+        });
+        Assert.True(captured.IsCancellationRequested);
+
+        release.SetResult();
+    }
+
+    [Fact]
+    public void OpenFolder_WhenOpeningPhase_RelabelsAndDropsCancel()
+    {
+        var release = new TaskCompletionSource();
+        _actions.OpenFolderAsync(Arg.Is(false), Arg.Any<bool>(), Arg.Any<CancellationToken>(), Arg.Any<Func<FolderOpenPhase, Task>?>())
+            .Returns(async ci =>
+            {
+                var onPhase = ci.Arg<Func<FolderOpenPhase, Task>>()!;
+                await onPhase(FolderOpenPhase.Scanning);
+                await onPhase(FolderOpenPhase.Opening);
+                await release.Task;
+            });
+
+        var cut = Render<EmptyStateDashboard>();
+        FindLaunch(cut, "Open Folder...").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            var chip = cut.Find(".empty-dashboard__chip--scanning");
+            Assert.Contains("Opening logs", chip.TextContent);
+            Assert.Empty(cut.FindAll(".empty-dashboard__chip--scanning button"));
+        });
+
+        release.SetResult();
+    }
+
+    [Fact]
+    public void OpenFolder_WhenScanning_ShowsGenericScanChipWithCancel()
+    {
+        var release = new TaskCompletionSource();
+        _actions.OpenFolderAsync(Arg.Is(false), Arg.Any<bool>(), Arg.Any<CancellationToken>(), Arg.Any<Func<FolderOpenPhase, Task>?>())
+            .Returns(async ci =>
+            {
+                await ci.Arg<Func<FolderOpenPhase, Task>>()!(FolderOpenPhase.Scanning);
+                await release.Task;
+            });
+
+        var cut = Render<EmptyStateDashboard>();
+        FindLaunch(cut, "Open Folder...").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            var chip = cut.Find(".empty-dashboard__chip--scanning");
+            Assert.Contains("Scanning folder for logs", chip.TextContent);
+            Assert.NotEmpty(cut.FindAll(".empty-dashboard__chip--scanning button"));
+        });
+
+        release.SetResult();
+        cut.WaitForAssertion(() => Assert.Empty(cut.FindAll(".empty-dashboard__chip--scanning")));
+    }
+
+    [Fact]
+    public void OpenFolder_WhenSubfoldersUnchecked_ScansTopLevelOnly()
+    {
+        _actions.OpenFolderAsync(Arg.Is(false), Arg.Any<bool>(), Arg.Any<CancellationToken>(), Arg.Any<Func<FolderOpenPhase, Task>?>())
+            .Returns(Task.CompletedTask);
+
+        var cut = Render<EmptyStateDashboard>();
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".empty-dashboard__empty")));
+        cut.Find(".empty-dashboard__subfolders input").Change(false);
+        FindLaunch(cut, "Open Folder...").Click();
+
+        cut.WaitForAssertion(() => _actions.Received(1).OpenFolderAsync(
+            false, false, Arg.Any<CancellationToken>(), Arg.Any<Func<FolderOpenPhase, Task>?>()));
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.UI.Tests/Dashboard/ScenarioDetailTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Dashboard/ScenarioDetailTests.cs
@@ -379,7 +379,7 @@ public sealed class ScenarioDetailTests : BunitContext
 
         var cut = Render<ScenarioDetail>(parameters => parameters
             .Add(detail => detail.Scenario, Scenario("application-crashes", "Application crashes"))
-            .Add(detail => detail.OnLaunchFromFolder, () => launched = true));
+            .Add(detail => detail.OnLaunchFromFolder, _ => launched = true));
 
         cut.Find(".scenario-detail__open-folder").Click();
 
@@ -397,7 +397,7 @@ public sealed class ScenarioDetailTests : BunitContext
             .Add(detail => detail.Scenario, Scenario("application-crashes", "Application crashes"))
             .Add(detail => detail.IsDisabled, true)
             .Add(detail => detail.IsLivePresent, false)
-            .Add(detail => detail.OnLaunchFromFolder, () => launched = true));
+            .Add(detail => detail.OnLaunchFromFolder, _ => launched = true));
 
         var folder = cut.Find(".scenario-detail__open-folder");
 

--- a/tests/Unit/EventLogExpert.Windows.Tests/EvtxFolderEnumeratorTests.cs
+++ b/tests/Unit/EventLogExpert.Windows.Tests/EvtxFolderEnumeratorTests.cs
@@ -18,14 +18,14 @@ public sealed class EvtxFolderEnumeratorTests : IDisposable
     }
 
     [Fact]
-    public void EnumerateTopLevel_DoesNotRecurseIntoSubfolders()
+    public void EnumerateEvtx_DoesNotRecurseIntoSubfolders()
     {
         var sub = Path.Combine(_tempRoot, "sub");
         Directory.CreateDirectory(sub);
         EvtxFolderFixtures.WriteEmptyFile(sub, "nested.evtx");
         EvtxFolderFixtures.WriteEmptyFile(_tempRoot, "top.evtx");
 
-        var result = EvtxFolderEnumerator.EnumerateEvtxTopLevel(_tempRoot, TestContext.Current.CancellationToken);
+        var result = EvtxFolderEnumerator.EnumerateEvtx(_tempRoot, includeSubfolders: false, TestContext.Current.CancellationToken);
 
         var success = Assert.IsType<EvtxEnumerationResult.Success>(result);
         Assert.Single(success.Files);
@@ -33,22 +33,22 @@ public sealed class EvtxFolderEnumeratorTests : IDisposable
     }
 
     [Fact]
-    public void EnumerateTopLevel_OnEmptyFolder_ReturnsEmptyVariant()
+    public void EnumerateEvtx_OnEmptyFolder_ReturnsEmptyVariant()
     {
-        var result = EvtxFolderEnumerator.EnumerateEvtxTopLevel(_tempRoot, TestContext.Current.CancellationToken);
+        var result = EvtxFolderEnumerator.EnumerateEvtx(_tempRoot, includeSubfolders: false, TestContext.Current.CancellationToken);
 
         Assert.IsType<EvtxEnumerationResult.Empty>(result);
     }
 
     [Fact]
-    public void EnumerateTopLevel_OnFolderWithEvtxAndOtherFiles_ReturnsOnlyEvtx()
+    public void EnumerateEvtx_OnFolderWithEvtxAndOtherFiles_ReturnsOnlyEvtx()
     {
         EvtxFolderFixtures.WriteEmptyFile(_tempRoot, "a.evtx");
         EvtxFolderFixtures.WriteEmptyFile(_tempRoot, "b.evtx");
         EvtxFolderFixtures.WriteEmptyFile(_tempRoot, "ignored.txt");
         EvtxFolderFixtures.WriteEmptyFile(_tempRoot, "ignored.log");
 
-        var result = EvtxFolderEnumerator.EnumerateEvtxTopLevel(_tempRoot, TestContext.Current.CancellationToken);
+        var result = EvtxFolderEnumerator.EnumerateEvtx(_tempRoot, includeSubfolders: false, TestContext.Current.CancellationToken);
 
         var success = Assert.IsType<EvtxEnumerationResult.Success>(result);
         Assert.Equal(2, success.Files.Count);
@@ -56,7 +56,7 @@ public sealed class EvtxFolderEnumeratorTests : IDisposable
     }
 
     [Fact]
-    public void EnumerateTopLevel_OnLongPathBeyondMax_StillReturnsEvtxFiles()
+    public void EnumerateEvtx_OnLongPathBeyondMax_StillReturnsEvtxFiles()
     {
         // Uses the \\?\ prefix to bypass the test process's MAX_PATH limit during setup; the
         // prefix is the cross-process portable long-path mechanism on Windows. The packaged
@@ -70,7 +70,7 @@ public sealed class EvtxFolderEnumeratorTests : IDisposable
         Directory.CreateDirectory(longPathPrefixed);
         EvtxFolderFixtures.WriteEmptyFile(longPathPrefixed, "longpath.evtx");
 
-        var result = EvtxFolderEnumerator.EnumerateEvtxTopLevel(longPathPrefixed, TestContext.Current.CancellationToken);
+        var result = EvtxFolderEnumerator.EnumerateEvtx(longPathPrefixed, includeSubfolders: false, TestContext.Current.CancellationToken);
 
         var success = Assert.IsType<EvtxEnumerationResult.Success>(result);
         Assert.Single(success.Files);
@@ -78,37 +78,54 @@ public sealed class EvtxFolderEnumeratorTests : IDisposable
     }
 
     [Fact]
-    public void EnumerateTopLevel_OnNonexistentFolder_ReturnsIoErrorVariant()
+    public void EnumerateEvtx_OnNonexistentFolder_ReturnsIoErrorVariant()
     {
         var nonexistent = Path.Combine(_tempRoot, "does-not-exist");
 
-        var result = EvtxFolderEnumerator.EnumerateEvtxTopLevel(nonexistent, TestContext.Current.CancellationToken);
+        var result = EvtxFolderEnumerator.EnumerateEvtx(nonexistent, includeSubfolders: false, TestContext.Current.CancellationToken);
 
         Assert.IsType<EvtxEnumerationResult.IoError>(result);
     }
 
     [Fact]
-    public void EnumerateTopLevel_RejectsNullOrWhitespace()
+    public void EnumerateEvtx_RejectsNullOrWhitespace()
     {
-        Assert.Throws<ArgumentException>(() => EvtxFolderEnumerator.EnumerateEvtxTopLevel("", TestContext.Current.CancellationToken));
-        Assert.Throws<ArgumentException>(() => EvtxFolderEnumerator.EnumerateEvtxTopLevel("   ", TestContext.Current.CancellationToken));
+        Assert.Throws<ArgumentException>(() => EvtxFolderEnumerator.EnumerateEvtx("", includeSubfolders: false, TestContext.Current.CancellationToken));
+        Assert.Throws<ArgumentException>(() => EvtxFolderEnumerator.EnumerateEvtx("   ", includeSubfolders: false, TestContext.Current.CancellationToken));
     }
 
     [Fact]
-    public void EnumerateTopLevel_WithCancelledToken_ThrowsOperationCanceled()
+    public void EnumerateEvtx_WithCancelledToken_ThrowsOperationCanceled()
     {
         EvtxFolderFixtures.WriteEmptyFile(_tempRoot, "a.evtx");
         using var cts = new CancellationTokenSource();
         cts.Cancel();
 
         Assert.Throws<OperationCanceledException>(
-            () => EvtxFolderEnumerator.EnumerateEvtxTopLevel(_tempRoot, cts.Token));
+            () => EvtxFolderEnumerator.EnumerateEvtx(_tempRoot, includeSubfolders: false, cts.Token));
+    }
+
+    [Fact]
+    public void EnumerateEvtx_WithSubfolders_ReturnsNestedAndTopLevelEvtx()
+    {
+        var nested = Path.Combine(_tempRoot, "sub", "deeper");
+        Directory.CreateDirectory(nested);
+        EvtxFolderFixtures.WriteEmptyFile(nested, "nested.evtx");
+        EvtxFolderFixtures.WriteEmptyFile(_tempRoot, "top.evtx");
+        EvtxFolderFixtures.WriteEmptyFile(_tempRoot, "ignored.txt");
+
+        var result = EvtxFolderEnumerator.EnumerateEvtx(_tempRoot, includeSubfolders: true, TestContext.Current.CancellationToken);
+
+        var success = Assert.IsType<EvtxEnumerationResult.Success>(result);
+        Assert.Equal(2, success.Files.Count);
+        Assert.Contains(success.Files, file => file.EndsWith("top.evtx", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(success.Files, file => file.EndsWith("nested.evtx", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
     public void ToAlertCopy_OnEmpty_ReturnsNull()
     {
-        var result = EvtxFolderEnumerator.EnumerateEvtxTopLevel(_tempRoot, TestContext.Current.CancellationToken);
+        var result = EvtxFolderEnumerator.EnumerateEvtx(_tempRoot, includeSubfolders: false, TestContext.Current.CancellationToken);
 
         Assert.Null(EvtxFolderEnumerator.ToAlertCopy(result));
     }
@@ -117,7 +134,7 @@ public sealed class EvtxFolderEnumeratorTests : IDisposable
     public void ToAlertCopy_OnSuccess_ReturnsNull()
     {
         EvtxFolderFixtures.WriteEmptyFile(_tempRoot, "a.evtx");
-        var result = EvtxFolderEnumerator.EnumerateEvtxTopLevel(_tempRoot, TestContext.Current.CancellationToken);
+        var result = EvtxFolderEnumerator.EnumerateEvtx(_tempRoot, includeSubfolders: false, TestContext.Current.CancellationToken);
 
         Assert.Null(EvtxFolderEnumerator.ToAlertCopy(result));
     }


### PR DESCRIPTION
## Problem
On the start page, the Quick Launch **Folder...** button and **Open > Folder** menu ran folder enumeration synchronously on the UI thread with no progress, so the UI froze with no indication anything was happening. (The per-scenario "Open from folder" path already ran in the background with a progress chip.)

## Changes
- **No freeze + visible progress.** `MauiMenuActionService.OpenFolderAsync` now enumerates on a background thread and reports Scanning/Opening phases; the dashboard shows a cancellable progress chip, with cancellation re-checks and a guard so concurrent menu-initiated scans do not clobber each other.
- **Subfolder scanning, on by default (opt-out).** Comparable forensic tooling (Hayabusa, Chainsaw, Velociraptor) recurses by default, and KAPE/triage output nests logs under `...\Windows\System32\winevt\Logs`, so top-level-only would load zero files. Surfaces: an **Include subfolders** checkbox (checked) next to the dashboard **Folder...** button and each scenario **Open from folder**, plus a **Folder (top level only)** menu item. Activation (drag-drop, "Open with", CLI) intentionally stays top-level.
- **Robust recursive enumerator.** Explicit stack walk that surfaces failures reading the selected root, skips descendants it cannot read, does not follow reparse points (junctions/symlinks), preserves the previous top-level matching semantics, and honors cancellation.
- Docs (`Opening-Logs.md`), scoped CSS, and tests updated.

## Testing
Unit tests pass (UI 1457, Runtime 2447, Windows 48); MAUI head builds with 0 warnings / 0 errors. New tests cover recursive enumeration, the plain-open progress chip (scanning/opening/cancel), and both the default-recurse and top-level-only toggles.
