### PR TITLE
Add Statistics panel with severity and top-contributor filtering

### DIFF
--- a/src/EventLogExpert.Eventing/Common/Events/EventColumnStore.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/EventColumnStore.cs
@@ -1322,6 +1322,52 @@ public sealed class EventColumnStore
         }
     }
 
+    internal void CountSeverity(ReadOnlySpan<int> rankByPhysical, int[] slotCounts, CancellationToken cancellationToken)
+    {
+        // Severity totals over the survivor projection: the un-bucketed sibling of BucketTimeTicksBySeverity. Resolve the
+        // five level names to pool indices once (missing -> int.MinValue) so sealed rows map level by integer compare; a
+        // null-level row (-1) falls to slot 0 (Unknown). Slots are ADDED to, so a combined view can accumulate readers.
+        int criticalIndex = _pool.TryGetIndex(nameof(SeverityLevel.Critical), out int critical) ? critical : int.MinValue;
+        int errorIndex = _pool.TryGetIndex(nameof(SeverityLevel.Error), out int error) ? error : int.MinValue;
+        int warningIndex = _pool.TryGetIndex(nameof(SeverityLevel.Warning), out int warning) ? warning : int.MinValue;
+        int informationIndex = _pool.TryGetIndex(nameof(SeverityLevel.Information), out int information) ? information : int.MinValue;
+        int verboseIndex = _pool.TryGetIndex(nameof(SeverityLevel.Verbose), out int verbose) ? verbose : int.MinValue;
+
+        int offset = 0;
+
+        foreach (EventColumnChunk chunk in _sealedChunks)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            ReadOnlySpan<int> levelColumn = chunk.PoolIndexColumn(EventColumnField.Level);
+
+            for (int row = 0; row < levelColumn.Length; row++)
+            {
+                if (rankByPhysical[offset + row] < 0) { continue; }
+
+                slotCounts[SlotOf(levelColumn[row])]++;
+            }
+
+            offset += chunk.RowCount;
+        }
+
+        for (int index = _sealedCount; index < Count; index++)
+        {
+            if (rankByPhysical[index] < 0) { continue; }
+
+            slotCounts[LevelSeverity.Slot(LevelSeverity.FromLevelName(Pending(index).Level))]++;
+        }
+
+        return;
+
+        int SlotOf(int levelPoolIndex) =>
+            levelPoolIndex == criticalIndex ? (int)SeverityLevel.Critical :
+            levelPoolIndex == errorIndex ? (int)SeverityLevel.Error :
+            levelPoolIndex == warningIndex ? (int)SeverityLevel.Warning :
+            levelPoolIndex == informationIndex ? (int)SeverityLevel.Information :
+            levelPoolIndex == verboseIndex ? (int)SeverityLevel.Verbose : 0;
+    }
+
     /// <summary>
     ///     Reconstructs a byte-faithful <see cref="ResolvedEvent" /> for the row at <paramref name="index" />,
     ///     reproducing every field's observable value. A pending row is returned as-is (perfect fidelity, zero work); a sealed

--- a/src/EventLogExpert.Eventing/Common/Events/EventColumnStoreReader.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/EventColumnStoreReader.cs
@@ -497,6 +497,15 @@ internal sealed class EventColumnStoreReader : IEventColumnReader
         _store.CountFieldValues(rankByPhysical, ToColumnField(field), counts, cancellationToken);
     }
 
+    public void CountSeverity(ReadOnlySpan<int> rankByPhysical, int[] slotCounts, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(slotCounts);
+        ArgumentOutOfRangeException.ThrowIfNotEqual(rankByPhysical.Length, Count);
+        ArgumentOutOfRangeException.ThrowIfLessThan(slotCounts.Length, LevelSeverity.SlotCount);
+
+        _store.CountSeverity(rankByPhysical, slotCounts, cancellationToken);
+    }
+
     public EventDataFieldEnumerator EnumerateEventData(EventLocator locator)
     {
         int index = Resolve(locator);

--- a/src/EventLogExpert.Eventing/Common/Events/IEventColumnReader.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/IEventColumnReader.cs
@@ -229,6 +229,8 @@ public interface IEventColumnReader
     /// </summary>
     void CountFieldValues(ReadOnlySpan<int> rankByPhysical, EventFieldId field, IDictionary<string, int> counts, CancellationToken cancellationToken);
 
+    void CountSeverity(ReadOnlySpan<int> rankByPhysical, int[] slotCounts, CancellationToken cancellationToken);
+
     EventDataFieldEnumerator EnumerateEventData(EventLocator locator);
 
     UserDataFieldEnumerator EnumerateUserData(EventLocator locator);

--- a/src/EventLogExpert.Runtime/DependencyInjection/RuntimeServiceCollectionExtensions.cs
+++ b/src/EventLogExpert.Runtime/DependencyInjection/RuntimeServiceCollectionExtensions.cs
@@ -35,6 +35,7 @@ using EventLogExpert.Runtime.Scenarios;
 using EventLogExpert.Runtime.Scenarios.Favorites;
 using EventLogExpert.Runtime.Settings;
 using EventLogExpert.Runtime.StatusBar;
+using EventLogExpert.Runtime.Stats;
 using EventLogExpert.Runtime.Update;
 using EventLogExpert.Runtime.Update.Deployment;
 using EventLogExpert.Scenarios.Catalog;
@@ -129,6 +130,8 @@ public static class RuntimeServiceCollectionExtensions
             services.AddSingleton<IFilterLibraryCommands, FilterLibraryCommands>();
             services.AddSingleton<IFilterPaneCommands, FilterPaneCommands>();
             services.AddSingleton<IHistogramCommands, HistogramCommands>();
+            services.AddSingleton<IStatsCommands, StatsCommands>();
+            services.AddSingleton<IStatsService, StatsService>();
             services.AddSingleton<ILogTableCommands, LogTableCommands>();
             services.AddSingleton<IScenarioFavoriteCommands, ScenarioFavoriteCommands>();
 
@@ -157,6 +160,7 @@ public static class RuntimeServiceCollectionExtensions
             services.AddSingleton<IFilterLensSource, FilterLensSource>();
             services.AddSingleton<IOpenLogsPresenceSource, OpenLogsPresenceSource>();
             services.AddSingleton<IHistogramVisibilitySource, HistogramVisibilitySource>();
+            services.AddSingleton<IStatsVisibilitySource, StatsVisibilitySource>();
             services.AddSingleton<IFilterAppliedSource, FilterAppliedSource>();
             services.AddSingleton<IEventFocusSource, EventFocusSource>();
             services.AddSingleton<IActiveEventLogSource, ActiveEventLogSource>();

--- a/src/EventLogExpert.Runtime/FilterLenses/FilterLensCommands.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/FilterLensCommands.cs
@@ -1,7 +1,9 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Filtering.Common.Filtering;
 using Fluxor;
+using System.Globalization;
 
 namespace EventLogExpert.Runtime.FilterLenses;
 
@@ -10,6 +12,18 @@ internal sealed class FilterLensCommands(IDispatcher dispatcher) : IFilterLensCo
     private readonly IDispatcher _dispatcher = dispatcher;
 
     public void ClearLenses() => _dispatcher.Dispatch(new ClearFilterLensesAction());
+
+    public void ExcludeEventId(int eventId, string? originLog = null) =>
+        PushLens(FilterLensFactory.ForExcludedValue(EventProperty.Id, eventId.ToString(CultureInfo.InvariantCulture), originLog));
+
+    public void ExcludeValue(EventProperty property, string value, string? originLog = null) =>
+        PushLens(FilterLensFactory.ForExcludedValue(property, value, originLog));
+
+    public void IncludeEventId(int eventId, string? originLog = null) =>
+        PushLens(FilterLensFactory.ForIncludedValue(EventProperty.Id, eventId.ToString(CultureInfo.InvariantCulture), originLog));
+
+    public void IncludeValue(EventProperty property, string value, string? originLog = null) =>
+        PushLens(FilterLensFactory.ForIncludedValue(property, value, originLog));
 
     public void RemoveLens(FilterLensId id) => _dispatcher.Dispatch(new RemoveFilterLensAction(id));
 

--- a/src/EventLogExpert.Runtime/FilterLenses/FilterLensFactory.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/FilterLensFactory.cs
@@ -16,6 +16,70 @@ internal static class FilterLensFactory
     public static FilterLens? ForActivityId(Guid activityId, string? originLog = null, string? label = null) =>
         BuildEqualityLens(EventProperty.ActivityId, activityId, label ?? $"Activity ID = {activityId}", originLog);
 
+    public static FilterLens? ForExcludedValue(EventProperty property, string value, string? originLog = null)
+    {
+        // Hide every event whose property equals this value: an EXCLUDED Equal comparison (the mirror of the keep-only
+        // NotEqual comparison BuildEqualityLens uses). The resulting view keeps events where property != value.
+        if (!TryFormatEqual(property, value, out var comparisonText)) { return null; }
+
+        var excluded = SavedFilter.TryCreate(
+            comparisonText,
+            isExcluded: true,
+            isEnabled: true,
+            mode: FilterMode.Advanced);
+
+        if (excluded?.Compiled is null) { return null; }
+
+        return new FilterLens
+        {
+            Label = $"{PropertyDisplayName(property)} \u2260 {value}",
+            Kind = LensKind.Property,
+            ExcludeFilters = [excluded],
+            OriginLog = originLog
+        };
+    }
+
+    public static FilterLens? ForIncludedValue(EventProperty property, string value, string? originLog = null)
+    {
+        // Keep only events whose property equals this value by EXCLUDING everything that does not match: an excluded
+        // NotEqual comparison (the same keep-only mechanism BuildEqualityLens uses for activity ids).
+        if (!TryFormatNotEqual(property, value, out var comparisonText)) { return null; }
+
+        var complement = SavedFilter.TryCreate(
+            comparisonText,
+            isExcluded: true,
+            isEnabled: true,
+            mode: FilterMode.Advanced);
+
+        if (complement?.Compiled is null) { return null; }
+
+        // The merged User field is presence-gated: `User != value` is NoMatch (i.e. kept) for events with no user
+        // identity, so the NotEqual complement alone would leak every no-user event into this keep-only view. Drop
+        // those rows with a second exclude clause (`User == null` matches exactly the no-identity events) so the kept
+        // set is precisely `User == value`. Source/Event ID/Task Category negate totally, so their lone complement
+        // already excludes absent values and needs no second clause.
+        SavedFilter? absentComplement = null;
+
+        if (property == EventProperty.UserDisplayName)
+        {
+            absentComplement = SavedFilter.TryCreate(
+                "User == null",
+                isExcluded: true,
+                isEnabled: true,
+                mode: FilterMode.Advanced);
+
+            if (absentComplement?.Compiled is null) { return null; }
+        }
+
+        return new FilterLens
+        {
+            Label = $"{PropertyDisplayName(property)} = {value}",
+            Kind = LensKind.Property,
+            ExcludeFilters = absentComplement is null ? [complement] : [complement, absentComplement],
+            OriginLog = originLog
+        };
+    }
+
     public static FilterLens? ForRelatedActivityId(Guid relatedActivityId, string? originLog = null) =>
         BuildEqualityLens(
             EventProperty.RelatedActivityId,
@@ -100,6 +164,28 @@ internal static class FilterLensFactory
         { Seconds: 0, Milliseconds: 0 } => $"{radius.TotalMinutes:0}m",
         _ => $"{radius.TotalSeconds:0}s"
     };
+
+    private static string PropertyDisplayName(EventProperty property) => property switch
+    {
+        EventProperty.Source => "Source",
+        EventProperty.Id => "Event ID",
+        EventProperty.TaskCategory => "Task Category",
+        EventProperty.UserDisplayName => "User",
+        _ => property.ToString()
+    };
+
+    private static bool TryFormatEqual(EventProperty property, string value, out string comparisonText)
+    {
+        var comparison = new FilterComparison
+        {
+            Property = property,
+            Operator = ComparisonOperator.Equals,
+            MatchMode = MatchMode.Single,
+            Value = value
+        };
+
+        return BasicFilterFormatter.TryFormat(new BasicFilter(comparison, []), out comparisonText);
+    }
 
     private static bool TryFormatNotEqual(EventProperty property, string value, out string comparisonText)
     {

--- a/src/EventLogExpert.Runtime/FilterLenses/IFilterLensCommands.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/IFilterLensCommands.cs
@@ -1,13 +1,21 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
-using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Filtering.Common.Filtering;
 
 namespace EventLogExpert.Runtime.FilterLenses;
 
 public interface IFilterLensCommands
 {
     void ClearLenses();
+
+    void ExcludeEventId(int eventId, string? originLog = null);
+
+    void ExcludeValue(EventProperty property, string value, string? originLog = null);
+
+    void IncludeEventId(int eventId, string? originLog = null);
+
+    void IncludeValue(EventProperty property, string value, string? originLog = null);
 
     void RemoveLens(FilterLensId id);
 

--- a/src/EventLogExpert.Runtime/LogTable/EmptyColumnView.cs
+++ b/src/EventLogExpert.Runtime/LogTable/EmptyColumnView.cs
@@ -156,6 +156,8 @@ internal sealed class EmptyColumnView : IEventColumnView
 
     public void CountFieldValues(EventFieldId field, IDictionary<string, int> counts, CancellationToken cancellationToken) { }
 
+    public void CountSeverity(int[] slotCounts, CancellationToken cancellationToken) { }
+
     public byte[] EnsureHighlightWinners(
         IReadOnlyList<SavedFilter> orderedColoredFilters,
         int planKey,

--- a/src/EventLogExpert.Runtime/LogTable/IEventColumnView.cs
+++ b/src/EventLogExpert.Runtime/LogTable/IEventColumnView.cs
@@ -146,6 +146,8 @@ public interface IEventColumnView
 
     void CountFieldValues(EventFieldId field, IDictionary<string, int> counts, CancellationToken cancellationToken);
 
+    void CountSeverity(int[] slotCounts, CancellationToken cancellationToken);
+
     byte[] EnsureHighlightWinners(
         IReadOnlyList<SavedFilter> orderedColoredFilters,
         int planKey,

--- a/src/EventLogExpert.Runtime/LogTable/OrderedView/CombinedOrderedColumnView.cs
+++ b/src/EventLogExpert.Runtime/LogTable/OrderedView/CombinedOrderedColumnView.cs
@@ -471,6 +471,16 @@ internal sealed class CombinedOrderedColumnView : IEventColumnView
         }
     }
 
+    public void CountSeverity(int[] slotCounts, CancellationToken cancellationToken)
+    {
+        Partition partition = GetPartition();
+
+        for (int slot = 0; slot < _readers.Length; slot++)
+        {
+            _readers[slot].CountSeverity(partition.RankByPhysical[slot], slotCounts, cancellationToken);
+        }
+    }
+
     public byte[] EnsureHighlightWinners(
         IReadOnlyList<SavedFilter> orderedColoredFilters,
         int planKey,

--- a/src/EventLogExpert.Runtime/LogTable/OrderedView/OrderedColumnView.cs
+++ b/src/EventLogExpert.Runtime/LogTable/OrderedView/OrderedColumnView.cs
@@ -288,6 +288,9 @@ internal sealed class OrderedColumnView : IEventColumnView
     public void CountFieldValues(EventFieldId field, IDictionary<string, int> counts, CancellationToken cancellationToken) =>
         _reader.CountFieldValues(RankByPhysical(), field, counts, cancellationToken);
 
+    public void CountSeverity(int[] slotCounts, CancellationToken cancellationToken) =>
+        _reader.CountSeverity(RankByPhysical(), slotCounts, cancellationToken);
+
     public byte[] EnsureHighlightWinners(
         IReadOnlyList<SavedFilter> orderedColoredFilters,
         int planKey,

--- a/src/EventLogExpert.Runtime/Stats/IStatsCommands.cs
+++ b/src/EventLogExpert.Runtime/Stats/IStatsCommands.cs
@@ -1,0 +1,9 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Stats;
+
+public interface IStatsCommands
+{
+    void SetVisible(bool visible);
+}

--- a/src/EventLogExpert.Runtime/Stats/IStatsDrawerPreferencesProvider.cs
+++ b/src/EventLogExpert.Runtime/Stats/IStatsDrawerPreferencesProvider.cs
@@ -1,0 +1,9 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Stats;
+
+public interface IStatsDrawerPreferencesProvider
+{
+    int StatsDrawerHeightPreference { get; set; }
+}

--- a/src/EventLogExpert.Runtime/Stats/IStatsService.cs
+++ b/src/EventLogExpert.Runtime/Stats/IStatsService.cs
@@ -1,0 +1,17 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.LogTable;
+
+namespace EventLogExpert.Runtime.Stats;
+
+/// <summary>
+///     Computes statistics over a supplied filtered view. Stateless and synchronous - the caller owns threading,
+///     throttling, and supersession (the statistics panel runs these off the UI thread with cancellation).
+/// </summary>
+public interface IStatsService
+{
+    DimensionStats BuildDimension(IEventColumnView view, StatsDimension dimension, int topN, CancellationToken cancellationToken);
+
+    SeverityStats BuildSeverity(IEventColumnView view, CancellationToken cancellationToken);
+}

--- a/src/EventLogExpert.Runtime/Stats/IStatsVisibilitySource.cs
+++ b/src/EventLogExpert.Runtime/Stats/IStatsVisibilitySource.cs
@@ -1,0 +1,11 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.Common.Sources;
+
+namespace EventLogExpert.Runtime.Stats;
+
+public interface IStatsVisibilitySource : IChangeNotifier
+{
+    bool IsVisible { get; }
+}

--- a/src/EventLogExpert.Runtime/Stats/SetStatsVisibleAction.cs
+++ b/src/EventLogExpert.Runtime/Stats/SetStatsVisibleAction.cs
@@ -1,0 +1,6 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Stats;
+
+internal sealed record SetStatsVisibleAction(bool IsVisible);

--- a/src/EventLogExpert.Runtime/Stats/StatsCommands.cs
+++ b/src/EventLogExpert.Runtime/Stats/StatsCommands.cs
@@ -1,0 +1,13 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Fluxor;
+
+namespace EventLogExpert.Runtime.Stats;
+
+internal sealed class StatsCommands(IDispatcher dispatcher) : IStatsCommands
+{
+    private readonly IDispatcher _dispatcher = dispatcher;
+
+    public void SetVisible(bool visible) => _dispatcher.Dispatch(new SetStatsVisibleAction(visible));
+}

--- a/src/EventLogExpert.Runtime/Stats/StatsDimension.cs
+++ b/src/EventLogExpert.Runtime/Stats/StatsDimension.cs
@@ -1,0 +1,84 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Filtering.Common.Filtering;
+using EventLogExpert.Runtime.FilterLenses;
+using System.Globalization;
+
+namespace EventLogExpert.Runtime.Stats;
+
+/// <summary>
+///     The contributor dimensions the statistics panel ranks (severity is handled separately). All four are
+///     filterable, so each supports one-click exclude.
+/// </summary>
+public enum StatsDimension
+{
+    Source,
+    EventId,
+    TaskCategory,
+    User
+}
+
+public static class StatsDimensions
+{
+    /// <summary>The contributor dimensions in default display order.</summary>
+    public static readonly IReadOnlyList<StatsDimension> All =
+        [StatsDimension.Source, StatsDimension.EventId, StatsDimension.TaskCategory, StatsDimension.User];
+
+    extension(StatsDimension dimension)
+    {
+        public string DisplayName() => dimension switch
+        {
+            StatsDimension.Source => "Source",
+            StatsDimension.EventId => "Event ID",
+            StatsDimension.TaskCategory => "Task Category",
+            StatsDimension.User => "User",
+            _ => dimension.ToString()
+        };
+
+        /// <summary>The filter property a contributor row excludes on (verified filterable for all four dimensions).</summary>
+        public EventProperty FilterProperty() => dimension switch
+        {
+            StatsDimension.Source => EventProperty.Source,
+            StatsDimension.EventId => EventProperty.Id,
+            StatsDimension.TaskCategory => EventProperty.TaskCategory,
+            StatsDimension.User => EventProperty.UserDisplayName,
+            _ => throw new ArgumentOutOfRangeException(nameof(dimension), dimension, "Unknown stats dimension.")
+        };
+
+        /// <summary>Pushes an include ("filter to only") or exclude ("filter out") lens for a contributor value of this dimension.</summary>
+        public void PushRowFilter(IFilterLensCommands commands, string value, string? originLog, bool include)
+        {
+            ArgumentNullException.ThrowIfNull(commands);
+
+            if (dimension == StatsDimension.EventId)
+            {
+                if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int eventId))
+                {
+                    if (include) { commands.IncludeEventId(eventId, originLog); }
+                    else { commands.ExcludeEventId(eventId, originLog); }
+                }
+
+                return;
+            }
+
+            EventProperty property = dimension.FilterProperty();
+
+            if (include) { commands.IncludeValue(property, value, originLog); }
+            else { commands.ExcludeValue(property, value, originLog); }
+        }
+
+        /// <summary>
+        ///     The pooled columnar field a string dimension counts over. Event ID counts through <c>CountEventIds</c>, not a
+        ///     field.
+        /// </summary>
+        internal EventFieldId FieldId() => dimension switch
+        {
+            StatsDimension.Source => EventFieldId.Source,
+            StatsDimension.TaskCategory => EventFieldId.TaskCategory,
+            StatsDimension.User => EventFieldId.UserDisplayName,
+            _ => throw new ArgumentOutOfRangeException(nameof(dimension), dimension, "Dimension has no pooled string field.")
+        };
+    }
+}

--- a/src/EventLogExpert.Runtime/Stats/StatsModels.cs
+++ b/src/EventLogExpert.Runtime/Stats/StatsModels.cs
@@ -1,0 +1,34 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Stats;
+
+/// <summary>
+///     The severity composition of the filtered set: dense slots (0 = Unknown, 1-5 = Critical..Verbose) summing to
+///     <see cref="Total" />.
+/// </summary>
+public readonly record struct SeverityStats(int Total, IReadOnlyList<int> Slots);
+
+/// <summary>One ranked contributor of a dimension: its value and how many filtered events carry it.</summary>
+public sealed record StatsContributor(string Value, int Count);
+
+/// <summary>The top contributors of one dimension over the filtered set, plus the totals needed for shares and coverage.</summary>
+public sealed record DimensionStats
+{
+    public required StatsDimension Dimension { get; init; }
+
+    /// <summary>The filtered-set total (the denominator for every share); includes events with an absent/empty value.</summary>
+    public required int Total { get; init; }
+
+    /// <summary>The number of distinct non-missing values.</summary>
+    public required int DistinctCount { get; init; }
+
+    /// <summary>Events with an absent/empty value (string dimensions only; always 0 for Event ID).</summary>
+    public required int MissingCount { get; init; }
+
+    /// <summary>The ranked top contributors (count desc, deterministic tie-break), capped at the requested top-N.</summary>
+    public required IReadOnlyList<StatsContributor> Top { get; init; }
+
+    /// <summary>The number of events represented by the shown <see cref="Top" /> rows (for the coverage line).</summary>
+    public int ShownEventCount => Top.Sum(contributor => contributor.Count);
+}

--- a/src/EventLogExpert.Runtime/Stats/StatsReducers.cs
+++ b/src/EventLogExpert.Runtime/Stats/StatsReducers.cs
@@ -1,0 +1,16 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Fluxor;
+
+namespace EventLogExpert.Runtime.Stats;
+
+internal sealed class StatsReducers
+{
+    [ReducerMethod]
+    public static StatsState ReduceSetStatsVisible(StatsState state, SetStatsVisibleAction action) =>
+        state.IsVisible == action.IsVisible ? state : new StatsState
+        {
+            IsVisible = action.IsVisible
+        };
+}

--- a/src/EventLogExpert.Runtime/Stats/StatsService.cs
+++ b/src/EventLogExpert.Runtime/Stats/StatsService.cs
@@ -1,0 +1,80 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Runtime.LogTable;
+using System.Globalization;
+
+namespace EventLogExpert.Runtime.Stats;
+
+internal sealed class StatsService : IStatsService
+{
+    public SeverityStats BuildSeverity(IEventColumnView view, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(view);
+
+        int[] slots = new int[LevelSeverity.SlotCount];
+        view.CountSeverity(slots, cancellationToken);
+
+        return new SeverityStats(view.Count, slots);
+    }
+
+    public DimensionStats BuildDimension(
+        IEventColumnView view,
+        StatsDimension dimension,
+        int topN,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(view);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(topN);
+
+        int total = view.Count;
+
+        if (dimension == StatsDimension.EventId)
+        {
+            var counts = new Dictionary<int, int>();
+            view.CountEventIds(counts, cancellationToken);
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var topIds = counts
+                .OrderByDescending(entry => entry.Value)
+                .ThenBy(entry => entry.Key)
+                .Take(topN)
+                .Select(entry => new StatsContributor(entry.Key.ToString(CultureInfo.InvariantCulture), entry.Value))
+                .ToList();
+
+            // Every event carries an Id, so the counted total equals the filtered total and nothing is missing.
+            return new DimensionStats
+            {
+                Dimension = dimension,
+                Total = total,
+                DistinctCount = counts.Count,
+                MissingCount = total - counts.Values.Sum(),
+                Top = topIds
+            };
+        }
+
+        var fieldCounts = new Dictionary<string, int>();
+        view.CountFieldValues(dimension.FieldId(), fieldCounts, cancellationToken);
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var topValues = fieldCounts
+            .OrderByDescending(entry => entry.Value)
+            .ThenBy(entry => entry.Key, StringComparer.Ordinal)
+            .Take(topN)
+            .Select(entry => new StatsContributor(entry.Key, entry.Value))
+            .ToList();
+
+        // CountFieldValues skips absent/empty values, so the counted total is the non-missing survivor count.
+        return new DimensionStats
+        {
+            Dimension = dimension,
+            Total = total,
+            DistinctCount = fieldCounts.Count,
+            MissingCount = total - fieldCounts.Values.Sum(),
+            Top = topValues
+        };
+    }
+}

--- a/src/EventLogExpert.Runtime/Stats/StatsState.cs
+++ b/src/EventLogExpert.Runtime/Stats/StatsState.cs
@@ -1,0 +1,12 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Fluxor;
+
+namespace EventLogExpert.Runtime.Stats;
+
+[FeatureState]
+public sealed record StatsState
+{
+    public bool IsVisible { get; init; }
+}

--- a/src/EventLogExpert.Runtime/Stats/StatsVisibilitySource.cs
+++ b/src/EventLogExpert.Runtime/Stats/StatsVisibilitySource.cs
@@ -1,0 +1,18 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.Common.Sources;
+using Fluxor;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EventLogExpert.Runtime.Stats;
+
+internal sealed class StatsVisibilitySource(
+    IState<StatsState> state,
+    [FromKeyedServices(LogCategories.EventLog)] ITraceLogger logger)
+    : ObservableStateSourceBase<StatsState, bool>(state, logger, static state => state.IsVisible),
+        IStatsVisibilitySource
+{
+    public bool IsVisible => CurrentProjection;
+}

--- a/src/EventLogExpert.UI/Layout/MainLayout.razor
+++ b/src/EventLogExpert.UI/Layout/MainLayout.razor
@@ -12,6 +12,8 @@
         <MainContent />
     </main>
 
+    <StatsDrawer />
+
     <footer>
         <StatusBar />
     </footer>

--- a/src/EventLogExpert.UI/LogTable/Stats/StatsDetailModal.razor
+++ b/src/EventLogExpert.UI/LogTable/Stats/StatsDetailModal.razor
@@ -1,0 +1,69 @@
+@using EventLogExpert.Runtime.Stats
+@inherits ModalBase<bool>
+
+<ModalChrome AriaLabel="@($"All {Dimension.DisplayName()} values")"
+    CloseLabel="Close"
+    Footer="FooterPreset.CloseOnly"
+    Height="70%"
+    InlineAlert="@CurrentInlineAlert"
+    MaxWidth="40rem"
+    MinWidth="26rem"
+    OnClose="OnCancelAsync"
+    OnDialogClosedByUser="HandleDialogClosedByUserAsync"
+    OnInlineAlertResolved="HandleInlineAlertResolvedAsync"
+    Title="@($"All {Dimension.DisplayName()} values")"
+    @ref="ChromeRef">
+    <ChildContent>
+        <div class="stats-detail">
+            <input aria-label="Filter values"
+                @bind="_search"
+                @bind:event="oninput"
+                class="input stats-detail-search"
+                placeholder="Filter values..."
+                type="text" />
+
+            @if (_loading)
+            {
+                <div class="stats-detail-status">Computing...</div>
+            }
+            else if (_failed)
+            {
+                <div class="stats-detail-status">These values could not be computed.</div>
+            }
+            else
+            {
+                @if (_distinct > _all.Count)
+                {
+                    <div class="stats-detail-truncated">Showing the top @FormatCount(_all.Count) of @FormatCount(_distinct) values.</div>
+                }
+
+                <div class="stats-detail-list">
+                    @foreach (var row in VisibleRows)
+                    {
+                        <div class="stats-detail-row">
+                            <span class="stats-detail-value" title="@row.Value">@row.Value</span>
+                            <span class="stats-detail-count">@FormatCount(row.Count)</span>
+                            <span class="stats-detail-percent">@FormatShare(row.Count)</span>
+                            <span class="stats-detail-actions">
+                                <button aria-label="@($"Filter to {Dimension.DisplayName()} {row.Value}")"
+                                    class="stats-detail-include"
+                                    @onclick="() => Include(row)"
+                                    title="Filter to only this value"
+                                    type="button">
+                                    <i aria-hidden="true" class="bi bi-plus-circle"></i>
+                                </button>
+                                <button aria-label="@($"Exclude {Dimension.DisplayName()} {row.Value}")"
+                                    class="stats-detail-exclude"
+                                    @onclick="() => Exclude(row)"
+                                    title="Exclude this value"
+                                    type="button">
+                                    <i aria-hidden="true" class="bi bi-dash-circle"></i>
+                                </button>
+                            </span>
+                        </div>
+                    }
+                </div>
+            }
+        </div>
+    </ChildContent>
+</ModalChrome>

--- a/src/EventLogExpert.UI/LogTable/Stats/StatsDetailModal.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/Stats/StatsDetailModal.razor.cs
@@ -37,10 +37,16 @@ public sealed partial class StatsDetailModal : ModalBase<bool>
 
     [Inject] private IStatsService StatsService { get; init; } = null!;
 
-    private IEnumerable<StatsContributor> VisibleRows =>
-        string.IsNullOrWhiteSpace(_search) ?
-            _all :
-            _all.Where(row => row.Value.Contains(_search.Trim(), StringComparison.OrdinalIgnoreCase));
+    private IEnumerable<StatsContributor> VisibleRows
+    {
+        get
+        {
+            if (string.IsNullOrWhiteSpace(_search)) { return _all; }
+
+            string needle = _search.Trim();
+            return _all.Where(row => row.Value.Contains(needle, StringComparison.OrdinalIgnoreCase));
+        }
+    }
 
     protected override ValueTask DisposeAsyncCore(bool disposing)
     {

--- a/src/EventLogExpert.UI/LogTable/Stats/StatsDetailModal.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/Stats/StatsDetailModal.razor.cs
@@ -1,0 +1,94 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.FilterLenses;
+using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.Runtime.Stats;
+using EventLogExpert.UI.Modal;
+using Microsoft.AspNetCore.Components;
+using System.Globalization;
+
+namespace EventLogExpert.UI.LogTable.Stats;
+
+public sealed partial class StatsDetailModal : ModalBase<bool>
+{
+    // Bounds the full-list scan so a dimension with near-event-count cardinality (Source / User) can't build an
+    // unbounded list; the search box narrows within what was collected.
+    private const int MaxRows = 2000;
+
+    private readonly CancellationTokenSource _cts = new();
+
+    private IReadOnlyList<StatsContributor> _all = [];
+    private int _distinct;
+    private bool _failed;
+    private bool _loading = true;
+    private string _search = string.Empty;
+    private int _total;
+
+    [EditorRequired]
+    [Parameter] public StatsDimension Dimension { get; set; }
+
+    [Parameter] public string? OriginLog { get; set; }
+
+    [EditorRequired]
+    [Parameter] public IEventColumnView View { get; set; } = null!;
+
+    [Inject] private IFilterLensCommands FilterLensCommands { get; init; } = null!;
+
+    [Inject] private IStatsService StatsService { get; init; } = null!;
+
+    private IEnumerable<StatsContributor> VisibleRows =>
+        string.IsNullOrWhiteSpace(_search) ?
+            _all :
+            _all.Where(row => row.Value.Contains(_search.Trim(), StringComparison.OrdinalIgnoreCase));
+
+    protected override ValueTask DisposeAsyncCore(bool disposing)
+    {
+        if (disposing)
+        {
+            _cts.Cancel();
+            _cts.Dispose();
+        }
+
+        return base.DisposeAsyncCore(disposing);
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        await base.OnInitializedAsync();
+
+        try
+        {
+            DimensionStats stats = await Task.Run(
+                () => StatsService.BuildDimension(View, Dimension, MaxRows, _cts.Token), _cts.Token);
+
+            _all = stats.Top;
+            _distinct = stats.DistinctCount;
+            _total = stats.Total;
+        }
+        catch (OperationCanceledException) { }
+        catch (Exception)
+        {
+            _failed = true;
+        }
+        finally
+        {
+            if (!IsDisposed)
+            {
+                _loading = false;
+                StateHasChanged();
+            }
+        }
+    }
+
+    private static string FormatCount(int value) => value.ToString("N0", CultureInfo.CurrentCulture);
+
+    private void Exclude(StatsContributor row) =>
+        Dimension.PushRowFilter(FilterLensCommands, row.Value, OriginLog, include: false);
+
+    private string FormatShare(int count) =>
+        _total == 0 ? "0%" : (count * 100.0 / _total).ToString("0.0", CultureInfo.CurrentCulture) + "%";
+
+    private void Include(StatsContributor row) =>
+        Dimension.PushRowFilter(FilterLensCommands, row.Value, OriginLog, include: true);
+}

--- a/src/EventLogExpert.UI/LogTable/Stats/StatsDetailModal.razor.css
+++ b/src/EventLogExpert.UI/LogTable/Stats/StatsDetailModal.razor.css
@@ -1,0 +1,90 @@
+.stats-detail {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    height: 100%;
+    min-height: 0;
+}
+
+.stats-detail-search {
+    flex: 0 0 auto;
+    margin: 0;
+}
+
+.stats-detail-status {
+    padding: 8px 2px;
+    font-style: italic;
+    color: var(--text-secondary);
+}
+
+.stats-detail-truncated {
+    flex: 0 0 auto;
+    padding: 0 4px;
+    color: var(--text-secondary);
+    font-size: 0.85em;
+}
+
+.stats-detail-list {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+}
+
+.stats-detail-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto 4em auto;
+    align-items: center;
+    gap: 10px;
+    padding: 2px 4px;
+}
+
+.stats-detail-row:hover { background: color-mix(in srgb, var(--text-secondary) 8%, transparent); }
+
+.stats-detail-value {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--text-primary);
+}
+
+.stats-detail-count,
+.stats-detail-percent {
+    font-variant-numeric: tabular-nums;
+    text-align: end;
+}
+
+.stats-detail-percent { color: var(--text-secondary); }
+
+.stats-detail-actions {
+    display: flex;
+    gap: 4px;
+}
+
+.stats-detail-include,
+.stats-detail-exclude {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    padding: 0;
+    border: 1px solid transparent;
+    border-radius: 3px;
+    background: none;
+    font-size: 14px;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.stats-detail-include { color: var(--toggle-accent); }
+.stats-detail-include:hover { background: color-mix(in srgb, var(--toggle-accent) 16%, transparent); }
+
+.stats-detail-exclude { color: var(--clr-red); }
+.stats-detail-exclude:hover { background: color-mix(in srgb, var(--clr-red) 16%, transparent); }
+
+.stats-detail-include:focus-visible,
+.stats-detail-exclude:focus-visible {
+    outline: 1px solid Highlight;
+    outline-offset: 1px;
+}

--- a/src/EventLogExpert.UI/LogTable/Stats/StatsDrawer.razor
+++ b/src/EventLogExpert.UI/LogTable/Stats/StatsDrawer.razor
@@ -1,0 +1,9 @@
+@inherits AppStateComponentBase
+
+<div class="stats-drawer@(IsOpen ? " stats-drawer-open" : "")">
+    <div aria-hidden="true" class="stats-drawer-resizer" title="Drag to resize"></div>
+    @if (IsOpen)
+    {
+        <StatsPane />
+    }
+</div>

--- a/src/EventLogExpert.UI/LogTable/Stats/StatsDrawer.razor
+++ b/src/EventLogExpert.UI/LogTable/Stats/StatsDrawer.razor
@@ -1,6 +1,6 @@
 @inherits AppStateComponentBase
 
-<div class="stats-drawer@(IsOpen ? " stats-drawer-open" : "")">
+<div class="stats-drawer@(IsOpen ? " stats-drawer-open" : "")" id="stats-drawer">
     <div aria-hidden="true" class="stats-drawer-resizer" title="Drag to resize"></div>
     @if (IsOpen)
     {

--- a/src/EventLogExpert.UI/LogTable/Stats/StatsDrawer.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/Stats/StatsDrawer.razor.cs
@@ -1,0 +1,83 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.Stats;
+using EventLogExpert.UI.Common;
+using EventLogExpert.UI.Common.Interop;
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+
+namespace EventLogExpert.UI.LogTable.Stats;
+
+public sealed partial class StatsDrawer : AppStateComponentBase
+{
+    private bool _disposed;
+    private DotNetObjectReference<StatsDrawer>? _dotNetRef;
+    private IJSObjectReference? _module;
+
+    // The status-bar count chip is the only stats toggle, and it disappears when no log is active. Gate the drawer on
+    // an open log too, so closing the last log auto-collapses the drawer instead of stranding it open with no control.
+    private bool IsOpen => StatsVisibility.IsVisible && OpenLogsPresence.HasOpenLogs;
+
+    [Inject] private IJSRuntime JsRuntime { get; init; } = null!;
+
+    [Inject] private IOpenLogsPresenceSource OpenLogsPresence { get; init; } = null!;
+
+    [Inject] private IStatsDrawerPreferencesProvider PreferencesProvider { get; init; } = null!;
+
+    [Inject] private IStatsVisibilitySource StatsVisibility { get; init; } = null!;
+
+    [JSInvokable]
+    public void OnStatsDrawerHeightChanged(int height)
+    {
+        if (height > 0)
+        {
+            PreferencesProvider.StatsDrawerHeightPreference = height;
+        }
+    }
+
+    protected override async ValueTask DisposeAsyncCore(bool disposing)
+    {
+        if (disposing)
+        {
+            _disposed = true;
+
+            await JsModuleInterop.DisposeModuleSafelyAsync(
+                _module,
+                static module => module.InvokeVoidAsync("disposeStatsDrawerResizer"));
+
+            _module = null;
+            _dotNetRef?.Dispose();
+            _dotNetRef = null;
+        }
+
+        await base.DisposeAsyncCore(disposing);
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender && !_disposed)
+        {
+            try
+            {
+                _dotNetRef = DotNetObjectReference.Create(this);
+                _module = await JsRuntime.InvokeAsync<IJSObjectReference>(
+                    "import", "./_content/EventLogExpert.UI/LogTable/Stats/StatsDrawer.razor.js");
+                await _module.InvokeVoidAsync(
+                    "enableStatsDrawerResizer", _dotNetRef, PreferencesProvider.StatsDrawerHeightPreference);
+            }
+            catch (JSDisconnectedException) { /* Circuit closed before the resizer attached. */ }
+            catch (ObjectDisposedException) { /* Component torn down mid-init. */ }
+        }
+
+        await base.OnAfterRenderAsync(firstRender);
+    }
+
+    protected override void OnInitialized()
+    {
+        ObserveSource(StatsVisibility);
+        ObserveSource(OpenLogsPresence);
+        base.OnInitialized();
+    }
+}

--- a/src/EventLogExpert.UI/LogTable/Stats/StatsDrawer.razor.css
+++ b/src/EventLogExpert.UI/LogTable/Stats/StatsDrawer.razor.css
@@ -1,0 +1,32 @@
+/* Slide-up drawer between the main content and the footer status bar (VS Code panel model): expanding it pushes the
+   main content up rather than overlaying it, because .page is a flex column and .page-content flexes. Height lives in
+   the --stats-drawer-height custom property (drag-resizable) so the collapsed height:0 rule still wins. */
+.stats-drawer {
+    position: relative;
+    flex: 0 0 auto;
+    height: 0;
+    max-height: 80vh;
+    overflow: hidden;
+    transition: height 0.2s ease;
+}
+
+.stats-drawer-open { height: var(--stats-drawer-height, 240px); }
+
+/* Applied by the resizer while dragging so the height tracks the pointer instead of easing. */
+.stats-drawer-resizing { transition: none; }
+
+.stats-drawer-resizer {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 6px;
+    z-index: 1;
+    cursor: n-resize;
+    user-select: none;
+    -webkit-user-select: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .stats-drawer { transition: none; }
+}

--- a/src/EventLogExpert.UI/LogTable/Stats/StatsDrawer.razor.js
+++ b/src/EventLogExpert.UI/LogTable/Stats/StatsDrawer.razor.js
@@ -1,0 +1,100 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+const drawerState = {
+    controller: null,
+    dotNetRef: null,
+    activeDocumentListeners: []
+};
+
+function trackDocumentListener(event, handler) {
+    const options = drawerState.controller ? { signal: drawerState.controller.signal } : undefined;
+    document.addEventListener(event, handler, options);
+    const entry = { event, handler };
+    drawerState.activeDocumentListeners.push(entry);
+
+    return () => {
+        document.removeEventListener(event, handler);
+        const i = drawerState.activeDocumentListeners.indexOf(entry);
+        if (i !== -1) { drawerState.activeDocumentListeners.splice(i, 1); }
+    };
+}
+
+// Drag the top edge to resize the drawer. Height lives in the --stats-drawer-height custom property so the collapsed
+// (height:0) state still wins without !important; the .NET side persists the final value on release.
+export function enableStatsDrawerResizer(dotNetRef, savedHeight) {
+    disposeStatsDrawerResizer();
+
+    const drawer = document.querySelector(".stats-drawer");
+    const resizer = drawer?.querySelector(".stats-drawer-resizer");
+
+    if (drawer == null || resizer == null) {
+        return;
+    }
+
+    if (savedHeight && savedHeight > 0) {
+        const maxHeight = Math.max(80, Math.floor(window.innerHeight * 0.8));
+        drawer.style.setProperty("--stats-drawer-height", `${Math.min(savedHeight, maxHeight)}px`);
+    }
+
+    drawerState.dotNetRef = dotNetRef;
+    drawerState.controller = new AbortController();
+    const signal = drawerState.controller.signal;
+
+    let y = 0;
+    let h = 0;
+    let maxHeight = 0;
+    let untrackMove = null;
+    let untrackUp = null;
+
+    const mouseMoveHandler = function(e) {
+        const distance = e.clientY - y;
+        // The drawer sits below the content, so dragging UP (negative distance) grows it. Clamp to a min so it stays
+        // grabbable and to an 80% viewport cap so growing it can never push the status-bar toggle off-screen.
+        const newHeight = Math.min(maxHeight, Math.max(80, h - distance));
+        drawer.style.setProperty("--stats-drawer-height", `${newHeight}px`);
+    };
+
+    const mouseUpHandler = function() {
+        if (untrackMove) { untrackMove(); untrackMove = null; }
+        if (untrackUp) { untrackUp(); untrackUp = null; }
+
+        drawer.classList.remove("stats-drawer-resizing");
+
+        const ref = drawerState.dotNetRef;
+
+        if (ref && drawer.isConnected) {
+            const newHeight = parseInt(window.getComputedStyle(drawer).height, 10);
+            ref.invokeMethodAsync("OnStatsDrawerHeightChanged", newHeight).catch(() => { });
+        }
+    };
+
+    const mouseDownHandler = function(e) {
+        if (e.button !== 0) { return; }
+
+        y = e.clientY;
+        h = parseInt(window.getComputedStyle(drawer).height, 10);
+        maxHeight = Math.max(80, Math.floor(window.innerHeight * 0.8));
+        // Suppress the open/close transition while dragging so the height tracks the pointer instead of easing.
+        drawer.classList.add("stats-drawer-resizing");
+
+        untrackMove = trackDocumentListener("mousemove", mouseMoveHandler);
+        untrackUp = trackDocumentListener("mouseup", mouseUpHandler);
+    };
+
+    resizer.addEventListener("mousedown", mouseDownHandler, { signal });
+}
+
+export function disposeStatsDrawerResizer() {
+    if (drawerState.controller) {
+        drawerState.controller.abort();
+        drawerState.controller = null;
+    }
+
+    for (const { event, handler } of drawerState.activeDocumentListeners) {
+        document.removeEventListener(event, handler);
+    }
+
+    drawerState.activeDocumentListeners = [];
+    drawerState.dotNetRef = null;
+}

--- a/src/EventLogExpert.UI/LogTable/Stats/StatsPane.razor
+++ b/src/EventLogExpert.UI/LogTable/Stats/StatsPane.razor
@@ -1,0 +1,129 @@
+@using EventLogExpert.Runtime.Stats
+@inherits PresentationViewComponentBase
+
+<div aria-label="Statistics" class="stats-pane" @ref="_paneElement" role="region">
+    <div class="stats-header">
+        <span class="stats-title">Statistics</span>
+        <span class="stats-headline@(IsSeverityStale ? " stats-stale" : "")">@HeadlineText()</span>
+    </div>
+
+    @if (_scanFailed)
+    {
+        <div class="stats-empty">Statistics could not be built for these events.</div>
+    }
+    else if (_severity is { Total: > 0 })
+    {
+        <div class="stats-severity@(IsSeverityStale ? " stats-stale" : "")">
+            <div aria-label="@SeverityBarAria()" class="stats-severity-bar" role="img">
+                @foreach (var segment in SeveritySegments())
+                {
+                    <span class="stats-severity-seg @segment.CssClass"
+                        style="flex-grow:@Css(segment.Percent)"
+                        title="@($"{segment.Label}: {FormatCount(segment.Count)} ({FormatPercent(segment.Percent)})")">
+                    </span>
+                }
+            </div>
+            <div class="stats-severity-legend">
+                @foreach (var segment in SeveritySegments())
+                {
+                    <span class="stats-legend-item">
+                        <span aria-hidden="true" class="stats-legend-swatch @segment.CssClass"></span>
+                        <span class="stats-legend-label">@segment.Label</span>
+                        <span class="stats-legend-count">@FormatCount(segment.Count)</span>
+                    </span>
+                }
+            </div>
+        </div>
+
+        <div class="stats-sections">
+            @foreach (var section in _sections)
+            {
+                <section class="stats-section@(IsSectionStale(section) ? " stats-stale" : "")">
+                    <div class="stats-section-header">
+                        <span class="stats-section-title">@section.Dimension.DisplayName()</span>
+                        @if (section.Stats is { } headerStats)
+                        {
+                            <span class="stats-section-distinct">@FormatCount(headerStats.DistinctCount)</span>
+                        }
+                        @if (IsSectionStale(section))
+                        {
+                            <span class="stats-updating">Updating...</span>
+                        }
+                    </div>
+
+                    @if (section.Stats is { } stats)
+                    {
+                        @if (stats.Top.Count == 0 && stats.MissingCount == 0)
+                        {
+                            <div class="stats-section-empty">No values in the current view.</div>
+                        }
+                        else
+                        {
+                            <ol class="stats-rows">
+                                @foreach (var contributor in stats.Top)
+                                {
+                                    <li class="stats-row">
+                                        <span class="stats-row-value" title="@contributor.Value">@contributor.Value</span>
+                                        <span class="stats-row-count">@FormatCount(contributor.Count)</span>
+                                        <span class="stats-row-percent">@FormatPercent(Share(contributor.Count, stats.Total))</span>
+                                        <span aria-hidden="true" class="stats-row-bar">
+                                            <span class="stats-row-bar-fill" style="width:@Css(Share(contributor.Count, stats.Total))%"></span>
+                                        </span>
+                                        <span aria-label="Filter actions" class="stats-row-actions" role="group">
+                                            <button aria-label="@($"Filter to {section.Dimension.DisplayName()} {contributor.Value}")"
+                                                class="stats-include"
+                                                disabled="@IsExcludeDisabled(section)"
+                                                @onclick="() => IncludeContributor(section, contributor)"
+                                                title="Filter to only this value"
+                                                type="button">
+                                                <i aria-hidden="true" class="bi bi-plus-circle"></i>
+                                            </button>
+                                            <button aria-label="@($"Exclude {section.Dimension.DisplayName()} {contributor.Value}")"
+                                                class="stats-exclude"
+                                                disabled="@IsExcludeDisabled(section)"
+                                                @onclick="() => ExcludeContributor(section, contributor)"
+                                                title="Exclude this value"
+                                                type="button">
+                                                <i aria-hidden="true" class="bi bi-dash-circle"></i>
+                                            </button>
+                                        </span>
+                                    </li>
+                                }
+                            </ol>
+
+                            @if (stats.MissingCount > 0 && section.Dimension != StatsDimension.EventId)
+                            {
+                                <div class="stats-none-pinned stats-row stats-row-none">
+                                    <span class="stats-row-value">(none)</span>
+                                    <span class="stats-row-count">@FormatCount(stats.MissingCount)</span>
+                                    <span class="stats-row-percent">@FormatPercent(Share(stats.MissingCount, stats.Total))</span>
+                                    <span aria-hidden="true" class="stats-row-bar">
+                                        <span class="stats-row-bar-fill" style="width:@Css(Share(stats.MissingCount, stats.Total))%"></span>
+                                    </span>
+                                    <span class="stats-actions-spacer"></span>
+                                </div>
+                            }
+
+                            <div class="stats-coverage">
+                                <span class="stats-coverage-text">@CoverageText(stats)</span>
+                                @if (stats.DistinctCount > stats.Top.Count)
+                                {
+                                    <button class="stats-more"
+                                        disabled="@IsSectionStale(section)"
+                                        @onclick="() => OpenDetail(section.Dimension)"
+                                        type="button">
+                                        View all
+                                    </button>
+                                }
+                            </div>
+                        }
+                    }
+                    else
+                    {
+                        <div class="stats-section-empty">Computing...</div>
+                    }
+                </section>
+            }
+        </div>
+    }
+</div>

--- a/src/EventLogExpert.UI/LogTable/Stats/StatsPane.razor
+++ b/src/EventLogExpert.UI/LogTable/Stats/StatsPane.razor
@@ -72,7 +72,7 @@
                                         <span aria-label="Filter actions" class="stats-row-actions" role="group">
                                             <button aria-label="@($"Filter to {section.Dimension.DisplayName()} {contributor.Value}")"
                                                 class="stats-include"
-                                                disabled="@IsExcludeDisabled(section)"
+                                                disabled="@AreRowActionsDisabled(section)"
                                                 @onclick="() => IncludeContributor(section, contributor)"
                                                 title="Filter to only this value"
                                                 type="button">
@@ -80,7 +80,7 @@
                                             </button>
                                             <button aria-label="@($"Exclude {section.Dimension.DisplayName()} {contributor.Value}")"
                                                 class="stats-exclude"
-                                                disabled="@IsExcludeDisabled(section)"
+                                                disabled="@AreRowActionsDisabled(section)"
                                                 @onclick="() => ExcludeContributor(section, contributor)"
                                                 title="Exclude this value"
                                                 type="button">

--- a/src/EventLogExpert.UI/LogTable/Stats/StatsPane.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/Stats/StatsPane.razor.cs
@@ -248,6 +248,8 @@ public sealed partial class StatsPane
         section.Dimension.PushRowFilter(FilterLensCommands, contributor.Value, Presentation.ActiveLogName, include);
     }
 
+    private bool AreRowActionsDisabled(DimensionSection section) => section.Stats is null || IsSectionStale(section);
+
     private void ExcludeContributor(DimensionSection section, StatsContributor contributor) =>
         ApplyRowLens(section, contributor, include: false);
 
@@ -295,8 +297,6 @@ public sealed partial class StatsPane
 
     private void IncludeContributor(DimensionSection section, StatsContributor contributor) =>
         ApplyRowLens(section, contributor, include: true);
-
-    private bool IsExcludeDisabled(DimensionSection section) => section.Stats is null || IsSectionStale(section);
 
     private bool IsSectionStale(DimensionSection section) => section.StatsToken != _currentToken;
 

--- a/src/EventLogExpert.UI/LogTable/Stats/StatsPane.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/Stats/StatsPane.razor.cs
@@ -1,0 +1,489 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.FilterLenses;
+using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.Runtime.LogTable.OrderedView;
+using EventLogExpert.Runtime.Stats;
+using EventLogExpert.UI.Common.Interop;
+using EventLogExpert.UI.Modal;
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+using System.Globalization;
+using System.Text;
+
+namespace EventLogExpert.UI.LogTable.Stats;
+
+public sealed partial class StatsPane
+{
+    private const int DefaultTopN = 8;
+    private const int HeadlineTopSourceCount = 3;
+    private const int MaxFitRows = 40;
+    private const int MinFitRows = 1;
+    private const int RecomputeThrottleMs = 500;
+    private const int RowHeightPx = 22;
+    // One section's non-row chrome: its header + coverage line + one row reserved for the pinned (none) footer. The
+    // resize observer reports a single section's height (not the whole pane), so this fit stays correct across the
+    // 1/2/4-column responsive layouts, and the reserved row keeps the pinned (none) bucket from ever being clipped.
+    private const int SectionChromePx = 68;
+
+    // Severity display order (most severe first) with the Unknown catch-all last. Slot indices come from
+    // SeverityLevel (0 = Unknown, 1-5 = Critical..Verbose), matching LevelSeverity.Slot.
+    private static readonly SeveritySlot[] s_severityOrder =
+    [
+        new((int)SeverityLevel.Critical, nameof(SeverityLevel.Critical), "stats-sev-critical"),
+        new((int)SeverityLevel.Error, nameof(SeverityLevel.Error), "stats-sev-error"),
+        new((int)SeverityLevel.Warning, nameof(SeverityLevel.Warning), "stats-sev-warning"),
+        new((int)SeverityLevel.Information, nameof(SeverityLevel.Information), "stats-sev-information"),
+        new((int)SeverityLevel.Verbose, nameof(SeverityLevel.Verbose), "stats-sev-verbose"),
+        new(0, "Unknown", "stats-sev-unknown")
+    ];
+
+    private static int s_resizeSession;
+
+    private readonly CancellationTokenSource _lifetimeCts = new();
+
+    private readonly List<DimensionSection> _sections =
+    [
+        new(StatsDimension.Source),
+        new(StatsDimension.EventId),
+        new(StatsDimension.TaskCategory),
+        new(StatsDimension.User)
+    ];
+
+    private ViewContentToken _currentToken = ViewContentToken.Empty;
+    private bool _disposed;
+    private bool _fitDirty;
+    private int _fitTopN = DefaultTopN;
+    private EventLogId? _lastScannedTab;
+    private ViewContentToken? _lastScannedToken;
+    private ElementReference _paneElement;
+    private bool _recomputePending;
+    private IJSObjectReference? _resizeModule;
+    private int _resizeSession;
+    private CancellationTokenSource? _scanCts;
+    private bool _scanFailed;
+    private int _scanVersion;
+    private DotNetObjectReference<StatsPane>? _selfRef;
+    private SeverityStats? _severity;
+    private ViewContentToken _severityToken = ViewContentToken.Empty;
+
+    [Inject] private IFilterLensCommands FilterLensCommands { get; init; } = null!;
+
+    [Inject] private IFilterLensSource FilterLenses { get; init; } = null!;
+
+    private bool IsSeverityStale => _severityToken != _currentToken;
+
+    [Inject] private IJSRuntime JsRuntime { get; init; } = null!;
+
+    [Inject] private IModalCoordinator ModalCoordinator { get; init; } = null!;
+
+    [Inject] private IStatsService StatsService { get; init; } = null!;
+
+    [Inject] private ITraceLogger TraceLogger { get; init; } = null!;
+
+    // Called from the resize observer with one section's height: fit the row count to a single column so every column
+    // fills its cell without a scrollbar. A fixed row height keeps this a pure arithmetic step (no layout thrash).
+    [JSInvokable]
+    public Task OnStatsResized(int height)
+    {
+        if (_disposed) { return Task.CompletedTask; }
+
+        int fit = Math.Clamp((height - SectionChromePx) / RowHeightPx, MinFitRows, MaxFitRows);
+
+        if (fit != _fitTopN)
+        {
+            _fitTopN = fit;
+            StartScan();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    protected override async ValueTask DisposeAsyncCore(bool disposing)
+    {
+        if (disposing)
+        {
+            _disposed = true;
+            _lifetimeCts.Cancel();
+            _lifetimeCts.Dispose();
+
+            try { _scanCts?.Cancel(); } catch (ObjectDisposedException) { /* Already disposed; cancel is moot. */ }
+
+            _scanCts?.Dispose();
+            _scanCts = null;
+
+            await JsModuleInterop.DisposeModuleSafelyAsync(
+                _resizeModule,
+                module => module.InvokeVoidAsync("disposeStatsResize", _resizeSession));
+
+            _resizeModule = null;
+            _selfRef?.Dispose();
+            _selfRef = null;
+        }
+
+        await base.DisposeAsyncCore(disposing);
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender && !_disposed)
+        {
+            try
+            {
+                _resizeModule = await JsRuntime.InvokeAsync<IJSObjectReference>(
+                    "import", "./_content/EventLogExpert.UI/LogTable/Stats/StatsPane.razor.js");
+
+                // The import can outlive a fast close/reopen. A pane disposed mid-import must NOT touch the shared
+                // observer state: it releases only its own module handle. Session-scoped ownership means the live pane
+                // keeps its observer, so calling disposeStatsResize here is deliberately avoided.
+                if (_disposed)
+                {
+                    try { await _resizeModule.DisposeAsync(); }
+                    catch (JSDisconnectedException) { /* Circuit already gone. */ }
+                    catch (ObjectDisposedException) { /* Reference already released. */ }
+
+                    _resizeModule = null;
+                    return;
+                }
+
+                _selfRef = DotNetObjectReference.Create(this);
+
+                // Own the session token BEFORE the interop so a disposal racing this init still tears down the exact
+                // observer initStatsResize is about to create - DisposeAsyncCore reads _resizeSession rather than a
+                // still-pending return value.
+                _resizeSession = Interlocked.Increment(ref s_resizeSession);
+                await _resizeModule.InvokeVoidAsync("initStatsResize", _resizeSession, _selfRef, _paneElement);
+            }
+            catch (JSDisconnectedException) { /* Circuit closed before the observer attached; nothing to observe. */ }
+            catch (ObjectDisposedException) { /* Component torn down mid-init. */ }
+        }
+
+        // Sections render only after a scan publishes, and their appearance does not resize the pane box, so the
+        // observer would not re-fire to correct the initial fit. Nudge one re-measure after such a render.
+        if (_fitDirty && !_disposed && _resizeModule is { } module)
+        {
+            _fitDirty = false;
+
+            try { await module.InvokeVoidAsync("remeasureStatsResize", _resizeSession); }
+            catch (JSDisconnectedException) { /* Circuit gone; the next resize re-fits. */ }
+            catch (ObjectDisposedException) { /* Torn down; nothing to re-fit. */ }
+        }
+
+        await base.OnAfterRenderAsync(firstRender);
+    }
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+
+        _lastScannedTab = Presentation.ActiveTabId;
+        _lastScannedToken = Presentation.ContentToken;
+        _currentToken = Presentation.ContentToken;
+
+        StartScan();
+    }
+
+    protected override void OnPresentationChanged()
+    {
+        // The publish guard also enforces ActiveTabId, so the recompute key must include it: a tab switch that keeps
+        // the same content token (e.g. between two empty tabs) would otherwise reject the in-flight scan on tab
+        // mismatch while scheduling no replacement, leaving the pane stuck.
+        if (_lastScannedTab == Presentation.ActiveTabId && _lastScannedToken == Presentation.ContentToken) { return; }
+
+        _lastScannedTab = Presentation.ActiveTabId;
+        _lastScannedToken = Presentation.ContentToken;
+        _currentToken = Presentation.ContentToken;
+        ScheduleRecompute();
+    }
+
+    private static string CoverageNoun(StatsDimension dimension, int count)
+    {
+        bool singular = count == 1;
+
+        return dimension switch
+        {
+            StatsDimension.Source => singular ? "source" : "sources",
+            StatsDimension.EventId => singular ? "event ID" : "event IDs",
+            StatsDimension.TaskCategory => singular ? "task category" : "task categories",
+            StatsDimension.User => singular ? "user" : "users",
+            _ => singular ? "value" : "values"
+        };
+    }
+
+    private static string CoverageText(DimensionStats stats)
+    {
+        string noun = CoverageNoun(stats.Dimension, stats.DistinctCount);
+        int coveredPercent = (int)Math.Round(Share(stats.ShownEventCount, stats.Total), MidpointRounding.AwayFromZero);
+
+        string scope = stats.Top.Count >= stats.DistinctCount
+            ? $"All {FormatCount(stats.DistinctCount)} {noun}"
+            : $"Top {stats.Top.Count} of {FormatCount(stats.DistinctCount)} {noun}";
+
+        return $"{scope} - {coveredPercent}% of events";
+    }
+
+    private static string Css(double value) => value.ToString("0.###", CultureInfo.InvariantCulture);
+
+    private static string FormatCount(int value) => value.ToString("N0", CultureInfo.CurrentCulture);
+
+    private static string FormatPercent(double percent) =>
+        (percent >= 9.95 ? percent.ToString("0", CultureInfo.CurrentCulture) : percent.ToString("0.0", CultureInfo.CurrentCulture)) + "%";
+
+    private static double Share(int count, int total) => total == 0 ? 0 : count * 100.0 / total;
+
+    private void ApplyRowLens(DimensionSection section, StatsContributor contributor, bool include)
+    {
+        // The row reflects a scan that may have been superseded by a newer view; filtering on a value that is no longer
+        // present would push a lens that matches nothing. Refuse and let the pending recompute redraw the live rows.
+        if (IsSectionStale(section))
+        {
+            ScheduleRecompute();
+            return;
+        }
+
+        section.Dimension.PushRowFilter(FilterLensCommands, contributor.Value, Presentation.ActiveLogName, include);
+    }
+
+    private void ExcludeContributor(DimensionSection section, StatsContributor contributor) =>
+        ApplyRowLens(section, contributor, include: false);
+
+    private string HeadlineText()
+    {
+        if (_severity is not var (total, slots)) { return "Computing statistics..."; }
+
+        if (total == 0)
+        {
+            return FilterLenses.Lenses.Count > 0 ?
+                "0 events - remove a lens to continue" :
+                "No events in the current view";
+        }
+
+        var headline = new StringBuilder();
+        headline.Append(FormatCount(total)).Append(total == 1 ? " event" : " events");
+
+        int errorCritical = slots[(int)SeverityLevel.Critical] + slots[(int)SeverityLevel.Error];
+
+        if (errorCritical > 0)
+        {
+            headline.Append(" - ").Append(FormatCount(errorCritical)).Append(" error/critical");
+        }
+
+        DimensionSection source = SectionFor(StatsDimension.Source);
+
+        if (!IsSectionStale(source) && source.Stats is { Top.Count: > 0 } sourceStats)
+        {
+            int shown = Math.Min(HeadlineTopSourceCount, sourceStats.Top.Count);
+            int covered = 0;
+
+            for (int index = 0; index < shown; index++) { covered += sourceStats.Top[index].Count; }
+
+            int percent = (int)Math.Round(covered * 100.0 / total, MidpointRounding.AwayFromZero);
+
+            headline.Append(" - top ")
+                .Append(shown)
+                .Append(shown == 1 ? " source = " : " sources = ")
+                .Append(percent)
+                .Append('%');
+        }
+
+        return headline.ToString();
+    }
+
+    private void IncludeContributor(DimensionSection section, StatsContributor contributor) =>
+        ApplyRowLens(section, contributor, include: true);
+
+    private bool IsExcludeDisabled(DimensionSection section) => section.Stats is null || IsSectionStale(section);
+
+    private bool IsSectionStale(DimensionSection section) => section.StatsToken != _currentToken;
+
+    private async Task MarkFailedAsync(int scanVersion, EventLogId? tab, ViewContentToken contentToken)
+    {
+        try
+        {
+            await InvokeAsync(() =>
+            {
+                if (_disposed || scanVersion != _scanVersion) { return; }
+
+                OrderedViewPresentation current = ViewSource.Current;
+
+                // A superseded or wrong-tab scan's failure says nothing about the request that replaced it.
+                if (tab != current.ActiveTabId || contentToken != current.ContentToken) { return; }
+
+                _scanFailed = true;
+                StateHasChanged();
+            });
+        }
+        catch (ObjectDisposedException) { /* Component torn down mid-failure; nothing to report. */ }
+    }
+
+    private void OpenDetail(StatsDimension dimension) =>
+        _ = ModalCoordinator.OpenStatsDetailAsync(dimension, ViewSource.Current.View, Presentation.ActiveLogName);
+
+    private async Task<bool> PublishAsync(int scanVersion, EventLogId? tab, ViewContentToken contentToken, Action apply)
+    {
+        bool applied = false;
+
+        try
+        {
+            await InvokeAsync(() =>
+            {
+                if (_disposed || scanVersion != _scanVersion) { return; }
+
+                OrderedViewPresentation current = ViewSource.Current;
+
+                // A scan is only true for the exact tab and content it ran against; a presentation swap mid-scan
+                // retires the result rather than stamping stale numbers onto the live view.
+                if (tab != current.ActiveTabId || contentToken != current.ContentToken) { return; }
+
+                apply();
+                applied = true;
+                StateHasChanged();
+            });
+        }
+        catch (ObjectDisposedException) { return false; }
+
+        return applied;
+    }
+
+    private async Task RunScanAsync(
+        IEventColumnView view,
+        EventLogId? tab,
+        ViewContentToken contentToken,
+        int scanVersion,
+        (StatsDimension Dimension, int TopN)[] requests,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            SeverityStats severity =
+                await Task.Run(() => StatsService.BuildSeverity(view, cancellationToken), cancellationToken);
+
+            if (!await PublishAsync(scanVersion, tab, contentToken, () =>
+                {
+                    _severity = severity;
+                    _severityToken = contentToken;
+                    _fitDirty = true;
+                }))
+            {
+                return;
+            }
+
+            foreach ((StatsDimension dimension, int topN) in requests)
+            {
+                DimensionStats stats = await Task.Run(
+                    () => StatsService.BuildDimension(view, dimension, topN, cancellationToken),
+                    cancellationToken);
+
+                if (!await PublishAsync(scanVersion, tab, contentToken, () =>
+                    {
+                        DimensionSection section = SectionFor(dimension);
+                        section.Stats = stats;
+                        section.StatsToken = contentToken;
+                    }))
+                {
+                    return;
+                }
+            }
+        }
+        catch (OperationCanceledException) { /* Superseded or torn down; the replacement scan owns the result. */ }
+        catch (Exception scanFailure)
+        {
+            TraceLogger.Error($"{nameof(StatsPane)}: statistics scan failed: {scanFailure}");
+            await MarkFailedAsync(scanVersion, tab, contentToken);
+        }
+    }
+
+    private void ScheduleRecompute()
+    {
+        if (_disposed) { return; }
+
+        _scanVersion++;
+
+        if (_recomputePending) { return; }
+
+        _recomputePending = true;
+        _ = ThrottleThenScanAsync();
+    }
+
+    private DimensionSection SectionFor(StatsDimension dimension) =>
+        _sections.First(section => section.Dimension == dimension);
+
+    private string SeverityBarAria() =>
+        "Severity breakdown: " +
+        string.Join(", ", SeveritySegments().Select(segment => $"{FormatCount(segment.Count)} {segment.Label.ToLower(CultureInfo.CurrentCulture)}"));
+
+    private IReadOnlyList<SeveritySegment> SeveritySegments()
+    {
+        if (_severity is not { Total: > 0 } severity) { return []; }
+
+        var segments = new List<SeveritySegment>(s_severityOrder.Length);
+
+        foreach (SeveritySlot slot in s_severityOrder)
+        {
+            int count = severity.Slots[slot.Index];
+
+            if (count == 0) { continue; }
+
+            segments.Add(new SeveritySegment(slot.Label, slot.CssClass, count, Share(count, severity.Total)));
+        }
+
+        return segments;
+    }
+
+    private void StartScan()
+    {
+        if (_disposed) { return; }
+
+        _scanCts?.Cancel();
+        _scanCts?.Dispose();
+        _scanCts = null;
+
+        int scanVersion = ++_scanVersion;
+
+        OrderedViewPresentation current = ViewSource.Current;
+        IEventColumnView view = current.View;
+        EventLogId? tab = current.ActiveTabId;
+        ViewContentToken contentToken = current.ContentToken;
+        _currentToken = contentToken;
+        _scanFailed = false;
+
+        // Every scan recomputes severity plus all four dimension columns; each column shows exactly the number of rows
+        // that fit the drawer height (no scrollbar), so the full list is reached by resizing the drawer or "View all".
+        (StatsDimension Dimension, int TopN)[] requests =
+        [
+            .. _sections
+                .Select(section => (section.Dimension, TopN: _fitTopN))
+        ];
+
+        var cts = new CancellationTokenSource();
+        _scanCts = cts;
+
+        _ = RunScanAsync(view, tab, contentToken, scanVersion, requests, cts.Token);
+    }
+
+    private async Task ThrottleThenScanAsync()
+    {
+        try { await Task.Delay(RecomputeThrottleMs, _lifetimeCts.Token); }
+        catch (OperationCanceledException) { return; }
+
+        _recomputePending = false;
+        StartScan();
+    }
+
+    private sealed class DimensionSection(StatsDimension dimension)
+    {
+        public StatsDimension Dimension { get; } = dimension;
+
+        public DimensionStats? Stats { get; set; }
+
+        public ViewContentToken StatsToken { get; set; } = ViewContentToken.Empty;
+    }
+
+    private sealed record SeveritySlot(int Index, string Label, string CssClass);
+
+    private sealed record SeveritySegment(string Label, string CssClass, int Count, double Percent);
+}

--- a/src/EventLogExpert.UI/LogTable/Stats/StatsPane.razor.css
+++ b/src/EventLogExpert.UI/LogTable/Stats/StatsPane.razor.css
@@ -1,0 +1,341 @@
+.stats-pane {
+    display: flex;
+    flex-direction: column;
+    flex: 0 0 auto;
+    container: stats-pane / inline-size;
+    height: 100%;
+    margin: 0 5px;
+    padding: 2px 0 4px;
+    border-top: solid var(--background-darkgray);
+    overflow: hidden;
+    color: var(--text-secondary);
+    user-select: none;
+    -webkit-user-select: none;
+}
+
+.stats-header {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 2px 8px;
+    padding: 1px 2px;
+}
+
+.stats-title {
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.stats-headline {
+    min-width: 0;
+    color: var(--text-secondary);
+}
+
+.stats-empty {
+    padding: 6px 2px;
+    font-style: italic;
+    color: var(--text-secondary);
+}
+
+.stats-section-empty {
+    padding: 2px 2px 4px 1.2em;
+    font-style: italic;
+    color: var(--text-secondary);
+}
+
+/* Severity composition band: the bar and its legend share one line, wrapping only when the pane is narrow. */
+.stats-severity {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 4px 12px;
+    padding: 3px 2px 5px;
+}
+
+.stats-severity-bar {
+    display: flex;
+    flex: 1 1 160px;
+    min-width: 120px;
+    height: 12px;
+    gap: 1px;
+    border-radius: 2px;
+    overflow: hidden;
+}
+
+.stats-severity-seg {
+    flex-basis: 0;
+    min-width: 2px;
+    height: 100%;
+}
+
+.stats-severity-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2px 12px;
+}
+
+.stats-legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    min-width: 0;
+}
+
+.stats-legend-swatch {
+    width: 9px;
+    height: 9px;
+    border-radius: 2px;
+    flex: 0 0 auto;
+}
+
+.stats-legend-label { color: var(--text-secondary); }
+
+.stats-legend-count {
+    font-variant-numeric: tabular-nums;
+    color: var(--text-primary);
+}
+
+/* Severity slot colors: critical is darkened red so it reads apart from error while staying in the table's red family. */
+.stats-sev-critical { background: color-mix(in srgb, var(--clr-red), black 22%); }
+.stats-sev-error { background: var(--clr-red); }
+.stats-sev-warning { background: var(--clr-yellow); }
+.stats-sev-information { background: var(--toggle-accent); }
+.stats-sev-verbose { background: var(--text-secondary); }
+.stats-sev-unknown { background: color-mix(in srgb, var(--text-secondary) 40%, transparent); }
+
+/* Contributor dimensions as side-by-side columns; the grid reflows 2 -> 4 columns by the pane's own width. Below the
+   two-column breakpoint the pane is too narrow to show the columns usefully, so they are hidden entirely and only the
+   header + severity band remain (they return, 2 then 4 across, as the pane widens). */
+.stats-sections {
+    display: none;
+    grid-auto-rows: minmax(0, 1fr);
+    flex: 1 1 auto;
+    min-height: 0;
+    border-top: 1px solid var(--background-darkgray);
+}
+
+@container stats-pane (min-width: 42rem) {
+    .stats-sections {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@container stats-pane (min-width: 75rem) {
+    /* Source values are the longest, so its column gets a little more room than the others. */
+    .stats-sections { grid-template-columns: 1.3fr 1fr 1fr 1fr; }
+}
+
+.stats-section {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    min-height: 0;
+    padding: 0 0 2px;
+    overflow: hidden;
+    container: stats-column / inline-size;
+}
+
+.stats-section:not(:last-child) { border-inline-end: 1px solid var(--background-darkgray); }
+
+.stats-section-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 6px;
+    color: var(--text-primary);
+}
+
+.stats-section-title { font-weight: 600; }
+
+.stats-section-distinct {
+    font-variant-numeric: tabular-nums;
+    color: var(--text-secondary);
+}
+
+.stats-updating {
+    margin-inline-start: auto;
+    font-style: italic;
+    color: var(--text-secondary);
+}
+
+.stats-rows {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: hidden;
+    margin: 0;
+    padding: 0 6px 2px;
+    list-style: none;
+}
+
+/* value | count | percent | proportion bar | +/- actions */
+.stats-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto 3.2em minmax(32px, 72px) 40px;
+    align-items: center;
+    gap: 6px;
+    padding: 1px 0;
+}
+
+/* Very narrow column: the proportion bar can no longer convey magnitude, so drop it (count + percent stay). */
+@container stats-column (max-width: 13rem) {
+    .stats-row { grid-template-columns: minmax(0, 1fr) auto 3.2em 40px; }
+    .stats-row-bar { display: none; }
+}
+
+.stats-row:hover:not(.stats-row-none) { background: color-mix(in srgb, var(--text-secondary) 8%, transparent); }
+
+.stats-row-value {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--text-primary);
+}
+
+.stats-row-count {
+    font-variant-numeric: tabular-nums;
+    text-align: end;
+    color: var(--text-primary);
+}
+
+.stats-row-percent {
+    font-variant-numeric: tabular-nums;
+    text-align: end;
+    color: var(--text-secondary);
+}
+
+.stats-row-bar {
+    display: block;
+    height: 8px;
+    border-radius: 2px;
+    background: color-mix(in srgb, var(--text-secondary) 16%, transparent);
+    overflow: hidden;
+}
+
+.stats-row-bar-fill {
+    display: block;
+    height: 100%;
+    background: var(--toggle-accent);
+}
+
+.stats-row-none {
+    font-style: italic;
+    color: var(--text-secondary);
+}
+
+.stats-row-none .stats-row-value,
+.stats-row-none .stats-row-count { color: var(--text-secondary); }
+
+/* The absent/empty bucket is a pinned summary row below the ranked (overflow-clipped) list: it stays out of the
+   clipped area so it is always fully visible and reads as an intentional footer, not the last ranked row. */
+.stats-none-pinned {
+    flex: 0 0 auto;
+    margin-top: 2px;
+    padding-inline: 6px;
+    box-shadow: inset 0 1px 0 var(--background-darkgray);
+}
+
+/* Include (+) / Exclude (-) actions: a fixed-width group reserved even at rest so hover never reflows the row,
+   revealed on row hover / keyboard focus. */
+.stats-row-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 2px;
+    opacity: 0;
+    transition: opacity 0.12s ease;
+}
+
+.stats-row:hover .stats-row-actions,
+.stats-row:focus-within .stats-row-actions { opacity: 1; }
+
+.stats-include,
+.stats-exclude {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    padding: 0;
+    border: 1px solid transparent;
+    border-radius: 2px;
+    background: none;
+    font-size: 13px;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.stats-include { color: var(--toggle-accent); }
+.stats-include:hover:not(:disabled) { background: color-mix(in srgb, var(--toggle-accent) 16%, transparent); }
+
+.stats-exclude { color: var(--clr-red); }
+.stats-exclude:hover:not(:disabled) { background: color-mix(in srgb, var(--clr-red) 16%, transparent); }
+
+.stats-include:focus-visible,
+.stats-exclude:focus-visible {
+    outline: 1px solid Highlight;
+    outline-offset: 1px;
+}
+
+/* While a scan is in flight the rows are provisional, so the filter actions stay hidden even on hover. */
+.stats-include:disabled,
+.stats-exclude:disabled {
+    opacity: 0;
+    cursor: default;
+    pointer-events: none;
+}
+
+.stats-actions-spacer { width: 40px; }
+
+.stats-more {
+    padding: 0 6px;
+    border: 1px solid var(--background-darkgray);
+    border-radius: 3px;
+    background: none;
+    color: var(--text-primary);
+    font: inherit;
+    cursor: pointer;
+}
+
+.stats-more:hover:not(:disabled) { background: color-mix(in srgb, var(--toggle-accent) 15%, transparent); }
+
+.stats-more:focus-visible {
+    outline: 1px solid Highlight;
+    outline-offset: 1px;
+}
+
+.stats-more:disabled {
+    opacity: 0.45;
+    cursor: default;
+}
+
+.stats-coverage {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 4px 8px;
+    padding: 1px 6px 2px;
+    color: var(--text-secondary);
+    font-size: 0.85em;
+}
+
+/* Recomputing: prior rows stay visible but read as provisional while the scan is in flight. */
+.stats-stale { opacity: 0.6; }
+
+@media (forced-colors: active) {
+    .stats-severity-seg,
+    .stats-legend-swatch {
+        forced-color-adjust: none;
+        border: 1px solid CanvasText;
+    }
+
+    .stats-sev-critical { background: CanvasText; }
+    .stats-sev-error { background: LinkText; }
+    .stats-sev-warning { background: Mark; }
+    .stats-sev-information { background: Highlight; }
+    .stats-sev-verbose { background: GrayText; }
+    .stats-sev-unknown { background: Canvas; }
+
+    .stats-row-bar { border: 1px solid CanvasText; }
+    .stats-row-bar-fill { background: Highlight; }
+}

--- a/src/EventLogExpert.UI/LogTable/Stats/StatsPane.razor.js
+++ b/src/EventLogExpert.UI/LogTable/Stats/StatsPane.razor.js
@@ -1,0 +1,101 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+const statsState = {
+    observer: null,
+    dotNetRef: null,
+    element: null,
+    debounceTimer: 0,
+    session: 0,
+    lastHeight: -1
+};
+
+// Report ONE section's height to .NET so it can fit the row count to the available per-column space. Sections share a
+// height (grid-auto-rows: 1fr), so the first one represents every column across the 1/2/4-column reflow. The .NET side
+// owns the session token (assigned before this interop), so a pane disposed mid-init tears down the exact observer it
+// created, and a stale teardown from a superseded pane no-ops - the live pane always keeps its observer.
+export function initStatsResize(session, dotNetRef, element) {
+    stopObserver();
+
+    if (element == null) {
+        return;
+    }
+
+    statsState.session = session;
+    statsState.dotNetRef = dotNetRef;
+    statsState.element = element;
+    statsState.lastHeight = -1;
+
+    statsState.observer = new ResizeObserver(() => measureAndReport(session));
+    statsState.observer.observe(element);
+}
+
+// One-shot re-measure after a scan first renders the section elements: their appearance does not resize the pane box,
+// so the ResizeObserver would not otherwise re-fire to correct the initial (sectionless) fit.
+export function remeasureStatsResize(session) {
+    measureAndReport(session);
+}
+
+export function disposeStatsResize(session) {
+    // Only the owning pane tears down; a stale token (a newer pane already re-init'd, or a pane that never bound) is a
+    // no-op, so a late-disposing pane can never disconnect the live pane's observer.
+    if (session !== statsState.session) {
+        return;
+    }
+
+    stopObserver();
+}
+
+function measureAndReport(session) {
+    const element = statsState.element;
+
+    if (element == null || session !== statsState.session) {
+        return;
+    }
+
+    // Sections exist only after the first scan publishes, and are display:none (clientHeight 0) in the narrow
+    // single-column layout; in both cases keep the current fit - which still feeds the always-visible header - rather
+    // than measuring a zero-height box.
+    const section = element.querySelector(".stats-section");
+
+    if (section == null || section.clientHeight === 0) {
+        return;
+    }
+
+    const height = Math.round(section.clientHeight);
+
+    if (statsState.debounceTimer) {
+        clearTimeout(statsState.debounceTimer);
+    }
+
+    // Debounced so a drag-resize (a burst of ResizeObserver callbacks) can't flood the circuit.
+    statsState.debounceTimer = setTimeout(() => {
+        statsState.debounceTimer = 0;
+
+        const ref = statsState.dotNetRef;
+
+        if (ref == null || session !== statsState.session || height === statsState.lastHeight) {
+            return;
+        }
+
+        statsState.lastHeight = height;
+        ref.invokeMethodAsync("OnStatsResized", height).catch(() => { });
+    }, 100);
+}
+
+function stopObserver() {
+    if (statsState.observer) {
+        statsState.observer.disconnect();
+        statsState.observer = null;
+    }
+
+    if (statsState.debounceTimer) {
+        clearTimeout(statsState.debounceTimer);
+        statsState.debounceTimer = 0;
+    }
+
+    statsState.session = 0;
+    statsState.dotNetRef = null;
+    statsState.element = null;
+    statsState.lastHeight = -1;
+}

--- a/src/EventLogExpert.UI/Modal/ModalCoordinatorLaunchers.cs
+++ b/src/EventLogExpert.UI/Modal/ModalCoordinatorLaunchers.cs
@@ -1,11 +1,14 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.Runtime.Stats;
 using EventLogExpert.Runtime.Update.ReleaseNotes;
 using EventLogExpert.UI.Database;
 using EventLogExpert.UI.DatabaseTools;
 using EventLogExpert.UI.DebugLog;
 using EventLogExpert.UI.FilterLibrary;
+using EventLogExpert.UI.LogTable.Stats;
 using EventLogExpert.UI.Settings;
 using EventLogExpert.UI.Update;
 
@@ -61,6 +64,19 @@ public static class ModalCoordinatorLaunchers
             ArgumentNullException.ThrowIfNull(coordinator);
 
             return coordinator.PushAsync<SettingsModal, bool>();
+        }
+
+        public Task<ModalOpenResult<bool>> OpenStatsDetailAsync(StatsDimension dimension, IEventColumnView view, string? originLog)
+        {
+            ArgumentNullException.ThrowIfNull(coordinator);
+            ArgumentNullException.ThrowIfNull(view);
+
+            return coordinator.PushAsync<StatsDetailModal, bool>(new Dictionary<string, object?>
+            {
+                [nameof(StatsDetailModal.Dimension)] = dimension,
+                [nameof(StatsDetailModal.View)] = view,
+                [nameof(StatsDetailModal.OriginLog)] = originLog
+            });
         }
     }
 }

--- a/src/EventLogExpert.UI/StatusBar/StatusBar.razor
+++ b/src/EventLogExpert.UI/StatusBar/StatusBar.razor
@@ -35,7 +35,14 @@
             var shown = Presentation.View.Count;
 
             <span aria-hidden="true" class="status-bar-sep">|</span>
-            <span class="status-bar-counts">@StatusBarFormatter.FormatCounts(total, shown, isFiltered && describesActiveTab, status.SelectionCount)</span>
+            <button aria-expanded="@(StatsVisibility.IsVisible ? "true" : "false")"
+                class="status-bar-stats"
+                @onclick="ToggleStats"
+                title="Show statistics for these events"
+                type="button">
+                <span class="status-bar-counts">@StatusBarFormatter.FormatCounts(total, shown, isFiltered && describesActiveTab, status.SelectionCount)</span>
+                <i aria-hidden="true" class="bi bi-caret-@(StatsVisibility.IsVisible ? "down" : "up")"></i>
+            </button>
         }
 
         @if (isFiltered)

--- a/src/EventLogExpert.UI/StatusBar/StatusBar.razor
+++ b/src/EventLogExpert.UI/StatusBar/StatusBar.razor
@@ -35,10 +35,11 @@
             var shown = Presentation.View.Count;
 
             <span aria-hidden="true" class="status-bar-sep">|</span>
-            <button aria-expanded="@(StatsVisibility.IsVisible ? "true" : "false")"
+            <button aria-controls="stats-drawer"
+                aria-expanded="@(StatsVisibility.IsVisible ? "true" : "false")"
                 class="status-bar-stats"
                 @onclick="ToggleStats"
-                title="Show statistics for these events"
+                title="@(StatsVisibility.IsVisible ? "Hide statistics for these events" : "Show statistics for these events")"
                 type="button">
                 <span class="status-bar-counts">@StatusBarFormatter.FormatCounts(total, shown, isFiltered && describesActiveTab, status.SelectionCount)</span>
                 <i aria-hidden="true" class="bi bi-caret-@(StatsVisibility.IsVisible ? "down" : "up")"></i>

--- a/src/EventLogExpert.UI/StatusBar/StatusBar.razor.cs
+++ b/src/EventLogExpert.UI/StatusBar/StatusBar.razor.cs
@@ -4,6 +4,7 @@
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.Runtime.FilterLenses;
 using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.Runtime.Stats;
 using EventLogExpert.Runtime.StatusBar;
 using Microsoft.AspNetCore.Components;
 using System.Collections.Immutable;
@@ -19,6 +20,10 @@ public sealed partial class StatusBar
     [Inject] private DisplayIndicatorGate IndicatorGate { get; init; } = null!;
 
     [Inject] private IFilterLensSource LensSource { get; init; } = null!;
+
+    [Inject] private IStatsCommands StatsCommands { get; init; } = null!;
+
+    [Inject] private IStatsVisibilitySource StatsVisibility { get; init; } = null!;
 
     [Inject] private IStatusBarSource StatusBarSource { get; init; } = null!;
 
@@ -39,6 +44,7 @@ public sealed partial class StatusBar
         ObserveSource(StatusBarSource);
         ObserveSource(FilterApplied);
         ObserveSource(LensSource);
+        ObserveSource(StatsVisibility);
 
         base.OnInitialized();
     }
@@ -67,4 +73,6 @@ public sealed partial class StatusBar
 
         return shown.Sentence;
     }
+
+    private void ToggleStats() => StatsCommands.SetVisible(!StatsVisibility.IsVisible);
 }

--- a/src/EventLogExpert.UI/StatusBar/StatusBar.razor.css
+++ b/src/EventLogExpert.UI/StatusBar/StatusBar.razor.css
@@ -42,6 +42,27 @@
     font-weight: 600;
 }
 
+.status-bar-stats {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    padding: 0 4px;
+    border: none;
+    border-radius: 2px;
+    background: none;
+    color: inherit;
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.status-bar-stats:hover { background: color-mix(in srgb, var(--clr-white) 18%, transparent); }
+
+.status-bar-stats:focus-visible {
+    outline: 1px solid var(--clr-white);
+    outline-offset: -1px;
+}
+
 /* White (inherited) text keeps WCAG AA contrast on the blue status bar; weight distinguishes the state. A color-coded
    status palette that meets AA on the status-bar fill is deferred to v2. */
 .status-bar-warn,

--- a/src/EventLogExpert.UI/_Imports.razor
+++ b/src/EventLogExpert.UI/_Imports.razor
@@ -32,6 +32,7 @@
 @using EventLogExpert.UI.Inputs
 @using EventLogExpert.UI.LogTable
 @using EventLogExpert.UI.LogTable.Histogram
+@using EventLogExpert.UI.LogTable.Stats
 @using EventLogExpert.UI.Menu
 @using EventLogExpert.UI.Modal
 @using EventLogExpert.UI.StatusBar

--- a/src/EventLogExpert/Adapters/Settings/StatsDrawerPreferencesAdapter.cs
+++ b/src/EventLogExpert/Adapters/Settings/StatsDrawerPreferencesAdapter.cs
@@ -1,0 +1,17 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.Stats;
+
+namespace EventLogExpert.Adapters.Settings;
+
+internal sealed class StatsDrawerPreferencesAdapter : IStatsDrawerPreferencesProvider
+{
+    private const string StatsDrawerHeight = "stats-drawer-height";
+
+    public int StatsDrawerHeightPreference
+    {
+        get => Preferences.Default.Get(StatsDrawerHeight, 0);
+        set => Preferences.Default.Set(StatsDrawerHeight, value);
+    }
+}

--- a/src/EventLogExpert/DependencyInjection/MauiProgramExtensions.cs
+++ b/src/EventLogExpert/DependencyInjection/MauiProgramExtensions.cs
@@ -24,6 +24,7 @@ using EventLogExpert.Runtime.LogTable;
 using EventLogExpert.Runtime.Menu;
 using EventLogExpert.Runtime.Scenarios;
 using EventLogExpert.Runtime.Settings;
+using EventLogExpert.Runtime.Stats;
 using EventLogExpert.UI.Alerts;
 using EventLogExpert.UI.Modal;
 using EventLogExpert.WindowsPlatform.Activation;
@@ -111,6 +112,7 @@ internal static class MauiProgramExtensions
             services.AddSingleton<ILogTablePreferencesProvider, LogTablePreferencesAdapter>();
             services.AddSingleton<ISettingsPreferencesProvider, SettingsPreferencesAdapter>();
             services.AddSingleton<IDetailsPanePreferencesProvider, DetailsPanePreferencesAdapter>();
+            services.AddSingleton<IStatsDrawerPreferencesProvider, StatsDrawerPreferencesAdapter>();
             services.AddSingleton<IDatabasePreferencesProvider, DatabasePreferencesAdapter>();
 
             return services;

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Common/Events/EventColumnStoreReaderTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Common/Events/EventColumnStoreReaderTests.cs
@@ -15,6 +15,51 @@ public sealed class EventColumnStoreReaderTests
     private static readonly EventLogId s_logId = EventLogId.Create();
     private static readonly DateTime s_time = new(2021, 6, 15, 10, 20, 30, DateTimeKind.Utc);
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CountSeverity_SkipsFilteredRows(bool sealRows)
+    {
+        ResolvedEvent[] sample = [Ev(1, "Critical"), Ev(2, "Error"), Ev(3, "Error")];
+
+        IEventColumnReader reader = ReaderOver(sample, sealRows);
+        int[] slots = new int[LevelSeverity.SlotCount];
+        int[] rank = new int[reader.Count];
+        rank[0] = -1; // filter out the Critical row
+
+        reader.CountSeverity(rank, slots, TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, slots[(int)SeverityLevel.Critical]);
+        Assert.Equal(2, slots[(int)SeverityLevel.Error]);
+        Assert.Equal(2, slots.Sum());
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CountSeverity_TalliesSurvivorsBySlot_AbsentAndUnknownToSlotZero(bool sealRows)
+    {
+        ResolvedEvent[] sample =
+        [
+            Ev(1, "Critical"), Ev(2, "Error"), Ev(3, "Error"), Ev(4, "Warning"),
+            Ev(5, "Information"), Ev(6, "Verbose"), Ev(7, ""), Ev(8, "Bogus")
+        ];
+
+        IEventColumnReader reader = ReaderOver(sample, sealRows);
+        int[] slots = new int[LevelSeverity.SlotCount];
+        int[] rank = new int[reader.Count]; // all >= 0 -> every row survives
+
+        reader.CountSeverity(rank, slots, TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, slots[(int)SeverityLevel.Critical]);
+        Assert.Equal(2, slots[(int)SeverityLevel.Error]);
+        Assert.Equal(1, slots[(int)SeverityLevel.Warning]);
+        Assert.Equal(1, slots[(int)SeverityLevel.Information]);
+        Assert.Equal(1, slots[(int)SeverityLevel.Verbose]);
+        Assert.Equal(2, slots[0]); // absent + unrecognized level -> Unknown
+        Assert.Equal(sample.Length, slots.Sum());
+    }
+
     [Fact]
     public void GetField_ForeignLogIdLocator_ThrowsArgumentException()
     {
@@ -54,6 +99,9 @@ public sealed class EventColumnStoreReaderTests
         Assert.Empty(reader.GetKeywords(reader.LocatorAt(1)));
         Assert.Equal(["Classic"], reader.GetKeywords(reader.LocatorAt(2)));
     }
+
+    private static ResolvedEvent Ev(int id, string level) =>
+        new("Application", LogPathType.Channel) { Id = id, Level = level, TimeCreated = s_time };
 
     private static IEventColumnReader ReaderOver(ResolvedEvent[] sample, bool sealRows) =>
         (sealRows

--- a/tests/Unit/EventLogExpert.Runtime.Tests/DependencyInjection/RuntimeServiceCollectionExtensionsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/DependencyInjection/RuntimeServiceCollectionExtensionsTests.cs
@@ -30,6 +30,7 @@ using EventLogExpert.Runtime.Menu;
 using EventLogExpert.Runtime.Scenarios;
 using EventLogExpert.Runtime.Scenarios.Favorites;
 using EventLogExpert.Runtime.Settings;
+using EventLogExpert.Runtime.Stats;
 using EventLogExpert.Runtime.StatusBar;
 using EventLogExpert.Runtime.Update;
 using EventLogExpert.Runtime.Update.Deployment;
@@ -166,6 +167,9 @@ public sealed class RuntimeServiceCollectionExtensionsTests
     [InlineData(typeof(IFilterLensSource))]
     [InlineData(typeof(IOpenLogsPresenceSource))]
     [InlineData(typeof(IHistogramVisibilitySource))]
+    [InlineData(typeof(IStatsVisibilitySource))]
+    [InlineData(typeof(IStatsCommands))]
+    [InlineData(typeof(IStatsService))]
     [InlineData(typeof(IEventFocusSource))]
     [InlineData(typeof(IActiveEventLogSource))]
     [InlineData(typeof(IFilterAppliedSource))]
@@ -252,6 +256,9 @@ public sealed class RuntimeServiceCollectionExtensionsTests
         var histogramState = Substitute.For<IState<HistogramState>>();
         histogramState.Value.Returns(new HistogramState());
         services.AddSingleton(histogramState);
+        var statsState = Substitute.For<IState<StatsState>>();
+        statsState.Value.Returns(new StatsState());
+        services.AddSingleton(statsState);
         var filterLibraryState = Substitute.For<IState<FilterLibraryState>>();
         filterLibraryState.Value.Returns(new FilterLibraryState());
         services.AddSingleton(filterLibraryState);
@@ -379,6 +386,7 @@ public sealed class RuntimeServiceCollectionExtensionsTests
         services.AddSingleton(Substitute.For<IState<RawEventStoreState>>());
         services.AddSingleton(Substitute.For<IState<FilteredLogPresenceState>>());
         services.AddSingleton(Substitute.For<IState<HistogramState>>());
+        services.AddSingleton(Substitute.For<IState<StatsState>>());
         services.AddSingleton(Substitute.For<IState<FilterLibraryState>>());
         services.AddSingleton(Substitute.For<IState<ScenarioFavoritesState>>());
         services.AddSingleton(Substitute.For<IStateSelection<EventLogState, bool>>());

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/EffectiveFilterBuilderTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/EffectiveFilterBuilderTests.cs
@@ -56,6 +56,27 @@ public sealed class EffectiveFilterBuilderTests
     }
 
     [Fact]
+    public void Build_TimeWindowLensFromFactory_KeepsEventsWithinRadius_IncludingInclusiveBoundsAndSource()
+    {
+        // The factory-built centered window [T-1h, T+1h] keeps the source event at T and neighbors exactly on the
+        // inclusive bounds, and hides anything past them.
+        var anchor = At(12);
+        var source = FilterEventBuilder.CreateTestEvent(id: 1, timeCreated: anchor);
+        var onLowerBound = FilterEventBuilder.CreateTestEvent(id: 2, timeCreated: At(11));
+        var onUpperBound = FilterEventBuilder.CreateTestEvent(id: 3, timeCreated: At(13));
+        var belowWindow = FilterEventBuilder.CreateTestEvent(id: 4, timeCreated: At(10));
+        var aboveWindow = FilterEventBuilder.CreateTestEvent(id: 5, timeCreated: At(14));
+
+        var lens = FilterLensFactory.ForTimeWindow(anchor, TimeSpan.FromHours(1), TimeZoneInfo.Utc);
+        var composed = EffectiveFilterBuilder.Build(new Filter(null, []), [lens]);
+
+        var result = s_filterService.GetFilteredEvents(
+            [source, onLowerBound, onUpperBound, belowWindow, aboveWindow], composed);
+
+        Assert.Equal([1, 2, 3], result.Select(e => e.Id).OrderBy(id => id));
+    }
+
+    [Fact]
     public void Build_TimeWindowLens_IntersectsWithBaseDate_TwoSidedEnabled()
     {
         // Arrange - base date [10:00, 14:00]; lens window [12:00, 16:00]; intersection [12:00, 14:00].
@@ -107,27 +128,6 @@ public sealed class EffectiveFilterBuilderTests
     }
 
     [Fact]
-    public void Build_TimeWindowLensFromFactory_KeepsEventsWithinRadius_IncludingInclusiveBoundsAndSource()
-    {
-        // The factory-built centered window [T-1h, T+1h] keeps the source event at T and neighbors exactly on the
-        // inclusive bounds, and hides anything past them.
-        var anchor = At(12);
-        var source = FilterEventBuilder.CreateTestEvent(id: 1, timeCreated: anchor);
-        var onLowerBound = FilterEventBuilder.CreateTestEvent(id: 2, timeCreated: At(11));
-        var onUpperBound = FilterEventBuilder.CreateTestEvent(id: 3, timeCreated: At(13));
-        var belowWindow = FilterEventBuilder.CreateTestEvent(id: 4, timeCreated: At(10));
-        var aboveWindow = FilterEventBuilder.CreateTestEvent(id: 5, timeCreated: At(14));
-
-        var lens = FilterLensFactory.ForTimeWindow(anchor, TimeSpan.FromHours(1), TimeZoneInfo.Utc);
-        var composed = EffectiveFilterBuilder.Build(new Filter(null, []), [lens]);
-
-        var result = s_filterService.GetFilteredEvents(
-            [source, onLowerBound, onUpperBound, belowWindow, aboveWindow], composed);
-
-        Assert.Equal([1, 2, 3], result.Select(e => e.Id).OrderBy(id => id));
-    }
-
-    [Fact]
     public void Build_WithActivityIdLensOnBaseInclude_NarrowsToIntersection()
     {
         // Arrange - base includes Level == Error (OR-combined include list); the lens must AND-narrow, so only the
@@ -163,6 +163,104 @@ public sealed class EffectiveFilterBuilderTests
 
         var result = s_filterService.GetFilteredEvents([matching, other, absent], composed);
 
+        Assert.Equal([1], result.Select(e => e.Id).OrderBy(id => id));
+    }
+
+    [Fact]
+    public void Build_WithExcludeEventIdLens_HidesMatchingId_KeepsOthers()
+    {
+        var drop = FilterEventBuilder.CreateTestEvent(id: 4624);
+        var keep = FilterEventBuilder.CreateTestEvent(id: 4625);
+
+        var lens = FilterLensFactory.ForExcludedValue(EventProperty.Id, "4624");
+        Assert.NotNull(lens);
+
+        var composed = EffectiveFilterBuilder.Build(new Filter(null, []), [lens]);
+        var result = s_filterService.GetFilteredEvents([drop, keep], composed);
+
+        Assert.Equal([4625], result.Select(e => e.Id).OrderBy(id => id));
+    }
+
+    [Fact]
+    public void Build_WithExcludeSourceLens_HidesMatchingSource_KeepsOthers()
+    {
+        var noisy1 = FilterEventBuilder.CreateTestEvent(id: 1, source: "NoisySource");
+        var noisy2 = FilterEventBuilder.CreateTestEvent(id: 2, source: "NoisySource");
+        var quiet = FilterEventBuilder.CreateTestEvent(id: 3, source: "QuietSource");
+
+        var lens = FilterLensFactory.ForExcludedValue(EventProperty.Source, "NoisySource");
+        Assert.NotNull(lens);
+        Assert.Equal("Source \u2260 NoisySource", lens!.Label);
+
+        var composed = EffectiveFilterBuilder.Build(new Filter(null, []), [lens]);
+        var result = s_filterService.GetFilteredEvents([noisy1, noisy2, quiet], composed);
+
+        Assert.Equal([3], result.Select(e => e.Id).OrderBy(id => id));
+    }
+
+    [Fact]
+    public void Build_WithExcludeUserLens_HidesMatchingUser_KeepsOthers()
+    {
+        // Locks that User (EventProperty.UserDisplayName) is actually filterable, so the User exclude button binds.
+        var system = FilterEventBuilder.CreateTestEvent(id: 1, userDisplayName: "SYSTEM");
+        var alice = FilterEventBuilder.CreateTestEvent(id: 2, userDisplayName: "CONTOSO\\alice");
+
+        var lens = FilterLensFactory.ForExcludedValue(EventProperty.UserDisplayName, "SYSTEM");
+        Assert.NotNull(lens);
+
+        var composed = EffectiveFilterBuilder.Build(new Filter(null, []), [lens]);
+        var result = s_filterService.GetFilteredEvents([system, alice], composed);
+
+        Assert.Equal([2], result.Select(e => e.Id).OrderBy(id => id));
+    }
+
+    [Fact]
+    public void Build_WithIncludeEventIdLens_KeepsMatchingId_HidesOthers()
+    {
+        var keep = FilterEventBuilder.CreateTestEvent(id: 4624);
+        var drop = FilterEventBuilder.CreateTestEvent(id: 4625);
+
+        var lens = FilterLensFactory.ForIncludedValue(EventProperty.Id, "4624");
+        Assert.NotNull(lens);
+
+        var composed = EffectiveFilterBuilder.Build(new Filter(null, []), [lens]);
+        var result = s_filterService.GetFilteredEvents([keep, drop], composed);
+
+        Assert.Equal([4624], result.Select(e => e.Id).OrderBy(id => id));
+    }
+
+    [Fact]
+    public void Build_WithIncludeSourceLens_KeepsMatchingSource_HidesOthers()
+    {
+        var keep1 = FilterEventBuilder.CreateTestEvent(id: 1, source: "TargetSource");
+        var keep2 = FilterEventBuilder.CreateTestEvent(id: 2, source: "TargetSource");
+        var other = FilterEventBuilder.CreateTestEvent(id: 3, source: "OtherSource");
+
+        var lens = FilterLensFactory.ForIncludedValue(EventProperty.Source, "TargetSource");
+        Assert.NotNull(lens);
+        Assert.Equal("Source = TargetSource", lens!.Label);
+
+        var composed = EffectiveFilterBuilder.Build(new Filter(null, []), [lens]);
+        var result = s_filterService.GetFilteredEvents([keep1, keep2, other], composed);
+
+        Assert.Equal([1, 2], result.Select(e => e.Id).OrderBy(id => id));
+    }
+
+    [Fact]
+    public void Build_WithIncludeUserLens_KeepsMatchingUser_HidesOthersAndNoUserEvents()
+    {
+        var system = FilterEventBuilder.CreateTestEvent(id: 1, userDisplayName: "SYSTEM");
+        var alice = FilterEventBuilder.CreateTestEvent(id: 2, userDisplayName: "CONTOSO\\alice");
+        var noUser = FilterEventBuilder.CreateTestEvent(id: 3);
+
+        var lens = FilterLensFactory.ForIncludedValue(EventProperty.UserDisplayName, "SYSTEM");
+        Assert.NotNull(lens);
+
+        var composed = EffectiveFilterBuilder.Build(new Filter(null, []), [lens]);
+        var result = s_filterService.GetFilteredEvents([system, alice, noUser], composed);
+
+        // The User field is presence-gated, so "User != SYSTEM" is NoMatch (kept) for the no-user event; the include
+        // lens must add a second "User == null" exclude clause so keep-only genuinely drops it, not just other users.
         Assert.Equal([1], result.Select(e => e.Id).OrderBy(id => id));
     }
 

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/TestSupport/AosReferenceCombinedView.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/TestSupport/AosReferenceCombinedView.cs
@@ -384,6 +384,14 @@ internal sealed class AosReferenceCombinedView : IEventColumnView
         }
     }
 
+    public void CountSeverity(int[] slotCounts, CancellationToken cancellationToken)
+    {
+        foreach (var view in _views)
+        {
+            view.CountSeverity(slotCounts, cancellationToken);
+        }
+    }
+
     public byte[] EnsureHighlightWinners(
         IReadOnlyList<SavedFilter> orderedColoredFilters,
         int planKey,

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/TestSupport/AosReferenceView.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/TestSupport/AosReferenceView.cs
@@ -298,6 +298,9 @@ internal sealed class AosReferenceView : IEventColumnView
         CancellationToken cancellationToken) =>
         _reader.CountFieldValues(_rankByPhysical, field, counts, cancellationToken);
 
+    public void CountSeverity(int[] slotCounts, CancellationToken cancellationToken) =>
+        _reader.CountSeverity(_rankByPhysical, slotCounts, cancellationToken);
+
     public byte[] EnsureHighlightWinners(
         IReadOnlyList<SavedFilter> orderedColoredFilters,
         int planKey,

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Stats/StatsServiceTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Stats/StatsServiceTests.cs
@@ -1,0 +1,117 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.Runtime.Stats;
+using EventLogExpert.Runtime.Tests.LogTable.TestSupport;
+using EventLogExpert.Runtime.Tests.TestUtils;
+
+namespace EventLogExpert.Runtime.Tests.Stats;
+
+public sealed class StatsServiceTests
+{
+    private static readonly EventLogId s_logId = EventLogId.Create();
+
+    private readonly IStatsService _service = new StatsService();
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    [Fact]
+    public void BuildDimension_CancelledToken_Throws()
+    {
+        var view = ViewOver(Ev(1, source: "A"), Ev(2, source: "B"), Ev(3, source: "C"));
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Cancellation is honored across the whole build (counting AND ranking), so a closed "View all" modal cannot
+        // keep sorting a high-cardinality dimension after its token is cancelled.
+        Assert.ThrowsAny<OperationCanceledException>(
+            () => _service.BuildDimension(view, StatsDimension.Source, topN: 8, cts.Token));
+    }
+
+    [Fact]
+    public void BuildDimension_CapsAtTopN_ButCountsAllDistinct()
+    {
+        var view = ViewOver(Ev(1, source: "A"), Ev(2, source: "B"), Ev(3, source: "C"), Ev(4, source: "D"));
+
+        var stats = _service.BuildDimension(view, StatsDimension.Source, topN: 2, Ct);
+
+        Assert.Equal(2, stats.Top.Count);
+        Assert.Equal(4, stats.DistinctCount);
+    }
+
+    [Fact]
+    public void BuildDimension_EventId_HasNoMissing()
+    {
+        var view = ViewOver(Ev(4624), Ev(4624), Ev(4625));
+
+        var stats = _service.BuildDimension(view, StatsDimension.EventId, topN: 8, Ct);
+
+        Assert.Equal(3, stats.Total);
+        Assert.Equal(0, stats.MissingCount);
+        Assert.Equal(["4624", "4625"], stats.Top.Select(contributor => contributor.Value));
+        Assert.Equal([2, 1], stats.Top.Select(contributor => contributor.Count));
+    }
+
+    [Fact]
+    public void BuildDimension_OverFilteredView_CountsOnlySurvivors()
+    {
+        ResolvedEvent[] events = [Ev(1, source: "Keep"), Ev(2, source: "Drop"), Ev(3, source: "Keep")];
+        var reader = EventColumnStore.Build(events, generation: 0, contentVersion: 0).CreateReader(s_logId);
+        var view = AosReferenceView.Create(
+            reader, [0, 2], orderBy: null, isDescending: false, groupBy: null, isGroupDescending: false);
+
+        var stats = _service.BuildDimension(view, StatsDimension.Source, topN: 8, Ct);
+
+        Assert.Equal(2, stats.Total);
+        Assert.Equal(["Keep"], stats.Top.Select(contributor => contributor.Value));
+        Assert.Equal([2], stats.Top.Select(contributor => contributor.Count));
+    }
+
+    [Fact]
+    public void BuildDimension_Source_RanksByCountThenOrdinal_AndCountsMissing()
+    {
+        var view = ViewOver(
+            Ev(1, source: "Bravo"), Ev(2, source: "Alpha"), Ev(3, source: "Alpha"), Ev(4, source: "Bravo"),
+            Ev(5, source: "Charlie"),
+            Ev(6, source: ""), Ev(7, source: "")); // absent source -> missing bucket, still in Total
+
+        var stats = _service.BuildDimension(view, StatsDimension.Source, topN: 8, Ct);
+
+        Assert.Equal(7, stats.Total);
+        Assert.Equal(3, stats.DistinctCount);
+        Assert.Equal(2, stats.MissingCount);
+        // Alpha(2) and Bravo(2) tie on count -> broken by ordinal (Alpha before Bravo); Charlie(1) last.
+        Assert.Equal(["Alpha", "Bravo", "Charlie"], stats.Top.Select(contributor => contributor.Value));
+        Assert.Equal([2, 2, 1], stats.Top.Select(contributor => contributor.Count));
+        Assert.Equal(5, stats.ShownEventCount);
+    }
+
+    [Fact]
+    public void BuildSeverity_TalliesSlotsAndTotal_AbsentToUnknown()
+    {
+        var view = ViewOver(
+            Ev(1, level: "Critical"), Ev(2, level: "Error"), Ev(3, level: "Error"),
+            Ev(4, level: "Warning"), Ev(5, level: "Information"), Ev(6, level: "Verbose"), Ev(7, level: ""));
+
+        var stats = _service.BuildSeverity(view, Ct);
+
+        Assert.Equal(7, stats.Total);
+        Assert.Equal(1, stats.Slots[(int)SeverityLevel.Critical]);
+        Assert.Equal(2, stats.Slots[(int)SeverityLevel.Error]);
+        Assert.Equal(1, stats.Slots[(int)SeverityLevel.Warning]);
+        Assert.Equal(1, stats.Slots[(int)SeverityLevel.Information]);
+        Assert.Equal(1, stats.Slots[(int)SeverityLevel.Verbose]);
+        Assert.Equal(1, stats.Slots[0]); // absent level -> Unknown
+        Assert.Equal(7, stats.Slots.Sum());
+    }
+
+    private static ResolvedEvent Ev(int id, string source = "TestSource", string level = "Information") =>
+        new("live", LogPathType.Channel) { Id = id, Source = source, Level = level };
+
+    private static IEventColumnView ViewOver(params ResolvedEvent[] events) =>
+        DisplayViewTestFactory.Build(s_logId, events);
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/Architecture/UIFluxorBoundaryTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Architecture/UIFluxorBoundaryTests.cs
@@ -40,8 +40,9 @@ public sealed class UIFluxorBoundaryTests
     [Fact]
     public void EveryModal_IsCoveredByTheBoundaryEnumeration() =>
         // Guards the reflection discovery against finding nothing and pins the known modal set; update the count
-        // deliberately when a modal is added or removed (currently the seven built-in modals plus FilterLibraryModal).
-        Assert.Equal(8, s_modalTypes.Length);
+        // deliberately when a modal is added or removed (the seven built-in modals plus FilterLibraryModal and
+        // StatsDetailModal).
+        Assert.Equal(9, s_modalTypes.Length);
 
     [Theory]
     [MemberData(nameof(ModalTypes))]

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/Stats/StatsDrawerTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/Stats/StatsDrawerTests.cs
@@ -1,0 +1,78 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using Bunit.TestDoubles;
+using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.Stats;
+using EventLogExpert.UI.LogTable.Stats;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace EventLogExpert.UI.Tests.LogTable.Stats;
+
+public sealed class StatsDrawerTests : BunitContext
+{
+    private readonly IOpenLogsPresenceSource _openLogs = Substitute.For<IOpenLogsPresenceSource>();
+    private readonly IStatsDrawerPreferencesProvider _preferences = Substitute.For<IStatsDrawerPreferencesProvider>();
+    private readonly IStatsVisibilitySource _statsVisibility = Substitute.For<IStatsVisibilitySource>();
+
+    public StatsDrawerTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        JSInterop.SetupModule("./_content/EventLogExpert.UI/LogTable/Stats/StatsDrawer.razor.js");
+
+        _openLogs.HasOpenLogs.Returns(true);
+
+        Services.AddSingleton(_openLogs);
+        Services.AddSingleton(_preferences);
+        Services.AddSingleton(_statsVisibility);
+        ComponentFactories.AddStub<StatsPane>();
+    }
+
+    [Fact]
+    public void Drawer_CarriesOpenClass_WhenVisible()
+    {
+        _statsVisibility.IsVisible.Returns(true);
+
+        var cut = Render<StatsDrawer>();
+
+        Assert.NotNull(cut.Find(".stats-drawer.stats-drawer-open"));
+    }
+
+    [Fact]
+    public void Drawer_ClosesWhenNoLogRemainsOpen_EvenWhenVisible()
+    {
+        _statsVisibility.IsVisible.Returns(true);
+        _openLogs.HasOpenLogs.Returns(false);
+
+        var cut = Render<StatsDrawer>();
+
+        Assert.Empty(cut.FindComponents<Stub<StatsPane>>());
+        Assert.Empty(cut.FindAll(".stats-drawer.stats-drawer-open"));
+    }
+
+    [Fact]
+    public void Drawer_RendersStatsPane_OnlyWhenVisible()
+    {
+        _statsVisibility.IsVisible.Returns(false);
+        var cut = Render<StatsDrawer>();
+        Assert.Empty(cut.FindComponents<Stub<StatsPane>>());
+
+        _statsVisibility.IsVisible.Returns(true);
+        _statsVisibility.Changed += Raise.Event<Action>();
+
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindComponents<Stub<StatsPane>>()));
+    }
+
+    [Fact]
+    public void OnStatsDrawerHeightChanged_PersistsPositiveHeight()
+    {
+        _statsVisibility.IsVisible.Returns(true);
+        var cut = Render<StatsDrawer>();
+
+        cut.Instance.OnStatsDrawerHeightChanged(300);
+
+        _preferences.Received().StatsDrawerHeightPreference = 300;
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/Stats/StatsPaneTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/Stats/StatsPaneTests.cs
@@ -1,0 +1,336 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Filtering.Common.Filtering;
+using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.FilterLenses;
+using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.Runtime.LogTable.OrderedView;
+using EventLogExpert.Runtime.Stats;
+using EventLogExpert.UI.LogTable.Stats;
+using EventLogExpert.UI.Modal;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using System.Collections.Immutable;
+
+namespace EventLogExpert.UI.Tests.LogTable.Stats;
+
+public sealed class StatsPaneTests : BunitContext
+{
+    private static readonly EventLogId s_tokenLog = EventLogId.Create();
+    private static readonly TimeSpan s_wait = TimeSpan.FromSeconds(10);
+
+    private readonly IFilterLensCommands _lensCommands = Substitute.For<IFilterLensCommands>();
+    private readonly IFilterLensSource _lensSource = Substitute.For<IFilterLensSource>();
+    private readonly IModalCoordinator _modalCoordinator = Substitute.For<IModalCoordinator>();
+    private readonly ManualResetEventSlim _severityGate = new(initialState: true);
+    private readonly IStatsService _statsService = Substitute.For<IStatsService>();
+    private readonly EventLogId _tabId = EventLogId.Create();
+    private readonly ITraceLogger _traceLogger = Substitute.For<ITraceLogger>();
+    private readonly IEventColumnView _view = Substitute.For<IEventColumnView>();
+    private readonly IOrderedViewSource _viewSource = Substitute.For<IOrderedViewSource>();
+
+    private OrderedViewPresentation _presentation;
+
+    public StatsPaneTests()
+    {
+        _presentation = PresentationWith(Token(1));
+        _viewSource.Current.Returns(_ => _presentation);
+        _lensSource.Lenses.Returns(ImmutableList<FilterLensSummary>.Empty);
+
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        JSInterop.SetupModule("./_content/EventLogExpert.UI/LogTable/Stats/StatsPane.razor.js");
+
+        Services.AddSingleton(_lensCommands);
+        Services.AddSingleton(_lensSource);
+        Services.AddSingleton(_modalCoordinator);
+        Services.AddSingleton(_statsService);
+        Services.AddSingleton(_traceLogger);
+        Services.AddSingleton(_viewSource);
+    }
+
+    [Fact]
+    public void AllExcluded_HeadlineAsksToRemoveLens()
+    {
+        SetupSeverity(total: 0, Slots(critical: 0, error: 0, warning: 0, info: 0, verbose: 0, unknown: 0));
+        _lensSource.Lenses.Returns([new FilterLensSummary(new FilterLensId(Guid.NewGuid()), "Source excludes Alpha")]);
+
+        var cut = Render<StatsPane>();
+
+        cut.WaitForAssertion(() => Assert.Contains("remove a lens", cut.Find(".stats-headline").TextContent), s_wait);
+    }
+
+    [Fact]
+    public void EmptyView_HeadlineSaysNoEvents()
+    {
+        SetupSeverity(total: 0, Slots(critical: 0, error: 0, warning: 0, info: 0, verbose: 0, unknown: 0));
+
+        var cut = Render<StatsPane>();
+
+        cut.WaitForAssertion(() => Assert.Contains("No events in the current view", cut.Find(".stats-headline").TextContent), s_wait);
+    }
+
+    [Fact]
+    public async Task ExcludeClick_EventId_PushesExcludeEventIdWithParsedValue()
+    {
+        SetupSeverity(total: 100, Slots(critical: 0, error: 0, warning: 0, info: 100, verbose: 0, unknown: 0));
+        SetupDimension(SourceStats(total: 100, missing: 0, distinct: 1, ("Alpha", 100)));
+        SetupDimension(EventIdStats(total: 100, distinct: 2, ("4624", 60), ("4625", 40)));
+        SetupDimension(Dim(StatsDimension.TaskCategory, total: 100, distinct: 1, ("Task", 100)));
+        SetupDimension(Dim(StatsDimension.User, total: 100, distinct: 1, ("User", 100)));
+
+        var cut = Render<StatsPane>();
+        cut.WaitForState(() => cut.FindAll(".stats-coverage").Count == 4, s_wait);
+
+        await cut.InvokeAsync(() => cut.Find("[aria-label='Exclude Event ID 4624']").Click());
+
+        _lensCommands.Received(1).ExcludeEventId(4624, "live");
+    }
+
+    [Fact]
+    public async Task ExcludeClick_StringDimension_PushesExcludeLensWithRawValue()
+    {
+        SetupSeverity(total: 100, Slots(critical: 0, error: 0, warning: 0, info: 100, verbose: 0, unknown: 0));
+        SetupDimension(SourceStats(total: 100, missing: 0, distinct: 2, ("Alpha", 60), ("Bravo", 40)));
+        SetupDimension(EventIdStats(total: 100, distinct: 1, ("1", 100)));
+        SetupDimension(Dim(StatsDimension.TaskCategory, total: 100, distinct: 1, ("Task", 100)));
+        SetupDimension(Dim(StatsDimension.User, total: 100, distinct: 1, ("User", 100)));
+
+        var cut = Render<StatsPane>();
+        cut.WaitForState(() => cut.FindAll(".stats-coverage").Count == 4, s_wait);
+
+        Assert.False(cut.Find("[aria-label='Exclude Source Alpha']").HasAttribute("disabled"));
+
+        // Find + click atomically on the renderer's dispatcher: the per-row onclick lambda is recreated every render,
+        // so a progressive-scan re-render between a separate find and click would retire the captured handler id.
+        await cut.InvokeAsync(() => cut.Find("[aria-label='Exclude Source Alpha']").Click());
+
+        _lensCommands.Received(1).ExcludeValue(EventProperty.Source, "Alpha", "live");
+    }
+
+    [Fact]
+    public async Task IncludeClick_EventId_PushesIncludeEventIdWithParsedValue()
+    {
+        SetupSeverity(total: 100, Slots(critical: 0, error: 0, warning: 0, info: 100, verbose: 0, unknown: 0));
+        SetupDimension(SourceStats(total: 100, missing: 0, distinct: 1, ("Alpha", 100)));
+        SetupDimension(EventIdStats(total: 100, distinct: 2, ("4624", 60), ("4625", 40)));
+        SetupDimension(Dim(StatsDimension.TaskCategory, total: 100, distinct: 1, ("Task", 100)));
+        SetupDimension(Dim(StatsDimension.User, total: 100, distinct: 1, ("User", 100)));
+
+        var cut = Render<StatsPane>();
+        cut.WaitForState(() => cut.FindAll(".stats-coverage").Count == 4, s_wait);
+
+        await cut.InvokeAsync(() => cut.Find("[aria-label='Filter to Event ID 4624']").Click());
+
+        _lensCommands.Received(1).IncludeEventId(4624, "live");
+    }
+
+    [Fact]
+    public async Task IncludeClick_StringDimension_PushesIncludeLensWithRawValue()
+    {
+        SetupSeverity(total: 100, Slots(critical: 0, error: 0, warning: 0, info: 100, verbose: 0, unknown: 0));
+        SetupDimension(SourceStats(total: 100, missing: 0, distinct: 2, ("Alpha", 60), ("Bravo", 40)));
+        SetupDimension(EventIdStats(total: 100, distinct: 1, ("1", 100)));
+        SetupDimension(Dim(StatsDimension.TaskCategory, total: 100, distinct: 1, ("Task", 100)));
+        SetupDimension(Dim(StatsDimension.User, total: 100, distinct: 1, ("User", 100)));
+
+        var cut = Render<StatsPane>();
+        cut.WaitForState(() => cut.FindAll(".stats-coverage").Count == 4, s_wait);
+
+        await cut.InvokeAsync(() => cut.Find("[aria-label='Filter to Source Alpha']").Click());
+
+        _lensCommands.Received(1).IncludeValue(EventProperty.Source, "Alpha", "live");
+    }
+
+    [Fact]
+    public async Task Recomputing_KeepsRowsMarksUpdatingAndDisablesExclude()
+    {
+        SetupSeverity(total: 100, Slots(critical: 0, error: 0, warning: 0, info: 100, verbose: 0, unknown: 0));
+        SetupDimension(SourceStats(total: 100, missing: 0, distinct: 1, ("Alpha", 100)));
+        SetupDimension(EventIdStats(total: 100, distinct: 1, ("1", 100)));
+
+        var cut = Render<StatsPane>();
+        cut.WaitForAssertion(() => Assert.False(cut.Find("[aria-label='Exclude Source Alpha']").HasAttribute("disabled")), s_wait);
+
+        // Block the recompute so the in-flight (stale) state is observable rather than a 500ms timing race.
+        _severityGate.Reset();
+        _presentation = PresentationWith(Token(2));
+        await cut.InvokeAsync(() => _viewSource.Updated += Raise.Event<Action<OrderedViewPresentation>>(_presentation));
+
+        try
+        {
+            cut.WaitForAssertion(() =>
+            {
+                Assert.Contains("Updating...", cut.Markup);
+                Assert.Contains("Alpha", cut.Markup);
+                Assert.True(cut.Find("[aria-label='Exclude Source Alpha']").HasAttribute("disabled"));
+            }, s_wait);
+        }
+        finally
+        {
+            _severityGate.Set();
+        }
+    }
+
+    [Fact]
+    public void Render_MissingValues_RendersNonExcludableNoneBucket()
+    {
+        SetupSeverity(total: 100, Slots(critical: 0, error: 0, warning: 0, info: 100, verbose: 0, unknown: 0));
+        SetupDimension(SourceStats(total: 100, missing: 15, distinct: 2, ("Alpha", 50), ("Bravo", 35)));
+        SetupDimension(EventIdStats(total: 100, distinct: 1, ("1", 100)));
+
+        var cut = Render<StatsPane>();
+
+        cut.WaitForAssertion(() =>
+        {
+            var noneRow = cut.Find(".stats-row-none");
+            Assert.Contains("(none)", noneRow.TextContent);
+            Assert.Contains("15", noneRow.TextContent);
+            Assert.Empty(noneRow.QuerySelectorAll("button.stats-exclude"));
+        }, s_wait);
+    }
+
+    [Fact]
+    public void Render_ShowsHeadlineSeverityLegendAndTopRows()
+    {
+        SetupSeverity(total: 100, Slots(critical: 2, error: 8, warning: 10, info: 70, verbose: 5, unknown: 5));
+        SetupDimension(SourceStats(total: 100, missing: 0, distinct: 3, ("Alpha", 40), ("Bravo", 30), ("Charlie", 20)));
+        SetupDimension(EventIdStats(total: 100, distinct: 2, ("4624", 60), ("4625", 40)));
+
+        var cut = Render<StatsPane>();
+
+        cut.WaitForAssertion(() =>
+        {
+            string headline = cut.Find(".stats-headline").TextContent;
+            Assert.Contains("100 events", headline);
+            Assert.Contains("10 error/critical", headline);
+            Assert.Contains("top 3 sources = 90%", headline);
+            Assert.Contains("Critical", cut.Markup);
+            Assert.Contains("Alpha", cut.Markup);
+        }, s_wait);
+    }
+
+    [Fact]
+    public async Task Resize_FitsDefaultRowCountToPaneHeight()
+    {
+        SetupSeverity(total: 100, Slots(critical: 0, error: 0, warning: 0, info: 100, verbose: 0, unknown: 0));
+        SetupDimension(SourceStats(total: 100, missing: 0, distinct: 20, ("Alpha", 100)));
+        SetupDimension(EventIdStats(total: 100, distinct: 1, ("1", 100)));
+        SetupDimension(Dim(StatsDimension.TaskCategory, total: 100, distinct: 1, ("Task", 100)));
+        SetupDimension(Dim(StatsDimension.User, total: 100, distinct: 1, ("User", 100)));
+
+        var cut = Render<StatsPane>();
+        cut.WaitForState(() => cut.FindAll(".stats-coverage").Count == 4, s_wait);
+        _statsService.ClearReceivedCalls();
+
+        // A tall section fits more rows than the default: (500 - 68) / 22 = 19, within the 40-row cap.
+        await cut.InvokeAsync(() => cut.Instance.OnStatsResized(500));
+
+        cut.WaitForAssertion(
+            () => _statsService.Received().BuildDimension(
+                Arg.Any<IEventColumnView>(), Arg.Is(StatsDimension.Source), 19, Arg.Any<CancellationToken>()),
+            s_wait);
+    }
+
+    [Fact]
+    public async Task TabChangeWithSameContentToken_TriggersRescan()
+    {
+        SetupSeverity(total: 100, Slots(critical: 0, error: 0, warning: 0, info: 100, verbose: 0, unknown: 0));
+        SetupDimension(SourceStats(total: 100, missing: 0, distinct: 1, ("Alpha", 100)));
+        SetupDimension(EventIdStats(total: 100, distinct: 1, ("1", 100)));
+
+        var cut = Render<StatsPane>();
+        cut.WaitForState(() => cut.FindAll(".stats-coverage").Count == 2, s_wait);
+        _statsService.ClearReceivedCalls();
+
+        // Switch to a different tab that resolves to the same content token (e.g. two empty/equivalent views). The
+        // publish guard enforces ActiveTabId, so the recompute key must key on it too or the pane never rescans.
+        _presentation = new OrderedViewPresentation(_view, EventLogId.Create(), default, PresentationState.Current, 2)
+        {
+            ContentToken = Token(1),
+            ActiveLogName = "other"
+        };
+        await cut.InvokeAsync(() => _viewSource.Updated += Raise.Event<Action<OrderedViewPresentation>>(_presentation));
+
+        cut.WaitForAssertion(
+            () => _statsService.Received().BuildSeverity(Arg.Any<IEventColumnView>(), Arg.Any<CancellationToken>()),
+            s_wait);
+    }
+
+    [Fact]
+    public async Task ViewAllClick_OpensDetailModalForDimension()
+    {
+        SetupSeverity(total: 100, Slots(critical: 0, error: 0, warning: 0, info: 100, verbose: 0, unknown: 0));
+        SetupDimension(SourceStats(total: 100, missing: 0, distinct: 20, ("Alpha", 60), ("Bravo", 40)));
+        SetupDimension(EventIdStats(total: 100, distinct: 1, ("1", 100)));
+        SetupDimension(Dim(StatsDimension.TaskCategory, total: 100, distinct: 1, ("Task", 100)));
+        SetupDimension(Dim(StatsDimension.User, total: 100, distinct: 1, ("User", 100)));
+
+        var cut = Render<StatsPane>();
+        cut.WaitForState(() => cut.FindAll(".stats-coverage").Count == 4, s_wait);
+
+        // Only Source has more distinct values than shown, so it is the single "View all".
+        var viewAll = cut.FindAll("button").First(button => button.TextContent.Trim() == "View all");
+        await cut.InvokeAsync(() => viewAll.Click());
+
+        _ = _modalCoordinator.Received(1).PushAsync<StatsDetailModal, bool>(Arg.Any<IDictionary<string, object?>>());
+    }
+
+    private static DimensionStats Dim(StatsDimension dimension, int total, int distinct, params (string Value, int Count)[] top) =>
+        new()
+        {
+            Dimension = dimension,
+            Total = total,
+            DistinctCount = distinct,
+            MissingCount = 0,
+            Top = top.Select(entry => new StatsContributor(entry.Value, entry.Count)).ToList()
+        };
+
+    private static DimensionStats EventIdStats(int total, int distinct, params (string Value, int Count)[] top) =>
+        new()
+        {
+            Dimension = StatsDimension.EventId,
+            Total = total,
+            DistinctCount = distinct,
+            MissingCount = 0,
+            Top = top.Select(entry => new StatsContributor(entry.Value, entry.Count)).ToList()
+        };
+
+    private static int[] Slots(int critical, int error, int warning, int info, int verbose, int unknown) =>
+        [unknown, critical, error, warning, info, verbose];
+
+    private static DimensionStats SourceStats(int total, int missing, int distinct, params (string Value, int Count)[] top) =>
+        new()
+        {
+            Dimension = StatsDimension.Source,
+            Total = total,
+            DistinctCount = distinct,
+            MissingCount = missing,
+            Top = top.Select(entry => new StatsContributor(entry.Value, entry.Count)).ToList()
+        };
+
+    private static ViewContentToken Token(long contentVersion) =>
+        ViewContentToken.FromStamps(default, [new ViewContentTokenReaderStamp(s_tokenLog, 0, contentVersion, 1)], 1);
+
+    private OrderedViewPresentation PresentationWith(ViewContentToken token) =>
+        new(_view, _tabId, default, PresentationState.Current, 1)
+        {
+            ContentToken = token,
+            ActiveLogName = "live"
+        };
+
+    private void SetupDimension(DimensionStats stats) =>
+        _statsService
+            .BuildDimension(Arg.Any<IEventColumnView>(), Arg.Is(stats.Dimension), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(stats);
+
+    private void SetupSeverity(int total, int[] slots) =>
+        _statsService.BuildSeverity(Arg.Any<IEventColumnView>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                _severityGate.Wait();
+                return new SeverityStats(total, slots);
+            });
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/StatusBar/StatusBarTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/StatusBar/StatusBarTests.cs
@@ -8,6 +8,7 @@ using EventLogExpert.Filtering.Evaluation;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.Runtime.FilterLenses;
 using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.Runtime.Stats;
 using EventLogExpert.Runtime.StatusBar;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
@@ -19,6 +20,8 @@ public sealed class StatusBarTests : BunitContext
 {
     private readonly IFilterAppliedSource _filterApplied = Substitute.For<IFilterAppliedSource>();
     private readonly IFilterLensSource _lensSource = Substitute.For<IFilterLensSource>();
+    private readonly IStatsCommands _statsCommands = Substitute.For<IStatsCommands>();
+    private readonly IStatsVisibilitySource _statsVisibility = Substitute.For<IStatsVisibilitySource>();
     private readonly IStatusBarSource _statusBarSource = Substitute.For<IStatusBarSource>();
     private readonly IOrderedViewSource _viewSource = Substitute.For<IOrderedViewSource>();
 
@@ -31,6 +34,8 @@ public sealed class StatusBarTests : BunitContext
 
         Services.AddSingleton(_filterApplied);
         Services.AddSingleton(_lensSource);
+        Services.AddSingleton(_statsCommands);
+        Services.AddSingleton(_statsVisibility);
         Services.AddSingleton(_statusBarSource);
         Services.AddSingleton(_viewSource);
 
@@ -262,6 +267,18 @@ public sealed class StatusBarTests : BunitContext
         var announce = cut.Find(".status-bar-announce");
         Assert.Equal("status", announce.GetAttribute("role"));
         Assert.Equal("polite", announce.GetAttribute("aria-live"));
+    }
+
+    [Fact]
+    public void StatsChip_TogglesStatisticsVisibility_ThroughTheCommand()
+    {
+        SetActiveLog(total: 100, shown: 100, filter: Unfiltered, selected: 0);
+        _statsVisibility.IsVisible.Returns(false);
+
+        var cut = Render<UI.StatusBar.StatusBar>();
+        cut.Find("button.status-bar-stats").Click();
+
+        _statsCommands.Received(1).SetVisible(true);
     }
 
     [Fact]


### PR DESCRIPTION
## Statistics panel

Adds a docked **Statistics** panel that summarizes the current filtered event set and turns it into a triage surface.

### What it does
- **Severity breakdown** bar (Critical / Error / Warning / Information / Verbose / Unknown) over the filtered set.
- **Top contributors** by **Source**, **Event ID**, **Task Category**, and **User**, each row with one-click **include (+)** / **exclude (-)** filtering that pushes a reversible filter lens.
- A **"View all"** detail modal per dimension (searchable, cancellable scan, honest "top N of M" label when capped).
- Rendered as a **drag-resizable drawer** above the status bar, toggled by the **event-count chip** in the status bar (count + caret); the previous View-menu toggle was folded into that chip.
- **Responsive**: four columns (wide) to two columns to header + severity only (narrow), and never a scrollbar - rows fit the available height and the empty "(none)" bucket is a pinned footer.

### Notes
- The **User** include lens matches SID-or-resolved-name and also excludes no-user events (a second `User == null` clause), so "filter to only this user" is exact.
- The off-thread scan loop mirrors `HistogramPane` (throttle + per-scan cancellation + `(tab, ContentToken)` publish guard); the resize observer uses a .NET-owned session token for a race-free lifecycle.
- The drawer auto-collapses when the last log closes; drag height is capped at 80% of the viewport and persisted.

### Testing
- UI 1497 / Runtime 2579 / Eventing 745 unit tests green; the MAUI Windows head builds clean.
- New tests cover the include/exclude semantics (including the no-user drop), the responsive height-fit, drawer visibility gating, and ranking cancellation.
