### PR TITLE
Add Resolution & Coverage view for unresolved event descriptions

### DIFF
--- a/src/EventLogExpert.Eventing/Common/Events/EventColumnChunk.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/EventColumnChunk.cs
@@ -26,7 +26,8 @@ internal enum EventColumnField : byte
     Xml,
     UserId,
     Opcode,
-    UserDisplayName
+    UserDisplayName,
+    ResolutionStatus
 }
 
 /// <summary>
@@ -101,6 +102,7 @@ internal sealed class EventColumnChunk
     private readonly bool[] _recordIdHas;
     private readonly Guid[] _relatedActivityId;
     private readonly bool[] _relatedActivityIdHas;
+    private readonly int[] _resolutionStatus;
     private readonly int[] _source;
     private readonly int[] _taskCategory;
     private readonly int[] _threadId;
@@ -108,7 +110,6 @@ internal sealed class EventColumnChunk
     private readonly long[] _timeTicks;
     private readonly int[] _userDataCount;
     private readonly bool[] _userDataIncomplete;
-
     private readonly int[] _userDataOffset;
     private readonly int[] _userDataPath;
     private readonly bool[] _userDataTruncated;
@@ -134,6 +135,7 @@ internal sealed class EventColumnChunk
         _userId = builder.UserId;
         _userDisplayName = builder.UserDisplayName;
         _opcode = builder.Opcode;
+        _resolutionStatus = builder.ResolutionStatus;
 
         _id = builder.Id;
         _timeTicks = builder.TimeTicks;
@@ -236,6 +238,7 @@ internal sealed class EventColumnChunk
         EventColumnField.UserId => _userId,
         EventColumnField.Opcode => _opcode,
         EventColumnField.UserDisplayName => _userDisplayName,
+        EventColumnField.ResolutionStatus => _resolutionStatus,
         _ => throw new ArgumentOutOfRangeException(nameof(column), column, null)
     };
 
@@ -283,6 +286,7 @@ internal sealed class EventColumnChunk
         EventColumnField.UserId => _userId[row],
         EventColumnField.Opcode => _opcode[row],
         EventColumnField.UserDisplayName => _userDisplayName[row],
+        EventColumnField.ResolutionStatus => _resolutionStatus[row],
         _ => throw new ArgumentOutOfRangeException(nameof(column), column, null)
     };
 
@@ -400,6 +404,7 @@ internal sealed class EventColumnChunk
         internal readonly bool[] RecordIdHas;
         internal readonly Guid[] RelatedActivityId;
         internal readonly bool[] RelatedActivityIdHas;
+        internal readonly int[] ResolutionStatus;
         internal readonly int[] Source;
         internal readonly int[] TaskCategory;
         internal readonly int[] ThreadId;
@@ -433,6 +438,7 @@ internal sealed class EventColumnChunk
             UserId = new int[count];
             UserDisplayName = new int[count];
             Opcode = new int[count];
+            ResolutionStatus = new int[count];
 
             Id = new int[count];
             TimeTicks = new long[count];
@@ -478,6 +484,7 @@ internal sealed class EventColumnChunk
             UserId[row] = pool.Intern(resolvedEvent.UserId?.Value);
             UserDisplayName[row] = pool.Intern(resolvedEvent.UserDisplayName.Length == 0 ? null : resolvedEvent.UserDisplayName);
             Opcode[row] = pool.Intern(resolvedEvent.Opcode);
+            ResolutionStatus[row] = pool.Intern(ResolutionStatusTokens.Format(resolvedEvent.ResolutionStatus));
 
             Id[row] = resolvedEvent.Id;
             TimeTicks[row] = resolvedEvent.TimeCreated.Ticks;

--- a/src/EventLogExpert.Eventing/Common/Events/EventColumnStore.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/EventColumnStore.cs
@@ -1322,6 +1322,143 @@ public sealed class EventColumnStore
         }
     }
 
+    internal void CountResolutionBySource(
+        ReadOnlySpan<int> rankByPhysical,
+        IDictionary<string, ProviderResolutionCounts> counts,
+        CancellationToken cancellationToken)
+    {
+        // Resolve the three non-resolved status tokens to pool indices once (missing -> int.MinValue) so sealed rows
+        // classify by integer compare; anything else is Resolved. Aggregate by Source pool index and reverse-resolve
+        // each distinct source once.
+        int noProviderIndex = _pool.TryGetIndex(ResolutionStatusTokens.NoProvider, out int noProvider) ? noProvider : int.MinValue;
+        int noMessageIndex = _pool.TryGetIndex(ResolutionStatusTokens.NoMessage, out int noMessage) ? noMessage : int.MinValue;
+        int failedIndex = _pool.TryGetIndex(ResolutionStatusTokens.Failed, out int failed) ? failed : int.MinValue;
+
+        var bySourceIndex = new Dictionary<int, ProviderResolutionCounts>();
+        int offset = 0;
+
+        foreach (EventColumnChunk chunk in _sealedChunks)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            ReadOnlySpan<int> sourceColumn = chunk.PoolIndexColumn(EventColumnField.Source);
+            ReadOnlySpan<int> statusColumn = chunk.PoolIndexColumn(EventColumnField.ResolutionStatus);
+
+            for (int row = 0; row < sourceColumn.Length; row++)
+            {
+                if (rankByPhysical[offset + row] < 0) { continue; }
+
+                int sourceIndex = sourceColumn[row];
+                bySourceIndex.TryGetValue(sourceIndex, out var current);
+                bySourceIndex[sourceIndex] = current.WithStatus(StatusOf(statusColumn[row]));
+            }
+
+            offset += chunk.RowCount;
+        }
+
+        foreach ((int sourceIndex, ProviderResolutionCounts value) in bySourceIndex)
+        {
+            string source = PoolGet(sourceIndex) ?? string.Empty;
+            counts[source] = counts.TryGetValue(source, out var existing) ? existing.Add(value) : value;
+        }
+
+        // Pending rows carry the enum directly (no pool index), so classify them by value.
+        for (int index = _sealedCount; index < Count; index++)
+        {
+            if (rankByPhysical[index] < 0) { continue; }
+
+            ResolvedEvent pending = Pending(index);
+            counts.TryGetValue(pending.Source, out var existing);
+            counts[pending.Source] = existing.WithStatus(pending.ResolutionStatus);
+        }
+
+        return;
+
+        EventResolutionStatus StatusOf(int statusIndex) =>
+            statusIndex == noProviderIndex ? EventResolutionStatus.NoProvider :
+            statusIndex == noMessageIndex ? EventResolutionStatus.NoMessage :
+            statusIndex == failedIndex ? EventResolutionStatus.Failed :
+            EventResolutionStatus.Resolved;
+    }
+
+    internal void CountResolutionDetailForSource(
+        ReadOnlySpan<int> rankByPhysical,
+        string source,
+        IDictionary<int, ProviderResolutionCounts> byId,
+        ProviderResolutionCounts[] byLevelSlot,
+        CancellationToken cancellationToken)
+    {
+        int sourceIndex = _pool.TryGetIndex(source, out int resolvedSource) ? resolvedSource : int.MinValue;
+        int noProviderIndex = _pool.TryGetIndex(ResolutionStatusTokens.NoProvider, out int noProvider) ? noProvider : int.MinValue;
+        int noMessageIndex = _pool.TryGetIndex(ResolutionStatusTokens.NoMessage, out int noMessage) ? noMessage : int.MinValue;
+        int failedIndex = _pool.TryGetIndex(ResolutionStatusTokens.Failed, out int failed) ? failed : int.MinValue;
+        int criticalIndex = _pool.TryGetIndex(nameof(SeverityLevel.Critical), out int critical) ? critical : int.MinValue;
+        int errorIndex = _pool.TryGetIndex(nameof(SeverityLevel.Error), out int error) ? error : int.MinValue;
+        int warningIndex = _pool.TryGetIndex(nameof(SeverityLevel.Warning), out int warning) ? warning : int.MinValue;
+        int informationIndex = _pool.TryGetIndex(nameof(SeverityLevel.Information), out int information) ? information : int.MinValue;
+        int verboseIndex = _pool.TryGetIndex(nameof(SeverityLevel.Verbose), out int verbose) ? verbose : int.MinValue;
+
+        int offset = 0;
+
+        foreach (EventColumnChunk chunk in _sealedChunks)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            ReadOnlySpan<int> sourceColumn = chunk.PoolIndexColumn(EventColumnField.Source);
+            ReadOnlySpan<int> statusColumn = chunk.PoolIndexColumn(EventColumnField.ResolutionStatus);
+            ReadOnlySpan<int> levelColumn = chunk.PoolIndexColumn(EventColumnField.Level);
+            ReadOnlySpan<int> idColumn = chunk.IdColumn;
+
+            for (int row = 0; row < sourceColumn.Length; row++)
+            {
+                if (rankByPhysical[offset + row] < 0) { continue; }
+
+                if (sourceColumn[row] != sourceIndex) { continue; }
+
+                EventResolutionStatus status = StatusOf(statusColumn[row]);
+                int id = idColumn[row];
+
+                byId.TryGetValue(id, out var currentId);
+                byId[id] = currentId.WithStatus(status);
+
+                int slot = SlotOf(levelColumn[row]);
+                byLevelSlot[slot] = byLevelSlot[slot].WithStatus(status);
+            }
+
+            offset += chunk.RowCount;
+        }
+
+        for (int index = _sealedCount; index < Count; index++)
+        {
+            if (rankByPhysical[index] < 0) { continue; }
+
+            ResolvedEvent pending = Pending(index);
+
+            if (!string.Equals(pending.Source, source, StringComparison.Ordinal)) { continue; }
+
+            byId.TryGetValue(pending.Id, out var currentId);
+            byId[pending.Id] = currentId.WithStatus(pending.ResolutionStatus);
+
+            int slot = LevelSeverity.Slot(LevelSeverity.FromLevelName(pending.Level));
+            byLevelSlot[slot] = byLevelSlot[slot].WithStatus(pending.ResolutionStatus);
+        }
+
+        return;
+
+        EventResolutionStatus StatusOf(int statusIndex) =>
+            statusIndex == noProviderIndex ? EventResolutionStatus.NoProvider :
+            statusIndex == noMessageIndex ? EventResolutionStatus.NoMessage :
+            statusIndex == failedIndex ? EventResolutionStatus.Failed :
+            EventResolutionStatus.Resolved;
+
+        int SlotOf(int levelPoolIndex) =>
+            levelPoolIndex == criticalIndex ? (int)SeverityLevel.Critical :
+            levelPoolIndex == errorIndex ? (int)SeverityLevel.Error :
+            levelPoolIndex == warningIndex ? (int)SeverityLevel.Warning :
+            levelPoolIndex == informationIndex ? (int)SeverityLevel.Information :
+            levelPoolIndex == verboseIndex ? (int)SeverityLevel.Verbose : 0;
+    }
+
     internal void CountSeverity(ReadOnlySpan<int> rankByPhysical, int[] slotCounts, CancellationToken cancellationToken)
     {
         // Severity totals over the survivor projection: the un-bucketed sibling of BucketTimeTicksBySeverity. Resolve the
@@ -1825,6 +1962,7 @@ public sealed class EventColumnStore
         EventColumnField.ComputerName => pending.ComputerName,
         EventColumnField.OwningLog => pending.OwningLog,
         EventColumnField.UserDisplayName => pending.UserDisplayName,
+        EventColumnField.ResolutionStatus => ResolutionStatusTokens.Format(pending.ResolutionStatus),
         _ => throw new ArgumentOutOfRangeException(nameof(field), field, "Field is not a supported group-by dimension.")
     };
 
@@ -2012,6 +2150,7 @@ public sealed class EventColumnStore
             Level = PoolGet(chunk.RowPoolIndex(EventColumnField.Level, row)) ?? string.Empty,
             LogName = PoolGet(chunk.RowPoolIndex(EventColumnField.LogName, row)) ?? string.Empty,
             Opcode = PoolGet(chunk.RowPoolIndex(EventColumnField.Opcode, row)) ?? string.Empty,
+            ResolutionStatus = ResolutionStatusTokens.Classify(PoolGet(chunk.RowPoolIndex(EventColumnField.ResolutionStatus, row)) ?? string.Empty),
             Source = PoolGet(chunk.RowPoolIndex(EventColumnField.Source, row)) ?? string.Empty,
             TaskCategory = PoolGet(chunk.RowPoolIndex(EventColumnField.TaskCategory, row)) ?? string.Empty,
             UserId = userIdPoolIndex < 0 ? null : new SecurityIdentifier(PoolGet(userIdPoolIndex)!),

--- a/src/EventLogExpert.Eventing/Common/Events/EventColumnStoreReader.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/EventColumnStoreReader.cs
@@ -497,6 +497,33 @@ internal sealed class EventColumnStoreReader : IEventColumnReader
         _store.CountFieldValues(rankByPhysical, ToColumnField(field), counts, cancellationToken);
     }
 
+    public void CountResolutionBySource(
+        ReadOnlySpan<int> rankByPhysical,
+        IDictionary<string, ProviderResolutionCounts> counts,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(counts);
+        ArgumentOutOfRangeException.ThrowIfNotEqual(rankByPhysical.Length, Count);
+
+        _store.CountResolutionBySource(rankByPhysical, counts, cancellationToken);
+    }
+
+    public void CountResolutionDetailForSource(
+        ReadOnlySpan<int> rankByPhysical,
+        string source,
+        IDictionary<int, ProviderResolutionCounts> byId,
+        ProviderResolutionCounts[] byLevelSlot,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(byId);
+        ArgumentNullException.ThrowIfNull(byLevelSlot);
+        ArgumentOutOfRangeException.ThrowIfNotEqual(byLevelSlot.Length, LevelSeverity.SlotCount);
+        ArgumentOutOfRangeException.ThrowIfNotEqual(rankByPhysical.Length, Count);
+
+        _store.CountResolutionDetailForSource(rankByPhysical, source, byId, byLevelSlot, cancellationToken);
+    }
+
     public void CountSeverity(ReadOnlySpan<int> rankByPhysical, int[] slotCounts, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(slotCounts);
@@ -599,6 +626,8 @@ internal sealed class EventColumnStoreReader : IEventColumnReader
                 return PooledField(EventColumnField.OwningLog, index);
             case EventFieldId.Opcode:
                 return PooledField(EventColumnField.Opcode, index);
+            case EventFieldId.ResolutionStatus:
+                return PooledField(EventColumnField.ResolutionStatus, index);
             case EventFieldId.RelatedActivityId:
             {
                 Guid value = _store.RawRelatedActivityId(index, out bool hasValue);
@@ -717,6 +746,7 @@ internal sealed class EventColumnStoreReader : IEventColumnReader
         EventColumnField.UserId => pending.UserId?.Value,
         EventColumnField.Opcode => pending.Opcode,
         EventColumnField.UserDisplayName => pending.UserDisplayName,
+        EventColumnField.ResolutionStatus => ResolutionStatusTokens.Format(pending.ResolutionStatus),
         _ => throw new ArgumentOutOfRangeException(nameof(column), column, null)
     };
 
@@ -733,6 +763,7 @@ internal sealed class EventColumnStoreReader : IEventColumnReader
         EventFieldId.OwningLog => EventColumnField.OwningLog,
         EventFieldId.Opcode => EventColumnField.Opcode,
         EventFieldId.UserDisplayName => EventColumnField.UserDisplayName,
+        EventFieldId.ResolutionStatus => EventColumnField.ResolutionStatus,
         _ => throw new ArgumentOutOfRangeException(nameof(field), field, "Not a single pooled string column.")
     };
 
@@ -755,6 +786,7 @@ internal sealed class EventColumnStoreReader : IEventColumnReader
             AddPendingValue(pending.UserId?.Value, indexByValue, extras);
             AddPendingValue(pending.UserDisplayName, indexByValue, extras);
             AddPendingValue(pending.Opcode, indexByValue, extras);
+            AddPendingValue(ResolutionStatusTokens.Format(pending.ResolutionStatus), indexByValue, extras);
         }
 
         return new PendingPoolExtension(_store.PoolDistinctCount, [.. extras], indexByValue);

--- a/src/EventLogExpert.Eventing/Common/Events/EventFieldId.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/EventFieldId.cs
@@ -24,5 +24,6 @@ public enum EventFieldId
     Opcode,
     RelatedActivityId,
     UserDisplayName,
-    UserIdSddl
+    UserIdSddl,
+    ResolutionStatus
 }

--- a/src/EventLogExpert.Eventing/Common/Events/EventResolutionStatus.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/EventResolutionStatus.cs
@@ -1,0 +1,12 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Eventing.Common.Events;
+
+public enum EventResolutionStatus
+{
+    Resolved,
+    NoProvider,
+    NoMessage,
+    Failed
+}

--- a/src/EventLogExpert.Eventing/Common/Events/IEventColumnReader.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/IEventColumnReader.cs
@@ -229,6 +229,10 @@ public interface IEventColumnReader
     /// </summary>
     void CountFieldValues(ReadOnlySpan<int> rankByPhysical, EventFieldId field, IDictionary<string, int> counts, CancellationToken cancellationToken);
 
+    void CountResolutionBySource(ReadOnlySpan<int> rankByPhysical, IDictionary<string, ProviderResolutionCounts> counts, CancellationToken cancellationToken);
+
+    void CountResolutionDetailForSource(ReadOnlySpan<int> rankByPhysical, string source, IDictionary<int, ProviderResolutionCounts> byId, ProviderResolutionCounts[] byLevelSlot, CancellationToken cancellationToken);
+
     void CountSeverity(ReadOnlySpan<int> rankByPhysical, int[] slotCounts, CancellationToken cancellationToken);
 
     EventDataFieldEnumerator EnumerateEventData(EventLocator locator);

--- a/src/EventLogExpert.Eventing/Common/Events/ProviderResolutionCounts.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/ProviderResolutionCounts.cs
@@ -1,0 +1,24 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Eventing.Common.Events;
+
+public readonly record struct ProviderResolutionCounts(int Total, int Resolved, int NoProvider, int NoMessage, int Failed)
+{
+    public int Unresolved => NoProvider + NoMessage + Failed;
+
+    public ProviderResolutionCounts Add(ProviderResolutionCounts other) => new(
+        Total + other.Total,
+        Resolved + other.Resolved,
+        NoProvider + other.NoProvider,
+        NoMessage + other.NoMessage,
+        Failed + other.Failed);
+
+    public ProviderResolutionCounts WithStatus(EventResolutionStatus status) => status switch
+    {
+        EventResolutionStatus.NoProvider => this with { Total = Total + 1, NoProvider = NoProvider + 1 },
+        EventResolutionStatus.NoMessage => this with { Total = Total + 1, NoMessage = NoMessage + 1 },
+        EventResolutionStatus.Failed => this with { Total = Total + 1, Failed = Failed + 1 },
+        _ => this with { Total = Total + 1, Resolved = Resolved + 1 }
+    };
+}

--- a/src/EventLogExpert.Eventing/Common/Events/ResolutionStatusTokens.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/ResolutionStatusTokens.cs
@@ -1,0 +1,42 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Diagnostics;
+
+namespace EventLogExpert.Eventing.Common.Events;
+
+/// <summary>
+///     The frozen, human-readable strings that <see cref="EventResolutionStatus" /> is stored and filtered as;
+///     changing one breaks every saved filter that references it.
+/// </summary>
+public static class ResolutionStatusTokens
+{
+    public const string Failed = "Resolution error";
+    public const string NoMessage = "No message match";
+    public const string NoProvider = "No provider metadata";
+    public const string Resolved = "Resolved";
+
+    public static EventResolutionStatus Classify(string token)
+    {
+        switch (token)
+        {
+            case NoProvider: return EventResolutionStatus.NoProvider;
+            case NoMessage: return EventResolutionStatus.NoMessage;
+            case Failed: return EventResolutionStatus.Failed;
+            case Resolved:
+            case "":
+                return EventResolutionStatus.Resolved;
+            default:
+                Debug.Assert(false, $"Unrecognized {nameof(EventResolutionStatus)} token: '{token}'.");
+                return EventResolutionStatus.Resolved;
+        }
+    }
+
+    public static string Format(EventResolutionStatus status) => status switch
+    {
+        EventResolutionStatus.NoProvider => NoProvider,
+        EventResolutionStatus.NoMessage => NoMessage,
+        EventResolutionStatus.Failed => Failed,
+        _ => Resolved
+    };
+}

--- a/src/EventLogExpert.Eventing/Common/Events/ResolvedEvent.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/ResolvedEvent.cs
@@ -44,6 +44,8 @@ public sealed record ResolvedEvent(
 
     public Guid? RelatedActivityId { get; init; }
 
+    public EventResolutionStatus ResolutionStatus { get; init; } = EventResolutionStatus.Resolved;
+
     public string Source { get; init; } = string.Empty;
 
     public string TaskCategory { get; init; } = string.Empty;

--- a/src/EventLogExpert.Eventing/Common/Events/ResolvedEventFieldReader.cs
+++ b/src/EventLogExpert.Eventing/Common/Events/ResolvedEventFieldReader.cs
@@ -32,6 +32,7 @@ internal static class ResolvedEventFieldReader
             EventFieldId.Xml => EventFieldValue.FromProperty(resolvedEvent.Xml),
             EventFieldId.OwningLog => EventFieldValue.FromProperty(resolvedEvent.OwningLog),
             EventFieldId.Opcode => EventFieldValue.FromProperty(resolvedEvent.Opcode),
+            EventFieldId.ResolutionStatus => EventFieldValue.FromProperty(ResolutionStatusTokens.Format(resolvedEvent.ResolutionStatus)),
             EventFieldId.RelatedActivityId => resolvedEvent.RelatedActivityId is { } relatedActivityId ?
                 EventFieldValue.FromProperty(relatedActivityId) : Absent,
             _ => Absent

--- a/src/EventLogExpert.Eventing/Resolvers/DescriptionFormatter.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/DescriptionFormatter.cs
@@ -1,6 +1,7 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Eventing.Common.Events;
 using EventLogExpert.Eventing.Interop;
 using EventLogExpert.Eventing.Readers;
 using EventLogExpert.Logging.Abstractions;
@@ -38,7 +39,7 @@ internal sealed partial class DescriptionFormatter(
     private readonly Func<EventRecord, ProviderDetails?> _supplementalProvider = supplementalProvider;
     private readonly TemplateAnalyzer _templates = templates;
 
-    public string Resolve(
+    public ResolvedDescription Resolve(
         EventRecord eventRecord,
         ProviderDetails? primaryDetails,
         ProviderDetails? descriptionDetails,
@@ -51,7 +52,7 @@ internal sealed partial class DescriptionFormatter(
         {
             _logger?.Debug($"{nameof(Resolve)}: No provider details available - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, RecordId={eventRecord.RecordId}");
 
-            return DefaultNoProviderDescription;
+            return new(DefaultNoProviderDescription, EventResolutionStatus.NoProvider);
         }
 
         var properties = GetFormattedProperties(primaryInfo?.Metadata ?? default, eventRecord.Properties, descriptionDetails.Maps);
@@ -125,19 +126,26 @@ internal sealed partial class DescriptionFormatter(
         {
             _logger?.Debug($"{nameof(Resolve)}: Using single-property description fallback - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}");
 
-            return FormatDescription(properties, null, null);
+            var singleProperty = FormatDescription(properties, null, null);
+
+            return singleProperty with
+            {
+                Status = descriptionDetails.IsEmpty && (supplemental is null || supplemental.IsEmpty) ?
+                    EventResolutionStatus.NoProvider :
+                    EventResolutionStatus.NoMessage
+            };
         }
 
         if (descriptionDetails.IsEmpty && (supplemental is null || supplemental.IsEmpty))
         {
             _logger?.Debug($"{nameof(Resolve)}: No provider metadata available - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, Version={eventRecord.Version}, LogName={eventRecord.LogName}, RecordId={eventRecord.RecordId}, Keywords=0x{eventRecord.Keywords ?? 0:X16}");
 
-            return BuildNoMetadataFallbackDescription(eventRecord, properties);
+            return new(BuildNoMetadataFallbackDescription(eventRecord, properties), EventResolutionStatus.NoProvider);
         }
 
         _logger?.Debug($"{nameof(Resolve)}: No matching description found - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, Version={eventRecord.Version}, LogName={eventRecord.LogName}, RecordId={eventRecord.RecordId}");
 
-        return DefaultNoMatchingDescription;
+        return new(DefaultNoMatchingDescription, EventResolutionStatus.NoMessage);
     }
 
     private static string? BuildEventDataTail(List<string> properties)
@@ -406,7 +414,7 @@ internal sealed partial class DescriptionFormatter(
         return _cache?.GetOrAddDescription(systemMessage!) ?? systemMessage!;
     }
 
-    private string FormatDescription(
+    private ResolvedDescription FormatDescription(
         List<string> properties,
         string? descriptionTemplate,
         ProviderDetails? parameterSource)
@@ -416,18 +424,20 @@ internal sealed partial class DescriptionFormatter(
         if (string.IsNullOrWhiteSpace(descriptionTemplate))
         {
             // Single-property empty-template events can be literal descriptions; multi-property cases are not renderable.
-            return properties.Count == 1
-                ? properties[0].TrimEnd('\0', '\r', '\n')
-                : DefaultNoMatchingDescription;
+            string fallbackText = properties.Count == 1 ?
+                properties[0].TrimEnd('\0', '\r', '\n') :
+                DefaultNoMatchingDescription;
+
+            return new(fallbackText, EventResolutionStatus.NoMessage);
         }
 
         const int MaxStackAllocChars = 4096;
         int cleanupBufferSize = descriptionTemplate.Length * 2;
         char[]? cleanupRented = null;
 
-        Span<char> description = cleanupBufferSize <= MaxStackAllocChars
-            ? stackalloc char[cleanupBufferSize]
-            : (cleanupRented = ArrayPool<char>.Shared.Rent(cleanupBufferSize));
+        Span<char> description = cleanupBufferSize <= MaxStackAllocChars ?
+            stackalloc char[cleanupBufferSize] :
+            (cleanupRented = ArrayPool<char>.Shared.Rent(cleanupBufferSize));
 
         CleanupFormatting(descriptionTemplate, ref description, out int length);
 
@@ -439,7 +449,7 @@ internal sealed partial class DescriptionFormatter(
 
             if (cleanupRented is not null) { ArrayPool<char>.Shared.Return(cleanupRented); }
 
-            return _cache?.GetOrAddDescription(returnDescription) ?? returnDescription;
+            return new(_cache?.GetOrAddDescription(returnDescription) ?? returnDescription, EventResolutionStatus.Resolved);
         }
 
         char[] buffer = ArrayPool<char>.Shared.Rent(description.Length * 2);
@@ -547,7 +557,7 @@ internal sealed partial class DescriptionFormatter(
             returnDescription = new string(updatedDescription[..currentLength]);
 
             // Intern repeated formatted descriptions; the bounded cache prevents high-cardinality growth.
-            return _cache?.GetOrAddDescription(returnDescription) ?? returnDescription;
+            return new(_cache?.GetOrAddDescription(returnDescription) ?? returnDescription, EventResolutionStatus.Resolved);
         }
         catch (InvalidOperationException ex)
         {
@@ -555,13 +565,13 @@ internal sealed partial class DescriptionFormatter(
 
             returnDescription = description.ToString();
 
-            return _cache?.GetOrAddDescription(returnDescription) ?? returnDescription;
+            return new(_cache?.GetOrAddDescription(returnDescription) ?? returnDescription, EventResolutionStatus.Resolved);
         }
         catch (Exception ex)
         {
             _logger?.Warning($"{nameof(FormatDescription)}: Unexpected exception - PropertyCount={properties.Count}, Template={descriptionTemplate}, Exception={ex}");
 
-            return DefaultFailedDescription;
+            return new(DefaultFailedDescription, EventResolutionStatus.Failed);
         }
         finally
         {

--- a/src/EventLogExpert.Eventing/Resolvers/EventResolverBase.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/EventResolverBase.cs
@@ -143,11 +143,20 @@ public class EventResolverBase : IDisposable
         var (eventDataValues, eventDataSchema) = BuildEventData(eventRecord, primaryInfo);
         var userId = _cache?.GetOrAddSid(eventRecord.UserId) ?? eventRecord.UserId;
 
+        var resolvedDescription = _descriptions.Resolve(
+            eventRecord,
+            details,
+            descriptionDetails,
+            modernEvent,
+            supplemental,
+            supplementalModernEvent,
+            primaryInfo);
+
         return new(eventRecord.PathName, eventRecord.LogPathType)
         {
             ActivityId = eventRecord.ActivityId,
             ComputerName = _cache?.GetOrAddValue(eventRecord.ComputerName) ?? eventRecord.ComputerName,
-            Description = _descriptions.Resolve(eventRecord, details, descriptionDetails, modernEvent, supplemental, supplementalModernEvent, primaryInfo),
+            Description = resolvedDescription.Text,
             EventDataValues = eventDataValues,
             EventDataSchema = eventDataSchema,
             Id = eventRecord.Id,
@@ -158,6 +167,7 @@ public class EventResolverBase : IDisposable
             ProcessId = eventRecord.ProcessId,
             RecordId = eventRecord.RecordId,
             RelatedActivityId = eventRecord.RelatedActivityId,
+            ResolutionStatus = resolvedDescription.Status,
             Source = _cache?.GetOrAddValue(eventRecord.ProviderName) ?? eventRecord.ProviderName,
             TaskCategory = _taskKeywords.ResolveTaskName(eventRecord, details, modernEvent, supplemental, supplementalModernEvent),
             ThreadId = eventRecord.ThreadId,

--- a/src/EventLogExpert.Eventing/Resolvers/ResolvedDescription.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/ResolvedDescription.cs
@@ -1,0 +1,8 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+
+namespace EventLogExpert.Eventing.Resolvers;
+
+internal readonly record struct ResolvedDescription(string Text, EventResolutionStatus Status);

--- a/src/EventLogExpert.Filtering/Basic/BasicFilterDecomposer.cs
+++ b/src/EventLogExpert.Filtering/Basic/BasicFilterDecomposer.cs
@@ -311,6 +311,7 @@ internal static class BasicFilterDecomposer
             case ResolvedEventField.Xml: property = EventProperty.Xml; return true;
             case ResolvedEventField.LogName: property = EventProperty.LogName; return true;
             case ResolvedEventField.Opcode: property = EventProperty.Opcode; return true;
+            case ResolvedEventField.ResolutionStatus: property = EventProperty.ResolutionStatus; return true;
             case ResolvedEventField.RelatedActivityId: property = EventProperty.RelatedActivityId; return true;
             case ResolvedEventField.ComputerName:
             case ResolvedEventField.RecordId:

--- a/src/EventLogExpert.Filtering/Common/Filtering/EventProperty.cs
+++ b/src/EventLogExpert.Filtering/Common/Filtering/EventProperty.cs
@@ -23,5 +23,6 @@ public enum EventProperty
     [EnumMember(Value = "User Data")] UserData,
     Opcode,
     [EnumMember(Value = "Related Activity ID")] RelatedActivityId,
-    [EnumMember(Value = "User")] UserDisplayName
+    [EnumMember(Value = "User")] UserDisplayName,
+    [EnumMember(Value = "Resolution Status")] ResolutionStatus
 }

--- a/src/EventLogExpert.Filtering/Common/Filtering/FilterPropertyConstraints.cs
+++ b/src/EventLogExpert.Filtering/Common/Filtering/FilterPropertyConstraints.cs
@@ -38,5 +38,6 @@ public static class FilterPropertyConstraints
             or EventProperty.TaskCategory
             or EventProperty.UserId
             or EventProperty.UserDisplayName
-            or EventProperty.Opcode;
+            or EventProperty.Opcode
+            or EventProperty.ResolutionStatus;
 }

--- a/src/EventLogExpert.Filtering/Emit/ColumnEmitter.cs
+++ b/src/EventLogExpert.Filtering/Emit/ColumnEmitter.cs
@@ -67,6 +67,7 @@ internal static class ColumnEmitter
             ResolvedEventField.UserDisplayName => EventFieldId.UserDisplayName,
             ResolvedEventField.TaskCategory => EventFieldId.TaskCategory,
             ResolvedEventField.Opcode => EventFieldId.Opcode,
+            ResolvedEventField.ResolutionStatus => EventFieldId.ResolutionStatus,
             ResolvedEventField.Xml => EventFieldId.Xml,
             _ => throw new EmitException($"Cannot emit Contains for field '{field}'.")
         };
@@ -443,6 +444,7 @@ internal static class ColumnEmitter
             ResolvedEventField.Source => EmitMultiEqualsString(EventFieldId.Source, node.Values),
             ResolvedEventField.TaskCategory => EmitMultiEqualsString(EventFieldId.TaskCategory, node.Values),
             ResolvedEventField.Opcode => EmitMultiEqualsString(EventFieldId.Opcode, node.Values),
+            ResolvedEventField.ResolutionStatus => EmitMultiEqualsString(EventFieldId.ResolutionStatus, node.Values),
             ResolvedEventField.Xml => EmitMultiEqualsString(EventFieldId.Xml, node.Values),
             _ => throw new EmitException($"Cannot emit MultiEquals for field '{node.Field}'.")
         };
@@ -691,6 +693,7 @@ internal static class ColumnEmitter
             case ResolvedEventField.Source:
             case ResolvedEventField.TaskCategory:
             case ResolvedEventField.Opcode:
+            case ResolvedEventField.ResolutionStatus:
             case ResolvedEventField.Xml:
                 // String properties default to string.Empty and are never null; the row emits a constant without
                 // reading the field, so the column does the same.
@@ -740,6 +743,7 @@ internal static class ColumnEmitter
             ResolvedEventField.UserDisplayName => EmitUserStringCompare(op, value),
             ResolvedEventField.TaskCategory => FilterCompare.StringOrdinal(EventFieldId.TaskCategory, op, value),
             ResolvedEventField.Opcode => FilterCompare.StringOrdinal(EventFieldId.Opcode, op, value),
+            ResolvedEventField.ResolutionStatus => FilterCompare.StringOrdinal(EventFieldId.ResolutionStatus, op, value),
             ResolvedEventField.Xml => FilterCompare.StringOrdinal(EventFieldId.Xml, op, value),
             ResolvedEventField.UserId => FilterCompare.UserIdString(op, value),
             ResolvedEventField.Id => FilterCompare.StringOrdinal(EventFieldId.Id, op, value),

--- a/src/EventLogExpert.Filtering/Emit/Emitter.cs
+++ b/src/EventLogExpert.Filtering/Emit/Emitter.cs
@@ -188,6 +188,7 @@ internal static class Emitter
             ResolvedEventField.UserDisplayName => EmitUserContains(needle, comparison, negated: false),
             ResolvedEventField.TaskCategory => resolvedEvent => resolvedEvent.TaskCategory.Contains(needle, comparison),
             ResolvedEventField.Opcode => resolvedEvent => resolvedEvent.Opcode.Contains(needle, comparison),
+            ResolvedEventField.ResolutionStatus => resolvedEvent => ResolutionStatusTokens.Format(resolvedEvent.ResolutionStatus).Contains(needle, comparison),
             ResolvedEventField.Xml => resolvedEvent => resolvedEvent.Xml.Contains(needle, comparison),
             _ => throw new EmitException($"Cannot emit Contains for field '{node.Field}'.")
         };
@@ -423,6 +424,7 @@ internal static class Emitter
             ResolvedEventField.Source => static resolvedEvent => resolvedEvent.Source,
             ResolvedEventField.TaskCategory => static resolvedEvent => resolvedEvent.TaskCategory,
             ResolvedEventField.Opcode => static resolvedEvent => resolvedEvent.Opcode,
+            ResolvedEventField.ResolutionStatus => static resolvedEvent => ResolutionStatusTokens.Format(resolvedEvent.ResolutionStatus),
             ResolvedEventField.Xml => static resolvedEvent => resolvedEvent.Xml,
             _ => throw new EmitException($"Cannot emit MultiContains for field '{node.Field}'.")
         };
@@ -533,6 +535,7 @@ internal static class Emitter
             ResolvedEventField.Source => EmitMultiEqualsString(static resolvedEvent => resolvedEvent.Source, node.Values),
             ResolvedEventField.TaskCategory => EmitMultiEqualsString(static resolvedEvent => resolvedEvent.TaskCategory, node.Values),
             ResolvedEventField.Opcode => EmitMultiEqualsString(static resolvedEvent => resolvedEvent.Opcode, node.Values),
+            ResolvedEventField.ResolutionStatus => EmitMultiEqualsString(static resolvedEvent => ResolutionStatusTokens.Format(resolvedEvent.ResolutionStatus), node.Values),
             ResolvedEventField.Xml => EmitMultiEqualsString(static resolvedEvent => resolvedEvent.Xml, node.Values),
             _ => throw new EmitException($"Cannot emit MultiEquals for field '{node.Field}'.")
         };
@@ -777,6 +780,7 @@ internal static class Emitter
             case ResolvedEventField.Source:
             case ResolvedEventField.TaskCategory:
             case ResolvedEventField.Opcode:
+            case ResolvedEventField.ResolutionStatus:
             case ResolvedEventField.Xml:
                 // ResolvedEvent string properties default to string.Empty and writer paths never assign null.
                 return op switch
@@ -877,6 +881,7 @@ internal static class Emitter
             ResolvedEventField.UserDisplayName => EmitUserStringCompare(op, value),
             ResolvedEventField.TaskCategory => EmitDirectStringCompare(static resolvedEvent => resolvedEvent.TaskCategory, op, value),
             ResolvedEventField.Opcode => EmitDirectStringCompare(static resolvedEvent => resolvedEvent.Opcode, op, value),
+            ResolvedEventField.ResolutionStatus => EmitDirectStringCompare(static resolvedEvent => ResolutionStatusTokens.Format(resolvedEvent.ResolutionStatus), op, value),
             ResolvedEventField.Xml => EmitDirectStringCompare(static resolvedEvent => resolvedEvent.Xml, op, value),
             ResolvedEventField.UserId => EmitUserIdStringCompare(op, value),
             ResolvedEventField.Id => EmitIntegerStringCompare(

--- a/src/EventLogExpert.Filtering/EventData/EventLogDataQueryExtensions.cs
+++ b/src/EventLogExpert.Filtering/EventData/EventLogDataQueryExtensions.cs
@@ -58,6 +58,7 @@ internal static class EventLogDataQueryExtensions
                 EventProperty.Source => events.Select(e => e.Source).Distinct(),
                 EventProperty.TaskCategory => events.Select(e => e.TaskCategory).Distinct(),
                 EventProperty.Opcode => events.Select(e => e.Opcode).Distinct(),
+                EventProperty.ResolutionStatus => events.Select(e => ResolutionStatusTokens.Format(e.ResolutionStatus)).Distinct(),
                 EventProperty.UserDisplayName => events.Select(e => e.UserDisplayName).Where(name => name.Length != 0).Distinct(),
                 EventProperty.LogName => events.Select(e => e.LogName).Distinct(),
                 _ => [],

--- a/src/EventLogExpert.Filtering/EventData/EventPropertyValuesCache.cs
+++ b/src/EventLogExpert.Filtering/EventData/EventPropertyValuesCache.cs
@@ -168,6 +168,7 @@ public static class EventPropertyValuesCache
         EventProperty.Source or
         EventProperty.TaskCategory or
         EventProperty.Opcode or
+        EventProperty.ResolutionStatus or
         EventProperty.UserDisplayName or
         EventProperty.LogName;
 }

--- a/src/EventLogExpert.Filtering/Lowering/Lowerer.cs
+++ b/src/EventLogExpert.Filtering/Lowering/Lowerer.cs
@@ -200,7 +200,8 @@ internal static class Lowerer
             or ResolvedEventField.TaskCategory
             or ResolvedEventField.UserId
             or ResolvedEventField.UserDisplayName
-            or ResolvedEventField.Xml;
+            or ResolvedEventField.Xml
+            or ResolvedEventField.ResolutionStatus;
 
     private static bool IsNullCheckOnIdentifier(BinarySyntax bin, string identifier)
     {

--- a/src/EventLogExpert.Filtering/Lowering/PropertyResolver.cs
+++ b/src/EventLogExpert.Filtering/Lowering/PropertyResolver.cs
@@ -65,6 +65,11 @@ internal static class PropertyResolver
                 literalKind = TypedLiteralKind.String;
 
                 return true;
+            case "RESOLUTIONSTATUS":
+                field = ResolvedEventField.ResolutionStatus;
+                literalKind = TypedLiteralKind.String;
+
+                return true;
             case "PROCESSID":
                 field = ResolvedEventField.ProcessId;
                 literalKind = TypedLiteralKind.Int;

--- a/src/EventLogExpert.Filtering/Lowering/ResolvedEventField.cs
+++ b/src/EventLogExpert.Filtering/Lowering/ResolvedEventField.cs
@@ -30,5 +30,6 @@ internal enum ResolvedEventField
     TimeCreated,
     UserId,
     UserDisplayName,
-    Xml
+    Xml,
+    ResolutionStatus
 }

--- a/src/EventLogExpert.Runtime/DependencyInjection/RuntimeServiceCollectionExtensions.cs
+++ b/src/EventLogExpert.Runtime/DependencyInjection/RuntimeServiceCollectionExtensions.cs
@@ -35,6 +35,7 @@ using EventLogExpert.Runtime.Scenarios;
 using EventLogExpert.Runtime.Scenarios.Favorites;
 using EventLogExpert.Runtime.Settings;
 using EventLogExpert.Runtime.StatusBar;
+using EventLogExpert.Runtime.ResolutionCoverage;
 using EventLogExpert.Runtime.Stats;
 using EventLogExpert.Runtime.Update;
 using EventLogExpert.Runtime.Update.Deployment;
@@ -132,6 +133,7 @@ public static class RuntimeServiceCollectionExtensions
             services.AddSingleton<IHistogramCommands, HistogramCommands>();
             services.AddSingleton<IStatsCommands, StatsCommands>();
             services.AddSingleton<IStatsService, StatsService>();
+            services.AddSingleton<IResolutionCoverageService, ResolutionCoverageService>();
             services.AddSingleton<ILogTableCommands, LogTableCommands>();
             services.AddSingleton<IScenarioFavoriteCommands, ScenarioFavoriteCommands>();
 

--- a/src/EventLogExpert.Runtime/DetailsPane/DetailsReaderFormatter.cs
+++ b/src/EventLogExpert.Runtime/DetailsPane/DetailsReaderFormatter.cs
@@ -181,6 +181,12 @@ public static class DetailsReaderFormatter
 
         AddIfPresent(properties, "Task Category", @event.TaskCategory);
         AddIfPresent(properties, "Opcode", @event.Opcode);
+
+        if (@event.ResolutionStatus != EventResolutionStatus.Resolved)
+        {
+            properties.Add(new DetailsProperty("Resolution Status", ResolutionStatusTokens.Format(@event.ResolutionStatus)));
+        }
+
         AddIfPresent(properties, "Keywords", @event.KeywordsDisplayName);
 
         if (@event.RecordId is { } recordId) { properties.Add(new DetailsProperty("Record ID", recordId.ToString(CultureInfo.InvariantCulture))); }

--- a/src/EventLogExpert.Runtime/Export/EventTableExporter.cs
+++ b/src/EventLogExpert.Runtime/Export/EventTableExporter.cs
@@ -3,7 +3,6 @@
 
 using EventLogExpert.Eventing.Common.Events;
 using EventLogExpert.Runtime.LogTable;
-using System.Buffers;
 using System.Runtime.CompilerServices;
 
 namespace EventLogExpert.Runtime.Export;
@@ -11,8 +10,6 @@ namespace EventLogExpert.Runtime.Export;
 internal sealed class EventTableExporter(ITabularExportWriter writer) : IEventTableExporter
 {
     private const string ExportDateTimeFormat = "yyyy-MM-dd HH:mm:ss";
-
-    private static readonly SearchValues<char> s_formulaInjectionTriggers = SearchValues.Create("=+-@");
 
     public async Task ExportAsync(
         Stream destination,
@@ -49,22 +46,6 @@ internal sealed class EventTableExporter(ITabularExportWriter writer) : IEventTa
             .ConfigureAwait(false);
     }
 
-    private static string NeutralizeCsvFormula(string value)
-    {
-        if (value.Length == 0) { return value; }
-
-        if (value[0] is '\t' or '\r') { return "'" + value; }
-
-        foreach (char character in value)
-        {
-            if (char.IsWhiteSpace(character)) { continue; }
-
-            return s_formulaInjectionTriggers.Contains(character) ? "'" + value : value;
-        }
-
-        return value;
-    }
-
     private static async IAsyncEnumerable<IReadOnlyList<string?>> ProjectRows(
         IEventColumnView events,
         IReadOnlyList<ColumnName> columns,
@@ -87,14 +68,14 @@ internal sealed class EventTableExporter(ITabularExportWriter writer) : IEventTa
             for (int i = 0; i < columns.Count; i++)
             {
                 string cell = EventTableColumnFormatter.GetCellText(@event, columns[i], timeZone, ExportDateTimeFormat);
-                cells[i] = neutralizeCsvFormula ? NeutralizeCsvFormula(cell) : cell;
+                cells[i] = neutralizeCsvFormula ? TabularCellSanitizer.NeutralizeFormula(cell) : cell;
             }
 
             if (includeDescription)
             {
                 cells[columns.Count] =
                     neutralizeCsvFormula ?
-                        NeutralizeCsvFormula(@event.Description) :
+                        TabularCellSanitizer.NeutralizeFormula(@event.Description) :
                         @event.Description;
             }
 

--- a/src/EventLogExpert.Runtime/Export/TabularCellSanitizer.cs
+++ b/src/EventLogExpert.Runtime/Export/TabularCellSanitizer.cs
@@ -1,0 +1,30 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Buffers;
+
+namespace EventLogExpert.Runtime.Export;
+
+// Neutralizes spreadsheet formula injection for tabular exports (CSV, TSV): a cell whose first non-whitespace character
+// is a formula trigger (= + - @) or a leading tab/CR is prefixed with an apostrophe so a spreadsheet treats it as text.
+// Shared by the event-table CSV exporter and the coverage-table TSV clipboard copy.
+internal static class TabularCellSanitizer
+{
+    private static readonly SearchValues<char> s_formulaInjectionTriggers = SearchValues.Create("=+-@");
+
+    public static string NeutralizeFormula(string value)
+    {
+        if (value.Length == 0) { return value; }
+
+        if (value[0] is '\t' or '\r') { return "'" + value; }
+
+        foreach (char character in value)
+        {
+            if (char.IsWhiteSpace(character)) { continue; }
+
+            return s_formulaInjectionTriggers.Contains(character) ? "'" + value : value;
+        }
+
+        return value;
+    }
+}

--- a/src/EventLogExpert.Runtime/FilterLenses/FilterLensFactory.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/FilterLensFactory.cs
@@ -171,6 +171,7 @@ internal static class FilterLensFactory
         EventProperty.Id => "Event ID",
         EventProperty.TaskCategory => "Task Category",
         EventProperty.UserDisplayName => "User",
+        EventProperty.ResolutionStatus => "Resolution Status",
         _ => property.ToString()
     };
 

--- a/src/EventLogExpert.Runtime/LogTable/EmptyColumnView.cs
+++ b/src/EventLogExpert.Runtime/LogTable/EmptyColumnView.cs
@@ -156,6 +156,14 @@ internal sealed class EmptyColumnView : IEventColumnView
 
     public void CountFieldValues(EventFieldId field, IDictionary<string, int> counts, CancellationToken cancellationToken) { }
 
+    public void CountResolutionBySource(IDictionary<string, ProviderResolutionCounts> counts, CancellationToken cancellationToken) { }
+
+    public void CountResolutionDetailForSource(
+        string source,
+        IDictionary<int, ProviderResolutionCounts> byId,
+        ProviderResolutionCounts[] byLevelSlot,
+        CancellationToken cancellationToken) { }
+
     public void CountSeverity(int[] slotCounts, CancellationToken cancellationToken) { }
 
     public byte[] EnsureHighlightWinners(

--- a/src/EventLogExpert.Runtime/LogTable/IEventColumnView.cs
+++ b/src/EventLogExpert.Runtime/LogTable/IEventColumnView.cs
@@ -146,6 +146,14 @@ public interface IEventColumnView
 
     void CountFieldValues(EventFieldId field, IDictionary<string, int> counts, CancellationToken cancellationToken);
 
+    void CountResolutionBySource(IDictionary<string, ProviderResolutionCounts> counts, CancellationToken cancellationToken);
+
+    void CountResolutionDetailForSource(
+        string source,
+        IDictionary<int, ProviderResolutionCounts> byId,
+        ProviderResolutionCounts[] byLevelSlot,
+        CancellationToken cancellationToken);
+
     void CountSeverity(int[] slotCounts, CancellationToken cancellationToken);
 
     byte[] EnsureHighlightWinners(

--- a/src/EventLogExpert.Runtime/LogTable/OrderedView/CombinedOrderedColumnView.cs
+++ b/src/EventLogExpert.Runtime/LogTable/OrderedView/CombinedOrderedColumnView.cs
@@ -471,6 +471,30 @@ internal sealed class CombinedOrderedColumnView : IEventColumnView
         }
     }
 
+    public void CountResolutionBySource(IDictionary<string, ProviderResolutionCounts> counts, CancellationToken cancellationToken)
+    {
+        Partition partition = GetPartition();
+
+        for (int slot = 0; slot < _readers.Length; slot++)
+        {
+            _readers[slot].CountResolutionBySource(partition.RankByPhysical[slot], counts, cancellationToken);
+        }
+    }
+
+    public void CountResolutionDetailForSource(
+        string source,
+        IDictionary<int, ProviderResolutionCounts> byId,
+        ProviderResolutionCounts[] byLevelSlot,
+        CancellationToken cancellationToken)
+    {
+        Partition partition = GetPartition();
+
+        for (int slot = 0; slot < _readers.Length; slot++)
+        {
+            _readers[slot].CountResolutionDetailForSource(partition.RankByPhysical[slot], source, byId, byLevelSlot, cancellationToken);
+        }
+    }
+
     public void CountSeverity(int[] slotCounts, CancellationToken cancellationToken)
     {
         Partition partition = GetPartition();

--- a/src/EventLogExpert.Runtime/LogTable/OrderedView/OrderedColumnView.cs
+++ b/src/EventLogExpert.Runtime/LogTable/OrderedView/OrderedColumnView.cs
@@ -288,6 +288,16 @@ internal sealed class OrderedColumnView : IEventColumnView
     public void CountFieldValues(EventFieldId field, IDictionary<string, int> counts, CancellationToken cancellationToken) =>
         _reader.CountFieldValues(RankByPhysical(), field, counts, cancellationToken);
 
+    public void CountResolutionBySource(IDictionary<string, ProviderResolutionCounts> counts, CancellationToken cancellationToken) =>
+        _reader.CountResolutionBySource(RankByPhysical(), counts, cancellationToken);
+
+    public void CountResolutionDetailForSource(
+        string source,
+        IDictionary<int, ProviderResolutionCounts> byId,
+        ProviderResolutionCounts[] byLevelSlot,
+        CancellationToken cancellationToken) =>
+        _reader.CountResolutionDetailForSource(RankByPhysical(), source, byId, byLevelSlot, cancellationToken);
+
     public void CountSeverity(int[] slotCounts, CancellationToken cancellationToken) =>
         _reader.CountSeverity(RankByPhysical(), slotCounts, cancellationToken);
 

--- a/src/EventLogExpert.Runtime/LogTable/RawEventCountReducers.cs
+++ b/src/EventLogExpert.Runtime/LogTable/RawEventCountReducers.cs
@@ -2,33 +2,30 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Eventing.Common.Events;
 using EventLogExpert.Runtime.EventLog;
 using Fluxor;
 using System.Collections.Immutable;
 
 namespace EventLogExpert.Runtime.LogTable;
 
-// Mirrors RawEventStoreReducers' FULL lifecycle so RawEventCountState.Total stays equal to the sum of the raw
-// store's per-log counts: AddTable seeds 0, CloseLog removes, CloseAll resets, IngestRawEvents replaces/adds by
-// mode. The same open-log guard (skip ids not currently present) prevents a stale post-close ingest from
-// resurrecting a count.
 internal sealed class RawEventCountReducers
 {
     [ReducerMethod]
     public static RawEventCountState ReduceAddTable(RawEventCountState state, AddTableAction action) =>
-        state with { ByLog = state.ByLog.SetItem(action.LogData.Id, 0) };
+        state with { ByLog = state.ByLog.SetItem(action.LogData.Id, default) };
 
     [ReducerMethod(typeof(CloseAllLogsAction))]
     public static RawEventCountState ReduceCloseAll(RawEventCountState state) =>
-        state.ByLog.IsEmpty
-            ? state
-            : state with { ByLog = ImmutableDictionary<EventLogId, int>.Empty };
+        state.ByLog.IsEmpty ?
+            state :
+            state with { ByLog = ImmutableDictionary<EventLogId, ProviderResolutionCounts>.Empty };
 
     [ReducerMethod]
     public static RawEventCountState ReduceCloseLog(RawEventCountState state, CloseLogAction action) =>
-        state.ByLog.ContainsKey(action.LogId)
-            ? state with { ByLog = state.ByLog.Remove(action.LogId) }
-            : state;
+        state.ByLog.ContainsKey(action.LogId) ?
+            state with { ByLog = state.ByLog.Remove(action.LogId) } :
+            state;
 
     [ReducerMethod]
     public static RawEventCountState ReduceIngestRawEvents(RawEventCountState state, IngestRawEventsAction action)
@@ -42,14 +39,16 @@ internal sealed class RawEventCountReducers
         {
             if (!builder.TryGetValue(logId, out var existing)) { continue; }
 
+            var batch = CountBatch(events);
+
             var updated = action.Mode switch
             {
-                RawIngestMode.Replace => events.Count,
-                RawIngestMode.Append or RawIngestMode.Prepend => existing + events.Count,
+                RawIngestMode.Replace => batch,
+                RawIngestMode.Append or RawIngestMode.Prepend => existing.Add(batch),
                 _ => throw new ArgumentOutOfRangeException(nameof(action), action.Mode, "Unknown raw ingest mode.")
             };
 
-            if (updated == existing) { continue; }
+            if (updated.Equals(existing)) { continue; }
 
             builder[logId] = updated;
             changed = true;
@@ -63,9 +62,11 @@ internal sealed class RawEventCountReducers
     {
         if (!state.ByLog.TryGetValue(action.LogData.Id, out var existing)) { return state; }
 
-        return existing == action.Events.Count
-            ? state
-            : state with { ByLog = state.ByLog.SetItem(action.LogData.Id, action.Events.Count) };
+        var updated = CountBatch(action.Events);
+
+        return existing.Equals(updated) ?
+            state :
+            state with { ByLog = state.ByLog.SetItem(action.LogData.Id, updated) };
     }
 
     [ReducerMethod]
@@ -73,10 +74,22 @@ internal sealed class RawEventCountReducers
     {
         if (!state.ByLog.TryGetValue(action.LogData.Id, out var existing)) { return state; }
 
-        var updated = existing + action.Events.Count;
+        var updated = existing.Add(CountBatch(action.Events));
 
-        return updated == existing
-            ? state
-            : state with { ByLog = state.ByLog.SetItem(action.LogData.Id, updated) };
+        return updated.Equals(existing) ?
+            state :
+            state with { ByLog = state.ByLog.SetItem(action.LogData.Id, updated) };
+    }
+
+    private static ProviderResolutionCounts CountBatch(IReadOnlyList<ResolvedEvent> events)
+    {
+        ProviderResolutionCounts counts = default;
+
+        foreach (var resolvedEvent in events)
+        {
+            counts = counts.WithStatus(resolvedEvent.ResolutionStatus);
+        }
+
+        return counts;
     }
 }

--- a/src/EventLogExpert.Runtime/LogTable/RawEventCountState.cs
+++ b/src/EventLogExpert.Runtime/LogTable/RawEventCountState.cs
@@ -2,20 +2,17 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Eventing.Common.Events;
 using Fluxor;
 using System.Collections.Immutable;
 
 namespace EventLogExpert.Runtime.LogTable;
 
-/// <summary>
-///     Public, render-isolated mirror of the raw event count per log. Carries only integer counts (never the raw
-///     events) so the status bar can show a live "Events Loaded" total without coupling the UI to the internal raw store.
-///     Kept in sync with <c>RawEventStoreState</c> by reducing the same lifecycle actions.
-/// </summary>
 [FeatureState]
 public sealed record RawEventCountState
 {
-    public ImmutableDictionary<EventLogId, int> ByLog { get; init; } = ImmutableDictionary<EventLogId, int>.Empty;
+    public ImmutableDictionary<EventLogId, ProviderResolutionCounts> ByLog { get; init; } =
+        ImmutableDictionary<EventLogId, ProviderResolutionCounts>.Empty;
 
-    public int Total => ByLog.Values.Sum();
+    public int Total => ByLog.Values.Sum(counts => counts.Total);
 }

--- a/src/EventLogExpert.Runtime/Menu/IMenuActionService.cs
+++ b/src/EventLogExpert.Runtime/Menu/IMenuActionService.cs
@@ -60,6 +60,8 @@ public interface IMenuActionService
 
     Task ShowReleaseNotesAsync();
 
+    Task ShowResolutionCoverageAsync();
+
     void ToggleGroupSortDirection();
 
     void ToggleShowAllEvents();

--- a/src/EventLogExpert.Runtime/ResolutionCoverage/CoverageTableFormatter.cs
+++ b/src/EventLogExpert.Runtime/ResolutionCoverage/CoverageTableFormatter.cs
@@ -1,0 +1,63 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.Export;
+using System.Globalization;
+using System.Text;
+
+namespace EventLogExpert.Runtime.ResolutionCoverage;
+
+/// <summary>
+///     Builds a TSV snapshot of a <see cref="ResolutionCoverageReport" /> for the clipboard. Bounded by
+///     <see cref="MaxCopyRows" /> so a pathological high-cardinality log cannot force an unbounded contiguous-string
+///     allocation; every cell is formula-neutralized and tab/newline-escaped so pasting into a spreadsheet is safe.
+/// </summary>
+public static class CoverageTableFormatter
+{
+    // Rows are distinct providers (far below this for any real log); the cap only bounds the single copied string.
+    internal const int MaxCopyRows = 10_000;
+
+    private const string RowSeparator = "\r\n";
+
+    public static string Format(ResolutionCoverageReport report, bool isFiltered)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+
+        var builder = new StringBuilder();
+        int rowCount = Math.Min(report.Rows.Count, MaxCopyRows);
+
+        builder
+            .Append("# ")
+            .Append(isFiltered ? "All providers in the current view (filtered view)" : "All providers in the current view");
+
+        if (report.Rows.Count > MaxCopyRows)
+        {
+            builder.Append(CultureInfo.InvariantCulture, $" - showing the first {rowCount:N0} of {report.Rows.Count:N0} providers");
+        }
+
+        builder.Append(RowSeparator);
+        builder.Append("Provider\tEvents\tResolved\tNo provider\tNo message\tError\tCoverage").Append(RowSeparator);
+
+        for (int i = 0; i < rowCount; i++)
+        {
+            var row = report.Rows[i];
+
+            builder
+                .Append(Cell(row.Provider)).Append('\t')
+                .Append(row.Counts.Total.ToString(CultureInfo.InvariantCulture)).Append('\t')
+                .Append(row.Counts.Resolved.ToString(CultureInfo.InvariantCulture)).Append('\t')
+                .Append(row.Counts.NoProvider.ToString(CultureInfo.InvariantCulture)).Append('\t')
+                .Append(row.Counts.NoMessage.ToString(CultureInfo.InvariantCulture)).Append('\t')
+                .Append(row.Counts.Failed.ToString(CultureInfo.InvariantCulture)).Append('\t')
+                .Append(CoverageStatusText.Label(row.Status)).Append(RowSeparator);
+        }
+
+        return builder.ToString();
+    }
+
+    // Formula-neutralize, then collapse tab/CR/LF to spaces so a value can never break the TSV grid.
+    private static string Cell(string value) => TabularCellSanitizer.NeutralizeFormula(value)
+        .Replace('\t', ' ')
+        .Replace('\r', ' ')
+        .Replace('\n', ' ');
+}

--- a/src/EventLogExpert.Runtime/ResolutionCoverage/IResolutionCoverageService.cs
+++ b/src/EventLogExpert.Runtime/ResolutionCoverage/IResolutionCoverageService.cs
@@ -1,0 +1,13 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.LogTable;
+
+namespace EventLogExpert.Runtime.ResolutionCoverage;
+
+public interface IResolutionCoverageService
+{
+    ResolutionCoverageReport Build(IEventColumnView view, CancellationToken cancellationToken);
+
+    ProviderCoverageDetail BuildProviderDetail(IEventColumnView view, string provider, CancellationToken cancellationToken);
+}

--- a/src/EventLogExpert.Runtime/ResolutionCoverage/ResolutionCoverageModels.cs
+++ b/src/EventLogExpert.Runtime/ResolutionCoverage/ResolutionCoverageModels.cs
@@ -1,0 +1,52 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+
+namespace EventLogExpert.Runtime.ResolutionCoverage;
+
+public enum CoverageStatus
+{
+    Full,
+    Partial,
+    None
+}
+
+/// <summary>
+///     Maps a <see cref="CoverageStatus" /> to its short display label. Shared by the coverage modal and the
+///     clipboard formatter so both render identical wording.
+/// </summary>
+public static class CoverageStatusText
+{
+    public static string Label(CoverageStatus status) => status switch
+    {
+        CoverageStatus.Full => "Full",
+        CoverageStatus.None => "None",
+        _ => "Partial"
+    };
+}
+
+public sealed record ProviderCoverageRow(string Provider, ProviderResolutionCounts Counts, CoverageStatus Status);
+
+public sealed record ResolutionCoverageReport(
+    ProviderResolutionCounts Summary,
+    IReadOnlyList<ProviderCoverageRow> Rows);
+
+/// <summary>One event ID's resolution breakdown within a provider (an F6 drill-down row).</summary>
+public sealed record EventIdCoverageRow(int EventId, ProviderResolutionCounts Counts);
+
+/// <summary>
+///     One severity level's resolution breakdown within a provider (an F8 drill-down row); <see cref="Level" /> is
+///     null for the Unknown / absent-level slot.
+/// </summary>
+public sealed record LevelCoverageRow(SeverityLevel? Level, ProviderResolutionCounts Counts);
+
+/// <summary>
+///     The lazily-computed per-provider drill-down: the top unresolved event IDs (capped, with the true
+///     <see cref="DistinctUnresolvedEventIdCount" /> so the UI can note "top N of M") plus the unresolved-by-severity
+///     breakdown.
+/// </summary>
+public sealed record ProviderCoverageDetail(
+    IReadOnlyList<EventIdCoverageRow> EventIds,
+    IReadOnlyList<LevelCoverageRow> Levels,
+    int DistinctUnresolvedEventIdCount);

--- a/src/EventLogExpert.Runtime/ResolutionCoverage/ResolutionCoverageService.cs
+++ b/src/EventLogExpert.Runtime/ResolutionCoverage/ResolutionCoverageService.cs
@@ -1,0 +1,82 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Runtime.LogTable;
+
+namespace EventLogExpert.Runtime.ResolutionCoverage;
+
+internal sealed class ResolutionCoverageService : IResolutionCoverageService
+{
+    // The Event-ID drill-down copies at most this many rows into the modal; the header still reports the true distinct
+    // count so a capped list reads "top N of M".
+    internal const int MaxEventIdRows = 100;
+
+    // Severity breakdown display order: Critical..Verbose (slots 1-5) then Unknown (slot 0).
+    private static readonly int[] s_levelDisplayOrder = [1, 2, 3, 4, 5, 0];
+
+    public ResolutionCoverageReport Build(IEventColumnView view, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(view);
+
+        var counts = new Dictionary<string, ProviderResolutionCounts>(StringComparer.Ordinal);
+        view.CountResolutionBySource(counts, cancellationToken);
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        ProviderResolutionCounts summary = default;
+
+        foreach (ProviderResolutionCounts value in counts.Values)
+        {
+            summary = summary.Add(value);
+        }
+
+        var rows = counts
+            .OrderByDescending(entry => entry.Value.Unresolved)
+            .ThenBy(entry => entry.Key, StringComparer.Ordinal)
+            .Select(entry => new ProviderCoverageRow(entry.Key, entry.Value, Classify(entry.Value)))
+            .ToList();
+
+        return new ResolutionCoverageReport(summary, rows);
+    }
+
+    public ProviderCoverageDetail BuildProviderDetail(IEventColumnView view, string provider, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(view);
+        ArgumentNullException.ThrowIfNull(provider);
+
+        var byId = new Dictionary<int, ProviderResolutionCounts>();
+        var byLevelSlot = new ProviderResolutionCounts[LevelSeverity.SlotCount];
+        view.CountResolutionDetailForSource(provider, byId, byLevelSlot, cancellationToken);
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var unresolvedIds = byId.Where(entry => entry.Value.Unresolved > 0).ToList();
+
+        var eventIds = unresolvedIds
+            .OrderByDescending(entry => entry.Value.Unresolved)
+            .ThenByDescending(entry => entry.Value.Total)
+            .ThenBy(entry => entry.Key)
+            .Take(MaxEventIdRows)
+            .Select(entry => new EventIdCoverageRow(entry.Key, entry.Value))
+            .ToList();
+
+        var levels = new List<LevelCoverageRow>(LevelSeverity.SlotCount);
+
+        foreach (int slot in s_levelDisplayOrder)
+        {
+            ProviderResolutionCounts counts = byLevelSlot[slot];
+
+            if (counts.Unresolved == 0) { continue; }
+
+            levels.Add(new LevelCoverageRow(slot == 0 ? null : (SeverityLevel)slot, counts));
+        }
+
+        return new ProviderCoverageDetail(eventIds, levels, unresolvedIds.Count);
+    }
+
+    private static CoverageStatus Classify(ProviderResolutionCounts counts) =>
+        counts.Unresolved == 0 ? CoverageStatus.Full :
+        counts.NoProvider == counts.Total ? CoverageStatus.None :
+        CoverageStatus.Partial;
+}

--- a/src/EventLogExpert.Runtime/StatusBar/StatusBarFormatter.cs
+++ b/src/EventLogExpert.Runtime/StatusBar/StatusBarFormatter.cs
@@ -7,6 +7,10 @@ namespace EventLogExpert.Runtime.StatusBar;
 
 public static class StatusBarFormatter
 {
+    public static string CoverageChipTooltip(int unresolved, int total) =>
+        $"{unresolved:N0} unresolved of {total:N0} events loaded in this tab/group. " +
+        "Filters are not applied - open Coverage for the current view's breakdown.";
+
     public static string? FilterIndicatorTooltip(bool persistentActive, int lensCount)
     {
         var lensText = lensCount switch
@@ -54,6 +58,8 @@ public static class StatusBarFormatter
 
         return selectedCount >= 2 ? $"{head} \u00b7 {selectedCount:N0} selected" : head;
     }
+
+    public static string FormatCoverageChip(int unresolved) => $"{unresolved:N0} unresolved";
 
     public static string FormatSource(
         LogView? active,

--- a/src/EventLogExpert.Runtime/StatusBar/StatusBarPresentation.cs
+++ b/src/EventLogExpert.Runtime/StatusBar/StatusBarPresentation.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Eventing.Common.Events;
 using EventLogExpert.Runtime.LogTable;
 using System.Collections.Immutable;
 
@@ -23,8 +24,8 @@ public sealed record StatusBarPresentation
 
     public int RawEventTotal { get; init; }
 
-    public ImmutableDictionary<EventLogId, int> RawEventCountsByLog { get; init; } =
-        ImmutableDictionary<EventLogId, int>.Empty;
+    public ImmutableDictionary<EventLogId, ProviderResolutionCounts> RawEventCountsByLog { get; init; } =
+        ImmutableDictionary<EventLogId, ProviderResolutionCounts>.Empty;
 
     public ImmutableDictionary<StatusActivityId, LoadingProgress> LoadingActivities { get; init; } =
         ImmutableDictionary<StatusActivityId, LoadingProgress>.Empty;
@@ -36,4 +37,43 @@ public sealed record StatusBarPresentation
     public ImmutableList<LogTabGroup> Groups { get; init; } = [];
 
     public EventLogId? ActiveTabId { get; init; }
+
+    /// <summary>
+    ///     Projects the per-log resolution tally for the active scope: the All-group sums every loaded log, a grouped tab
+    ///     sums its members, and an ungrouped tab reads its own entry. Returns the full tally so the stats chip reads
+    ///     <see cref="ProviderResolutionCounts.Total" /> and the coverage chip reads
+    ///     <see cref="ProviderResolutionCounts.Unresolved" /> from one call.
+    /// </summary>
+    public ProviderResolutionCounts ScopedCounts(LogView activeTable)
+    {
+        ArgumentNullException.ThrowIfNull(activeTable);
+
+        if (activeTable.GroupId?.IsAll == true)
+        {
+            return SumCounts(RawEventCountsByLog.Values);
+        }
+
+        if (activeTable.GroupId is not { } groupId)
+        {
+            return RawEventCountsByLog.GetValueOrDefault(activeTable.Id, default);
+        }
+
+        var group = Groups.FirstOrDefault(candidate => candidate.Id == groupId);
+
+        return group is null ?
+            default :
+            SumCounts(group.MemberIds.Select(id => RawEventCountsByLog.GetValueOrDefault(id, default)));
+    }
+
+    private static ProviderResolutionCounts SumCounts(IEnumerable<ProviderResolutionCounts> counts)
+    {
+        ProviderResolutionCounts total = default;
+
+        foreach (var value in counts)
+        {
+            total = total.Add(value);
+        }
+
+        return total;
+    }
 }

--- a/src/EventLogExpert.Runtime/StatusBar/StatusBarSource.cs
+++ b/src/EventLogExpert.Runtime/StatusBar/StatusBarSource.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Eventing.Common.Events;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.Runtime.FilterPane;
@@ -26,7 +27,7 @@ internal sealed class StatusBarSource : IStatusBarSource, IDisposable
     private (bool ContinuouslyUpdate, int BufferCount, bool BufferFull, int SelectionCount) _eventLogFacets;
     private (ImmutableList<LogView> Tabs, ImmutableList<LogTabGroup> Groups, EventLogId? ActiveTabId) _logTableFacets;
     private bool _persistentFilterActive;
-    private (int Total, ImmutableDictionary<EventLogId, int> ByLog) _rawCountFacets;
+    private (int Total, ImmutableDictionary<EventLogId, ProviderResolutionCounts> ByLog) _rawCountFacets;
     private (ImmutableDictionary<StatusActivityId, (int, int)> Loading, string Resolver) _statusFacets;
 
     public StatusBarSource(
@@ -139,7 +140,7 @@ internal sealed class StatusBarSource : IStatusBarSource, IDisposable
         LogTableState state) =>
         (state.EventTables, state.Groups, state.ActiveEventLogId);
 
-    private static (int, ImmutableDictionary<EventLogId, int>) ProjectRawCount(RawEventCountState state) =>
+    private static (int, ImmutableDictionary<EventLogId, ProviderResolutionCounts>) ProjectRawCount(RawEventCountState state) =>
         (state.Total, state.ByLog);
 
     private static (ImmutableDictionary<StatusActivityId, (int, int)>, string) ProjectStatus(StatusBarState state) =>

--- a/src/EventLogExpert.UI/LogTable/CellFilterBuilder.cs
+++ b/src/EventLogExpert.UI/LogTable/CellFilterBuilder.cs
@@ -51,6 +51,7 @@ internal static class CellFilterBuilder
             EventProperty.Source => @event.Source,
             EventProperty.TaskCategory => @event.TaskCategory,
             EventProperty.Opcode => @event.Opcode,
+            EventProperty.ResolutionStatus => ResolutionStatusTokens.Format(@event.ResolutionStatus),
             EventProperty.ProcessId => @event.ProcessId?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
             EventProperty.ThreadId => @event.ThreadId?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
             EventProperty.UserDisplayName => @event.UserDisplayName,

--- a/src/EventLogExpert.UI/LogTable/Resolution/ResolutionCoverageModal.razor
+++ b/src/EventLogExpert.UI/LogTable/Resolution/ResolutionCoverageModal.razor
@@ -1,0 +1,309 @@
+@using EventLogExpert.Eventing.Common.Events
+@using EventLogExpert.Runtime.ResolutionCoverage
+@inherits ModalBase<bool>
+
+<ModalChrome AriaLabel="Resolution and coverage"
+    CloseLabel="Close"
+    Footer="FooterPreset.CloseOnly"
+    Height="70%"
+    InlineAlert="@CurrentInlineAlert"
+    MaxWidth="min(72rem, calc(100vw - 2rem))"
+    MinWidth="min(30rem, calc(100vw - 2rem))"
+    OnClose="OnCancelAsync"
+    OnDialogClosedByUser="HandleDialogClosedByUserAsync"
+    OnInlineAlertResolved="HandleInlineAlertResolvedAsync"
+    Title="Resolution & Coverage"
+    @ref="ChromeRef">
+    <ChildContent>
+        <div class="resolution-coverage">
+            @if (_loading)
+            {
+                <div class="resolution-coverage-status">Computing...</div>
+            }
+            else if (_updating)
+            {
+                <div class="resolution-coverage-status">The view is still updating - reopen to see coverage.</div>
+            }
+            else if (_failed)
+            {
+                <div class="resolution-coverage-status">@(_faultCause is { Length: > 0 } cause ? $"Coverage is unavailable. {cause}" : "Coverage could not be computed.")</div>
+            }
+            else if (_report is not null && _report.Summary.Total == 0)
+            {
+                <div class="resolution-coverage-status">@(_isFiltered ? "No events match the current filter." : "No events to analyze.")</div>
+            }
+            else if (_report is not null)
+            {
+                var matched = FilteredSortedRows();
+                var shown = matched.Count > MaxProviders ? matched.Take(MaxProviders).ToList() : matched;
+
+                <div class="resolution-coverage-summary">
+                    <div class="resolution-coverage-scope">
+                        <span>@FormatCount(_report.Summary.Total) events in the current view</span>
+                        @if (_isFiltered)
+                        {
+                            <span class="resolution-coverage-badge" title="Coverage reflects the current filtered view, not all loaded events.">Filtered view</span>
+                        }
+                    </div>
+                    <div class="resolution-coverage-tallies">
+                        <span class="resolution-tally">Resolved: <strong>@FormatCount(_report.Summary.Resolved)</strong> (@FormatShare(_report.Summary.Resolved))</span>
+                        <span class="resolution-tally">Unresolved: <strong>@FormatCount(Unresolved)</strong> (@FormatShare(Unresolved))</span>
+                    </div>
+                    @{
+                        var segments = ProportionSegments().ToList();
+                    }
+                    @if (segments.Count > 0)
+                    {
+                        <div aria-label="@ProportionAriaLabel()" class="resolution-coverage-bar" role="img">
+                            @foreach (var segment in segments)
+                            {
+                                <div class="resolution-coverage-seg @segment.CssClass" style="@SegmentWidth(segment.Percent)" title="@segment.Label"></div>
+                            }
+                        </div>
+                    }
+                    <div class="resolution-coverage-breakdown">
+                        @foreach (var cause in CauseBreakdown())
+                        {
+                            @if (cause.Count > 0)
+                            {
+                                <button class="resolution-cause-filter"
+                                    @onclick="() => FilterByCauseAsync(cause.Token)"
+                                    title="@($"Filter the view to {cause.Token} events")"
+                                    type="button">
+                                    @cause.Token: @FormatCount(cause.Count)
+                                </button>
+                            }
+                            else
+                            {
+                                <span class="resolution-cause-empty">@cause.Token: @FormatCount(cause.Count)</span>
+                            }
+                        }
+                    </div>
+                </div>
+
+                <input aria-label="Filter providers"
+                    @bind="_search"
+                    @bind:event="oninput"
+                    class="input resolution-coverage-search"
+                    placeholder="Filter providers..."
+                    type="text" />
+
+                @if (matched.Count > shown.Count)
+                {
+                    <div class="resolution-coverage-truncated">Showing the top @FormatCount(shown.Count) of @FormatCount(matched.Count) providers.</div>
+                }
+
+                <div class="resolution-coverage-table" role="table">
+                    <div class="resolution-coverage-head" role="row">
+                        <span aria-sort="@AriaSort(CoverageSortColumn.Provider)" role="columnheader">
+                            <button class="resolution-sort" @onclick="() => ToggleSort(CoverageSortColumn.Provider)" type="button">Provider</button>
+                        </span>
+                        <span aria-sort="@AriaSort(CoverageSortColumn.Total)" role="columnheader">
+                            <button class="resolution-num resolution-sort" @onclick="() => ToggleSort(CoverageSortColumn.Total)" type="button">Events</button>
+                        </span>
+                        <span aria-sort="@AriaSort(CoverageSortColumn.Resolved)" role="columnheader">
+                            <button class="resolution-num resolution-sort" @onclick="() => ToggleSort(CoverageSortColumn.Resolved)" type="button">Resolved</button>
+                        </span>
+                        <span aria-sort="@AriaSort(CoverageSortColumn.NoProvider)" role="columnheader" title="@ResolutionStatusTokens.NoProvider">
+                            <button class="resolution-num resolution-sort" @onclick="() => ToggleSort(CoverageSortColumn.NoProvider)" type="button">No provider</button>
+                        </span>
+                        <span aria-sort="@AriaSort(CoverageSortColumn.NoMessage)" role="columnheader" title="@ResolutionStatusTokens.NoMessage">
+                            <button class="resolution-num resolution-sort" @onclick="() => ToggleSort(CoverageSortColumn.NoMessage)" type="button">No message</button>
+                        </span>
+                        <span aria-sort="@AriaSort(CoverageSortColumn.Failed)" role="columnheader" title="@ResolutionStatusTokens.Failed">
+                            <button class="resolution-num resolution-sort" @onclick="() => ToggleSort(CoverageSortColumn.Failed)" type="button">Error</button>
+                        </span>
+                        <span aria-sort="@AriaSort(CoverageSortColumn.Coverage)" role="columnheader">
+                            <button class="resolution-cov resolution-sort" @onclick="() => ToggleSort(CoverageSortColumn.Coverage)" type="button">Coverage</button>
+                        </span>
+                        <span role="columnheader"></span>
+                    </div>
+                    @for (int index = 0; index < shown.Count; index++)
+                    {
+                        var row = shown[index];
+                        <div class="resolution-coverage-row@(index % 2 == 1 ? " resolution-row-alt" : null)" role="row">
+                            <span class="resolution-provider" role="cell" title="@row.Provider">
+                                @if (row.Status != CoverageStatus.Full && !string.IsNullOrWhiteSpace(row.Provider))
+                                {
+                                    <button aria-controls="@(IsExpanded(row) ? DetailId(index) : null)"
+                                        aria-expanded="@(IsExpanded(row) ? "true" : "false")"
+                                        class="resolution-provider-toggle"
+                                        @onclick="() => ToggleExpandAsync(row)"
+                                        type="button">
+                                        <i aria-hidden="true" class="bi bi-caret-@(IsExpanded(row) ? "down" : "right")"></i>
+                                        <span class="resolution-provider-name">@row.Provider</span>
+                                    </button>
+                                }
+                                else
+                                {
+                                    <span class="resolution-provider-name">@row.Provider</span>
+                                }
+                            </span>
+                            <span class="resolution-num" role="cell">@FormatCount(row.Counts.Total)</span>
+                            <span class="resolution-num" role="cell">@FormatCount(row.Counts.Resolved)</span>
+                            <span class="resolution-num" role="cell">@FormatCount(row.Counts.NoProvider)</span>
+                            <span class="resolution-num" role="cell">@FormatCount(row.Counts.NoMessage)</span>
+                            <span class="resolution-num" role="cell">@FormatCount(row.Counts.Failed)</span>
+                            <span class="resolution-cov" role="cell"><span class="@CoverageCssClass(row.Status)" title="@CoverageTooltip(row)">@CoverageStatusText.Label(row.Status)</span></span>
+                            <span class="resolution-actions" role="cell">
+                                <button aria-label="@($"Filter to {row.Provider}")"
+                                    class="resolution-include"
+                                    @onclick="() => IncludeProviderAsync(row)"
+                                    title="Filter to only this provider"
+                                    type="button">
+                                    <i aria-hidden="true" class="bi bi-plus-circle"></i>
+                                </button>
+                                <button aria-label="@($"Exclude {row.Provider}")"
+                                    class="resolution-exclude"
+                                    @onclick="() => ExcludeProviderAsync(row)"
+                                    title="Exclude this provider"
+                                    type="button">
+                                    <i aria-hidden="true" class="bi bi-dash-circle"></i>
+                                </button>
+                                @if (row.Status != CoverageStatus.Full && !string.IsNullOrWhiteSpace(row.Provider))
+                                {
+                                    <button aria-label="@($"Filter to {row.Provider}'s unresolved events")"
+                                        class="resolution-lens"
+                                        @onclick="() => FilterProviderUnresolvedAsync(row)"
+                                        title="Filter the view to this provider's unresolved events"
+                                        type="button">
+                                        <i aria-hidden="true" class="bi bi-funnel"></i>
+                                    </button>
+                                }
+                                @if (ShowDatabaseAction(row))
+                                {
+                                    <button aria-label="@($"Open Database Tools for {row.Provider}")"
+                                        class="resolution-dbtools"
+                                        @onclick="OpenDatabaseToolsAsync"
+                                        title="@DatabaseActionTooltip(row)"
+                                        type="button">
+                                        <i aria-hidden="true" class="bi bi-database-add"></i>
+                                    </button>
+                                }
+                            </span>
+                        </div>
+
+                        @if (IsExpanded(row))
+                        {
+                            <div class="resolution-coverage-detail" role="row">
+                                <div aria-colspan="8" class="resolution-detail-cell" role="cell">
+                                    <div aria-label="@($"Coverage details for {row.Provider}")" class="resolution-detail-region" id="@DetailId(index)" role="region">
+                                        @if (_detailLoading)
+                                        {
+                                            <div aria-busy="true" class="resolution-detail-status">Analyzing @row.Provider...</div>
+                                        }
+                                        else if (_detailFailed)
+                                        {
+                                            <div class="resolution-detail-status">
+                                                Could not analyze this provider.
+                                                <button class="resolution-cause-filter" @onclick="() => RetryDetailAsync(row)" type="button">Retry</button>
+                                            </div>
+                                        }
+                                        else if (_detail is { } detail)
+                                        {
+                                            <div class="resolution-detail-hint">@RemediationHint(row)</div>
+
+                                            @if (detail.Levels.Count > 0)
+                                            {
+                                                var sevSegments = SeveritySegments(detail).ToList();
+
+                                                <div class="resolution-detail-section">
+                                                    <div class="resolution-detail-heading">Unresolved by severity</div>
+                                                    @if (sevSegments.Count > 0)
+                                                    {
+                                                        <div aria-label="@SeverityBarLabel(detail)" class="resolution-detail-sevbar" role="img">
+                                                            @foreach (var seg in sevSegments)
+                                                            {
+                                                                <div class="resolution-detail-sevseg coverage-sev-@SeverityDisplay.Key(seg.Level)" style="@SegmentWidth(seg.Percent)" title="@($"{SeverityDisplay.Label(seg.Level)}: {FormatCount(seg.Unresolved)}")"></div>
+                                                            }
+                                                        </div>
+                                                    }
+                                                    <div class="resolution-detail-sevcounts">
+                                                        @foreach (var level in detail.Levels)
+                                                        {
+                                                            <span class="resolution-detail-sevcount"><span class="resolution-detail-sevdot coverage-sev-@SeverityDisplay.Key(level.Level)"></span>@SeverityDisplay.Label(level.Level): <strong>@FormatCount(level.Counts.Unresolved)</strong></span>
+                                                        }
+                                                    </div>
+                                                </div>
+                                            }
+
+                                            @if (detail.EventIds.Count > 0)
+                                            {
+                                                <div class="resolution-detail-section">
+                                                    <div class="resolution-detail-heading">
+                                                        Unresolved event IDs
+                                                        @if (detail.DistinctUnresolvedEventIdCount > detail.EventIds.Count)
+                                                        {
+                                                            <span class="resolution-detail-note">top @FormatCount(detail.EventIds.Count) of @FormatCount(detail.DistinctUnresolvedEventIdCount)</span>
+                                                        }
+                                                    </div>
+                                                    <div class="resolution-detail-idtable" role="table">
+                                                        <div class="resolution-detail-idhead resolution-detail-idrow" role="row">
+                                                            <span role="columnheader">Event ID</span>
+                                                            <span class="resolution-num" role="columnheader">Total</span>
+                                                            <span class="resolution-num" role="columnheader">Unresolved</span>
+                                                            <span role="columnheader">Cause</span>
+                                                            <span role="columnheader"></span>
+                                                        </div>
+                                                        @foreach (var idRow in detail.EventIds)
+                                                        {
+                                                            <div class="resolution-detail-idrow" role="row">
+                                                                <span role="cell">@idRow.EventId</span>
+                                                                <span class="resolution-num" role="cell">@FormatCount(idRow.Counts.Total)</span>
+                                                                <span class="resolution-num" role="cell">@FormatCount(idRow.Counts.Unresolved)</span>
+                                                                <span role="cell">@DominantCauseLabel(idRow.Counts)</span>
+                                                                <span role="cell">
+                                                                    @if (!string.IsNullOrWhiteSpace(row.Provider))
+                                                                    {
+                                                                        <button aria-label="@($"Filter to event ID {idRow.EventId} unresolved events for {row.Provider}")"
+                                                                            class="resolution-lens"
+                                                                            @onclick="() => FilterEventIdUnresolvedAsync(row.Provider, idRow.EventId)"
+                                                                            title="Filter the view to this event ID's unresolved events"
+                                                                            type="button">
+                                                                            <i aria-hidden="true" class="bi bi-funnel"></i>
+                                                                        </button>
+                                                                    }
+                                                                </span>
+                                                            </div>
+                                                        }
+                                                    </div>
+                                                </div>
+                                            }
+                                        }
+                                    </div>
+                                </div>
+                            </div>
+                        }
+                    }
+                </div>
+            }
+        </div>
+    </ChildContent>
+    <ExtraFooterContent>
+        @if (HasReport)
+        {
+            <div class="resolution-coverage-footer">
+                @if (Unresolved > 0)
+                {
+                    <Button CssClass="resolution-coverage-filter"
+                        OnClick="ShowOnlyUnresolvedAsync"
+                        title="Filter the view to only unresolved events">
+                        Show only unresolved events
+                    </Button>
+                }
+                <Button CssClass="resolution-coverage-copy"
+                    Disabled="@_copying"
+                    OnClick="CopyTableAsync"
+                    title="Copy the coverage table as TSV">
+                    Copy table
+                </Button>
+                <span aria-live="polite" class="resolution-coverage-copied" role="status">
+                    @if (_showCopied)
+                    {
+                        <span class="resolution-coverage-copied-chip">Copied</span>
+                    }
+                </span>
+            </div>
+        }
+    </ExtraFooterContent>
+</ModalChrome>

--- a/src/EventLogExpert.UI/LogTable/Resolution/ResolutionCoverageModal.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/Resolution/ResolutionCoverageModal.razor.cs
@@ -1,0 +1,517 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Filtering.Common.Filtering;
+using EventLogExpert.Runtime.Common.Clipboard;
+using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.FilterLenses;
+using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.Runtime.ResolutionCoverage;
+using EventLogExpert.UI.Modal;
+using Microsoft.AspNetCore.Components;
+
+namespace EventLogExpert.UI.LogTable.Resolution;
+
+public sealed partial class ResolutionCoverageModal : ModalBase<bool>
+{
+    // The display cap only guards a pathological log with thousands of distinct sources; sorting happens before it.
+    private const int MaxProviders = 500;
+
+    private static readonly TimeSpan s_copiedFeedbackDuration = TimeSpan.FromSeconds(2);
+
+    private readonly CancellationTokenSource _cts = new();
+
+    private readonly Dictionary<string, ProviderCoverageDetail> _detailCache = new(StringComparer.Ordinal);
+    private CancellationTokenSource? _copiedCts;
+    private bool _copying;
+    private ProviderCoverageDetail? _detail;
+    private CancellationTokenSource? _detailCts;
+    private bool _detailFailed;
+    private int _detailGeneration;
+    private bool _detailLoading;
+    private string? _expandedProvider;
+    private bool _failed;
+    private string? _faultCause;
+    private bool _isFiltered;
+    private bool _loading = true;
+    private string? _originLog;
+    private ResolutionCoverageReport? _report;
+    private string _search = string.Empty;
+    private bool _showCopied;
+    private CoverageSortColumn _sortColumn = CoverageSortColumn.Unresolved;
+    private bool _sortDescending = true;
+    private bool _updating;
+    private IEventColumnView? _view;
+
+    private enum CoverageSortColumn { Unresolved, Provider, Total, Resolved, NoProvider, NoMessage, Failed, Coverage }
+
+    private enum ResolutionCause { NoProvider, NoMessage, Failed }
+
+    [Inject] private IClipboardService ClipboardService { get; init; } = null!;
+
+    [Inject] private IResolutionCoverageService CoverageService { get; init; } = null!;
+
+    [Inject] private IFilterAppliedSource FilterApplied { get; init; } = null!;
+
+    [Inject] private IFilterLensCommands FilterLensCommands { get; init; } = null!;
+
+    // Gates the footer action fragment, which lives OUTSIDE the body's _report render chain: the actions only make
+    // sense once a non-empty report is shown (mirrors the body's terminal branch), so they stay hidden while the modal
+    // is loading, updating, faulted, or empty.
+    private bool HasReport => !_loading && !_updating && !_failed && _report is { Summary.Total: > 0 };
+
+    private int Unresolved => _report?.Summary.Unresolved ?? 0;
+
+    [Inject] private IOrderedViewSource ViewSource { get; init; } = null!;
+
+    protected override ValueTask DisposeAsyncCore(bool disposing)
+    {
+        if (disposing)
+        {
+            _cts.Cancel();
+            _cts.Dispose();
+
+            CancellationTokenSource? copiedCts = _copiedCts;
+            _copiedCts = null;
+            copiedCts?.Cancel();
+            copiedCts?.Dispose();
+
+            CancellationTokenSource? detailCts = _detailCts;
+            _detailCts = null;
+            detailCts?.Cancel();
+            detailCts?.Dispose();
+
+            _view = null;
+            _detailCache.Clear();
+        }
+
+        return base.DisposeAsyncCore(disposing);
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        await base.OnInitializedAsync();
+
+        OrderedViewPresentation presentation = ViewSource.Current;
+        _isFiltered = FilterApplied.IsFilteringEnabled;
+        _originLog = presentation.ActiveLogName;
+
+        switch (presentation.IndicatorKind)
+        {
+            case DisplayIndicatorKind.Fault:
+                _faultCause = presentation.FaultCause;
+                _failed = true;
+                _loading = false;
+                return;
+            case DisplayIndicatorKind.EmptyPending:
+                _updating = true;
+                _loading = false;
+                return;
+        }
+
+        _view = presentation.View;
+
+        try
+        {
+            IEventColumnView view = _view;
+            _report = await Task.Run(() => CoverageService.Build(view, _cts.Token), _cts.Token);
+        }
+        catch (OperationCanceledException) { }
+        catch (Exception)
+        {
+            _failed = true;
+        }
+        finally
+        {
+            if (!IsDisposed)
+            {
+                _loading = false;
+                StateHasChanged();
+            }
+        }
+    }
+
+    private static string CoverageCssClass(CoverageStatus status) => status switch
+    {
+        CoverageStatus.Full => "coverage-pill coverage-full",
+        CoverageStatus.None => "coverage-pill coverage-none",
+        _ => "coverage-pill coverage-partial"
+    };
+
+    private static string? CoverageTooltip(ProviderCoverageRow row)
+    {
+        if (row.Status == CoverageStatus.Full) { return null; }
+
+        if (row.Status == CoverageStatus.None)
+        {
+            return "No provider metadata for any of this provider's events - readable fallback text may still be shown.";
+        }
+
+        var causes = new List<string>(3);
+
+        if (row.Counts.NoProvider > 0) { causes.Add("no provider metadata"); }
+        if (row.Counts.NoMessage > 0) { causes.Add("no message match"); }
+        if (row.Counts.Failed > 0) { causes.Add("a resolution error"); }
+
+        return $"Some events could not be fully resolved: {string.Join(", ", causes)}.";
+    }
+
+    private static string DatabaseActionTooltip(ProviderCoverageRow row) => row.Counts.NoProvider > 0 ?
+        $"Loading a provider database may add descriptions for {row.Provider}." :
+        $"Loading a newer provider database may add message definitions for {row.Provider}.";
+
+    private static string DetailId(int index) => $"coverage-detail-{index}";
+
+    private static ResolutionCause DominantCause(ProviderResolutionCounts counts)
+    {
+        // Tie precedence NoProvider > NoMessage > Failed, matching the database-action gate and CoverageStatus.Classify.
+        if (counts.NoProvider >= counts.NoMessage && counts.NoProvider >= counts.Failed) { return ResolutionCause.NoProvider; }
+
+        return counts.NoMessage >= counts.Failed ? ResolutionCause.NoMessage : ResolutionCause.Failed;
+    }
+
+    private static string DominantCauseLabel(ProviderResolutionCounts counts) => DominantCause(counts) switch
+    {
+        ResolutionCause.NoProvider => ResolutionStatusTokens.NoProvider,
+        ResolutionCause.NoMessage => ResolutionStatusTokens.NoMessage,
+        _ => ResolutionStatusTokens.Failed
+    };
+
+    private static string FormatCount(int value) => TallyFormatter.Count(value);
+
+    private static string SegmentWidth(double percent) => FormattableString.Invariant($"width:{percent:0.###}%;");
+
+    private static string SeverityBarLabel(ProviderCoverageDetail detail) =>
+        "Unresolved by severity: " +
+        string.Join(", ", detail.Levels.Select(level => $"{SeverityDisplay.Label(level.Level)} {level.Counts.Unresolved}"));
+
+    private static IEnumerable<(SeverityLevel? Level, int Unresolved, double Percent)> SeveritySegments(ProviderCoverageDetail detail)
+    {
+        int total = detail.Levels.Sum(level => level.Counts.Unresolved);
+
+        if (total == 0) { yield break; }
+
+        foreach (LevelCoverageRow level in detail.Levels)
+        {
+            yield return (level.Level, level.Counts.Unresolved, level.Counts.Unresolved * 100.0 / total);
+        }
+    }
+
+    private static bool ShowDatabaseAction(ProviderCoverageRow row) =>
+        row.Counts.NoProvider > 0 || row.Counts.NoMessage > 0;
+
+    private string AriaSort(CoverageSortColumn column) =>
+        _sortColumn != column ? "none" : _sortDescending ? "descending" : "ascending";
+
+    private void CancelDetailScan()
+    {
+        CancellationTokenSource? scan = _detailCts;
+        _detailCts = null;
+        scan?.Cancel();
+        scan?.Dispose();
+    }
+
+    private IEnumerable<(string Token, int Count)> CauseBreakdown()
+    {
+        if (_report is null) { yield break; }
+
+        yield return (ResolutionStatusTokens.NoProvider, _report.Summary.NoProvider);
+        yield return (ResolutionStatusTokens.NoMessage, _report.Summary.NoMessage);
+        yield return (ResolutionStatusTokens.Failed, _report.Summary.Failed);
+    }
+
+    private void CollapseDetail()
+    {
+        CancelDetailScan();
+        _expandedProvider = null;
+        _detail = null;
+        _detailLoading = false;
+        _detailFailed = false;
+
+        // Invalidate any in-flight scan so a late completion cannot repopulate a collapsed row.
+        ++_detailGeneration;
+    }
+
+    private async Task CopyTableAsync()
+    {
+        // The synchronous formatter cannot be canceled mid-build, so the guard - not a superseding CTS - is what
+        // prevents concurrent large allocations from rapid clicks.
+        if (_copying || _report is null) { return; }
+
+        _copying = true;
+
+        try
+        {
+            ResolutionCoverageReport report = _report;
+            bool isFiltered = _isFiltered;
+            string tsv = await Task.Run(() => CoverageTableFormatter.Format(report, isFiltered), _cts.Token);
+            await ClipboardService.CopyTextAsync(tsv);
+
+            if (IsDisposed) { return; }
+
+            _ = ShowCopiedFeedbackAsync();
+        }
+        catch (OperationCanceledException) { }
+        finally
+        {
+            _copying = false;
+        }
+    }
+
+    private async Task ExcludeProviderAsync(ProviderCoverageRow row)
+    {
+        FilterLensCommands.ExcludeValue(EventProperty.Source, row.Provider, _originLog);
+        await CompleteAsync(true);
+    }
+
+    private async Task FilterByCauseAsync(string token)
+    {
+        FilterLensCommands.IncludeValue(EventProperty.ResolutionStatus, token, _originLog);
+        await CompleteAsync(true);
+    }
+
+    private async Task FilterEventIdUnresolvedAsync(string provider, int eventId)
+    {
+        if (string.IsNullOrWhiteSpace(provider)) { return; }
+
+        FilterLensCommands.IncludeValue(EventProperty.Source, provider, _originLog);
+        FilterLensCommands.IncludeEventId(eventId, _originLog);
+        FilterLensCommands.ExcludeValue(EventProperty.ResolutionStatus, ResolutionStatusTokens.Resolved, _originLog);
+        await CompleteAsync(true);
+    }
+
+    private async Task FilterProviderUnresolvedAsync(ProviderCoverageRow row)
+    {
+        if (string.IsNullOrWhiteSpace(row.Provider) || row.Status == CoverageStatus.Full) { return; }
+
+        // Include the provider first, then exclude resolved events, so the view narrows to exactly this provider's
+        // unresolved events (both lenses remain independently removable afterward).
+        FilterLensCommands.IncludeValue(EventProperty.Source, row.Provider, _originLog);
+        FilterLensCommands.ExcludeValue(EventProperty.ResolutionStatus, ResolutionStatusTokens.Resolved, _originLog);
+        await CompleteAsync(true);
+    }
+
+    private List<ProviderCoverageRow> FilteredSortedRows()
+    {
+        if (_report is null) { return []; }
+
+        IEnumerable<ProviderCoverageRow> rows = _report.Rows;
+
+        if (!string.IsNullOrWhiteSpace(_search))
+        {
+            string needle = _search.Trim();
+            rows = rows.Where(row => row.Provider.Contains(needle, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return [.. SortRows(rows)];
+    }
+
+    private string FormatShare(int count) => TallyFormatter.Share(count, _report?.Summary.Total ?? 0);
+
+    private async Task IncludeProviderAsync(ProviderCoverageRow row)
+    {
+        FilterLensCommands.IncludeValue(EventProperty.Source, row.Provider, _originLog);
+        await CompleteAsync(true);
+    }
+
+    private bool IsExpanded(ProviderCoverageRow row) =>
+        string.Equals(_expandedProvider, row.Provider, StringComparison.Ordinal);
+
+    private async Task LoadDetailAsync(ProviderCoverageRow row)
+    {
+        // Supersede any in-flight scan; cancel the LINKED cts, never the shared _cts the copy path also uses.
+        CancelDetailScan();
+
+        _detailFailed = false;
+        int generation = ++_detailGeneration;
+
+        if (_detailCache.TryGetValue(row.Provider, out ProviderCoverageDetail? cached))
+        {
+            _detail = cached;
+            _detailLoading = false;
+
+            return;
+        }
+
+        _detail = null;
+
+        if (_view is not { } view)
+        {
+            _detailLoading = false;
+            _detailFailed = true;
+
+            return;
+        }
+
+        _detailLoading = true;
+
+        CancellationTokenSource linked = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token);
+        _detailCts = linked;
+        string provider = row.Provider;
+
+        ProviderCoverageDetail? detail = null;
+        bool failed = false;
+
+        try
+        {
+            detail = await Task.Run(() => CoverageService.BuildProviderDetail(view, provider, linked.Token), linked.Token);
+        }
+        catch (OperationCanceledException) { return; }
+        catch (Exception) { failed = true; }
+
+        // Ignore a completion that was superseded by another expand/collapse or that arrived after disposal.
+        if (IsDisposed || generation != _detailGeneration) { return; }
+
+        _detailLoading = false;
+
+        if (failed)
+        {
+            _detailFailed = true;
+        }
+        else
+        {
+            _detailCache[provider] = detail!;
+            _detail = detail;
+        }
+
+        StateHasChanged();
+    }
+
+    private async Task OpenDatabaseToolsAsync()
+    {
+        await CompleteAsync(true);
+        await ModalCoordinator.OpenDatabaseToolsAsync();
+    }
+
+    private string ProportionAriaLabel()
+    {
+        if (_report is null) { return string.Empty; }
+
+        ProviderResolutionCounts summary = _report.Summary;
+
+        return $"Resolution mix: {FormatShare(summary.Resolved)} resolved, " +
+            $"{FormatShare(summary.NoProvider)} no provider metadata, " +
+            $"{FormatShare(summary.NoMessage)} no message match, " +
+            $"{FormatShare(summary.Failed)} resolution error.";
+    }
+
+    private IEnumerable<(string Label, string CssClass, double Percent)> ProportionSegments()
+    {
+        if (_report is null || _report.Summary.Total == 0) { yield break; }
+
+        ProviderResolutionCounts summary = _report.Summary;
+        double total = summary.Total;
+
+        if (summary.Resolved > 0) { yield return ("Resolved", "coverage-seg-resolved", summary.Resolved * 100.0 / total); }
+        if (summary.NoProvider > 0) { yield return (ResolutionStatusTokens.NoProvider, "coverage-seg-noprovider", summary.NoProvider * 100.0 / total); }
+        if (summary.NoMessage > 0) { yield return (ResolutionStatusTokens.NoMessage, "coverage-seg-nomessage", summary.NoMessage * 100.0 / total); }
+        if (summary.Failed > 0) { yield return (ResolutionStatusTokens.Failed, "coverage-seg-failed", summary.Failed * 100.0 / total); }
+    }
+
+    private string RemediationHint(ProviderCoverageRow row) => DominantCause(row.Counts) switch
+    {
+        ResolutionCause.NoProvider =>
+            $"No provider metadata is installed for {row.Provider} on this machine. Import a provider database from Database Tools, or open this log where the source software is installed.",
+        ResolutionCause.NoMessage =>
+            $"{row.Provider} has provider metadata but no message definition for these event IDs. A newer provider database may add them.",
+        _ =>
+            $"Resolution hit an unexpected error for some of {row.Provider}'s events. Reopening the log, or inspecting the raw event XML, may help."
+    };
+
+    // Re-runs the scan for the already-expanded provider (the failure-state Retry) without collapsing first, so Retry
+    // cannot land on ToggleExpandAsync's collapse branch.
+    private Task RetryDetailAsync(ProviderCoverageRow row) => LoadDetailAsync(row);
+
+    // Mirrors the CriticalBanner feedback timer: only the newest cycle clears the flag, and disposal (which nulls
+    // _copiedCts and cancels the token) makes the ReferenceEquals guard fail so StateHasChanged never runs afterward.
+    private async Task ShowCopiedFeedbackAsync()
+    {
+        if (IsDisposed) { return; }
+
+        CancellationTokenSource? previous = _copiedCts;
+        _copiedCts = null;
+
+        if (previous is not null)
+        {
+            await previous.CancelAsync();
+            previous.Dispose();
+        }
+
+        var cts = new CancellationTokenSource();
+        _copiedCts = cts;
+        _showCopied = true;
+        StateHasChanged();
+
+        try
+        {
+            await Task.Delay(s_copiedFeedbackDuration, cts.Token);
+
+            if (ReferenceEquals(_copiedCts, cts))
+            {
+                _showCopied = false;
+                StateHasChanged();
+            }
+        }
+        catch (TaskCanceledException) { /* Feedback cycle cancelled by the next copy or by disposal. */ }
+    }
+
+    private async Task ShowOnlyUnresolvedAsync()
+    {
+        FilterLensCommands.ExcludeValue(EventProperty.ResolutionStatus, ResolutionStatusTokens.Resolved, _originLog);
+        await CompleteAsync(true);
+    }
+
+    private IEnumerable<ProviderCoverageRow> SortRows(IEnumerable<ProviderCoverageRow> rows)
+    {
+        if (_sortColumn == CoverageSortColumn.Provider)
+        {
+            return _sortDescending ?
+                rows.OrderByDescending(row => row.Provider, StringComparer.Ordinal) :
+                rows.OrderBy(row => row.Provider, StringComparer.Ordinal);
+        }
+
+        Func<ProviderCoverageRow, int> key = _sortColumn switch
+        {
+            CoverageSortColumn.Total => row => row.Counts.Total,
+            CoverageSortColumn.Resolved => row => row.Counts.Resolved,
+            CoverageSortColumn.NoProvider => row => row.Counts.NoProvider,
+            CoverageSortColumn.NoMessage => row => row.Counts.NoMessage,
+            CoverageSortColumn.Failed => row => row.Counts.Failed,
+            CoverageSortColumn.Coverage => row => (int)row.Status,
+            _ => row => row.Counts.Unresolved
+        };
+
+        return _sortDescending ?
+            rows.OrderByDescending(key).ThenBy(row => row.Provider, StringComparer.Ordinal) :
+            rows.OrderBy(key).ThenBy(row => row.Provider, StringComparer.Ordinal);
+    }
+
+    private async Task ToggleExpandAsync(ProviderCoverageRow row)
+    {
+        if (IsExpanded(row))
+        {
+            CollapseDetail();
+
+            return;
+        }
+
+        _expandedProvider = row.Provider;
+        await LoadDetailAsync(row);
+    }
+
+    private void ToggleSort(CoverageSortColumn column)
+    {
+        if (_sortColumn == column)
+        {
+            _sortDescending = !_sortDescending;
+
+            return;
+        }
+
+        _sortColumn = column;
+
+        // Provider is textual and reads best ascending; numeric columns lead with the largest counts.
+        _sortDescending = column != CoverageSortColumn.Provider;
+    }
+}

--- a/src/EventLogExpert.UI/LogTable/Resolution/ResolutionCoverageModal.razor.css
+++ b/src/EventLogExpert.UI/LogTable/Resolution/ResolutionCoverageModal.razor.css
@@ -1,0 +1,378 @@
+.resolution-coverage {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    height: 100%;
+    overflow: hidden;
+}
+
+.resolution-coverage-status {
+    padding: 1rem;
+    text-align: center;
+    opacity: 0.7;
+}
+
+.resolution-coverage-summary {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--border-color, rgba(128, 128, 128, 0.3));
+}
+
+.resolution-coverage-scope {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    opacity: 0.7;
+    font-size: var(--font-size-sm);
+}
+
+.resolution-coverage-badge {
+    opacity: 1;
+    padding: 0.05rem 0.4rem;
+    border-radius: 0.75rem;
+    font-size: var(--font-size-xs);
+    font-weight: 600;
+    background: rgba(255, 193, 7, 0.25);
+}
+
+.resolution-coverage-tallies {
+    display: flex;
+    gap: 1.5rem;
+    font-size: var(--font-size-sm);
+}
+
+.resolution-coverage-breakdown {
+    display: flex;
+    gap: 1.5rem;
+    font-size: var(--font-size-sm);
+}
+
+.resolution-coverage-search {
+    width: 100%;
+}
+
+.resolution-coverage-truncated {
+    font-size: var(--font-size-sm);
+    opacity: 0.7;
+}
+
+.resolution-coverage-table {
+    display: flex;
+    flex-direction: column;
+    overflow-x: auto;
+    overflow-y: auto;
+    flex: 1 1 auto;
+    font-size: var(--font-size-base);
+}
+
+.resolution-coverage-head,
+.resolution-coverage-row {
+    display: grid;
+    grid-template-columns: minmax(12rem, 2.5fr) repeat(5, minmax(3.5rem, 1fr)) minmax(5rem, 1fr) 6.5rem;
+    gap: 0.25rem;
+    align-items: center;
+    padding: 0.15rem 0.25rem;
+}
+
+.resolution-row-alt {
+    background: rgba(128, 128, 128, 0.06);
+}
+
+.resolution-num {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+}
+
+.resolution-cov {
+    text-align: center;
+}
+
+.resolution-sort {
+    background: transparent;
+    border: none;
+    color: inherit;
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+    padding: 0;
+    width: 100%;
+    text-align: left;
+}
+
+.resolution-sort.resolution-num {
+    text-align: right;
+}
+
+.resolution-sort.resolution-cov {
+    text-align: center;
+}
+
+.resolution-sort:hover {
+    text-decoration: underline;
+}
+
+[aria-sort="ascending"] .resolution-sort::after {
+    content: " \2191";
+}
+
+[aria-sort="descending"] .resolution-sort::after {
+    content: " \2193";
+}
+
+.resolution-coverage-head {
+    position: sticky;
+    top: 0;
+    font-weight: 600;
+    background: var(--background-color, #1e1e1e);
+    border-bottom: 1px solid var(--border-color, rgba(128, 128, 128, 0.3));
+}
+
+.resolution-provider {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.coverage-pill {
+    padding: 0.05rem 0.4rem;
+    border-radius: 0.75rem;
+    font-size: var(--font-size-xs);
+}
+
+.coverage-full {
+    background: rgba(40, 167, 69, 0.25);
+}
+
+.coverage-partial {
+    background: rgba(255, 193, 7, 0.25);
+}
+
+.coverage-none {
+    background: rgba(220, 53, 69, 0.25);
+}
+
+.resolution-actions {
+    display: flex;
+    gap: 0.15rem;
+}
+
+.resolution-actions button {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    color: inherit;
+    padding: 0.1rem;
+}
+
+.resolution-coverage-bar {
+    display: flex;
+    height: 0.5rem;
+    border-radius: 0.25rem;
+    overflow: hidden;
+    background: rgba(128, 128, 128, 0.15);
+}
+
+.resolution-coverage-seg {
+    min-width: 3px;
+    height: 100%;
+}
+
+.coverage-seg-resolved {
+    background: rgba(40, 167, 69, 0.7);
+}
+
+.coverage-seg-noprovider {
+    background: rgba(220, 53, 69, 0.7);
+}
+
+.coverage-seg-nomessage {
+    background: rgba(255, 193, 7, 0.7);
+}
+
+.coverage-seg-failed {
+    background: rgba(108, 117, 125, 0.7);
+}
+
+.resolution-coverage-footer {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.resolution-coverage-copied-chip {
+    color: rgba(40, 167, 69, 1);
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+}
+
+.resolution-cause-filter {
+    background: transparent;
+    border: none;
+    color: inherit;
+    font: inherit;
+    cursor: pointer;
+    padding: 0;
+    text-decoration: underline dotted;
+    text-underline-offset: 2px;
+}
+
+.resolution-cause-filter:hover {
+    color: var(--clr-lightblue);
+    text-decoration-style: solid;
+}
+
+.resolution-cause-empty {
+    opacity: 0.55;
+}
+
+.resolution-provider-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    width: 100%;
+    background: transparent;
+    border: none;
+    color: inherit;
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+    padding: 0;
+    overflow: hidden;
+}
+
+.resolution-provider-toggle:hover .resolution-provider-name {
+    text-decoration: underline;
+}
+
+.resolution-provider-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.resolution-coverage-detail {
+    padding: 0.5rem 0.75rem 0.75rem 1.75rem;
+    background: rgba(128, 128, 128, 0.06);
+    border-bottom: 1px solid var(--border-color, rgba(128, 128, 128, 0.2));
+}
+
+.resolution-detail-region {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+}
+
+.resolution-detail-status {
+    font-size: var(--font-size-sm);
+    opacity: 0.8;
+}
+
+.resolution-detail-hint {
+    padding: 0.35rem 0.5rem;
+    border-radius: 0.25rem;
+    background: rgba(128, 128, 128, 0.12);
+}
+
+.resolution-detail-section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+}
+
+.resolution-detail-heading {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    font-weight: 600;
+}
+
+.resolution-detail-note {
+    font-weight: 400;
+    font-size: var(--font-size-sm);
+    opacity: 0.7;
+}
+
+.resolution-detail-sevbar {
+    display: flex;
+    height: 0.5rem;
+    max-width: 24rem;
+    border-radius: 0.25rem;
+    overflow: hidden;
+    background: rgba(128, 128, 128, 0.15);
+}
+
+.resolution-detail-sevseg {
+    min-width: 3px;
+    height: 100%;
+}
+
+.resolution-detail-sevcounts {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.resolution-detail-sevcount {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+}
+
+.resolution-detail-sevdot {
+    display: inline-block;
+    width: 0.6rem;
+    height: 0.6rem;
+    border-radius: 50%;
+}
+
+.coverage-sev-critical { background: rgba(220, 53, 69, 0.85); }
+
+.coverage-sev-error { background: rgba(240, 108, 0, 0.85); }
+
+.coverage-sev-warning { background: rgba(255, 193, 7, 0.85); }
+
+.coverage-sev-information { background: rgba(13, 110, 253, 0.7); }
+
+.coverage-sev-verbose { background: rgba(108, 117, 125, 0.7); }
+
+.coverage-sev-unknown { background: rgba(128, 128, 128, 0.5); }
+
+.resolution-detail-idtable {
+    display: flex;
+    flex-direction: column;
+    max-height: 16rem;
+    overflow-y: auto;
+}
+
+.resolution-detail-idrow {
+    display: grid;
+    grid-template-columns: 6rem minmax(4rem, 1fr) minmax(4rem, 1fr) minmax(8rem, 1.5fr) 2.5rem;
+    gap: 0.25rem;
+    align-items: center;
+    padding: 0.1rem 0.25rem;
+}
+
+.resolution-detail-idrow:nth-child(even) {
+    background: rgba(128, 128, 128, 0.05);
+}
+
+.resolution-detail-idhead {
+    position: sticky;
+    top: 0;
+    font-weight: 600;
+    background: var(--background-color, #1e1e1e);
+}
+
+.resolution-detail-idrow button {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    color: inherit;
+    padding: 0.1rem;
+}
+
+.resolution-detail-idrow .resolution-lens {
+    justify-self: end;
+}

--- a/src/EventLogExpert.UI/LogTable/SeverityDisplay.cs
+++ b/src/EventLogExpert.UI/LogTable/SeverityDisplay.cs
@@ -1,0 +1,23 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+
+namespace EventLogExpert.UI.LogTable;
+
+// Shared display vocabulary for a severity level (null = the Unknown/absent slot), so the coverage severity breakdown
+// renders the same names the rest of the app uses without hardcoding a second copy.
+internal static class SeverityDisplay
+{
+    public static string Label(SeverityLevel? level) => level?.ToString() ?? "Unknown";
+
+    public static string Key(SeverityLevel? level) => level switch
+    {
+        SeverityLevel.Critical => "critical",
+        SeverityLevel.Error => "error",
+        SeverityLevel.Warning => "warning",
+        SeverityLevel.Information => "information",
+        SeverityLevel.Verbose => "verbose",
+        _ => "unknown"
+    };
+}

--- a/src/EventLogExpert.UI/LogTable/Stats/StatsDetailModal.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/Stats/StatsDetailModal.razor.cs
@@ -6,7 +6,6 @@ using EventLogExpert.Runtime.LogTable;
 using EventLogExpert.Runtime.Stats;
 using EventLogExpert.UI.Modal;
 using Microsoft.AspNetCore.Components;
-using System.Globalization;
 
 namespace EventLogExpert.UI.LogTable.Stats;
 
@@ -87,13 +86,12 @@ public sealed partial class StatsDetailModal : ModalBase<bool>
         }
     }
 
-    private static string FormatCount(int value) => value.ToString("N0", CultureInfo.CurrentCulture);
+    private static string FormatCount(int value) => TallyFormatter.Count(value);
 
     private void Exclude(StatsContributor row) =>
         Dimension.PushRowFilter(FilterLensCommands, row.Value, OriginLog, include: false);
 
-    private string FormatShare(int count) =>
-        _total == 0 ? "0%" : (count * 100.0 / _total).ToString("0.0", CultureInfo.CurrentCulture) + "%";
+    private string FormatShare(int count) => TallyFormatter.Share(count, _total);
 
     private void Include(StatsContributor row) =>
         Dimension.PushRowFilter(FilterLensCommands, row.Value, OriginLog, include: true);

--- a/src/EventLogExpert.UI/LogTable/Stats/StatsPane.razor
+++ b/src/EventLogExpert.UI/LogTable/Stats/StatsPane.razor
@@ -5,6 +5,13 @@
     <div class="stats-header">
         <span class="stats-title">Statistics</span>
         <span class="stats-headline@(IsSeverityStale ? " stats-stale" : "")">@HeadlineText()</span>
+        <button aria-label="Open Resolution and Coverage"
+            class="stats-coverage-link"
+            @onclick="OpenCoverage"
+            title="Show unresolved events and provider coverage"
+            type="button">
+            Resolution &amp; Coverage
+        </button>
     </div>
 
     @if (_scanFailed)

--- a/src/EventLogExpert.UI/LogTable/Stats/StatsPane.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/Stats/StatsPane.razor.cs
@@ -320,6 +320,9 @@ public sealed partial class StatsPane
         catch (ObjectDisposedException) { /* Component torn down mid-failure; nothing to report. */ }
     }
 
+    private void OpenCoverage() =>
+        _ = ModalCoordinator.OpenResolutionCoverageAsync();
+
     private void OpenDetail(StatsDimension dimension) =>
         _ = ModalCoordinator.OpenStatsDetailAsync(dimension, ViewSource.Current.View, Presentation.ActiveLogName);
 

--- a/src/EventLogExpert.UI/LogTable/Stats/StatsPane.razor.css
+++ b/src/EventLogExpert.UI/LogTable/Stats/StatsPane.razor.css
@@ -1,3 +1,14 @@
+.stats-coverage-link {
+    margin-left: auto;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    padding: 0;
+    text-decoration: underline;
+}
+
 .stats-pane {
     display: flex;
     flex-direction: column;

--- a/src/EventLogExpert.UI/LogTable/TallyFormatter.cs
+++ b/src/EventLogExpert.UI/LogTable/TallyFormatter.cs
@@ -1,0 +1,16 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Globalization;
+
+namespace EventLogExpert.UI.LogTable;
+
+// Shared count/percentage formatting for the stats and coverage contributor tables so the "N0" and share math
+// (including the zero-total guard and culture) lives in exactly one place.
+internal static class TallyFormatter
+{
+    public static string Count(int value) => value.ToString("N0", CultureInfo.CurrentCulture);
+
+    public static string Share(int count, int total) =>
+        total == 0 ? "0%" : (count * 100.0 / total).ToString("0.0", CultureInfo.CurrentCulture) + "%";
+}

--- a/src/EventLogExpert.UI/Menu/MenuBar.razor.cs
+++ b/src/EventLogExpert.UI/Menu/MenuBar.razor.cs
@@ -274,6 +274,7 @@ public sealed partial class MenuBar
         bool isGrouping = LogTableQueries.IsGrouping();
         bool isGroupDescending = LogTableQueries.IsGroupDescending();
         bool isHistogramVisible = HistogramVisibility.IsVisible;
+        bool hasActiveLogs = LogTableQueries.HasActiveLogs();
 
         return
         [
@@ -309,6 +310,11 @@ public sealed partial class MenuBar
                 "Timeline",
                 () => Actions.SetHistogramVisible(!isHistogramVisible),
                 isChecked: isHistogramVisible),
+            MenuItem.Item(
+                "Resolution & Coverage",
+                () => Actions.ShowResolutionCoverageAsync(),
+                isEnabled: hasActiveLogs,
+                disabledReason: hasActiveLogs ? null : "Open a log to view resolution coverage."),
         ];
     }
 

--- a/src/EventLogExpert.UI/Modal/ModalChrome.razor.css
+++ b/src/EventLogExpert.UI/Modal/ModalChrome.razor.css
@@ -43,7 +43,7 @@ dialog:not(:modal) {
 
     white-space: nowrap;
     text-overflow: ellipsis;
-    font-size: 1.1rem;
+    font-size: var(--font-size-lg);
     color: var(--clr-lightblue);
 }
 
@@ -111,7 +111,7 @@ dialog[data-body-layout="content"] .dialog-body {
 
     white-space: nowrap;
     text-overflow: ellipsis;
-    font-size: 1.05rem;
+    font-size: var(--font-size-lg);
     color: var(--clr-lightblue);
 }
 
@@ -134,7 +134,7 @@ dialog[data-body-layout="content"] .dialog-body {
     color: var(--text-error);
     background: color-mix(in srgb, var(--clr-red) 8%, transparent);
     border-radius: .2rem;
-    font-size: .85rem;
+    font-size: var(--font-size-sm);
 }
 
 .inline-alert-buttons {

--- a/src/EventLogExpert.UI/Modal/ModalCoordinatorLaunchers.cs
+++ b/src/EventLogExpert.UI/Modal/ModalCoordinatorLaunchers.cs
@@ -8,6 +8,7 @@ using EventLogExpert.UI.Database;
 using EventLogExpert.UI.DatabaseTools;
 using EventLogExpert.UI.DebugLog;
 using EventLogExpert.UI.FilterLibrary;
+using EventLogExpert.UI.LogTable.Resolution;
 using EventLogExpert.UI.LogTable.Stats;
 using EventLogExpert.UI.Settings;
 using EventLogExpert.UI.Update;
@@ -64,6 +65,13 @@ public static class ModalCoordinatorLaunchers
             ArgumentNullException.ThrowIfNull(coordinator);
 
             return coordinator.PushAsync<SettingsModal, bool>();
+        }
+
+        public Task<ModalOpenResult<bool>> OpenResolutionCoverageAsync()
+        {
+            ArgumentNullException.ThrowIfNull(coordinator);
+
+            return coordinator.PushAsync<ResolutionCoverageModal, bool>();
         }
 
         public Task<ModalOpenResult<bool>> OpenStatsDetailAsync(StatsDimension dimension, IEventColumnView view, string? originLog)

--- a/src/EventLogExpert.UI/StatusBar/StatusBar.razor
+++ b/src/EventLogExpert.UI/StatusBar/StatusBar.razor
@@ -27,7 +27,7 @@
 
         @if (activeTable is not null)
         {
-            var total = TotalRawCount(activeTable, status.Groups, status);
+            var scoped = status.ScopedCounts(activeTable);
 
             var describesActiveTab = Presentation.ActiveTabId == activeTable.Id &&
                 Presentation.State == PresentationState.Current;
@@ -41,8 +41,20 @@
                 @onclick="ToggleStats"
                 title="@(StatsVisibility.IsVisible ? "Hide statistics for these events" : "Show statistics for these events")"
                 type="button">
-                <span class="status-bar-counts">@StatusBarFormatter.FormatCounts(total, shown, isFiltered && describesActiveTab, status.SelectionCount)</span>
+                <span class="status-bar-counts">
+                    @StatusBarFormatter.FormatCounts(scoped.Total, shown, isFiltered && describesActiveTab, status.SelectionCount)
+                </span>
                 <i aria-hidden="true" class="bi bi-caret-@(StatsVisibility.IsVisible ? "down" : "up")"></i>
+            </button>
+
+            <span aria-hidden="true" class="status-bar-sep">|</span>
+            <button aria-label="@($"Resolution and coverage: {StatusBarFormatter.FormatCoverageChip(scoped.Unresolved)}. Open for details.")"
+                class="status-bar-coverage status-bar-stats"
+                @onclick="OpenCoverage"
+                title="@StatusBarFormatter.CoverageChipTooltip(scoped.Unresolved, scoped.Total)"
+                type="button">
+                <i aria-hidden="true" class="bi bi-patch-question"></i>
+                <span class="status-bar-counts">@StatusBarFormatter.FormatCoverageChip(scoped.Unresolved)</span>
             </button>
         }
 

--- a/src/EventLogExpert.UI/StatusBar/StatusBar.razor.cs
+++ b/src/EventLogExpert.UI/StatusBar/StatusBar.razor.cs
@@ -6,8 +6,8 @@ using EventLogExpert.Runtime.FilterLenses;
 using EventLogExpert.Runtime.LogTable;
 using EventLogExpert.Runtime.Stats;
 using EventLogExpert.Runtime.StatusBar;
+using EventLogExpert.UI.Modal;
 using Microsoft.AspNetCore.Components;
-using System.Collections.Immutable;
 
 namespace EventLogExpert.UI.StatusBar;
 
@@ -20,6 +20,8 @@ public sealed partial class StatusBar
     [Inject] private DisplayIndicatorGate IndicatorGate { get; init; } = null!;
 
     [Inject] private IFilterLensSource LensSource { get; init; } = null!;
+
+    [Inject] private IModalCoordinator ModalCoordinator { get; init; } = null!;
 
     [Inject] private IStatsCommands StatsCommands { get; init; } = null!;
 
@@ -49,19 +51,7 @@ public sealed partial class StatusBar
         base.OnInitialized();
     }
 
-    private static int TotalRawCount(LogView activeTable, ImmutableList<LogTabGroup> groups, StatusBarPresentation status)
-    {
-        if (activeTable.GroupId?.IsAll == true) { return status.RawEventTotal; }
-
-        if (activeTable.GroupId is not { } groupId)
-        {
-            return status.RawEventCountsByLog.GetValueOrDefault(activeTable.Id, 0);
-        }
-
-        var group = groups.FirstOrDefault(candidate => candidate.Id == groupId);
-
-        return group is null ? 0 : group.MemberIds.Sum(id => status.RawEventCountsByLog.GetValueOrDefault(id, 0));
-    }
+    private void OpenCoverage() => _ = ModalCoordinator.OpenResolutionCoverageAsync();
 
     private void RequestIndicatorRender() => RequestGuardedRender(StateHasChanged);
 

--- a/src/EventLogExpert.UI/wwwroot/Banner/banner.css
+++ b/src/EventLogExpert.UI/wwwroot/Banner/banner.css
@@ -102,18 +102,18 @@
 
     background-color: rgba(255, 255, 255, 0.2);
     border-radius: .75rem;
-    font-size: .85rem;
+    font-size: var(--font-size-sm);
 }
 
 .banner-subtitle {
-    font-size: .85rem;
+    font-size: var(--font-size-sm);
     opacity: .9;
 }
 
 .banner-pagination {
     flex: 0 0 auto;
 
-    font-size: .85rem;
+    font-size: var(--font-size-sm);
     opacity: .85;
 }
 

--- a/src/EventLogExpert.UI/wwwroot/app.css
+++ b/src/EventLogExpert.UI/wwwroot/app.css
@@ -87,6 +87,16 @@
     --z-error-ui: 40;
     --z-menu-overlay: 60;
     --z-submenu: 80;
+
+    /* Typography scale. Use these tokens for text font-size; do not hardcode
+       px/em/rem for text (em is reserved for glyphs that track their own
+       label). Root is 10pt, so 1rem = 13.3px; xs/md/lg land on whole pixels. */
+    --font-size-xs: 0.75rem;
+    --font-size-sm: 0.85rem;
+    --font-size-md: 0.9rem;
+    --font-size-base: 1rem;
+    --font-size-lg: 1.2rem;
+    --font-size-xl: 1.4rem;
 }
 
 /* Explicit user choice overrides the OS preference. Setting color-scheme to a

--- a/src/EventLogExpert/Adapters/Menu/MauiMenuActionService.cs
+++ b/src/EventLogExpert/Adapters/Menu/MauiMenuActionService.cs
@@ -20,6 +20,7 @@ using EventLogExpert.Runtime.Settings;
 using EventLogExpert.Runtime.Update;
 using EventLogExpert.UI.DatabaseTools;
 using EventLogExpert.UI.DebugLog;
+using EventLogExpert.UI.LogTable.Resolution;
 using EventLogExpert.UI.Modal;
 using EventLogExpert.UI.Settings;
 using EventLogExpert.WindowsPlatform.Activation;
@@ -301,6 +302,11 @@ public sealed class MauiMenuActionService(
             _traceLogger.Error($"Failed to display release notes: {ex}");
         }
     }
+
+    public Task ShowResolutionCoverageAsync() =>
+        TryOpenModalAsync(
+            () => _modalCoordinator.OpenResolutionCoverageAsync(),
+            nameof(ResolutionCoverageModal));
 
     public void ToggleGroupSortDirection() => _logTableCommands.ToggleGroupSortDirection();
 

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Common/Events/EventColumnRehydrationTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Common/Events/EventColumnRehydrationTests.cs
@@ -49,6 +49,16 @@ public sealed class EventColumnRehydrationTests
     }
 
     [Fact]
+    public void GetDetail_PendingRow_PreservesResolutionStatus()
+    {
+        ResolvedEvent pending = new("live", LogPathType.Channel) { Id = 1, ResolutionStatus = EventResolutionStatus.NoMessage };
+        EventColumnStore store = EventColumnStore.Build([], generation: 1, contentVersion: 1).Append([pending]);
+
+        Assert.True(store.IsPending(0));
+        Assert.Equal(EventResolutionStatus.NoMessage, store.GetDetail(0).ResolutionStatus);
+    }
+
+    [Fact]
     public void GetDetail_PendingRow_ReturnsSamePendingEvent()
     {
         ResolvedEvent pending = BuildRichEvent();
@@ -274,6 +284,26 @@ public sealed class EventColumnRehydrationTests
         Assert.Equal(string.Empty, store.GetDetail(0).KeywordsDisplayName);
         Assert.Equal("Classic", store.GetDetail(1).KeywordsDisplayName);
         Assert.Equal("Audit Success, Audit Failure, Classic", store.GetDetail(2).KeywordsDisplayName);
+    }
+
+    [Fact]
+    public void GetDetail_SealedRows_RoundTripResolutionStatus()
+    {
+        ResolvedEvent[] sources =
+        [
+            new("live", LogPathType.Channel) { Id = 1, ResolutionStatus = EventResolutionStatus.NoProvider },
+            new("live", LogPathType.Channel) { Id = 2, ResolutionStatus = EventResolutionStatus.NoMessage },
+            new("live", LogPathType.Channel) { Id = 3, ResolutionStatus = EventResolutionStatus.Failed },
+            new("live", LogPathType.Channel) { Id = 4, ResolutionStatus = EventResolutionStatus.Resolved }
+        ];
+
+        EventColumnStore store = EventColumnStore.Build(sources, generation: 1, contentVersion: 1);
+
+        Assert.False(store.IsPending(0));
+        Assert.Equal(EventResolutionStatus.NoProvider, store.GetDetail(0).ResolutionStatus);
+        Assert.Equal(EventResolutionStatus.NoMessage, store.GetDetail(1).ResolutionStatus);
+        Assert.Equal(EventResolutionStatus.Failed, store.GetDetail(2).ResolutionStatus);
+        Assert.Equal(EventResolutionStatus.Resolved, store.GetDetail(3).ResolutionStatus);
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Common/Events/EventColumnStoreReaderTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Common/Events/EventColumnStoreReaderTests.cs
@@ -18,6 +18,66 @@ public sealed class EventColumnStoreReaderTests
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
+    public void CountResolutionDetailForSource_ScopesToProvider_TalliesByIdAndLevel(bool sealRows)
+    {
+        ResolvedEvent[] sample =
+        [
+            Detail(1, "Prov", "Error", EventResolutionStatus.NoProvider),
+            Detail(1, "Prov", "Error", EventResolutionStatus.NoProvider),
+            Detail(2, "Prov", "Critical", EventResolutionStatus.Resolved),
+            Detail(9, "Other", "Error", EventResolutionStatus.NoProvider),
+            Detail(3, "Prov", "", EventResolutionStatus.NoMessage)
+        ];
+
+        IEventColumnReader reader = ReaderOver(sample, sealRows);
+        int[] rank = new int[reader.Count]; // all survive
+        var byId = new Dictionary<int, ProviderResolutionCounts>();
+        var byLevel = new ProviderResolutionCounts[LevelSeverity.SlotCount];
+
+        reader.CountResolutionDetailForSource(rank, "Prov", byId, byLevel, TestContext.Current.CancellationToken);
+
+        // Only "Prov" rows contribute: id 1 (x2 NoProvider), id 2 (Resolved), id 3 (NoMessage). "Other" is excluded.
+        Assert.Equal(3, byId.Count);
+        Assert.Equal(2, byId[1].NoProvider);
+        Assert.Equal(2, byId[1].Total);
+        Assert.Equal(1, byId[2].Resolved);
+        Assert.Equal(1, byId[3].NoMessage);
+
+        Assert.Equal(2, byLevel[(int)SeverityLevel.Error].Total);
+        Assert.Equal(1, byLevel[(int)SeverityLevel.Critical].Total);
+        Assert.Equal(1, byLevel[0].Total); // empty level -> Unknown slot
+
+        // Invariant: Sum(byId totals) == Sum(byLevel totals) == the provider's surviving row count.
+        Assert.Equal(4, byId.Values.Sum(counts => counts.Total));
+        Assert.Equal(4, byLevel.Sum(counts => counts.Total));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CountResolutionDetailForSource_SkipsFilteredRows(bool sealRows)
+    {
+        ResolvedEvent[] sample =
+        [
+            Detail(1, "Prov", "Error", EventResolutionStatus.NoProvider),
+            Detail(1, "Prov", "Error", EventResolutionStatus.NoProvider)
+        ];
+
+        IEventColumnReader reader = ReaderOver(sample, sealRows);
+        int[] rank = new int[reader.Count];
+        rank[0] = -1; // filter out the first row
+        var byId = new Dictionary<int, ProviderResolutionCounts>();
+        var byLevel = new ProviderResolutionCounts[LevelSeverity.SlotCount];
+
+        reader.CountResolutionDetailForSource(rank, "Prov", byId, byLevel, TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, byId[1].Total);
+        Assert.Equal(1, byLevel[(int)SeverityLevel.Error].Total);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
     public void CountSeverity_SkipsFilteredRows(bool sealRows)
     {
         ResolvedEvent[] sample = [Ev(1, "Critical"), Ev(2, "Error"), Ev(3, "Error")];
@@ -99,6 +159,9 @@ public sealed class EventColumnStoreReaderTests
         Assert.Empty(reader.GetKeywords(reader.LocatorAt(1)));
         Assert.Equal(["Classic"], reader.GetKeywords(reader.LocatorAt(2)));
     }
+
+    private static ResolvedEvent Detail(int id, string source, string level, EventResolutionStatus status) =>
+        new("Application", LogPathType.Channel) { Id = id, Source = source, Level = level, ResolutionStatus = status, TimeCreated = s_time };
 
     private static ResolvedEvent Ev(int id, string level) =>
         new("Application", LogPathType.Channel) { Id = id, Level = level, TimeCreated = s_time };

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Common/Events/EventColumnStoreTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Common/Events/EventColumnStoreTests.cs
@@ -115,6 +115,38 @@ public sealed class EventColumnStoreTests
     }
 
     [Fact]
+    public void BuildMultiChunkThenAppend_MinMaxSpanSealedChunksAndPendingTail()
+    {
+        // Build columnarizes the whole batch into sealed chunks (empty tail); a short Append then stays in the pending
+        // tail, so the global min sits in a sealed chunk and the global max in the pending tail.
+        const int SealedRows = 4096 * 2; // Two full sealed chunks.
+        const int TailRows = 37;         // Below the reseal threshold, so it remains pending.
+
+        long baseTicks = new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Utc).Ticks;
+
+        ResolvedEvent[] sealedBatch = new ResolvedEvent[SealedRows];
+        for (int i = 0; i < SealedRows; i++) { sealedBatch[i] = EventAt(i, baseTicks + 1000 + i); }
+
+        long expectedMin = baseTicks; // Below every other value; placed in the second sealed chunk, not at a physical end.
+        sealedBatch[SealedRows - 100] = EventAt(SealedRows - 100, expectedMin);
+
+        ResolvedEvent[] tailBatch = new ResolvedEvent[TailRows];
+        for (int i = 0; i < TailRows; i++) { tailBatch[i] = EventAt(SealedRows + i, baseTicks + 2000 + i); }
+
+        long expectedMax = baseTicks + 10_000_000; // Above every other value; placed in the pending tail, not the last row.
+        tailBatch[TailRows - 5] = EventAt(SealedRows + TailRows - 5, expectedMax);
+
+        EventColumnStore store = EventColumnStore.Build(sealedBatch, generation: 1, contentVersion: 1).Append(tailBatch);
+
+        Assert.Equal(2, store.SealedChunkCount);
+        Assert.Equal(SealedRows, store.SealedCount);
+        Assert.Equal(TailRows, store.Count - store.SealedCount);
+        Assert.True(store.TryGetTimeRange(out long minTicks, out long maxTicks));
+        Assert.Equal(expectedMin, minTicks);
+        Assert.Equal(expectedMax, maxTicks);
+    }
+
+    [Fact]
     public void Build_AbsentNullableScalars_HasFlagsFalse()
     {
         ResolvedEvent resolvedEvent = new("live", LogPathType.Channel);
@@ -150,8 +182,8 @@ public sealed class EventColumnStoreTests
         Assert.Equal(-1, store.RawPoolIndex(EventColumnField.UserId, 0));
         Assert.Null(store.PoolGet(-1));
 
-        // Only the distinct strings {"live", "", "Info"} are pooled.
-        Assert.Equal(3, store.PoolDistinctCount);
+        // Only the distinct strings {"live", "", "Info", "Resolved"} are pooled ("Resolved" is the default ResolutionStatus token).
+        Assert.Equal(4, store.PoolDistinctCount);
     }
 
     [Fact]
@@ -463,29 +495,6 @@ public sealed class EventColumnStoreTests
     }
 
     [Fact]
-    public void Build_UserData_RoundTripsPathValuesTruncatedAndIncomplete()
-    {
-        ResolvedEvent resolvedEvent = new("live", LogPathType.Channel)
-        {
-            UserData = ImmutableArray.Create(
-                new UserDataField("Result/@value", ImmutableArray.Create("ok", "retry"), IsTruncated: true)),
-            UserDataIncomplete = true
-        };
-
-        EventColumnStore store = EventColumnStore.Build([resolvedEvent], generation: 1, contentVersion: 1);
-
-        Assert.True(store.RawUserDataIncomplete(0));
-        Assert.Equal(1, store.RawUserDataCount(0));
-        Assert.Equal("Result/@value", store.PoolGet(store.RawUserDataPathIndex(0, 0)));
-        Assert.True(store.RawUserDataTruncated(0, 0));
-
-        ReadOnlySpan<int> values = store.RawUserDataValues(0, 0);
-        Assert.Equal(2, values.Length);
-        Assert.Equal("ok", store.PoolGet(values[0]));
-        Assert.Equal("retry", store.PoolGet(values[1]));
-    }
-
-    [Fact]
     public void Build_UserDataMultipleFieldsAndRows_NestsWithoutCrossFieldBleed()
     {
         ResolvedEvent first = new("live", LogPathType.Channel)
@@ -520,35 +529,26 @@ public sealed class EventColumnStoreTests
     }
 
     [Fact]
-    public void BuildMultiChunkThenAppend_MinMaxSpanSealedChunksAndPendingTail()
+    public void Build_UserData_RoundTripsPathValuesTruncatedAndIncomplete()
     {
-        // Build columnarizes the whole batch into sealed chunks (empty tail); a short Append then stays in the pending
-        // tail, so the global min sits in a sealed chunk and the global max in the pending tail.
-        const int SealedRows = 4096 * 2; // Two full sealed chunks.
-        const int TailRows = 37;         // Below the reseal threshold, so it remains pending.
+        ResolvedEvent resolvedEvent = new("live", LogPathType.Channel)
+        {
+            UserData = ImmutableArray.Create(
+                new UserDataField("Result/@value", ImmutableArray.Create("ok", "retry"), IsTruncated: true)),
+            UserDataIncomplete = true
+        };
 
-        long baseTicks = new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Utc).Ticks;
+        EventColumnStore store = EventColumnStore.Build([resolvedEvent], generation: 1, contentVersion: 1);
 
-        ResolvedEvent[] sealedBatch = new ResolvedEvent[SealedRows];
-        for (int i = 0; i < SealedRows; i++) { sealedBatch[i] = EventAt(i, baseTicks + 1000 + i); }
+        Assert.True(store.RawUserDataIncomplete(0));
+        Assert.Equal(1, store.RawUserDataCount(0));
+        Assert.Equal("Result/@value", store.PoolGet(store.RawUserDataPathIndex(0, 0)));
+        Assert.True(store.RawUserDataTruncated(0, 0));
 
-        long expectedMin = baseTicks; // Below every other value; placed in the second sealed chunk, not at a physical end.
-        sealedBatch[SealedRows - 100] = EventAt(SealedRows - 100, expectedMin);
-
-        ResolvedEvent[] tailBatch = new ResolvedEvent[TailRows];
-        for (int i = 0; i < TailRows; i++) { tailBatch[i] = EventAt(SealedRows + i, baseTicks + 2000 + i); }
-
-        long expectedMax = baseTicks + 10_000_000; // Above every other value; placed in the pending tail, not the last row.
-        tailBatch[TailRows - 5] = EventAt(SealedRows + TailRows - 5, expectedMax);
-
-        EventColumnStore store = EventColumnStore.Build(sealedBatch, generation: 1, contentVersion: 1).Append(tailBatch);
-
-        Assert.Equal(2, store.SealedChunkCount);
-        Assert.Equal(SealedRows, store.SealedCount);
-        Assert.Equal(TailRows, store.Count - store.SealedCount);
-        Assert.True(store.TryGetTimeRange(out long minTicks, out long maxTicks));
-        Assert.Equal(expectedMin, minTicks);
-        Assert.Equal(expectedMax, maxTicks);
+        ReadOnlySpan<int> values = store.RawUserDataValues(0, 0);
+        Assert.Equal(2, values.Length);
+        Assert.Equal("ok", store.PoolGet(values[0]));
+        Assert.Equal("retry", store.PoolGet(values[1]));
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Common/Events/ResolutionStatusTokensTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Common/Events/ResolutionStatusTokensTests.cs
@@ -1,0 +1,29 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+
+namespace EventLogExpert.Eventing.Tests.Common.Events;
+
+public sealed class ResolutionStatusTokensTests
+{
+    [Fact]
+    public void Classify_ForEmptyToken_ReturnsResolved() =>
+        Assert.Equal(EventResolutionStatus.Resolved, ResolutionStatusTokens.Classify(string.Empty));
+
+    [Theory]
+    [InlineData(EventResolutionStatus.Resolved)]
+    [InlineData(EventResolutionStatus.NoProvider)]
+    [InlineData(EventResolutionStatus.NoMessage)]
+    [InlineData(EventResolutionStatus.Failed)]
+    public void Classify_RoundTripsEveryFormattedToken(EventResolutionStatus status) =>
+        Assert.Equal(status, ResolutionStatusTokens.Classify(ResolutionStatusTokens.Format(status)));
+
+    [Theory]
+    [InlineData(EventResolutionStatus.Resolved, ResolutionStatusTokens.Resolved)]
+    [InlineData(EventResolutionStatus.NoProvider, ResolutionStatusTokens.NoProvider)]
+    [InlineData(EventResolutionStatus.NoMessage, ResolutionStatusTokens.NoMessage)]
+    [InlineData(EventResolutionStatus.Failed, ResolutionStatusTokens.Failed)]
+    public void Format_ForEachStatus_ReturnsItsFrozenToken(EventResolutionStatus status, string expectedToken) =>
+        Assert.Equal(expectedToken, ResolutionStatusTokens.Format(status));
+}

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Resolvers/EventResolverBaseTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Resolvers/EventResolverBaseTests.cs
@@ -442,6 +442,25 @@ public sealed class EventResolverBaseTests
     }
 
     [Fact]
+    public void ResolveEvent_WhenModernEventResolves_ShouldReportResolvedStatus()
+    {
+        // Arrange
+        var (details, eventRecord) = EventUtils.CreateModernEvent(
+            "Service started: %1",
+            """<template><data name="Service" inType="win:UnicodeString"/></template>""",
+            ["TestService"]);
+
+        var resolver = new TestEventResolver([details]);
+
+        // Act
+        var displayEvent = resolver.ResolveEvent(eventRecord);
+
+        // Assert
+        Assert.Contains("TestService", displayEvent.Description);
+        Assert.Equal(EventResolutionStatus.Resolved, displayEvent.ResolutionStatus);
+    }
+
+    [Fact]
     public void ResolveEvent_WithAmbiguousPrimaryAndSupplementalDescription_ShouldUseSupplementalParameters()
     {
         // Arrange - regression: when the description is selected from supplemental, %%n
@@ -1090,6 +1109,61 @@ public sealed class EventResolverBaseTests
     }
 
     [Fact]
+    public void ResolveEvent_WithEmptyPrimaryAndNonMatchingSupplemental_ShouldReportNoMessageStatus()
+    {
+        // Arrange - a supplemental source HAS metadata for the provider, just no match for THIS event id,
+        // so a provider is available (NoMessage) rather than absent (NoProvider).
+        var primaryDetails = new ProviderDetails
+        {
+            ProviderName = Constants.TestProviderName,
+            Events = [],
+            Messages = [],
+            Parameters = [],
+            Keywords = new Dictionary<long, string>(),
+            Opcodes = new Dictionary<int, string>(),
+            Tasks = new Dictionary<int, string>()
+        };
+
+        var supplementalDetails = new ProviderDetails
+        {
+            ProviderName = Constants.TestProviderName,
+            Events =
+            [
+                new EventModel
+                {
+                    Id = 100,
+                    Version = 0,
+                    LogName = Constants.ApplicationLogName,
+                    Description = "Some unrelated event: %1",
+                    Keywords = [],
+                    Template = "<template><data name=\"Val\" inType=\"win:UnicodeString\" outType=\"xs:string\"/></template>"
+                }
+            ],
+            Messages = [],
+            Parameters = [],
+            Keywords = new Dictionary<long, string>(),
+            Opcodes = new Dictionary<int, string>(),
+            Tasks = new Dictionary<int, string>()
+        };
+
+        var resolver = new SupplementalTestResolver([primaryDetails], supplementalDetails);
+
+        var eventRecord = new EventRecord
+        {
+            ProviderName = Constants.TestProviderName,
+            Id = 9999,
+            Properties = ["a", "b", "c"]
+        };
+
+        // Act
+        var displayEvent = resolver.ResolveEvent(eventRecord);
+
+        // Assert
+        Assert.Contains("No matching message", displayEvent.Description);
+        Assert.Equal(EventResolutionStatus.NoMessage, displayEvent.ResolutionStatus);
+    }
+
+    [Fact]
     public void ResolveEvent_WithEmptyPrimaryAndNonMatchingSupplemental_ShouldReturnNoMatchingMessage()
     {
         // Arrange - primary provider returned an empty ProviderDetails (provider not installed
@@ -1264,6 +1338,38 @@ public sealed class EventResolverBaseTests
         // Assert
         Assert.NotNull(displayEvent);
         Assert.Equal(Constants.SupplementalTask, displayEvent.TaskCategory);
+    }
+
+    [Fact]
+    public void ResolveEvent_WithEmptyProviderAndSingleProperty_ShouldReportNoProviderStatus()
+    {
+        // Arrange - a metadata-less provider with a single self-contained property still renders that
+        // property, but no template matched, so it is a NoProvider coverage gap.
+        var providerDetails = new ProviderDetails
+        {
+            ProviderName = Constants.TestProviderName,
+            Events = [],
+            Messages = [],
+            Parameters = [],
+            Keywords = new Dictionary<long, string>(),
+            Tasks = new Dictionary<int, string>()
+        };
+
+        var resolver = new TestEventResolver([providerDetails]);
+
+        var eventRecord = new EventRecord
+        {
+            ProviderName = Constants.TestProviderName,
+            Id = 1000,
+            Properties = ["The entire description is this single string."]
+        };
+
+        // Act
+        var displayEvent = resolver.ResolveEvent(eventRecord);
+
+        // Assert
+        Assert.Equal("The entire description is this single string.", displayEvent.Description);
+        Assert.Equal(EventResolutionStatus.NoProvider, displayEvent.ResolutionStatus);
     }
 
     [Fact]
@@ -2654,6 +2760,37 @@ public sealed class EventResolverBaseTests
         Assert.Contains("Admin", displayEvent.Description);
         Assert.Contains("Login", displayEvent.Description);
         Assert.DoesNotContain("Failed to resolve", displayEvent.Description);
+    }
+
+    [Fact]
+    public void ResolveEvent_WithNoMetadataAndMultipleProperties_ShouldReportNoProviderStatus()
+    {
+        // Arrange
+        var providerDetails = new ProviderDetails
+        {
+            ProviderName = Constants.TestProviderName,
+            Events = [],
+            Messages = [],
+            Parameters = [],
+            Keywords = new Dictionary<long, string>(),
+            Tasks = new Dictionary<int, string>()
+        };
+
+        var resolver = new TestEventResolver([providerDetails]);
+
+        var eventRecord = new EventRecord
+        {
+            ProviderName = Constants.TestProviderName,
+            Id = 2000,
+            Properties = ["first", "second"]
+        };
+
+        // Act
+        var displayEvent = resolver.ResolveEvent(eventRecord);
+
+        // Assert
+        Assert.Contains("The following information was included with the event:", displayEvent.Description);
+        Assert.Equal(EventResolutionStatus.NoProvider, displayEvent.ResolutionStatus);
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Filtering.Tests/Basic/BasicFilterDecomposerTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/Basic/BasicFilterDecomposerTests.cs
@@ -12,7 +12,8 @@ public sealed class BasicFilterDecomposerTests
         from property in new[]
         {
             EventProperty.Source, EventProperty.Level, EventProperty.LogName,
-            EventProperty.TaskCategory, EventProperty.UserId, EventProperty.Opcode
+            EventProperty.TaskCategory, EventProperty.UserId, EventProperty.Opcode,
+            EventProperty.ResolutionStatus
         }
         from op in new[] { ComparisonOperator.Contains, ComparisonOperator.NotEqual, ComparisonOperator.NotContains }
         select new object[] { property, op };
@@ -506,6 +507,7 @@ public sealed class BasicFilterDecomposerTests
             EventProperty.UserId => ["S-1-5-18", "S-1-5-19"],
             EventProperty.UserDisplayName => [@"CONTOSO\alice", @"NT AUTHORITY\SYSTEM"],
             EventProperty.LogName => ["Application", "System"],
+            EventProperty.ResolutionStatus => ["Resolved", "No provider metadata"],
             _ => null
         };
 
@@ -527,6 +529,7 @@ public sealed class BasicFilterDecomposerTests
             EventProperty.Description => "An error occurred",
             EventProperty.Xml => "<x/>",
             EventProperty.LogName => "Application",
+            EventProperty.ResolutionStatus => "Resolved",
             _ => null
         };
 }

--- a/tests/Unit/EventLogExpert.Filtering.Tests/Basic/FilterComparisonJsonConverterTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/Basic/FilterComparisonJsonConverterTests.cs
@@ -11,8 +11,8 @@ public sealed class FilterComparisonJsonConverterTests
     [Fact]
     public void EventProperty_MemberCount_IsFrozenForWireCompatibility()
     {
-        // Members are appended at the end (Opcode=15, RelatedActivityId=16, UserDisplayName=17); appending is JSON-by-name wire-safe.
-        Assert.Equal(17, Enum.GetValues<EventProperty>().Length);
+        // Members are appended at the end (Opcode=15, RelatedActivityId=16, UserDisplayName=17, ResolutionStatus=18); appending is JSON-by-name wire-safe.
+        Assert.Equal(18, Enum.GetValues<EventProperty>().Length);
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Common/Display/FilterPropertyDisplayOrderTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Common/Display/FilterPropertyDisplayOrderTests.cs
@@ -39,6 +39,7 @@ public sealed class FilterPropertyDisplayOrderTests
                 "Opcode",
                 "Process ID",
                 "Related Activity ID",
+                "Resolution Status",
                 "Source",
                 "Task Category",
                 "Thread ID",

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensCommandsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensCommandsTests.cs
@@ -1,6 +1,7 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Eventing.Common.Events;
 using EventLogExpert.Runtime.FilterLenses;
 using Fluxor;
 using NSubstitute;
@@ -17,6 +18,31 @@ public sealed class FilterLensCommandsTests
         new FilterLensCommands(dispatcher).ClearLenses();
 
         dispatcher.Received(1).Dispatch(Arg.Any<ClearFilterLensesAction>());
+    }
+
+    [Fact]
+    public void IncludeEventId_PushesNonNullLens()
+    {
+        var dispatcher = Substitute.For<IDispatcher>();
+
+        new FilterLensCommands(dispatcher).IncludeEventId(4624);
+
+        dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action => action != null && action.Lens != null));
+    }
+
+    [Theory]
+    [InlineData(ResolutionStatusTokens.NoProvider)]
+    [InlineData(ResolutionStatusTokens.NoMessage)]
+    [InlineData(ResolutionStatusTokens.Failed)]
+    public void IncludeValue_ResolutionStatus_PushesNonNullLens(string token)
+    {
+        // The coverage cause-filters rely on this producing a lens; PushLens silently swallows a null, so a formatter
+        // regression would make those buttons no-ops.
+        var dispatcher = Substitute.For<IDispatcher>();
+
+        new FilterLensCommands(dispatcher).IncludeValue(EventProperty.ResolutionStatus, token);
+
+        dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action => action != null && action.Lens != null));
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/RawEventCountReducersTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/RawEventCountReducersTests.cs
@@ -32,7 +32,7 @@ public sealed class RawEventCountReducersTests
 
         (store, count) = Ingest(store, count, RawIngestMode.Prepend, (logA.Id, Events(50, 2)));
         AssertInSync(store, count);
-        Assert.Equal(5, count.ByLog[logA.Id]);
+        Assert.Equal(5, count.ByLog[logA.Id].Total);
 
         (store, count) = Ingest(store, count, RawIngestMode.Append, (logB.Id, Events(10, 4)));
         AssertInSync(store, count);
@@ -45,7 +45,7 @@ public sealed class RawEventCountReducersTests
 
         (store, count) = Ingest(store, count, RawIngestMode.Replace, (logA.Id, Events(200, 1)));
         AssertInSync(store, count);
-        Assert.Equal(1, count.ByLog[logA.Id]);
+        Assert.Equal(1, count.ByLog[logA.Id].Total);
 
         (store, count) = CloseLog(store, count, logB.Id);
         AssertInSync(store, count);
@@ -72,11 +72,11 @@ public sealed class RawEventCountReducersTests
 
         (store, count) = LoadPartial(store, count, logA, Events(10, 2));
         AssertInSync(store, count);
-        Assert.Equal(5, count.ByLog[logA.Id]);
+        Assert.Equal(5, count.ByLog[logA.Id].Total);
 
         (store, count) = Load(store, count, logA, Events(100, 1));
         AssertInSync(store, count);
-        Assert.Equal(1, count.ByLog[logA.Id]);
+        Assert.Equal(1, count.ByLog[logA.Id].Total);
 
         var unopened = new EventLogData("LogB", LogPathType.Channel);
         (store, count) = Load(store, count, unopened, Events(1, 4));
@@ -90,13 +90,81 @@ public sealed class RawEventCountReducersTests
     }
 
     [Fact]
+    public void CountState_TalliesResolutionBreakdown_IngestAppendsThenReplaceResets()
+    {
+        // The partial/load test covers CountBatch via the load path; this locks the same breakdown on the ingest path
+        // where Append/Prepend ADD their batch and Replace re-tallies only its own batch.
+        var count = new RawEventCountState();
+        var logData = new EventLogData("LogA", LogPathType.Channel);
+        count = RawEventCountReducers.ReduceAddTable(count, new AddTableAction(logData));
+
+        count = IngestCount(count, RawIngestMode.Append, logData.Id, Mixed(
+            EventResolutionStatus.Resolved, EventResolutionStatus.NoProvider));
+        count = IngestCount(count, RawIngestMode.Prepend, logData.Id, Mixed(
+            EventResolutionStatus.NoMessage, EventResolutionStatus.Failed, EventResolutionStatus.Resolved));
+
+        var afterAdds = count.ByLog[logData.Id];
+        Assert.Equal(5, afterAdds.Total);
+        Assert.Equal(2, afterAdds.Resolved);
+        Assert.Equal(1, afterAdds.NoProvider);
+        Assert.Equal(1, afterAdds.NoMessage);
+        Assert.Equal(1, afterAdds.Failed);
+
+        count = IngestCount(count, RawIngestMode.Replace, logData.Id, Mixed(EventResolutionStatus.Failed));
+
+        var afterReplace = count.ByLog[logData.Id];
+        Assert.Equal(1, afterReplace.Total);
+        Assert.Equal(0, afterReplace.Resolved);
+        Assert.Equal(0, afterReplace.NoProvider);
+        Assert.Equal(0, afterReplace.NoMessage);
+        Assert.Equal(1, afterReplace.Failed);
+    }
+
+    [Fact]
+    public void CountState_TalliesResolutionBreakdown_PartialAddsThenLoadReplaces()
+    {
+        var count = new RawEventCountState();
+        var logData = new EventLogData("LogA", LogPathType.Channel);
+        count = RawEventCountReducers.ReduceAddTable(count, new AddTableAction(logData));
+
+        count = RawEventCountReducers.ReduceLoadEventsPartial(count, new LoadEventsPartialAction(logData, Mixed(
+            EventResolutionStatus.Resolved, EventResolutionStatus.Resolved, EventResolutionStatus.NoProvider)));
+
+        var afterFirst = count.ByLog[logData.Id];
+        Assert.Equal(3, afterFirst.Total);
+        Assert.Equal(2, afterFirst.Resolved);
+        Assert.Equal(1, afterFirst.NoProvider);
+
+        count = RawEventCountReducers.ReduceLoadEventsPartial(count, new LoadEventsPartialAction(logData, Mixed(
+            EventResolutionStatus.NoMessage, EventResolutionStatus.Failed)));
+
+        var afterSecond = count.ByLog[logData.Id];
+        Assert.Equal(5, afterSecond.Total);
+        Assert.Equal(2, afterSecond.Resolved);
+        Assert.Equal(1, afterSecond.NoProvider);
+        Assert.Equal(1, afterSecond.NoMessage);
+        Assert.Equal(1, afterSecond.Failed);
+
+        // The terminal full load re-tallies the whole cumulative list and REPLACES the accumulated partial tallies.
+        count = RawEventCountReducers.ReduceLoadEvents(count, new LoadEventsAction(logData, Mixed(
+            EventResolutionStatus.Resolved)));
+
+        var afterLoad = count.ByLog[logData.Id];
+        Assert.Equal(1, afterLoad.Total);
+        Assert.Equal(1, afterLoad.Resolved);
+        Assert.Equal(0, afterLoad.NoProvider);
+        Assert.Equal(0, afterLoad.NoMessage);
+        Assert.Equal(0, afterLoad.Failed);
+    }
+
+    [Fact]
     public void ReduceAddTable_SeedsZeroCount()
     {
         var logData = new EventLogData("LogA", LogPathType.Channel);
 
         var count = RawEventCountReducers.ReduceAddTable(new RawEventCountState(), new AddTableAction(logData));
 
-        Assert.Equal(0, count.ByLog[logData.Id]);
+        Assert.Equal(0, count.ByLog[logData.Id].Total);
         Assert.Equal(0, count.Total);
     }
 
@@ -112,11 +180,11 @@ public sealed class RawEventCountReducersTests
 
         (store, count) = Ingest(store, count, RawIngestMode.Replace, (logData.Id, Events(1, 5)));
         AssertInSync(store, count);
-        Assert.Equal(5, count.ByLog[logData.Id]);
+        Assert.Equal(5, count.ByLog[logData.Id].Total);
 
         (store, count) = Ingest(store, count, RawIngestMode.Replace, (logData.Id, Events(100, 5)));
         AssertInSync(store, count);
-        Assert.Equal(5, count.ByLog[logData.Id]);
+        Assert.Equal(5, count.ByLog[logData.Id].Total);
     }
 
     private static (RawEventStoreState, RawEventCountState) AddTable(
@@ -133,7 +201,7 @@ public sealed class RawEventCountReducersTests
         foreach (var (id, list) in store.ByLog)
         {
             Assert.True(count.ByLog.ContainsKey(id), $"count missing id {id.Value}");
-            Assert.Equal(list.Count, count.ByLog[id]);
+            Assert.Equal(list.Count, count.ByLog[id].Total);
         }
 
         Assert.Equal(store.ByLog.Values.Sum(list => list.Count), count.Total);
@@ -169,6 +237,17 @@ public sealed class RawEventCountReducersTests
             RawEventCountReducers.ReduceIngestRawEvents(count, action));
     }
 
+    private static RawEventCountState IngestCount(
+        RawEventCountState count,
+        RawIngestMode mode,
+        EventLogId id,
+        IReadOnlyList<ResolvedEvent> events) =>
+        RawEventCountReducers.ReduceIngestRawEvents(
+            count,
+            new IngestRawEventsAction(
+                new Dictionary<EventLogId, IReadOnlyList<ResolvedEvent>> { [id] = events },
+                mode));
+
     private static (RawEventStoreState, RawEventCountState) Load(
         RawEventStoreState store,
         RawEventCountState count,
@@ -192,4 +271,8 @@ public sealed class RawEventCountReducersTests
         return (RawEventStoreReducers.ReduceLoadEventsPartial(store, action),
             RawEventCountReducers.ReduceLoadEventsPartial(count, action));
     }
+
+    private static IReadOnlyList<ResolvedEvent> Mixed(params EventResolutionStatus[] statuses) =>
+        [.. statuses.Select((status, index) =>
+            new ResolvedEvent("LogA", LogPathType.Channel) { Id = index + 1, ResolutionStatus = status })];
 }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/TestSupport/AosReferenceCombinedView.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/TestSupport/AosReferenceCombinedView.cs
@@ -384,6 +384,22 @@ internal sealed class AosReferenceCombinedView : IEventColumnView
         }
     }
 
+    public void CountResolutionBySource(IDictionary<string, ProviderResolutionCounts> counts, CancellationToken cancellationToken)
+    {
+        foreach (var view in _views)
+        {
+            view.CountResolutionBySource(counts, cancellationToken);
+        }
+    }
+
+    public void CountResolutionDetailForSource(string source, IDictionary<int, ProviderResolutionCounts> byId, ProviderResolutionCounts[] byLevelSlot, CancellationToken cancellationToken)
+    {
+        foreach (var view in _views)
+        {
+            view.CountResolutionDetailForSource(source, byId, byLevelSlot, cancellationToken);
+        }
+    }
+
     public void CountSeverity(int[] slotCounts, CancellationToken cancellationToken)
     {
         foreach (var view in _views)

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/TestSupport/AosReferenceView.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/TestSupport/AosReferenceView.cs
@@ -298,6 +298,12 @@ internal sealed class AosReferenceView : IEventColumnView
         CancellationToken cancellationToken) =>
         _reader.CountFieldValues(_rankByPhysical, field, counts, cancellationToken);
 
+    public void CountResolutionBySource(IDictionary<string, ProviderResolutionCounts> counts, CancellationToken cancellationToken) =>
+        _reader.CountResolutionBySource(_rankByPhysical, counts, cancellationToken);
+
+    public void CountResolutionDetailForSource(string source, IDictionary<int, ProviderResolutionCounts> byId, ProviderResolutionCounts[] byLevelSlot, CancellationToken cancellationToken) =>
+        _reader.CountResolutionDetailForSource(_rankByPhysical, source, byId, byLevelSlot, cancellationToken);
+
     public void CountSeverity(int[] slotCounts, CancellationToken cancellationToken) =>
         _reader.CountSeverity(_rankByPhysical, slotCounts, cancellationToken);
 

--- a/tests/Unit/EventLogExpert.Runtime.Tests/ResolutionCoverage/CoverageTableFormatterTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/ResolutionCoverage/CoverageTableFormatterTests.cs
@@ -1,0 +1,70 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Runtime.ResolutionCoverage;
+
+namespace EventLogExpert.Runtime.Tests.ResolutionCoverage;
+
+public sealed class CoverageTableFormatterTests
+{
+    [Fact]
+    public void Format_ExceedingMaxCopyRows_TruncatesWithNote()
+    {
+        var rows = Enumerable.Range(0, CoverageTableFormatter.MaxCopyRows + 50)
+            .Select(index => Row($"P{index:D6}", total: 1, noProvider: 1, status: CoverageStatus.None))
+            .ToArray();
+
+        string tsv = CoverageTableFormatter.Format(Report(rows), isFiltered: false);
+
+        Assert.Contains("showing the first", tsv, StringComparison.Ordinal);
+
+        // Scope comment + column header + exactly MaxCopyRows data rows.
+        int lineCount = tsv.Split("\r\n", StringSplitOptions.RemoveEmptyEntries).Length;
+        Assert.Equal(CoverageTableFormatter.MaxCopyRows + 2, lineCount);
+    }
+
+    [Fact]
+    public void Format_FilteredView_NotesFilteredScope()
+    {
+        string tsv = CoverageTableFormatter.Format(
+            Report(Row("A", total: 1, resolved: 1, status: CoverageStatus.Full)),
+            isFiltered: true);
+
+        Assert.Contains("(filtered view)", tsv, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Format_NeutralizesFormulaInjectionAndCollapsesTabs()
+    {
+        var report = Report(
+            Row("=cmd|calc", total: 3, noProvider: 3, status: CoverageStatus.None),
+            Row("Normal\tProvider", total: 2, resolved: 2, status: CoverageStatus.Full));
+
+        string tsv = CoverageTableFormatter.Format(report, isFiltered: false);
+
+        Assert.Contains("'=cmd|calc", tsv, StringComparison.Ordinal);
+        Assert.Contains("Normal Provider", tsv, StringComparison.Ordinal);
+        Assert.DoesNotContain("Normal\tProvider", tsv, StringComparison.Ordinal);
+        Assert.Contains("All providers in the current view", tsv, StringComparison.Ordinal);
+    }
+
+    private static ResolutionCoverageReport Report(params ProviderCoverageRow[] rows)
+    {
+        ProviderResolutionCounts summary = default;
+
+        foreach (var row in rows) { summary = summary.Add(row.Counts); }
+
+        return new ResolutionCoverageReport(summary, rows);
+    }
+
+    private static ProviderCoverageRow Row(
+        string provider,
+        int total,
+        int resolved = 0,
+        int noProvider = 0,
+        int noMessage = 0,
+        int failed = 0,
+        CoverageStatus status = CoverageStatus.Partial) =>
+        new(provider, new ProviderResolutionCounts(total, resolved, noProvider, noMessage, failed), status);
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/ResolutionCoverage/ResolutionCoverageServiceTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/ResolutionCoverage/ResolutionCoverageServiceTests.cs
@@ -1,0 +1,214 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.Runtime.ResolutionCoverage;
+using EventLogExpert.Runtime.Tests.LogTable.TestSupport;
+
+namespace EventLogExpert.Runtime.Tests.ResolutionCoverage;
+
+public sealed class ResolutionCoverageServiceTests
+{
+    private static readonly EventLogId s_logId = EventLogId.Create();
+
+    private readonly IResolutionCoverageService _service = new ResolutionCoverageService();
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    [Fact]
+    public void BuildProviderDetail_CancelledToken_Throws()
+    {
+        var view = ViewOver(EvL(1, "P", EventResolutionStatus.NoProvider, "Error"));
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Assert.ThrowsAny<OperationCanceledException>(() => _service.BuildProviderDetail(view, "P", cts.Token));
+    }
+
+    [Fact]
+    public void BuildProviderDetail_CapsEventIds_AndReportsDistinctUnresolvedCount()
+    {
+        var events = Enumerable.Range(1, 120)
+            .Select(id => EvL(id, "P", EventResolutionStatus.NoProvider, "Error"))
+            .ToArray();
+
+        var detail = _service.BuildProviderDetail(ViewOver(events), "P", Ct);
+
+        Assert.Equal(ResolutionCoverageService.MaxEventIdRows, detail.EventIds.Count);
+        Assert.Equal(120, detail.DistinctUnresolvedEventIdCount);
+    }
+
+    [Fact]
+    public void BuildProviderDetail_EventIds_ExcludeFullyResolved_AndRankByUnresolvedDescending()
+    {
+        var view = ViewOver(
+            EvL(100, "P", EventResolutionStatus.Resolved, "Error"),
+            EvL(200, "P", EventResolutionStatus.NoProvider, "Error"),
+            EvL(300, "P", EventResolutionStatus.NoProvider, "Error"),
+            EvL(300, "P", EventResolutionStatus.NoMessage, "Error"));
+
+        var detail = _service.BuildProviderDetail(view, "P", Ct);
+
+        Assert.Equal(new[] { 300, 200 }, detail.EventIds.Select(row => row.EventId).ToArray());
+        Assert.Equal(2, detail.DistinctUnresolvedEventIdCount);
+    }
+
+    [Fact]
+    public void BuildProviderDetail_Levels_BreakDownUnresolvedBySeverity_OmittingResolvedOnlyLevels()
+    {
+        var view = ViewOver(
+            EvL(1, "P", EventResolutionStatus.NoProvider, "Critical"),
+            EvL(2, "P", EventResolutionStatus.NoProvider, "Error"),
+            EvL(3, "P", EventResolutionStatus.NoMessage, "Error"),
+            EvL(4, "P", EventResolutionStatus.Resolved, "Warning"),
+            EvL(5, "P", EventResolutionStatus.Failed, ""));
+
+        var detail = _service.BuildProviderDetail(view, "P", Ct);
+
+        Assert.Equal(1, UnresolvedAtLevel(detail, SeverityLevel.Critical));
+        Assert.Equal(2, UnresolvedAtLevel(detail, SeverityLevel.Error));
+        Assert.Equal(1, UnresolvedAtLevel(detail, level: null));
+        Assert.DoesNotContain(detail.Levels, row => row.Level == SeverityLevel.Warning);
+    }
+
+    [Fact]
+    public void BuildProviderDetail_ScopesToProvider_IgnoresOthers()
+    {
+        var view = ViewOver(
+            EvL(1, "P", EventResolutionStatus.NoProvider, "Error"),
+            EvL(2, "Other", EventResolutionStatus.NoProvider, "Error"));
+
+        var detail = _service.BuildProviderDetail(view, "P", Ct);
+
+        Assert.Equal(1, detail.DistinctUnresolvedEventIdCount);
+        Assert.Equal(1, Assert.Single(detail.EventIds).EventId);
+    }
+
+    [Fact]
+    public void Build_CancelledToken_Throws()
+    {
+        var view = ViewOver(Ev(1, "A", EventResolutionStatus.NoProvider));
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Assert.ThrowsAny<OperationCanceledException>(() => _service.Build(view, cts.Token));
+    }
+
+    [Fact]
+    public void Build_ClassifiesCoverageAndSumsSummary()
+    {
+        var view = ViewOver(
+            Ev(1, "FullProvider", EventResolutionStatus.Resolved),
+            Ev(2, "FullProvider", EventResolutionStatus.Resolved),
+            Ev(3, "NoneProvider", EventResolutionStatus.NoProvider),
+            Ev(4, "PartialProvider", EventResolutionStatus.Resolved),
+            Ev(5, "PartialProvider", EventResolutionStatus.NoMessage));
+
+        var report = _service.Build(view, Ct);
+
+        Assert.Equal(3, report.Rows.Count);
+        Assert.Equal(5, report.Summary.Total);
+        Assert.Equal(3, report.Summary.Resolved);
+        Assert.Equal(1, report.Summary.NoProvider);
+        Assert.Equal(1, report.Summary.NoMessage);
+
+        var byProvider = report.Rows.ToDictionary(row => row.Provider);
+        Assert.Equal(CoverageStatus.Full, byProvider["FullProvider"].Status);
+        Assert.Equal(CoverageStatus.None, byProvider["NoneProvider"].Status);
+        Assert.Equal(CoverageStatus.Partial, byProvider["PartialProvider"].Status);
+    }
+
+    [Fact]
+    public void Build_PreservesTotalAndSumOfProviderTotalsMatchesViewCount()
+    {
+        var view = ViewOver(
+            Ev(1, "A", EventResolutionStatus.Resolved),
+            Ev(2, "A", EventResolutionStatus.NoProvider),
+            Ev(3, "B", EventResolutionStatus.NoMessage),
+            Ev(4, "B", EventResolutionStatus.Failed));
+
+        var report = _service.Build(view, Ct);
+
+        foreach (var row in report.Rows)
+        {
+            Assert.Equal(
+                row.Counts.Total,
+                row.Counts.Resolved + row.Counts.NoProvider + row.Counts.NoMessage + row.Counts.Failed);
+        }
+
+        Assert.Equal(4, report.Rows.Sum(row => row.Counts.Total));
+    }
+
+    [Fact]
+    public void Build_ProviderWithAllNoMessage_IsPartialNotNone()
+    {
+        var view = ViewOver(
+            Ev(1, "MetadataButNoMatch", EventResolutionStatus.NoMessage),
+            Ev(2, "MetadataButNoMatch", EventResolutionStatus.NoMessage));
+
+        var report = _service.Build(view, Ct);
+
+        Assert.Equal(CoverageStatus.Partial, Assert.Single(report.Rows).Status);
+    }
+
+    [Fact]
+    public void Build_ReturnsAllProviders_OrderedByUnresolvedDescending()
+    {
+        var view = ViewOver(
+            Ev(1, "Low", EventResolutionStatus.Resolved),
+            Ev(2, "Low", EventResolutionStatus.NoProvider),
+            Ev(3, "High", EventResolutionStatus.NoProvider),
+            Ev(4, "High", EventResolutionStatus.NoProvider),
+            Ev(5, "High", EventResolutionStatus.NoMessage),
+            Ev(6, "Mid", EventResolutionStatus.NoProvider),
+            Ev(7, "Mid", EventResolutionStatus.NoMessage));
+
+        var report = _service.Build(view, Ct);
+
+        Assert.Equal(new[] { "High", "Mid", "Low" }, report.Rows.Select(row => row.Provider).ToArray());
+    }
+
+    [Fact]
+    public void CountResolutionBySource_ColumnValues_AreOnlyTheFourFrozenTokens()
+    {
+        var view = ViewOver(
+            Ev(1, "A", EventResolutionStatus.Resolved),
+            Ev(2, "A", EventResolutionStatus.NoProvider),
+            Ev(3, "B", EventResolutionStatus.NoMessage),
+            Ev(4, "B", EventResolutionStatus.Failed));
+
+        var counts = new Dictionary<string, int>();
+        view.CountFieldValues(EventFieldId.ResolutionStatus, counts, Ct);
+
+        string[] expected =
+        [
+            ResolutionStatusTokens.Failed,
+            ResolutionStatusTokens.NoMessage,
+            ResolutionStatusTokens.NoProvider,
+            ResolutionStatusTokens.Resolved
+        ];
+
+        Assert.Equal(expected.Order(), counts.Keys.Order());
+    }
+
+    private static ResolvedEvent Ev(int id, string source, EventResolutionStatus status) =>
+        new("live", LogPathType.Channel) { Id = id, Source = source, ResolutionStatus = status };
+
+    private static ResolvedEvent EvL(int id, string source, EventResolutionStatus status, string level) =>
+        new("live", LogPathType.Channel) { Id = id, Source = source, ResolutionStatus = status, Level = level };
+
+    private static int UnresolvedAtLevel(ProviderCoverageDetail detail, SeverityLevel? level) =>
+        detail.Levels.Single(row => row.Level == level).Counts.Unresolved;
+
+    private static IEventColumnView ViewOver(params ResolvedEvent[] events) =>
+        AosReferenceView.Create(
+            EventColumnStore.Build(events, generation: 0, contentVersion: 0).CreateReader(s_logId),
+            [.. Enumerable.Range(0, events.Length)],
+            orderBy: null,
+            isDescending: false,
+            groupBy: null,
+            isGroupDescending: false);
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/StatusBar/StatusBarSourceTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/StatusBar/StatusBarSourceTests.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Eventing.Common.Events;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.Runtime.FilterPane;
@@ -27,7 +28,7 @@ public sealed class StatusBarSourceTests
         harness.Source.Changed += () => throw new InvalidOperationException("subscriber blew up");
         harness.Source.Changed += () => reachedSecond++;
 
-        harness.RawCount = new RawEventCountState { ByLog = ImmutableDictionary<EventLogId, int>.Empty.Add(LogA, 5) };
+        harness.RawCount = new RawEventCountState { ByLog = ImmutableDictionary<EventLogId, ProviderResolutionCounts>.Empty.Add(LogA, Counts(5)) };
         harness.RaiseRawCount();
 
         Assert.Equal(1, reachedSecond);
@@ -71,12 +72,12 @@ public sealed class StatusBarSourceTests
     public void Changed_DoesNotFire_WhenRawCountsByLogIsEquivalent()
     {
         var harness = new Harness();
-        harness.RawCount = new RawEventCountState { ByLog = ImmutableDictionary<EventLogId, int>.Empty.Add(LogA, 5) };
+        harness.RawCount = new RawEventCountState { ByLog = ImmutableDictionary<EventLogId, ProviderResolutionCounts>.Empty.Add(LogA, Counts(5)) };
         harness.RaiseRawCount();
         var raised = 0;
         harness.Source.Changed += () => raised++;
 
-        harness.RawCount = new RawEventCountState { ByLog = ImmutableDictionary.CreateRange([new KeyValuePair<EventLogId, int>(LogA, 5)]) };
+        harness.RawCount = new RawEventCountState { ByLog = ImmutableDictionary.CreateRange([new KeyValuePair<EventLogId, ProviderResolutionCounts>(LogA, Counts(5))]) };
         harness.RaiseRawCount();
 
         Assert.Equal(0, raised);
@@ -147,19 +148,41 @@ public sealed class StatusBarSourceTests
     public void Changed_Fires_WhenRawCountsRedistributeAtTheSameTotal()
     {
         var harness = new Harness();
-        harness.RawCount = new RawEventCountState { ByLog = ImmutableDictionary<EventLogId, int>.Empty.Add(LogA, 5) };
+        harness.RawCount = new RawEventCountState { ByLog = ImmutableDictionary<EventLogId, ProviderResolutionCounts>.Empty.Add(LogA, Counts(5)) };
         harness.RaiseRawCount();
         var raised = 0;
         harness.Source.Changed += () => raised++;
 
         harness.RawCount = new RawEventCountState
         {
-            ByLog = ImmutableDictionary<EventLogId, int>.Empty.Add(LogA, 2).Add(LogB, 3)
+            ByLog = ImmutableDictionary<EventLogId, ProviderResolutionCounts>.Empty.Add(LogA, Counts(2)).Add(LogB, Counts(3))
         };
         harness.RaiseRawCount();
 
         Assert.Equal(1, raised);
         Assert.Equal(5, harness.Source.Current.RawEventTotal);
+    }
+
+    [Fact]
+    public void Changed_Fires_WhenResolutionStatusChangesAtSameTotal()
+    {
+        var harness = new Harness();
+        harness.RawCount = new RawEventCountState
+        {
+            ByLog = ImmutableDictionary<EventLogId, ProviderResolutionCounts>.Empty.Add(LogA, new ProviderResolutionCounts(5, 5, 0, 0, 0))
+        };
+        harness.RaiseRawCount();
+        var raised = 0;
+        harness.Source.Changed += () => raised++;
+
+        // Same total (5), different resolution breakdown - full-struct facet equality must still detect the change.
+        harness.RawCount = new RawEventCountState
+        {
+            ByLog = ImmutableDictionary<EventLogId, ProviderResolutionCounts>.Empty.Add(LogA, new ProviderResolutionCounts(5, 3, 2, 0, 0))
+        };
+        harness.RaiseRawCount();
+
+        Assert.Equal(1, raised);
     }
 
     [Fact]
@@ -179,7 +202,7 @@ public sealed class StatusBarSourceTests
     [Fact]
     public void Construction_ReconcilesARawCountChangeBetweenSeedAndSubscribe_SoALaterUnchangedNotificationDoesNotRaise()
     {
-        var populated = new RawEventCountState { ByLog = ImmutableDictionary<EventLogId, int>.Empty.Add(LogA, 7) };
+        var populated = new RawEventCountState { ByLog = ImmutableDictionary<EventLogId, ProviderResolutionCounts>.Empty.Add(LogA, Counts(7)) };
         var rawCount = Substitute.For<IState<RawEventCountState>>();
         rawCount.Value.Returns(new RawEventCountState(), populated);
         using var source = NewSource(rawCount: rawCount);
@@ -215,7 +238,7 @@ public sealed class StatusBarSourceTests
 
         harness.EventLog = harness.EventLog with { ContinuouslyUpdate = true };
         harness.FilterPane = harness.FilterPane with { FilteredDateRange = new DateFilter { IsEnabled = true } };
-        harness.RawCount = new RawEventCountState { ByLog = ImmutableDictionary<EventLogId, int>.Empty.Add(LogA, 9) };
+        harness.RawCount = new RawEventCountState { ByLog = ImmutableDictionary<EventLogId, ProviderResolutionCounts>.Empty.Add(LogA, Counts(9)) };
         harness.LogTable = harness.LogTable with { ActiveEventLogId = LogA };
 
         var current = harness.Source.Current;
@@ -272,6 +295,8 @@ public sealed class StatusBarSourceTests
 
         Assert.Equal(0, raised);
     }
+
+    private static ProviderResolutionCounts Counts(int total) => new(total, total, 0, 0, 0);
 
     private static StatusBarSource NewSource(
         IState<EventLogState>? eventLog = null,

--- a/tests/Unit/EventLogExpert.UI.Tests/Architecture/TypographyScaleTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Architecture/TypographyScaleTests.cs
@@ -1,0 +1,83 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Text.RegularExpressions;
+
+namespace EventLogExpert.UI.Tests.Architecture;
+
+public sealed partial class TypographyScaleTests
+{
+    // The distinct raw font-size values that predate the type-scale migration. New component CSS should use the
+    // --font-size-* tokens (src/EventLogExpert.UI/wwwroot/app.css :root). This freezes the set of distinct raw VALUES
+    // (not the declaration count), so it fails on any NEW distinct value; remove entries as the app-wide follow-up
+    // migrates components to tokens.
+    private static readonly HashSet<string> s_allowedRawFontSizes = new(StringComparer.Ordinal)
+    {
+        ".75rem", ".8rem", ".85rem", ".9rem", ".8em", ".85em",
+        "0.65rem", "0.7rem", "0.75rem", "0.78rem", "0.8rem", "0.85rem", "0.9rem", "0.95rem",
+        "0.75em", "0.85em", "0.9em", "0.95em",
+        "1rem", "1.05rem", "1.1rem", "1.1em", "1.2rem", "1.25rem", "1.4rem", "1.6rem",
+        "11px", "12px", "13px", "14px", "10pt"
+    };
+
+    // The only sanctioned font-size var() forms; anything else (a typo like --font-size-huge, or a non-size var used as
+    // a font-size) is treated as drift.
+    private static readonly HashSet<string> s_allowedTokens = new(StringComparer.Ordinal)
+    {
+        "var(--font-size-xs)", "var(--font-size-sm)", "var(--font-size-md)",
+        "var(--font-size-base)", "var(--font-size-lg)", "var(--font-size-xl)"
+    };
+
+    [Fact]
+    public void RazorCssFontSizes_UseTokensOrTheFrozenBaseline()
+    {
+        string sourceRoot = Path.Combine(RepoRoot(), "src");
+        string uiWwwroot = Path.Combine(sourceRoot, "EventLogExpert.UI", "wwwroot");
+
+        // First-party component sheets plus the two migrated global sheets (the highest-blast-radius chrome CSS). Vendor
+        // bundles live under EventLogExpert/wwwroot/css and are not *.razor.css, so they are excluded.
+        var files = Directory.EnumerateFiles(sourceRoot, "*.razor.css", SearchOption.AllDirectories).ToList();
+        files.Add(Path.Combine(uiWwwroot, "app.css"));
+        files.Add(Path.Combine(uiWwwroot, "Banner", "banner.css"));
+
+        Regex fontSize = FontSizeRegex();
+        var offenders = new List<string>();
+
+        foreach (string file in files)
+        {
+            foreach (Match match in fontSize.Matches(File.ReadAllText(file)))
+            {
+                string value = match.Groups[1].Value.Trim();
+
+                if (s_allowedTokens.Contains(value)) { continue; }
+
+                if (!s_allowedRawFontSizes.Contains(value))
+                {
+                    offenders.Add($"{Path.GetFileName(file)}: font-size: {value}");
+                }
+            }
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            "New raw font-size value(s) found in first-party CSS. Use a --font-size-* token from " +
+            "src/EventLogExpert.UI/wwwroot/app.css :root instead:\n" + string.Join("\n", offenders));
+    }
+
+    [GeneratedRegex(@"font-size:\s*([^;}]+)[;}]")]
+    private static partial Regex FontSizeRegex();
+
+    private static string RepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "EventLogExpert.slnx")))
+        {
+            directory = directory.Parent;
+        }
+
+        Assert.NotNull(directory);
+
+        return directory.FullName;
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/Architecture/UIFluxorBoundaryTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Architecture/UIFluxorBoundaryTests.cs
@@ -27,10 +27,12 @@ public sealed class UIFluxorBoundaryTests
 
     // Every concrete modal, discovered by reflection so an omitted modal cannot silently escape the disposal-contract
     // check below (this is what regressed the DatabaseToolsModal coverage when the modal set was tracked by hand).
-    private static readonly Type[] s_modalTypes = typeof(ModalBase<>).Assembly.GetTypes()
-        .Where(type => type is { IsClass: true, IsAbstract: false } && InheritsModalBase(type))
-        .OrderBy(type => type.Name)
-        .ToArray();
+    private static readonly Type[] s_modalTypes =
+    [
+        .. typeof(ModalBase<>).Assembly.GetTypes()
+            .Where(type => type is { IsClass: true, IsAbstract: false } && InheritsModalBase(type))
+            .OrderBy(type => type.Name)
+    ];
 
     public static TheoryData<Type> ModalTypes => [.. s_modalTypes];
 
@@ -40,9 +42,9 @@ public sealed class UIFluxorBoundaryTests
     [Fact]
     public void EveryModal_IsCoveredByTheBoundaryEnumeration() =>
         // Guards the reflection discovery against finding nothing and pins the known modal set; update the count
-        // deliberately when a modal is added or removed (the seven built-in modals plus FilterLibraryModal and
-        // StatsDetailModal).
-        Assert.Equal(9, s_modalTypes.Length);
+        // deliberately when a modal is added or removed (the seven built-in modals plus FilterLibraryModal,
+        // StatsDetailModal, and ResolutionCoverageModal).
+        Assert.Equal(10, s_modalTypes.Length);
 
     [Theory]
     [MemberData(nameof(ModalTypes))]

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/Resolution/ResolutionCoverageModalTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/Resolution/ResolutionCoverageModalTests.cs
@@ -1,0 +1,420 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Filtering.Common.Filtering;
+using EventLogExpert.Runtime.Common.Clipboard;
+using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.FilterLenses;
+using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.Runtime.ResolutionCoverage;
+using EventLogExpert.UI.LogTable.Resolution;
+using EventLogExpert.UI.Modal;
+using EventLogExpert.UI.Tests.TestUtils;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace EventLogExpert.UI.Tests.LogTable.Resolution;
+
+public sealed class ResolutionCoverageModalTests : BunitContext
+{
+    private static readonly TimeSpan s_wait = TimeSpan.FromSeconds(10);
+
+    private readonly IClipboardService _clipboard = Substitute.For<IClipboardService>();
+    private readonly IResolutionCoverageService _coverageService = Substitute.For<IResolutionCoverageService>();
+    private readonly IFilterAppliedSource _filterApplied = Substitute.For<IFilterAppliedSource>();
+    private readonly IFilterLensCommands _lensCommands = Substitute.For<IFilterLensCommands>();
+    private readonly IModalCoordinator _modalCoordinator = Substitute.For<IModalCoordinator>();
+    private readonly ModalId _modalId = new(1L);
+    private readonly IModalService _modalService = Substitute.For<IModalService>();
+    private readonly IEventColumnView _view = Substitute.For<IEventColumnView>();
+    private readonly IOrderedViewSource _viewSource = Substitute.For<IOrderedViewSource>();
+
+    private OrderedViewPresentation _presentation;
+
+    public ResolutionCoverageModalTests()
+    {
+        Services.AddBannerHostDependencies();
+        Services.AddMenuMocks();
+
+        _modalService.ActiveModalId.Returns(_modalId);
+
+        _presentation = PresentationWith(PresentationState.Current);
+        _viewSource.Current.Returns(_ => _presentation);
+
+        Services.AddSingleton(_clipboard);
+        Services.AddSingleton(_coverageService);
+        Services.AddSingleton(_filterApplied);
+        Services.AddSingleton(_lensCommands);
+        Services.AddSingleton(_modalCoordinator);
+        Services.AddSingleton(_modalService);
+        Services.AddSingleton(_viewSource);
+
+        JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    [Fact]
+    public async Task CauseFilter_ClickingNoProvider_AppliesResolutionStatusLens()
+    {
+        SetReport(Report(Row("A", total: 5, noProvider: 5, status: CoverageStatus.None)));
+
+        var cut = Render<ResolutionCoverageModal>();
+        cut.WaitForState(() => cut.FindAll(".resolution-cause-filter").Count > 0, s_wait);
+
+        // Only the non-zero cause (No provider metadata) renders as a button.
+        await cut.Find(".resolution-cause-filter").ClickAsync(new MouseEventArgs());
+
+        _lensCommands.Received(1).IncludeValue(EventProperty.ResolutionStatus, ResolutionStatusTokens.NoProvider, Arg.Any<string?>());
+    }
+
+    [Fact]
+    public void ClickingProviderHeader_SortsByProviderAscending()
+    {
+        SetReport(Report(
+            Row("Zeta", total: 5, noProvider: 5, status: CoverageStatus.None),
+            Row("Alpha", total: 3, noProvider: 3, status: CoverageStatus.None)));
+
+        var cut = Render<ResolutionCoverageModal>();
+        cut.WaitForState(() => cut.FindAll(".resolution-coverage-row").Count == 2, s_wait);
+
+        Assert.Equal("Zeta", cut.FindAll(".resolution-coverage-row")[0].QuerySelector(".resolution-provider-name")!.TextContent);
+
+        cut.FindAll(".resolution-sort")[0].Click();
+
+        Assert.Equal("Alpha", cut.FindAll(".resolution-coverage-row")[0].QuerySelector(".resolution-provider-name")!.TextContent);
+    }
+
+    [Fact]
+    public async Task CopyButton_CopiesTableToClipboard()
+    {
+        SetReport(Report(Row("Alpha", total: 5, noProvider: 5, status: CoverageStatus.None)));
+
+        var cut = Render<ResolutionCoverageModal>();
+        cut.WaitForState(() => cut.FindAll(".resolution-coverage-copy").Count > 0, s_wait);
+
+        await cut.Find(".resolution-coverage-copy").ClickAsync(new MouseEventArgs());
+
+        await _clipboard.Received(1).CopyTextAsync(Arg.Is<string>(text => text != null && text.Contains("Alpha", StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public void DatabaseAction_ShownForMetadataGaps_HiddenForFailedOnly()
+    {
+        SetReport(Report(
+            Row("NoMeta", total: 5, noProvider: 5, status: CoverageStatus.None),
+            Row("Erroring", total: 3, failed: 3, status: CoverageStatus.Partial)));
+
+        var cut = Render<ResolutionCoverageModal>();
+        cut.WaitForState(() => cut.FindAll(".resolution-coverage-row").Count == 2, s_wait);
+
+        var rows = cut.FindAll(".resolution-coverage-row");
+        Assert.Single(rows[0].QuerySelectorAll(".resolution-dbtools"));
+        Assert.Empty(rows[1].QuerySelectorAll(".resolution-dbtools"));
+    }
+
+    [Fact]
+    public void EmptyReport_Filtered_SaysNoMatch()
+    {
+        _filterApplied.IsFilteringEnabled.Returns(true);
+        SetReport(Report());
+
+        var cut = Render<ResolutionCoverageModal>();
+
+        cut.WaitForAssertion(
+            () => Assert.Contains("No events match the current filter", cut.Find(".resolution-coverage-status").TextContent),
+            s_wait);
+    }
+
+    [Fact]
+    public void EmptyReport_Unfiltered_SaysNoEvents()
+    {
+        _filterApplied.IsFilteringEnabled.Returns(false);
+        SetReport(Report());
+
+        var cut = Render<ResolutionCoverageModal>();
+
+        cut.WaitForAssertion(
+            () => Assert.Contains("No events to analyze", cut.Find(".resolution-coverage-status").TextContent),
+            s_wait);
+    }
+
+    [Fact]
+    public void ExpandProvider_LoadsAndShowsEventIdBreakdown()
+    {
+        SetReport(Report(Row("A", total: 5, noProvider: 5, status: CoverageStatus.None)));
+        SetProviderDetail(Detail(eventIds: [IdRow(4624, total: 3, noProvider: 3)], distinctUnresolved: 1));
+
+        var cut = Render<ResolutionCoverageModal>();
+        cut.WaitForState(() => cut.FindAll(".resolution-provider-toggle").Count > 0, s_wait);
+
+        cut.Find(".resolution-provider-toggle").Click();
+
+        cut.WaitForAssertion(() => Assert.Contains("4624", cut.Find(".resolution-detail-idtable").TextContent), s_wait);
+    }
+
+    [Fact]
+    public async Task ExpandedEventIdLens_AppliesProviderEventIdUnresolvedLenses()
+    {
+        SetReport(Report(Row("A", total: 5, noProvider: 5, status: CoverageStatus.None)));
+        SetProviderDetail(Detail(eventIds: [IdRow(4624, total: 3, noProvider: 3)], distinctUnresolved: 1));
+
+        var cut = Render<ResolutionCoverageModal>();
+        cut.WaitForState(() => cut.FindAll(".resolution-provider-toggle").Count > 0, s_wait);
+        cut.Find(".resolution-provider-toggle").Click();
+        cut.WaitForState(() => cut.FindAll(".resolution-detail-idtable .resolution-lens").Count > 0, s_wait);
+
+        await cut.Find(".resolution-detail-idtable .resolution-lens").ClickAsync(new MouseEventArgs());
+
+        _lensCommands.Received(1).IncludeValue(EventProperty.Source, "A", Arg.Any<string?>());
+        _lensCommands.Received(1).IncludeEventId(4624, Arg.Any<string?>());
+        _lensCommands.Received(1).ExcludeValue(EventProperty.ResolutionStatus, ResolutionStatusTokens.Resolved, Arg.Any<string?>());
+    }
+
+    [Fact]
+    public void ExpandedEventIds_ShowTruncationNote_WhenCapped()
+    {
+        SetReport(Report(Row("A", total: 5, noProvider: 5, status: CoverageStatus.None)));
+        SetProviderDetail(Detail(eventIds: [IdRow(1, total: 1, noProvider: 1)], distinctUnresolved: 50));
+
+        var cut = Render<ResolutionCoverageModal>();
+        cut.WaitForState(() => cut.FindAll(".resolution-provider-toggle").Count > 0, s_wait);
+
+        cut.Find(".resolution-provider-toggle").Click();
+
+        cut.WaitForAssertion(() => Assert.Contains("of 50", cut.Find(".resolution-detail-note").TextContent), s_wait);
+    }
+
+    [Fact]
+    public void FaultedView_ShowsUnavailableMessage()
+    {
+        _presentation = new OrderedViewPresentation(_view, EventLogId.Create(), default, PresentationState.Faulted, 1, "boom")
+        {
+            ActiveLogName = "Live"
+        };
+
+        var cut = Render<ResolutionCoverageModal>();
+
+        cut.WaitForAssertion(
+            () => Assert.Contains("Coverage is unavailable", cut.Find(".resolution-coverage-status").TextContent),
+            s_wait);
+    }
+
+    [Fact]
+    public void FilteredView_ShowsBadge()
+    {
+        _filterApplied.IsFilteringEnabled.Returns(true);
+        SetReport(Report(Row("A", total: 5, noProvider: 5, status: CoverageStatus.None)));
+
+        var cut = Render<ResolutionCoverageModal>();
+
+        cut.WaitForAssertion(() => Assert.Single(cut.FindAll(".resolution-coverage-badge")), s_wait);
+    }
+
+    [Fact]
+    public void FooterActions_HiddenWhenReportEmpty()
+    {
+        // The footer action fragment lives outside the body's _report render chain; the HasReport gate must keep the
+        // Copy / Show-unresolved buttons out of the loading/empty/fault states so they are never dead controls.
+        SetReport(Report());
+
+        var cut = Render<ResolutionCoverageModal>();
+        cut.WaitForAssertion(
+            () => Assert.Contains("No events to analyze", cut.Find(".resolution-coverage-status").TextContent),
+            s_wait);
+
+        Assert.Empty(cut.FindAll(".resolution-coverage-copy"));
+        Assert.Empty(cut.FindAll(".resolution-coverage-filter"));
+    }
+
+    [Fact]
+    public void FullProvider_HasNoDisclosureToggle()
+    {
+        SetReport(Report(Row("Full", total: 5, resolved: 5, status: CoverageStatus.Full)));
+
+        var cut = Render<ResolutionCoverageModal>();
+        cut.WaitForState(() => cut.FindAll(".resolution-coverage-row").Count > 0, s_wait);
+
+        Assert.Empty(cut.FindAll(".resolution-provider-toggle"));
+    }
+
+    [Fact]
+    public async Task LensAction_FiltersToProviderUnresolvedEvents()
+    {
+        SetReport(Report(Row("Alpha", total: 5, noProvider: 5, status: CoverageStatus.None)));
+
+        var cut = Render<ResolutionCoverageModal>();
+        cut.WaitForState(() => cut.FindAll(".resolution-lens").Count > 0, s_wait);
+
+        await cut.Find(".resolution-lens").ClickAsync(new MouseEventArgs());
+
+        _lensCommands.Received(1).IncludeValue(EventProperty.Source, "Alpha", Arg.Any<string?>());
+        _lensCommands.Received(1).ExcludeValue(EventProperty.ResolutionStatus, ResolutionStatusTokens.Resolved, Arg.Any<string?>());
+    }
+
+    [Fact]
+    public void LensAction_HiddenForBlankProviderRow()
+    {
+        // A blank-provider row cannot produce a meaningful provider lens, so the button must not render (its handler
+        // would otherwise be a silent no-op).
+        SetReport(Report(Row(" ", total: 5, noProvider: 5, status: CoverageStatus.None)));
+
+        var cut = Render<ResolutionCoverageModal>();
+        cut.WaitForState(() => cut.FindAll(".resolution-coverage-row").Count > 0, s_wait);
+
+        Assert.Empty(cut.FindAll(".resolution-lens"));
+    }
+
+    [Fact]
+    public void ProportionBar_RendersOneSegmentPerNonZeroCategory()
+    {
+        SetReport(Report(Row("A", total: 8, resolved: 5, noProvider: 3, status: CoverageStatus.Partial)));
+
+        var cut = Render<ResolutionCoverageModal>();
+        cut.WaitForState(() => cut.FindAll(".resolution-coverage-row").Count > 0, s_wait);
+
+        // Resolved + NoProvider are non-zero; NoMessage + Failed are zero and omitted.
+        Assert.Equal(2, cut.FindAll(".resolution-coverage-seg").Count);
+    }
+
+    [Fact]
+    public void RetryDetail_AfterFailure_RerunsScan_AndRecovers()
+    {
+        SetReport(Report(Row("A", total: 5, noProvider: 5, status: CoverageStatus.None)));
+        int calls = 0;
+        _coverageService.BuildProviderDetail(Arg.Any<IEventColumnView>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                calls++;
+
+                return calls == 1
+                    ? throw new InvalidOperationException("boom")
+                    : Detail(eventIds: [IdRow(4624, total: 3, noProvider: 3)], distinctUnresolved: 1);
+            });
+
+        var cut = Render<ResolutionCoverageModal>();
+        cut.WaitForState(() => cut.FindAll(".resolution-provider-toggle").Count > 0, s_wait);
+        cut.Find(".resolution-provider-toggle").Click();
+        cut.WaitForAssertion(() => Assert.Contains("Could not analyze", cut.Find(".resolution-detail-status").TextContent), s_wait);
+
+        cut.Find(".resolution-detail-status .resolution-cause-filter").Click();
+
+        // Retry re-scans (and here recovers) rather than collapsing: the second scan's Event-ID table appears, which is
+        // impossible if Retry had taken ToggleExpandAsync's collapse branch.
+        cut.WaitForAssertion(() => Assert.Contains("4624", cut.Find(".resolution-detail-idtable").TextContent), s_wait);
+    }
+
+    [Fact]
+    public void SortThenCap_SurfacesTrueTopForTheActiveSort()
+    {
+        var rows = new List<ProviderCoverageRow>();
+
+        for (int i = 0; i < 500; i++)
+        {
+            rows.Add(Row($"Filler{i:D3}", total: 100, noProvider: 100, status: CoverageStatus.None));
+        }
+
+        // Low unresolved (501st by the default order, so hidden) but the largest Events total.
+        rows.Add(Row("BigTotal", total: 100000, resolved: 99999, noProvider: 1, status: CoverageStatus.Partial));
+        SetReport(Report([.. rows]));
+
+        var cut = Render<ResolutionCoverageModal>();
+        cut.WaitForState(() => cut.FindAll(".resolution-coverage-row").Count == 500, s_wait);
+
+        Assert.DoesNotContain(cut.FindAll(".resolution-provider-name"), cell => cell.TextContent == "BigTotal");
+        Assert.Contains("Showing the top", cut.Find(".resolution-coverage-truncated").TextContent);
+
+        cut.FindAll(".resolution-sort")[1].Click();
+
+        cut.WaitForAssertion(
+            () => Assert.Equal("BigTotal", cut.FindAll(".resolution-coverage-row")[0].QuerySelector(".resolution-provider-name")!.TextContent),
+            s_wait);
+    }
+
+    [Fact]
+    public void Tooltip_ComposesOnlyPresentCauses()
+    {
+        SetReport(Report(
+            Row("Mixed", total: 7, resolved: 1, noProvider: 2, noMessage: 3, failed: 1, status: CoverageStatus.Partial),
+            Row("FailedOnly", total: 4, resolved: 1, failed: 3, status: CoverageStatus.Partial)));
+
+        var cut = Render<ResolutionCoverageModal>();
+        cut.WaitForState(() => cut.FindAll(".resolution-coverage-row").Count == 2, s_wait);
+
+        var rows = cut.FindAll(".resolution-coverage-row");
+        var mixedTip = rows[0].QuerySelector(".coverage-pill")!.GetAttribute("title");
+        var failedTip = rows[1].QuerySelector(".coverage-pill")!.GetAttribute("title");
+
+        Assert.Contains("no provider metadata", mixedTip);
+        Assert.Contains("no message match", mixedTip);
+        Assert.Contains("a resolution error", mixedTip);
+
+        Assert.Contains("a resolution error", failedTip);
+        Assert.DoesNotContain("no provider metadata", failedTip);
+        Assert.DoesNotContain("no message match", failedTip);
+    }
+
+    [Fact]
+    public void UnfilteredView_HasNoBadge()
+    {
+        _filterApplied.IsFilteringEnabled.Returns(false);
+        SetReport(Report(Row("A", total: 5, noProvider: 5, status: CoverageStatus.None)));
+
+        var cut = Render<ResolutionCoverageModal>();
+        cut.WaitForState(() => cut.FindAll(".resolution-coverage-row").Count > 0, s_wait);
+
+        Assert.Empty(cut.FindAll(".resolution-coverage-badge"));
+    }
+
+    [Fact]
+    public void UpdatingView_ShowsReopenMessage()
+    {
+        _presentation = PresentationWith(PresentationState.Updating);
+
+        var cut = Render<ResolutionCoverageModal>();
+
+        cut.WaitForAssertion(
+            () => Assert.Contains("still updating", cut.Find(".resolution-coverage-status").TextContent),
+            s_wait);
+    }
+
+    private static ProviderCoverageDetail Detail(
+        IReadOnlyList<EventIdCoverageRow>? eventIds = null,
+        IReadOnlyList<LevelCoverageRow>? levels = null,
+        int distinctUnresolved = 0) =>
+        new(eventIds ?? [], levels ?? [], distinctUnresolved);
+
+    private static EventIdCoverageRow IdRow(int eventId, int total, int noProvider = 0, int noMessage = 0, int failed = 0) =>
+        new(eventId, new ProviderResolutionCounts(total, total - noProvider - noMessage - failed, noProvider, noMessage, failed));
+
+    private static ResolutionCoverageReport Report(params ProviderCoverageRow[] rows)
+    {
+        ProviderResolutionCounts summary = default;
+
+        foreach (var row in rows) { summary = summary.Add(row.Counts); }
+
+        return new ResolutionCoverageReport(summary, rows);
+    }
+
+    private static ProviderCoverageRow Row(
+        string provider,
+        int total,
+        int resolved = 0,
+        int noProvider = 0,
+        int noMessage = 0,
+        int failed = 0,
+        CoverageStatus status = CoverageStatus.Partial) =>
+        new(provider, new ProviderResolutionCounts(total, resolved, noProvider, noMessage, failed), status);
+
+    private OrderedViewPresentation PresentationWith(PresentationState state) =>
+        new(_view, EventLogId.Create(), default, state, 1) { ActiveLogName = "Live" };
+
+    private void SetProviderDetail(ProviderCoverageDetail detail) =>
+        _coverageService.BuildProviderDetail(Arg.Any<IEventColumnView>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(detail);
+
+    private void SetReport(ResolutionCoverageReport report) =>
+        _coverageService.Build(Arg.Any<IEventColumnView>(), Arg.Any<CancellationToken>()).Returns(report);
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/Modal/ModalCoordinatorLaunchersTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Modal/ModalCoordinatorLaunchersTests.cs
@@ -6,6 +6,7 @@ using EventLogExpert.UI.Database;
 using EventLogExpert.UI.DatabaseTools;
 using EventLogExpert.UI.DebugLog;
 using EventLogExpert.UI.FilterLibrary;
+using EventLogExpert.UI.LogTable.Resolution;
 using EventLogExpert.UI.Modal;
 using EventLogExpert.UI.Settings;
 using EventLogExpert.UI.Update;
@@ -91,6 +92,18 @@ public sealed class ModalCoordinatorLaunchersTests
 
         await coordinator.Received(1).PushAsync<ReleaseNotesModal, bool>(
             Arg.Is<IDictionary<string, object?>?>(d => d != null && d.ContainsKey(nameof(ReleaseNotesModal.Content)) && content.Equals((ReleaseNotesContent)d[nameof(ReleaseNotesModal.Content)]!)));
+    }
+
+    [Fact]
+    public async Task OpenResolutionCoverageAsync_DelegatesToPushAsync()
+    {
+        var coordinator = Substitute.For<IModalCoordinator>();
+        coordinator.PushAsync<ResolutionCoverageModal, bool>(Arg.Any<IDictionary<string, object?>?>())
+            .Returns(new ModalOpenResult<bool>(false, WasOpened: true));
+
+        await coordinator.OpenResolutionCoverageAsync();
+
+        await coordinator.Received(1).PushAsync<ResolutionCoverageModal, bool>(Arg.Any<IDictionary<string, object?>?>());
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.UI.Tests/StatusBar/StatusBarTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/StatusBar/StatusBarTests.cs
@@ -4,12 +4,15 @@
 using Bunit;
 using EventLogExpert.Eventing.Common.Channels;
 using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Eventing.Common.Events;
 using EventLogExpert.Filtering.Evaluation;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.Runtime.FilterLenses;
 using EventLogExpert.Runtime.LogTable;
 using EventLogExpert.Runtime.Stats;
 using EventLogExpert.Runtime.StatusBar;
+using EventLogExpert.UI.LogTable.Resolution;
+using EventLogExpert.UI.Modal;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using System.Collections.Immutable;
@@ -20,6 +23,7 @@ public sealed class StatusBarTests : BunitContext
 {
     private readonly IFilterAppliedSource _filterApplied = Substitute.For<IFilterAppliedSource>();
     private readonly IFilterLensSource _lensSource = Substitute.For<IFilterLensSource>();
+    private readonly IModalCoordinator _modalCoordinator = Substitute.For<IModalCoordinator>();
     private readonly IStatsCommands _statsCommands = Substitute.For<IStatsCommands>();
     private readonly IStatsVisibilitySource _statsVisibility = Substitute.For<IStatsVisibilitySource>();
     private readonly IStatusBarSource _statusBarSource = Substitute.For<IStatusBarSource>();
@@ -34,6 +38,7 @@ public sealed class StatusBarTests : BunitContext
 
         Services.AddSingleton(_filterApplied);
         Services.AddSingleton(_lensSource);
+        Services.AddSingleton(_modalCoordinator);
         Services.AddSingleton(_statsCommands);
         Services.AddSingleton(_statsVisibility);
         Services.AddSingleton(_statusBarSource);
@@ -95,7 +100,7 @@ public sealed class StatusBarTests : BunitContext
         {
             Tabs = ImmutableList.Create(new LogView(id) { LogName = "Application", LogPathType = LogPathType.Channel }),
             ActiveTabId = id,
-            RawEventCountsByLog = ImmutableDictionary<EventLogId, int>.Empty.Add(id, 0)
+            RawEventCountsByLog = ImmutableDictionary<EventLogId, ProviderResolutionCounts>.Empty.Add(id, default)
         };
         _viewSource.Current.Returns(pending);
 
@@ -134,7 +139,7 @@ public sealed class StatusBarTests : BunitContext
         {
             Tabs = ImmutableList.Create(channel),
             ActiveTabId = id,
-            RawEventCountsByLog = ImmutableDictionary<EventLogId, int>.Empty.Add(id, 0),
+            RawEventCountsByLog = ImmutableDictionary<EventLogId, ProviderResolutionCounts>.Empty.Add(id, default),
             NewEventBufferCount = 42
         };
 
@@ -142,6 +147,17 @@ public sealed class StatusBarTests : BunitContext
 
         var newEvents = cut.FindAll(".status-bar-activity").Single(node => node.TextContent.Contains("New Events"));
         Assert.Equal("off", newEvents.GetAttribute("aria-live"));
+    }
+
+    [Fact]
+    public void CoverageChip_Click_OpensCoverageModal()
+    {
+        SetActiveLog(total: 100, shown: 100, filter: Unfiltered, selected: 0);
+
+        var cut = Render<UI.StatusBar.StatusBar>();
+        cut.Find(".status-bar-coverage").Click();
+
+        _modalCoordinator.Received(1).PushAsync<ResolutionCoverageModal, bool>(Arg.Any<IDictionary<string, object?>?>());
     }
 
     [Fact]
@@ -323,7 +339,7 @@ public sealed class StatusBarTests : BunitContext
             Tabs = ImmutableList.Create(log),
             ActiveTabId = id,
             RawEventTotal = total,
-            RawEventCountsByLog = ImmutableDictionary<EventLogId, int>.Empty.Add(id, total),
+            RawEventCountsByLog = ImmutableDictionary<EventLogId, ProviderResolutionCounts>.Empty.Add(id, new ProviderResolutionCounts(total, total, 0, 0, 0)),
             SelectionCount = selected
         };
     }


### PR DESCRIPTION
## Summary

Adds a **Resolution & Coverage** view that surfaces which loaded events have unresolved descriptions and *why*, so users can act on provider-metadata coverage gaps directly from the log.

ADO: **62704682** — Resolution & Coverage

## What's included

**Status-bar coverage chip (live)**
- A resolved/unresolved tally chip in the status bar that stays in sync as logs load, with an accessible `role="status"` live region and a descriptive `aria-label`. Click to open the full modal.

**Resolution & Coverage modal**
- Per-provider breakdown table with resolution status and tallies.
- **Clickable cause-filters** — turn a coverage cause (e.g. a specific unresolved provider) into an actual event filter with one click.
- **Remediation hints** — inline guidance on how to close a given coverage gap.
- **Expandable Event-ID sub-table** per provider, with a **severity (level) split**.
- Footer actions: **Show only unresolved events** toggle and **Copy table**, gated on report availability.
- Robust modal lifecycle: linked per-expand `CancellationTokenSource`, a stale-generation guard, and a retained view snapshot so retries and re-expands never collapse or race the copy path.

**Columnar aggregation**
- New single-pass `CountResolutionDetailForSource(...)` across the column-store interface chain (store, readers, ordered/combined/AOS views) that accumulates by Event ID and by level slot without per-row allocation.

**App-wide typography scale**
- Six `--font-size-*` design tokens in `app.css`; migrated the coverage modal, `ModalChrome`, and `banner` chrome onto them.
- A `TypographyScaleTests` drift guard that scans `*.razor.css` (plus the global sheets) and fails on off-scale `font-size` values.

## Tests

- `EventColumnStoreReaderTests`, `ResolutionCoverageServiceTests`, `FilterLensCommandsTests`, `ResolutionCoverageModalTests`, `TypographyScaleTests`.
- Full suites green: **Eventing 764 · Runtime 2600 · UI 1522**, MAUI head build **0 warnings / 0 errors**.

## Notes for reviewers

- 80 files, +3365 / -181.
- Rebased onto current `main` (statistics-panel #688 already merged); this branch is exactly one commit ahead of `main`.
