### PR TITLE
Add a within-log activity correlation timeline to the event details pane

### DIFF
--- a/src/EventLogExpert.Runtime/ActivityCorrelation/ActivityCorrelationService.cs
+++ b/src/EventLogExpert.Runtime/ActivityCorrelation/ActivityCorrelationService.cs
@@ -1,0 +1,350 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Runtime.LogTable;
+using Fluxor;
+
+namespace EventLogExpert.Runtime.ActivityCorrelation;
+
+internal sealed class ActivityCorrelationService(IState<RawEventStoreState> rawStore) : IActivityCorrelationService
+{
+    private const int MaxLeavesPerNode = 200;
+    private const int SharedActivityThreshold = 500;
+    private const int SharedPreviewCap = 25;
+
+    private readonly Lock _cacheGate = new();
+    private readonly IState<RawEventStoreState> _rawStore = rawStore;
+
+    private CachedView? _cache;
+
+    public async Task<ActivityCorrelationView?> BuildAsync(EventLocator focusedEvent, CancellationToken cancellationToken)
+    {
+        var byLog = _rawStore.Value.ByLog;
+
+        if (!byLog.TryGetValue(focusedEvent.LogId, out var store)) { return null; }
+
+        // A locator from a superseded generation, or one that no longer addresses a row, cannot be correlated against
+        // the current snapshot. ContentVersion is folded into the freshness token so a same-generation replace still
+        // rebuilds rather than resolving stale content.
+        if (focusedEvent.Generation != store.Generation ||
+            focusedEvent.Index < 0 ||
+            focusedEvent.Index >= store.Count)
+        {
+            return null;
+        }
+
+        var token = new CorrelationContentToken(focusedEvent.LogId, store.Generation, store.ContentVersion, store.Count);
+
+        lock (_cacheGate)
+        {
+            if (_cache is { } cached && cached.Focused == focusedEvent && cached.Token == token)
+            {
+                return cached.View;
+            }
+        }
+
+        var view = await Task.Run(() => BuildCore(store, focusedEvent, token, cancellationToken), cancellationToken);
+
+        lock (_cacheGate) { _cache = new CachedView(focusedEvent, token, view); }
+
+        return view;
+    }
+
+    public bool TryGetContentToken(EventLogId logId, out CorrelationContentToken token)
+    {
+        if (_rawStore.Value.ByLog.TryGetValue(logId, out var store))
+        {
+            token = new CorrelationContentToken(logId, store.Generation, store.ContentVersion, store.Count);
+
+            return true;
+        }
+
+        token = default;
+
+        return false;
+    }
+
+    private static void AddRow(Dictionary<Guid, List<int>> rowsByActivity, Guid activity, int row)
+    {
+        if (!rowsByActivity.TryGetValue(activity, out var rows))
+        {
+            rows = [];
+            rowsByActivity[activity] = rows;
+        }
+
+        rows.Add(row);
+    }
+
+    private static ActivityCorrelationView BuildCore(
+        EventColumnStore store,
+        EventLocator focused,
+        CorrelationContentToken token,
+        CancellationToken cancellationToken)
+    {
+        var reader = store.CreateReader(focused.LogId);
+        int count = reader.Count;
+
+        var activityIds = new Guid[count];
+        var activityHas = new bool[count];
+        reader.CopyGuidColumn(EventFieldId.ActivityId, activityIds, activityHas);
+
+        Guid focusActivity = activityHas[focused.Index] ? activityIds[focused.Index] : Guid.Empty;
+
+        if (focusActivity == Guid.Empty)
+        {
+            return new ActivityCorrelationView { LogId = focused.LogId, FocusActivityId = Guid.Empty, Token = token };
+        }
+
+        var relatedIds = new Guid[count];
+        var relatedHas = new bool[count];
+        reader.CopyGuidColumn(EventFieldId.RelatedActivityId, relatedIds, relatedHas);
+
+        // Pooled Level codes for a topology-only severity tally (no string materialization); -1 marks an absent level.
+        var levelPoolIndex = new int[count];
+        reader.CopyPoolIndexColumn(EventFieldId.Level, levelPoolIndex);
+        var pool = reader.Pool;
+        var severityByPoolIndex = new Dictionary<int, SeverityLevel?>();
+
+        var memberRows = new List<int>();
+        var parentsOfFocus = new HashSet<Guid>();
+        var childActivities = new HashSet<Guid>();
+
+        for (int i = 0; i < count; i++)
+        {
+            if ((i & 0xFFFF) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
+
+            bool hasActivity = activityHas[i];
+            Guid activity = hasActivity ? activityIds[i] : Guid.Empty;
+
+            if (hasActivity && activity == focusActivity)
+            {
+                memberRows.Add(i);
+
+                if (relatedHas[i] && relatedIds[i] != Guid.Empty && relatedIds[i] != focusActivity)
+                {
+                    parentsOfFocus.Add(relatedIds[i]);
+                }
+            }
+            else if (relatedHas[i] && relatedIds[i] == focusActivity && hasActivity && activity != Guid.Empty)
+            {
+                // Record the child's identity; the full-membership pass below gathers every event of that activity,
+                // since typically only the child's first (transfer) event carries the RelatedActivityId link.
+                childActivities.Add(activity);
+            }
+        }
+
+        var parentRowsByActivity = new Dictionary<Guid, List<int>>();
+        var childRowsByActivity = new Dictionary<Guid, List<int>>();
+
+        // Second pass: gather ALL rows of each parent and child activity (not just the linking rows), so a node's count,
+        // span, tallies, leaves, and false-fusion flag reflect the activity's full membership.
+        if (parentsOfFocus.Count > 0 || childActivities.Count > 0)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                if ((i & 0xFFFF) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
+
+                if (!activityHas[i]) { continue; }
+
+                Guid activity = activityIds[i];
+
+                if (activity == focusActivity) { continue; }
+
+                if (parentsOfFocus.Contains(activity)) { AddRow(parentRowsByActivity, activity, i); }
+
+                if (childActivities.Contains(activity)) { AddRow(childRowsByActivity, activity, i); }
+            }
+        }
+
+        // An activity that is both a parent and a child of the focus is a 2-cycle; surface it once (as a flagged parent).
+        var cyclicActivities = new HashSet<Guid>(parentsOfFocus);
+        cyclicActivities.IntersectWith(childActivities);
+
+        var focusNode = BuildNode(
+            reader,
+            SeverityOfRow,
+            focusActivity,
+            ActivityNodeRole.Focus,
+            memberRows,
+            [.. parentsOfFocus],
+            pinnedRow: focused.Index,
+            isCycle: false,
+            cancellationToken);
+
+        var parentNodes = new List<ActivityNode>();
+
+        foreach (var parent in parentsOfFocus)
+        {
+            var rows = parentRowsByActivity.GetValueOrDefault(parent) ?? [];
+
+            parentNodes.Add(BuildNode(
+                reader,
+                SeverityOfRow,
+                parent,
+                ActivityNodeRole.Parent,
+                rows,
+                [],
+                pinnedRow: null,
+                isCycle: cyclicActivities.Contains(parent),
+                cancellationToken));
+        }
+
+        var childNodes = new List<ActivityNode>();
+
+        foreach (var child in childActivities.Where(activity => !cyclicActivities.Contains(activity)))
+        {
+            childNodes.Add(BuildNode(
+                reader,
+                SeverityOfRow,
+                child,
+                ActivityNodeRole.Child,
+                childRowsByActivity[child],
+                [focusActivity],
+                pinnedRow: null,
+                isCycle: false,
+                cancellationToken));
+        }
+
+        // Newest activity first; a referenced-but-absent parent (MaxTicks 0) sorts last.
+        parentNodes.Sort(static (left, right) => right.MaxTicks.CompareTo(left.MaxTicks));
+        childNodes.Sort(static (left, right) => right.MaxTicks.CompareTo(left.MaxTicks));
+
+        var nodes = new List<ActivityNode>(1 + parentNodes.Count + childNodes.Count) { focusNode };
+        nodes.AddRange(parentNodes);
+        nodes.AddRange(childNodes);
+
+        return new ActivityCorrelationView
+        {
+            LogId = focused.LogId,
+            FocusActivityId = focusActivity,
+            Token = token,
+            Activities = nodes,
+            HasHierarchy = parentsOfFocus.Count > 0 || childActivities.Count > 0
+        };
+
+        SeverityLevel? SeverityOfRow(int row)
+        {
+            int poolIndex = levelPoolIndex[row];
+
+            if (poolIndex < 0) { return null; }
+
+            if (!severityByPoolIndex.TryGetValue(poolIndex, out var severity))
+            {
+                severity = LevelSeverity.FromLevelName(poolIndex < pool.Count ? pool[poolIndex] : null);
+                severityByPoolIndex[poolIndex] = severity;
+            }
+
+            return severity;
+        }
+    }
+
+    private static ActivityNode BuildNode(
+        IEventColumnReader reader,
+        Func<int, SeverityLevel?> severityOfRow,
+        Guid activityId,
+        ActivityNodeRole role,
+        List<int> rows,
+        IReadOnlyList<Guid> parents,
+        int? pinnedRow,
+        bool isCycle,
+        CancellationToken cancellationToken)
+    {
+        int eventCount = rows.Count;
+        bool oversized = eventCount > SharedActivityThreshold;
+        int cap = oversized ? SharedPreviewCap : MaxLeavesPerNode;
+
+        long minTicks = long.MaxValue;
+        long maxTicks = long.MinValue;
+        int critical = 0;
+        int error = 0;
+        int warning = 0;
+
+        // Reserve one display slot for the selected (pinned) event so it is never capped out.
+        int heapCap = pinnedRow is null ? cap : Math.Max(cap - 1, 0);
+
+        // A bounded min-heap keeps the top heapCap rows by priority (lowest-priority evicted): non-errors before errors
+        // (oversized only), then oldest, then lowest index. This bounds display selection to O(cap) memory and
+        // O(eventCount log cap), and the single tally/span/selection pass stays cancellable.
+        var heap = new PriorityQueue<RowInfo, (int Rank, long Ticks, int Row)>(heapCap + 1);
+        RowInfo? pinned = null;
+
+        for (int k = 0; k < eventCount; k++)
+        {
+            if ((k & 0xFFFF) == 0) { cancellationToken.ThrowIfCancellationRequested(); }
+
+            int row = rows[k];
+            long ticks = reader.GetTimeTicks(reader.LocatorAt(row));
+
+            if (ticks < minTicks) { minTicks = ticks; }
+
+            if (ticks > maxTicks) { maxTicks = ticks; }
+
+            var severity = severityOfRow(row);
+
+            switch (severity)
+            {
+                case SeverityLevel.Critical: critical++; break;
+                case SeverityLevel.Error: error++; break;
+                case SeverityLevel.Warning: warning++; break;
+            }
+
+            if (row == pinnedRow)
+            {
+                pinned = new RowInfo(row, ticks);
+
+                continue;
+            }
+
+            if (heapCap == 0) { continue; }
+
+            int rank = oversized && severity is SeverityLevel.Critical or SeverityLevel.Error ? 1 : 0;
+            heap.Enqueue(new RowInfo(row, ticks), (rank, ticks, row));
+
+            if (heap.Count > heapCap) { heap.Dequeue(); }
+        }
+
+        var chosen = new List<RowInfo>(heap.Count + 1);
+
+        while (heap.Count > 0) { chosen.Add(heap.Dequeue()); }
+
+        if (pinned is { } pin) { chosen.Add(pin); }
+
+        // Render newest-first to match the table's default sort.
+        chosen.Sort(static (left, right) =>
+        {
+            int byTime = right.Ticks.CompareTo(left.Ticks);
+
+            return byTime != 0 ? byTime : right.Row.CompareTo(left.Row);
+        });
+
+        var leaves = new List<CorrelationEventLeaf>(chosen.Count);
+
+        foreach (var candidate in chosen)
+        {
+            leaves.Add(new CorrelationEventLeaf(reader.LocatorAt(candidate.Row), candidate.Ticks));
+        }
+
+        return new ActivityNode
+        {
+            ActivityId = activityId,
+            Role = role,
+            EventCount = eventCount,
+            MinTicks = eventCount == 0 ? 0 : minTicks,
+            MaxTicks = eventCount == 0 ? 0 : maxTicks,
+            IsSharedOversized = oversized,
+            Parents = parents,
+            IsCycle = isCycle,
+            CriticalCount = critical,
+            ErrorCount = error,
+            WarningCount = warning,
+            Leaves = leaves,
+            LeavesTruncated = eventCount > leaves.Count
+        };
+    }
+
+    private readonly record struct RowInfo(int Row, long Ticks);
+
+    private sealed record CachedView(EventLocator Focused, CorrelationContentToken Token, ActivityCorrelationView View);
+}

--- a/src/EventLogExpert.Runtime/ActivityCorrelation/ActivityCorrelationService.cs
+++ b/src/EventLogExpert.Runtime/ActivityCorrelation/ActivityCorrelationService.cs
@@ -264,9 +264,10 @@ internal sealed class ActivityCorrelationService(IState<RawEventStoreState> rawS
         // Reserve one display slot for the selected (pinned) event so it is never capped out.
         int heapCap = pinnedRow is null ? cap : Math.Max(cap - 1, 0);
 
-        // A bounded min-heap keeps the top heapCap rows by priority (lowest-priority evicted): non-errors before errors
-        // (oversized only), then oldest, then lowest index. This bounds display selection to O(cap) memory and
-        // O(eventCount log cap), and the single tally/span/selection pass stays cancellable.
+        // A bounded min-heap of size heapCap keeps the highest-priority rows and evicts the lowest on overflow. Priority
+        // (Rank, Ticks, Row): for an oversized node Critical/Error rows (Rank 1) outrank non-errors (Rank 0), then newer
+        // outranks older, then higher row index. So the heap retains errors and the newest events, evicting
+        // non-errors/oldest/lowest-index first.
         var heap = new PriorityQueue<RowInfo, (int Rank, long Ticks, int Row)>(heapCap + 1);
         RowInfo? pinned = null;
 

--- a/src/EventLogExpert.Runtime/ActivityCorrelation/ActivityCorrelationService.cs
+++ b/src/EventLogExpert.Runtime/ActivityCorrelation/ActivityCorrelationService.cs
@@ -10,7 +10,7 @@ namespace EventLogExpert.Runtime.ActivityCorrelation;
 
 internal sealed class ActivityCorrelationService(IState<RawEventStoreState> rawStore) : IActivityCorrelationService
 {
-    private const int MaxLeavesPerNode = 200;
+    private const int MaxEventsPerActivity = 200;
     private const int SharedActivityThreshold = 500;
     private const int SharedPreviewCap = 25;
 
@@ -139,7 +139,7 @@ internal sealed class ActivityCorrelationService(IState<RawEventStoreState> rawS
         var childRowsByActivity = new Dictionary<Guid, List<int>>();
 
         // Second pass: gather ALL rows of each parent and child activity (not just the linking rows), so a node's count,
-        // span, tallies, leaves, and false-fusion flag reflect the activity's full membership.
+        // span, tallies, events, and false-fusion flag reflect the activity's full membership.
         if (parentsOfFocus.Count > 0 || childActivities.Count > 0)
         {
             for (int i = 0; i < count; i++)
@@ -253,7 +253,7 @@ internal sealed class ActivityCorrelationService(IState<RawEventStoreState> rawS
     {
         int eventCount = rows.Count;
         bool oversized = eventCount > SharedActivityThreshold;
-        int cap = oversized ? SharedPreviewCap : MaxLeavesPerNode;
+        int cap = oversized ? SharedPreviewCap : MaxEventsPerActivity;
 
         long minTicks = long.MaxValue;
         long maxTicks = long.MinValue;
@@ -320,11 +320,11 @@ internal sealed class ActivityCorrelationService(IState<RawEventStoreState> rawS
             return byTime != 0 ? byTime : right.Row.CompareTo(left.Row);
         });
 
-        var leaves = new List<CorrelationEventLeaf>(chosen.Count);
+        var events = new List<CorrelatedEvent>(chosen.Count);
 
         foreach (var candidate in chosen)
         {
-            leaves.Add(new CorrelationEventLeaf(reader.LocatorAt(candidate.Row), candidate.Ticks));
+            events.Add(new CorrelatedEvent(reader.LocatorAt(candidate.Row), candidate.Ticks));
         }
 
         return new ActivityNode
@@ -340,8 +340,8 @@ internal sealed class ActivityCorrelationService(IState<RawEventStoreState> rawS
             CriticalCount = critical,
             ErrorCount = error,
             WarningCount = warning,
-            Leaves = leaves,
-            LeavesTruncated = eventCount > leaves.Count
+            Events = events,
+            EventsTruncated = eventCount > events.Count
         };
     }
 

--- a/src/EventLogExpert.Runtime/ActivityCorrelation/ActivityCorrelationSource.cs
+++ b/src/EventLogExpert.Runtime/ActivityCorrelation/ActivityCorrelationSource.cs
@@ -1,0 +1,55 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.LogTable;
+using Fluxor;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EventLogExpert.Runtime.ActivityCorrelation;
+
+internal sealed class ActivityCorrelationSource : IActivityCorrelationSource, IDisposable
+{
+    private readonly ITraceLogger _logger;
+    private readonly IState<RawEventStoreState> _rawStore;
+
+    private bool _disposed;
+
+    public ActivityCorrelationSource(
+        IState<RawEventStoreState> rawStore,
+        [FromKeyedServices(LogCategories.EventLog)] ITraceLogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(rawStore);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _rawStore = rawStore;
+        _logger = logger;
+        _rawStore.StateChanged += OnRawStoreChanged;
+    }
+
+    public event Action? Changed;
+
+    public void Dispose()
+    {
+        if (_disposed) { return; }
+
+        _disposed = true;
+        _rawStore.StateChanged -= OnRawStoreChanged;
+    }
+
+    private void OnRawStoreChanged(object? sender, EventArgs e)
+    {
+        var handlers = Changed;
+
+        if (_disposed || handlers is null) { return; }
+
+        foreach (var handler in handlers.GetInvocationList().Cast<Action>())
+        {
+            try { handler(); }
+            catch (Exception fault)
+            {
+                _logger.Trace($"{nameof(ActivityCorrelationSource)}: a subscriber threw and was isolated: {fault}");
+            }
+        }
+    }
+}

--- a/src/EventLogExpert.Runtime/ActivityCorrelation/ActivityCorrelationView.cs
+++ b/src/EventLogExpert.Runtime/ActivityCorrelation/ActivityCorrelationView.cs
@@ -24,7 +24,7 @@ public enum ActivityNodeRole
 ///     selects/reveals it plus its timestamp for sorting); display fields (level, source, event id) are resolved lazily by
 ///     the UI for the rows it actually renders, so the neighborhood never materializes strings for the whole log.
 /// </summary>
-public readonly record struct CorrelationEventLeaf(EventLocator Locator, long TimeTicks);
+public readonly record struct CorrelatedEvent(EventLocator Locator, long TimeTicks);
 
 /// <summary>The snapshot identity a correlation view was built from, for freshness comparison against the live store.</summary>
 public readonly record struct CorrelationContentToken(EventLogId LogId, int Generation, long ContentVersion, int Count);
@@ -38,13 +38,13 @@ public sealed record ActivityNode
     /// <summary>Whether this is the focus activity, a parent, or a child.</summary>
     public required ActivityNodeRole Role { get; init; }
 
-    /// <summary>The total number of member events in this log (may exceed <see cref="Leaves" />.Count when truncated).</summary>
+    /// <summary>The total number of member events in this log (may exceed <see cref="Events" />.Count when truncated).</summary>
     public required int EventCount { get; init; }
 
-    /// <summary>The UTC-tick timestamp of the earliest built leaf (0 when the activity has no rows in this log).</summary>
+    /// <summary>The UTC-tick timestamp of the earliest built event (0 when the activity has no rows in this log).</summary>
     public required long MinTicks { get; init; }
 
-    /// <summary>The UTC-tick timestamp of the latest built leaf (0 when the activity has no rows in this log).</summary>
+    /// <summary>The UTC-tick timestamp of the latest built event (0 when the activity has no rows in this log).</summary>
     public required long MaxTicks { get; init; }
 
     /// <summary>
@@ -72,10 +72,13 @@ public sealed record ActivityNode
     public int ErrorTotal => CriticalCount + ErrorCount;
 
     /// <summary>The member events (capped for display), sorted by time.</summary>
-    public IReadOnlyList<CorrelationEventLeaf> Leaves { get; init; } = [];
+    public IReadOnlyList<CorrelatedEvent> Events { get; init; } = [];
 
-    /// <summary>True when <see cref="EventCount" /> exceeds the per-node display cap, so <see cref="Leaves" /> is a prefix.</summary>
-    public bool LeavesTruncated { get; init; }
+    /// <summary>
+    ///     True when <see cref="EventCount" /> exceeds the per-activity display cap, so <see cref="Events" /> is a
+    ///     prefix.
+    /// </summary>
+    public bool EventsTruncated { get; init; }
 
     /// <summary>True when this node has more than one distinct parent activity (parentage cannot be a single tree edge).</summary>
     public bool HasMultipleParents => Parents.Count > 1;

--- a/src/EventLogExpert.Runtime/ActivityCorrelation/ActivityCorrelationView.cs
+++ b/src/EventLogExpert.Runtime/ActivityCorrelation/ActivityCorrelationView.cs
@@ -1,0 +1,108 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Eventing.Common.Events;
+
+namespace EventLogExpert.Runtime.ActivityCorrelation;
+
+/// <summary>The role a correlated activity plays relative to the selected event's activity.</summary>
+public enum ActivityNodeRole
+{
+    /// <summary>The selected event's own activity.</summary>
+    Focus,
+
+    /// <summary>An activity the focus activity points at via <c>RelatedActivityId</c> (a causal parent).</summary>
+    Parent,
+
+    /// <summary>An activity that points at the focus activity via <c>RelatedActivityId</c> (a causal child).</summary>
+    Child
+}
+
+/// <summary>
+///     A single correlated event within an <see cref="ActivityNode" />. Carries only topology (the locator that
+///     selects/reveals it plus its timestamp for sorting); display fields (level, source, event id) are resolved lazily by
+///     the UI for the rows it actually renders, so the neighborhood never materializes strings for the whole log.
+/// </summary>
+public readonly record struct CorrelationEventLeaf(EventLocator Locator, long TimeTicks);
+
+/// <summary>The snapshot identity a correlation view was built from, for freshness comparison against the live store.</summary>
+public readonly record struct CorrelationContentToken(EventLogId LogId, int Generation, long ContentVersion, int Count);
+
+/// <summary>One activity (a distinct <c>ActivityId</c>) in the selected event's within-log correlation neighborhood.</summary>
+public sealed record ActivityNode
+{
+    /// <summary>The distinct <c>ActivityId</c> this node groups.</summary>
+    public required Guid ActivityId { get; init; }
+
+    /// <summary>Whether this is the focus activity, a parent, or a child.</summary>
+    public required ActivityNodeRole Role { get; init; }
+
+    /// <summary>The total number of member events in this log (may exceed <see cref="Leaves" />.Count when truncated).</summary>
+    public required int EventCount { get; init; }
+
+    /// <summary>The UTC-tick timestamp of the earliest built leaf (0 when the activity has no rows in this log).</summary>
+    public required long MinTicks { get; init; }
+
+    /// <summary>The UTC-tick timestamp of the latest built leaf (0 when the activity has no rows in this log).</summary>
+    public required long MaxTicks { get; init; }
+
+    /// <summary>
+    ///     True when the member count exceeds the false-fusion threshold, marking a likely shared / sentinel
+    ///     <c>ActivityId</c> that may span unrelated operations; such a node is not auto-expanded.
+    /// </summary>
+    public required bool IsSharedOversized { get; init; }
+
+    /// <summary>The distinct parent activities referenced by this node's members; more than one is an ambiguous parentage.</summary>
+    public IReadOnlyList<Guid> Parents { get; init; } = [];
+
+    /// <summary>True when this activity both references and is referenced by the focus activity (a 2-cycle); shown once.</summary>
+    public bool IsCycle { get; init; }
+
+    /// <summary>The number of member events at Critical severity (part of the error headline).</summary>
+    public int CriticalCount { get; init; }
+
+    /// <summary>The number of member events at Error severity.</summary>
+    public int ErrorCount { get; init; }
+
+    /// <summary>The number of member events at Warning severity.</summary>
+    public int WarningCount { get; init; }
+
+    /// <summary>The headline "errors" count: Critical plus Error.</summary>
+    public int ErrorTotal => CriticalCount + ErrorCount;
+
+    /// <summary>The member events (capped for display), sorted by time.</summary>
+    public IReadOnlyList<CorrelationEventLeaf> Leaves { get; init; } = [];
+
+    /// <summary>True when <see cref="EventCount" /> exceeds the per-node display cap, so <see cref="Leaves" /> is a prefix.</summary>
+    public bool LeavesTruncated { get; init; }
+
+    /// <summary>True when this node has more than one distinct parent activity (parentage cannot be a single tree edge).</summary>
+    public bool HasMultipleParents => Parents.Count > 1;
+}
+
+/// <summary>
+///     The within-log activity correlation neighborhood of a selected event: its own activity plus, where
+///     <c>RelatedActivityId</c> links exist, the immediate parent and child activities. When no <c>RelatedActivityId</c>
+///     edges are present (the common case) this degrades to the focus activity's grouped events alone.
+/// </summary>
+public sealed record ActivityCorrelationView
+{
+    /// <summary>The log the neighborhood was built from (correlation is scoped to a single log).</summary>
+    public required EventLogId LogId { get; init; }
+
+    /// <summary>The selected event's <c>ActivityId</c>; <see cref="Guid.Empty" /> when the event carries no activity.</summary>
+    public required Guid FocusActivityId { get; init; }
+
+    /// <summary>The snapshot identity this view was built from, for staleness detection against live-tail updates.</summary>
+    public required CorrelationContentToken Token { get; init; }
+
+    /// <summary>The focus activity followed by its parent and child activities, ordered for display.</summary>
+    public IReadOnlyList<ActivityNode> Activities { get; init; } = [];
+
+    /// <summary>True when any <c>RelatedActivityId</c> parent/child edge was found in the neighborhood.</summary>
+    public bool HasHierarchy { get; init; }
+
+    /// <summary>True when the selected event carries no usable <c>ActivityId</c>, so there is nothing to correlate.</summary>
+    public bool IsEmpty => FocusActivityId == Guid.Empty || Activities.Count == 0;
+}

--- a/src/EventLogExpert.Runtime/ActivityCorrelation/IActivityCorrelationService.cs
+++ b/src/EventLogExpert.Runtime/ActivityCorrelation/IActivityCorrelationService.cs
@@ -1,0 +1,28 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Eventing.Common.Events;
+
+namespace EventLogExpert.Runtime.ActivityCorrelation;
+
+/// <summary>
+///     Builds the within-log activity correlation neighborhood of a selected event on demand from the raw columnar
+///     store. The build is topology-only (no per-row string materialization) and runs off the caller's thread.
+/// </summary>
+public interface IActivityCorrelationService
+{
+    /// <summary>
+    ///     Builds the correlation neighborhood rooted on <paramref name="focusedEvent" />, or returns <c>null</c> when
+    ///     the event's log is not loaded or the locator is stale against the current snapshot. A returned view is
+    ///     <see cref="ActivityCorrelationView.IsEmpty" /> when the event carries no usable <c>ActivityId</c>.
+    /// </summary>
+    Task<ActivityCorrelationView?> BuildAsync(EventLocator focusedEvent, CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Reads the current snapshot identity for <paramref name="logId" /> so a caller can detect that a previously
+    ///     built view has gone stale (a live-tail append bumps <c>ContentVersion</c>). Returns <c>false</c> when the log is
+    ///     not loaded.
+    /// </summary>
+    bool TryGetContentToken(EventLogId logId, out CorrelationContentToken token);
+}

--- a/src/EventLogExpert.Runtime/ActivityCorrelation/IActivityCorrelationSource.cs
+++ b/src/EventLogExpert.Runtime/ActivityCorrelation/IActivityCorrelationSource.cs
@@ -1,0 +1,12 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.Common.Sources;
+
+namespace EventLogExpert.Runtime.ActivityCorrelation;
+
+/// <summary>
+///     Notifies when the raw event store changes, so a correlation consumer can re-check whether a built view has
+///     gone stale (via <see cref="IActivityCorrelationService.TryGetContentToken" />) and offer a refresh.
+/// </summary>
+public interface IActivityCorrelationSource : IChangeNotifier;

--- a/src/EventLogExpert.Runtime/DependencyInjection/RuntimeServiceCollectionExtensions.cs
+++ b/src/EventLogExpert.Runtime/DependencyInjection/RuntimeServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ using EventLogExpert.Logging.Routing;
 using EventLogExpert.Logging.Sinks;
 using EventLogExpert.Provider.Maintenance;
 using EventLogExpert.Provider.Resolution;
+using EventLogExpert.Runtime.ActivityCorrelation;
 using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.Runtime.Banner;
 using EventLogExpert.Runtime.Common.AppTitle;
@@ -170,6 +171,7 @@ public static class RuntimeServiceCollectionExtensions
             services.AddSingleton<IScenarioFavoritesSource, ScenarioFavoritesSource>();
             services.AddSingleton<ILogTabBarSource, LogTabBarSource>();
             services.AddSingleton<IStatusBarSource, StatusBarSource>();
+            services.AddSingleton<IActivityCorrelationSource, ActivityCorrelationSource>();
 
             // Change notifiers (concrete raises; interface subscribes; one shared instance)
             services.AddSingleton<GroupCollapseNotifier>();
@@ -184,6 +186,7 @@ public static class RuntimeServiceCollectionExtensions
             // Indicators, resolvers, formatters, and selectors
             services.AddSingleton<DisplayIndicatorGate>();
             services.AddSingleton<IEventDetailResolver, EventDetailResolver>();
+            services.AddSingleton<IActivityCorrelationService, ActivityCorrelationService>();
             services.AddSingleton<IEventXmlResolver, EventXmlResolver>();
             services.AddSingleton<IEventCopyFormatter, EventCopyFormatter>();
             services.AddSingleton<IHighlightSelector, HighlightSelector>();

--- a/src/EventLogExpert.Runtime/EventLog/EventLogCommands.cs
+++ b/src/EventLogExpert.Runtime/EventLog/EventLogCommands.cs
@@ -20,12 +20,15 @@ internal sealed class EventLogCommands(IDispatcher dispatcher) : IEventLogComman
         _dispatcher.Dispatch(new LogClosedByUserAction(logId, logName));
     }
 
-    public void ConsumeRevealFocus(EventLocator target) => _dispatcher.Dispatch(new RevealFocusConsumedAction(target));
+    public void ConsumeRevealFocus(RevealFocusRequest request) => _dispatcher.Dispatch(new RevealFocusConsumedAction(request));
 
     public void LoadNewEvents() => _dispatcher.Dispatch(new LoadNewEventsAction());
 
     public void OpenLog(string logName, LogPathType logPathType, CancellationToken token = default) =>
         _dispatcher.Dispatch(new OpenLogAction(logName, logPathType, token));
+
+    public void RequestRevealFocus(EventLocator target, bool waitForView = true) =>
+        _dispatcher.Dispatch(new RequestRevealFocusAction(target, waitForView));
 
     public void SetContinuouslyUpdate(bool continuouslyUpdate) =>
         _dispatcher.Dispatch(new SetContinuouslyUpdateAction(continuouslyUpdate));

--- a/src/EventLogExpert.Runtime/EventLog/EventLogState.cs
+++ b/src/EventLogExpert.Runtime/EventLog/EventLogState.cs
@@ -38,5 +38,5 @@ public sealed record EventLogState
 
     public ImmutableList<SelectionEntry> Selection { get; init; } = [];
 
-    public EventLocator? PendingRevealFocus { get; init; }
+    public RevealFocusRequest? PendingRevealFocus { get; init; }
 }

--- a/src/EventLogExpert.Runtime/EventLog/IEventLogCommands.cs
+++ b/src/EventLogExpert.Runtime/EventLog/IEventLogCommands.cs
@@ -13,11 +13,13 @@ public interface IEventLogCommands
 
     void CloseLog(EventLogId logId, string logName);
 
-    void ConsumeRevealFocus(EventLocator target);
+    void ConsumeRevealFocus(RevealFocusRequest request);
 
     void LoadNewEvents();
 
     void OpenLog(string logName, LogPathType logPathType, CancellationToken token = default);
+
+    void RequestRevealFocus(EventLocator target, bool waitForView = true);
 
     void SetContinuouslyUpdate(bool continuouslyUpdate);
 

--- a/src/EventLogExpert.Runtime/EventLog/IRevealFocusSource.cs
+++ b/src/EventLogExpert.Runtime/EventLog/IRevealFocusSource.cs
@@ -1,12 +1,11 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
-using EventLogExpert.Eventing.Common.Events;
 using EventLogExpert.Runtime.Common.Sources;
 
 namespace EventLogExpert.Runtime.EventLog;
 
 public interface IRevealFocusSource : IChangeNotifier
 {
-    EventLocator? Current { get; }
+    RevealFocusRequest? Current { get; }
 }

--- a/src/EventLogExpert.Runtime/EventLog/LogReloadEffects.cs
+++ b/src/EventLogExpert.Runtime/EventLog/LogReloadEffects.cs
@@ -112,6 +112,6 @@ internal sealed class LogReloadEffects(
         SelectionEntry? focused = focusEntry ?? (restored.Count > 0 ? restored[^1] : null);
         dispatcher.Dispatch(new SetSelectedEventsAction(restored, focused));
 
-        dispatcher.Dispatch(new RequestRevealFocusAction(focused!.Value.OriginHandle));
+        dispatcher.Dispatch(new RequestRevealFocusAction(focused!.Value.OriginHandle, WaitForView: true));
     }
 }

--- a/src/EventLogExpert.Runtime/EventLog/Reducers.cs
+++ b/src/EventLogExpert.Runtime/EventLog/Reducers.cs
@@ -76,15 +76,10 @@ internal sealed class Reducers
         var newSelection = state.Selection
             .RemoveAll(entry => entry.OriginHandle.LogId == action.LogId);
 
-        var newFocus =
-            state.Focus is { } focus && focus.OriginHandle.LogId == action.LogId
-                ? null
-                : state.Focus;
+        var newFocus = state.Focus is { } focus && focus.OriginHandle.LogId == action.LogId ? null : state.Focus;
 
-        var newPendingRevealFocus =
-            state.PendingRevealFocus is { } reveal && reveal.LogId == action.LogId
-                ? null
-                : state.PendingRevealFocus;
+        var newPendingRevealFocus = state.PendingRevealFocus is { } reveal && reveal.Target.LogId == action.LogId ?
+            null : state.PendingRevealFocus;
 
         var newNamesByLog = state.NamesByLog.Remove(action.LogName);
 
@@ -138,9 +133,7 @@ internal sealed class Reducers
             return state;
         }
 
-        var existingSet = state.NamesByLog.TryGetValue(action.LogData.Name, out var current)
-            ? current
-            : s_emptyNames;
+        var existingSet = state.NamesByLog.TryGetValue(action.LogData.Name, out var current) ? current : s_emptyNames;
 
         var newSet = existingSet.Union(DistinctLogNames(action.Events));
 
@@ -177,9 +170,9 @@ internal sealed class Reducers
 
         var openLogId = action.PreassignedId ?? EventLogId.Create();
 
-        var perLogNames = action.LogPathType == LogPathType.Channel
-            ? s_emptyNames.Add(action.LogName)
-            : s_emptyNames;
+        var perLogNames = action.LogPathType == LogPathType.Channel ?
+            s_emptyNames.Add(action.LogName) :
+            s_emptyNames;
 
         var newNamesByLog = state.NamesByLog.SetItem(action.LogName, perLogNames);
 
@@ -192,13 +185,17 @@ internal sealed class Reducers
     }
 
     [ReducerMethod]
-    public static EventLogState ReduceRequestRevealFocus(EventLogState state, RequestRevealFocusAction action) =>
-        state.PendingRevealFocus == action.Target ? state : state with { PendingRevealFocus = action.Target };
+    public static EventLogState ReduceRequestRevealFocus(EventLogState state, RequestRevealFocusAction action)
+    {
+        var request = new RevealFocusRequest(action.Target, action.WaitForView);
+
+        return state.PendingRevealFocus == request ? state : state with { PendingRevealFocus = request };
+    }
 
     [ReducerMethod]
     public static EventLogState ReduceRevealFocusConsumed(EventLogState state, RevealFocusConsumedAction action)
     {
-        if (state.PendingRevealFocus != action.Target) { return state; }
+        if (state.PendingRevealFocus != action.Request) { return state; }
 
         return state with { PendingRevealFocus = null };
     }
@@ -229,9 +226,9 @@ internal sealed class Reducers
 
         if (action.ShouldStaySelected)
         {
-            return FocusEqualsByOriginHandle(state.Focus, action.Selection)
-                ? state
-                : state with { Focus = action.Selection };
+            return FocusEqualsByOriginHandle(state.Focus, action.Selection) ?
+                state :
+                state with { Focus = action.Selection };
         }
 
         return state with { Selection = [action.Selection], Focus = action.Selection };

--- a/src/EventLogExpert.Runtime/EventLog/RequestRevealFocusAction.cs
+++ b/src/EventLogExpert.Runtime/EventLog/RequestRevealFocusAction.cs
@@ -5,4 +5,4 @@ using EventLogExpert.Eventing.Common.Events;
 
 namespace EventLogExpert.Runtime.EventLog;
 
-internal sealed record RequestRevealFocusAction(EventLocator Target);
+internal sealed record RequestRevealFocusAction(EventLocator Target, bool WaitForView = true);

--- a/src/EventLogExpert.Runtime/EventLog/RevealFocusConsumedAction.cs
+++ b/src/EventLogExpert.Runtime/EventLog/RevealFocusConsumedAction.cs
@@ -1,8 +1,6 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
-using EventLogExpert.Eventing.Common.Events;
-
 namespace EventLogExpert.Runtime.EventLog;
 
-internal sealed record RevealFocusConsumedAction(EventLocator Target);
+internal sealed record RevealFocusConsumedAction(RevealFocusRequest Request);

--- a/src/EventLogExpert.Runtime/EventLog/RevealFocusRequest.cs
+++ b/src/EventLogExpert.Runtime/EventLog/RevealFocusRequest.cs
@@ -1,0 +1,15 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+
+namespace EventLogExpert.Runtime.EventLog;
+
+/// <summary>
+///     A pending request to scroll the log table to <paramref name="Target" />. <paramref name="WaitForView" />
+///     distinguishes the two reveal intents the consumer must treat differently: a wait-for-settle reveal (reload
+///     restoration) lingers until the target appears in a rebuilt view, whereas a one-shot selection-driven reveal is
+///     discarded the moment the consumer finds the target absent from its current settled view (so a concurrent view
+///     change can never strand it).
+/// </summary>
+public readonly record struct RevealFocusRequest(EventLocator Target, bool WaitForView);

--- a/src/EventLogExpert.Runtime/EventLog/RevealFocusSource.cs
+++ b/src/EventLogExpert.Runtime/EventLog/RevealFocusSource.cs
@@ -1,7 +1,6 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
-using EventLogExpert.Eventing.Common.Events;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Runtime.Common.Sources;
 using Fluxor;
@@ -12,8 +11,8 @@ namespace EventLogExpert.Runtime.EventLog;
 internal sealed class RevealFocusSource(
     IState<EventLogState> state,
     [FromKeyedServices(LogCategories.EventLog)] ITraceLogger logger)
-    : ObservableStateSourceBase<EventLogState, EventLocator?>(state, logger, static state => state.PendingRevealFocus),
+    : ObservableStateSourceBase<EventLogState, RevealFocusRequest?>(state, logger, static state => state.PendingRevealFocus),
         IRevealFocusSource
 {
-    public EventLocator? Current => CurrentProjection;
+    public RevealFocusRequest? Current => CurrentProjection;
 }

--- a/src/EventLogExpert.Runtime/LogTable/EventDetailResolver.cs
+++ b/src/EventLogExpert.Runtime/LogTable/EventDetailResolver.cs
@@ -11,7 +11,13 @@ internal sealed class EventDetailResolver(IState<RawEventStoreState> rawEventSto
 {
     private readonly IState<RawEventStoreState> _rawEventStore = rawEventStore;
 
-    public bool TryResolve(EventLocator locator, [NotNullWhen(true)] out ResolvedEvent? detail)
+    public bool TryResolve(EventLocator locator, [NotNullWhen(true)] out ResolvedEvent? detail) =>
+        TryReconstruct(locator, lean: false, out detail);
+
+    public bool TryResolveLean(EventLocator locator, [NotNullWhen(true)] out ResolvedEvent? detail) =>
+        TryReconstruct(locator, lean: true, out detail);
+
+    private bool TryReconstruct(EventLocator locator, bool lean, [NotNullWhen(true)] out ResolvedEvent? detail)
     {
         detail = null;
 
@@ -23,7 +29,7 @@ internal sealed class EventDetailResolver(IState<RawEventStoreState> rawEventSto
 
         if (locator.Index < 0 || locator.Index >= reader.Count) { return false; }
 
-        detail = reader.GetDetail(locator);
+        detail = lean ? reader.GetDetailLean(locator) : reader.GetDetail(locator);
 
         return true;
     }

--- a/src/EventLogExpert.Runtime/LogTable/IEventDetailResolver.cs
+++ b/src/EventLogExpert.Runtime/LogTable/IEventDetailResolver.cs
@@ -9,4 +9,10 @@ namespace EventLogExpert.Runtime.LogTable;
 public interface IEventDetailResolver
 {
     bool TryResolve(EventLocator locator, [NotNullWhen(true)] out ResolvedEvent? detail);
+
+    /// <summary>
+    ///     Like <see cref="TryResolve" /> but rehydrates only the grid-visible fields (Description/Level/Source/Id; no
+    ///     XML, EventData, or UserData), for lightweight list rendering.
+    /// </summary>
+    bool TryResolveLean(EventLocator locator, [NotNullWhen(true)] out ResolvedEvent? detail);
 }

--- a/src/EventLogExpert.UI/DetailsPane/ActivityCorrelationPanel.razor
+++ b/src/EventLogExpert.UI/DetailsPane/ActivityCorrelationPanel.razor
@@ -1,0 +1,184 @@
+@using EventLogExpert.Runtime.ActivityCorrelation
+@inherits AppStateComponentBase
+
+@{
+    RenderFragment Timeline(ActivityNode node) =>
+        @<text>
+             <ul class="correlation-timeline">
+                 @foreach (var leaf in node.Leaves)
+                 {
+                     LeafDisplay display = ResolveLeaf(leaf);
+
+                     <li class="correlation-row @(IsSelected(leaf) ? "selected" : null)">
+                         <button class="correlation-row-button"
+                             disabled="@_stale"
+                             @onclick="() => OnLeafActivated(leaf)"
+                             title="@(display.MessageSnippet.Length > 0 ? display.MessageSnippet : "No message")"
+                             type="button">
+                             <span aria-hidden="true" class="correlation-row-severity @SeverityIconClass(display.Severity)"></span>
+                             <span class="correlation-row-time">@FormatTime(leaf.TimeTicks)</span>
+                             @if (display.EventId is { } eventId)
+                             {
+                                 <span class="correlation-row-id">@eventId</span>
+                             }
+                             @if (display.Source.Length > 0)
+                             {
+                                 <span class="correlation-row-source">@display.Source</span>
+                             }
+                             <span class="correlation-row-message">
+                                 @if (display.MessageSnippet.Length > 0) { @display.MessageSnippet }
+                                 else
+                                 {
+                                     <span class="details-muted">No message</span>
+                                 }
+                             </span>
+                         </button>
+                     </li>
+                 }
+             </ul>
+             @if (node.LeavesTruncated)
+             {
+                 <p class="correlation-truncated details-muted">
+                     @if (node.IsSharedOversized)
+                     {
+                         @:Shared Activity ID: showing @node.Leaves.Count of @node.EventCount events (the selected event and the most recent errors/events).
+                     }
+                     else
+                     {
+                         @:Showing the newest @node.Leaves.Count of @node.EventCount events (plus the selected event).
+                     }
+                 </p>
+             }
+    </text>;
+}
+
+<div class="correlation-panel">
+    @if (SelectedEvent?.ActivityId is not { } activity || activity == Guid.Empty)
+    {
+        <p class="details-muted">The selected event has no Activity ID, so there is nothing to correlate.</p>
+    }
+    else if (_building)
+    {
+        <p class="details-muted">Building correlation&hellip;</p>
+    }
+    else if (_view is null)
+    {
+        <p class="details-muted">Correlation is unavailable for the current selection.</p>
+    }
+    else if (_view.IsEmpty)
+    {
+        <p class="details-muted">No related events were found for this activity in this log.</p>
+    }
+    else
+    {
+        var focus = _view.Activities.First(node => node.Role == ActivityNodeRole.Focus);
+        var related = _view.Activities.Where(node => node.Role != ActivityNodeRole.Focus).ToList();
+
+        @if (_stale)
+        {
+            <div class="correlation-stale" role="status">
+                <span>The log changed since this correlation was built, so it may be out of date.</span>
+                <button class="button" @onclick="RefreshAsync" type="button">Refresh</button>
+            </div>
+        }
+
+        <div class="correlation-summary">
+            <div class="correlation-summary-line">
+                <span class="correlation-summary-count">@FormatEventCount(focus.EventCount)</span>
+                @if (focus.EventCount > 0)
+                {
+                    <span class="correlation-summary-span">@FormatSpan(focus)</span>
+                }
+                @if (focus.ErrorTotal > 0)
+                {
+                    <span class="correlation-summary-error" title="Critical and Error events (counts reflect events within this log only).">
+                        <i aria-hidden="true" class="bi bi-exclamation-circle"></i> @focus.ErrorTotal error@(focus.ErrorTotal == 1 ? "" : "s")
+                    </span>
+                }
+                @if (focus.WarningCount > 0)
+                {
+                    <span class="correlation-summary-warning" title="Warning events (counts reflect events within this log only).">
+                        <i aria-hidden="true" class="bi bi-exclamation-triangle"></i> @focus.WarningCount warning@(focus.WarningCount == 1 ? "" : "s")
+                    </span>
+                }
+                <span class="correlation-activity-id" title="@focus.ActivityId">@FormatActivityId(focus.ActivityId)</span>
+            </div>
+            <div class="correlation-summary-actions">
+                <button class="correlation-filter-action"
+                    @onclick="() => OnFilterToActivity(focus.ActivityId)"
+                    title="Narrow the event table to this Activity ID (a filter lens; existing filters may still hide events)."
+                    type="button">
+                    Filter table to this activity
+                </button>
+                @if (focus.IsSharedOversized)
+                {
+                    <span class="correlation-warn" title="This Activity ID is attached to an unusually large number of events and may span unrelated operations; showing the selected event and the most recent errors/events.">
+                        shared Activity ID
+                    </span>
+                }
+            </div>
+        </div>
+
+        @Timeline(focus)
+
+        @if (related.Count > 0)
+        {
+            <div class="correlation-related">
+                <h4 class="correlation-related-title">Related activities</h4>
+                @foreach (var node in related)
+                {
+                    <div class="correlation-chip" data-role="@node.Role.ToString().ToLowerInvariant()">
+                        <button aria-expanded="@(IsExpanded(node) ? "true" : "false")"
+                            class="correlation-chip-head"
+                            @onclick="() => ToggleExpand(node.ActivityId)"
+                            type="button">
+                            <i aria-hidden="true" class="bi @(IsExpanded(node) ? "bi-caret-down-fill" : "bi-caret-right-fill")"></i>
+                            <span class="correlation-role">@RoleLabel(node.Role)</span>
+                            <span class="correlation-activity-id" title="@node.ActivityId">@FormatActivityId(node.ActivityId)</span>
+                            <span class="correlation-count">@FormatEventCount(node.EventCount)</span>
+                            @if (node.ErrorTotal > 0)
+                            {
+                                <span class="correlation-summary-error">@node.ErrorTotal error@(node.ErrorTotal == 1 ? "" : "s")</span>
+                            }
+                            @if (node.WarningCount > 0)
+                            {
+                                <span class="correlation-summary-warning">@node.WarningCount warning@(node.WarningCount == 1 ? "" : "s")</span>
+                            }
+                            @if (node.IsCycle)
+                            {
+                                <span class="correlation-warn" title="This activity both references and is referenced by the selected event's activity (a cycle).">cycle</span>
+                            }
+                            @if (node.HasMultipleParents)
+                            {
+                                <span class="correlation-warn" title="This activity is referenced by more than one parent activity.">multiple parents</span>
+                            }
+                            @if (node.IsSharedOversized)
+                            {
+                                <span class="correlation-warn" title="Unusually large activity; may span unrelated operations.">shared Activity ID</span>
+                            }
+                        </button>
+                        @if (IsExpanded(node))
+                        {
+                            @if (node.EventCount == 0)
+                            {
+                                <p class="correlation-missing details-muted">This activity is referenced but has no events in this log.</p>
+                            }
+                            else
+                            {
+                                @Timeline(node)
+                                <div class="correlation-chip-actions">
+                                    <button class="correlation-filter-action"
+                                        @onclick="() => OnFilterToActivity(node.ActivityId)"
+                                        title="Narrow the event table to this Activity ID."
+                                        type="button">
+                                        Filter table to this activity
+                                    </button>
+                                </div>
+                            }
+                        }
+                    </div>
+                }
+            </div>
+        }
+    }
+</div>

--- a/src/EventLogExpert.UI/DetailsPane/ActivityCorrelationPanel.razor
+++ b/src/EventLogExpert.UI/DetailsPane/ActivityCorrelationPanel.razor
@@ -5,18 +5,18 @@
     RenderFragment Timeline(ActivityNode node) =>
         @<text>
              <ul class="correlation-timeline">
-                 @foreach (var leaf in node.Leaves)
+                 @foreach (var correlatedEvent in node.Events)
                  {
-                     LeafDisplay display = ResolveLeaf(leaf);
+                     EventDisplay display = ResolveEvent(correlatedEvent);
 
-                     <li class="correlation-row @(IsSelected(leaf) ? "selected" : null)">
+                     <li class="correlation-row @(IsSelected(correlatedEvent) ? "selected" : null)">
                          <button class="correlation-row-button"
                              disabled="@_stale"
-                             @onclick="() => OnLeafActivated(leaf)"
+                             @onclick="() => OnEventActivated(correlatedEvent)"
                              title="@(display.MessageSnippet.Length > 0 ? display.MessageSnippet : "No message")"
                              type="button">
                              <span aria-hidden="true" class="correlation-row-severity @SeverityIconClass(display.Severity)"></span>
-                             <span class="correlation-row-time">@FormatTime(leaf.TimeTicks)</span>
+                             <span class="correlation-row-time">@FormatTime(correlatedEvent.TimeTicks)</span>
                              @if (display.EventId is { } eventId)
                              {
                                  <span class="correlation-row-id">@eventId</span>
@@ -36,16 +36,16 @@
                      </li>
                  }
              </ul>
-             @if (node.LeavesTruncated)
+             @if (node.EventsTruncated)
              {
                  <p class="correlation-truncated details-muted">
                      @if (node.IsSharedOversized)
                      {
-                         @:Shared Activity ID: showing @node.Leaves.Count of @node.EventCount events (the selected event and the most recent errors/events).
+                         @:Shared Activity ID: showing @node.Events.Count of @node.EventCount events (the selected event and the most recent errors/events).
                      }
                      else
                      {
-                         @:Showing the newest @node.Leaves.Count of @node.EventCount events (plus the selected event).
+                         @:Showing the newest @node.Events.Count of @node.EventCount events (plus the selected event).
                      }
                  </p>
              }

--- a/src/EventLogExpert.UI/DetailsPane/ActivityCorrelationPanel.razor.cs
+++ b/src/EventLogExpert.UI/DetailsPane/ActivityCorrelationPanel.razor.cs
@@ -1,0 +1,299 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.ActivityCorrelation;
+using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.FilterLenses;
+using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.Runtime.Settings;
+using EventLogExpert.UI.Common;
+using Microsoft.AspNetCore.Components;
+using System.Globalization;
+
+namespace EventLogExpert.UI.DetailsPane;
+
+public sealed partial class ActivityCorrelationPanel : AppStateComponentBase
+{
+    private const int SnippetMaxLength = 120;
+
+    private readonly HashSet<Guid> _expanded = [];
+    private readonly Dictionary<EventLocator, LeafDisplay> _leafCache = [];
+
+    private CancellationTokenSource? _buildCts;
+    private bool _building;
+    private EventLocator? _builtHandle;
+    private Guid _lastFocusActivity;
+    private bool _stale;
+    private ActivityCorrelationView? _view;
+
+    [Parameter] public EventLocator? FocusedHandle { get; set; }
+
+    [Parameter] public bool IsActive { get; set; }
+
+    [Parameter] public ResolvedEvent? SelectedEvent { get; set; }
+
+    [Inject] private IActivityCorrelationService CorrelationService { get; init; } = null!;
+
+    [Inject] private IActivityCorrelationSource CorrelationSource { get; init; } = null!;
+
+    [Inject] private IEventDetailResolver DetailResolver { get; init; } = null!;
+
+    [Inject] private IEventLogCommands EventLogCommands { get; init; } = null!;
+
+    [Inject] private IFilterLensCommands FilterLensCommands { get; init; } = null!;
+
+    [Inject] private ISettingsService Settings { get; init; } = null!;
+
+    [Inject] private ITraceLogger TraceLogger { get; init; } = null!;
+
+    protected override ValueTask DisposeAsyncCore(bool disposing)
+    {
+        if (disposing) { CancelBuild(); }
+
+        return base.DisposeAsyncCore(disposing);
+    }
+
+    protected override void OnInitialized()
+    {
+        ObserveSource(CorrelationSource, OnStoreChangedAsync);
+
+        base.OnInitialized();
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        // Lazy: only build while the Correlation tab is the active tab.
+        if (!IsActive) { return; }
+
+        if (SelectedEvent?.ActivityId is not { } activity || activity == Guid.Empty || FocusedHandle is not { } handle)
+        {
+            CancelBuild();
+            _view = null;
+            _building = false;
+            _stale = false;
+            _builtHandle = null;
+
+            return;
+        }
+
+        if (handle == _builtHandle) { return; }
+
+        await BuildAsync(handle);
+    }
+
+    private static string BuildSnippet(string? description)
+    {
+        if (string.IsNullOrEmpty(description)) { return string.Empty; }
+
+        int i = 0;
+        int length = description.Length;
+
+        // Return the first non-empty logical line, trimmed and length-capped; keeps the DOM bounded and skips blank lines.
+        while (i < length)
+        {
+            int lineStart = i;
+
+            while (i < length && description[i] != '\n' && description[i] != '\r') { i++; }
+
+            ReadOnlySpan<char> line = description.AsSpan(lineStart, i - lineStart).Trim();
+
+            if (line.Length > 0)
+            {
+                return line.Length > SnippetMaxLength ? string.Concat(line[..SnippetMaxLength], "\u2026") : line.ToString();
+            }
+
+            while (i < length && (description[i] == '\n' || description[i] == '\r')) { i++; }
+        }
+
+        return string.Empty;
+    }
+
+    private static string FormatActivityId(Guid activityId)
+    {
+        string text = activityId.ToString();
+
+        return text.Length > 8 ? text[..8] : text;
+    }
+
+    private static string FormatEventCount(int count) => $"{count} event{(count == 1 ? "" : "s")}";
+
+    private static string RoleLabel(ActivityNodeRole role) =>
+        role switch
+        {
+            ActivityNodeRole.Focus => "This activity",
+            ActivityNodeRole.Parent => "Parent",
+            ActivityNodeRole.Child => "Child",
+            _ => string.Empty
+        };
+
+    private static string SeverityIconClass(SeverityLevel? severity) => SeverityIcon.CssClass(severity);
+
+    private async Task BuildAsync(EventLocator handle)
+    {
+        CancelBuild();
+
+        var cts = new CancellationTokenSource();
+        _buildCts = cts;
+        _builtHandle = handle;
+        _building = true;
+        _stale = false;
+        _view = null;
+        StateHasChanged();
+
+        ActivityCorrelationView? view;
+
+        try
+        {
+            view = await CorrelationService.BuildAsync(handle, cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            // A newer selection superseded this build; that build owns the panel state.
+            return;
+        }
+        catch (Exception ex)
+        {
+            TraceLogger.Error($"{nameof(ActivityCorrelationPanel)}: correlation build failed: {ex}");
+
+            if (!IsDisposed && ReferenceEquals(_buildCts, cts))
+            {
+                _building = false;
+                _view = null;
+                StateHasChanged();
+            }
+
+            return;
+        }
+
+        if (IsDisposed || cts.IsCancellationRequested || !ReferenceEquals(_buildCts, cts)) { return; }
+
+        _view = view;
+        _building = false;
+
+        // If the store changed while this build ran, the freshly built view is already stale: offer Refresh and block
+        // navigation immediately rather than presenting content the live store has moved past.
+        _stale = IsStale();
+        _leafCache.Clear();
+        SeedExpansion(view);
+        StateHasChanged();
+    }
+
+    private void CancelBuild()
+    {
+        if (_buildCts is { } cts)
+        {
+            try { cts.Cancel(); } catch (ObjectDisposedException) { /* Already disposed; cancel is moot. */ }
+
+            cts.Dispose();
+            _buildCts = null;
+        }
+    }
+
+    private string FormatSpan(ActivityNode node)
+    {
+        if (node.EventCount == 0) { return "not in this log"; }
+
+        string start = FormatTime(node.MinTicks);
+
+        return node.MinTicks == node.MaxTicks ? start : $"{start} to {FormatTime(node.MaxTicks)}";
+    }
+
+    private string FormatTime(long ticks) =>
+        TimeZoneInfo.ConvertTimeFromUtc(new DateTime(ticks, DateTimeKind.Utc), Settings.TimeZoneInfo)
+            .ToString("g", CultureInfo.CurrentCulture);
+
+    private bool IsExpanded(ActivityNode node) => _expanded.Contains(node.ActivityId);
+
+    private bool IsSelected(CorrelationEventLeaf leaf) => FocusedHandle == leaf.Locator;
+
+    private bool IsStale() =>
+        _view is { } view && (!CorrelationService.TryGetContentToken(view.LogId, out var token) || token != view.Token);
+
+    private void OnFilterToActivity(Guid activityId) =>
+        FilterLensCommands.ShowRelatedByActivityId(activityId, SelectedEvent?.OwningLog);
+
+    private void OnLeafActivated(CorrelationEventLeaf leaf)
+    {
+        // Navigation is disabled while the tree is stale (its locators may address replaced content); Refresh rebuilds it.
+        // Re-validate the snapshot synchronously too, closing the window between a live-tail change and its async notification.
+        if (_stale || IsStale())
+        {
+            _stale = true;
+            StateHasChanged();
+
+            return;
+        }
+
+        var entry = new SelectionEntry(leaf.Locator, leaf.Locator, null);
+        EventLogCommands.SetSelectedEvents([entry], entry);
+
+        // One-shot reveal: scrolls the table if the row is in the current view, otherwise the consumer discards it - so a
+        // filtered-out leaf still selects (details resolve from raw storage) without leaving a pending reveal.
+        EventLogCommands.RequestRevealFocus(leaf.Locator, waitForView: false);
+    }
+
+    private Task OnStoreChangedAsync()
+    {
+        if (!_stale && IsStale())
+        {
+            _stale = true;
+            StateHasChanged();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private async Task RefreshAsync()
+    {
+        if (FocusedHandle is { } handle) { await BuildAsync(handle); }
+    }
+
+    private LeafDisplay ResolveLeaf(CorrelationEventLeaf leaf)
+    {
+        if (_leafCache.TryGetValue(leaf.Locator, out var cached)) { return cached; }
+
+        // Only timezone-independent fields are cached; the row time is formatted at render from TimeTicks so a timezone
+        // change is reflected without invalidating this cache.
+        LeafDisplay display = DetailResolver.TryResolveLean(leaf.Locator, out var detail) ?
+            new LeafDisplay(detail.Id,
+                detail.Source,
+                BuildSnippet(detail.Description),
+                LevelSeverity.FromLevelName(detail.Level)) : new LeafDisplay(null, string.Empty, string.Empty, null);
+
+        _leafCache[leaf.Locator] = display;
+
+        return display;
+    }
+
+    private void SeedExpansion(ActivityCorrelationView? view)
+    {
+        if (view is null)
+        {
+            _expanded.Clear();
+            _lastFocusActivity = Guid.Empty;
+
+            return;
+        }
+
+        // The focus activity's timeline is always shown; only the secondary parent/child chips use expand state. On a new
+        // root focus, reset chip expansions; on a same-focus Refresh, keep expansions for activities still present.
+        if (view.FocusActivityId != _lastFocusActivity)
+        {
+            _lastFocusActivity = view.FocusActivityId;
+            _expanded.Clear();
+
+            return;
+        }
+
+        _expanded.RemoveWhere(activityId => view.Activities.All(node => node.ActivityId != activityId));
+    }
+
+    private void ToggleExpand(Guid activityId)
+    {
+        if (!_expanded.Add(activityId)) { _expanded.Remove(activityId); }
+    }
+
+    private readonly record struct LeafDisplay(int? EventId, string Source, string MessageSnippet, SeverityLevel? Severity);
+}

--- a/src/EventLogExpert.UI/DetailsPane/ActivityCorrelationPanel.razor.cs
+++ b/src/EventLogExpert.UI/DetailsPane/ActivityCorrelationPanel.razor.cs
@@ -17,9 +17,9 @@ namespace EventLogExpert.UI.DetailsPane;
 public sealed partial class ActivityCorrelationPanel : AppStateComponentBase
 {
     private const int SnippetMaxLength = 120;
+    private readonly Dictionary<EventLocator, EventDisplay> _eventCache = [];
 
     private readonly HashSet<Guid> _expanded = [];
-    private readonly Dictionary<EventLocator, LeafDisplay> _leafCache = [];
 
     private CancellationTokenSource? _buildCts;
     private bool _building;
@@ -192,7 +192,7 @@ public sealed partial class ActivityCorrelationPanel : AppStateComponentBase
         // If the store changed while this build ran, the freshly built view is already stale: offer Refresh and block
         // navigation immediately rather than presenting content the live store has moved past.
         _stale = IsStale();
-        _leafCache.Clear();
+        _eventCache.Clear();
         SeedExpansion(view);
         StateHasChanged();
     }
@@ -223,17 +223,14 @@ public sealed partial class ActivityCorrelationPanel : AppStateComponentBase
 
     private bool IsExpanded(ActivityNode node) => _expanded.Contains(node.ActivityId);
 
-    private bool IsSelected(CorrelationEventLeaf leaf) => FocusedHandle == leaf.Locator;
+    private bool IsSelected(CorrelatedEvent correlatedEvent) => FocusedHandle == correlatedEvent.Locator;
 
     private bool IsStale() =>
         _view is { } view && (!CorrelationService.TryGetContentToken(view.LogId, out var token) || token != view.Token);
 
-    private void OnFilterToActivity(Guid activityId) =>
-        FilterLensCommands.ShowRelatedByActivityId(activityId, SelectedEvent?.OwningLog);
-
-    private void OnLeafActivated(CorrelationEventLeaf leaf)
+    private void OnEventActivated(CorrelatedEvent correlatedEvent)
     {
-        // Navigation is disabled while the tree is stale (its locators may address replaced content); Refresh rebuilds it.
+        // Navigation is disabled while the correlation view is stale (its locators may address replaced content); Refresh rebuilds it.
         // Re-validate the snapshot synchronously too, closing the window between a live-tail change and its async notification.
         if (_stale || IsStale())
         {
@@ -243,13 +240,16 @@ public sealed partial class ActivityCorrelationPanel : AppStateComponentBase
             return;
         }
 
-        var entry = new SelectionEntry(leaf.Locator, leaf.Locator, null);
+        var entry = new SelectionEntry(correlatedEvent.Locator, correlatedEvent.Locator, null);
         EventLogCommands.SetSelectedEvents([entry], entry);
 
         // One-shot reveal: scrolls the table if the row is in the current view, otherwise the consumer discards it - so a
-        // filtered-out leaf still selects (details resolve from raw storage) without leaving a pending reveal.
-        EventLogCommands.RequestRevealFocus(leaf.Locator, waitForView: false);
+        // filtered-out event still selects (details resolve from raw storage) without leaving a pending reveal.
+        EventLogCommands.RequestRevealFocus(correlatedEvent.Locator, waitForView: false);
     }
+
+    private void OnFilterToActivity(Guid activityId) =>
+        FilterLensCommands.ShowRelatedByActivityId(activityId, SelectedEvent?.OwningLog);
 
     private Task OnStoreChangedAsync()
     {
@@ -267,19 +267,19 @@ public sealed partial class ActivityCorrelationPanel : AppStateComponentBase
         if (FocusedHandle is { } handle) { await BuildAsync(handle); }
     }
 
-    private LeafDisplay ResolveLeaf(CorrelationEventLeaf leaf)
+    private EventDisplay ResolveEvent(CorrelatedEvent correlatedEvent)
     {
-        if (_leafCache.TryGetValue(leaf.Locator, out var cached)) { return cached; }
+        if (_eventCache.TryGetValue(correlatedEvent.Locator, out var cached)) { return cached; }
 
         // Only timezone-independent fields are cached; the row time is formatted at render from TimeTicks so a timezone
         // change is reflected without invalidating this cache.
-        LeafDisplay display = DetailResolver.TryResolveLean(leaf.Locator, out var detail) ?
-            new LeafDisplay(detail.Id,
+        EventDisplay display = DetailResolver.TryResolveLean(correlatedEvent.Locator, out var detail) ?
+            new EventDisplay(detail.Id,
                 detail.Source,
                 BuildSnippet(detail.Description),
-                LevelSeverity.FromLevelName(detail.Level)) : new LeafDisplay(null, string.Empty, string.Empty, null);
+                LevelSeverity.FromLevelName(detail.Level)) : new EventDisplay(null, string.Empty, string.Empty, null);
 
-        _leafCache[leaf.Locator] = display;
+        _eventCache[correlatedEvent.Locator] = display;
 
         return display;
     }
@@ -312,5 +312,5 @@ public sealed partial class ActivityCorrelationPanel : AppStateComponentBase
         if (!_expanded.Add(activityId)) { _expanded.Remove(activityId); }
     }
 
-    private readonly record struct LeafDisplay(int? EventId, string Source, string MessageSnippet, SeverityLevel? Severity);
+    private readonly record struct EventDisplay(int? EventId, string Source, string MessageSnippet, SeverityLevel? Severity);
 }

--- a/src/EventLogExpert.UI/DetailsPane/ActivityCorrelationPanel.razor.cs
+++ b/src/EventLogExpert.UI/DetailsPane/ActivityCorrelationPanel.razor.cs
@@ -64,8 +64,20 @@ public sealed partial class ActivityCorrelationPanel : AppStateComponentBase
 
     protected override async Task OnParametersSetAsync()
     {
-        // Lazy: only build while the Correlation tab is the active tab.
-        if (!IsActive) { return; }
+        // Lazy: only build while the Correlation tab is active. On deactivation cancel any in-flight build; if one was
+        // actually running, drop the built handle so re-activation rebuilds. A completed view is retained for instant reuse.
+        if (!IsActive)
+        {
+            CancelBuild();
+
+            if (_building)
+            {
+                _builtHandle = null;
+                _building = false;
+            }
+
+            return;
+        }
 
         if (SelectedEvent?.ActivityId is not { } activity || activity == Guid.Empty || FocusedHandle is not { } handle)
         {
@@ -161,6 +173,7 @@ public sealed partial class ActivityCorrelationPanel : AppStateComponentBase
             {
                 _building = false;
                 _view = null;
+                _builtHandle = null;
                 StateHasChanged();
             }
 
@@ -171,6 +184,10 @@ public sealed partial class ActivityCorrelationPanel : AppStateComponentBase
 
         _view = view;
         _building = false;
+
+        // A null result (log not yet in the store, or a superseded locator) is not a durable build: drop the built
+        // handle so re-activation or a re-selection retries instead of sticking on the unavailable state.
+        if (view is null) { _builtHandle = null; }
 
         // If the store changed while this build ran, the freshly built view is already stale: offer Refresh and block
         // navigation immediately rather than presenting content the live store has moved past.

--- a/src/EventLogExpert.UI/DetailsPane/ActivityCorrelationPanel.razor.css
+++ b/src/EventLogExpert.UI/DetailsPane/ActivityCorrelationPanel.razor.css
@@ -1,0 +1,221 @@
+.correlation-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 0.4rem 0.2rem;
+    font-size: 12px;
+}
+
+.details-muted {
+    margin: 0.25rem 0;
+    color: var(--text-secondary);
+    font-size: 12px;
+}
+
+.correlation-stale {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.4rem 0.6rem;
+    border: 1px solid var(--clr-yellow);
+    border-radius: 4px;
+    color: var(--text-primary);
+}
+
+.correlation-summary {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    padding-bottom: 0.35rem;
+    border-bottom: 1px solid var(--border-divider);
+}
+
+.correlation-summary-line {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.6rem;
+}
+
+.correlation-summary-count {
+    color: var(--text-primary);
+    font-weight: 600;
+}
+
+.correlation-summary-span {
+    color: var(--text-secondary);
+    font-variant-numeric: tabular-nums;
+}
+
+.correlation-summary-error {
+    color: var(--clr-red, #e05a5a);
+    font-weight: 600;
+}
+
+.correlation-summary-warning {
+    color: var(--clr-yellow);
+    font-weight: 600;
+}
+
+.correlation-activity-id {
+    margin-left: auto;
+    color: var(--text-secondary);
+    font-family: var(--font-mono, monospace);
+}
+
+.correlation-summary-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.correlation-warn {
+    color: var(--clr-yellow);
+    font-weight: 600;
+}
+
+.correlation-filter-action {
+    padding: 0.1rem 0.45rem;
+    border: 1px solid var(--border-divider);
+    border-radius: 4px;
+    background: none;
+    color: var(--text-primary);
+    font-size: 11px;
+    cursor: pointer;
+}
+
+.correlation-timeline {
+    display: flex;
+    flex-direction: column;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.correlation-row {
+    border-left: 2px solid transparent;
+}
+
+.correlation-row.selected {
+    border-left-color: var(--clr-lightblue, #4aa3df);
+    background: var(--bg-hover, rgba(127, 127, 127, 0.12));
+}
+
+.correlation-row-button {
+    display: grid;
+    grid-template-columns: 1.2rem auto auto auto 1fr;
+    align-items: baseline;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0.15rem 0.35rem;
+    border: none;
+    background: none;
+    color: var(--text-primary);
+    text-align: left;
+    cursor: pointer;
+}
+
+.correlation-row-button:hover:not(:disabled) {
+    background: var(--bg-hover, rgba(127, 127, 127, 0.15));
+}
+
+.correlation-row-button:disabled {
+    opacity: 0.6;
+    cursor: default;
+}
+
+.correlation-row-severity {
+    justify-self: center;
+}
+
+.correlation-row-severity.critical,
+.correlation-row-severity.error {
+    color: var(--clr-red, #e05a5a);
+}
+
+.correlation-row-severity.warning {
+    color: var(--clr-yellow);
+}
+
+.correlation-row-time {
+    color: var(--text-secondary);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+
+.correlation-row-id {
+    color: var(--text-primary);
+    font-weight: 600;
+}
+
+.correlation-row-source {
+    color: var(--text-secondary);
+    white-space: nowrap;
+}
+
+.correlation-row-message {
+    min-width: 0;
+    overflow: hidden;
+    color: var(--text-primary);
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+
+.correlation-truncated,
+.correlation-missing {
+    margin: 0.2rem 0 0.2rem 0.35rem;
+}
+
+.correlation-related {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding-top: 0.35rem;
+    border-top: 1px solid var(--border-divider);
+}
+
+.correlation-related-title {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+}
+
+.correlation-chip {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+}
+
+.correlation-chip-head {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.15rem 0.2rem;
+    border: none;
+    background: none;
+    color: var(--text-primary);
+    text-align: left;
+    cursor: pointer;
+}
+
+.correlation-role {
+    color: var(--text-primary);
+    font-weight: 600;
+}
+
+.correlation-chip-head[data-role="focus"] .correlation-role {
+    color: var(--clr-accent, var(--text-primary));
+}
+
+.correlation-count {
+    color: var(--text-secondary);
+}
+
+.correlation-chip-actions {
+    margin: 0.1rem 0 0.3rem 1.2rem;
+}

--- a/src/EventLogExpert.UI/DetailsPane/DetailsPane.razor
+++ b/src/EventLogExpert.UI/DetailsPane/DetailsPane.razor
@@ -31,6 +31,16 @@
                     type="button">
                     XML
                 </button>
+                <button aria-controls="details-tabpanel-correlation"
+                    aria-selected="@(_activeTab == DetailsTab.Correlation ? "true" : "false")"
+                    class="details-tab"
+                    data-active="@(_activeTab == DetailsTab.Correlation ? "true" : "false")"
+                    id="details-tab-correlation"
+                    @onclick="() => SetTab(DetailsTab.Correlation)"
+                    role="tab"
+                    type="button">
+                    Correlation
+                </button>
             </div>
         }
         else
@@ -247,6 +257,16 @@
                     }
                 }
             </p>
+
+            <div aria-labelledby="details-tab-correlation"
+                class="details-correlation-tab"
+                hidden="@(_activeTab != DetailsTab.Correlation)"
+                id="details-tabpanel-correlation"
+                role="tabpanel">
+                <ActivityCorrelationPanel FocusedHandle="_selectedHandle"
+                    IsActive="_activeTab == DetailsTab.Correlation"
+                    SelectedEvent="_selectedEvent" />
+            </div>
         }
     </div>
 </div>

--- a/src/EventLogExpert.UI/DetailsPane/DetailsPane.razor.cs
+++ b/src/EventLogExpert.UI/DetailsPane/DetailsPane.razor.cs
@@ -37,7 +37,8 @@ public sealed partial class DetailsPane
     private enum DetailsTab
     {
         Reader,
-        Xml
+        Xml,
+        Correlation
     }
 
     [Inject] private IActiveEventLogSource ActiveEventLog { get; init; } = null!;

--- a/src/EventLogExpert.UI/DetailsPane/DetailsPane.razor.css
+++ b/src/EventLogExpert.UI/DetailsPane/DetailsPane.razor.css
@@ -334,3 +334,10 @@
     text-wrap: pretty;
     white-space: pre-wrap;
 }
+
+.details-correlation-tab {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-x: hidden;
+    overflow-y: auto;
+}

--- a/src/EventLogExpert.UI/FilterLenses/LensBreadcrumb.razor
+++ b/src/EventLogExpert.UI/FilterLenses/LensBreadcrumb.razor
@@ -17,10 +17,10 @@
         @foreach (var lens in lenses)
         {
             var lensId = lens.Id;
-            <span class="lens-lens">
-                <span class="lens-lens-label" title="@lens.Label">@lens.Label</span>
+            <span class="lens-chip">
+                <span class="lens-chip-label" title="@lens.Label">@lens.Label</span>
                 <button aria-label="@($"Remove lens: {lens.Label}")"
-                    class="lens-lens-remove"
+                    class="lens-chip-remove"
                     @onclick="@(() => Commands.RemoveLens(lensId))"
                     type="button">
                     &times;

--- a/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
@@ -251,30 +251,37 @@ public sealed partial class LogTablePane
             }
         }
 
-        if (RevealFocusSource.Current is { } revealTarget)
+        if (RevealFocusSource.Current is { } reveal)
         {
             var liveSelection = Selection.Current;
-            var currentFocusTarget = Focus.Current?.CurrentHandle
-                ?? (liveSelection.Count > 0 ? liveSelection[^1].CurrentHandle : null);
+            var currentFocusTarget = Focus.Current?.CurrentHandle ??
+                (liveSelection.Count > 0 ? liveSelection[^1].CurrentHandle : null);
 
-            if (currentFocusTarget != revealTarget)
+            if (currentFocusTarget != reveal.Target)
             {
-                EventLogCommands.ConsumeRevealFocus(revealTarget);
+                EventLogCommands.ConsumeRevealFocus(reveal);
             }
             else
             {
                 try
                 {
-                    if (await TryScrollToRow(revealTarget))
+                    if (await TryScrollToRow(reveal.Target))
                     {
-                        EventLogCommands.ConsumeRevealFocus(revealTarget);
+                        EventLogCommands.ConsumeRevealFocus(reveal);
                         rescrollRequested = false;
+                    }
+                    else if (!reveal.WaitForView)
+                    {
+                        // One-shot selection-driven reveal: the target is not in the current settled view, so discard it
+                        // instead of leaving it pending. Only a wait-for-settle reveal (reload restoration) lingers until a
+                        // rebuilt view contains the target.
+                        EventLogCommands.ConsumeRevealFocus(reveal);
                     }
                 }
                 catch (JSDisconnectedException) { /* Circuit gone; leave the reveal pending so a reconnected or remounted pane can retry. */ }
                 catch (Exception e)
                 {
-                    EventLogCommands.ConsumeRevealFocus(revealTarget);
+                    EventLogCommands.ConsumeRevealFocus(reveal);
                     TraceLogger.Error($"Failed to scroll to the restored selection: {e}");
                 }
             }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/ActivityCorrelation/ActivityCorrelationServiceTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/ActivityCorrelation/ActivityCorrelationServiceTests.cs
@@ -1,0 +1,419 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Runtime.ActivityCorrelation;
+using EventLogExpert.Runtime.LogTable;
+using Fluxor;
+using NSubstitute;
+using System.Collections.Immutable;
+
+namespace EventLogExpert.Runtime.Tests.ActivityCorrelation;
+
+public sealed class ActivityCorrelationServiceTests
+{
+    private static readonly DateTime s_base = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly Guid s_child = Guid.Parse("33333333-3333-3333-3333-333333333333");
+    private static readonly Guid s_childTwo = Guid.Parse("55555555-5555-5555-5555-555555555555");
+    private static readonly Guid s_focus = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly EventLogId s_logId = EventLogId.Create();
+    private static readonly Guid s_parent = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid s_parentTwo = Guid.Parse("44444444-4444-4444-4444-444444444444");
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    [Fact]
+    public async Task BuildAsync_AbsentOrUnknownLevel_ContributesToNoSeverityTally()
+    {
+        var (service, _) = ServiceWith(1, 1,
+            Event(1, s_focus, offset: 0, level: ""),
+            Event(2, s_focus, offset: 1, level: "Bogus"));
+
+        var view = await service.BuildAsync(Locator(1, 0), Ct);
+
+        var focus = view!.Activities.Single(node => node.Role == ActivityNodeRole.Focus);
+        Assert.Equal(0, focus.CriticalCount);
+        Assert.Equal(0, focus.ErrorCount);
+        Assert.Equal(0, focus.WarningCount);
+    }
+
+    [Fact]
+    public async Task BuildAsync_BuildsParentAndChildActivitiesFromRelatedActivityId()
+    {
+        var (service, _) = ServiceWith(1, 1,
+            Event(1, s_parent, offset: 0),
+            Event(2, s_focus, s_parent, offset: 1),
+            Event(3, s_focus, s_parent, offset: 2),
+            Event(4, s_child, s_focus, offset: 3));
+
+        var view = await service.BuildAsync(Locator(1, 1), Ct);
+
+        Assert.NotNull(view);
+        Assert.True(view!.HasHierarchy);
+
+        var focus = view.Activities.Single(node => node.Role == ActivityNodeRole.Focus);
+        Assert.Equal([s_parent], focus.Parents);
+        Assert.Contains(view.Activities, node =>
+            node.Role == ActivityNodeRole.Parent && node.ActivityId == s_parent && node.EventCount == 1);
+        Assert.Contains(view.Activities, node =>
+            node.Role == ActivityNodeRole.Child && node.ActivityId == s_child && node.EventCount == 1);
+    }
+
+    [Fact]
+    public async Task BuildAsync_ChildNodeIncludesAllEventsOfTheChildActivity_NotOnlyTheLinkingRow()
+    {
+        var (service, _) = ServiceWith(1, 1,
+            Event(1, s_focus, offset: 0),
+            Event(2, s_child, s_focus, offset: 1),   // the child's linking (transfer) event carries RelatedActivityId
+            Event(3, s_child, offset: 2),            // an ordinary child event with no RelatedActivityId link
+            Event(4, s_child, offset: 3));
+
+        var view = await service.BuildAsync(Locator(1, 0), Ct);
+
+        var child = view!.Activities.Single(node => node.Role == ActivityNodeRole.Child);
+        Assert.Equal(s_child, child.ActivityId);
+        Assert.Equal(3, child.EventCount);
+        Assert.Equal(3, child.Leaves.Count);
+    }
+
+    [Fact]
+    public async Task BuildAsync_DoesNotExceedTheDisplayCapWhenRetainingTheSelectedEvent()
+    {
+        var events = new ResolvedEvent[260];
+
+        for (int i = 0; i < events.Length; i++) { events[i] = Event(i, s_focus, offset: i); }
+
+        var (service, _) = ServiceWith(1, 1, events);
+
+        // Focus the OLDEST event (index 0): it must be retained without pushing the total past MaxLeavesPerNode.
+        var view = await service.BuildAsync(Locator(1, 0), Ct);
+
+        var focus = view!.Activities.Single(node => node.Role == ActivityNodeRole.Focus);
+        Assert.True(focus.LeavesTruncated);
+        Assert.Equal(200, focus.Leaves.Count);
+        Assert.Contains(focus.Leaves, leaf => leaf.Locator.Index == 0);
+    }
+
+    [Fact]
+    public async Task BuildAsync_DoesNotTreatASelfReferenceAsAParent()
+    {
+        var (service, _) = ServiceWith(1, 1, Event(1, s_focus, s_focus, offset: 0));
+
+        var view = await service.BuildAsync(Locator(1, 0), Ct);
+
+        var focus = view!.Activities.Single(node => node.Role == ActivityNodeRole.Focus);
+        Assert.Empty(focus.Parents);
+        Assert.False(view.HasHierarchy);
+        Assert.Single(view.Activities);
+    }
+
+    [Fact]
+    public async Task BuildAsync_ExcludesEventsWithoutActivityIdFromTheFocusGroup()
+    {
+        var (service, _) = ServiceWith(1, 1,
+            Event(1, s_focus, offset: 0),
+            Event(2, activityId: null, offset: 1),
+            Event(3, s_focus, offset: 2));
+
+        var view = await service.BuildAsync(Locator(1, 0), Ct);
+
+        var focus = Assert.Single(view!.Activities);
+        Assert.Equal(2, focus.EventCount);
+    }
+
+    [Fact]
+    public async Task BuildAsync_FlagsAndCapsAnOversizedSharedActivity()
+    {
+        var events = new ResolvedEvent[600];
+
+        for (int i = 0; i < events.Length; i++) { events[i] = Event(i, s_focus, offset: i); }
+
+        var (service, _) = ServiceWith(1, 1, events);
+
+        var view = await service.BuildAsync(Locator(1, 0), Ct);
+
+        var focus = view!.Activities.Single(node => node.Role == ActivityNodeRole.Focus);
+        Assert.True(focus.IsSharedOversized);
+        Assert.True(focus.LeavesTruncated);
+        Assert.Equal(600, focus.EventCount);
+        Assert.Equal(25, focus.Leaves.Count);
+        Assert.Contains(focus.Leaves, leaf => leaf.Locator.Index == 0);
+    }
+
+    [Fact]
+    public async Task BuildAsync_FlagsMultipleParents()
+    {
+        var (service, _) = ServiceWith(1, 1,
+            Event(1, s_focus, s_parent, offset: 0),
+            Event(2, s_focus, s_parentTwo, offset: 1));
+
+        var view = await service.BuildAsync(Locator(1, 0), Ct);
+
+        var focus = view!.Activities.Single(node => node.Role == ActivityNodeRole.Focus);
+        Assert.True(focus.HasMultipleParents);
+        Assert.Equal(2, focus.Parents.Count);
+        Assert.Contains(s_parent, focus.Parents);
+        Assert.Contains(s_parentTwo, focus.Parents);
+    }
+
+    [Fact]
+    public async Task BuildAsync_GroupsFocusActivityAndFlatDegradesWithoutRelated()
+    {
+        var (service, _) = ServiceWith(1, 1,
+            Event(1, s_focus, offset: 0),
+            Event(2, s_focus, offset: 1),
+            Event(3, Guid.NewGuid(), offset: 2));
+
+        var view = await service.BuildAsync(Locator(1, 0), Ct);
+
+        Assert.NotNull(view);
+        Assert.False(view!.IsEmpty);
+        Assert.False(view.HasHierarchy);
+        Assert.Equal(s_focus, view.FocusActivityId);
+
+        var focus = Assert.Single(view.Activities);
+        Assert.Equal(ActivityNodeRole.Focus, focus.Role);
+        Assert.Equal(2, focus.EventCount);
+        Assert.Equal(2, focus.Leaves.Count);
+        Assert.Empty(focus.Parents);
+    }
+
+    [Fact]
+    public async Task BuildAsync_MutualCycle_RendersTheActivityOnceFlaggedAsCycle()
+    {
+        // focus <-> s_child: a focus member points at s_child (parent) and an s_child row points at focus (child).
+        var (service, _) = ServiceWith(1, 1,
+            Event(1, s_focus, s_child, offset: 0),
+            Event(2, s_child, s_focus, offset: 1));
+
+        var view = await service.BuildAsync(Locator(1, 0), Ct);
+
+        var node = Assert.Single(view!.Activities, candidate => candidate.ActivityId == s_child);
+        Assert.True(node.IsCycle);
+        Assert.Equal(ActivityNodeRole.Parent, node.Role);
+    }
+
+    [Fact]
+    public async Task BuildAsync_NodeSpanCoversAllRows_NotJustTheDisplayedLeaves()
+    {
+        var events = new ResolvedEvent[300];
+
+        for (int i = 0; i < events.Length; i++) { events[i] = Event(i, s_focus, offset: i); }
+
+        var (service, _) = ServiceWith(1, 1, events);
+
+        var view = await service.BuildAsync(Locator(1, 299), Ct);
+
+        var focus = view!.Activities.Single(node => node.Role == ActivityNodeRole.Focus);
+        Assert.True(focus.LeavesTruncated);
+        Assert.Equal(200, focus.Leaves.Count);
+        Assert.Equal(299, TimeSpan.FromTicks(focus.MaxTicks - focus.MinTicks).TotalSeconds);
+    }
+
+    [Fact]
+    public async Task BuildAsync_OrdersLeavesNewestFirst()
+    {
+        var (service, _) = ServiceWith(1, 1,
+            Event(1, s_focus, offset: 0),
+            Event(2, s_focus, offset: 1),
+            Event(3, s_focus, offset: 2));
+
+        var view = await service.BuildAsync(Locator(1, 0), Ct);
+
+        var focus = view!.Activities.Single(node => node.Role == ActivityNodeRole.Focus);
+        Assert.Equal(3, focus.Leaves.Count);
+        Assert.True(focus.Leaves[0].TimeTicks >= focus.Leaves[1].TimeTicks);
+        Assert.True(focus.Leaves[1].TimeTicks >= focus.Leaves[2].TimeTicks);
+    }
+
+    [Fact]
+    public async Task BuildAsync_OrdersRelatedActivitiesByMostRecentFirst()
+    {
+        var (service, _) = ServiceWith(1, 1,
+            Event(1, s_focus, offset: 0),
+            Event(2, s_child, s_focus, offset: 1),
+            Event(3, s_childTwo, s_focus, offset: 9));
+
+        var view = await service.BuildAsync(Locator(1, 0), Ct);
+
+        var children = view!.Activities.Where(node => node.Role == ActivityNodeRole.Child).ToList();
+        Assert.Equal(2, children.Count);
+        Assert.Equal(s_childTwo, children[0].ActivityId);
+        Assert.True(children[0].MaxTicks >= children[1].MaxTicks);
+    }
+
+    [Fact]
+    public async Task BuildAsync_RebuildsWhenContentVersionBumpsAtTheSameGeneration()
+    {
+        var (service, storeState) = ServiceWith(1, 1, Event(1, s_focus, offset: 0));
+        var first = await service.BuildAsync(Locator(1, 0), Ct);
+
+        var bumped = EventColumnStore.Build([Event(1, s_focus, offset: 0)], generation: 1, contentVersion: 2);
+        storeState.Value.Returns(new RawEventStoreState
+        {
+            ByLog = ImmutableDictionary<EventLogId, EventColumnStore>.Empty.Add(s_logId, bumped)
+        });
+
+        var second = await service.BuildAsync(Locator(1, 0), Ct);
+
+        Assert.NotSame(first, second);
+        Assert.Equal(2, second!.Token.ContentVersion);
+    }
+
+    [Fact]
+    public async Task BuildAsync_RetainsTheSelectedEventEvenWhenOlderThanTheDisplayCap()
+    {
+        var events = new ResolvedEvent[300];
+
+        for (int i = 0; i < events.Length; i++) { events[i] = Event(i, s_focus, offset: i); }
+
+        var (service, _) = ServiceWith(1, 1, events);
+
+        var view = await service.BuildAsync(Locator(1, 0), Ct);
+
+        var focus = view!.Activities.Single(node => node.Role == ActivityNodeRole.Focus);
+        Assert.True(focus.LeavesTruncated);
+        Assert.Contains(focus.Leaves, leaf => leaf.Locator.Index == 0);
+    }
+
+    [Fact]
+    public async Task BuildAsync_ReturnsNull_WhenTheLocatorGenerationIsStale()
+    {
+        var (service, _) = ServiceWith(2, 1, Event(1, s_focus, offset: 0));
+
+        var view = await service.BuildAsync(Locator(1, 0), Ct);
+
+        Assert.Null(view);
+    }
+
+    [Fact]
+    public async Task BuildAsync_ReturnsNull_WhenTheLogIsNotLoaded()
+    {
+        var storeState = Substitute.For<IState<RawEventStoreState>>();
+        storeState.Value.Returns(new RawEventStoreState());
+        var service = new ActivityCorrelationService(storeState);
+
+        var view = await service.BuildAsync(Locator(1, 0), Ct);
+
+        Assert.Null(view);
+    }
+
+    [Fact]
+    public async Task BuildAsync_ReturnsTheCachedViewForTheSameSelectionAndSnapshot()
+    {
+        var (service, _) = ServiceWith(1, 1, Event(1, s_focus, offset: 0));
+
+        var first = await service.BuildAsync(Locator(1, 0), Ct);
+        var second = await service.BuildAsync(Locator(1, 0), Ct);
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public async Task BuildAsync_SurfacesAReferencedParentThatHasNoEventsInThisLog()
+    {
+        var (service, _) = ServiceWith(1, 1, Event(1, s_focus, s_parent, offset: 0));
+
+        var view = await service.BuildAsync(Locator(1, 0), Ct);
+
+        var parent = view!.Activities.Single(node => node.Role == ActivityNodeRole.Parent);
+        Assert.Equal(s_parent, parent.ActivityId);
+        Assert.Equal(0, parent.EventCount);
+        Assert.Empty(parent.Leaves);
+        Assert.True(view.HasHierarchy);
+    }
+
+    [Fact]
+    public async Task BuildAsync_TalliesSeverityBeyondTheDisplayCap()
+    {
+        var events = new ResolvedEvent[300];
+
+        for (int i = 0; i < events.Length; i++)
+        {
+            events[i] = Event(i, s_focus, offset: i, level: i % 2 == 0 ? "Error" : "Information");
+        }
+
+        var (service, _) = ServiceWith(1, 1, events);
+
+        var view = await service.BuildAsync(Locator(1, 299), Ct);
+
+        var focus = view!.Activities.Single(node => node.Role == ActivityNodeRole.Focus);
+        Assert.Equal(150, focus.ErrorCount);
+    }
+
+    [Fact]
+    public async Task BuildAsync_TalliesSeverityOverAllMemberRows()
+    {
+        var (service, _) = ServiceWith(1, 1,
+            Event(1, s_focus, offset: 0, level: "Critical"),
+            Event(2, s_focus, offset: 1, level: "Error"),
+            Event(3, s_focus, offset: 2, level: "Error"),
+            Event(4, s_focus, offset: 3, level: "Warning"),
+            Event(5, s_focus, offset: 4, level: "Information"));
+
+        var view = await service.BuildAsync(Locator(1, 0), Ct);
+
+        var focus = view!.Activities.Single(node => node.Role == ActivityNodeRole.Focus);
+        Assert.Equal(1, focus.CriticalCount);
+        Assert.Equal(2, focus.ErrorCount);
+        Assert.Equal(1, focus.WarningCount);
+        Assert.Equal(3, focus.ErrorTotal);
+    }
+
+    [Fact]
+    public async Task BuildAsync_WhenFocusEventHasNoActivityId_ReturnsEmptyView()
+    {
+        var (service, _) = ServiceWith(1, 1,
+            Event(1, activityId: null, offset: 0),
+            Event(2, s_focus, offset: 1));
+
+        var view = await service.BuildAsync(Locator(1, 0), Ct);
+
+        Assert.NotNull(view);
+        Assert.True(view!.IsEmpty);
+        Assert.Equal(Guid.Empty, view.FocusActivityId);
+        Assert.Empty(view.Activities);
+    }
+
+    [Fact]
+    public void TryGetContentToken_ReturnsTheStoreTokenAndFalseForAnAbsentLog()
+    {
+        var (service, _) = ServiceWith(3, 7, Event(1, s_focus, offset: 0));
+
+        Assert.True(service.TryGetContentToken(s_logId, out var token));
+        Assert.Equal(3, token.Generation);
+        Assert.Equal(7, token.ContentVersion);
+        Assert.Equal(1, token.Count);
+        Assert.False(service.TryGetContentToken(EventLogId.Create(), out _));
+    }
+
+    private static ResolvedEvent Event(int id, Guid? activityId, Guid? relatedActivityId = null, int offset = 0, string level = "Information") =>
+        new("live", LogPathType.Channel)
+        {
+            Id = id,
+            TimeCreated = s_base.AddSeconds(offset),
+            ActivityId = activityId,
+            RelatedActivityId = relatedActivityId,
+            Level = level,
+            Source = "TestSource"
+        };
+
+    private static EventLocator Locator(int generation, int index) => new(s_logId, generation, index);
+
+    private static (IActivityCorrelationService Service, IState<RawEventStoreState> StoreState) ServiceWith(
+        int generation,
+        long contentVersion,
+        params ResolvedEvent[] events)
+    {
+        var store = EventColumnStore.Build(events, generation, contentVersion);
+        var storeState = Substitute.For<IState<RawEventStoreState>>();
+        storeState.Value.Returns(new RawEventStoreState
+        {
+            ByLog = ImmutableDictionary<EventLogId, EventColumnStore>.Empty.Add(s_logId, store)
+        });
+
+        return (new ActivityCorrelationService(storeState), storeState);
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/ActivityCorrelation/ActivityCorrelationServiceTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/ActivityCorrelation/ActivityCorrelationServiceTests.cs
@@ -75,7 +75,7 @@ public sealed class ActivityCorrelationServiceTests
         var child = view!.Activities.Single(node => node.Role == ActivityNodeRole.Child);
         Assert.Equal(s_child, child.ActivityId);
         Assert.Equal(3, child.EventCount);
-        Assert.Equal(3, child.Leaves.Count);
+        Assert.Equal(3, child.Events.Count);
     }
 
     [Fact]
@@ -87,13 +87,13 @@ public sealed class ActivityCorrelationServiceTests
 
         var (service, _) = ServiceWith(1, 1, events);
 
-        // Focus the OLDEST event (index 0): it must be retained without pushing the total past MaxLeavesPerNode.
+        // Focus the OLDEST event (index 0): it must be retained without pushing the total past the per-activity display cap.
         var view = await service.BuildAsync(Locator(1, 0), Ct);
 
         var focus = view!.Activities.Single(node => node.Role == ActivityNodeRole.Focus);
-        Assert.True(focus.LeavesTruncated);
-        Assert.Equal(200, focus.Leaves.Count);
-        Assert.Contains(focus.Leaves, leaf => leaf.Locator.Index == 0);
+        Assert.True(focus.EventsTruncated);
+        Assert.Equal(200, focus.Events.Count);
+        Assert.Contains(focus.Events, correlatedEvent => correlatedEvent.Locator.Index == 0);
     }
 
     [Fact]
@@ -136,10 +136,10 @@ public sealed class ActivityCorrelationServiceTests
 
         var focus = view!.Activities.Single(node => node.Role == ActivityNodeRole.Focus);
         Assert.True(focus.IsSharedOversized);
-        Assert.True(focus.LeavesTruncated);
+        Assert.True(focus.EventsTruncated);
         Assert.Equal(600, focus.EventCount);
-        Assert.Equal(25, focus.Leaves.Count);
-        Assert.Contains(focus.Leaves, leaf => leaf.Locator.Index == 0);
+        Assert.Equal(25, focus.Events.Count);
+        Assert.Contains(focus.Events, correlatedEvent => correlatedEvent.Locator.Index == 0);
     }
 
     [Fact]
@@ -176,7 +176,7 @@ public sealed class ActivityCorrelationServiceTests
         var focus = Assert.Single(view.Activities);
         Assert.Equal(ActivityNodeRole.Focus, focus.Role);
         Assert.Equal(2, focus.EventCount);
-        Assert.Equal(2, focus.Leaves.Count);
+        Assert.Equal(2, focus.Events.Count);
         Assert.Empty(focus.Parents);
     }
 
@@ -196,7 +196,7 @@ public sealed class ActivityCorrelationServiceTests
     }
 
     [Fact]
-    public async Task BuildAsync_NodeSpanCoversAllRows_NotJustTheDisplayedLeaves()
+    public async Task BuildAsync_NodeSpanCoversAllRows_NotJustTheDisplayedEvents()
     {
         var events = new ResolvedEvent[300];
 
@@ -207,13 +207,13 @@ public sealed class ActivityCorrelationServiceTests
         var view = await service.BuildAsync(Locator(1, 299), Ct);
 
         var focus = view!.Activities.Single(node => node.Role == ActivityNodeRole.Focus);
-        Assert.True(focus.LeavesTruncated);
-        Assert.Equal(200, focus.Leaves.Count);
+        Assert.True(focus.EventsTruncated);
+        Assert.Equal(200, focus.Events.Count);
         Assert.Equal(299, TimeSpan.FromTicks(focus.MaxTicks - focus.MinTicks).TotalSeconds);
     }
 
     [Fact]
-    public async Task BuildAsync_OrdersLeavesNewestFirst()
+    public async Task BuildAsync_OrdersEventsNewestFirst()
     {
         var (service, _) = ServiceWith(1, 1,
             Event(1, s_focus, offset: 0),
@@ -223,9 +223,9 @@ public sealed class ActivityCorrelationServiceTests
         var view = await service.BuildAsync(Locator(1, 0), Ct);
 
         var focus = view!.Activities.Single(node => node.Role == ActivityNodeRole.Focus);
-        Assert.Equal(3, focus.Leaves.Count);
-        Assert.True(focus.Leaves[0].TimeTicks >= focus.Leaves[1].TimeTicks);
-        Assert.True(focus.Leaves[1].TimeTicks >= focus.Leaves[2].TimeTicks);
+        Assert.Equal(3, focus.Events.Count);
+        Assert.True(focus.Events[0].TimeTicks >= focus.Events[1].TimeTicks);
+        Assert.True(focus.Events[1].TimeTicks >= focus.Events[2].TimeTicks);
     }
 
     [Fact]
@@ -274,8 +274,8 @@ public sealed class ActivityCorrelationServiceTests
         var view = await service.BuildAsync(Locator(1, 0), Ct);
 
         var focus = view!.Activities.Single(node => node.Role == ActivityNodeRole.Focus);
-        Assert.True(focus.LeavesTruncated);
-        Assert.Contains(focus.Leaves, leaf => leaf.Locator.Index == 0);
+        Assert.True(focus.EventsTruncated);
+        Assert.Contains(focus.Events, correlatedEvent => correlatedEvent.Locator.Index == 0);
     }
 
     [Fact]
@@ -321,7 +321,7 @@ public sealed class ActivityCorrelationServiceTests
         var parent = view!.Activities.Single(node => node.Role == ActivityNodeRole.Parent);
         Assert.Equal(s_parent, parent.ActivityId);
         Assert.Equal(0, parent.EventCount);
-        Assert.Empty(parent.Leaves);
+        Assert.Empty(parent.Events);
         Assert.True(view.HasHierarchy);
     }
 

--- a/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/RevealFocusReducersTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/RevealFocusReducersTests.cs
@@ -15,7 +15,7 @@ public sealed class RevealFocusReducersTests
     [Fact]
     public void ReduceCloseAll_ClearsThePendingReveal()
     {
-        var state = new EventLogState { PendingRevealFocus = new EventLocator(s_logA, 0, 7) };
+        var state = new EventLogState { PendingRevealFocus = new RevealFocusRequest(new EventLocator(s_logA, 0, 7), true) };
 
         state = Reducers.ReduceCloseAll(state);
 
@@ -25,7 +25,7 @@ public sealed class RevealFocusReducersTests
     [Fact]
     public void ReduceCloseLog_ClearsThePendingReveal_WhenItTargetsTheClosedLog()
     {
-        var state = new EventLogState { PendingRevealFocus = new EventLocator(s_logA, 0, 7) };
+        var state = new EventLogState { PendingRevealFocus = new RevealFocusRequest(new EventLocator(s_logA, 0, 7), true) };
 
         state = Reducers.ReduceCloseLog(state, new CloseLogAction(s_logA, "Application"));
 
@@ -35,12 +35,23 @@ public sealed class RevealFocusReducersTests
     [Fact]
     public void ReduceCloseLog_KeepsThePendingReveal_WhenItTargetsADifferentLog()
     {
-        var revealForA = new EventLocator(s_logA, 0, 7);
+        var revealForA = new RevealFocusRequest(new EventLocator(s_logA, 0, 7), true);
         var state = new EventLogState { PendingRevealFocus = revealForA };
 
         state = Reducers.ReduceCloseLog(state, new CloseLogAction(s_logB, "System"));
 
         Assert.Equal(revealForA, state.PendingRevealFocus);
+    }
+
+    [Fact]
+    public void ReduceRequestRevealFocus_ADifferentWaitForView_Supersedes()
+    {
+        var target = new EventLocator(s_logA, 0, 7);
+        var state = Reducers.ReduceRequestRevealFocus(new EventLogState(), new RequestRevealFocusAction(target, WaitForView: true));
+
+        state = Reducers.ReduceRequestRevealFocus(state, new RequestRevealFocusAction(target, WaitForView: false));
+
+        Assert.Equal(new RevealFocusRequest(target, false), state.PendingRevealFocus);
     }
 
     [Fact]
@@ -52,7 +63,17 @@ public sealed class RevealFocusReducersTests
 
         state = Reducers.ReduceRequestRevealFocus(state, new RequestRevealFocusAction(second));
 
-        Assert.Equal(second, state.PendingRevealFocus);
+        Assert.Equal(new RevealFocusRequest(second, true), state.PendingRevealFocus);
+    }
+
+    [Fact]
+    public void ReduceRequestRevealFocus_CarriesTheWaitForViewFlag()
+    {
+        var target = new EventLocator(s_logA, 0, 7);
+
+        var state = Reducers.ReduceRequestRevealFocus(new EventLogState(), new RequestRevealFocusAction(target, WaitForView: false));
+
+        Assert.Equal(new RevealFocusRequest(target, false), state.PendingRevealFocus);
     }
 
     [Fact]
@@ -73,7 +94,7 @@ public sealed class RevealFocusReducersTests
 
         var state = Reducers.ReduceRequestRevealFocus(new EventLogState(), new RequestRevealFocusAction(target));
 
-        Assert.Equal(target, state.PendingRevealFocus);
+        Assert.Equal(new RevealFocusRequest(target, true), state.PendingRevealFocus);
     }
 
     [Fact]
@@ -82,7 +103,7 @@ public sealed class RevealFocusReducersTests
         var target = new EventLocator(s_logA, 0, 7);
         var state = Reducers.ReduceRequestRevealFocus(new EventLogState(), new RequestRevealFocusAction(target));
 
-        state = Reducers.ReduceRevealFocusConsumed(state, new RevealFocusConsumedAction(target));
+        state = Reducers.ReduceRevealFocusConsumed(state, new RevealFocusConsumedAction(new RevealFocusRequest(target, true)));
 
         Assert.Null(state.PendingRevealFocus);
     }
@@ -91,11 +112,24 @@ public sealed class RevealFocusReducersTests
     public void ReduceRevealFocusConsumed_DoesNotClearANewerTarget_WhenConsumingAnOlderOne()
     {
         var older = new EventLocator(s_logA, 0, 1);
-        var newer = new EventLocator(s_logB, 0, 3);
+        var newerLocator = new EventLocator(s_logB, 0, 3);
+        var newer = new RevealFocusRequest(newerLocator, true);
         var state = new EventLogState { PendingRevealFocus = newer };
 
-        state = Reducers.ReduceRevealFocusConsumed(state, new RevealFocusConsumedAction(older));
+        state = Reducers.ReduceRevealFocusConsumed(state, new RevealFocusConsumedAction(new RevealFocusRequest(older, true)));
 
         Assert.Equal(newer, state.PendingRevealFocus);
+    }
+
+    [Fact]
+    public void ReduceRevealFocusConsumed_DoesNotClear_WhenOnlyWaitForViewDiffers()
+    {
+        var target = new EventLocator(s_logA, 0, 7);
+        var state = Reducers.ReduceRequestRevealFocus(new EventLogState(), new RequestRevealFocusAction(target, WaitForView: true));
+
+        // A stale one-shot consumer (WaitForView=false) must not clear the newer wait-for-view (reload) request.
+        state = Reducers.ReduceRevealFocusConsumed(state, new RevealFocusConsumedAction(new RevealFocusRequest(target, false)));
+
+        Assert.Equal(new RevealFocusRequest(target, true), state.PendingRevealFocus);
     }
 }

--- a/tests/Unit/EventLogExpert.UI.Tests/DetailsPane/ActivityCorrelationPanelTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/DetailsPane/ActivityCorrelationPanelTests.cs
@@ -79,7 +79,7 @@ public sealed class ActivityCorrelationPanelTests : BunitContext
         Assert.True(buildToken.IsCancellationRequested);
 
         // A stale build that completes after cancellation must not surface a timeline.
-        pendingBuild.SetResult(ViewWithLeaf(new EventLocator(_logId, 0, 0)));
+        pendingBuild.SetResult(ViewWithEvent(new EventLocator(_logId, 0, 0)));
         Assert.Empty(cut.FindAll(".correlation-timeline"));
     }
 
@@ -93,7 +93,7 @@ public sealed class ActivityCorrelationPanelTests : BunitContext
 
                 return true;
             });
-        StubBuild(ViewWithLeaf(new EventLocator(_logId, 0, 3)));
+        StubBuild(ViewWithEvent(new EventLocator(_logId, 0, 3)));
 
         var cut = RenderActive();
 
@@ -102,45 +102,10 @@ public sealed class ActivityCorrelationPanelTests : BunitContext
     }
 
     [Fact]
-    public void FilterToActivity_DispatchesTheActivityIdLens()
+    public void EventClick_SelectsAndRequestsAOneShotReveal()
     {
-        StubBuild(ViewWithLeaf(new EventLocator(_logId, 0, 0)));
-
-        var cut = RenderActive();
-        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".correlation-filter-action")));
-
-        cut.Find(".correlation-filter-action").Click();
-
-        _lensCommands.Received().ShowRelatedByActivityId(s_focus, Arg.Any<string?>());
-    }
-
-    [Fact]
-    public void HeaderShowsErrorAndWarningCounts()
-    {
-        StubBuild(ViewWithLeaf(new EventLocator(_logId, 0, 0), errorCount: 2, warningCount: 1));
-
-        var cut = RenderActive();
-
-        cut.WaitForAssertion(() => Assert.Contains("2 errors", cut.Markup));
-        Assert.Contains("1 warning", cut.Markup);
-    }
-
-    [Fact]
-    public void HighlightsTheSelectedEventRow()
-    {
-        // The rendered focus handle (0,0) matches this leaf, so its row is the selected one.
-        StubBuild(ViewWithLeaf(new EventLocator(_logId, 0, 0)));
-
-        var cut = RenderActive();
-
-        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".correlation-row.selected")));
-    }
-
-    [Fact]
-    public void LeafClick_SelectsAndRequestsAOneShotReveal()
-    {
-        var leafLocator = new EventLocator(_logId, 0, 3);
-        StubBuild(ViewWithLeaf(leafLocator));
+        var eventLocator = new EventLocator(_logId, 0, 3);
+        StubBuild(ViewWithEvent(eventLocator));
 
         var cut = RenderActive();
         cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".correlation-row-button")));
@@ -148,13 +113,13 @@ public sealed class ActivityCorrelationPanelTests : BunitContext
         cut.Find(".correlation-row-button").Click();
 
         _commands.Received().SetSelectedEvents(Arg.Any<IReadOnlyCollection<SelectionEntry>>(), Arg.Any<SelectionEntry?>());
-        _commands.Received().RequestRevealFocus(leafLocator, false);
+        _commands.Received().RequestRevealFocus(eventLocator, false);
     }
 
     [Fact]
-    public void LeafClick_WhenSnapshotChangedBeforeTheAsyncNotification_RevalidatesAndBlocksNavigation()
+    public void EventClick_WhenSnapshotChangedBeforeTheAsyncNotification_RevalidatesAndBlocksNavigation()
     {
-        StubBuild(ViewWithLeaf(new EventLocator(_logId, 0, 3)));
+        StubBuild(ViewWithEvent(new EventLocator(_logId, 0, 3)));
 
         var cut = RenderActive();
         cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".correlation-row-button")));
@@ -174,6 +139,41 @@ public sealed class ActivityCorrelationPanelTests : BunitContext
     }
 
     [Fact]
+    public void FilterToActivity_DispatchesTheActivityIdLens()
+    {
+        StubBuild(ViewWithEvent(new EventLocator(_logId, 0, 0)));
+
+        var cut = RenderActive();
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".correlation-filter-action")));
+
+        cut.Find(".correlation-filter-action").Click();
+
+        _lensCommands.Received().ShowRelatedByActivityId(s_focus, Arg.Any<string?>());
+    }
+
+    [Fact]
+    public void HeaderShowsErrorAndWarningCounts()
+    {
+        StubBuild(ViewWithEvent(new EventLocator(_logId, 0, 0), errorCount: 2, warningCount: 1));
+
+        var cut = RenderActive();
+
+        cut.WaitForAssertion(() => Assert.Contains("2 errors", cut.Markup));
+        Assert.Contains("1 warning", cut.Markup);
+    }
+
+    [Fact]
+    public void HighlightsTheSelectedEventRow()
+    {
+        // The rendered focus handle (0,0) matches this event, so its row is the selected one.
+        StubBuild(ViewWithEvent(new EventLocator(_logId, 0, 0)));
+
+        var cut = RenderActive();
+
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".correlation-row.selected")));
+    }
+
+    [Fact]
     public void MessageSnippet_IsBoundedToTheFirstLineAndKeepsTheFullDescriptionOutOfTheDom()
     {
         string description = "OPERATIONSTART " + new string('x', 300) + "\nSECONDLINEMARKER should not render";
@@ -184,7 +184,7 @@ public sealed class ActivityCorrelationPanelTests : BunitContext
 
                 return true;
             });
-        StubBuild(ViewWithLeaf(new EventLocator(_logId, 0, 3)));
+        StubBuild(ViewWithEvent(new EventLocator(_logId, 0, 3)));
 
         var cut = RenderActive();
 
@@ -197,7 +197,7 @@ public sealed class ActivityCorrelationPanelTests : BunitContext
     [Fact]
     public void ReactivatingAfterACompletedBuild_ReusesItWithoutRebuilding()
     {
-        StubBuild(ViewWithLeaf(new EventLocator(_logId, 0, 0)));
+        StubBuild(ViewWithEvent(new EventLocator(_logId, 0, 0)));
 
         var cut = RenderActive();
         cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".correlation-timeline")));
@@ -244,7 +244,7 @@ public sealed class ActivityCorrelationPanelTests : BunitContext
     [Fact]
     public void RendersTheFocusTimelineWithMessageSnippetViaLeanResolve()
     {
-        StubBuild(ViewWithLeaf(new EventLocator(_logId, 0, 3)));
+        StubBuild(ViewWithEvent(new EventLocator(_logId, 0, 3)));
 
         var cut = RenderActive();
 
@@ -256,9 +256,9 @@ public sealed class ActivityCorrelationPanelTests : BunitContext
     }
 
     [Fact]
-    public void StaleTree_ShowsRefreshAndBlocksLeafNavigation()
+    public void StaleView_ShowsRefreshAndBlocksEventNavigation()
     {
-        StubBuild(ViewWithLeaf(new EventLocator(_logId, 0, 3)));
+        StubBuild(ViewWithEvent(new EventLocator(_logId, 0, 3)));
 
         var cut = RenderActive();
         cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".correlation-row-button")));
@@ -333,10 +333,10 @@ public sealed class ActivityCorrelationPanelTests : BunitContext
         _service.BuildAsync(Arg.Any<EventLocator>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<ActivityCorrelationView?>(view));
 
-    private ActivityCorrelationView ViewWithLeaf(EventLocator leafLocator, int errorCount = 0, int warningCount = 0)
+    private ActivityCorrelationView ViewWithEvent(EventLocator eventLocator, int errorCount = 0, int warningCount = 0)
     {
         long ticks = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc).Ticks;
-        var leaf = new CorrelationEventLeaf(leafLocator, ticks);
+        var correlatedEvent = new CorrelatedEvent(eventLocator, ticks);
 
         var focus = new ActivityNode
         {
@@ -350,8 +350,8 @@ public sealed class ActivityCorrelationPanelTests : BunitContext
             CriticalCount = 0,
             ErrorCount = errorCount,
             WarningCount = warningCount,
-            Leaves = [leaf],
-            LeavesTruncated = false
+            Events = [correlatedEvent],
+            EventsTruncated = false
         };
 
         return new ActivityCorrelationView

--- a/tests/Unit/EventLogExpert.UI.Tests/DetailsPane/ActivityCorrelationPanelTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/DetailsPane/ActivityCorrelationPanelTests.cs
@@ -1,0 +1,293 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.ActivityCorrelation;
+using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.FilterLenses;
+using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.Runtime.Settings;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using PanelComponent = EventLogExpert.UI.DetailsPane.ActivityCorrelationPanel;
+
+namespace EventLogExpert.UI.Tests.DetailsPane;
+
+public sealed class ActivityCorrelationPanelTests : BunitContext
+{
+    private static readonly Guid s_focus = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    private readonly IEventLogCommands _commands = Substitute.For<IEventLogCommands>();
+    private readonly IEventDetailResolver _detailResolver = Substitute.For<IEventDetailResolver>();
+    private readonly IFilterLensCommands _lensCommands = Substitute.For<IFilterLensCommands>();
+    private readonly EventLogId _logId = EventLogId.Create();
+    private readonly ITraceLogger _logger = Substitute.For<ITraceLogger>();
+    private readonly IActivityCorrelationService _service = Substitute.For<IActivityCorrelationService>();
+    private readonly ISettingsService _settings = Substitute.For<ISettingsService>();
+    private readonly IActivityCorrelationSource _source = Substitute.For<IActivityCorrelationSource>();
+
+    public ActivityCorrelationPanelTests()
+    {
+        _settings.TimeZoneInfo.Returns(TimeZoneInfo.Utc);
+        _detailResolver.TryResolveLean(Arg.Any<EventLocator>(), out Arg.Any<ResolvedEvent?>())
+            .Returns(call =>
+            {
+                call[1] = LeanEvent();
+
+                return true;
+            });
+        _service.TryGetContentToken(_logId, out Arg.Any<CorrelationContentToken>())
+            .Returns(call =>
+            {
+                call[1] = FreshToken();
+
+                return true;
+            });
+
+        Services.AddSingleton(_service);
+        Services.AddSingleton(_source);
+        Services.AddSingleton(_detailResolver);
+        Services.AddSingleton(_commands);
+        Services.AddSingleton(_lensCommands);
+        Services.AddSingleton(_settings);
+        Services.AddSingleton(_logger);
+    }
+
+    [Fact]
+    public void EmptyDescription_ShowsTheNoMessageFallback()
+    {
+        _detailResolver.TryResolveLean(Arg.Any<EventLocator>(), out Arg.Any<ResolvedEvent?>())
+            .Returns(call =>
+            {
+                call[1] = LeanEventWith(string.Empty);
+
+                return true;
+            });
+        StubBuild(ViewWithLeaf(new EventLocator(_logId, 0, 3)));
+
+        var cut = RenderActive();
+
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".correlation-row-message")));
+        Assert.Contains("No message", cut.Markup);
+    }
+
+    [Fact]
+    public void FilterToActivity_DispatchesTheActivityIdLens()
+    {
+        StubBuild(ViewWithLeaf(new EventLocator(_logId, 0, 0)));
+
+        var cut = RenderActive();
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".correlation-filter-action")));
+
+        cut.Find(".correlation-filter-action").Click();
+
+        _lensCommands.Received().ShowRelatedByActivityId(s_focus, Arg.Any<string?>());
+    }
+
+    [Fact]
+    public void HeaderShowsErrorAndWarningCounts()
+    {
+        StubBuild(ViewWithLeaf(new EventLocator(_logId, 0, 0), errorCount: 2, warningCount: 1));
+
+        var cut = RenderActive();
+
+        cut.WaitForAssertion(() => Assert.Contains("2 errors", cut.Markup));
+        Assert.Contains("1 warning", cut.Markup);
+    }
+
+    [Fact]
+    public void HighlightsTheSelectedEventRow()
+    {
+        // The rendered focus handle (0,0) matches this leaf, so its row is the selected one.
+        StubBuild(ViewWithLeaf(new EventLocator(_logId, 0, 0)));
+
+        var cut = RenderActive();
+
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".correlation-row.selected")));
+    }
+
+    [Fact]
+    public void LeafClick_SelectsAndRequestsAOneShotReveal()
+    {
+        var leafLocator = new EventLocator(_logId, 0, 3);
+        StubBuild(ViewWithLeaf(leafLocator));
+
+        var cut = RenderActive();
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".correlation-row-button")));
+
+        cut.Find(".correlation-row-button").Click();
+
+        _commands.Received().SetSelectedEvents(Arg.Any<IReadOnlyCollection<SelectionEntry>>(), Arg.Any<SelectionEntry?>());
+        _commands.Received().RequestRevealFocus(leafLocator, false);
+    }
+
+    [Fact]
+    public void LeafClick_WhenSnapshotChangedBeforeTheAsyncNotification_RevalidatesAndBlocksNavigation()
+    {
+        StubBuild(ViewWithLeaf(new EventLocator(_logId, 0, 3)));
+
+        var cut = RenderActive();
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".correlation-row-button")));
+
+        _service.TryGetContentToken(_logId, out Arg.Any<CorrelationContentToken>())
+            .Returns(call =>
+            {
+                call[1] = new CorrelationContentToken(_logId, 0, 99, 1);
+
+                return true;
+            });
+
+        cut.Find(".correlation-row-button").Click();
+
+        _commands.DidNotReceive().SetSelectedEvents(Arg.Any<IReadOnlyCollection<SelectionEntry>>(), Arg.Any<SelectionEntry?>());
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".correlation-stale")));
+    }
+
+    [Fact]
+    public void MessageSnippet_IsBoundedToTheFirstLineAndKeepsTheFullDescriptionOutOfTheDom()
+    {
+        string description = "OPERATIONSTART " + new string('x', 300) + "\nSECONDLINEMARKER should not render";
+        _detailResolver.TryResolveLean(Arg.Any<EventLocator>(), out Arg.Any<ResolvedEvent?>())
+            .Returns(call =>
+            {
+                call[1] = LeanEventWith(description);
+
+                return true;
+            });
+        StubBuild(ViewWithLeaf(new EventLocator(_logId, 0, 3)));
+
+        var cut = RenderActive();
+
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".correlation-row-message")));
+        Assert.Contains("OPERATIONSTART", cut.Markup);
+        Assert.DoesNotContain("SECONDLINEMARKER", cut.Markup);
+        Assert.DoesNotContain(new string('x', 300), cut.Markup);
+    }
+
+    [Fact]
+    public void RendersTheFocusTimelineWithMessageSnippetViaLeanResolve()
+    {
+        StubBuild(ViewWithLeaf(new EventLocator(_logId, 0, 3)));
+
+        var cut = RenderActive();
+
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".correlation-timeline")));
+        Assert.NotEmpty(cut.FindAll(".correlation-row"));
+        Assert.Contains("Something went wrong", cut.Markup);
+        _detailResolver.Received().TryResolveLean(Arg.Any<EventLocator>(), out Arg.Any<ResolvedEvent?>());
+        _detailResolver.DidNotReceive().TryResolve(Arg.Any<EventLocator>(), out Arg.Any<ResolvedEvent?>());
+    }
+
+    [Fact]
+    public void StaleTree_ShowsRefreshAndBlocksLeafNavigation()
+    {
+        StubBuild(ViewWithLeaf(new EventLocator(_logId, 0, 3)));
+
+        var cut = RenderActive();
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".correlation-row-button")));
+
+        _service.TryGetContentToken(_logId, out Arg.Any<CorrelationContentToken>())
+            .Returns(call =>
+            {
+                call[1] = new CorrelationContentToken(_logId, 0, 99, 1);
+
+                return true;
+            });
+
+        cut.InvokeAsync(() => _source.Changed += Raise.Event<Action>());
+
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".correlation-stale")));
+        Assert.True(cut.Find(".correlation-row-button").HasAttribute("disabled"));
+
+        cut.Find(".correlation-row-button").Click();
+
+        _commands.DidNotReceive().SetSelectedEvents(Arg.Any<IReadOnlyCollection<SelectionEntry>>(), Arg.Any<SelectionEntry?>());
+    }
+
+    [Fact]
+    public void WhenSelectedEventHasNoActivityId_ShowsEmptyStateWithoutBuilding()
+    {
+        var cut = Render<PanelComponent>(parameters => parameters
+            .Add(panel => panel.SelectedEvent, new ResolvedEvent("live", LogPathType.Channel) { Id = 1 })
+            .Add(panel => panel.FocusedHandle, new EventLocator(_logId, 0, 0))
+            .Add(panel => panel.IsActive, true));
+
+        Assert.Contains("no Activity ID", cut.Markup);
+        _service.DidNotReceive().BuildAsync(Arg.Any<EventLocator>(), Arg.Any<CancellationToken>());
+    }
+
+    private static ResolvedEvent FocusEvent() =>
+        new("live", LogPathType.Channel)
+        {
+            Id = 1,
+            ActivityId = s_focus,
+            TimeCreated = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+    private static ResolvedEvent LeanEvent() =>
+        new("live", LogPathType.Channel)
+        {
+            Id = 4624,
+            Level = "Error",
+            Source = "TestSource",
+            Description = "Something went wrong in the operation.",
+            TimeCreated = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+    private static ResolvedEvent LeanEventWith(string description) =>
+        new("live", LogPathType.Channel)
+        {
+            Id = 4624,
+            Level = "Error",
+            Source = "TestSource",
+            Description = description,
+            TimeCreated = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+    private CorrelationContentToken FreshToken() => new(_logId, 0, 1, 1);
+
+    private IRenderedComponent<PanelComponent> RenderActive() =>
+        Render<PanelComponent>(parameters => parameters
+            .Add(panel => panel.SelectedEvent, FocusEvent())
+            .Add(panel => panel.FocusedHandle, new EventLocator(_logId, 0, 0))
+            .Add(panel => panel.IsActive, true));
+
+    private void StubBuild(ActivityCorrelationView view) =>
+        _service.BuildAsync(Arg.Any<EventLocator>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ActivityCorrelationView?>(view));
+
+    private ActivityCorrelationView ViewWithLeaf(EventLocator leafLocator, int errorCount = 0, int warningCount = 0)
+    {
+        long ticks = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc).Ticks;
+        var leaf = new CorrelationEventLeaf(leafLocator, ticks);
+
+        var focus = new ActivityNode
+        {
+            ActivityId = s_focus,
+            Role = ActivityNodeRole.Focus,
+            EventCount = 1,
+            MinTicks = ticks,
+            MaxTicks = ticks,
+            IsSharedOversized = false,
+            Parents = [],
+            CriticalCount = 0,
+            ErrorCount = errorCount,
+            WarningCount = warningCount,
+            Leaves = [leaf],
+            LeavesTruncated = false
+        };
+
+        return new ActivityCorrelationView
+        {
+            LogId = _logId,
+            FocusActivityId = s_focus,
+            Token = FreshToken(),
+            Activities = [focus],
+            HasHierarchy = false
+        };
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/DetailsPane/ActivityCorrelationPanelTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/DetailsPane/ActivityCorrelationPanelTests.cs
@@ -58,6 +58,32 @@ public sealed class ActivityCorrelationPanelTests : BunitContext
     }
 
     [Fact]
+    public void DeactivatingTheTab_CancelsTheInFlightBuild()
+    {
+        var pendingBuild = new TaskCompletionSource<ActivityCorrelationView?>();
+        CancellationToken buildToken = default;
+        _service.BuildAsync(Arg.Any<EventLocator>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                buildToken = call.Arg<CancellationToken>();
+
+                return pendingBuild.Task;
+            });
+
+        var cut = RenderActive();
+        cut.WaitForAssertion(() => Assert.Contains("Building correlation", cut.Markup));
+
+        // Deactivating while the build is still in flight must cancel its token, not leave it running.
+        cut.Render(parameters => parameters.Add(panel => panel.IsActive, false));
+
+        Assert.True(buildToken.IsCancellationRequested);
+
+        // A stale build that completes after cancellation must not surface a timeline.
+        pendingBuild.SetResult(ViewWithLeaf(new EventLocator(_logId, 0, 0)));
+        Assert.Empty(cut.FindAll(".correlation-timeline"));
+    }
+
+    [Fact]
     public void EmptyDescription_ShowsTheNoMessageFallback()
     {
         _detailResolver.TryResolveLean(Arg.Any<EventLocator>(), out Arg.Any<ResolvedEvent?>())
@@ -166,6 +192,53 @@ public sealed class ActivityCorrelationPanelTests : BunitContext
         Assert.Contains("OPERATIONSTART", cut.Markup);
         Assert.DoesNotContain("SECONDLINEMARKER", cut.Markup);
         Assert.DoesNotContain(new string('x', 300), cut.Markup);
+    }
+
+    [Fact]
+    public void ReactivatingAfterACompletedBuild_ReusesItWithoutRebuilding()
+    {
+        StubBuild(ViewWithLeaf(new EventLocator(_logId, 0, 0)));
+
+        var cut = RenderActive();
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".correlation-timeline")));
+
+        // A completed view survives tab toggles: leaving and returning reuses it rather than rebuilding.
+        cut.Render(parameters => parameters.Add(panel => panel.IsActive, false));
+        cut.Render(parameters => parameters.Add(panel => panel.IsActive, true));
+
+        _service.Received(1).BuildAsync(Arg.Any<EventLocator>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void ReactivatingAfterAFailedBuild_Retries()
+    {
+        _service.BuildAsync(Arg.Any<EventLocator>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<ActivityCorrelationView?>(new InvalidOperationException("boom")));
+
+        var cut = RenderActive();
+        cut.WaitForAssertion(() => Assert.Contains("unavailable", cut.Markup));
+
+        // A faulted build must not strand the panel: returning to the tab retries.
+        cut.Render(parameters => parameters.Add(panel => panel.IsActive, false));
+        cut.Render(parameters => parameters.Add(panel => panel.IsActive, true));
+
+        _service.Received(2).BuildAsync(Arg.Any<EventLocator>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void ReactivatingAfterAnUnavailableBuild_Retries()
+    {
+        _service.BuildAsync(Arg.Any<EventLocator>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ActivityCorrelationView?>(null));
+
+        var cut = RenderActive();
+        cut.WaitForAssertion(() => Assert.Contains("unavailable", cut.Markup));
+
+        // A null (unavailable) result is not a durable build: returning to the tab retries instead of sticking.
+        cut.Render(parameters => parameters.Add(panel => panel.IsActive, false));
+        cut.Render(parameters => parameters.Add(panel => panel.IsActive, true));
+
+        _service.Received(2).BuildAsync(Arg.Any<EventLocator>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.UI.Tests/DetailsPane/DetailsPaneTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/DetailsPane/DetailsPaneTests.cs
@@ -514,14 +514,14 @@ public sealed class DetailsPaneTests : BunitContext
             Xml = "<Event/>"
         };
 
-    private static IElement CorrelationTab(IRenderedComponent<DetailsPaneComponent> cut) => cut.FindAll(".details-tab")[2];
+    private static IElement CorrelationTab(IRenderedComponent<DetailsPaneComponent> cut) => cut.Find("#details-tab-correlation");
 
     private static ResolvedEvent EventWithData(params (string Name, object? Value)[] fields) =>
         BaseEvent().WithEventData(fields);
 
-    private static IElement ReaderTab(IRenderedComponent<DetailsPaneComponent> cut) => cut.FindAll(".details-tab")[0];
+    private static IElement ReaderTab(IRenderedComponent<DetailsPaneComponent> cut) => cut.Find("#details-tab-reader");
 
-    private static IElement XmlTab(IRenderedComponent<DetailsPaneComponent> cut) => cut.FindAll(".details-tab")[1];
+    private static IElement XmlTab(IRenderedComponent<DetailsPaneComponent> cut) => cut.Find("#details-tab-xml");
 
     private void RaiseFocusChanged(ResolvedEvent @event)
     {

--- a/tests/Unit/EventLogExpert.UI.Tests/DetailsPane/DetailsPaneTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/DetailsPane/DetailsPaneTests.cs
@@ -10,6 +10,7 @@ using EventLogExpert.Eventing.Resolvers;
 using EventLogExpert.Eventing.Structured;
 using EventLogExpert.Eventing.TestUtils;
 using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.ActivityCorrelation;
 using EventLogExpert.Runtime.Common.Clipboard;
 using EventLogExpert.Runtime.DetailsPane;
 using EventLogExpert.Runtime.EventLog;
@@ -28,8 +29,11 @@ public sealed class DetailsPaneTests : BunitContext
 {
     private readonly IActiveEventLogSource _activeEventLog = Substitute.For<IActiveEventLogSource>();
     private readonly IClipboardService _clipboard = Substitute.For<IClipboardService>();
+    private readonly IActivityCorrelationService _correlationService = Substitute.For<IActivityCorrelationService>();
+    private readonly IActivityCorrelationSource _correlationSource = Substitute.For<IActivityCorrelationSource>();
     private readonly IEventDetailResolver _detailResolver = Substitute.For<IEventDetailResolver>();
     private readonly IEventFocusSource _eventFocus = Substitute.For<IEventFocusSource>();
+    private readonly IEventLogCommands _eventLogCommands = Substitute.For<IEventLogCommands>();
     private readonly IFilterLensCommands _filterLensCommands = Substitute.For<IFilterLensCommands>();
     private readonly EventLogId _logId = EventLogId.Create();
     private readonly IDetailsPanePreferencesProvider _preferences = Substitute.For<IDetailsPanePreferencesProvider>();
@@ -54,6 +58,9 @@ public sealed class DetailsPaneTests : BunitContext
         Services.AddSingleton(_settings);
         Services.AddSingleton(_traceLogger);
         Services.AddSingleton(_xmlResolver);
+        Services.AddSingleton(_correlationService);
+        Services.AddSingleton(_correlationSource);
+        Services.AddSingleton(_eventLogCommands);
     }
 
     [Fact]
@@ -191,6 +198,26 @@ public sealed class DetailsPaneTests : BunitContext
         var button = Assert.Single(cut.FindAll(".details-correlation-action"));
 
         Assert.Contains("Show related events", button.TextContent);
+    }
+
+    [Fact]
+    public void CorrelationTab_IsPresentAndLinkedToItsPanel()
+    {
+        var cut = SelectAndRender(EventWithData(("LogonType", 3)));
+
+        Assert.Equal("details-tabpanel-correlation", cut.Find("#details-tab-correlation").GetAttribute("aria-controls"));
+        Assert.Equal("details-tab-correlation", cut.Find("#details-tabpanel-correlation").GetAttribute("aria-labelledby"));
+    }
+
+    [Fact]
+    public void CorrelationTab_WhenSelectedEventHasNoActivityId_ActivatesAndShowsEmptyState()
+    {
+        var cut = SelectAndRender(EventWithData(("LogonType", 3)));
+
+        CorrelationTab(cut).Click();
+
+        cut.WaitForAssertion(() => Assert.Equal("true", CorrelationTab(cut).GetAttribute("aria-selected")));
+        Assert.Contains("no Activity ID", cut.Markup);
     }
 
     [Fact]
@@ -486,6 +513,8 @@ public sealed class DetailsPaneTests : BunitContext
             Description = "A logon occurred.",
             Xml = "<Event/>"
         };
+
+    private static IElement CorrelationTab(IRenderedComponent<DetailsPaneComponent> cut) => cut.FindAll(".details-tab")[2];
 
     private static ResolvedEvent EventWithData(params (string Name, object? Value)[] fields) =>
         BaseEvent().WithEventData(fields);

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterLenses/LensBreadcrumbTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterLenses/LensBreadcrumbTests.cs
@@ -83,7 +83,7 @@ public sealed class LensBreadcrumbTests : BunitContext
 
         Assert.Contains("Activity ID = abc", cut.Markup);
 
-        cut.Find(".lens-lens-remove").Click();
+        cut.Find(".lens-chip-remove").Click();
 
         _commands.Received(1).RemoveLens(lens.Id);
     }

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneViewSourceTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneViewSourceTests.cs
@@ -62,15 +62,15 @@ public sealed class LogTablePaneViewSourceTests : BunitContext
         _settings.TimeZoneInfo.Returns(TimeZoneInfo.Utc);
         _selectedEvent.Current.Returns((SelectionEntry?)null);
         _selectedEvents.Current.Returns(ImmutableList<SelectionEntry>.Empty);
-        _revealFocus.Current.Returns((EventLocator?)null);
+        _revealFocus.Current.Returns((RevealFocusRequest?)null);
 
         _eventLogCommands
-            .When(commands => commands.ConsumeRevealFocus(Arg.Any<EventLocator>()))
+            .When(commands => commands.ConsumeRevealFocus(Arg.Any<RevealFocusRequest>()))
             .Do(call =>
             {
-                if (_revealFocus.Current == call.Arg<EventLocator>())
+                if (_revealFocus.Current == call.Arg<RevealFocusRequest>())
                 {
-                    _revealFocus.Current.Returns((EventLocator?)null);
+                    _revealFocus.Current.Returns((RevealFocusRequest?)null);
                 }
             });
 
@@ -411,13 +411,13 @@ public sealed class LogTablePaneViewSourceTests : BunitContext
         SetCommittedState(_logId, [_logId], Event(1, "Alpha"), Event(2, "Beta"));
         _viewSource.Current.Returns(DisplayViewTestFactory.Presentation(_logId, [Event(1, "Alpha"), Event(2, "Beta")]));
         _selectedEvent.Current.Returns(EntryFor(Event(2, "Beta")));
-        _revealFocus.Current.Returns(target);
+        _revealFocus.Current.Returns(new RevealFocusRequest(target, true));
 
         var cut = Render<LogTablePane>();
 
         cut.WaitForAssertion(() => Assert.Equal(1, ScrollCount()));
         Assert.Equal(1, LastScrollRow());
-        _eventLogCommands.Received().ConsumeRevealFocus(target);
+        _eventLogCommands.Received().ConsumeRevealFocus(Arg.Is<RevealFocusRequest>(request => request.Target == target));
     }
 
     [Fact]
@@ -435,12 +435,12 @@ public sealed class LogTablePaneViewSourceTests : BunitContext
 
         var target = new EventLocator(_logId, 0, 1);
         _selectedEvent.Current.Returns(EntryFor(Event(2, "Beta")));
-        _revealFocus.Current.Returns(target);
+        _revealFocus.Current.Returns(new RevealFocusRequest(target, true));
         cut.InvokeAsync(() => _revealFocus.Changed += Raise.Event<Action>());
 
         cut.WaitForAssertion(() => Assert.Equal(scrollsAfterReloadPublish + 1, ScrollCount()));
         Assert.Equal(1, LastScrollRow());
-        _eventLogCommands.Received().ConsumeRevealFocus(target);
+        _eventLogCommands.Received().ConsumeRevealFocus(Arg.Is<RevealFocusRequest>(request => request.Target == target));
     }
 
     [Fact]
@@ -455,12 +455,12 @@ public sealed class LogTablePaneViewSourceTests : BunitContext
 
         Assert.Equal(0, ScrollCount());
 
-        _revealFocus.Current.Returns(target);
+        _revealFocus.Current.Returns(new RevealFocusRequest(target, true));
         cut.InvokeAsync(() => _revealFocus.Changed += Raise.Event<Action>());
 
         cut.WaitForAssertion(() => Assert.Equal(1, ScrollCount()));
         Assert.Equal(1, LastScrollRow());
-        _eventLogCommands.Received().ConsumeRevealFocus(target);
+        _eventLogCommands.Received().ConsumeRevealFocus(Arg.Is<RevealFocusRequest>(request => request.Target == target));
     }
 
     [Fact]
@@ -470,12 +470,12 @@ public sealed class LogTablePaneViewSourceTests : BunitContext
         SetCommittedState(_logId, [_logId], Event(1, "Alpha"), Event(2, "Beta"), Event(3, "Gamma"));
         _viewSource.Current.Returns(DisplayViewTestFactory.Presentation(_logId, [Event(1, "Alpha"), Event(2, "Beta")]));
         _selectedEvent.Current.Returns(EntryFor(Event(3, "Gamma")));
-        _revealFocus.Current.Returns(target);
+        _revealFocus.Current.Returns(new RevealFocusRequest(target, true));
 
         var cut = Render<LogTablePane>();
 
         Assert.Equal(0, ScrollCount());
-        _eventLogCommands.DidNotReceive().ConsumeRevealFocus(Arg.Any<EventLocator>());
+        _eventLogCommands.DidNotReceive().ConsumeRevealFocus(Arg.Any<RevealFocusRequest>());
 
         var withGamma = DisplayViewTestFactory.Presentation(
             _logId, [Event(1, "Alpha"), Event(2, "Beta"), Event(3, "Gamma")], revision: 2);
@@ -483,7 +483,7 @@ public sealed class LogTablePaneViewSourceTests : BunitContext
 
         cut.WaitForAssertion(() => Assert.Equal(1, ScrollCount()));
         Assert.Equal(2, LastScrollRow());
-        _eventLogCommands.Received().ConsumeRevealFocus(target);
+        _eventLogCommands.Received().ConsumeRevealFocus(Arg.Is<RevealFocusRequest>(request => request.Target == target));
     }
 
     [Fact]
@@ -493,11 +493,11 @@ public sealed class LogTablePaneViewSourceTests : BunitContext
         SetCommittedState(_logId, [_logId], Event(1, "Alpha"), Event(2, "Beta"));
         _viewSource.Current.Returns(DisplayViewTestFactory.Presentation(_logId, [Event(1, "Alpha"), Event(2, "Beta")]));
         _selectedEvent.Current.Returns(EntryFor(Event(2, "Beta")));
-        _revealFocus.Current.Returns(staleTarget);
+        _revealFocus.Current.Returns(new RevealFocusRequest(staleTarget, true));
 
         var cut = Render<LogTablePane>();
 
-        cut.WaitForAssertion(() => _eventLogCommands.Received().ConsumeRevealFocus(staleTarget));
+        cut.WaitForAssertion(() => _eventLogCommands.Received().ConsumeRevealFocus(Arg.Is<RevealFocusRequest>(request => request.Target == staleTarget)));
         Assert.Equal(0, ScrollCount());
     }
 
@@ -511,6 +511,39 @@ public sealed class LogTablePaneViewSourceTests : BunitContext
 
         Assert.Contains("Beta", cut.Markup);
         Assert.Contains("Gamma", cut.Markup);
+    }
+
+    [Fact]
+    public void SelectionReveal_WhenTheTargetIsInTheView_ScrollsAndConsumes()
+    {
+        var target = new EventLocator(_logId, 0, 1);
+        SetCommittedState(_logId, [_logId], Event(1, "Alpha"), Event(2, "Beta"));
+        _viewSource.Current.Returns(DisplayViewTestFactory.Presentation(_logId, [Event(1, "Alpha"), Event(2, "Beta")]));
+        _selectedEvent.Current.Returns(EntryFor(Event(2, "Beta")));
+        _revealFocus.Current.Returns(new RevealFocusRequest(target, false));
+
+        var cut = Render<LogTablePane>();
+
+        cut.WaitForAssertion(() => Assert.Equal(1, ScrollCount()));
+        Assert.Equal(1, LastScrollRow());
+        _eventLogCommands.Received().ConsumeRevealFocus(Arg.Is<RevealFocusRequest>(request => request.Target == target));
+    }
+
+    [Fact]
+    public void SelectionReveal_WhenTheTargetIsNotInTheView_DiscardsWithoutScrolling()
+    {
+        // A one-shot (WaitForView=false) reveal whose target is filtered out of the current settled view is discarded
+        // rather than left pending - contrast with the reload reveal above, which lingers until the row appears.
+        var target = new EventLocator(_logId, 0, 2);
+        SetCommittedState(_logId, [_logId], Event(1, "Alpha"), Event(2, "Beta"), Event(3, "Gamma"));
+        _viewSource.Current.Returns(DisplayViewTestFactory.Presentation(_logId, [Event(1, "Alpha"), Event(2, "Beta")]));
+        _selectedEvent.Current.Returns(EntryFor(Event(3, "Gamma")));
+        _revealFocus.Current.Returns(new RevealFocusRequest(target, false));
+
+        var cut = Render<LogTablePane>();
+
+        cut.WaitForAssertion(() => _eventLogCommands.Received().ConsumeRevealFocus(Arg.Is<RevealFocusRequest>(request => request.Target == target)));
+        Assert.Equal(0, ScrollCount());
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.UI.Tests/TestUtils/LogTablePaneDependenciesExtensions.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/TestUtils/LogTablePaneDependenciesExtensions.cs
@@ -1,7 +1,6 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
-using EventLogExpert.Eventing.Common.Events;
 using EventLogExpert.Filtering.Compilation;
 using EventLogExpert.Filtering.Persistence;
 using EventLogExpert.Logging.Abstractions;
@@ -59,7 +58,7 @@ internal static class LogTablePaneDependenciesExtensions
             services.AddSingleton(Substitute.For<IGroupCollapseNotifier>());
 
             var revealFocus = Substitute.For<IRevealFocusSource>();
-            revealFocus.Current.Returns((EventLocator?)null);
+            revealFocus.Current.Returns((RevealFocusRequest?)null);
             services.AddSingleton(revealFocus);
 
             var presenceState = Substitute.For<IState<FilteredLogPresenceState>>();


### PR DESCRIPTION
## Summary

Adds a **Correlation** tab to the event details pane that presents the selected event's within-log activity as an operation timeline: the events sharing its Activity ID (newest first), with a header summarizing event count, time span, and error/warning tallies, plus secondary parent/child activity chips linked through `RelatedActivityId`.

## What's included

- **Activity correlation service + view** (`EventLogExpert.Runtime/ActivityCorrelation`): topology-only neighborhood build (grouping by Activity ID, discovering `RelatedActivityId` parent/child edges), a false-fusion guard for oversized/shared Activity IDs, a service-side Critical/Error/Warning tally over full membership, and a bounded, cancellable top-K display-leaf selector that always retains the selected event.
- **Timeline panel** (`ActivityCorrelationPanel`): lazy (builds only while the Correlation tab is active), lean per-row resolve with a bounded message snippet so full descriptions never enter the DOM, stale-aware with a Refresh action, and a "Filter table to this activity" lens action.
- **One-shot reveal pipeline**: `RevealFocusRequest` now carries a `WaitForView` flag so a selection-driven reveal is discarded when its target is not in the settled view, while reload-restoration reveals still wait for the rebuilt view.
- **Filter-lens chip styling fix**: the active-lens breadcrumb chips referenced `lens-lens*` classes that no longer matched the scoped CSS (`lens-chip*`), leaving the chips and their remove ("x") button unstyled. Aligned the markup and its test to the CSS.

## Testing

- Runtime: correlation service unit tests covering grouping, display caps, severity tally, cancellation, and cycle/multi-parent handling.
- UI: correlation panel bUnit tests (timeline render, lean resolve, snippet bounding, stale handling, reveal) plus the lens breadcrumb tests.
- Full solution builds clean; Runtime and UI unit suites are green.

Work item: ADO 62704692.
