### PR TITLE
Fix classic event resolution for driver .sys message tables

### DIFF
--- a/src/EventLogExpert.Eventing.OfflineImaging/Extraction/OfflineLegacyMessageFileResolver.cs
+++ b/src/EventLogExpert.Eventing.OfflineImaging/Extraction/OfflineLegacyMessageFileResolver.cs
@@ -13,8 +13,6 @@ internal sealed class OfflineLegacyMessageFileResolver(
     OfflineImagePathResolver pathResolver,
     ITraceLogger? logger) : ILegacyMessageFileResolver
 {
-    private static readonly string[] s_supportedExtensions = [".dll", ".exe"];
-
     public IReadOnlyList<string> EnumerateProviderNames()
     {
         using IOfflineRegistryKey? eventLogKey = OpenEventLogKey();
@@ -116,11 +114,7 @@ internal sealed class OfflineLegacyMessageFileResolver(
 
     private IReadOnlyList<string> ResolveProviderFiles(string eventMessageFile, string? categoryMessageFile)
     {
-        // Filter raw registrations to .dll/.exe because some providers register .sys drivers that must not be loaded.
-        var messageFiles = eventMessageFile
-            .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .Where(path => s_supportedExtensions.Contains(Path.GetExtension(path).ToLowerInvariant()))
-            .ToList();
+        IReadOnlyList<string> messageFiles = LegacyMessageFilePaths.GetSupportedModulePaths(eventMessageFile);
 
         var orderedRawFiles = new List<string>();
 
@@ -128,18 +122,22 @@ internal sealed class OfflineLegacyMessageFileResolver(
         if (categoryMessageFile is not null)
         {
             orderedRawFiles.Add(categoryMessageFile);
-            orderedRawFiles.AddRange(messageFiles.Where(path => !string.Equals(path, categoryMessageFile, StringComparison.Ordinal)));
-        }
-        else
-        {
-            orderedRawFiles.AddRange(messageFiles);
         }
 
+        orderedRawFiles.AddRange(messageFiles);
+
+        // De-duplicate on the resolved image-local path: distinct raw registrations (category vs event-message-file,
+        // or %SystemRoot% vs an absolute path) can map to the same file, and loading it twice would feed duplicate
+        // messages into disambiguation.
         var resolved = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (string rawFile in orderedRawFiles)
         {
-            if (pathResolver.Resolve(rawFile, "legacy message file") is { } file) { resolved.Add(file); }
+            if (pathResolver.Resolve(rawFile, "legacy message file") is { } file && seen.Add(file))
+            {
+                resolved.Add(file);
+            }
         }
 
         return resolved;

--- a/src/EventLogExpert.Eventing/ProviderMetadata/LegacyMessageFilePaths.cs
+++ b/src/EventLogExpert.Eventing/ProviderMetadata/LegacyMessageFilePaths.cs
@@ -1,0 +1,24 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Collections.Frozen;
+
+namespace EventLogExpert.Eventing.ProviderMetadata;
+
+public static class LegacyMessageFilePaths
+{
+    private static readonly FrozenSet<string> s_supportedExtensions =
+        new[] { ".dll", ".exe", ".sys" }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+    public static IReadOnlyList<string> GetSupportedModulePaths(string messageFileValue)
+    {
+        ArgumentNullException.ThrowIfNull(messageFileValue);
+
+        return
+        [
+            .. messageFileValue
+                .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Where(path => s_supportedExtensions.Contains(Path.GetExtension(path)))
+        ];
+    }
+}

--- a/src/EventLogExpert.Eventing/ProviderMetadata/MessageTableReader.cs
+++ b/src/EventLogExpert.Eventing/ProviderMetadata/MessageTableReader.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 namespace EventLogExpert.Eventing.ProviderMetadata;
 
 /// <summary>
-///     Reads a provider DLL's RT_MESSAGETABLE. Every walk is bounds-checked against the resource size from
+///     Reads a provider module's (DLL/EXE/SYS) RT_MESSAGETABLE. Every walk is bounds-checked against the resource size from
 ///     <see cref="NativeMethods.SizeofResource" /> so a malformed offset/length can never read outside the mapped
 ///     resource: CountEntries returns -1 when the table is malformed anywhere (callers treat it as no table), while
 ///     per-id extraction stops at the first malformed region and returns only the matches from the well-formed prefix,

--- a/src/EventLogExpert.Eventing/ProviderMetadata/RegistryProvider.cs
+++ b/src/EventLogExpert.Eventing/ProviderMetadata/RegistryProvider.cs
@@ -54,28 +54,28 @@ internal sealed class RegistryProvider(ITraceLogger? logger = null) : ILegacyMes
             _logger?.Debug(
                 $"Found message file for legacy provider {providerName} in subkey {providerSubKey.Name}. EventMessageFile={eventMessageFilePath}, CategoryMessageFile={categoryMessageFilePath ?? "<null>"}, ParameterMessageFile={parameterMessageFilePath ?? "<null>"}.");
 
-            // Loading FltMgr's .sys EventMessageFile causes an access violation; only datafile DLL/EXE loads are safe.
-            var supportedExtensions = new[] { ".dll", ".exe" };
+            IReadOnlyList<string> messageFiles = LegacyMessageFilePaths.GetSupportedModulePaths(eventMessageFilePath);
 
-            var messageFiles = eventMessageFilePath
-                .Split(';')
-                .Where(path => supportedExtensions.Contains(Path.GetExtension(path).ToLower()))
-                .ToList();
+            var orderedFiles = new List<string>(messageFiles.Count + 1);
 
-            IEnumerable<string> files;
+            if (categoryMessageFilePath is not null) { orderedFiles.Add(categoryMessageFilePath); }
 
-            if (categoryMessageFilePath is not null)
+            orderedFiles.AddRange(messageFiles);
+
+            // Expand first, then de-duplicate on the resolved path: the same module can appear as both the category and
+            // an event-message-file entry, or via %SystemRoot% vs an absolute path, and loading it twice would feed
+            // duplicate messages into disambiguation.
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var result = new List<string>(orderedFiles.Count);
+
+            for (int i = 0; i < orderedFiles.Count; i++)
             {
-                var fileList = new List<string> { categoryMessageFilePath };
-                fileList.AddRange(messageFiles.Where(f => f != categoryMessageFilePath));
-                files = fileList;
-            }
-            else
-            {
-                files = messageFiles;
+                string file = Environment.ExpandEnvironmentVariables(orderedFiles[i]);
+
+                if (seen.Add(file)) { result.Add(file); }
             }
 
-            return files.Select(Environment.ExpandEnvironmentVariables).ToList();
+            return result;
         }
 
         _logger?.Debug($"No legacy EventMessageFile found for provider {providerName}");

--- a/src/EventLogExpert.Eventing/Resolvers/DescriptionFormatter.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/DescriptionFormatter.cs
@@ -66,7 +66,7 @@ internal sealed partial class DescriptionFormatter(
                 PickParameterSourceForDescription(modernEvent.Description, primaryDetails, descriptionFromSupplemental, ref supplemental, eventRecord));
         }
 
-        var legacyMessages = descriptionDetails.GetMessagesByShortId(eventRecord.Id);
+        var legacyMessages = ModernEventMatcher.GetCompatibleLegacyMessages(descriptionDetails, eventRecord);
 
         if (legacyMessages.Count == 1)
         {
@@ -107,7 +107,7 @@ internal sealed partial class DescriptionFormatter(
                         PickParameterSourceForDescription(supplementalModernEvent.Description, primaryDetails, true, ref supplemental, eventRecord));
                 }
 
-                var supplementalLegacy = supplemental.GetMessagesByShortId(eventRecord.Id);
+                var supplementalLegacy = ModernEventMatcher.GetCompatibleLegacyMessages(supplemental, eventRecord);
                 var supplementalBest = ModernEventMatcher.DisambiguateLegacyMessage(eventRecord, supplementalLegacy);
 
                 if (supplementalBest is not null)

--- a/src/EventLogExpert.Eventing/Resolvers/EventResolverBase.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/EventResolverBase.cs
@@ -63,7 +63,7 @@ public class EventResolverBase : IDisposable
             return CreateEventModel(eventRecord, modernEvent, details, descriptionDetails, supplemental, null);
         }
 
-        var primaryLegacyCount = details.GetMessagesByShortId(eventRecord.Id).Count;
+        var primaryLegacyCount = ModernEventMatcher.GetCompatibleLegacyMessages(details, eventRecord).Count;
 
         if (primaryLegacyCount == 1)
         {
@@ -90,7 +90,7 @@ public class EventResolverBase : IDisposable
                 modernEvent = supplementalModernEvent;
                 descriptionDetails = supplemental;
             }
-            else if (supplemental.GetMessagesByShortId(eventRecord.Id).Count > 0)
+            else if (ModernEventMatcher.GetCompatibleLegacyMessages(supplemental, eventRecord).Count > 0)
             {
                 // Supplemental has legacy messages for this EventId
                 descriptionDetails = supplemental;

--- a/src/EventLogExpert.Eventing/Resolvers/ModernEventMatcher.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/ModernEventMatcher.cs
@@ -101,6 +101,54 @@ internal sealed class ModernEventMatcher(TemplateAnalyzer templates, ITraceLogge
     }
 
     /// <summary>
+    ///     Drops short-id matches whose encoded qualifier conflicts with the event's, so a different provider's message
+    ///     that merely shares the low-16 id is never rendered.
+    /// </summary>
+    public static IReadOnlyList<MessageModel> FilterByQualifier(EventRecord eventRecord, IReadOnlyList<MessageModel> legacyMessages)
+    {
+        // Classic events resolve by full 32-bit id (Qualifiers in the high 16 bits), so a message whose high-16 is a
+        // different non-zero value is a collision from another module that happens to share the low-16 short id (e.g.
+        // netevent.dll's 7001 vs a driver's 7001). Keep the exact-qualifier matches; when there are none, keep the
+        // provider's own unqualified (high-16 == 0) messages ONLY if no conflicting-qualifier collision is present -
+        // otherwise prefer no match over rendering a message that is provably not this event's.
+        if (eventRecord.Qualifiers is not { } qualifier || legacyMessages.Count == 0)
+        {
+            return legacyMessages;
+        }
+
+        int exactMatchCount = 0;
+        bool anyConflictingQualifier = false;
+
+        for (int i = 0; i < legacyMessages.Count; i++)
+        {
+            ushort high = (ushort)((legacyMessages[i].RawId >> 16) & 0xFFFF);
+
+            if (high == qualifier) { exactMatchCount++; }
+            else if (high != 0) { anyConflictingQualifier = true; }
+        }
+
+        // Return the original list (no allocation) when it is already exactly the compatible set.
+        if (exactMatchCount == legacyMessages.Count) { return legacyMessages; }
+
+        if (exactMatchCount == 0) { return anyConflictingQualifier ? [] : legacyMessages; }
+
+        var exactMatches = new List<MessageModel>(exactMatchCount);
+
+        for (int i = 0; i < legacyMessages.Count; i++)
+        {
+            MessageModel message = legacyMessages[i];
+
+            if ((ushort)((message.RawId >> 16) & 0xFFFF) == qualifier) { exactMatches.Add(message); }
+        }
+
+        return exactMatches;
+    }
+
+    /// <summary>Legacy short-id messages for the event, with qualifier-conflicting collisions removed.</summary>
+    public static IReadOnlyList<MessageModel> GetCompatibleLegacyMessages(ProviderDetails details, EventRecord eventRecord) =>
+        FilterByQualifier(eventRecord, details.GetMessagesByShortId(eventRecord.Id));
+
+    /// <summary>
     ///     Locates the <see cref="EventModel" /> in <paramref name="details" /> whose template matches the
     ///     <paramref name="eventRecord" />, walking the documented fallback chain. Returns null when no candidate passes both
     ///     Id/Version/LogName and template-property-count checks.

--- a/tests/Integration/EventLogExpert.Eventing.IntegrationTests/ProviderMetadata/RegistryProviderTests.cs
+++ b/tests/Integration/EventLogExpert.Eventing.IntegrationTests/ProviderMetadata/RegistryProviderTests.cs
@@ -75,26 +75,6 @@ public sealed class RegistryProviderTests
         Assert.NotNull(result);
     }
 
-    [Fact]
-    public void GetMessageFilesForLegacyProvider_WhenCalled_ShouldNotIncludeSysFiles()
-    {
-        // Arrange
-        var provider = new RegistryProvider();
-
-        // Act
-        var result = FindAnyLegacyProviderFiles(provider);
-
-        // Assert
-        Assert.NotEmpty(result);
-
-        Assert.All(result,
-            path =>
-            {
-                var extension = Path.GetExtension(path).ToLower();
-                Assert.NotEqual(".sys", extension);
-            });
-    }
-
     [Theory]
     [InlineData(Constants.ApplicationLogName)]
     [InlineData(Constants.SystemLogName)]
@@ -307,7 +287,7 @@ public sealed class RegistryProviderTests
     }
 
     [Fact]
-    public void GetMessageFilesForLegacyProvider_WhenReturnedPaths_ShouldBeDllOrExe()
+    public void GetMessageFilesForLegacyProvider_WhenReturnedPaths_ShouldBeDllExeOrSys()
     {
         // Arrange
         var provider = new RegistryProvider();
@@ -323,8 +303,8 @@ public sealed class RegistryProviderTests
             {
                 var extension = Path.GetExtension(path).ToLower();
 
-                Assert.True(extension is ".dll" or ".exe",
-                    $"Expected .dll or .exe, but got {extension} for path: {path}");
+                Assert.True(extension is ".dll" or ".exe" or ".sys",
+                    $"Expected .dll, .exe, or .sys, but got {extension} for path: {path}");
             });
     }
 

--- a/tests/Unit/EventLogExpert.Eventing.OfflineImaging.Tests/Extraction/OfflineLegacyMessageFileResolverTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.OfflineImaging.Tests/Extraction/OfflineLegacyMessageFileResolverTests.cs
@@ -33,18 +33,20 @@ public sealed class OfflineLegacyMessageFileResolverTests
     }
 
     [Fact]
-    public void GetMessageFiles_FiltersNonDllExeExtensions()
+    public void GetMessageFiles_DeduplicatesModulesThatResolveToTheSamePath()
     {
         using OfflineTestImage image = OfflineTestImage.Create(seedSystem: system =>
         {
             SetCurrentControlSet(system, 1);
-            using RegistryKey provider = system.CreateSubKey(@"ControlSet001\Services\EventLog\Application\DriverProvider");
-            provider.SetValue("EventMessageFile", @"C:\Windows\System32\drivers\flt.sys;C:\Windows\System32\evt.dll", RegistryValueKind.ExpandString);
+            using RegistryKey provider = system.CreateSubKey(@"ControlSet001\Services\EventLog\Application\DupProvider");
+            provider.SetValue("EventMessageFile", @"C:\Windows\System32\evt.dll;C:\Windows\System32\evt.dll", RegistryValueKind.ExpandString);
         });
         using OfflineHiveFile hive = LoadSystemHive(image);
 
-        IReadOnlyList<string> files = ResolverFor(image, hive).GetMessageFilesForLegacyProvider("DriverProvider");
+        IReadOnlyList<string> files = ResolverFor(image, hive).GetMessageFilesForLegacyProvider("DupProvider");
 
+        // The same module listed twice in EventMessageFile resolves to one path; loading it twice would feed duplicate
+        // messages into disambiguation, so it must appear once.
         Assert.Equal(Path.Combine(image.RootDirectory, "Windows", "System32", "evt.dll"), Assert.Single(files), ignoreCase: true);
     }
 
@@ -62,6 +64,25 @@ public sealed class OfflineLegacyMessageFileResolverTests
         IReadOnlyList<string> files = ResolverFor(image, hive).GetMessageFilesForLegacyProvider("OnSetTwo");
 
         Assert.Equal(Path.Combine(image.RootDirectory, "Windows", "System32", "two.dll"), Assert.Single(files), ignoreCase: true);
+    }
+
+    [Fact]
+    public void GetMessageFiles_IncludesSysDriverModulesAndFiltersUnsupportedExtensions()
+    {
+        using OfflineTestImage image = OfflineTestImage.Create(seedSystem: system =>
+        {
+            SetCurrentControlSet(system, 1);
+            using RegistryKey provider = system.CreateSubKey(@"ControlSet001\Services\EventLog\Application\DriverProvider");
+            provider.SetValue("EventMessageFile", @"C:\Windows\System32\drivers\flt.sys;C:\Windows\System32\evt.dll;C:\Windows\System32\notes.txt", RegistryValueKind.ExpandString);
+        });
+        using OfflineHiveFile hive = LoadSystemHive(image);
+
+        IReadOnlyList<string> files = ResolverFor(image, hive).GetMessageFilesForLegacyProvider("DriverProvider");
+
+        // The driver .sys is kept (its message table is authoritative); the unsupported .txt is filtered out.
+        Assert.Equal(2, files.Count);
+        Assert.Equal(Path.Combine(image.RootDirectory, "Windows", "System32", "drivers", "flt.sys"), files[0], ignoreCase: true);
+        Assert.Equal(Path.Combine(image.RootDirectory, "Windows", "System32", "evt.dll"), files[1], ignoreCase: true);
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Eventing.Tests/ProviderMetadata/LegacyMessageFilePathsTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/ProviderMetadata/LegacyMessageFilePathsTests.cs
@@ -1,0 +1,64 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.ProviderMetadata;
+
+namespace EventLogExpert.Eventing.Tests.ProviderMetadata;
+
+public sealed class LegacyMessageFilePathsTests
+{
+    [Fact]
+    public void GetSupportedModulePaths_DropsEmptyAndWhitespaceEntriesAndTrimsPaths()
+    {
+        var result = LegacyMessageFilePaths.GetSupportedModulePaths(
+            @"C:\a.dll;;   ; C:\b.sys ");
+
+        Assert.Equal([@"C:\a.dll", @"C:\b.sys"], result);
+    }
+
+    [Fact]
+    public void GetSupportedModulePaths_EmptyValue_ReturnsEmpty()
+    {
+        Assert.Empty(LegacyMessageFilePaths.GetSupportedModulePaths(string.Empty));
+    }
+
+    [Fact]
+    public void GetSupportedModulePaths_FiltersUnsupportedExtensions()
+    {
+        var result = LegacyMessageFilePaths.GetSupportedModulePaths(
+            @"C:\keep.dll;C:\notes.txt;C:\keep.sys;C:\config.ini");
+
+        Assert.Equal([@"C:\keep.dll", @"C:\keep.sys"], result);
+    }
+
+    [Fact]
+    public void GetSupportedModulePaths_IncludesSysDriverModules()
+    {
+        // A driver's own .sys module holds the authoritative message table; it must not be filtered out the way the
+        // pre-fix code did, or its events (e.g. mtkwecx 7001/1035) resolve against an unrelated system DLL instead.
+        var result = LegacyMessageFilePaths.GetSupportedModulePaths(
+            @"C:\Windows\System32\netevent.dll;C:\Windows\System32\drivers\example.sys");
+
+        Assert.Equal(
+            [@"C:\Windows\System32\netevent.dll", @"C:\Windows\System32\drivers\example.sys"],
+            result);
+    }
+
+    [Fact]
+    public void GetSupportedModulePaths_KeepsSupportedExtensionsInRegistryOrder()
+    {
+        var result = LegacyMessageFilePaths.GetSupportedModulePaths(
+            @"C:\a.exe;C:\b.sys;C:\c.dll");
+
+        Assert.Equal([@"C:\a.exe", @"C:\b.sys", @"C:\c.dll"], result);
+    }
+
+    [Fact]
+    public void GetSupportedModulePaths_MatchesExtensionsCaseInsensitively()
+    {
+        var result = LegacyMessageFilePaths.GetSupportedModulePaths(
+            @"C:\a.DLL;C:\b.SyS;C:\c.ExE");
+
+        Assert.Equal([@"C:\a.DLL", @"C:\b.SyS", @"C:\c.ExE"], result);
+    }
+}

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Resolvers/EventResolverBaseTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Resolvers/EventResolverBaseTests.cs
@@ -266,6 +266,23 @@ public sealed class EventResolverBaseTests
     }
 
     [Fact]
+    public void ResolveEvent_MSExchangeReplEvent_ShouldResolveCorrectly()
+    {
+        // Arrange
+        var providerDetails = EventUtils.CreateExchangeProviderDetails();
+        var resolver = new TestEventResolver([providerDetails]);
+        var eventRecord = EventUtils.CreateExchangeEventRecord();
+
+        // Act
+        var displayEvent = resolver.ResolveEvent(eventRecord);
+
+        // Assert
+        Assert.NotNull(displayEvent);
+        Assert.Equal(Constants.ExchangeFormattedDescription, displayEvent.Description);
+        Assert.Equal("Service", displayEvent.TaskCategory);
+    }
+
+    [Fact]
     public void ResolveEvent_ModernTemplateWithMatchingProperties_PopulatesNamedEventData()
     {
         var (details, eventRecord) = EventUtils.CreateModernEvent(
@@ -283,23 +300,6 @@ public sealed class EventResolverBaseTests
         Assert.Equal("alice", user.AsString());
         Assert.True(resolved.EventData.TryGetValue("Source", out var source));
         Assert.Equal("10.0.0.1", source.AsString());
-    }
-
-    [Fact]
-    public void ResolveEvent_MSExchangeReplEvent_ShouldResolveCorrectly()
-    {
-        // Arrange
-        var providerDetails = EventUtils.CreateExchangeProviderDetails();
-        var resolver = new TestEventResolver([providerDetails]);
-        var eventRecord = EventUtils.CreateExchangeEventRecord();
-
-        // Act
-        var displayEvent = resolver.ResolveEvent(eventRecord);
-
-        // Assert
-        Assert.NotNull(displayEvent);
-        Assert.Equal(Constants.ExchangeFormattedDescription, displayEvent.Description);
-        Assert.Equal("Service", displayEvent.TaskCategory);
     }
 
     [Fact]
@@ -577,6 +577,69 @@ public sealed class EventResolverBaseTests
     }
 
     [Fact]
+    public void ResolveEvent_WithAmbiguousPrimaryLegacyAndSupplementalMatch_ShouldUseSupplementalDescription()
+    {
+        // Arrange - primary has 2 legacy messages for the same event ID with no LogLink
+        // and identical severity (so disambiguation fails). Supplemental has a matching
+        // modern event. Should fall back to supplemental's description.
+        var primaryDetails = new ProviderDetails
+        {
+            ProviderName = Constants.TestProviderName,
+            Events = [],
+            Messages =
+            [
+                new MessageModel { ShortId = 500, RawId = 0x40000500, Text = Constants.PrimaryMessageA, LogLink = null },
+                new MessageModel { ShortId = 500, RawId = 0x40000500, Text = Constants.PrimaryMessageB, LogLink = null }
+            ],
+            Parameters = [],
+            Keywords = new Dictionary<long, string>(),
+            Opcodes = new Dictionary<int, string>(),
+            Tasks = new Dictionary<int, string>()
+        };
+
+        var supplementalDetails = new ProviderDetails
+        {
+            ProviderName = Constants.TestProviderName,
+            Events =
+            [
+                new EventModel
+                {
+                    Id = 500,
+                    Version = 0,
+                    LogName = Constants.ApplicationLogName,
+                    Description = "Supplemental modern: %1",
+                    Keywords = [],
+                    Template = "<template><data name=\"Val\" inType=\"win:UnicodeString\" outType=\"xs:string\"/></template>"
+                }
+            ],
+            Messages = [],
+            Parameters = [],
+            Keywords = new Dictionary<long, string>(),
+            Opcodes = new Dictionary<int, string>(),
+            Tasks = new Dictionary<int, string>()
+        };
+
+        var resolver = new SupplementalTestResolver([primaryDetails], supplementalDetails);
+
+        var eventRecord = new EventRecord
+        {
+            ProviderName = Constants.TestProviderName,
+            Id = 500,
+            Version = 0,
+            Level = 4,
+            LogName = Constants.ApplicationLogName,
+            Properties = ["resolved"]
+        };
+
+        // Act
+        var displayEvent = resolver.ResolveEvent(eventRecord);
+
+        // Assert
+        Assert.NotNull(displayEvent);
+        Assert.Contains("Supplemental modern: resolved", displayEvent.Description);
+    }
+
+    [Fact]
     public void ResolveEvent_WithAmbiguousPrimaryLegacyAndSupplemental_ShouldAlsoUseSupplementalForKeywordsAndTask()
     {
         // Arrange - regression for the cross-issue case: when primary has ambiguous legacy
@@ -641,69 +704,6 @@ public sealed class EventResolverBaseTests
         Assert.Contains(Constants.SupplementalDescription, displayEvent.Description);
         Assert.Equal(Constants.SupplementalTask, displayEvent.TaskCategory);
         Assert.Contains(Constants.SupplementalKeyword, displayEvent.Keywords);
-    }
-
-    [Fact]
-    public void ResolveEvent_WithAmbiguousPrimaryLegacyAndSupplementalMatch_ShouldUseSupplementalDescription()
-    {
-        // Arrange - primary has 2 legacy messages for the same event ID with no LogLink
-        // and identical severity (so disambiguation fails). Supplemental has a matching
-        // modern event. Should fall back to supplemental's description.
-        var primaryDetails = new ProviderDetails
-        {
-            ProviderName = Constants.TestProviderName,
-            Events = [],
-            Messages =
-            [
-                new MessageModel { ShortId = 500, RawId = 0x40000500, Text = Constants.PrimaryMessageA, LogLink = null },
-                new MessageModel { ShortId = 500, RawId = 0x40000500, Text = Constants.PrimaryMessageB, LogLink = null }
-            ],
-            Parameters = [],
-            Keywords = new Dictionary<long, string>(),
-            Opcodes = new Dictionary<int, string>(),
-            Tasks = new Dictionary<int, string>()
-        };
-
-        var supplementalDetails = new ProviderDetails
-        {
-            ProviderName = Constants.TestProviderName,
-            Events =
-            [
-                new EventModel
-                {
-                    Id = 500,
-                    Version = 0,
-                    LogName = Constants.ApplicationLogName,
-                    Description = "Supplemental modern: %1",
-                    Keywords = [],
-                    Template = "<template><data name=\"Val\" inType=\"win:UnicodeString\" outType=\"xs:string\"/></template>"
-                }
-            ],
-            Messages = [],
-            Parameters = [],
-            Keywords = new Dictionary<long, string>(),
-            Opcodes = new Dictionary<int, string>(),
-            Tasks = new Dictionary<int, string>()
-        };
-
-        var resolver = new SupplementalTestResolver([primaryDetails], supplementalDetails);
-
-        var eventRecord = new EventRecord
-        {
-            ProviderName = Constants.TestProviderName,
-            Id = 500,
-            Version = 0,
-            Level = 4,
-            LogName = Constants.ApplicationLogName,
-            Properties = ["resolved"]
-        };
-
-        // Act
-        var displayEvent = resolver.ResolveEvent(eventRecord);
-
-        // Assert
-        Assert.NotNull(displayEvent);
-        Assert.Contains("Supplemental modern: resolved", displayEvent.Description);
     }
 
     [Fact]
@@ -953,6 +953,57 @@ public sealed class EventResolverBaseTests
     }
 
     [Fact]
+    public void ResolveEvent_WithCollidingSystemAndDriverMessages_ShouldResolveToTheQualifierMatch()
+    {
+        // Arrange - the mtkwecx case: a shared system DLL (netevent) and the driver both expose a short-id 7001
+        // message, but only the driver's full id (0x40021B59) matches the event's Qualifiers (0x4002).
+        var providerDetails = new ProviderDetails
+        {
+            ProviderName = Constants.TestProviderName,
+            Events = [],
+            Messages =
+            [
+                new MessageModel
+                {
+                    ProviderName = Constants.TestProviderName,
+                    ShortId = 7001,
+                    RawId = unchecked(0xC0001B59), // netevent SCM message, Qualifier 0xC000
+                    Text = "The %1 service depends on the %2 service which failed to start because of the following error: %3"
+                },
+                new MessageModel
+                {
+                    ProviderName = Constants.TestProviderName,
+                    ShortId = 7001,
+                    RawId = 0x40021B59, // driver message, Qualifier 0x4002
+                    Text = "Power Save Information"
+                }
+            ],
+            Parameters = [],
+            Keywords = new Dictionary<long, string>(),
+            Tasks = new Dictionary<int, string>()
+        };
+
+        var resolver = new TestEventResolver([providerDetails]);
+
+        var eventRecord = new EventRecord
+        {
+            ProviderName = Constants.TestProviderName,
+            Id = 7001,
+            Qualifiers = 0x4002,
+            Level = 4,
+            LogName = Constants.SystemLogName,
+            Properties = ["", new byte[] { 0x00 }]
+        };
+
+        // Act
+        var displayEvent = resolver.ResolveEvent(eventRecord);
+
+        // Assert
+        Assert.NotNull(displayEvent);
+        Assert.Equal("Power Save Information", displayEvent.Description);
+    }
+
+    [Fact]
     public void ResolveEvent_WithDataElementsMissingOutType_ShouldResolveDescription()
     {
         // Arrange - template has 3 data elements, only first has outType
@@ -998,6 +1049,44 @@ public sealed class EventResolverBaseTests
         Assert.NotNull(displayEvent);
         Assert.Contains("TestValue", displayEvent.Description);
         Assert.DoesNotContain("Failed to resolve", displayEvent.Description);
+    }
+
+    [Fact]
+    public void ResolveEvent_WithEmptyPrimaryAndNoSupplemental_ShouldReturnEventDataTail()
+    {
+        // Arrange - empty primary AND no supplemental should fall through to the
+        // no-metadata fallback. With multiple properties present, that surfaces them
+        // under the "included with the event" header (mmc-style payload dump).
+        var primaryDetails = new ProviderDetails
+        {
+            ProviderName = Constants.TestProviderName,
+            Events = [],
+            Messages = [],
+            Parameters = [],
+            Keywords = new Dictionary<long, string>(),
+            Opcodes = new Dictionary<int, string>(),
+            Tasks = new Dictionary<int, string>()
+        };
+
+        var resolver = new SupplementalTestResolver([primaryDetails], null);
+
+        var eventRecord = new EventRecord
+        {
+            ProviderName = Constants.TestProviderName,
+            Id = 9999,
+            Properties = ["a", "b", "c"]
+        };
+
+        // Act
+        var displayEvent = resolver.ResolveEvent(eventRecord);
+
+        // Assert
+        Assert.NotNull(displayEvent);
+        Assert.Contains("The following information was included with the event:", displayEvent.Description);
+        Assert.Contains("a", displayEvent.Description);
+        Assert.Contains("b", displayEvent.Description);
+        Assert.Contains("c", displayEvent.Description);
+        Assert.DoesNotContain("No matching message", displayEvent.Description);
     }
 
     [Fact]
@@ -1057,44 +1146,6 @@ public sealed class EventResolverBaseTests
         Assert.Contains("No matching message", displayEvent.Description);
         Assert.DoesNotContain("No matching provider", displayEvent.Description);
         Assert.DoesNotContain("Failed to resolve", displayEvent.Description);
-    }
-
-    [Fact]
-    public void ResolveEvent_WithEmptyPrimaryAndNoSupplemental_ShouldReturnEventDataTail()
-    {
-        // Arrange - empty primary AND no supplemental should fall through to the
-        // no-metadata fallback. With multiple properties present, that surfaces them
-        // under the "included with the event" header (mmc-style payload dump).
-        var primaryDetails = new ProviderDetails
-        {
-            ProviderName = Constants.TestProviderName,
-            Events = [],
-            Messages = [],
-            Parameters = [],
-            Keywords = new Dictionary<long, string>(),
-            Opcodes = new Dictionary<int, string>(),
-            Tasks = new Dictionary<int, string>()
-        };
-
-        var resolver = new SupplementalTestResolver([primaryDetails], null);
-
-        var eventRecord = new EventRecord
-        {
-            ProviderName = Constants.TestProviderName,
-            Id = 9999,
-            Properties = ["a", "b", "c"]
-        };
-
-        // Act
-        var displayEvent = resolver.ResolveEvent(eventRecord);
-
-        // Assert
-        Assert.NotNull(displayEvent);
-        Assert.Contains("The following information was included with the event:", displayEvent.Description);
-        Assert.Contains("a", displayEvent.Description);
-        Assert.Contains("b", displayEvent.Description);
-        Assert.Contains("c", displayEvent.Description);
-        Assert.DoesNotContain("No matching message", displayEvent.Description);
     }
 
     [Fact]
@@ -1385,22 +1436,6 @@ public sealed class EventResolverBaseTests
     }
 
     [Fact]
-    public void ResolveEvent_WithGuid_ShouldFormatWithBraces()
-    {
-        var (details, eventRecord) = EventUtils.CreateModernEvent(
-            "Id: %1",
-            """<template><data name="Id" inType="win:GUID"/></template>""",
-            [new Guid("12345678-1234-1234-1234-123456789abc")]);
-
-        var resolver = new TestEventResolver([details]);
-
-        var displayEvent = resolver.ResolveEvent(eventRecord);
-
-        Assert.NotNull(displayEvent);
-        Assert.Contains("{12345678-1234-1234-1234-123456789abc}", displayEvent.Description);
-    }
-
-    [Fact]
     public void ResolveEvent_WithGuidProperty_ShouldRenderWithBraces()
     {
         // Arrange - Windows renders GUID insertions wrapped in braces.
@@ -1422,6 +1457,42 @@ public sealed class EventResolverBaseTests
         // Assert
         Assert.NotNull(displayEvent);
         Assert.Contains("Volume Id: {4cff5b8e-e659-4f3a-8b2f-1a2b3c4d5e6f}", displayEvent.Description);
+    }
+
+    [Fact]
+    public void ResolveEvent_WithGuid_ShouldFormatWithBraces()
+    {
+        var (details, eventRecord) = EventUtils.CreateModernEvent(
+            "Id: %1",
+            """<template><data name="Id" inType="win:GUID"/></template>""",
+            [new Guid("12345678-1234-1234-1234-123456789abc")]);
+
+        var resolver = new TestEventResolver([details]);
+
+        var displayEvent = resolver.ResolveEvent(eventRecord);
+
+        Assert.NotNull(displayEvent);
+        Assert.Contains("{12345678-1234-1234-1234-123456789abc}", displayEvent.Description);
+    }
+
+    [Fact]
+    public void ResolveEvent_WithHResultOutType_ShouldResolveDynamically()
+    {
+        // Arrange - win:HResult with a common error code should resolve dynamically
+        var (details, eventRecord) = EventUtils.CreateModernEvent(
+            "Error: %1",
+            """<template><data name="Error" inType="win:Int32" outType="win:HResult"/></template>""",
+            [unchecked((int)0x80070005)]);
+
+        var resolver = new TestEventResolver([details]);
+
+        // Act
+        var displayEvent = resolver.ResolveEvent(eventRecord);
+
+        // Assert - 0x80070005 is ACCESS_DENIED; resolved message should not contain the raw hex code
+        Assert.NotNull(displayEvent);
+        Assert.DoesNotContain("0x80070005", displayEvent.Description);
+        Assert.DoesNotContain("0x00000005", displayEvent.Description);
     }
 
     [Fact]
@@ -1561,26 +1632,6 @@ public sealed class EventResolverBaseTests
 
         Assert.NotNull(displayEvent);
         Assert.Contains("18446744073709551615", displayEvent.Description);
-    }
-
-    [Fact]
-    public void ResolveEvent_WithHResultOutType_ShouldResolveDynamically()
-    {
-        // Arrange - win:HResult with a common error code should resolve dynamically
-        var (details, eventRecord) = EventUtils.CreateModernEvent(
-            "Error: %1",
-            """<template><data name="Error" inType="win:Int32" outType="win:HResult"/></template>""",
-            [unchecked((int)0x80070005)]);
-
-        var resolver = new TestEventResolver([details]);
-
-        // Act
-        var displayEvent = resolver.ResolveEvent(eventRecord);
-
-        // Assert - 0x80070005 is ACCESS_DENIED; resolved message should not contain the raw hex code
-        Assert.NotNull(displayEvent);
-        Assert.DoesNotContain("0x80070005", displayEvent.Description);
-        Assert.DoesNotContain("0x00000005", displayEvent.Description);
     }
 
     [Fact]
@@ -2284,6 +2335,59 @@ public sealed class EventResolverBaseTests
     }
 
     [Fact]
+    public void ResolveEvent_WithMultipleLegacyMessagesSameSeverity_ShouldDisambiguateByQualifier()
+    {
+        // Arrange - reproduces the Microsoft-Windows-Defrag EventID 258 case where two
+        // messages share the same EventId and severity but differ in their high 16 bits
+        // (Qualifier). Windows identifies the right entry by full message ID, so
+        // RawId == (Qualifiers << 16) | EventId.
+        var providerDetails = new ProviderDetails
+        {
+            ProviderName = Constants.TestProviderName,
+            Events = [],
+            Messages =
+            [
+                new MessageModel
+                {
+                    ProviderName = Constants.TestProviderName,
+                    ShortId = 258,
+                    RawId = 0x00000102, // Qualifier=0, severity 00=Success
+                    Text = "The storage optimizer successfully completed %1 on %2"
+                },
+                new MessageModel
+                {
+                    ProviderName = Constants.TestProviderName,
+                    ShortId = 258,
+                    RawId = 0x09000102, // Qualifier=0x900, severity 00=Success
+                    Text = "The retrim operation was skipped"
+                }
+            ],
+            Parameters = [],
+            Keywords = new Dictionary<long, string>(),
+            Tasks = new Dictionary<int, string>()
+        };
+
+        var resolver = new TestEventResolver([providerDetails]);
+
+        var eventRecord = new EventRecord
+        {
+            ProviderName = Constants.TestProviderName,
+            Id = 258,
+            Qualifiers = 0,
+            Level = 0,
+            LogName = Constants.ApplicationLogName,
+            Properties = ["defragmentation", "Data (E:)"]
+        };
+
+        // Act
+        var displayEvent = resolver.ResolveEvent(eventRecord);
+
+        // Assert
+        Assert.NotNull(displayEvent);
+        Assert.Equal("The storage optimizer successfully completed defragmentation on Data (E:)", displayEvent.Description);
+    }
+
+    [Fact]
     public void ResolveEvent_WithMultipleLegacyMessages_ShouldDisambiguateByLogLink()
     {
         // Arrange - two messages with same ShortId, but different LogLinks
@@ -2416,59 +2520,6 @@ public sealed class EventResolverBaseTests
         // Assert
         Assert.NotNull(displayEvent);
         Assert.Contains("No matching message", displayEvent.Description);
-    }
-
-    [Fact]
-    public void ResolveEvent_WithMultipleLegacyMessagesSameSeverity_ShouldDisambiguateByQualifier()
-    {
-        // Arrange - reproduces the Microsoft-Windows-Defrag EventID 258 case where two
-        // messages share the same EventId and severity but differ in their high 16 bits
-        // (Qualifier). Windows identifies the right entry by full message ID, so
-        // RawId == (Qualifiers << 16) | EventId.
-        var providerDetails = new ProviderDetails
-        {
-            ProviderName = Constants.TestProviderName,
-            Events = [],
-            Messages =
-            [
-                new MessageModel
-                {
-                    ProviderName = Constants.TestProviderName,
-                    ShortId = 258,
-                    RawId = 0x00000102, // Qualifier=0, severity 00=Success
-                    Text = "The storage optimizer successfully completed %1 on %2"
-                },
-                new MessageModel
-                {
-                    ProviderName = Constants.TestProviderName,
-                    ShortId = 258,
-                    RawId = 0x09000102, // Qualifier=0x900, severity 00=Success
-                    Text = "The retrim operation was skipped"
-                }
-            ],
-            Parameters = [],
-            Keywords = new Dictionary<long, string>(),
-            Tasks = new Dictionary<int, string>()
-        };
-
-        var resolver = new TestEventResolver([providerDetails]);
-
-        var eventRecord = new EventRecord
-        {
-            ProviderName = Constants.TestProviderName,
-            Id = 258,
-            Qualifiers = 0,
-            Level = 0,
-            LogName = Constants.ApplicationLogName,
-            Properties = ["defragmentation", "Data (E:)"]
-        };
-
-        // Act
-        var displayEvent = resolver.ResolveEvent(eventRecord);
-
-        // Assert
-        Assert.NotNull(displayEvent);
-        Assert.Equal("The storage optimizer successfully completed defragmentation on Data (E:)", displayEvent.Description);
     }
 
     [Fact]
@@ -2606,6 +2657,29 @@ public sealed class EventResolverBaseTests
     }
 
     [Fact]
+    public void ResolveEvent_WithNoProviderDetails_ShouldReturnDefaultDescription()
+    {
+        // Arrange
+        var resolver = new TestEventResolver();
+
+        var eventRecord = new EventRecord
+        {
+            ProviderName = Constants.NonExistentProviderName,
+            Id = 1000,
+            ComputerName = Constants.TestComputer,
+            LogName = Constants.ApplicationLogName
+        };
+
+        // Act
+        resolver.LoadProviderDetails(eventRecord);
+        var displayEvent = resolver.ResolveEvent(eventRecord);
+
+        // Assert
+        Assert.NotNull(displayEvent);
+        Assert.Contains("No matching provider", displayEvent.Description);
+    }
+
+    [Fact]
     public void ResolveEvent_WithNonClassicEventIdZeroAndNoProviderMetadata_ShouldNotPrependSystemMessage()
     {
         // Arrange - regression guard: only classic-keyword events get the Win32
@@ -2646,29 +2720,6 @@ public sealed class EventResolverBaseTests
 
         Assert.Contains("The following information was included with the event:", displayEvent.Description);
         Assert.Contains("payload-a", displayEvent.Description);
-    }
-
-    [Fact]
-    public void ResolveEvent_WithNoProviderDetails_ShouldReturnDefaultDescription()
-    {
-        // Arrange
-        var resolver = new TestEventResolver();
-
-        var eventRecord = new EventRecord
-        {
-            ProviderName = Constants.NonExistentProviderName,
-            Id = 1000,
-            ComputerName = Constants.TestComputer,
-            LogName = Constants.ApplicationLogName
-        };
-
-        // Act
-        resolver.LoadProviderDetails(eventRecord);
-        var displayEvent = resolver.ResolveEvent(eventRecord);
-
-        // Assert
-        Assert.NotNull(displayEvent);
-        Assert.Contains("No matching provider", displayEvent.Description);
     }
 
     [Fact]
@@ -2897,6 +2948,97 @@ public sealed class EventResolverBaseTests
         // Assert
         Assert.NotNull(displayEvent);
         Assert.Equal(string.Empty, displayEvent.Xml);
+    }
+
+    [Fact]
+    public void ResolveEvent_WithOnlyAConflictingSystemMessage_ShouldReportNoMatch()
+    {
+        // Arrange - only the shared system DLL's short-id 7001 (Qualifier 0xC000) is loaded; the event carries 0x4002.
+        // The old behavior rendered this unrelated SCM template (with the event's binary blob as %2). The resolver must
+        // report no matching message rather than mis-resolve.
+        var providerDetails = new ProviderDetails
+        {
+            ProviderName = Constants.TestProviderName,
+            Events = [],
+            Messages =
+            [
+                new MessageModel
+                {
+                    ProviderName = Constants.TestProviderName,
+                    ShortId = 7001,
+                    RawId = unchecked(0xC0001B59),
+                    Text = "The %1 service depends on the %2 service which failed to start because of the following error: %3"
+                }
+            ],
+            Parameters = [],
+            Keywords = new Dictionary<long, string>(),
+            Tasks = new Dictionary<int, string>()
+        };
+
+        var resolver = new TestEventResolver([providerDetails]);
+
+        var eventRecord = new EventRecord
+        {
+            ProviderName = Constants.TestProviderName,
+            Id = 7001,
+            Qualifiers = 0x4002,
+            Level = 4,
+            LogName = Constants.SystemLogName,
+            Properties = ["", new byte[] { 0x00 }]
+        };
+
+        // Act
+        var displayEvent = resolver.ResolveEvent(eventRecord);
+
+        // Assert
+        Assert.NotNull(displayEvent);
+        Assert.DoesNotContain("service depends on", displayEvent.Description);
+        Assert.Contains("No matching message", displayEvent.Description);
+    }
+
+    [Fact]
+    public void ResolveEvent_WithOnlyUnqualifiedMessageAndQualifierSet_ShouldStillResolveIt()
+    {
+        // Arrange - the provider stores only an unqualified (high 0) message and the event carries a non-zero
+        // Qualifier. With no conflicting-qualifier collision present, the provider's own generic message is used (the
+        // pre-existing unqualified-provider fallback).
+        var providerDetails = new ProviderDetails
+        {
+            ProviderName = Constants.TestProviderName,
+            Events = [],
+            Messages =
+            [
+                new MessageModel
+                {
+                    ProviderName = Constants.TestProviderName,
+                    ShortId = 300,
+                    RawId = 0x0000012C, // high 0, only candidate
+                    Text = "Generic: %1"
+                }
+            ],
+            Parameters = [],
+            Keywords = new Dictionary<long, string>(),
+            Tasks = new Dictionary<int, string>()
+        };
+
+        var resolver = new TestEventResolver([providerDetails]);
+
+        var eventRecord = new EventRecord
+        {
+            ProviderName = Constants.TestProviderName,
+            Id = 300,
+            Qualifiers = 0x4002,
+            Level = 4,
+            LogName = Constants.ApplicationLogName,
+            Properties = ["payload"]
+        };
+
+        // Act
+        var displayEvent = resolver.ResolveEvent(eventRecord);
+
+        // Assert
+        Assert.NotNull(displayEvent);
+        Assert.Equal("Generic: payload", displayEvent.Description);
     }
 
     [Fact]
@@ -3361,42 +3503,6 @@ public sealed class EventResolverBaseTests
     }
 
     [Fact]
-    public void ResolveEvent_WithProviderKeywords_ShouldResolveKeywords()
-    {
-        // Arrange
-        var providerDetails = new ProviderDetails
-        {
-            ProviderName = Constants.TestProviderName,
-            Events = [],
-            Messages = [],
-            Parameters = [],
-            Keywords = new Dictionary<long, string>
-            {
-                { 0x1, "CustomKeyword1" },
-                { 0x2, "CustomKeyword2" }
-            },
-            Tasks = new Dictionary<int, string>()
-        };
-
-        var resolver = new TestEventResolver([providerDetails]);
-
-        var eventRecord = new EventRecord
-        {
-            ProviderName = Constants.TestProviderName,
-            Id = 1000,
-            Keywords = 0x3 // Both custom keywords
-        };
-
-        // Act
-        var displayEvent = resolver.ResolveEvent(eventRecord);
-
-        // Assert
-        Assert.NotNull(displayEvent);
-        Assert.Contains("CustomKeyword1", displayEvent.Keywords);
-        Assert.Contains("CustomKeyword2", displayEvent.Keywords);
-    }
-
-    [Fact]
     public void ResolveEvent_WithProviderKeywordsInBits32To47_ShouldResolveKeywords()
     {
         // Arrange - keyword in bit 32 (0x100000000), which was previously masked out
@@ -3430,6 +3536,42 @@ public sealed class EventResolverBaseTests
         Assert.NotNull(displayEvent);
         Assert.Contains("HighBitKeyword", displayEvent.Keywords);
         Assert.Contains("LowBitKeyword", displayEvent.Keywords);
+    }
+
+    [Fact]
+    public void ResolveEvent_WithProviderKeywords_ShouldResolveKeywords()
+    {
+        // Arrange
+        var providerDetails = new ProviderDetails
+        {
+            ProviderName = Constants.TestProviderName,
+            Events = [],
+            Messages = [],
+            Parameters = [],
+            Keywords = new Dictionary<long, string>
+            {
+                { 0x1, "CustomKeyword1" },
+                { 0x2, "CustomKeyword2" }
+            },
+            Tasks = new Dictionary<int, string>()
+        };
+
+        var resolver = new TestEventResolver([providerDetails]);
+
+        var eventRecord = new EventRecord
+        {
+            ProviderName = Constants.TestProviderName,
+            Id = 1000,
+            Keywords = 0x3 // Both custom keywords
+        };
+
+        // Act
+        var displayEvent = resolver.ResolveEvent(eventRecord);
+
+        // Assert
+        Assert.NotNull(displayEvent);
+        Assert.Contains("CustomKeyword1", displayEvent.Keywords);
+        Assert.Contains("CustomKeyword2", displayEvent.Keywords);
     }
 
     [Fact]
@@ -3495,10 +3637,12 @@ public sealed class EventResolverBaseTests
     }
 
     [Fact]
-    public void ResolveEvent_WithQualifierMismatch_ShouldFallThroughToSeverity()
+    public void ResolveEvent_WithQualifierMatchingNoLoadedMessage_ShouldReportNoMatchRatherThanGuess()
     {
-        // Arrange - event has a Qualifier value that no message matches; disambiguation
-        // must fall through to the existing severity-based check rather than failing.
+        // Arrange - the event's Qualifier (0x1234) matches neither message: one is unqualified (high 0) and one carries
+        // a different, conflicting qualifier (0xC000). Rendering either - e.g. the Error message via a severity guess -
+        // would be a mis-resolution, so with a conflicting-qualifier collision present and no exact match the resolver
+        // reports no matching message.
         var providerDetails = new ProviderDetails
         {
             ProviderName = Constants.TestProviderName,
@@ -3527,7 +3671,7 @@ public sealed class EventResolverBaseTests
 
         var resolver = new TestEventResolver([providerDetails]);
 
-        // Qualifier 0x1234 matches no message in the table.
+        // No properties so the empty result reaches DefaultNoMatchingDescription rather than the single-property dump.
         var eventRecord = new EventRecord
         {
             ProviderName = Constants.TestProviderName,
@@ -3535,15 +3679,17 @@ public sealed class EventResolverBaseTests
             Qualifiers = 0x1234,
             Level = 2,
             LogName = Constants.ApplicationLogName,
-            Properties = ["payload"]
+            Properties = []
         };
 
         // Act
         var displayEvent = resolver.ResolveEvent(eventRecord);
 
-        // Assert - Level=2 maps to severity 11=Error, so fall-through picks the Error message.
+        // Assert
         Assert.NotNull(displayEvent);
-        Assert.Contains("Error: payload", displayEvent.Description);
+        Assert.DoesNotContain("Error", displayEvent.Description);
+        Assert.DoesNotContain("Success", displayEvent.Description);
+        Assert.Contains("No matching message", displayEvent.Description);
     }
 
     [Fact]
@@ -3815,6 +3961,49 @@ public sealed class EventResolverBaseTests
         // Assert
         Assert.NotNull(displayEvent);
         Assert.Equal("This is the description from property", displayEvent.Description);
+    }
+
+    [Fact]
+    public void ResolveEvent_WithSingleQualifierMatchingMessage_ShouldResolveIt()
+    {
+        // Arrange - the driver's short-id 1035 (0x4002040B) is the only match and its qualifier matches the event.
+        var providerDetails = new ProviderDetails
+        {
+            ProviderName = Constants.TestProviderName,
+            Events = [],
+            Messages =
+            [
+                new MessageModel
+                {
+                    ProviderName = Constants.TestProviderName,
+                    ShortId = 1035,
+                    RawId = 0x4002040B,
+                    Text = "Send EAPOL"
+                }
+            ],
+            Parameters = [],
+            Keywords = new Dictionary<long, string>(),
+            Tasks = new Dictionary<int, string>()
+        };
+
+        var resolver = new TestEventResolver([providerDetails]);
+
+        var eventRecord = new EventRecord
+        {
+            ProviderName = Constants.TestProviderName,
+            Id = 1035,
+            Qualifiers = 0x4002,
+            Level = 4,
+            LogName = Constants.SystemLogName,
+            Properties = ["", new byte[] { 0x00 }]
+        };
+
+        // Act
+        var displayEvent = resolver.ResolveEvent(eventRecord);
+
+        // Assert
+        Assert.NotNull(displayEvent);
+        Assert.Equal("Send EAPOL", displayEvent.Description);
     }
 
     [Fact]
@@ -4179,6 +4368,57 @@ public sealed class EventResolverBaseTests
         // Assert
         Assert.NotNull(displayEvent);
         Assert.EndsWith("\r\n", displayEvent.Description);
+    }
+
+    [Fact]
+    public void ResolveEvent_WithUnqualifiedAndExactMessages_ShouldPreferTheExactQualifierMatch()
+    {
+        // Arrange - the provider stores both an unqualified (high 0) generic and an exact-qualifier variant for one
+        // short id; the exact-qualifier match wins.
+        var providerDetails = new ProviderDetails
+        {
+            ProviderName = Constants.TestProviderName,
+            Events = [],
+            Messages =
+            [
+                new MessageModel
+                {
+                    ProviderName = Constants.TestProviderName,
+                    ShortId = 200,
+                    RawId = 0x000000C8, // high 0, unqualified generic
+                    Text = "Generic: %1"
+                },
+                new MessageModel
+                {
+                    ProviderName = Constants.TestProviderName,
+                    ShortId = 200,
+                    RawId = 0x400200C8, // high 0x4002, exact qualifier
+                    Text = "Exact: %1"
+                }
+            ],
+            Parameters = [],
+            Keywords = new Dictionary<long, string>(),
+            Tasks = new Dictionary<int, string>()
+        };
+
+        var resolver = new TestEventResolver([providerDetails]);
+
+        var eventRecord = new EventRecord
+        {
+            ProviderName = Constants.TestProviderName,
+            Id = 200,
+            Qualifiers = 0x4002,
+            Level = 4,
+            LogName = Constants.ApplicationLogName,
+            Properties = ["payload"]
+        };
+
+        // Act
+        var displayEvent = resolver.ResolveEvent(eventRecord);
+
+        // Assert
+        Assert.NotNull(displayEvent);
+        Assert.Equal("Exact: payload", displayEvent.Description);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

Classic (legacy) events from a provider whose registry `EventMessageFile` lists a driver's own `.sys` module resolved incorrectly. Example: the MediaTek Wi-Fi driver `mtkwecx` registers `EventMessageFile = %SystemRoot%\System32\netevent.dll;...\mtkwecxa.sys`. EventLogExpert filtered that list to `.dll`/`.exe`, dropping `mtkwecxa.sys` — where the driver's real messages live.

On affected machines:
- Event 1035 → "No matching message found" (Windows shows "Send EAPOL")
- Event 7001 → `netevent.dll`'s unrelated Service Control Manager template with the event's `<Binary>` blob substituted as `%2` (Windows shows "Power Save Information")

`netevent.dll`'s short-ID-7001 message has full id `0xC0001B59` (Qualifiers `0xC000`), which differs from the event's `0x40021B59` (Qualifiers `0x4002`). Windows resolves classic events by full 32-bit id, so it falls through to the driver's `.sys`; EventLogExpert never loaded it, so 7001 false-matched on the 16-bit short id and 1035 matched nothing.

## Fix

**Include driver `.sys` modules.** A new `LegacyMessageFilePaths.GetSupportedModulePaths` keeps `.sys` entries alongside `.dll`/`.exe`; the live (`RegistryProvider`) and offline (`OfflineLegacyMessageFileResolver`) resolvers use it and de-duplicate on the resolved path. `.sys` modules are read safely: `MessageTableReader` maps them read-only (`LOAD_LIBRARY_AS_IMAGE_RESOURCE | LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE`, never executed) and walks the message table with full bounds checking.

**Reject qualifier collisions.** New `ModernEventMatcher.FilterByQualifier` compares each candidate's high-16 (`Qualifiers`) to the event's: keep exact-qualifier matches; if none, keep the provider's own unqualified (`high-16 == 0`) messages only when no conflicting-qualifier collision is present; otherwise return nothing so the resolver reports "No matching message" instead of rendering a message that is provably not this event's. Applied at every legacy short-id lookup in `EventResolverBase`/`DescriptionFormatter`; `DisambiguateLegacyMessage` is unchanged.

## Verification

- On an affected machine the events now resolve to "Send EAPOL" (1035) and "Power Save Information" (7001), matching Windows Event Viewer.
- Tests: `EventLogExpert.Eventing.Tests` 741, `EventLogExpert.Eventing.OfflineImaging.Tests` 143, `RegistryProviderTests` 23 — all pass. New: `LegacyMessageFilePathsTests`, offline `.sys`-inclusion + dedup tests, and resolver tests for the collision, exact-match, unqualified-fallback, and no-match cases.

Users relying on a pre-built provider database should regenerate it to pick up driver `.sys` messages.
