### PR TITLE
Add a Keep action to promote a filter lens into a persistent filter

### DIFF
--- a/src/EventLogExpert.Runtime/DependencyInjection/RuntimeServiceCollectionExtensions.cs
+++ b/src/EventLogExpert.Runtime/DependencyInjection/RuntimeServiceCollectionExtensions.cs
@@ -188,6 +188,8 @@ public static class RuntimeServiceCollectionExtensions
             services.Forward<IClearAllFiltersNotifier, ClearAllFiltersNotifier>();
             services.AddSingleton<SetFilterDateRangeSucceededNotifier>();
             services.Forward<ISetFilterDateRangeSucceededNotifier, SetFilterDateRangeSucceededNotifier>();
+            services.AddSingleton<FilterPromotedNotifier>();
+            services.Forward<IFilterPromotedNotifier, FilterPromotedNotifier>();
 
             // Indicators, resolvers, formatters, and selectors
             services.AddSingleton<DisplayIndicatorGate>();

--- a/src/EventLogExpert.Runtime/FilterLenses/CommitPromotedLensAction.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/CommitPromotedLensAction.cs
@@ -1,0 +1,13 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Evaluation;
+using EventLogExpert.Filtering.Persistence;
+using System.Collections.Immutable;
+
+namespace EventLogExpert.Runtime.FilterLenses;
+
+internal sealed record CommitPromotedLensAction(
+    FilterLensId Id,
+    ImmutableList<SavedFilter> Filters,
+    DateFilter? Window);

--- a/src/EventLogExpert.Runtime/FilterLenses/EffectiveFilterBuilder.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/EffectiveFilterBuilder.cs
@@ -37,15 +37,14 @@ internal static class EffectiveFilterBuilder
         return new Filter(date, filters);
     }
 
-    private static DateTime Earlier(DateTime first, DateTime second) => first <= second ? first : second;
-
     /// <summary>
     ///     Intersects <paramref name="window" /> into <paramref name="baseDate" />, producing a two-sided, enabled
     ///     <see cref="DateFilter" />. A null or disabled base imposes no gate (treated as unbounded); any null bound (base or
     ///     lens) is treated as -/+ infinity so the result never carries a null bound - an enabled date filter with a null
-    ///     bound matches nothing. An empty overlap (After > Before) intentionally yields an empty view.
+    ///     bound matches nothing. An empty overlap (After > Before) intentionally yields an empty view. Also reused by the
+    ///     promote-lens reducer to fold a time-window lens into the persistent pane date range.
     /// </summary>
-    private static DateFilter IntersectWindow(DateFilter? baseDate, DateFilter window)
+    internal static DateFilter IntersectWindow(DateFilter? baseDate, DateFilter window)
     {
         var baseActive = baseDate is { IsEnabled: true };
 
@@ -59,6 +58,8 @@ internal static class EffectiveFilterBuilder
 
         return new DateFilter { After = after, Before = before, IsEnabled = true };
     }
+
+    private static DateTime Earlier(DateTime first, DateTime second) => first <= second ? first : second;
 
     private static DateTime Later(DateTime first, DateTime second) => first >= second ? first : second;
 }

--- a/src/EventLogExpert.Runtime/FilterLenses/Effects.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/Effects.cs
@@ -1,6 +1,7 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.Runtime.FilterPane;
 using Fluxor;
@@ -13,8 +14,12 @@ namespace EventLogExpert.Runtime.FilterLenses;
 ///     the existing apply/concurrency path (last dispatch wins via the filter token); lenses are never written back into
 ///     the persistent <see cref="FilterPaneState" />.
 /// </summary>
-internal sealed class Effects(IState<FilterLensState> lensState, IState<FilterPaneState> filterPaneState)
+internal sealed class Effects(
+    IState<FilterLensState> lensState,
+    IState<FilterPaneState> filterPaneState,
+    IAnnouncementService announcementService)
 {
+    private readonly IAnnouncementService _announcementService = announcementService;
     private readonly IState<FilterPaneState> _filterPaneState = filterPaneState;
     private readonly IState<FilterLensState> _lensState = lensState;
 
@@ -43,6 +48,31 @@ internal sealed class Effects(IState<FilterLensState> lensState, IState<FilterPa
         {
             dispatcher.Dispatch(new RemoveLensesForLogAction(action.LogName));
         }
+
+        return Task.CompletedTask;
+    }
+
+    [EffectMethod]
+    public Task HandlePromote(PromoteFilterLensAction action, IDispatcher dispatcher)
+    {
+        var lens = _lensState.Value.Lenses.FirstOrDefault(candidate => candidate.Id == action.Id);
+
+        if (lens is null) { return Task.CompletedTask; }
+
+        // Persist the lens's natural promote form (a positive include for keep-only lenses), falling back to the
+        // transient exclude-of-complement for hide lenses, whose exclude form is already the natural one.
+        var filters = lens.PromoteFilters.IsEmpty ? lens.ExcludeFilters : lens.PromoteFilters;
+
+        // An absent (already removed) or degenerate (nothing to keep) lens neither announces nor commits. The factory
+        // never produces a degenerate lens; this is a defensive gate.
+        if (filters.IsEmpty && lens.Window is not { IsEnabled: true })
+        {
+            return Task.CompletedTask;
+        }
+
+        _announcementService.Announce($"Kept as filter: {lens.Label}");
+
+        dispatcher.Dispatch(new CommitPromotedLensAction(lens.Id, filters, lens.Window));
 
         return Task.CompletedTask;
     }

--- a/src/EventLogExpert.Runtime/FilterLenses/FilterLens.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/FilterLens.cs
@@ -20,19 +20,11 @@ public sealed record FilterLens
 
     public required LensKind Kind { get; init; }
 
-    /// <summary>
-    ///     Exclude criteria whose "hide everything else" arm is decisive (Match) for an absent field value, so the lens
-    ///     narrows to exactly the intended rows without leaking absent-field rows. Only <see cref="FilterLensFactory" /> may
-    ///     produce these, which is what enforces the total-operator invariant.
-    /// </summary>
     public ImmutableList<SavedFilter> ExcludeFilters { get; init; } = [];
+
+    public ImmutableList<SavedFilter> PromoteFilters { get; init; } = [];
 
     public DateFilter? Window { get; init; }
 
-    /// <summary>
-    ///     The owning log the lens originated from - the source event's <c>OwningLog</c> (the app's internal log name,
-    ///     which is also the name carried by a user-initiated log close). Used only for lifecycle: the lens is dropped when
-    ///     that log is closed by the user. A null origin clears only on close-all.
-    /// </summary>
     public string? OriginLog { get; init; }
 }

--- a/src/EventLogExpert.Runtime/FilterLenses/FilterLensCommands.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/FilterLensCommands.cs
@@ -25,6 +25,8 @@ internal sealed class FilterLensCommands(IDispatcher dispatcher) : IFilterLensCo
     public void IncludeValue(EventProperty property, string value, string? originLog = null) =>
         PushLens(FilterLensFactory.ForIncludedValue(property, value, originLog));
 
+    public void PromoteLens(FilterLensId id) => _dispatcher.Dispatch(new PromoteFilterLensAction(id));
+
     public void RemoveLens(FilterLensId id) => _dispatcher.Dispatch(new RemoveFilterLensAction(id));
 
     public void ShowEventsNearTime(DateTime timeCreated, TimeSpan radius, TimeZoneInfo displayZone, string? originLog = null) =>

--- a/src/EventLogExpert.Runtime/FilterLenses/FilterLensFactory.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/FilterLensFactory.cs
@@ -6,6 +6,7 @@ using EventLogExpert.Filtering.Common.Filtering;
 using EventLogExpert.Filtering.Evaluation;
 using EventLogExpert.Filtering.Persistence;
 using EventLogExpert.Runtime.Common.Display;
+using System.Collections.Immutable;
 
 namespace EventLogExpert.Runtime.FilterLenses;
 
@@ -76,6 +77,7 @@ internal static class FilterLensFactory
             Label = $"{PropertyDisplayName(property)} = {value}",
             Kind = LensKind.Property,
             ExcludeFilters = absentComplement is null ? [complement] : [complement, absentComplement],
+            PromoteFilters = BuildKeepOnlyPromoteForm(property, value),
             OriginLog = originLog
         };
     }
@@ -154,8 +156,18 @@ internal static class FilterLensFactory
             Label = label,
             Kind = LensKind.Property,
             ExcludeFilters = [complement],
+            PromoteFilters = BuildKeepOnlyPromoteForm(property, value.ToString()),
             OriginLog = originLog
         };
+    }
+
+    private static ImmutableList<SavedFilter> BuildKeepOnlyPromoteForm(EventProperty property, string value)
+    {
+        if (!TryFormatEqual(property, value, out var comparisonText)) { return []; }
+
+        var include = SavedFilter.TryCreate(comparisonText, isExcluded: false, isEnabled: true, mode: FilterMode.Advanced);
+
+        return include?.Compiled is null ? [] : [include];
     }
 
     private static string FormatRadius(TimeSpan radius) => radius switch

--- a/src/EventLogExpert.Runtime/FilterLenses/IFilterLensCommands.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/IFilterLensCommands.cs
@@ -17,6 +17,8 @@ public interface IFilterLensCommands
 
     void IncludeValue(EventProperty property, string value, string? originLog = null);
 
+    void PromoteLens(FilterLensId id);
+
     void RemoveLens(FilterLensId id);
 
     void ShowEventsNearTime(DateTime timeCreated, TimeSpan radius, TimeZoneInfo displayZone, string? originLog = null);

--- a/src/EventLogExpert.Runtime/FilterLenses/PromoteFilterLensAction.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/PromoteFilterLensAction.cs
@@ -1,0 +1,6 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.FilterLenses;
+
+internal sealed record PromoteFilterLensAction(FilterLensId Id);

--- a/src/EventLogExpert.Runtime/FilterLenses/Reducers.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/Reducers.cs
@@ -12,6 +12,14 @@ internal sealed class Reducers
         state.Lenses.IsEmpty ? state : new FilterLensState();
 
     [ReducerMethod]
+    public static FilterLensState ReduceCommitPromoted(FilterLensState state, CommitPromotedLensAction action)
+    {
+        var updated = state.Lenses.RemoveAll(lens => lens.Id == action.Id);
+
+        return updated.Count == state.Lenses.Count ? state : state with { Lenses = updated };
+    }
+
+    [ReducerMethod]
     public static FilterLensState ReducePush(FilterLensState state, PushFilterLensAction action) =>
         state with { Lenses = state.Lenses.Add(action.Lens) };
 

--- a/src/EventLogExpert.Runtime/FilterPane/Effects.cs
+++ b/src/EventLogExpert.Runtime/FilterPane/Effects.cs
@@ -16,6 +16,7 @@ internal sealed class Effects
     private readonly IStateSelection<EventLogState, Filter> _appliedFilter;
     private readonly ClearAllFiltersNotifier _clearAllFiltersNotifier;
     private readonly IState<FilterPaneState> _filterPaneState;
+    private readonly FilterPromotedNotifier _filterPromotedNotifier;
     private readonly IState<FilterLensState> _lensState;
     private readonly IState<RawEventStoreState> _rawEventStore;
     private readonly SetFilterDateRangeSucceededNotifier _setFilterDateRangeSucceededNotifier;
@@ -26,7 +27,8 @@ internal sealed class Effects
         IState<FilterPaneState> filterPaneState,
         IState<FilterLensState> lensState,
         ClearAllFiltersNotifier clearAllFiltersNotifier,
-        SetFilterDateRangeSucceededNotifier setFilterDateRangeSucceededNotifier)
+        SetFilterDateRangeSucceededNotifier setFilterDateRangeSucceededNotifier,
+        FilterPromotedNotifier filterPromotedNotifier)
     {
         _appliedFilter = appliedFilter;
         _rawEventStore = rawEventStore;
@@ -34,6 +36,7 @@ internal sealed class Effects
         _lensState = lensState;
         _clearAllFiltersNotifier = clearAllFiltersNotifier;
         _setFilterDateRangeSucceededNotifier = setFilterDateRangeSucceededNotifier;
+        _filterPromotedNotifier = filterPromotedNotifier;
 
         _appliedFilter.Select(static s => s.AppliedFilter);
     }
@@ -58,6 +61,21 @@ internal sealed class Effects
     {
         UpdateEventTableFilters(_filterPaneState.Value, dispatcher);
         _clearAllFiltersNotifier.Raise();
+        return Task.CompletedTask;
+    }
+
+    [EffectMethod]
+    public Task HandleCommitPromoted(CommitPromotedLensAction action, IDispatcher dispatcher)
+    {
+        dispatcher.Dispatch(new ApplyFilterAction(BuildCandidate(_filterPaneState.Value)));
+
+        if (action.Window is { IsEnabled: true })
+        {
+            _setFilterDateRangeSucceededNotifier.Raise();
+        }
+
+        _filterPromotedNotifier.Raise();
+
         return Task.CompletedTask;
     }
 
@@ -183,11 +201,12 @@ internal sealed class Effects
         return Task.CompletedTask;
     }
 
+    private Filter BuildCandidate(FilterPaneState filterPaneState) =>
+        EffectiveFilterBuilder.Build(FilterPaneFilterBuilder.Build(filterPaneState), _lensState.Value.Lenses);
+
     private void UpdateEventTableFilters(FilterPaneState filterPaneState, IDispatcher dispatcher)
     {
-        var candidate = EffectiveFilterBuilder.Build(
-            FilterPaneFilterBuilder.Build(filterPaneState),
-            _lensState.Value.Lenses);
+        var candidate = BuildCandidate(filterPaneState);
 
         if (!candidate.HasFilteringChangedFrom(_appliedFilter.Value))
         {

--- a/src/EventLogExpert.Runtime/FilterPane/FilterPromotedNotifier.cs
+++ b/src/EventLogExpert.Runtime/FilterPane/FilterPromotedNotifier.cs
@@ -1,0 +1,46 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Logging.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EventLogExpert.Runtime.FilterPane;
+
+/// <summary>
+///     Raised by the FilterPane commit effect after a lens is promoted into a persistent filter, so the FilterPane
+///     component can expand its (otherwise collapsed) filter list to reveal the newly kept row. Mirrors
+///     <see cref="SetFilterDateRangeSucceededNotifier" />: the concrete type raises, the interface subscribes, and one
+///     shared instance is registered.
+/// </summary>
+internal sealed class FilterPromotedNotifier : IFilterPromotedNotifier
+{
+    private readonly ITraceLogger _logger;
+
+    public FilterPromotedNotifier([FromKeyedServices(LogCategories.EventLog)] ITraceLogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _logger = logger;
+    }
+
+    public event Action? Promoted;
+
+    public void Raise()
+    {
+        var handlers = Promoted;
+
+        if (handlers is null) { return; }
+
+        foreach (var handler in handlers.GetInvocationList().Cast<Action>())
+        {
+            try
+            {
+                handler();
+            }
+            catch (Exception fault)
+            {
+                _logger.Trace($"{nameof(FilterPromotedNotifier)}: a subscriber threw and was isolated: {fault}");
+            }
+        }
+    }
+}

--- a/src/EventLogExpert.Runtime/FilterPane/IFilterPromotedNotifier.cs
+++ b/src/EventLogExpert.Runtime/FilterPane/IFilterPromotedNotifier.cs
@@ -1,0 +1,9 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.FilterPane;
+
+public interface IFilterPromotedNotifier
+{
+    event Action Promoted;
+}

--- a/src/EventLogExpert.Runtime/FilterPane/Reducers.cs
+++ b/src/EventLogExpert.Runtime/FilterPane/Reducers.cs
@@ -3,6 +3,7 @@
 
 using EventLogExpert.Filtering.Evaluation;
 using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Runtime.FilterLenses;
 using Fluxor;
 using System.Collections.Immutable;
 
@@ -16,6 +17,48 @@ internal sealed class Reducers
 
     [ReducerMethod(typeof(ClearAllFiltersAction))]
     public static FilterPaneState ReduceClearFilters(FilterPaneState state) => new() { IsEnabled = state.IsEnabled };
+
+    [ReducerMethod]
+    public static FilterPaneState ReduceCommitPromoted(FilterPaneState state, CommitPromotedLensAction action)
+    {
+        var filters = state.Filters;
+
+        foreach (var promoted in action.Filters)
+        {
+            // Match only a USABLE (compiled) equivalent, ordinal-exact so case-variant values stay distinct predicates
+            // (filter string equality is ordinal, unlike the lowercased library MRU in ReduceMergeFilters). A dead
+            // (uncompiled) ordinal match narrows nothing, so it is passed over and the working filter is added below.
+            var existingIndex = filters.FindIndex(filter =>
+                string.Equals(filter.ComparisonText, promoted.ComparisonText, StringComparison.Ordinal) &&
+                filter.Mode == promoted.Mode &&
+                filter.IsExcluded == promoted.IsExcluded &&
+                filter.Compiled is not null);
+
+            if (existingIndex >= 0)
+            {
+                var existing = filters[existingIndex];
+
+                // Re-enable a disabled equivalent in place so the promoted narrowing stays active; an already-enabled
+                // equivalent needs no change. Either way, no duplicate row.
+                if (!existing.IsEnabled)
+                {
+                    filters = filters.SetItem(existingIndex, existing with { IsEnabled = true });
+                }
+
+                continue;
+            }
+
+            filters = filters.Add(promoted with { Id = FilterId.Create(), IsEnabled = promoted.Compiled is not null });
+        }
+
+        var date = action.Window is { IsEnabled: true } window
+            ? EffectiveFilterBuilder.IntersectWindow(state.FilteredDateRange, window)
+            : state.FilteredDateRange;
+
+        return ReferenceEquals(filters, state.Filters) && date == state.FilteredDateRange
+            ? state
+            : state with { Filters = filters, FilteredDateRange = date };
+    }
 
     [ReducerMethod]
     public static FilterPaneState ReduceMergeFilters(FilterPaneState state, MergeFiltersAction action)

--- a/src/EventLogExpert.UI/FilterLenses/LensBreadcrumb.razor
+++ b/src/EventLogExpert.UI/FilterLenses/LensBreadcrumb.razor
@@ -19,6 +19,12 @@
             var lensId = lens.Id;
             <span class="lens-chip">
                 <span class="lens-chip-label" title="@lens.Label">@lens.Label</span>
+                <button aria-label="@($"Keep lens as filter: {lens.Label}")"
+                    class="lens-chip-keep"
+                    @onclick="@(() => Commands.PromoteLens(lensId))"
+                    type="button">
+                    <i aria-hidden="true" class="bi bi-pin-angle"></i>
+                </button>
                 <button aria-label="@($"Remove lens: {lens.Label}")"
                     class="lens-chip-remove"
                     @onclick="@(() => Commands.RemoveLens(lensId))"

--- a/src/EventLogExpert.UI/FilterLenses/LensBreadcrumb.razor.css
+++ b/src/EventLogExpert.UI/FilterLenses/LensBreadcrumb.razor.css
@@ -31,6 +31,7 @@
     white-space: nowrap;
 }
 
+.lens-chip-keep,
 .lens-chip-remove,
 .lens-clear {
     background: transparent;
@@ -46,12 +47,17 @@
     font-size: 0.85em;
 }
 
+.lens-chip-keep:hover {
+    color: var(--clr-lightblue);
+}
+
 .lens-chip-remove:hover,
 .lens-clear:hover {
     color: var(--clr-red);
 }
 
 .lens-breadcrumb:focus-visible,
+.lens-chip-keep:focus-visible,
 .lens-chip-remove:focus-visible,
 .lens-clear:focus-visible {
     outline: 2px solid var(--toggle-accent);

--- a/src/EventLogExpert.UI/FilterPane/FilterPane.razor.cs
+++ b/src/EventLogExpert.UI/FilterPane/FilterPane.razor.cs
@@ -97,6 +97,8 @@ public sealed partial class FilterPane
 
     [Inject] private IFilterPaneCommands FilterPaneCommands { get; init; } = null!;
 
+    [Inject] private IFilterPromotedNotifier FilterPromotedNotifier { get; init; } = null!;
+
     [Inject] private IFilteredDateRangeSource FilteredDateRange { get; init; } = null!;
 
     private bool HasClearableFilters =>
@@ -436,6 +438,12 @@ public sealed partial class FilterPane
 
     protected override void OnInitialized()
     {
+        // Seed the display zone and hydrate the date model from any already-applied range BEFORE binding the
+        // EditContext, so an externally-set FilteredDateRange (e.g. a promoted time-window lens) renders in local time
+        // rather than UTC, and the EditContext wraps the populated model.
+        _currentTimeZone = Settings.TimeZoneInfo;
+        UpdateFilterDate(FilteredDateRange.Current);
+
         _editContext = new EditContext(_model);
 
         ObserveSource(LibraryEntries);
@@ -471,6 +479,21 @@ public sealed partial class FilterPane
                 if (_disposed) { return Task.CompletedTask; }
 
                 UpdateFilterDate(FilteredDateRange.Current);
+                StateHasChanged();
+
+                return Task.CompletedTask;
+            });
+
+        ObserveSource(
+            handler => FilterPromotedNotifier.Promoted += handler,
+            handler => FilterPromotedNotifier.Promoted -= handler,
+            () =>
+            {
+                if (_disposed) { return Task.CompletedTask; }
+
+                // A promoted lens adds its row to the (possibly collapsed) filter list; expand it so the kept filter
+                // is visible, matching every other filter-adding path.
+                _isFilterListVisible = true;
                 StateHasChanged();
 
                 return Task.CompletedTask;

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/EffectiveFilterBuilderTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/EffectiveFilterBuilderTests.cs
@@ -302,6 +302,26 @@ public sealed class EffectiveFilterBuilderTests
         Assert.Equal([1], result.Select(e => e.Id).OrderBy(id => id));
     }
 
+    [Fact]
+    public void PromoteForm_IncludeUserLens_KeepsMatchingUser_DropsOthersAndNoUserEvents()
+    {
+        // The keep-only lens's PROMOTE form is a single positive include (User == SYSTEM). Unlike the transient
+        // exclude-of-complement (which needs a second "User == null" clause), an include drops a no-user row on its own
+        // (a decisive NoMatch), so the promoted pane view keeps exactly the same set as the live lens.
+        var system = FilterEventBuilder.CreateTestEvent(id: 1, userDisplayName: "SYSTEM");
+        var alice = FilterEventBuilder.CreateTestEvent(id: 2, userDisplayName: "CONTOSO\\alice");
+        var noUser = FilterEventBuilder.CreateTestEvent(id: 3);
+
+        var lens = FilterLensFactory.ForIncludedValue(EventProperty.UserDisplayName, "SYSTEM");
+        Assert.NotNull(lens);
+        Assert.Single(lens!.PromoteFilters);
+        Assert.False(lens.PromoteFilters[0].IsExcluded);
+
+        var result = s_filterService.GetFilteredEvents([system, alice, noUser], new Filter(null, lens.PromoteFilters));
+
+        Assert.Equal([1], result.Select(e => e.Id).OrderBy(id => id));
+    }
+
     private static DateTime At(int hourUtc) => new(2024, 1, 1, hourUtc, 0, 0, DateTimeKind.Utc);
 
     private static SavedFilter SavedFilterFor(string comparisonText) =>

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensCommandsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensCommandsTests.cs
@@ -30,6 +30,25 @@ public sealed class FilterLensCommandsTests
         dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action => action != null && action.Lens != null));
     }
 
+    [Fact]
+    public void IncludeValue_ProducesKeepOnlyLens_WithPositiveIncludePromoteForm()
+    {
+        var dispatcher = Substitute.For<IDispatcher>();
+
+        new FilterLensCommands(dispatcher).IncludeValue(EventProperty.Source, "Contoso");
+
+        dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action =>
+            action != null &&
+            // Transient form stays an exclude-of-complement for master-toggle-independent live narrowing...
+            action.Lens.ExcludeFilters.Count == 1 &&
+            action.Lens.ExcludeFilters[0].IsExcluded &&
+            // ...but the promote form is a single positive include that reads as the user's intent.
+            action.Lens.PromoteFilters.Count == 1 &&
+            !action.Lens.PromoteFilters[0].IsExcluded &&
+            action.Lens.PromoteFilters[0].Compiled != null &&
+            action.Lens.PromoteFilters[0].ComparisonText!.Contains("==")));
+    }
+
     [Theory]
     [InlineData(ResolutionStatusTokens.NoProvider)]
     [InlineData(ResolutionStatusTokens.NoMessage)]
@@ -43,6 +62,24 @@ public sealed class FilterLensCommandsTests
         new FilterLensCommands(dispatcher).IncludeValue(EventProperty.ResolutionStatus, token);
 
         dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action => action != null && action.Lens != null));
+    }
+
+    [Fact]
+    public void IncludeValue_User_KeepsTwoExcludeComplement_ButPromotesToSinglePositiveInclude()
+    {
+        var dispatcher = Substitute.For<IDispatcher>();
+
+        new FilterLensCommands(dispatcher).IncludeValue(EventProperty.UserDisplayName, "CONTOSO\\jdoe");
+
+        dispatcher.Received(1).Dispatch(Arg.Is<PushFilterLensAction>(action =>
+            action != null &&
+            // The presence-gated User keep-only lens needs TWO transient excludes (!= value + == null) to avoid
+            // leaking no-user rows...
+            action.Lens.ExcludeFilters.Count == 2 &&
+            // ...but promotes to a SINGLE positive include, since an include drops a no-user (NoMatch) row on its own.
+            action.Lens.PromoteFilters.Count == 1 &&
+            !action.Lens.PromoteFilters[0].IsExcluded &&
+            action.Lens.PromoteFilters[0].Compiled != null));
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensEffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensEffectsTests.cs
@@ -3,6 +3,7 @@
 
 using EventLogExpert.Eventing.Common.EventLogs;
 using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.Runtime.FilterLenses;
 using EventLogExpert.Runtime.FilterPane;
@@ -59,6 +60,82 @@ public sealed class FilterLensEffectsTests
     }
 
     [Fact]
+    public async Task HandlePromote_AbsentLens_DoesNotAnnounceOrCommit()
+    {
+        var lens = FilterLensFactory.ForActivityId(Guid.NewGuid())!;
+        var (effects, dispatcher, announcer) =
+            CreateEffectsWithAnnouncer(new FilterLensState { Lenses = [lens] }, new FilterPaneState());
+
+        await effects.HandlePromote(new PromoteFilterLensAction(FilterLensId.Create()), dispatcher);
+
+        announcer.DidNotReceive().Announce(Arg.Any<string>());
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<CommitPromotedLensAction>());
+    }
+
+    [Fact]
+    public async Task HandlePromote_DegenerateLens_DoesNotAnnounceOrCommit()
+    {
+        var lens = new FilterLens { Label = "empty", Kind = LensKind.Property, ExcludeFilters = [] };
+        var (effects, dispatcher, announcer) =
+            CreateEffectsWithAnnouncer(new FilterLensState { Lenses = [lens] }, new FilterPaneState());
+
+        await effects.HandlePromote(new PromoteFilterLensAction(lens.Id), dispatcher);
+
+        announcer.DidNotReceive().Announce(Arg.Any<string>());
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<CommitPromotedLensAction>());
+    }
+
+    [Fact]
+    public async Task HandlePromote_HideLens_DispatchesExcludeFallback()
+    {
+        var lens = FilterLensFactory.ForExcludedValue(EventProperty.Source, "Contoso")!;
+        var (effects, dispatcher, announcer) =
+            CreateEffectsWithAnnouncer(new FilterLensState { Lenses = [lens] }, new FilterPaneState());
+
+        await effects.HandlePromote(new PromoteFilterLensAction(lens.Id), dispatcher);
+
+        announcer.Received(1).Announce(Arg.Any<string>());
+
+        // A hide lens has no positive promote form, so it falls back to its natural exclude.
+        dispatcher.Received(1).Dispatch(Arg.Is<CommitPromotedLensAction>(action =>
+            action != null && action.Id == lens.Id && action.Filters.Count == 1 &&
+            action.Filters[0].IsExcluded && action.Window == null));
+    }
+
+    [Fact]
+    public async Task HandlePromote_KeepOnlyLens_AnnouncesAndDispatchesPositiveInclude()
+    {
+        var lens = FilterLensFactory.ForActivityId(Guid.NewGuid())!;
+        var (effects, dispatcher, announcer) =
+            CreateEffectsWithAnnouncer(new FilterLensState { Lenses = [lens] }, new FilterPaneState());
+
+        await effects.HandlePromote(new PromoteFilterLensAction(lens.Id), dispatcher);
+
+        announcer.Received(1).Announce(Arg.Is<string>(message =>
+            message != null && message.Contains(lens.Label, StringComparison.Ordinal)));
+
+        // A keep-only lens promotes as a single POSITIVE INCLUDE (== value), not the transient exclude-of-complement.
+        dispatcher.Received(1).Dispatch(Arg.Is<CommitPromotedLensAction>(action =>
+            action != null && action.Id == lens.Id && action.Filters.Count == 1 &&
+            !action.Filters[0].IsExcluded && action.Filters[0].Compiled != null && action.Window == null));
+    }
+
+    [Fact]
+    public async Task HandlePromote_TimeWindowLens_DispatchesCommitWithWindow()
+    {
+        var lens = FilterLensFactory.ForTimeWindow(DateTime.UtcNow, TimeSpan.FromMinutes(5), TimeZoneInfo.Utc);
+        var (effects, dispatcher, announcer) =
+            CreateEffectsWithAnnouncer(new FilterLensState { Lenses = [lens] }, new FilterPaneState());
+
+        await effects.HandlePromote(new PromoteFilterLensAction(lens.Id), dispatcher);
+
+        announcer.Received(1).Announce(Arg.Any<string>());
+        dispatcher.Received(1).Dispatch(Arg.Is<CommitPromotedLensAction>(action =>
+            action != null && action.Id == lens.Id && action.Filters.IsEmpty &&
+            action.Window != null && action.Window.IsEnabled));
+    }
+
+    [Fact]
     public async Task HandlePush_ComposesLensOntoBase_DispatchesApplyFilter_WithoutTouchingBase()
     {
         // The base is a single include (Level == Error). Pushing an ActivityId lens must dispatch an effective filter
@@ -92,12 +169,23 @@ public sealed class FilterLensEffectsTests
         FilterLensState lensState,
         FilterPaneState paneState)
     {
+        var (effects, dispatcher, _) = CreateEffectsWithAnnouncer(lensState, paneState);
+
+        return (effects, dispatcher);
+    }
+
+    private static (LensEffects Effects, IDispatcher Dispatcher, IAnnouncementService Announcer) CreateEffectsWithAnnouncer(
+        FilterLensState lensState,
+        FilterPaneState paneState)
+    {
         var lens = Substitute.For<IState<FilterLensState>>();
         lens.Value.Returns(lensState);
 
         var pane = Substitute.For<IState<FilterPaneState>>();
         pane.Value.Returns(paneState);
 
-        return (new LensEffects(lens, pane), Substitute.For<IDispatcher>());
+        var announcer = Substitute.For<IAnnouncementService>();
+
+        return (new LensEffects(lens, pane, announcer), Substitute.For<IDispatcher>(), announcer);
     }
 }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensReducerTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensReducerTests.cs
@@ -28,6 +28,29 @@ public sealed class FilterLensReducerTests
     }
 
     [Fact]
+    public void CommitPromoted_RemovesLensById()
+    {
+        var a = Lens("a");
+        var b = Lens("b");
+        var state = new FilterLensState { Lenses = [a, b] };
+
+        var result = Reducers.ReduceCommitPromoted(state, new CommitPromotedLensAction(a.Id, [], null));
+
+        Assert.Single(result.Lenses);
+        Assert.Same(b, result.Lenses[0]);
+    }
+
+    [Fact]
+    public void CommitPromoted_UnknownId_ReturnsSameStateInstance()
+    {
+        var state = new FilterLensState { Lenses = [Lens("a")] };
+
+        var result = Reducers.ReduceCommitPromoted(state, new CommitPromotedLensAction(Lens("other").Id, [], null));
+
+        Assert.Same(state, result);
+    }
+
+    [Fact]
     public void Push_AddsLensToTopOfStack()
     {
         var a = Lens("a");

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterPane/EffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterPane/EffectsTests.cs
@@ -102,7 +102,8 @@ public sealed class EffectsTests
 
         var effects = new Effects(
             appliedFilter, rawEventStore, filterPaneState, lensState,
-            notifier, new SetFilterDateRangeSucceededNotifier(Substitute.For<ITraceLogger>()));
+            notifier, new SetFilterDateRangeSucceededNotifier(Substitute.For<ITraceLogger>()),
+            new FilterPromotedNotifier(Substitute.For<ITraceLogger>()));
 
         await effects.HandleClearAllFilters(Substitute.For<IDispatcher>());
         await effects.HandleClearAllFilters(Substitute.For<IDispatcher>());
@@ -120,6 +121,57 @@ public sealed class EffectsTests
         await effects.HandleClearAllFilters(mockDispatcher);
 
         mockDispatcher.Received(1).Dispatch(Arg.Any<ApplyFilterAction>());
+    }
+
+    [Fact]
+    public async Task HandleCommitPromoted_AppliesEvenWhenFilteringUnchanged()
+    {
+        // The empty candidate equals the empty applied filter, so the guarded path would suppress. The unconditional
+        // promote apply must dispatch anyway so it lands last and wins any race with a queued wide apply.
+        var (effects, dispatcher, promotedRaised, _) = CreateCommitPromotedEffects(
+            new FilterPaneState(),
+            appliedFilter: new Filter(null, []));
+
+        await effects.HandleCommitPromoted(new CommitPromotedLensAction(FilterLensId.Create(), [], null), dispatcher);
+
+        dispatcher.Received(1).Dispatch(Arg.Any<ApplyFilterAction>());
+        Assert.Equal(1, promotedRaised());
+    }
+
+    [Fact]
+    public async Task HandleCommitPromoted_PropertyLens_DispatchesBakedFilter_RaisesPromoted_NotDateResync()
+    {
+        var promoted = FilterBuilder.CreateTestFilter(isEnabled: true, isExcluded: true);
+        var (effects, dispatcher, promotedRaised, dateResyncRaised) = CreateCommitPromotedEffects(
+            new FilterPaneState { Filters = [promoted] },
+            appliedFilter: new Filter(null, []));
+
+        await effects.HandleCommitPromoted(new CommitPromotedLensAction(FilterLensId.Create(), [], null), dispatcher);
+
+        dispatcher.Received(1).Dispatch(Arg.Is<ApplyFilterAction>(applied =>
+            applied != null && applied.Filter.Filters.Count == 1 && applied.Filter.Filters[0].IsExcluded));
+        Assert.Equal(1, promotedRaised());
+        Assert.Equal(0, dateResyncRaised());
+    }
+
+    [Fact]
+    public async Task HandleCommitPromoted_TimeWindow_RaisesDateResyncNotifier()
+    {
+        // A promoted window writes FilteredDateRange, so the date editor must be told to resync its model.
+        var window = new DateFilter
+        {
+            After = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            Before = new DateTime(2024, 1, 2, 0, 0, 0, DateTimeKind.Utc),
+            IsEnabled = true
+        };
+        var (effects, dispatcher, promotedRaised, dateResyncRaised) = CreateCommitPromotedEffects(
+            new FilterPaneState { FilteredDateRange = window },
+            appliedFilter: new Filter(null, []));
+
+        await effects.HandleCommitPromoted(new CommitPromotedLensAction(FilterLensId.Create(), [], window), dispatcher);
+
+        Assert.Equal(1, dateResyncRaised());
+        Assert.Equal(1, promotedRaised());
     }
 
     [Fact]
@@ -162,7 +214,8 @@ public sealed class EffectsTests
 
         var effects = new Effects(
             appliedFilter, rawEventStore, filterPaneState, lensState,
-            new ClearAllFiltersNotifier(Substitute.For<ITraceLogger>()), notifier);
+            new ClearAllFiltersNotifier(Substitute.For<ITraceLogger>()), notifier,
+            new FilterPromotedNotifier(Substitute.For<ITraceLogger>()));
 
         await effects.HandleSetFilterDateRangeSuccess(Substitute.For<IDispatcher>());
         await effects.HandleSetFilterDateRangeSuccess(Substitute.For<IDispatcher>());
@@ -526,6 +579,38 @@ public sealed class EffectsTests
             },
             []);
 
+    private static (Effects Effects, IDispatcher Dispatcher, Func<int> PromotedRaised, Func<int> DateResyncRaised)
+        CreateCommitPromotedEffects(FilterPaneState paneState, Filter appliedFilter)
+    {
+        var filterPaneState = Substitute.For<IState<FilterPaneState>>();
+        filterPaneState.Value.Returns(paneState);
+
+        var applied = Substitute.For<IStateSelection<EventLogState, Filter>>();
+        applied.Value.Returns(appliedFilter);
+
+        var rawEventStore = Substitute.For<IState<RawEventStoreState>>();
+        rawEventStore.Value.Returns(new RawEventStoreState());
+
+        var lensState = Substitute.For<IState<FilterLensState>>();
+        lensState.Value.Returns(new FilterLensState());
+
+        var promotedNotifier = new FilterPromotedNotifier(Substitute.For<ITraceLogger>());
+        var promotedRaised = 0;
+        promotedNotifier.Promoted += () => promotedRaised++;
+
+        var dateResyncNotifier = new SetFilterDateRangeSucceededNotifier(Substitute.For<ITraceLogger>());
+        var dateResyncRaised = 0;
+        dateResyncNotifier.Succeeded += () => dateResyncRaised++;
+
+        var effects = new Effects(
+            applied, rawEventStore, filterPaneState, lensState,
+            new ClearAllFiltersNotifier(Substitute.For<ITraceLogger>()),
+            dateResyncNotifier,
+            promotedNotifier);
+
+        return (effects, Substitute.For<IDispatcher>(), () => promotedRaised, () => dateResyncRaised);
+    }
+
     private static (Effects effects, IDispatcher mockDispatcher) CreateEffects(
         bool isEnabled = false,
         ImmutableList<SavedFilter>? filters = null,
@@ -564,7 +649,7 @@ public sealed class EffectsTests
         var mockLensState = Substitute.For<IState<FilterLensState>>();
         mockLensState.Value.Returns(new FilterLensState());
 
-        var effects = new Effects(mockAppliedFilter, mockRawEventStore, mockFilterPaneState, mockLensState, new ClearAllFiltersNotifier(Substitute.For<ITraceLogger>()), new SetFilterDateRangeSucceededNotifier(Substitute.For<ITraceLogger>()));
+        var effects = new Effects(mockAppliedFilter, mockRawEventStore, mockFilterPaneState, mockLensState, new ClearAllFiltersNotifier(Substitute.For<ITraceLogger>()), new SetFilterDateRangeSucceededNotifier(Substitute.For<ITraceLogger>()), new FilterPromotedNotifier(Substitute.For<ITraceLogger>()));
         var mockDispatcher = Substitute.For<IDispatcher>();
 
         return (effects, mockDispatcher);

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterPane/FilterPaneStoreTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterPane/FilterPaneStoreTests.cs
@@ -4,8 +4,10 @@
 using EventLogExpert.Filtering.Persistence;
 using EventLogExpert.Filtering.TestUtils;
 using EventLogExpert.Filtering.TestUtils.Constants;
+using EventLogExpert.Runtime.FilterLenses;
 using EventLogExpert.Runtime.FilterPane;
 using System.Collections.Immutable;
+using Reducers = EventLogExpert.Runtime.FilterPane.Reducers;
 
 namespace EventLogExpert.Runtime.Tests.FilterPane;
 
@@ -228,6 +230,151 @@ public sealed class FilterPaneReducerTests
     }
 
     [Fact]
+    public void ReduceCommitPromoted_CaseVariantValue_TreatedAsDistinct()
+    {
+        // Ordinal-exact dedup: the lens preserves the EXACT predicate it matched, so a case-variant value is a
+        // distinct predicate and must NOT be folded the way the lowercased library MRU (ReduceMergeFilters) would.
+        var existing = PromotedExclude("Source == \"foo\"", isEnabled: false);
+        var promoted = PromotedExclude("Source == \"FOO\"");
+        Assert.NotEqual(existing.ComparisonText, promoted.ComparisonText);
+        var state = new FilterPaneState { Filters = [existing] };
+
+        var result = Reducers.ReduceCommitPromoted(
+            state,
+            new CommitPromotedLensAction(FilterLensId.Create(), [promoted], null));
+
+        Assert.Equal(2, result.Filters.Count);
+        Assert.False(result.Filters[0].IsEnabled);
+        Assert.True(result.Filters[1].IsEnabled);
+    }
+
+    [Fact]
+    public void ReduceCommitPromoted_DisabledEquivalent_ReEnabledInPlace()
+    {
+        var existing = PromotedExclude("Source != \"foo\"", isEnabled: false);
+        var state = new FilterPaneState { Filters = [existing] };
+
+        var result = Reducers.ReduceCommitPromoted(
+            state,
+            new CommitPromotedLensAction(FilterLensId.Create(), [PromotedExclude("Source != \"foo\"")], null));
+
+        Assert.Single(result.Filters);
+        Assert.True(result.Filters[0].IsEnabled);
+        Assert.Equal(existing.Id, result.Filters[0].Id);
+    }
+
+    [Fact]
+    public void ReduceCommitPromoted_EmptyPayload_ReturnsSameStateInstance()
+    {
+        var state = new FilterPaneState { Filters = [PromotedExclude("Source != \"foo\"")] };
+
+        var result = Reducers.ReduceCommitPromoted(
+            state,
+            new CommitPromotedLensAction(FilterLensId.Create(), [], null));
+
+        Assert.Same(state, result);
+    }
+
+    [Fact]
+    public void ReduceCommitPromoted_EnabledEquivalent_LeavesStateUnchanged()
+    {
+        var state = new FilterPaneState { Filters = [PromotedExclude("Source != \"foo\"")] };
+
+        var result = Reducers.ReduceCommitPromoted(
+            state,
+            new CommitPromotedLensAction(FilterLensId.Create(), [PromotedExclude("Source != \"foo\"")], null));
+
+        Assert.Same(state, result);
+    }
+
+    [Fact]
+    public void ReduceCommitPromoted_NetNewExclude_AddsEnabledWithFreshId()
+    {
+        var promoted = PromotedExclude("Source != \"foo\"");
+        var state = new FilterPaneState();
+
+        var result = Reducers.ReduceCommitPromoted(
+            state,
+            new CommitPromotedLensAction(FilterLensId.Create(), [promoted], null));
+
+        Assert.Single(result.Filters);
+        Assert.True(result.Filters[0].IsExcluded);
+        Assert.True(result.Filters[0].IsEnabled);
+        Assert.Equal(promoted.ComparisonText, result.Filters[0].ComparisonText);
+        Assert.NotEqual(promoted.Id, result.Filters[0].Id);
+    }
+
+    [Fact]
+    public void ReduceCommitPromoted_OrdinalMatchDisabledAndUncompiled_StillAddsWorkingPromotedFilter()
+    {
+        var promoted = PromotedExclude("Source != \"foo\"");
+        var deadExisting = promoted with { Id = FilterId.Create(), Compiled = null, IsEnabled = false };
+        var state = new FilterPaneState { Filters = [deadExisting] };
+
+        var result = Reducers.ReduceCommitPromoted(
+            state,
+            new CommitPromotedLensAction(FilterLensId.Create(), [promoted], null));
+
+        // The dead uncompiled row narrows nothing, so the working promoted filter must still be added, not dropped.
+        Assert.Equal(2, result.Filters.Count);
+        Assert.Contains(result.Filters, filter => filter.Compiled is not null && filter.IsEnabled && filter.IsExcluded);
+    }
+
+    [Fact]
+    public void ReduceCommitPromoted_PositiveInclude_AddsEnabledIncludeRow()
+    {
+        var include = SavedFilter.TryCreate("Source == \"foo\"", isExcluded: false, isEnabled: true, mode: FilterMode.Advanced);
+        Assert.NotNull(include);
+        var state = new FilterPaneState();
+
+        var result = Reducers.ReduceCommitPromoted(
+            state,
+            new CommitPromotedLensAction(FilterLensId.Create(), [include], null));
+
+        Assert.Single(result.Filters);
+        Assert.False(result.Filters[0].IsExcluded);
+        Assert.True(result.Filters[0].IsEnabled);
+        Assert.NotEqual(include.Id, result.Filters[0].Id);
+    }
+
+    [Fact]
+    public void ReduceCommitPromoted_SkipsDeadRowAndReusesLiveEquivalent_WithoutDuplicating()
+    {
+        var promoted = PromotedExclude("Source != \"foo\"");
+        var deadExisting = promoted with { Id = FilterId.Create(), Compiled = null, IsEnabled = false };
+        var liveExisting = promoted with { Id = FilterId.Create(), IsEnabled = true };
+        var state = new FilterPaneState { Filters = [deadExisting, liveExisting] };
+
+        var result = Reducers.ReduceCommitPromoted(
+            state,
+            new CommitPromotedLensAction(FilterLensId.Create(), [promoted], null));
+
+        // The dead row (lower index) is passed over; the live equivalent is reused, so no third row is added.
+        Assert.Same(state, result);
+    }
+
+    [Fact]
+    public void ReduceCommitPromoted_TimeWindow_IntersectsIntoDateRange()
+    {
+        var window = new DateFilter
+        {
+            After = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            Before = new DateTime(2024, 1, 2, 0, 0, 0, DateTimeKind.Utc),
+            IsEnabled = true
+        };
+        var state = new FilterPaneState();
+
+        var result = Reducers.ReduceCommitPromoted(
+            state,
+            new CommitPromotedLensAction(FilterLensId.Create(), [], window));
+
+        Assert.NotNull(result.FilteredDateRange);
+        Assert.True(result.FilteredDateRange.IsEnabled);
+        Assert.Equal(window.After, result.FilteredDateRange.After);
+        Assert.Equal(window.Before, result.FilteredDateRange.Before);
+    }
+
+    [Fact]
     public void ReduceMergeFilters_DifferentCaseSameTuple_DedupesAsDuplicate()
     {
         var existing = SavedFilter.TryCreate("Level == 4");
@@ -392,6 +539,46 @@ public sealed class FilterPaneReducerTests
     }
 
     [Fact]
+    public void ReduceSetFilterDateRangeSuccess_ShouldSetDateRange()
+    {
+        // Arrange
+        var state = new FilterPaneState();
+
+        var dateModel = new DateFilter
+        {
+            After = DateTime.UtcNow.AddDays(-1),
+            Before = DateTime.UtcNow
+        };
+
+        var action = new SetFilterDateRangeSuccessAction(dateModel);
+
+        // Act
+        var result = Reducers.ReduceSetFilterDateRangeSuccess(state, action);
+
+        // Assert
+        Assert.NotNull(result.FilteredDateRange);
+        Assert.Equal(dateModel, result.FilteredDateRange);
+    }
+
+    [Fact]
+    public void ReduceSetFilterDateRangeSuccess_WithNull_ShouldSetNullDateRange()
+    {
+        // Arrange
+        var state = new FilterPaneState
+        {
+            FilteredDateRange = new DateFilter { After = DateTime.UtcNow }
+        };
+
+        var action = new SetFilterDateRangeSuccessAction(null);
+
+        // Act
+        var result = Reducers.ReduceSetFilterDateRangeSuccess(state, action);
+
+        // Assert
+        Assert.Null(result.FilteredDateRange);
+    }
+
+    [Fact]
     public void ReduceSetFilter_ShouldReplaceFilter()
     {
         // Arrange
@@ -472,46 +659,6 @@ public sealed class FilterPaneReducerTests
         Assert.Equal(2, result.Filters.Count);
         Assert.Equal(FilterTestConstants.FilterIdEquals100, result.Filters[0].ComparisonText);
         Assert.Equal(FilterTestConstants.FilterIdEquals200, result.Filters[1].ComparisonText);
-    }
-
-    [Fact]
-    public void ReduceSetFilterDateRangeSuccess_ShouldSetDateRange()
-    {
-        // Arrange
-        var state = new FilterPaneState();
-
-        var dateModel = new DateFilter
-        {
-            After = DateTime.UtcNow.AddDays(-1),
-            Before = DateTime.UtcNow
-        };
-
-        var action = new SetFilterDateRangeSuccessAction(dateModel);
-
-        // Act
-        var result = Reducers.ReduceSetFilterDateRangeSuccess(state, action);
-
-        // Assert
-        Assert.NotNull(result.FilteredDateRange);
-        Assert.Equal(dateModel, result.FilteredDateRange);
-    }
-
-    [Fact]
-    public void ReduceSetFilterDateRangeSuccess_WithNull_ShouldSetNullDateRange()
-    {
-        // Arrange
-        var state = new FilterPaneState
-        {
-            FilteredDateRange = new DateFilter { After = DateTime.UtcNow }
-        };
-
-        var action = new SetFilterDateRangeSuccessAction(null);
-
-        // Act
-        var result = Reducers.ReduceSetFilterDateRangeSuccess(state, action);
-
-        // Assert
-        Assert.Null(result.FilteredDateRange);
     }
 
     [Fact]
@@ -616,6 +763,10 @@ public sealed class FilterPaneReducerTests
         // Assert
         Assert.True(result.IsEnabled);
     }
+
+    private static SavedFilter PromotedExclude(string text, bool isEnabled = true) =>
+        SavedFilter.TryCreate(text, isExcluded: true, isEnabled: isEnabled, mode: FilterMode.Advanced)
+        ?? throw new InvalidOperationException($"test filter failed to compile: {text}");
 }
 
 public sealed class FilterPaneIntegrationTests

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterPane/ReplaceFiltersTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterPane/ReplaceFiltersTests.cs
@@ -96,7 +96,7 @@ public sealed class ReplaceFiltersTests
         var mockLensState = Substitute.For<IState<FilterLensState>>();
         mockLensState.Value.Returns(new FilterLensState());
 
-        var effects = new Effects(mockAppliedFilter, mockRawEventStore, mockFilterPaneState, mockLensState, new ClearAllFiltersNotifier(Substitute.For<ITraceLogger>()), new SetFilterDateRangeSucceededNotifier(Substitute.For<ITraceLogger>()));
+        var effects = new Effects(mockAppliedFilter, mockRawEventStore, mockFilterPaneState, mockLensState, new ClearAllFiltersNotifier(Substitute.For<ITraceLogger>()), new SetFilterDateRangeSucceededNotifier(Substitute.For<ITraceLogger>()), new FilterPromotedNotifier(Substitute.For<ITraceLogger>()));
         var dispatcher = Substitute.For<IDispatcher>();
 
         return (effects, dispatcher);

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterPane/RestoreFilterPaneStateTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterPane/RestoreFilterPaneStateTests.cs
@@ -66,7 +66,7 @@ public sealed class RestoreFilterPaneStateTests
         var lensState = Substitute.For<IState<FilterLensState>>();
         lensState.Value.Returns(new FilterLensState());
 
-        var effects = new Effects(appliedFilter, rawEventStore, filterPaneState, lensState, new ClearAllFiltersNotifier(Substitute.For<ITraceLogger>()), new SetFilterDateRangeSucceededNotifier(Substitute.For<ITraceLogger>()));
+        var effects = new Effects(appliedFilter, rawEventStore, filterPaneState, lensState, new ClearAllFiltersNotifier(Substitute.For<ITraceLogger>()), new SetFilterDateRangeSucceededNotifier(Substitute.For<ITraceLogger>()), new FilterPromotedNotifier(Substitute.For<ITraceLogger>()));
 
         return (effects, Substitute.For<IDispatcher>());
     }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/ScenarioApplyIntegrationTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Scenarios/ScenarioApplyIntegrationTests.cs
@@ -52,7 +52,7 @@ public sealed class ScenarioApplyIntegrationTests
         var lensState = Substitute.For<IState<FilterLensState>>();
         lensState.Value.Returns(new FilterLensState());
 
-        var effects = new FilterPaneEffects(appliedFilter, rawEventStore, paneStateAccessor, lensState, new ClearAllFiltersNotifier(Substitute.For<ITraceLogger>()), new SetFilterDateRangeSucceededNotifier(Substitute.For<ITraceLogger>()));
+        var effects = new FilterPaneEffects(appliedFilter, rawEventStore, paneStateAccessor, lensState, new ClearAllFiltersNotifier(Substitute.For<ITraceLogger>()), new SetFilterDateRangeSucceededNotifier(Substitute.For<ITraceLogger>()), new FilterPromotedNotifier(Substitute.For<ITraceLogger>()));
         var dispatcher = Substitute.For<IDispatcher>();
 
         ApplyFilterAction? captured = null;

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterLenses/LensBreadcrumbTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterLenses/LensBreadcrumbTests.cs
@@ -64,6 +64,22 @@ public sealed class LensBreadcrumbTests : BunitContext
     }
 
     [Fact]
+    public void KeepButton_DispatchesPromoteLens_AndHasAccessibleLabel()
+    {
+        var lens = Summary("Activity ID = abc");
+        _source.Lenses.Returns(ImmutableList.Create(lens));
+
+        var cut = Render<LensBreadcrumb>();
+
+        var keep = cut.Find(".lens-chip-keep");
+        Assert.Equal($"Keep lens as filter: {lens.Label}", keep.GetAttribute("aria-label"));
+
+        keep.Click();
+
+        _commands.Received(1).PromoteLens(lens.Id);
+    }
+
+    [Fact]
     public void NoLenses_RendersNothing()
     {
         _source.Lenses.Returns(ImmutableList<FilterLensSummary>.Empty);

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterPane/FilterPaneTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterPane/FilterPaneTests.cs
@@ -40,6 +40,7 @@ public sealed class FilterPaneTests : BunitContext
     private readonly IState<EventLogState> _eventLogStateMock = Substitute.For<IState<EventLogState>>();
     private readonly IFilterLibraryCommands _filterLibraryCommands = Substitute.For<IFilterLibraryCommands>();
     private readonly IFilterPaneCommands _filterPaneCommands = Substitute.For<IFilterPaneCommands>();
+    private readonly IFilterPromotedNotifier _filterPromotedNotifier = Substitute.For<IFilterPromotedNotifier>();
     private readonly IFilteredDateRangeSource _filteredDateRange = Substitute.For<IFilteredDateRangeSource>();
     private readonly ILibraryEntriesSource _libraryEntries = Substitute.For<ILibraryEntriesSource>();
     private readonly ILibraryLoadStatusSource _libraryLoadStatus = Substitute.For<ILibraryLoadStatusSource>();
@@ -112,6 +113,7 @@ public sealed class FilterPaneTests : BunitContext
 
         Services.AddSingleton(_clearAllFiltersNotifier);
         Services.AddSingleton(_setFilterDateRangeSucceededNotifier);
+        Services.AddSingleton(_filterPromotedNotifier);
 
         Services.AddFluxor(options => options.ScanAssemblies(typeof(UI.FilterPane.FilterPane).Assembly));
 
@@ -404,6 +406,22 @@ public sealed class FilterPaneTests : BunitContext
     }
 
     [Fact]
+    public async Task FilterPromotedNotifier_ExpandsTheCollapsedFilterList()
+    {
+        var promoted = SavedFilter.TryCreate("Level == 4");
+        Assert.NotNull(promoted);
+        SetPaneState(new FilterPaneState { Filters = [promoted] });
+        var component = Render<UI.FilterPane.FilterPane>();
+
+        // The list starts collapsed even though it has a filter (matches production: _isFilterListVisible defaults false).
+        Assert.Equal("false", component.Find(".filter-set").GetAttribute("data-toggle"));
+
+        await component.InvokeAsync(() => _filterPromotedNotifier.Promoted += Raise.Event<Action>());
+
+        Assert.Equal("true", component.Find(".filter-set").GetAttribute("data-toggle"));
+    }
+
+    [Fact]
     public void FilterSetReplaceButton_DisabledGatingMirrorsSelection()
     {
         var filterSet = BuildFilterSet("Picked");
@@ -528,6 +546,20 @@ public sealed class FilterPaneTests : BunitContext
         var reason = component.Instance.GetRecentDisabledReason();
 
         Assert.Equal(expectedReason, reason);
+    }
+
+    [Fact]
+    public void OnInitialized_HydratesDateModelFromAppliedRange_InLocalTime()
+    {
+        // A range applied externally (e.g. a promoted time-window lens) must render in the display zone, not UTC.
+        var timeZone = TimeZoneInfo.CreateCustomTimeZone("H+05", TimeSpan.FromHours(5), "H+05", "H+05");
+        _settings.TimeZoneInfo.Returns(timeZone);
+        var afterUtc = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        SetPaneState(new FilterPaneState { FilteredDateRange = new DateFilter { After = afterUtc, IsEnabled = true } });
+
+        var component = Render<UI.FilterPane.FilterPane>();
+
+        Assert.Equal(TimeZoneInfo.ConvertTimeFromUtc(afterUtc, timeZone), GetDateModel(component).After);
     }
 
     [Fact]
@@ -752,6 +784,27 @@ public sealed class FilterPaneTests : BunitContext
         Assert.Contains(
             component.FindAll("button"),
             button => button.GetAttribute("aria-label")?.Contains("scenario JSON") == true);
+    }
+
+    [Fact]
+    public async Task Promote_TimeWindowOnMountedPane_ResyncsDateEditorAndExpands()
+    {
+        // Mirror the commit effect's production ordering for a window promote onto an already-mounted pane: the reducer
+        // has written FilteredDateRange, then both notifiers fire. The date editor model must resync (in local time)
+        // and the collapsed list must expand - the case the OnInitialized hydration cannot reach.
+        var timeZone = TimeZoneInfo.CreateCustomTimeZone("H+05", TimeSpan.FromHours(5), "H+05", "H+05");
+        _settings.TimeZoneInfo.Returns(timeZone);
+        SetPaneState(new FilterPaneState());
+        var component = Render<UI.FilterPane.FilterPane>();
+        Assert.Null(GetDateModel(component).After);
+
+        var afterUtc = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        SetPaneState(new FilterPaneState { FilteredDateRange = new DateFilter { After = afterUtc, IsEnabled = true } });
+        await component.InvokeAsync(() => _setFilterDateRangeSucceededNotifier.Succeeded += Raise.Event<Action>());
+        await component.InvokeAsync(() => _filterPromotedNotifier.Promoted += Raise.Event<Action>());
+
+        Assert.Equal(TimeZoneInfo.ConvertTimeFromUtc(afterUtc, timeZone), GetDateModel(component).After);
+        Assert.Equal("true", component.Find(".filter-set").GetAttribute("data-toggle"));
     }
 
     [Fact]
@@ -1022,11 +1075,16 @@ public sealed class FilterPaneTests : BunitContext
     [Fact]
     public async Task SetFilterDateRangeSucceededNotifier_ResyncsTheDateEditorFromTheSource_EvenWhenTheSourceIsSilent()
     {
-        var applied = new DateFilter { After = DateTimeOffset.UnixEpoch.UtcDateTime, IsEnabled = true };
-        SetPaneState(new FilterPaneState { FilteredDateRange = applied });
+        // Render with no applied range so the initial model is empty and the notifier - not an eager source read on
+        // init - is what drives this resync. Initial hydration of a present range is covered by
+        // OnInitialized_HydratesDateModelFromAppliedRange_InLocalTime.
+        SetPaneState(new FilterPaneState());
         var component = Render<UI.FilterPane.FilterPane>();
 
         Assert.Null(GetDateModel(component).After);
+
+        var applied = new DateFilter { After = DateTimeOffset.UnixEpoch.UtcDateTime, IsEnabled = true };
+        SetPaneState(new FilterPaneState { FilteredDateRange = applied });
 
         await component.InvokeAsync(() => _setFilterDateRangeSucceededNotifier.Succeeded += Raise.Event<Action>());
 


### PR DESCRIPTION
**What**
Adds a **Keep** (pushpin) button to each active filter-lens chip. Clicking it promotes the transient lens into a persistent FilterPane filter and removes the lens - the event-list view is preserved, the pane expands to reveal the kept filter, and the action is announced for screen readers.

**How**
- A keep-only lens (e.g. "Activity ID = X") promotes to a positive include (`ActivityId == X`), matching a filter created via "Add Filter". The lens's transient exclude-of-complement form is unchanged, so live lens narrowing is unaffected.
- A time-window lens promotes into the pane's date range; the date editor resyncs in local time.
- Promotion is an atomic Fluxor commit (FilterLenses reducer drops the lens; FilterPane reducer folds in the filter/date range; the commit effect applies unconditionally so it wins any concurrent re-apply).
- The presence-gated User field is handled: a single positive `User == value` include drops no-user events on its own.

**Tests**
Adds effect/reducer/factory/notifier/bUnit coverage (ordinal dedup, positive-include semantics, User presence-gating parity, collapsed-pane expansion, timezone hydration, commit ordering). Runtime 2622 and UI 1526 pass; MAUI head build clean.
