### PR TITLE
Remove the temporary AngleSharp security pin by upgrading bUnit to 2.9.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
     <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="10.0.10" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
     <!-- Pinned to the version transitively resolved through Microsoft.Maui.Controls (per
              dotnet list package, include-transitive) so the ExplorerExtension companion exe and
@@ -39,15 +39,6 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="xunit.v3.mtp-off" Version="3.2.2" />
-    <PackageVersion Include="bunit" Version="2.7.2" />
-    <!-- Security override for CVE-2026-54570 (GHSA-pgww-w46g-26qg, moderate).
-         bunit 2.7.2 (test-only) transitively resolves AngleSharp 1.4.0, which mis-parses
-         MathML annotation-xml HTML integration points and does not escape &lt; or &gt; when
-         serializing attribute values (a mutation-XSS vector that can bypass sanitizers built
-         on AngleSharp). The fix first shipped in AngleSharp 1.5.0 and there is no 1.4.x patch,
-         so this pins the transitively-resolved core package to 1.5.2 (latest 1.5.x stable).
-         The sibling AngleSharp.Css / AngleSharp.Diffing packages are not covered by the
-         advisory. Remove once bunit ships an AngleSharp reference >= 1.5.0. -->
-    <PackageVersion Include="AngleSharp" Version="1.5.2" />
+    <PackageVersion Include="bunit" Version="2.9.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Removes the temporary `AngleSharp` security override (CVE-2026-54570 / GHSA-pgww-w46g-26qg) now that the upstream fix is available transitively.

- Bump `bUnit` **2.7.2 → 2.9.0** (test-only). bUnit ≥ 2.8.6 references a non-vulnerable `AngleSharp` on its own; 2.9.0 now resolves **AngleSharp 1.7.0** transitively (the fix first shipped in 1.5.0).
- Bump `Microsoft.AspNetCore.Components.Web` **10.0.0 → 10.0.10** — bUnit 2.9.0 requires `>= 10.0.10`, and this aligns it with the rest of the repo's 10.0.10 baseline.
- Remove the `<PackageVersion Include="AngleSharp" Version="1.5.2" />` override and its comment.

`CentralPackageTransitivePinningEnabled` is **retained** — it is still required by the separate `SQLitePCLRaw.lib.e_sqlite3` override tracked in #604.

## Verification

- `dotnet nuget why` confirms `AngleSharp` now resolves to **1.7.0** transitively through bUnit 2.9.0.
- Solution-wide `dotnet list package --vulnerable --include-transitive` is **clean** (no vulnerable packages in any project).
- `EventLogExpert.UI.Tests` (bUnit) builds 0-warn and passes **1457/1457**.

## Not included

#604 (`SQLitePCLRaw.lib.e_sqlite3` 3.53.3 pin for CVE-2025-6965) stays — its fix ships only in `Microsoft.Data.Sqlite` / EF Core **11.0-preview**; there is no stable 10.x servicing backport, so that override remains on the stable 10.x line.

Closes #655
