### PR TITLE
Consolidate the multi-log loading indicator and tidy the status bar

### DIFF
--- a/src/EventLogExpert.Runtime/EventLog/OpenLogEffects.cs
+++ b/src/EventLogExpert.Runtime/EventLog/OpenLogEffects.cs
@@ -147,7 +147,7 @@ internal sealed class OpenLogEffects(
         {
             _logger.Warning($"Open '{action.LogName}' aborted: log not found in OpenLogs (no prior AddLog dispatch).");
 
-            dispatcher.Dispatch(new SetResolverStatusAction($"Error: Failed to open {action.LogName}"));
+            dispatcher.Dispatch(new SetResolverStatusAction($"Error: Failed to open {DescribeLog(action)}"));
 
             return;
         }
@@ -240,6 +240,11 @@ internal sealed class OpenLogEffects(
         }
     }
 
+    private static string DescribeLog(OpenLogAction action) =>
+        action.LogPathType == LogPathType.File ?
+            $"{Path.GetFileName(action.LogName)} ({action.LogName})" :
+            action.LogName;
+
     private void CancelAllLoads()
     {
         CancellationTokenSource oldGlobalCts;
@@ -326,216 +331,219 @@ internal sealed class OpenLogEffects(
 
         var partialDispatchGate = new object();
 
-        await using var timer = new Timer(
-            _ =>
-            {
-                dispatcher.Dispatch(new SetEventsLoadingAction(activityId, Volatile.Read(ref resolved), Volatile.Read(ref failed)));
-
-                if (Interlocked.Increment(ref timerTick) <= 1) { return; }
-
-                TryDispatchPartial();
-            },
-            null,
-            TimeSpan.Zero,
-            s_partialDispatchInterval);
-
-        bool renderXml = _eventLogState.Value.AppliedFilter.RequiresXml;
-
-        using var reader = _readerFactory.CreateReader(action.LogName, action.LogPathType, renderXml, reverseDirection: true);
-
-        var producerTask = Task.Run(async () =>
-        {
-            long sequence = 0;
-
-            try
-            {
-                while (reader.TryGetEvents(out EventRecord[] batch, ReadBatchSize))
-                {
-                    token.ThrowIfCancellationRequested();
-
-                    if (batch.Length == 0) { continue; }
-
-                    await channel.Writer.WriteAsync((sequence++, batch), token);
-                }
-            }
-            catch (Exception ex)
-            {
-                channel.Writer.Complete(ex);
-
-                throw;
-            }
-
-            channel.Writer.Complete();
-        }, token);
-
         try
         {
-            if (!reader.IsValid)
+            dispatcher.Dispatch(new SetEventsLoadingAction(activityId, 0, 0));
+
+            bool renderXml = _eventLogState.Value.AppliedFilter.RequiresXml;
+
+            using var reader = TryCreateReader(action, logData, renderXml, dispatcher, stopwatch);
+
+            if (reader is null) { return; }
+
+            var producerTask = Task.Run(async () =>
             {
-                int openError = reader.OpenErrorCode ?? 0;
+                long sequence = 0;
 
-                throw new Win32Exception(openError, $"Opening '{action.LogName}' failed (Win32 {openError}: {Marshal.GetPInvokeErrorMessage(openError)}).");
-            }
-
-            await Parallel.ForEachAsync(
-                channel.Reader.ReadAllAsync(token),
-                new ParallelOptions
+                try
                 {
-                    CancellationToken = token,
-                    MaxDegreeOfParallelism = s_maxGlobalConcurrency
-                },
-                async (item, innerToken) =>
-                {
-                    EventRecord[] batch = item.Batch;
-
-                    var priority = Volatile.Read(ref highAdmitted) < EagerFirstPaintThreshold ?
-                        ResolutionPriority.FirstScreenful :
-                        ResolutionPriority.Bulk;
-
-                    if (priority == ResolutionPriority.FirstScreenful)
+                    while (reader.TryGetEvents(out EventRecord[] batch, ReadBatchSize))
                     {
-                        Interlocked.Add(ref highAdmitted, batch.Length);
+                        token.ThrowIfCancellationRequested();
+
+                        if (batch.Length == 0) { continue; }
+
+                        await channel.Writer.WriteAsync((sequence++, batch), token);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    channel.Writer.Complete(ex);
+
+                    throw;
+                }
+
+                channel.Writer.Complete();
+            }, token);
+
+            await using (var timer = new Timer(
+                    _ =>
+                    {
+                        dispatcher.Dispatch(new SetEventsLoadingAction(activityId, Volatile.Read(ref resolved), Volatile.Read(ref failed)));
+
+                        if (Interlocked.Increment(ref timerTick) <= 1) { return; }
+
+                        TryDispatchPartial();
+                    },
+                    null,
+                    TimeSpan.Zero,
+                    s_partialDispatchInterval))
+            {
+                try
+                {
+                    if (!reader.IsValid)
+                    {
+                        int openError = reader.OpenErrorCode ?? 0;
+
+                        throw new Win32Exception(openError, $"Opening '{action.LogName}' failed (Win32 {openError}: {Marshal.GetPInvokeErrorMessage(openError)}).");
                     }
 
-                    await s_resolutionGate.WaitAsync(priority, innerToken);
-
-                    try
-                    {
-                        List<ResolvedEvent> localBatch = new(batch.Length);
-                        int localResolved = 0;
-
-                        foreach (var @event in batch)
+                    await Parallel.ForEachAsync(
+                        channel.Reader.ReadAllAsync(token),
+                        new ParallelOptions
                         {
-                            innerToken.ThrowIfCancellationRequested();
+                            CancellationToken = token,
+                            MaxDegreeOfParallelism = s_maxGlobalConcurrency
+                        },
+                        async (item, innerToken) =>
+                        {
+                            EventRecord[] batch = item.Batch;
+
+                            var priority = Volatile.Read(ref highAdmitted) < EagerFirstPaintThreshold ?
+                                ResolutionPriority.FirstScreenful :
+                                ResolutionPriority.Bulk;
+
+                            if (priority == ResolutionPriority.FirstScreenful)
+                            {
+                                Interlocked.Add(ref highAdmitted, batch.Length);
+                            }
+
+                            await s_resolutionGate.WaitAsync(priority, innerToken);
 
                             try
                             {
-                                if (!@event.IsSuccess)
+                                List<ResolvedEvent> localBatch = new(batch.Length);
+                                int localResolved = 0;
+
+                                foreach (var @event in batch)
                                 {
-                                    Interlocked.Increment(ref failed);
+                                    innerToken.ThrowIfCancellationRequested();
 
-                                    _logger.Warning($"{@event.PathName}: Bad Event: {@event.Error}");
+                                    try
+                                    {
+                                        if (!@event.IsSuccess)
+                                        {
+                                            Interlocked.Increment(ref failed);
 
-                                    continue;
+                                            _logger.Warning($"{@event.PathName}: Bad Event: {@event.Error}");
+
+                                            continue;
+                                        }
+
+                                        localBatch.Add(eventResolver.ResolveEvent(@event));
+                                        localResolved++;
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        _logger.Warning($"Failed to resolve RecordId: {@event.RecordId}, {ex.Message}");
+                                    }
                                 }
 
-                                localBatch.Add(eventResolver.ResolveEvent(@event));
-                                localResolved++;
+                                bool dispatchEager = false;
+
+                                lock (events)
+                                {
+                                    resolvedBySeq[item.Seq] = localBatch;
+
+                                    while (resolvedBySeq.Remove(nextDrainSeq, out var ready))
+                                    {
+                                        events.AddRange(ready);
+                                        nextDrainSeq++;
+                                    }
+
+                                    if (events.Count >= EagerFirstPaintThreshold && Interlocked.Exchange(ref eagerFired, 1) == 0)
+                                    {
+                                        dispatchEager = true;
+                                    }
+                                }
+
+                                Interlocked.Add(ref resolved, localResolved);
+
+                                if (dispatchEager) { TryDispatchPartial(); }
                             }
-                            catch (Exception ex)
+                            finally
                             {
-                                _logger.Warning($"Failed to resolve RecordId: {@event.RecordId}, {ex.Message}");
+                                s_resolutionGate.Release();
                             }
-                        }
+                        });
 
-                        bool dispatchEager = false;
+                    await producerTask;
 
-                        lock (events)
-                        {
-                            resolvedBySeq[item.Seq] = localBatch;
+                    lastEvent = reader.NewestBookmark;
 
-                            while (resolvedBySeq.Remove(nextDrainSeq, out var ready))
-                            {
-                                events.AddRange(ready);
-                                nextDrainSeq++;
-                            }
-
-                            if (events.Count >= EagerFirstPaintThreshold && Interlocked.Exchange(ref eagerFired, 1) == 0)
-                            {
-                                dispatchEager = true;
-                            }
-                        }
-
-                        Interlocked.Add(ref resolved, localResolved);
-
-                        if (dispatchEager) { TryDispatchPartial(); }
-                    }
-                    finally
+                    if (reader.LastErrorCode is { } readErrorCode)
                     {
-                        s_resolutionGate.Release();
+                        throw new Win32Exception(readErrorCode, $"Reading '{action.LogName}' stopped (Win32 {readErrorCode}: {Marshal.GetPInvokeErrorMessage(readErrorCode)}).");
                     }
-                });
+                }
+                catch (OperationCanceledException)
+                {
+                    await EventLogEffectsUtility.StopProducerAsync(producerTask);
 
-            await producerTask;
+                    _closeCoordinator.ClearPendingRestore(logData.Name);
 
-            lastEvent = reader.NewestBookmark;
+                    _logger.Trace($"Open '{action.LogName}': canceled after {stopwatch.ElapsedMilliseconds}ms ({Volatile.Read(ref resolved)} resolved, {Volatile.Read(ref failed)} failed).");
 
-            if (reader.LastErrorCode is { } readErrorCode)
-            {
-                throw new Win32Exception(readErrorCode, $"Reading '{action.LogName}' stopped (Win32 {readErrorCode}: {Marshal.GetPInvokeErrorMessage(readErrorCode)}).");
+                    if (_eventLogState.Value.OpenLogs.TryGetValue(logData.Name, out var currentLog)
+                        && currentLog.Id == logData.Id)
+                    {
+                        dispatcher.Dispatch(new CloseLogAction(logData.Id, logData.Name));
+                    }
+
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    _logger.Error($"Failed to load log {action.LogName} after {stopwatch.ElapsedMilliseconds}ms: {ex.Message}");
+
+                    await EventLogEffectsUtility.StopProducerAsync(producerTask);
+
+                    _closeCoordinator.ClearPendingRestore(logData.Name);
+
+                    if (_eventLogState.Value.OpenLogs.TryGetValue(logData.Name, out var currentLog)
+                        && currentLog.Id == logData.Id)
+                    {
+                        dispatcher.Dispatch(new CloseLogAction(logData.Id, logData.Name));
+                    }
+
+                    dispatcher.Dispatch(new SetResolverStatusAction($"Error: Failed to load {DescribeLog(action)}"));
+
+                    return;
+                }
             }
+
+            token.ThrowIfCancellationRequested();
+
+            if (!_eventLogState.Value.OpenLogs.TryGetValue(logData.Name, out var activeLog) ||
+                activeLog.Id != logData.Id)
+            {
+                _logger.Trace($"Open '{action.LogName}': log was closed or replaced after producer completed; discarding {events.Count} resolved events after {stopwatch.ElapsedMilliseconds}ms.");
+
+                _closeCoordinator.ClearPendingRestore(logData.Name);
+
+                return;
+            }
+
+            if (renderXml)
+            {
+                _concurrencyState.MarkLoadedWithXml(logData.Id);
+            }
+
+            dispatcher.Dispatch(new LoadEventsAction(logData, events.AsReadOnly()));
+
+            if (action.LogPathType == LogPathType.Channel)
+            {
+                _logWatcherService.AddLog(action.LogName, lastEvent, renderXml);
+            }
+
+            dispatcher.Dispatch(new SetResolverStatusAction(string.Empty));
+
+            _logger.Debug($"Loaded '{action.LogName}': {events.Count} events ({failed} failed) in {stopwatch.ElapsedMilliseconds}ms.");
         }
-        catch (OperationCanceledException)
+        finally
         {
-            await EventLogEffectsUtility.StopProducerAsync(producerTask);
-
-            _closeCoordinator.ClearPendingRestore(logData.Name);
-
-            _logger.Trace($"Open '{action.LogName}': canceled after {stopwatch.ElapsedMilliseconds}ms ({Volatile.Read(ref resolved)} resolved, {Volatile.Read(ref failed)} failed).");
-
-            if (_eventLogState.Value.OpenLogs.TryGetValue(logData.Name, out var currentLog)
-                && currentLog.Id == logData.Id)
-            {
-                dispatcher.Dispatch(new CloseLogAction(logData.Id, logData.Name));
-            }
-
             dispatcher.Dispatch(new ClearStatusAction(activityId));
-
-            return;
         }
-        catch (Exception ex)
-        {
-            _logger.Error($"Failed to load log {action.LogName} after {stopwatch.ElapsedMilliseconds}ms: {ex.Message}");
-
-            await EventLogEffectsUtility.StopProducerAsync(producerTask);
-
-            _closeCoordinator.ClearPendingRestore(logData.Name);
-
-            if (_eventLogState.Value.OpenLogs.TryGetValue(logData.Name, out var currentLog)
-                && currentLog.Id == logData.Id)
-            {
-                dispatcher.Dispatch(new CloseLogAction(logData.Id, logData.Name));
-            }
-
-            dispatcher.Dispatch(new ClearStatusAction(activityId));
-            dispatcher.Dispatch(new SetResolverStatusAction($"Error: Failed to load {action.LogName}"));
-
-            return;
-        }
-
-        await timer.DisposeAsync();
-
-        token.ThrowIfCancellationRequested();
-
-        if (!_eventLogState.Value.OpenLogs.TryGetValue(logData.Name, out var activeLog)
-            || activeLog.Id != logData.Id)
-        {
-            _logger.Trace($"Open '{action.LogName}': log was closed or replaced after producer completed; discarding {events.Count} resolved events after {stopwatch.ElapsedMilliseconds}ms.");
-
-            _closeCoordinator.ClearPendingRestore(logData.Name);
-
-            return;
-        }
-
-        if (renderXml)
-        {
-            _concurrencyState.MarkLoadedWithXml(logData.Id);
-        }
-
-        dispatcher.Dispatch(new LoadEventsAction(logData, events.AsReadOnly()));
-
-        dispatcher.Dispatch(new SetEventsLoadingAction(activityId, 0, 0));
-
-        if (action.LogPathType == LogPathType.Channel)
-        {
-            _logWatcherService.AddLog(action.LogName, lastEvent, renderXml);
-        }
-
-        dispatcher.Dispatch(new SetResolverStatusAction(string.Empty));
-
-        _logger.Debug($"Loaded '{action.LogName}': {events.Count} events ({failed} failed) in {stopwatch.ElapsedMilliseconds}ms.");
-
-        return;
 
         void TryDispatchPartial()
         {
@@ -555,6 +563,35 @@ internal sealed class OpenLogEffects(
 
                 dispatcher.Dispatch(new LoadEventsPartialAction(logData, delta.AsReadOnly()));
             }
+        }
+    }
+
+    private IEventLogReader? TryCreateReader(
+        OpenLogAction action,
+        EventLogData logData,
+        bool renderXml,
+        IDispatcher dispatcher,
+        Stopwatch stopwatch)
+    {
+        try
+        {
+            return _readerFactory.CreateReader(action.LogName, action.LogPathType, renderXml, reverseDirection: true);
+        }
+        catch (Exception ex)
+        {
+            _logger.Error($"Failed to create reader for {action.LogName} after {stopwatch.ElapsedMilliseconds}ms: {ex.Message}");
+
+            _closeCoordinator.ClearPendingRestore(logData.Name);
+
+            if (_eventLogState.Value.OpenLogs.TryGetValue(logData.Name, out var currentLog) &&
+                currentLog.Id == logData.Id)
+            {
+                dispatcher.Dispatch(new CloseLogAction(logData.Id, logData.Name));
+            }
+
+            dispatcher.Dispatch(new SetResolverStatusAction($"Error: Failed to load {DescribeLog(action)}"));
+
+            return null;
         }
     }
 }

--- a/src/EventLogExpert.Runtime/StatusBar/Reducers.cs
+++ b/src/EventLogExpert.Runtime/StatusBar/Reducers.cs
@@ -36,7 +36,7 @@ public sealed class Reducers
     [ReducerMethod]
     public static StatusBarState
         ReduceSetResolverStatus(StatusBarState state, SetResolverStatusAction action) =>
-        new() { ResolverStatus = action.ResolverStatus };
+        state with { ResolverStatus = action.ResolverStatus };
 
     private static ImmutableDictionary<StatusActivityId, (int, int)> CommonLoadingReducer(
         ImmutableDictionary<StatusActivityId, (int, int)> loadingEntries,
@@ -49,8 +49,6 @@ public sealed class Reducers
             return loadingEntries;
         }
 
-        var updated = loadingEntries.Remove(activityId);
-
-        return count == 0 ? updated : updated.Add(activityId, (count, failedCount));
+        return loadingEntries.SetItem(activityId, (count, failedCount));
     }
 }

--- a/src/EventLogExpert.Runtime/StatusBar/StatusBarFormatter.cs
+++ b/src/EventLogExpert.Runtime/StatusBar/StatusBarFormatter.cs
@@ -5,6 +5,8 @@ using EventLogExpert.Runtime.LogTable;
 
 namespace EventLogExpert.Runtime.StatusBar;
 
+public readonly record struct LoadingSummary(string Text, int FailedEvents);
+
 public static class StatusBarFormatter
 {
     public static string CoverageChipTooltip(int unresolved, int total) =>
@@ -60,6 +62,31 @@ public static class StatusBarFormatter
     }
 
     public static string FormatCoverageChip(int unresolved) => $"{unresolved:N0} unresolved";
+
+    public static LoadingSummary? FormatLoading(IReadOnlyDictionary<StatusActivityId, LoadingProgress> activities)
+    {
+        var loadingCount = activities.Count;
+
+        if (loadingCount == 0) { return null; }
+
+        var totalFailed = 0;
+        var singleLoaded = 0;
+
+        foreach (var progress in activities.Values)
+        {
+            totalFailed += progress.Failed;
+            singleLoaded = progress.Loaded;
+        }
+
+        var text = loadingCount switch
+        {
+            1 when singleLoaded == 0 => "Loading...",
+            1 => $"Loading: {singleLoaded:N0}",
+            _ => $"Loading {loadingCount:N0} logs..."
+        };
+
+        return new LoadingSummary(text, totalFailed);
+    }
 
     public static string FormatSource(
         LogView? active,

--- a/src/EventLogExpert.UI/StatusBar/StatusBar.razor
+++ b/src/EventLogExpert.UI/StatusBar/StatusBar.razor
@@ -10,6 +10,8 @@
     var isFiltered = FilterApplied.IsFilteringEnabled;
     var isLoading = !status.LoadingActivities.IsEmpty;
 
+    var loadingSummary = StatusBarFormatter.FormatLoading(status.LoadingActivities);
+
     var source = StatusBarFormatter.FormatSource(activeTable, status.Tabs, status.Groups);
     var filterTooltip = StatusBarFormatter.FilterIndicatorTooltip(status.IsPersistentFilterActive, LensSource.Lenses.Count);
 
@@ -68,13 +70,13 @@
     <div class="status-bar-right">
         <span aria-atomic="true" aria-live="polite" class="status-bar-announce" role="status">@announcement</span>
 
-        @foreach (var loadingProgress in status.LoadingActivities)
+        @if (loadingSummary is { } loading)
         {
-            <span class="status-bar-activity">Loading: @loadingProgress.Value.Loaded</span>
+            <span class="status-bar-activity">@loading.Text</span>
 
-            @if (loadingProgress.Value.Failed > 0)
+            @if (loading.FailedEvents > 0)
             {
-                <span class="status-bar-activity status-bar-warn">Failed: @loadingProgress.Value.Failed</span>
+                <span class="status-bar-activity status-bar-warn">Failed: @(loading.FailedEvents.ToString("N0"))</span>
             }
         }
 
@@ -97,7 +99,7 @@
 
         @if (!string.IsNullOrEmpty(status.ResolverStatus))
         {
-            <span class="status-bar-activity">@status.ResolverStatus</span>
+            <span class="status-bar-activity status-bar-resolver" title="@status.ResolverStatus">@status.ResolverStatus</span>
         }
     </div>
 </div>

--- a/src/EventLogExpert.UI/StatusBar/StatusBar.razor.css
+++ b/src/EventLogExpert.UI/StatusBar/StatusBar.razor.css
@@ -34,6 +34,12 @@
     white-space: nowrap;
 }
 
+.status-bar-resolver {
+    max-width: 32ch;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .status-bar-sep {
     opacity: 0.5;
 }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EffectsTests.cs
@@ -1170,6 +1170,24 @@ public sealed class EffectsTests
     }
 
     [Fact]
+    public async Task HandleOpenLog_ReverseEagerLoad_SuccessfulLoad_ClearsLoadingStatusOnCompletion()
+    {
+        var fakeFactory = new FakeEventLogReaderFactory(
+            new FakeEventLogReader(BuildReverseBatches(60, batchSize: 30), newestBookmark: "NEWEST"));
+
+        var (openLog, dispatcher, _) = CreateEagerLoadEffects(fakeFactory);
+
+        await openLog.HandleOpenLog(new OpenLogAction(Constants.LogNameApplication, LogPathType.Channel), dispatcher);
+
+        dispatcher.Received(1).Dispatch(Arg.Any<ClearStatusAction>());
+
+        var dispatched = dispatcher.ReceivedCalls().Select(call => call.GetArguments()[0]).ToList();
+        var lastLoadingIndex = dispatched.FindLastIndex(action => action is SetEventsLoadingAction);
+        var clearIndex = dispatched.FindLastIndex(action => action is ClearStatusAction);
+        Assert.True(clearIndex > lastLoadingIndex, "ClearStatusAction must be the terminal loading dispatch.");
+    }
+
+    [Fact]
     public async Task HandleOpenLog_ReverseEagerLoad_WhenReadStopsOnError_SurfacesLoadFailureNotFinalLoad()
     {
         const int total = 60;
@@ -1243,7 +1261,21 @@ public sealed class EffectsTests
         await effects.HandleOpenLog(action, mockDispatcher);
 
         mockDispatcher.Received().Dispatch(Arg.Any<CloseLogAction>());
-        mockDispatcher.Received().Dispatch(Arg.Any<ClearStatusAction>());
+        mockDispatcher.Received(1).Dispatch(Arg.Any<ClearStatusAction>());
+    }
+
+    [Fact]
+    public async Task HandleOpenLog_WhenFileLogNotInOpenLogs_ErrorLeadsWithBasenameAndKeepsFullPath()
+    {
+        var (effects, mockDispatcher) = CreateEffects(hasEventResolver: true);
+        var action = new OpenLogAction(@"C:\logs\Security.evtx", LogPathType.File);
+
+        await effects.HandleOpenLog(action, mockDispatcher);
+
+        mockDispatcher.Received(1)
+            .Dispatch(Arg.Is<SetResolverStatusAction>(a => a != null &&
+                a.ResolverStatus.StartsWith("Error: Failed to open Security.evtx") &&
+                a.ResolverStatus.Contains(@"C:\logs\Security.evtx")));
     }
 
     [Fact]
@@ -1276,6 +1308,18 @@ public sealed class EffectsTests
         mockDispatcher.Received(1)
             .Dispatch(Arg.Is<SetResolverStatusAction>(a => a != null &&
                 a.ResolverStatus.Contains("Error")));
+    }
+
+    [Fact]
+    public async Task HandleOpenLog_WhenReaderCreationThrows_ClosesLogAndClearsStatus()
+    {
+        var (openLog, dispatcher, _) = CreateEagerLoadEffects(new ThrowingReaderFactory());
+
+        await openLog.HandleOpenLog(new OpenLogAction(Constants.LogNameApplication, LogPathType.Channel), dispatcher);
+
+        dispatcher.Received(1).Dispatch(Arg.Any<ClearStatusAction>());
+        dispatcher.Received().Dispatch(Arg.Any<CloseLogAction>());
+        dispatcher.Received().Dispatch(Arg.Is<SetResolverStatusAction>(action => action != null && action.ResolverStatus.Contains("Error")));
     }
 
     [Fact]
@@ -1970,5 +2014,11 @@ public sealed class EffectsTests
 
             return reader;
         }
+    }
+
+    private sealed class ThrowingReaderFactory : IEventLogReaderFactory
+    {
+        public IEventLogReader CreateReader(string path, LogPathType pathType, bool renderXml = false, bool reverseDirection = false) =>
+            throw new InvalidOperationException("Simulated reader creation failure.");
     }
 }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/StatusBar/StatusBarFormatterTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/StatusBar/StatusBarFormatterTests.cs
@@ -5,6 +5,7 @@ using EventLogExpert.Eventing.Common.Channels;
 using EventLogExpert.Eventing.Common.EventLogs;
 using EventLogExpert.Runtime.LogTable;
 using EventLogExpert.Runtime.StatusBar;
+using System.Collections.Immutable;
 
 namespace EventLogExpert.Runtime.Tests.StatusBar;
 
@@ -94,6 +95,63 @@ public sealed class StatusBarFormatterTests
         Assert.Equal($"{1234:N0} events", StatusBarFormatter.FormatCounts(1234, 1234, isFiltered: false, selectedCount: 0));
 
     [Fact]
+    public void FormatLoading_ManyActivities_GroupsLogCountAndSumsFailedEvents()
+    {
+        var progresses = Enumerable.Range(0, 1500)
+            .Select(_ => new LoadingProgress(10, 1))
+            .ToArray();
+
+        var summary = StatusBarFormatter.FormatLoading(Loading(progresses));
+
+        Assert.NotNull(summary);
+        Assert.Equal($"Loading {1500:N0} logs...", summary.Value.Text);
+        Assert.Equal(1500, summary.Value.FailedEvents);
+    }
+
+    [Fact]
+    public void FormatLoading_NoActivities_ReturnsNull() =>
+        Assert.Null(StatusBarFormatter.FormatLoading(Loading()));
+
+    [Fact]
+    public void FormatLoading_SingleActivityAtZero_ShowsPendingText()
+    {
+        var summary = StatusBarFormatter.FormatLoading(Loading(new LoadingProgress(0, 0)));
+
+        Assert.NotNull(summary);
+        Assert.Equal("Loading...", summary.Value.Text);
+        Assert.Equal(0, summary.Value.FailedEvents);
+    }
+
+    [Fact]
+    public void FormatLoading_SingleActivityWithProgress_GroupsTheLoadedCount()
+    {
+        var summary = StatusBarFormatter.FormatLoading(Loading(new LoadingProgress(12_345, 0)));
+
+        Assert.NotNull(summary);
+        Assert.Equal($"Loading: {12345:N0}", summary.Value.Text);
+    }
+
+    [Fact]
+    public void FormatLoading_SingleFailedOnlyActivity_StaysPendingAndReportsFailures()
+    {
+        var summary = StatusBarFormatter.FormatLoading(Loading(new LoadingProgress(0, 3)));
+
+        Assert.NotNull(summary);
+        Assert.Equal("Loading...", summary.Value.Text);
+        Assert.Equal(3, summary.Value.FailedEvents);
+    }
+
+    [Fact]
+    public void FormatLoading_TwoActivities_SwitchesToLogCount()
+    {
+        var summary = StatusBarFormatter.FormatLoading(
+            Loading(new LoadingProgress(100, 0), new LoadingProgress(50, 0)));
+
+        Assert.NotNull(summary);
+        Assert.Equal("Loading 2 logs...", summary.Value.Text);
+    }
+
+    [Fact]
     public void FormatSource_AllLogs_CountsOnlyStandaloneTabs()
     {
         var allLogs = Combined(LogTabGroupId.AllLogs);
@@ -142,4 +200,16 @@ public sealed class StatusBarFormatterTests
 
     private static LogView File(string path) =>
         new(EventLogId.Create()) { FileName = path, LogPathType = LogPathType.File };
+
+    private static ImmutableDictionary<StatusActivityId, LoadingProgress> Loading(params LoadingProgress[] progresses)
+    {
+        var builder = ImmutableDictionary.CreateBuilder<StatusActivityId, LoadingProgress>();
+
+        foreach (var progress in progresses)
+        {
+            builder.Add(StatusActivityId.Create(), progress);
+        }
+
+        return builder.ToImmutable();
+    }
 }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/StatusBar/StatusBarStoreTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/StatusBar/StatusBarStoreTests.cs
@@ -208,20 +208,18 @@ public sealed class StatusBarReducerTests
     }
 
     [Fact]
-    public void ReduceSetEventsLoading_WithZeroCount_ShouldRemoveActivity()
+    public void ReduceSetEventsLoading_WithZeroCount_ShouldRegisterPendingActivity()
     {
         var activityId = StatusActivityId.Create();
 
-        var state = new StatusBarState
-        {
-            EventsLoading = ImmutableDictionary<StatusActivityId, (int, int)>.Empty.Add(activityId, (100, 5))
-        };
+        var state = new StatusBarState();
 
         var action = new SetEventsLoadingAction(activityId, 0, 0);
 
         var result = Reducers.ReduceSetEventsLoading(state, action);
 
-        Assert.Empty(result.EventsLoading);
+        Assert.Single(result.EventsLoading);
+        Assert.Equal((0, 0), result.EventsLoading[activityId]);
     }
 
     [Fact]
@@ -352,11 +350,11 @@ public sealed class StatusBarIntegrationTests
             new SetResolverStatusAction("Resolving events..."));
 
         Assert.Equal("Resolving events...", state.ResolverStatus);
-        Assert.Empty(state.EventsLoading);
+        Assert.Single(state.EventsLoading);
 
-        state = Reducers.ReduceSetEventsLoading(
+        state = Reducers.ReduceClearStatus(
             state,
-            new SetEventsLoadingAction(activityId, 0, 0));
+            new ClearStatusAction(activityId));
 
         Assert.Empty(state.EventsLoading);
         Assert.Equal("Resolving events...", state.ResolverStatus);
@@ -420,6 +418,25 @@ public sealed class StatusBarIntegrationTests
     }
 
     [Fact]
+    public void ReduceClearStatus_WithConcurrentLoads_RemovesOnlyTheClearedActivity()
+    {
+        var firstActivity = StatusActivityId.Create();
+        var secondActivity = StatusActivityId.Create();
+
+        var state = new StatusBarState();
+        state = Reducers.ReduceSetEventsLoading(state, new SetEventsLoadingAction(firstActivity, 100, 0));
+        state = Reducers.ReduceSetEventsLoading(state, new SetEventsLoadingAction(secondActivity, 50, 0));
+
+        Assert.Equal(2, state.EventsLoading.Count);
+
+        state = Reducers.ReduceClearStatus(state, new ClearStatusAction(firstActivity));
+
+        Assert.Single(state.EventsLoading);
+        Assert.Equal((50, 0), state.EventsLoading[secondActivity]);
+        Assert.False(state.EventsLoading.ContainsKey(firstActivity));
+    }
+
+    [Fact]
     public void ResolverStatus_ShouldUpdateIndependentlyOfLoading()
     {
         var state = new StatusBarState();
@@ -444,6 +461,6 @@ public sealed class StatusBarIntegrationTests
             new SetResolverStatusAction("Resolution in progress..."));
 
         Assert.Equal("Resolution in progress...", state.ResolverStatus);
-        Assert.Empty(state.EventsLoading);
+        Assert.Single(state.EventsLoading);
     }
 }

--- a/tests/Unit/EventLogExpert.UI.Tests/StatusBar/StatusBarTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/StatusBar/StatusBarTests.cs
@@ -227,6 +227,45 @@ public sealed class StatusBarTests : BunitContext
     }
 
     [Fact]
+    public void MultipleLoadingActivities_RenderAsASingleAggregateChip()
+    {
+        _status = new StatusBarPresentation
+        {
+            LoadingActivities = ImmutableDictionary<StatusActivityId, LoadingProgress>.Empty
+                .Add(new StatusActivityId(Guid.NewGuid()), new LoadingProgress(100, 0))
+                .Add(new StatusActivityId(Guid.NewGuid()), new LoadingProgress(50, 2))
+        };
+
+        var cut = Render<UI.StatusBar.StatusBar>();
+
+        Assert.Contains("Loading 2 logs...", cut.Markup);
+        Assert.DoesNotContain("Loading: 100", cut.Markup);
+        Assert.DoesNotContain("Loading: 50", cut.Markup);
+        Assert.Contains("Failed: 2", cut.Markup);
+    }
+
+    [Fact]
+    public void NewEventsCounter_StaysVisibleWhileAnotherLogLoads()
+    {
+        var id = EventLogId.Create();
+        var channel = new LogView(id) { LogName = "Application", LogPathType = LogPathType.Channel };
+        _status = new StatusBarPresentation
+        {
+            Tabs = ImmutableList.Create(channel),
+            ActiveTabId = id,
+            RawEventCountsByLog = ImmutableDictionary<EventLogId, ProviderResolutionCounts>.Empty.Add(id, default),
+            NewEventBufferCount = 42,
+            LoadingActivities = ImmutableDictionary<StatusActivityId, LoadingProgress>.Empty
+                .Add(new StatusActivityId(Guid.NewGuid()), new LoadingProgress(500, 0))
+        };
+
+        var cut = Render<UI.StatusBar.StatusBar>();
+
+        Assert.Contains("Loading: 500", cut.Markup);
+        Assert.Contains("New Events: 42", cut.Markup);
+    }
+
+    [Fact]
     public void NoActiveLog_ShowsNoLogOpen_AndNoCounts()
     {
         var cut = Render<UI.StatusBar.StatusBar>();
@@ -270,6 +309,17 @@ public sealed class StatusBarTests : BunitContext
     }
 
     [Fact]
+    public void ResolverError_RendersInATruncatingSpanWithFullTitle()
+    {
+        _status = new StatusBarPresentation { ResolverStatus = "Error: Failed to load Security.evtx" };
+
+        var cut = Render<UI.StatusBar.StatusBar>();
+
+        var resolver = cut.Find(".status-bar-resolver");
+        Assert.Equal("Error: Failed to load Security.evtx", resolver.GetAttribute("title"));
+    }
+
+    [Fact]
     public void Root_HasNoLiveRegion_ButAnnounceRegionIsPoliteStatus()
     {
         SetActiveLog(total: 500, shown: 500, filter: Unfiltered, selected: 0);
@@ -283,6 +333,35 @@ public sealed class StatusBarTests : BunitContext
         var announce = cut.Find(".status-bar-announce");
         Assert.Equal("status", announce.GetAttribute("role"));
         Assert.Equal("polite", announce.GetAttribute("aria-live"));
+    }
+
+    [Fact]
+    public void SingleLoadingActivityAtZero_RendersPendingTextNotZero()
+    {
+        _status = new StatusBarPresentation
+        {
+            LoadingActivities = ImmutableDictionary<StatusActivityId, LoadingProgress>.Empty
+                .Add(new StatusActivityId(Guid.NewGuid()), new LoadingProgress(0, 0))
+        };
+
+        var cut = Render<UI.StatusBar.StatusBar>();
+
+        Assert.Contains("Loading...", cut.Markup);
+        Assert.DoesNotContain("Loading: 0", cut.Markup);
+    }
+
+    [Fact]
+    public void SingleLoadingActivity_GroupsLargeFailedCount()
+    {
+        _status = new StatusBarPresentation
+        {
+            LoadingActivities = ImmutableDictionary<StatusActivityId, LoadingProgress>.Empty
+                .Add(new StatusActivityId(Guid.NewGuid()), new LoadingProgress(5000, 1500))
+        };
+
+        var cut = Render<UI.StatusBar.StatusBar>();
+
+        Assert.Contains($"Failed: {1500:N0}", cut.Markup);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Consolidates the status bar's multi-log loading indicator and tidies the right-hand cluster.

When several logs load at once (Open Folder / multi-file import), the status bar previously rendered one `Loading: <events>` span per log, producing an unreadable wall of text (and a cluster that could push the source name off screen). This change collapses those into a single aggregate indicator and cleans up the surrounding presentation.

## What changed

**Multi-log loading, consolidated**
- A single loading indicator: `Loading: N` for one log, `Loading N logs...` for several, and `Loading...` before the first count arrives. A single `Failed: N` is appended only when there are unreadable event records.

**Loading state made correct**
- Setting the resolver status no longer wipes the in-flight loading state of other logs (it previously reset the whole status-bar state on every log completion).
- In-flight logs are tracked as first-class entries, so the "N logs" count is accurate and the indicator no longer blinks out as sibling logs finish.
- The per-log load lifecycle now clears its loading status on every exit path via a single `finally`, and a reader-creation failure closes the tab and surfaces an error instead of stranding it.

**Right cluster tidied**
- The live channel state (`New Events` / `Buffer full` / `Continuously updating`) stays visible while a background log loads.
- The resolver-status text is bounded (ellipsis + tooltip) so a long error path can't widen the cluster; file errors lead with the file name.

## Tests

- New/updated coverage for the loading formatter (single/multi/pending/failed arms), the loading-state reducers (preserve-on-resolver-status, register-pending, concurrent lifecycle), the per-log load terminal-clear (success, cancel, reader-throw), and the status-bar rendering (single aggregate chip, live-channel coexistence, resolver overflow).
- Green: Eventing 764, Runtime 2610, UI 1527; Windows MAUI head builds clean.

## Notes

- Rebased onto current `main` (Resolution & Coverage already merged); one commit.
