### PR TITLE
Make the status-bar New Events indicator clickable to load new events

### DIFF
--- a/docs/Opening-Logs.md
+++ b/docs/Opening-Logs.md
@@ -44,14 +44,14 @@ The submenu always lists `Application`, `System`, and `Security`. Below them, an
 Two `View` menu items only matter while a live log is open:
 
 - **`Continuously Update`** is a toggle. When `on`, new events stream into the table as they arrive. When `off`, new events accumulate in a buffer and the table view stays put.
-- **`Load New Events`** drains the buffer into the table once. Useful when `Continuously Update` is off but you want to catch up to "now" before going back to a static view.
+- **`Load New Events`** drains the buffer into the table once. Useful when `Continuously Update` is off but you want to catch up to "now" before going back to a static view. You can also click the `New Events: {n}` status-bar indicator to do the same.
 
 The status bar surfaces both:
 
 | Status bar token | Condition |
 | --- | --- |
 | `Continuously Updating` | At least one live log is open and `Continuously Update` is on. |
-| `New Events: {n}` | At least one live log is open and `Continuously Update` is off; `{n}` is the buffer size. |
+| `New Events: {n}` | At least one live log is open and `Continuously Update` is off; `{n}` is the buffer size. Click it to load the buffered events. |
 | `Buffer Full` | The new-event buffer reached its cap. Live watchers are stopped while this is set, so no further events arrive until either `Load New Events` drains the buffer or `Continuously Update` is turned on (both clear the buffer and restart the watchers). |
 
 ### Close All

--- a/src/EventLogExpert.UI/StatusBar/StatusBar.razor
+++ b/src/EventLogExpert.UI/StatusBar/StatusBar.razor
@@ -88,7 +88,13 @@
             }
             else
             {
-                <span aria-live="off" class="status-bar-activity">New Events: @status.NewEventBufferCount</span>
+                <button aria-live="off"
+                    class="status-bar-activity status-bar-newevents"
+                    @onclick="LoadNewEvents"
+                    title="@(status.NewEventBufferCount == 0 ? "No new events to load" : "Load new events into the view")"
+                    type="button">
+                    New Events: @status.NewEventBufferCount
+                </button>
 
                 @if (status.NewEventBufferIsFull)
                 {

--- a/src/EventLogExpert.UI/StatusBar/StatusBar.razor.cs
+++ b/src/EventLogExpert.UI/StatusBar/StatusBar.razor.cs
@@ -15,6 +15,8 @@ public sealed partial class StatusBar
 {
     private DisplayIndicatorState _indicatorState = null!;
 
+    [Inject] private IEventLogCommands EventLogCommands { get; init; } = null!;
+
     [Inject] private IFilterAppliedSource FilterApplied { get; init; } = null!;
 
     [Inject] private DisplayIndicatorGate IndicatorGate { get; init; } = null!;
@@ -50,6 +52,8 @@ public sealed partial class StatusBar
 
         base.OnInitialized();
     }
+
+    private void LoadNewEvents() => EventLogCommands.LoadNewEvents();
 
     private void OpenCoverage() => _ = ModalCoordinator.OpenResolutionCoverageAsync();
 

--- a/src/EventLogExpert.UI/StatusBar/StatusBar.razor.css
+++ b/src/EventLogExpert.UI/StatusBar/StatusBar.razor.css
@@ -69,6 +69,26 @@
     outline-offset: -1px;
 }
 
+/* The New Events counter is a button (click to load buffered live-tail events) but keeps the normal counter weight -
+   weight-600 below is reserved to encode state (warn/live), and bolding the counter would dilute the adjacent
+   "Buffer full" chip. */
+.status-bar-newevents {
+    padding: 0 4px;
+    border: none;
+    border-radius: 2px;
+    background: none;
+    color: inherit;
+    font: inherit;
+    cursor: pointer;
+}
+
+.status-bar-newevents:hover { background: color-mix(in srgb, var(--clr-white) 18%, transparent); }
+
+.status-bar-newevents:focus-visible {
+    outline: 1px solid var(--clr-white);
+    outline-offset: -1px;
+}
+
 /* White (inherited) text keeps WCAG AA contrast on the blue status bar; weight distinguishes the state. A color-coded
    status palette that meets AA on the status-bar fill is deferred to v2. */
 .status-bar-warn,

--- a/tests/Unit/EventLogExpert.UI.Tests/StatusBar/StatusBarTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/StatusBar/StatusBarTests.cs
@@ -21,6 +21,7 @@ namespace EventLogExpert.UI.Tests.StatusBar;
 
 public sealed class StatusBarTests : BunitContext
 {
+    private readonly IEventLogCommands _eventLogCommands = Substitute.For<IEventLogCommands>();
     private readonly IFilterAppliedSource _filterApplied = Substitute.For<IFilterAppliedSource>();
     private readonly IFilterLensSource _lensSource = Substitute.For<IFilterLensSource>();
     private readonly IModalCoordinator _modalCoordinator = Substitute.For<IModalCoordinator>();
@@ -36,6 +37,7 @@ public sealed class StatusBarTests : BunitContext
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
 
+        Services.AddSingleton(_eventLogCommands);
         Services.AddSingleton(_filterApplied);
         Services.AddSingleton(_lensSource);
         Services.AddSingleton(_modalCoordinator);
@@ -150,6 +152,17 @@ public sealed class StatusBarTests : BunitContext
     }
 
     [Fact]
+    public void ContinuouslyUpdating_RendersNoNewEventsButton()
+    {
+        SetChannelStatus(newEventCount: 5, continuous: true);
+
+        var cut = Render<UI.StatusBar.StatusBar>();
+
+        Assert.Empty(cut.FindAll("button.status-bar-newevents"));
+        Assert.Contains("Continuously updating", cut.Find(".status-bar-live").TextContent);
+    }
+
+    [Fact]
     public void CoverageChip_Click_OpensCoverageModal()
     {
         SetActiveLog(total: 100, shown: 100, filter: Unfiltered, selected: 0);
@@ -173,6 +186,22 @@ public sealed class StatusBarTests : BunitContext
         _statusBarSource.Received(1).Changed -= Arg.Any<Action>();
         _filterApplied.Received(1).Changed -= Arg.Any<Action>();
         _lensSource.Received(1).Changed -= Arg.Any<Action>();
+    }
+
+    [Fact]
+    public void FileLogOnly_RendersNoNewEventsButton()
+    {
+        var id = EventLogId.Create();
+        _activeLogId = id;
+        var file = new LogView(id) { LogName = "app.evtx", LogPathType = LogPathType.File };
+        _status = new StatusBarPresentation
+        {
+            Tabs = ImmutableList.Create(file),
+            ActiveTabId = id,
+            RawEventCountsByLog = ImmutableDictionary<EventLogId, ProviderResolutionCounts>.Empty.Add(id, default)
+        };
+
+        Assert.Empty(Render<UI.StatusBar.StatusBar>().FindAll("button.status-bar-newevents"));
     }
 
     [Fact]
@@ -263,6 +292,48 @@ public sealed class StatusBarTests : BunitContext
 
         Assert.Contains("Loading: 500", cut.Markup);
         Assert.Contains("New Events: 42", cut.Markup);
+    }
+
+    [Fact]
+    public void NewEventsButton_BufferFull_CoexistsWithWarnChip_AndIsClickable()
+    {
+        SetChannelStatus(newEventCount: 1000, bufferFull: true);
+
+        var cut = Render<UI.StatusBar.StatusBar>();
+        var button = cut.Find("button.status-bar-newevents");
+        Assert.False(button.HasAttribute("disabled"));
+        Assert.Contains(cut.FindAll(".status-bar-warn"), node => node.TextContent.Contains("Buffer full"));
+
+        button.Click();
+
+        _eventLogCommands.Received(1).LoadNewEvents();
+    }
+
+    [Fact]
+    public void NewEventsButton_Click_LoadsNewEvents()
+    {
+        SetChannelStatus(newEventCount: 42);
+
+        var button = Render<UI.StatusBar.StatusBar>().Find("button.status-bar-newevents");
+        Assert.Contains("New Events: 42", button.TextContent);
+        Assert.False(button.HasAttribute("aria-label"));
+        Assert.Equal("Load new events into the view", button.GetAttribute("title"));
+
+        button.Click();
+
+        _eventLogCommands.Received(1).LoadNewEvents();
+    }
+
+    [Fact]
+    public void NewEventsButton_ZeroCount_IsRenderedAndEnabled()
+    {
+        SetChannelStatus(newEventCount: 0);
+
+        var button = Render<UI.StatusBar.StatusBar>().Find("button.status-bar-newevents");
+
+        Assert.False(button.HasAttribute("disabled"));
+        Assert.Contains("New Events: 0", button.TextContent);
+        Assert.Equal("No new events to load", button.GetAttribute("title"));
     }
 
     [Fact]
@@ -420,6 +491,22 @@ public sealed class StatusBarTests : BunitContext
             RawEventTotal = total,
             RawEventCountsByLog = ImmutableDictionary<EventLogId, ProviderResolutionCounts>.Empty.Add(id, new ProviderResolutionCounts(total, total, 0, 0, 0)),
             SelectionCount = selected
+        };
+    }
+
+    private void SetChannelStatus(int newEventCount, bool bufferFull = false, bool continuous = false)
+    {
+        var id = EventLogId.Create();
+        _activeLogId = id;
+        var channel = new LogView(id) { LogName = "Application", LogPathType = LogPathType.Channel };
+        _status = new StatusBarPresentation
+        {
+            Tabs = ImmutableList.Create(channel),
+            ActiveTabId = id,
+            RawEventCountsByLog = ImmutableDictionary<EventLogId, ProviderResolutionCounts>.Empty.Add(id, default),
+            NewEventBufferCount = newEventCount,
+            NewEventBufferIsFull = bufferFull,
+            ContinuouslyUpdate = continuous
         };
     }
 


### PR DESCRIPTION
**What**
The status-bar `New Events: {n}` indicator (shown for a live channel when Continuously Update is off) is now a button. Click it to load the buffered live-tail events into the view - the same as the View -> Load New Events menu item.

**How**
- The counter becomes a lightweight button that invokes `IEventLogCommands.LoadNewEvents()`; the visible "New Events: {n}" text is the accessible name (WCAG 2.5.3 Label-in-Name), with a `title` describing the action.
- Always-enabled: the load effect is already a no-op on an empty buffer, so a zero-count click does nothing - this avoids a self-disabling control that would drop keyboard focus, and matches the always-enabled menu item.
- Especially useful when the buffer is full (live watchers stop until it drains): the button and the "Buffer full" chip coexist.

**Tests**
Adds bUnit coverage for click-loads-command, buffer-full coexistence, zero-count enabled, both `title` branches, and hidden-when-continuous / hidden-for-file-logs; the existing non-announcement regression test is preserved.
