### PR TITLE
Add an advisory status-bar memory usage indicator

### DIFF
--- a/src/EventLogExpert.Runtime/ActivityCorrelation/ActivityCorrelationCacheEffects.cs
+++ b/src/EventLogExpert.Runtime/ActivityCorrelation/ActivityCorrelationCacheEffects.cs
@@ -1,0 +1,34 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.EventLog;
+using Fluxor;
+using CloseLogAction = EventLogExpert.Runtime.LogTable.CloseLogAction;
+using IDispatcher = Fluxor.IDispatcher;
+
+namespace EventLogExpert.Runtime.ActivityCorrelation;
+
+/// <summary>
+///     Drops the correlation view cache when a log closes so it neither retains the closed log's neighborhood nor is
+///     repopulated by a build that completes after the close.
+/// </summary>
+internal sealed class ActivityCorrelationCacheEffects(IActivityCorrelationCacheControl cacheControl)
+{
+    private readonly IActivityCorrelationCacheControl _cacheControl = cacheControl;
+
+    [EffectMethod(typeof(CloseAllLogsAction))]
+    public Task HandleCloseAllLogs(IDispatcher dispatcher)
+    {
+        _cacheControl.Invalidate();
+
+        return Task.CompletedTask;
+    }
+
+    [EffectMethod(typeof(CloseLogAction))]
+    public Task HandleCloseLog(IDispatcher dispatcher)
+    {
+        _cacheControl.Invalidate();
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/EventLogExpert.Runtime/ActivityCorrelation/ActivityCorrelationService.cs
+++ b/src/EventLogExpert.Runtime/ActivityCorrelation/ActivityCorrelationService.cs
@@ -8,7 +8,8 @@ using Fluxor;
 
 namespace EventLogExpert.Runtime.ActivityCorrelation;
 
-internal sealed class ActivityCorrelationService(IState<RawEventStoreState> rawStore) : IActivityCorrelationService
+internal sealed class ActivityCorrelationService(IState<RawEventStoreState> rawStore)
+    : IActivityCorrelationService, IActivityCorrelationCacheControl
 {
     private const int MaxEventsPerActivity = 200;
     private const int SharedActivityThreshold = 500;
@@ -47,9 +48,23 @@ internal sealed class ActivityCorrelationService(IState<RawEventStoreState> rawS
 
         var view = await Task.Run(() => BuildCore(store, focusedEvent, token, cancellationToken), cancellationToken);
 
-        lock (_cacheGate) { _cache = new CachedView(focusedEvent, token, view); }
+        // Cache only if the snapshot is still current: a close or content change during the build must not repopulate
+        // the neighborhood of a log that is no longer open. TryGetContentToken reads the live store, and the check runs
+        // under the same gate as Invalidate, so a close landing during the build always wins.
+        lock (_cacheGate)
+        {
+            if (TryGetContentToken(focusedEvent.LogId, out var current) && current == token)
+            {
+                _cache = new CachedView(focusedEvent, token, view);
+            }
+        }
 
         return view;
+    }
+
+    public void Invalidate()
+    {
+        lock (_cacheGate) { _cache = null; }
     }
 
     public bool TryGetContentToken(EventLogId logId, out CorrelationContentToken token)

--- a/src/EventLogExpert.Runtime/ActivityCorrelation/IActivityCorrelationCacheControl.cs
+++ b/src/EventLogExpert.Runtime/ActivityCorrelation/IActivityCorrelationCacheControl.cs
@@ -1,0 +1,14 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.ActivityCorrelation;
+
+/// <summary>
+///     Lets the close pipeline drop the single-slot correlation view cache so a closed log's neighborhood is not
+///     retained. A build that completes after a close is separately kept from repopulating the cache by the content-token
+///     recheck in <c>BuildAsync</c>.
+/// </summary>
+internal interface IActivityCorrelationCacheControl
+{
+    void Invalidate();
+}

--- a/src/EventLogExpert.Runtime/DependencyInjection/RuntimeServiceCollectionExtensions.cs
+++ b/src/EventLogExpert.Runtime/DependencyInjection/RuntimeServiceCollectionExtensions.cs
@@ -31,12 +31,13 @@ using EventLogExpert.Runtime.FilterPane;
 using EventLogExpert.Runtime.Histogram;
 using EventLogExpert.Runtime.LogTable;
 using EventLogExpert.Runtime.LogTable.OrderedView;
+using EventLogExpert.Runtime.Memory;
+using EventLogExpert.Runtime.ResolutionCoverage;
 using EventLogExpert.Runtime.Scenarios;
 using EventLogExpert.Runtime.Scenarios.Favorites;
 using EventLogExpert.Runtime.Settings;
-using EventLogExpert.Runtime.StatusBar;
-using EventLogExpert.Runtime.ResolutionCoverage;
 using EventLogExpert.Runtime.Stats;
+using EventLogExpert.Runtime.StatusBar;
 using EventLogExpert.Runtime.Update;
 using EventLogExpert.Runtime.Update.Deployment;
 using EventLogExpert.Scenarios.Catalog;
@@ -151,6 +152,7 @@ public static class RuntimeServiceCollectionExtensions
             services.AddSingleton<LiveTailIngestCoordinator>();
             services.AddSingleton<FilteredLogPresenceCoordinator>();
             services.AddSingleton<IEventLogReaderFactory, EventLogReaderFactory>();
+            services.AddSingleton<IProcessMemoryMeter, ProcessMemoryMeter>();
 
             // Ordered-view engine
             services.AddSingleton<OrderedViewWriter>(static _ => new OrderedViewWriter());
@@ -194,7 +196,9 @@ public static class RuntimeServiceCollectionExtensions
             // Indicators, resolvers, formatters, and selectors
             services.AddSingleton<DisplayIndicatorGate>();
             services.AddSingleton<IEventDetailResolver, EventDetailResolver>();
-            services.AddSingleton<IActivityCorrelationService, ActivityCorrelationService>();
+            services.AddSingleton<ActivityCorrelationService>();
+            services.Forward<IActivityCorrelationService, ActivityCorrelationService>();
+            services.Forward<IActivityCorrelationCacheControl, ActivityCorrelationService>();
             services.AddSingleton<IEventXmlResolver, EventXmlResolver>();
             services.AddSingleton<IEventCopyFormatter, EventCopyFormatter>();
             services.AddSingleton<IHighlightSelector, HighlightSelector>();

--- a/src/EventLogExpert.Runtime/EventLog/EventLogCommands.cs
+++ b/src/EventLogExpert.Runtime/EventLog/EventLogCommands.cs
@@ -16,7 +16,7 @@ internal sealed class EventLogCommands(IDispatcher dispatcher) : IEventLogComman
 
     public void CloseLog(EventLogId logId, string logName)
     {
-        _dispatcher.Dispatch(new CloseLogAction(logId, logName));
+        _dispatcher.Dispatch(new CloseLogAction(logId, logName, UserInitiated: true));
         _dispatcher.Dispatch(new LogClosedByUserAction(logId, logName));
     }
 

--- a/src/EventLogExpert.Runtime/EventLog/LogClosedByUserCompletedAction.cs
+++ b/src/EventLogExpert.Runtime/EventLog/LogClosedByUserCompletedAction.cs
@@ -5,4 +5,4 @@ using EventLogExpert.Eventing.Common.EventLogs;
 
 namespace EventLogExpert.Runtime.EventLog;
 
-internal sealed record CloseLogAction(EventLogId LogId, string LogName, bool UserInitiated = false);
+internal sealed record LogClosedByUserCompletedAction(EventLogId LogId);

--- a/src/EventLogExpert.Runtime/EventLog/OpenLogEffects.cs
+++ b/src/EventLogExpert.Runtime/EventLog/OpenLogEffects.cs
@@ -123,6 +123,11 @@ internal sealed class OpenLogEffects(
 
             dispatcher.Dispatch(new LogTable.CloseLogAction(action.LogId));
 
+            if (action.UserInitiated)
+            {
+                dispatcher.Dispatch(new LogClosedByUserCompletedAction(action.LogId));
+            }
+
             if (_eventLogState.Value.OpenLogs.IsEmpty)
             {
                 _resolverCache.ClearAll();

--- a/src/EventLogExpert.Runtime/Memory/IProcessMemoryMeter.cs
+++ b/src/EventLogExpert.Runtime/Memory/IProcessMemoryMeter.cs
@@ -1,0 +1,58 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Diagnostics;
+
+namespace EventLogExpert.Runtime.Memory;
+
+/// <summary>
+///     Reads process memory for the advisory status-bar indicator. All reads are cheap and non-collecting; the only
+///     collection is the explicit, infrequent <see cref="RequestBackgroundReclaim" /> issued after a log is closed so the
+///     freed managed heap becomes visible.
+/// </summary>
+internal interface IProcessMemoryMeter
+{
+    /// <summary>
+    ///     Free physical memory (total minus the system-wide memory load), or 0 when it cannot yet be determined (no GC
+    ///     has run, so the load reading is not populated). Used once to size the advisory color bands to the headroom actually
+    ///     available to the app.
+    /// </summary>
+    long GetAvailablePhysicalBytes();
+
+    /// <summary>The current managed-heap size (does not force a collection).</summary>
+    long GetManagedHeapBytes();
+
+    /// <summary>The current process working set (OS-resident bytes).</summary>
+    long GetWorkingSetBytes();
+
+    /// <summary>
+    ///     Requests a non-blocking background gen2 collection so a just-closed log's managed memory is reclaimed and the
+    ///     indicator can reflect the drop. Never blocks the caller.
+    /// </summary>
+    void RequestBackgroundReclaim();
+}
+
+internal sealed class ProcessMemoryMeter : IProcessMemoryMeter
+{
+    public long GetAvailablePhysicalBytes()
+    {
+        GCMemoryInfo info = GC.GetGCMemoryInfo();
+
+        // MemoryLoadBytes is 0 until the first GC populates it; return 0 so the caller keeps the bands unsized (Normal)
+        // rather than treating the whole machine as free.
+        return info.MemoryLoadBytes > 0 && info.TotalAvailableMemoryBytes > info.MemoryLoadBytes ?
+            info.TotalAvailableMemoryBytes - info.MemoryLoadBytes : 0;
+    }
+
+    public long GetManagedHeapBytes() => GC.GetTotalMemory(forceFullCollection: false);
+
+    public long GetWorkingSetBytes()
+    {
+        using Process self = Process.GetCurrentProcess();
+
+        return self.WorkingSet64;
+    }
+
+    public void RequestBackgroundReclaim() =>
+        GC.Collect(2, GCCollectionMode.Forced, blocking: false, compacting: false);
+}

--- a/src/EventLogExpert.Runtime/Memory/MemoryIndicatorEffect.cs
+++ b/src/EventLogExpert.Runtime/Memory/MemoryIndicatorEffect.cs
@@ -1,14 +1,12 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
-using EventLogExpert.Eventing.Common.EventLogs;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Runtime.EventLog;
 using Fluxor;
 using Microsoft.Extensions.DependencyInjection;
 using System.Diagnostics;
 using IDispatcher = Fluxor.IDispatcher;
-using LogTableCloseLogAction = EventLogExpert.Runtime.LogTable.CloseLogAction;
 
 namespace EventLogExpert.Runtime.Memory;
 
@@ -16,10 +14,9 @@ namespace EventLogExpert.Runtime.Memory;
 ///     Samples the managed heap on a cheap 1 Hz cadence (no forced GC on the sampling path) and publishes an advisory
 ///     <see cref="MemoryIndicatorRecomputedAction" /> when the displayed whole-MiB value or the effective
 ///     <see cref="MemoryUsageLevel" /> changes. A user-initiated log close schedules one deadline-gated, non-blocking
-///     background gen2 so the reclaimed heap becomes visible without stalling the UI. The schedule is armed by the
-///     terminal close (after the store is actually unrooted) but only when a <see cref="LogClosedByUserAction" /> was
-///     recorded, so filter-driven XML reloads (which close-and-reopen via the same terminal action, without the user
-///     action) never trigger a collection.
+///     background gen2 so the reclaimed heap becomes visible without stalling the UI. That schedule is armed by
+///     <see cref="LogClosedByUserCompletedAction" />, which the close pipeline raises only after the store is unrooted and
+///     only for user closes, so filter-driven XML reloads (which close-and-reopen without it) never trigger a collection.
 /// </summary>
 internal sealed class MemoryIndicatorEffect : IDisposable
 {
@@ -31,7 +28,6 @@ internal sealed class MemoryIndicatorEffect : IDisposable
     private const double ElevatedAvailableFraction = 0.50;
     private const double HighAvailableFraction = 0.75;
 
-    private readonly Lock _closeGate = new();
     private readonly long _collectDelayTicks;
     private readonly IDispatcher _dispatcher;
     private readonly Lock _gate = new();
@@ -40,7 +36,6 @@ internal sealed class MemoryIndicatorEffect : IDisposable
     private readonly ITraceLogger _logger;
     private readonly IProcessMemoryMeter _meter;
     private readonly Func<long> _now;
-    private readonly HashSet<EventLogId> _pendingUserClosedLogs = [];
     private readonly Timer _timer;
 
     private MemoryUsageLevel _candidateLevel = MemoryUsageLevel.Normal;
@@ -51,7 +46,6 @@ internal sealed class MemoryIndicatorEffect : IDisposable
     private long _highBytes;
     private long _lastDispatchedMebibytes = -1;
     private MemoryUsageLevel _lastLevel = MemoryUsageLevel.Normal;
-    private EventLogId? _lastTerminalClose;
     private int _sampling;
     private bool _thresholdsReady;
 
@@ -113,56 +107,7 @@ internal sealed class MemoryIndicatorEffect : IDisposable
     [EffectMethod(typeof(CloseAllLogsAction))]
     public Task HandleCloseAllLogs(IDispatcher dispatcher)
     {
-        lock (_closeGate)
-        {
-            _pendingUserClosedLogs.Clear();
-            _lastTerminalClose = null;
-        }
-
         ScheduleCloseReclaim();
-
-        return Task.CompletedTask;
-    }
-
-    [EffectMethod]
-    public Task HandleLogClosed(LogTableCloseLogAction action, IDispatcher dispatcher)
-    {
-        // The terminal close fires for both user closes and filter-driven reloads, and may arrive before OR after the
-        // matching LogClosedByUserAction (the user-close path dispatches them separately, and Fluxor can drain the
-        // terminal synchronously). Reclaim now if the user intent was already recorded; otherwise remember this
-        // terminal so a user marker arriving next can reclaim. A reload never emits LogClosedByUserAction, so its
-        // terminal is remembered but never acted on.
-        bool reclaim;
-
-        lock (_closeGate)
-        {
-            reclaim = _pendingUserClosedLogs.Remove(action.LogId);
-
-            if (!reclaim) { _lastTerminalClose = action.LogId; }
-        }
-
-        if (reclaim) { ScheduleCloseReclaim(); }
-
-        return Task.CompletedTask;
-    }
-
-    [EffectMethod]
-    public Task HandleLogClosedByUser(LogClosedByUserAction action, IDispatcher dispatcher)
-    {
-        // If the terminal close already ran for this log the store is unrooted, so reclaim now; otherwise record the
-        // intent for the terminal close that follows. Either way the gen2 lands after the store is dropped.
-        bool reclaim;
-
-        lock (_closeGate)
-        {
-            // EventLogId is unique per open, so a matching remembered terminal is exactly this log's close.
-            reclaim = _lastTerminalClose == action.LogId;
-
-            if (reclaim) { _lastTerminalClose = null; }
-            else { _pendingUserClosedLogs.Add(action.LogId); }
-        }
-
-        if (reclaim) { ScheduleCloseReclaim(); }
 
         return Task.CompletedTask;
     }
@@ -171,6 +116,14 @@ internal sealed class MemoryIndicatorEffect : IDisposable
     public Task HandleStoreInitialized(IDispatcher dispatcher)
     {
         Arm(TimeSpan.Zero);
+
+        return Task.CompletedTask;
+    }
+
+    [EffectMethod]
+    public Task HandleUserCloseCompleted(LogClosedByUserCompletedAction action, IDispatcher dispatcher)
+    {
+        ScheduleCloseReclaim();
 
         return Task.CompletedTask;
     }

--- a/src/EventLogExpert.Runtime/Memory/MemoryIndicatorEffect.cs
+++ b/src/EventLogExpert.Runtime/Memory/MemoryIndicatorEffect.cs
@@ -1,0 +1,292 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.EventLog;
+using Fluxor;
+using Microsoft.Extensions.DependencyInjection;
+using System.Diagnostics;
+using IDispatcher = Fluxor.IDispatcher;
+using LogTableCloseLogAction = EventLogExpert.Runtime.LogTable.CloseLogAction;
+
+namespace EventLogExpert.Runtime.Memory;
+
+/// <summary>
+///     Samples the managed heap on a cheap 1 Hz cadence (no forced GC on the sampling path) and publishes an advisory
+///     <see cref="MemoryIndicatorRecomputedAction" /> when the displayed whole-MiB value or the effective
+///     <see cref="MemoryUsageLevel" /> changes. A user-initiated log close schedules one deadline-gated, non-blocking
+///     background gen2 so the reclaimed heap becomes visible without stalling the UI. The schedule is armed by the
+///     terminal close (after the store is actually unrooted) but only when a <see cref="LogClosedByUserAction" /> was
+///     recorded, so filter-driven XML reloads (which close-and-reopen via the same terminal action, without the user
+///     action) never trigger a collection.
+/// </summary>
+internal sealed class MemoryIndicatorEffect : IDisposable
+{
+    private const long BytesPerMebibyte = 1024L * 1024L;
+
+    // Color bands measure the app's managed heap against a fraction of the physical memory that was free to the app
+    // (Elevated at 50%, High at 75% of available RAM). Basing this on free rather than total memory keeps the bands
+    // meaningful on a busy machine and reachable on a large one - it is the headroom the app can actually grow into.
+    private const double ElevatedAvailableFraction = 0.50;
+    private const double HighAvailableFraction = 0.75;
+
+    private readonly Lock _closeGate = new();
+    private readonly long _collectDelayTicks;
+    private readonly IDispatcher _dispatcher;
+    private readonly Lock _gate = new();
+    private readonly TimeSpan _interval;
+    private readonly long _levelDwellTicks;
+    private readonly ITraceLogger _logger;
+    private readonly IProcessMemoryMeter _meter;
+    private readonly Func<long> _now;
+    private readonly HashSet<EventLogId> _pendingUserClosedLogs = [];
+    private readonly Timer _timer;
+
+    private MemoryUsageLevel _candidateLevel = MemoryUsageLevel.Normal;
+    private long _candidateSince;
+    private long _collectDueAt;
+    private bool _disposed;
+    private long _elevatedBytes;
+    private long _highBytes;
+    private long _lastDispatchedMebibytes = -1;
+    private MemoryUsageLevel _lastLevel = MemoryUsageLevel.Normal;
+    private EventLogId? _lastTerminalClose;
+    private int _sampling;
+    private bool _thresholdsReady;
+
+    public MemoryIndicatorEffect(
+        IProcessMemoryMeter meter,
+        IDispatcher dispatcher,
+        [FromKeyedServices(LogCategories.EventLog)] ITraceLogger logger,
+        TimeSpan? sampleInterval = null,
+        TimeSpan? closeReclaimDelay = null,
+        TimeSpan? levelDwell = null,
+        long? elevatedBytes = null,
+        long? highBytes = null,
+        Func<long>? monotonicTimestampProvider = null)
+    {
+        ArgumentNullException.ThrowIfNull(meter);
+        ArgumentNullException.ThrowIfNull(dispatcher);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _meter = meter;
+        _dispatcher = dispatcher;
+        _logger = logger;
+        _interval = sampleInterval ?? TimeSpan.FromSeconds(1);
+        _now = monotonicTimestampProvider ?? Stopwatch.GetTimestamp;
+        _collectDelayTicks = ToTicks(closeReclaimDelay ?? TimeSpan.FromSeconds(1.5));
+        _levelDwellTicks = ToTicks(levelDwell ?? TimeSpan.FromSeconds(2));
+
+        if (elevatedBytes is { } elevated && highBytes is { } high)
+        {
+            if (elevated <= 0 || elevated >= high)
+            {
+                throw new ArgumentException(
+                    $"Memory thresholds must satisfy 0 < elevated ({elevated}) < high ({high}).",
+                    nameof(elevatedBytes));
+            }
+
+            _elevatedBytes = elevated;
+            _highBytes = high;
+            _thresholdsReady = true;
+        }
+
+        // Otherwise the thresholds derive lazily from available RAM on the first sample that can read it (see
+        // EnsureThresholds); until then the indicator stays Normal rather than sizing against an unknown machine.
+
+        // Constructed disarmed; StoreInitializedAction arms it so no sample can precede store initialization.
+        _timer = new Timer(_ => Tick(), null, Timeout.Infinite, Timeout.Infinite);
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            if (_disposed) { return; }
+
+            _disposed = true;
+            _timer.Dispose();
+        }
+    }
+
+    [EffectMethod(typeof(CloseAllLogsAction))]
+    public Task HandleCloseAllLogs(IDispatcher dispatcher)
+    {
+        lock (_closeGate)
+        {
+            _pendingUserClosedLogs.Clear();
+            _lastTerminalClose = null;
+        }
+
+        ScheduleCloseReclaim();
+
+        return Task.CompletedTask;
+    }
+
+    [EffectMethod]
+    public Task HandleLogClosed(LogTableCloseLogAction action, IDispatcher dispatcher)
+    {
+        // The terminal close fires for both user closes and filter-driven reloads, and may arrive before OR after the
+        // matching LogClosedByUserAction (the user-close path dispatches them separately, and Fluxor can drain the
+        // terminal synchronously). Reclaim now if the user intent was already recorded; otherwise remember this
+        // terminal so a user marker arriving next can reclaim. A reload never emits LogClosedByUserAction, so its
+        // terminal is remembered but never acted on.
+        bool reclaim;
+
+        lock (_closeGate)
+        {
+            reclaim = _pendingUserClosedLogs.Remove(action.LogId);
+
+            if (!reclaim) { _lastTerminalClose = action.LogId; }
+        }
+
+        if (reclaim) { ScheduleCloseReclaim(); }
+
+        return Task.CompletedTask;
+    }
+
+    [EffectMethod]
+    public Task HandleLogClosedByUser(LogClosedByUserAction action, IDispatcher dispatcher)
+    {
+        // If the terminal close already ran for this log the store is unrooted, so reclaim now; otherwise record the
+        // intent for the terminal close that follows. Either way the gen2 lands after the store is dropped.
+        bool reclaim;
+
+        lock (_closeGate)
+        {
+            // EventLogId is unique per open, so a matching remembered terminal is exactly this log's close.
+            reclaim = _lastTerminalClose == action.LogId;
+
+            if (reclaim) { _lastTerminalClose = null; }
+            else { _pendingUserClosedLogs.Add(action.LogId); }
+        }
+
+        if (reclaim) { ScheduleCloseReclaim(); }
+
+        return Task.CompletedTask;
+    }
+
+    [EffectMethod(typeof(StoreInitializedAction))]
+    public Task HandleStoreInitialized(IDispatcher dispatcher)
+    {
+        Arm(TimeSpan.Zero);
+
+        return Task.CompletedTask;
+    }
+
+    internal void Tick()
+    {
+        // Single-flight: a re-entrant callback (or a manual test drive overlapping a timer tick) exits immediately.
+        if (Interlocked.Exchange(ref _sampling, 1) == 1) { return; }
+
+        try
+        {
+            if (Volatile.Read(ref _disposed)) { return; }
+
+            long due = Volatile.Read(ref _collectDueAt);
+
+            if (due != 0 && _now() >= due)
+            {
+                _meter.RequestBackgroundReclaim();
+
+                // CAS-clear so a second close landing between the read and the clear keeps its later deadline.
+                Interlocked.CompareExchange(ref _collectDueAt, 0, due);
+            }
+
+            long heapBytes = _meter.GetManagedHeapBytes();
+            long usedMebibytes = heapBytes / BytesPerMebibyte;
+            EnsureThresholds();
+            MemoryUsageLevel effective = ResolveEffectiveLevel(LevelFor(heapBytes));
+
+            if (usedMebibytes == _lastDispatchedMebibytes && effective == _lastLevel) { return; }
+
+            long workingSet = _meter.GetWorkingSetBytes();
+
+            if (Volatile.Read(ref _disposed)) { return; }
+
+            _dispatcher.Dispatch(new MemoryIndicatorRecomputedAction(usedMebibytes, effective, workingSet));
+
+            // Commit the last-dispatched markers only after a successful dispatch, so a throwing dispatch is retried on
+            // the next tick rather than silently swallowed.
+            _lastDispatchedMebibytes = usedMebibytes;
+            _lastLevel = effective;
+        }
+        catch (Exception fault)
+        {
+            _logger.Trace($"{nameof(MemoryIndicatorEffect)}: a sample failed and was isolated: {fault}");
+        }
+        finally
+        {
+            Volatile.Write(ref _sampling, 0);
+            Arm(_interval);
+        }
+    }
+
+    private static long NonZero(long value) => value == 0 ? 1 : value;
+
+    private static long ToTicks(TimeSpan span) => (long)(span.TotalSeconds * Stopwatch.Frequency);
+
+    private void Arm(TimeSpan due)
+    {
+        lock (_gate)
+        {
+            if (_disposed) { return; }
+
+            try { _timer.Change(due, Timeout.InfiniteTimeSpan); }
+            catch (ObjectDisposedException) { }
+        }
+    }
+
+    // Sizes the color bands to the memory that was free to the app once a load reading is available. Runs on the tick
+    // thread (single-flighted), so the plain fields need no lock.
+    private void EnsureThresholds()
+    {
+        if (_thresholdsReady) { return; }
+
+        long availableBytes = _meter.GetAvailablePhysicalBytes();
+
+        if (availableBytes <= 0) { return; }
+
+        long elevated = (long)(ElevatedAvailableFraction * availableBytes);
+        long high = (long)(HighAvailableFraction * availableBytes);
+
+        // Hold the same invariant the injected path enforces; a pathologically tiny reading that collapses the bands is
+        // ignored until a real one arrives.
+        if (elevated <= 0 || elevated >= high) { return; }
+
+        _elevatedBytes = elevated;
+        _highBytes = high;
+        _thresholdsReady = true;
+    }
+
+    private MemoryUsageLevel LevelFor(long heapBytes) =>
+        !_thresholdsReady ? MemoryUsageLevel.Normal :
+        heapBytes >= _highBytes ? MemoryUsageLevel.High :
+        heapBytes >= _elevatedBytes ? MemoryUsageLevel.Elevated :
+        MemoryUsageLevel.Normal;
+
+    private MemoryUsageLevel ResolveEffectiveLevel(MemoryUsageLevel raw)
+    {
+        if (raw == _lastLevel)
+        {
+            _candidateLevel = raw;
+
+            return raw;
+        }
+
+        if (raw != _candidateLevel)
+        {
+            _candidateLevel = raw;
+            _candidateSince = _now();
+
+            return _lastLevel;
+        }
+
+        // The candidate differs from the effective level; promote it only once it has held for the dwell window, so a
+        // value oscillating across a threshold at 1 Hz does not flicker the chip color or spam announcements.
+        return _now() - _candidateSince >= _levelDwellTicks ? raw : _lastLevel;
+    }
+
+    private void ScheduleCloseReclaim() => Volatile.Write(ref _collectDueAt, NonZero(_now() + _collectDelayTicks));
+}

--- a/src/EventLogExpert.Runtime/Memory/MemoryIndicatorRecomputedAction.cs
+++ b/src/EventLogExpert.Runtime/Memory/MemoryIndicatorRecomputedAction.cs
@@ -1,0 +1,13 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Memory;
+
+/// <summary>
+///     Published by <see cref="MemoryIndicatorEffect" /> when the displayed whole-MiB managed heap or the effective
+///     <see cref="MemoryUsageLevel" /> changes. <paramref name="WorkingSetBytes" /> is sampled only at this point.
+/// </summary>
+internal sealed record MemoryIndicatorRecomputedAction(
+    long UsedMebibytes,
+    MemoryUsageLevel Level,
+    long WorkingSetBytes);

--- a/src/EventLogExpert.Runtime/Memory/MemoryIndicatorReducer.cs
+++ b/src/EventLogExpert.Runtime/Memory/MemoryIndicatorReducer.cs
@@ -1,0 +1,20 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Fluxor;
+
+namespace EventLogExpert.Runtime.Memory;
+
+internal sealed class MemoryIndicatorReducer
+{
+    [ReducerMethod]
+    public static MemoryIndicatorState ReduceRecomputed(
+        MemoryIndicatorState state,
+        MemoryIndicatorRecomputedAction action) =>
+        state with
+        {
+            UsedMebibytes = action.UsedMebibytes,
+            Level = action.Level,
+            WorkingSetBytes = action.WorkingSetBytes
+        };
+}

--- a/src/EventLogExpert.Runtime/Memory/MemoryIndicatorState.cs
+++ b/src/EventLogExpert.Runtime/Memory/MemoryIndicatorState.cs
@@ -1,0 +1,21 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Fluxor;
+
+namespace EventLogExpert.Runtime.Memory;
+
+/// <summary>
+///     The advisory memory-indicator state projected to the status bar. <see cref="UsedMebibytes" /> is the managed
+///     heap quantized to whole MiB (the displayed value); <see cref="WorkingSetBytes" /> is the process working set for
+///     the reconciliation tooltip; <see cref="Level" /> drives the chip color.
+/// </summary>
+[FeatureState]
+internal sealed record MemoryIndicatorState
+{
+    internal long UsedMebibytes { get; init; }
+
+    internal long WorkingSetBytes { get; init; }
+
+    internal MemoryUsageLevel Level { get; init; } = MemoryUsageLevel.Normal;
+}

--- a/src/EventLogExpert.Runtime/Memory/MemoryUsageLevel.cs
+++ b/src/EventLogExpert.Runtime/Memory/MemoryUsageLevel.cs
@@ -1,0 +1,15 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Memory;
+
+/// <summary>
+///     The advisory memory-usage band shown by the status-bar indicator. Purely presentational: it drives the chip
+///     color and the screen-reader announcement, and never changes app behavior.
+/// </summary>
+public enum MemoryUsageLevel
+{
+    Normal,
+    Elevated,
+    High
+}

--- a/src/EventLogExpert.Runtime/StatusBar/StatusBarFormatter.cs
+++ b/src/EventLogExpert.Runtime/StatusBar/StatusBarFormatter.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.Runtime.Memory;
 
 namespace EventLogExpert.Runtime.StatusBar;
 
@@ -88,6 +89,19 @@ public static class StatusBarFormatter
         return new LoadingSummary(text, totalFailed);
     }
 
+    public static string FormatMemory(long usedMebibytes, MemoryUsageLevel level)
+    {
+        var value = FormatMebibytes(usedMebibytes);
+
+        // The level word is rendered in the chip so the band is never conveyed by color alone (WCAG 1.4.1).
+        return level switch
+        {
+            MemoryUsageLevel.High => $"Memory: {value} \u00b7 High",
+            MemoryUsageLevel.Elevated => $"Memory: {value} \u00b7 Elevated",
+            _ => $"Memory: {value}"
+        };
+    }
+
     public static string FormatSource(
         LogView? active,
         IReadOnlyList<LogView> eventTables,
@@ -118,4 +132,58 @@ public static class StatusBarFormatter
 
         return string.IsNullOrEmpty(group.Name) ? $"Combined ({group.MemberIds.Count} logs)" : group.Name;
     }
+
+    /// <summary>
+    ///     The screen-reader text for the memory band. Announced only when the effective level transitions (the chip
+    ///     value itself is not announced); the initial Normal content is not announced on mount.
+    /// </summary>
+    public static string MemoryLevelAnnouncement(MemoryUsageLevel level) => level switch
+    {
+        MemoryUsageLevel.High => "Memory usage high",
+        MemoryUsageLevel.Elevated => "Memory usage elevated",
+        _ => "Memory usage normal"
+    };
+
+    /// <summary>The CSS modifier class for the memory chip's color band; empty for <see cref="MemoryUsageLevel.Normal" />.</summary>
+    public static string MemoryLevelClass(MemoryUsageLevel level) => level switch
+    {
+        MemoryUsageLevel.High => "status-bar-memory-high",
+        MemoryUsageLevel.Elevated => "status-bar-memory-elevated",
+        _ => string.Empty
+    };
+
+    /// <summary>
+    ///     The indicator tooltip. Explains that the visible number is the managed heap (which drops as logs close), while
+    ///     the process working set - closer to Task Manager's figure - may be released later by the OS.
+    /// </summary>
+    public static string MemoryTooltip(long usedMebibytes, long workingSetBytes, MemoryUsageLevel level)
+    {
+        var levelSuffix = level switch
+        {
+            MemoryUsageLevel.High => " Level: high.",
+            MemoryUsageLevel.Elevated => " Level: elevated.",
+            _ => string.Empty
+        };
+
+        return $"Managed heap (app data): {FormatMebibytes(usedMebibytes)} - drops as logs close. " +
+            $"Process working set: {FormatBytes(workingSetBytes)} - the OS may release this later.{levelSuffix}";
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+        const long OneKibibyte = 1024;
+        const long OneMebibyte = OneKibibyte * 1024;
+        const long OneGibibyte = OneMebibyte * 1024;
+
+        return bytes switch
+        {
+            >= OneGibibyte => $"{bytes / (double)OneGibibyte:0.0} GB",
+            >= OneMebibyte => $"{bytes / (double)OneMebibyte:0} MB",
+            >= OneKibibyte => $"{bytes / (double)OneKibibyte:0} KB",
+            _ => $"{bytes} B"
+        };
+    }
+
+    private static string FormatMebibytes(long mebibytes) =>
+        mebibytes >= 1024 ? $"{mebibytes / 1024.0:0.0} GB" : $"{mebibytes:N0} MB";
 }

--- a/src/EventLogExpert.Runtime/StatusBar/StatusBarPresentation.cs
+++ b/src/EventLogExpert.Runtime/StatusBar/StatusBarPresentation.cs
@@ -4,6 +4,7 @@
 using EventLogExpert.Eventing.Common.EventLogs;
 using EventLogExpert.Eventing.Common.Events;
 using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.Runtime.Memory;
 using System.Collections.Immutable;
 
 namespace EventLogExpert.Runtime.StatusBar;
@@ -37,6 +38,15 @@ public sealed record StatusBarPresentation
     public ImmutableList<LogTabGroup> Groups { get; init; } = [];
 
     public EventLogId? ActiveTabId { get; init; }
+
+    /// <summary>The managed heap quantized to whole MiB - the advisory memory indicator's displayed value.</summary>
+    public long MemoryUsedMebibytes { get; init; }
+
+    /// <summary>The process working set, shown in the indicator tooltip for reconciliation with Task Manager.</summary>
+    public long MemoryWorkingSetBytes { get; init; }
+
+    /// <summary>The advisory memory band that drives the indicator's chip color and announcement.</summary>
+    public MemoryUsageLevel MemoryLevel { get; init; }
 
     /// <summary>
     ///     Projects the per-log resolution tally for the active scope: the All-group sums every loaded log, a grouped tab

--- a/src/EventLogExpert.Runtime/StatusBar/StatusBarSource.cs
+++ b/src/EventLogExpert.Runtime/StatusBar/StatusBarSource.cs
@@ -7,6 +7,7 @@ using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.Runtime.FilterPane;
 using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.Runtime.Memory;
 using Fluxor;
 using Microsoft.Extensions.DependencyInjection;
 using System.Collections.Immutable;
@@ -20,12 +21,14 @@ internal sealed class StatusBarSource : IStatusBarSource, IDisposable
     private readonly Lock _gate = new();
     private readonly IState<LogTableState> _logTableState;
     private readonly ITraceLogger _logger;
+    private readonly IState<MemoryIndicatorState> _memoryState;
     private readonly IState<RawEventCountState> _rawCountState;
     private readonly IState<StatusBarState> _statusBarState;
 
     private bool _disposed;
     private (bool ContinuouslyUpdate, int BufferCount, bool BufferFull, int SelectionCount) _eventLogFacets;
     private (ImmutableList<LogView> Tabs, ImmutableList<LogTabGroup> Groups, EventLogId? ActiveTabId) _logTableFacets;
+    private (long UsedMebibytes, long WorkingSetBytes, MemoryUsageLevel Level) _memoryFacets;
     private bool _persistentFilterActive;
     private (int Total, ImmutableDictionary<EventLogId, ProviderResolutionCounts> ByLog) _rawCountFacets;
     private (ImmutableDictionary<StatusActivityId, (int, int)> Loading, string Resolver) _statusFacets;
@@ -36,6 +39,7 @@ internal sealed class StatusBarSource : IStatusBarSource, IDisposable
         IState<RawEventCountState> rawCountState,
         IState<StatusBarState> statusBarState,
         IState<LogTableState> logTableState,
+        IState<MemoryIndicatorState> memoryState,
         [FromKeyedServices(LogCategories.EventLog)] ITraceLogger logger)
     {
         ArgumentNullException.ThrowIfNull(eventLogState);
@@ -43,6 +47,7 @@ internal sealed class StatusBarSource : IStatusBarSource, IDisposable
         ArgumentNullException.ThrowIfNull(rawCountState);
         ArgumentNullException.ThrowIfNull(statusBarState);
         ArgumentNullException.ThrowIfNull(logTableState);
+        ArgumentNullException.ThrowIfNull(memoryState);
         ArgumentNullException.ThrowIfNull(logger);
 
         _eventLogState = eventLogState;
@@ -50,6 +55,7 @@ internal sealed class StatusBarSource : IStatusBarSource, IDisposable
         _rawCountState = rawCountState;
         _statusBarState = statusBarState;
         _logTableState = logTableState;
+        _memoryState = memoryState;
         _logger = logger;
 
         SeedFacets();
@@ -59,6 +65,7 @@ internal sealed class StatusBarSource : IStatusBarSource, IDisposable
         _rawCountState.StateChanged += OnRawCountChanged;
         _statusBarState.StateChanged += OnStatusBarChanged;
         _logTableState.StateChanged += OnLogTableChanged;
+        _memoryState.StateChanged += OnMemoryChanged;
 
         lock (_gate) { SeedFacets(); }
     }
@@ -70,7 +77,8 @@ internal sealed class StatusBarSource : IStatusBarSource, IDisposable
         _filterPaneState.Value,
         _rawCountState.Value,
         _statusBarState.Value,
-        _logTableState.Value);
+        _logTableState.Value,
+        _memoryState.Value);
 
     public void Dispose()
     {
@@ -86,6 +94,7 @@ internal sealed class StatusBarSource : IStatusBarSource, IDisposable
         _rawCountState.StateChanged -= OnRawCountChanged;
         _statusBarState.StateChanged -= OnStatusBarChanged;
         _logTableState.StateChanged -= OnLogTableChanged;
+        _memoryState.StateChanged -= OnMemoryChanged;
     }
 
     private static bool DictEquals<TKey, TValue>(
@@ -114,7 +123,8 @@ internal sealed class StatusBarSource : IStatusBarSource, IDisposable
         FilterPaneState filterPane,
         RawEventCountState rawCount,
         StatusBarState statusBar,
-        LogTableState logTable) =>
+        LogTableState logTable,
+        MemoryIndicatorState memory) =>
         new()
         {
             ContinuouslyUpdate = eventLog.ContinuouslyUpdate,
@@ -130,7 +140,10 @@ internal sealed class StatusBarSource : IStatusBarSource, IDisposable
             ResolverStatus = statusBar.ResolverStatus,
             Tabs = logTable.EventTables,
             Groups = logTable.Groups,
-            ActiveTabId = logTable.ActiveEventLogId
+            ActiveTabId = logTable.ActiveEventLogId,
+            MemoryUsedMebibytes = memory.UsedMebibytes,
+            MemoryWorkingSetBytes = memory.WorkingSetBytes,
+            MemoryLevel = memory.Level
         };
 
     private static (bool, int, bool, int) ProjectEventLog(EventLogState state) =>
@@ -139,6 +152,9 @@ internal sealed class StatusBarSource : IStatusBarSource, IDisposable
     private static (ImmutableList<LogView>, ImmutableList<LogTabGroup>, EventLogId?) ProjectLogTable(
         LogTableState state) =>
         (state.EventTables, state.Groups, state.ActiveEventLogId);
+
+    private static (long, long, MemoryUsageLevel) ProjectMemory(MemoryIndicatorState state) =>
+        (state.UsedMebibytes, state.WorkingSetBytes, state.Level);
 
     private static (int, ImmutableDictionary<EventLogId, ProviderResolutionCounts>) ProjectRawCount(RawEventCountState state) =>
         (state.Total, state.ByLog);
@@ -189,6 +205,20 @@ internal sealed class StatusBarSource : IStatusBarSource, IDisposable
             }
 
             _logTableFacets = next;
+        }
+
+        RaiseChanged();
+    }
+
+    private void OnMemoryChanged(object? sender, EventArgs e)
+    {
+        var next = ProjectMemory(_memoryState.Value);
+
+        lock (_gate)
+        {
+            if (_disposed || next == _memoryFacets) { return; }
+
+            _memoryFacets = next;
         }
 
         RaiseChanged();
@@ -249,5 +279,6 @@ internal sealed class StatusBarSource : IStatusBarSource, IDisposable
         _rawCountFacets = ProjectRawCount(_rawCountState.Value);
         _statusFacets = ProjectStatus(_statusBarState.Value);
         _logTableFacets = ProjectLogTable(_logTableState.Value);
+        _memoryFacets = ProjectMemory(_memoryState.Value);
     }
 }

--- a/src/EventLogExpert.UI/StatusBar/StatusBar.razor
+++ b/src/EventLogExpert.UI/StatusBar/StatusBar.razor
@@ -76,7 +76,9 @@
         </span>
         @* Always rendered so this live region is present from first paint - only its content changes, so a band
            transition is announced but the initial Normal content on mount is not. *@
-        <span aria-live="polite" class="status-bar-announce" role="status">@StatusBarFormatter.MemoryLevelAnnouncement(status.MemoryLevel)</span>
+        <span aria-live="polite" class="status-bar-announce status-bar-memory-announce" role="status">
+            @StatusBarFormatter.MemoryLevelAnnouncement(status.MemoryLevel)
+        </span>
 
         @if (loadingSummary is { } loading)
         {
@@ -101,6 +103,11 @@
             }
             else
             {
+                @if (status.NewEventBufferIsFull)
+                {
+                    <span class="status-bar-activity status-bar-warn">Buffer full</span>
+                }
+
                 <button aria-live="off"
                     class="status-bar-activity status-bar-newevents"
                     @onclick="LoadNewEvents"
@@ -108,11 +115,6 @@
                     type="button">
                     New Events: @status.NewEventBufferCount
                 </button>
-
-                @if (status.NewEventBufferIsFull)
-                {
-                    <span class="status-bar-activity status-bar-warn">Buffer full</span>
-                }
             }
         }
     </div>

--- a/src/EventLogExpert.UI/StatusBar/StatusBar.razor
+++ b/src/EventLogExpert.UI/StatusBar/StatusBar.razor
@@ -70,6 +70,14 @@
     <div class="status-bar-right">
         <span aria-atomic="true" aria-live="polite" class="status-bar-announce" role="status">@announcement</span>
 
+        <span class="status-bar-activity status-bar-memory @StatusBarFormatter.MemoryLevelClass(status.MemoryLevel)"
+            title="@StatusBarFormatter.MemoryTooltip(status.MemoryUsedMebibytes, status.MemoryWorkingSetBytes, status.MemoryLevel)">
+            @StatusBarFormatter.FormatMemory(status.MemoryUsedMebibytes, status.MemoryLevel)
+        </span>
+        @* Always rendered so this live region is present from first paint - only its content changes, so a band
+           transition is announced but the initial Normal content on mount is not. *@
+        <span aria-live="polite" class="status-bar-announce" role="status">@StatusBarFormatter.MemoryLevelAnnouncement(status.MemoryLevel)</span>
+
         @if (loadingSummary is { } loading)
         {
             <span class="status-bar-activity">@loading.Text</span>
@@ -78,6 +86,11 @@
             {
                 <span class="status-bar-activity status-bar-warn">Failed: @(loading.FailedEvents.ToString("N0"))</span>
             }
+        }
+
+        @if (!string.IsNullOrEmpty(status.ResolverStatus))
+        {
+            <span class="status-bar-activity status-bar-resolver" title="@status.ResolverStatus">@status.ResolverStatus</span>
         }
 
         @if (hasChannel)
@@ -101,11 +114,6 @@
                     <span class="status-bar-activity status-bar-warn">Buffer full</span>
                 }
             }
-        }
-
-        @if (!string.IsNullOrEmpty(status.ResolverStatus))
-        {
-            <span class="status-bar-activity status-bar-resolver" title="@status.ResolverStatus">@status.ResolverStatus</span>
         }
     </div>
 </div>

--- a/src/EventLogExpert.UI/StatusBar/StatusBar.razor.css
+++ b/src/EventLogExpert.UI/StatusBar/StatusBar.razor.css
@@ -89,11 +89,38 @@
     outline-offset: -1px;
 }
 
-/* White (inherited) text keeps WCAG AA contrast on the blue status bar; weight distinguishes the state. A color-coded
-   status palette that meets AA on the status-bar fill is deferred to v2. */
+/* White (inherited) text keeps WCAG AA contrast on the blue status bar; weight distinguishes the warn/live states. */
 .status-bar-warn,
 .status-bar-live {
     font-weight: 600;
+}
+
+/* Advisory memory bands: Normal inherits the plain white chip text; Elevated/High use a colored fill with an
+   AA-compliant on-fill text token (the color-coded status palette previously deferred), plus a visible level word in
+   the chip so the band is never conveyed by color alone. */
+.status-bar-memory {
+    padding: 0 4px;
+    border-radius: 2px;
+}
+
+.status-bar-memory-elevated {
+    background: var(--clr-status-fill-elevated);
+    color: var(--clr-on-status-elevated);
+    font-weight: 600;
+}
+
+.status-bar-memory-high {
+    background: var(--clr-status-fill-high);
+    color: var(--clr-on-status-high);
+    font-weight: 600;
+}
+
+/* Forced-colors: keep a visible pill boundary; the level word still carries the state. */
+@media (forced-colors: active) {
+    .status-bar-memory-elevated,
+    .status-bar-memory-high {
+        border: 1px solid;
+    }
 }
 
 /* Screen-reader-only region: announces the coarse activity transition without showing a duplicate visual label. */

--- a/src/EventLogExpert.UI/wwwroot/app.css
+++ b/src/EventLogExpert.UI/wwwroot/app.css
@@ -23,6 +23,13 @@
     --clr-find:    light-dark(#FFE066, #F8C84B);
     --clr-on-find: #1A1A1A;
 
+    /* Status-bar advisory memory bands. Colored fills (not foreground text, which fails WCAG AA on the blue bar) with
+       theme-flipped on-fill text; each fill/on-fill pair clears AA in both themes. */
+    --clr-status-fill-elevated: light-dark(#8A6D00, #F8C84B);
+    --clr-on-status-elevated:   light-dark(#FFF, #1A1A1A);
+    --clr-status-fill-high:     light-dark(#C0392B, #EF523B);
+    --clr-on-status-high:       light-dark(#FFF, #1A1A1A);
+
     --background-dark:     light-dark(#E0E0E0, #222222);
     --background-darkgray: light-dark(#CECECE, #353535);
 

--- a/tests/Unit/EventLogExpert.Runtime.Tests/ActivityCorrelation/ActivityCorrelationCacheEffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/ActivityCorrelation/ActivityCorrelationCacheEffectsTests.cs
@@ -1,0 +1,33 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.ActivityCorrelation;
+using NSubstitute;
+using IDispatcher = Fluxor.IDispatcher;
+
+namespace EventLogExpert.Runtime.Tests.ActivityCorrelation;
+
+public sealed class ActivityCorrelationCacheEffectsTests
+{
+    [Fact]
+    public async Task HandleCloseAllLogs_InvalidatesTheCache()
+    {
+        var control = Substitute.For<IActivityCorrelationCacheControl>();
+        var effects = new ActivityCorrelationCacheEffects(control);
+
+        await effects.HandleCloseAllLogs(Substitute.For<IDispatcher>());
+
+        control.Received(1).Invalidate();
+    }
+
+    [Fact]
+    public async Task HandleCloseLog_InvalidatesTheCache()
+    {
+        var control = Substitute.For<IActivityCorrelationCacheControl>();
+        var effects = new ActivityCorrelationCacheEffects(control);
+
+        await effects.HandleCloseLog(Substitute.For<IDispatcher>());
+
+        control.Received(1).Invalidate();
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/ActivityCorrelation/ActivityCorrelationServiceTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/ActivityCorrelation/ActivityCorrelationServiceTests.cs
@@ -378,6 +378,23 @@ public sealed class ActivityCorrelationServiceTests
     }
 
     [Fact]
+    public async Task Invalidate_DropsTheCachedView_SoTheNextBuildRebuilds()
+    {
+        var (service, _) = ServiceWith(1, 1,
+            Event(1, s_parent, offset: 0),
+            Event(2, s_focus, s_parent, offset: 1));
+
+        var first = await service.BuildAsync(Locator(1, 1), Ct);
+        var cached = await service.BuildAsync(Locator(1, 1), Ct);
+        Assert.Same(first, cached); // same reference proves the second call was served from cache
+
+        ((IActivityCorrelationCacheControl)service).Invalidate();
+        var rebuilt = await service.BuildAsync(Locator(1, 1), Ct);
+
+        Assert.NotSame(first, rebuilt);
+    }
+
+    [Fact]
     public void TryGetContentToken_ReturnsTheStoreTokenAndFalseForAnAbsentLog()
     {
         var (service, _) = ServiceWith(3, 7, Event(1, s_focus, offset: 0));

--- a/tests/Unit/EventLogExpert.Runtime.Tests/DependencyInjection/RuntimeServiceCollectionExtensionsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/DependencyInjection/RuntimeServiceCollectionExtensionsTests.cs
@@ -26,6 +26,7 @@ using EventLogExpert.Runtime.FilterLibrary;
 using EventLogExpert.Runtime.FilterPane;
 using EventLogExpert.Runtime.Histogram;
 using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.Runtime.Memory;
 using EventLogExpert.Runtime.Menu;
 using EventLogExpert.Runtime.Scenarios;
 using EventLogExpert.Runtime.Scenarios.Favorites;
@@ -249,6 +250,9 @@ public sealed class RuntimeServiceCollectionExtensionsTests
         var logTableState = Substitute.For<IState<LogTableState>>();
         logTableState.Value.Returns(new LogTableState());
         services.AddSingleton(logTableState);
+        var memoryIndicatorState = Substitute.For<IState<MemoryIndicatorState>>();
+        memoryIndicatorState.Value.Returns(new MemoryIndicatorState());
+        services.AddSingleton(memoryIndicatorState);
         services.AddSingleton(Substitute.For<IState<RawEventStoreState>>());
         var filteredLogPresenceState = Substitute.For<IState<FilteredLogPresenceState>>();
         filteredLogPresenceState.Value.Returns(new FilteredLogPresenceState());
@@ -383,6 +387,7 @@ public sealed class RuntimeServiceCollectionExtensionsTests
         services.AddSingleton(Substitute.For<IState<StatusBarState>>());
         services.AddSingleton(Substitute.For<IState<FilterLensState>>());
         services.AddSingleton(Substitute.For<IState<LogTableState>>());
+        services.AddSingleton(Substitute.For<IState<MemoryIndicatorState>>());
         services.AddSingleton(Substitute.For<IState<RawEventStoreState>>());
         services.AddSingleton(Substitute.For<IState<FilteredLogPresenceState>>());
         services.AddSingleton(Substitute.For<IState<HistogramState>>());

--- a/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EffectsTests.cs
@@ -734,6 +734,18 @@ public sealed class EffectsTests
     }
 
     [Fact]
+    public async Task HandleCloseLog_WhenNotUserInitiated_DoesNotDispatchUserCloseCompleted()
+    {
+        var logId = EventLogId.Create();
+        var (effects, mockDispatcher, _, _, _) = CreateEffectsWithServices();
+        var action = new CloseLogAction(logId, Constants.LogNameTestLog);
+
+        await effects.HandleCloseLog(action, mockDispatcher);
+
+        mockDispatcher.DidNotReceive().Dispatch(Arg.Any<LogClosedByUserCompletedAction>());
+    }
+
+    [Fact]
     public async Task HandleCloseLog_WhenOtherLogsRemain_ShouldNotClearResolverCache()
     {
         var logData = new EventLogData(Constants.LogNameLog1, LogPathType.Channel);
@@ -748,6 +760,22 @@ public sealed class EffectsTests
         await effects.HandleCloseLog(action, mockDispatcher);
 
         mockResolverCache.DidNotReceive().ClearAll();
+    }
+
+    [Fact]
+    public async Task HandleCloseLog_WhenUserInitiated_DispatchesUserCloseCompletedAfterTerminal()
+    {
+        var logId = EventLogId.Create();
+        var (effects, mockDispatcher, _, _, _) = CreateEffectsWithServices();
+        var action = new CloseLogAction(logId, Constants.LogNameTestLog, UserInitiated: true);
+
+        await effects.HandleCloseLog(action, mockDispatcher);
+
+        Received.InOrder(() =>
+        {
+            mockDispatcher.Dispatch(Arg.Is<Runtime.LogTable.CloseLogAction>(a => a != null && a.LogId == logId));
+            mockDispatcher.Dispatch(Arg.Is<LogClosedByUserCompletedAction>(a => a != null && a.LogId == logId));
+        });
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EventLogCommandsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EventLogCommandsTests.cs
@@ -1,0 +1,27 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Runtime.EventLog;
+using NSubstitute;
+using IDispatcher = Fluxor.IDispatcher;
+
+namespace EventLogExpert.Runtime.Tests.EventLog;
+
+public sealed class EventLogCommandsTests
+{
+    [Fact]
+    public void CloseLog_DispatchesUserInitiatedCloseActionAndUserMarker()
+    {
+        var dispatcher = Substitute.For<IDispatcher>();
+        var commands = new EventLogCommands(dispatcher);
+        var logId = EventLogId.Create();
+
+        commands.CloseLog(logId, "Application");
+
+        dispatcher.Received(1).Dispatch(Arg.Is<CloseLogAction>(action =>
+            action != null && action.LogId == logId && action.LogName == "Application" && action.UserInitiated));
+        dispatcher.Received(1).Dispatch(Arg.Is<LogClosedByUserAction>(action =>
+            action != null && action.LogId == logId && action.LogName == "Application"));
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Memory/MemoryIndicatorEffectTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Memory/MemoryIndicatorEffectTests.cs
@@ -1,0 +1,380 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.Memory;
+using NSubstitute;
+using System.Diagnostics;
+using IDispatcher = Fluxor.IDispatcher;
+using LogTableCloseLogAction = EventLogExpert.Runtime.LogTable.CloseLogAction;
+
+namespace EventLogExpert.Runtime.Tests.Memory;
+
+public sealed class MemoryIndicatorEffectTests
+{
+    private const long ElevatedBytes = 100;
+    private const long HighBytes = 200;
+
+    [Fact]
+    public void AfterDispose_TickDoesNotDispatch()
+    {
+        var harness = new Harness();
+        harness.Meter.Heap = 5 * 1024 * 1024;
+        var effect = harness.CreateEffect();
+
+        effect.Dispose();
+        effect.Dispose(); // idempotent
+        effect.Tick();
+
+        Assert.Empty(harness.Dispatched);
+    }
+
+    [Fact]
+    public void CloseHandshake_HasNoExpiryWindow_RegardlessOfOrderOrDelay()
+    {
+        var userFirst = new Harness();
+        using var userFirstEffect = userFirst.CreateEffect();
+        var logA = EventLogId.Create();
+        _ = userFirstEffect.HandleLogClosedByUser(new LogClosedByUserAction(logA, "A"), userFirst.Dispatcher);
+        userFirst.Advance(TimeSpan.FromSeconds(30)); // a slow unwind must not drop the pending intent
+        _ = userFirstEffect.HandleLogClosed(new LogTableCloseLogAction(logA), userFirst.Dispatcher);
+        userFirst.Advance(TimeSpan.FromSeconds(2));
+        userFirstEffect.Tick();
+        Assert.Equal(1, userFirst.Meter.ReclaimCount);
+
+        var terminalFirst = new Harness();
+        using var terminalFirstEffect = terminalFirst.CreateEffect();
+        var logB = EventLogId.Create();
+        _ = terminalFirstEffect.HandleLogClosed(new LogTableCloseLogAction(logB), terminalFirst.Dispatcher);
+        terminalFirst.Advance(TimeSpan.FromSeconds(30)); // a remembered terminal must not expire
+        _ = terminalFirstEffect.HandleLogClosedByUser(new LogClosedByUserAction(logB, "B"), terminalFirst.Dispatcher);
+        terminalFirst.Advance(TimeSpan.FromSeconds(2));
+        terminalFirstEffect.Tick();
+        Assert.Equal(1, terminalFirst.Meter.ReclaimCount);
+    }
+
+    [Fact]
+    public void CloseReclaim_IsIssuedExactlyOnce_AfterTheDeadline()
+    {
+        var harness = new Harness();
+        using var effect = harness.CreateEffect();
+
+        _ = effect.HandleCloseAllLogs(harness.Dispatcher);
+        harness.Advance(TimeSpan.FromSeconds(2)); // past the 1.5s deadline
+        effect.Tick();
+        effect.Tick();
+        effect.Tick();
+
+        Assert.Equal(1, harness.Meter.ReclaimCount);
+    }
+
+    [Fact]
+    public void CloseReclaim_IsNotIssuedBeforeTheDeadline()
+    {
+        var harness = new Harness();
+        using var effect = harness.CreateEffect();
+
+        _ = effect.HandleCloseAllLogs(harness.Dispatcher);
+        harness.Advance(TimeSpan.FromSeconds(1)); // deadline is 1.5s
+        effect.Tick();
+
+        Assert.Equal(0, harness.Meter.ReclaimCount);
+    }
+
+    [Fact]
+    public void Ctor_Throws_WhenThresholdsAreOutOfOrder()
+    {
+        var harness = new Harness();
+
+        Assert.Throws<ArgumentException>(() =>
+            harness.CreateEffect(elevatedBytes: 200, highBytes: 100));
+    }
+
+    [Fact]
+    public void DefaultThresholds_DeriveFrom50And75PercentOfAvailableRam()
+    {
+        var harness = new Harness();
+        harness.Meter.Available = 1000; // 50% => 500, 75% => 750
+        using var effect = harness.CreateEffect(elevatedBytes: null, highBytes: null);
+
+        // 600 is >= 50% (500) and < 75% (750) of the 1000-byte available RAM, so it is Elevated once the dwell elapses.
+        harness.Meter.Heap = 600;
+        effect.Tick();
+        harness.Advance(TimeSpan.FromSeconds(3));
+        effect.Tick();
+        Assert.Equal(MemoryUsageLevel.Elevated, harness.Dispatched[^1].Level);
+
+        // 800 crosses 75% (750) -> High.
+        harness.Meter.Heap = 800;
+        effect.Tick();
+        harness.Advance(TimeSpan.FromSeconds(3));
+        effect.Tick();
+        Assert.Equal(MemoryUsageLevel.High, harness.Dispatched[^1].Level);
+    }
+
+    [Fact]
+    public void FirstTick_DispatchesCurrentHeapAsNormal()
+    {
+        var harness = new Harness();
+        harness.Meter.Heap = 5 * 1024 * 1024;
+        harness.Meter.WorkingSet = 900;
+        using var effect = harness.CreateEffect();
+
+        effect.Tick();
+
+        var action = Assert.Single(harness.Dispatched);
+        Assert.Equal(5, action.UsedMebibytes);
+        Assert.Equal(MemoryUsageLevel.Normal, action.Level);
+        Assert.Equal(900, action.WorkingSetBytes);
+    }
+
+    [Fact]
+    public void HandleStoreInitialized_ArmsTheSelfReschedulingSampler()
+    {
+        var meter = new IncrementingHeapMeter(); // each read grows the heap so the dedupe never suppresses a tick
+        var dispatched = 0;
+        var dispatcher = Substitute.For<IDispatcher>();
+        dispatcher.When(call => call.Dispatch(Arg.Any<object>())).Do(_ => Interlocked.Increment(ref dispatched));
+
+        using var effect = new MemoryIndicatorEffect(
+            meter,
+            dispatcher,
+            Substitute.For<ITraceLogger>(),
+            sampleInterval: TimeSpan.FromMilliseconds(15),
+            elevatedBytes: ElevatedBytes,
+            highBytes: HighBytes);
+
+        // Exercises the real arm-on-StoreInitialized AND the self-reschedule (>= 3 requires the finally re-arm to keep
+        // firing), which the manual-Tick tests cannot cover.
+        _ = effect.HandleStoreInitialized(dispatcher);
+
+        Assert.True(
+            SpinWait.SpinUntil(() => Volatile.Read(ref dispatched) >= 3, TimeSpan.FromSeconds(5)),
+            $"the sampler did not self-reschedule (dispatch count={Volatile.Read(ref dispatched)}).");
+    }
+
+    [Fact]
+    public void Level_DoesNotEscalate_WhenTheBandOscillatesWithinTheDwell()
+    {
+        var harness = new Harness();
+        using var effect = harness.CreateEffect();
+
+        harness.Meter.Heap = 150; // Elevated candidate
+        effect.Tick();
+        harness.Advance(TimeSpan.FromSeconds(1)); // still under the 2s dwell
+        harness.Meter.Heap = 0; // back to Normal - resets the candidate
+        effect.Tick();
+        harness.Advance(TimeSpan.FromSeconds(1));
+        harness.Meter.Heap = 150; // Elevated candidate again
+        effect.Tick();
+
+        Assert.All(harness.Dispatched, action => Assert.Equal(MemoryUsageLevel.Normal, action.Level));
+    }
+
+    [Fact]
+    public void Level_EscalatesToElevated_OnlyAfterTheDwellWindow()
+    {
+        var harness = new Harness();
+        harness.Meter.Heap = 150; // between elevated (100) and high (200)
+        using var effect = harness.CreateEffect();
+
+        effect.Tick();
+        Assert.Equal(MemoryUsageLevel.Normal, harness.Dispatched[^1].Level); // candidate pending, not yet effective
+
+        harness.Advance(TimeSpan.FromSeconds(3)); // past the 2s dwell
+        effect.Tick();
+
+        Assert.Equal(MemoryUsageLevel.Elevated, harness.Dispatched[^1].Level);
+    }
+
+    [Fact]
+    public void Level_EscalatesToHigh_WhenHeapCrossesTheHighThreshold()
+    {
+        var harness = new Harness();
+        harness.Meter.Heap = 250; // above high (200)
+        using var effect = harness.CreateEffect();
+
+        effect.Tick();
+        harness.Advance(TimeSpan.FromSeconds(3));
+        effect.Tick();
+
+        Assert.Equal(MemoryUsageLevel.High, harness.Dispatched[^1].Level);
+    }
+
+    [Fact]
+    public void Level_StaysNormal_UntilAvailableRamCanBeRead()
+    {
+        var harness = new Harness();
+        harness.Meter.Available = 0; // no load reading yet (no GC has run), so the bands cannot be sized
+        harness.Meter.Heap = 1_000_000_000;
+        using var effect = harness.CreateEffect(elevatedBytes: null, highBytes: null);
+
+        effect.Tick();
+        harness.Advance(TimeSpan.FromSeconds(5));
+        effect.Tick();
+
+        Assert.All(harness.Dispatched, action => Assert.Equal(MemoryUsageLevel.Normal, action.Level));
+    }
+
+    [Fact]
+    public void RepeatedTick_WithSameQuantizedValueAndLevel_DoesNotDispatchAgain()
+    {
+        var harness = new Harness();
+        harness.Meter.Heap = 5 * 1024 * 1024;
+        using var effect = harness.CreateEffect();
+
+        effect.Tick();
+        effect.Tick();
+        effect.Tick();
+
+        Assert.Single(harness.Dispatched);
+    }
+
+    [Fact]
+    public void TerminalClose_ThenUserClose_SchedulesReclaim()
+    {
+        var harness = new Harness();
+        using var effect = harness.CreateEffect();
+        var logId = EventLogId.Create();
+
+        // Production ordering for a loaded file log: the terminal close drains synchronously before the user marker is
+        // recorded. The handshake must reclaim regardless of order.
+        _ = effect.HandleLogClosed(new LogTableCloseLogAction(logId), harness.Dispatcher);
+        _ = effect.HandleLogClosedByUser(new LogClosedByUserAction(logId, "System"), harness.Dispatcher);
+        harness.Advance(TimeSpan.FromSeconds(2));
+        effect.Tick();
+
+        Assert.Equal(1, harness.Meter.ReclaimCount);
+    }
+
+    [Fact]
+    public void TerminalClose_WithoutAUserClose_DoesNotReclaim()
+    {
+        var harness = new Harness();
+        using var effect = harness.CreateEffect();
+
+        // A filter-driven XML reload dispatches the terminal close with no preceding LogClosedByUserAction.
+        _ = effect.HandleLogClosed(new LogTableCloseLogAction(EventLogId.Create()), harness.Dispatcher);
+        harness.Advance(TimeSpan.FromSeconds(2));
+        effect.Tick();
+
+        Assert.Equal(0, harness.Meter.ReclaimCount);
+    }
+
+    [Fact]
+    public void Tick_QuantizesHeapToWholeMebibytes()
+    {
+        var harness = new Harness();
+        harness.Meter.Heap = (5 * 1024 * 1024) + (900 * 1024); // 5.9 MiB
+        using var effect = harness.CreateEffect();
+
+        effect.Tick();
+
+        Assert.Equal(5, Assert.Single(harness.Dispatched).UsedMebibytes);
+    }
+
+    [Fact]
+    public void Tick_WithoutAClose_NeverForcesACollection()
+    {
+        var harness = new Harness();
+        using var effect = harness.CreateEffect();
+
+        // The steady-state sampling path only reads the heap; no forced GC ever occurs without an explicit close.
+        for (var i = 0; i < 100; i++)
+        {
+            harness.Meter.Heap = i * 1024 * 1024;
+            harness.Advance(TimeSpan.FromSeconds(1));
+            effect.Tick();
+        }
+
+        Assert.Equal(0, harness.Meter.ReclaimCount);
+    }
+
+    [Fact]
+    public void UserClose_ThenTerminalClose_SchedulesReclaim()
+    {
+        var harness = new Harness();
+        using var effect = harness.CreateEffect();
+        var logId = EventLogId.Create();
+
+        _ = effect.HandleLogClosedByUser(new LogClosedByUserAction(logId, "System"), harness.Dispatcher);
+        _ = effect.HandleLogClosed(new LogTableCloseLogAction(logId), harness.Dispatcher);
+        harness.Advance(TimeSpan.FromSeconds(2)); // past the 1.5s deadline
+        effect.Tick();
+
+        Assert.Equal(1, harness.Meter.ReclaimCount);
+    }
+
+    private sealed class FakeMeter : IProcessMemoryMeter
+    {
+        public long Available { get; set; }
+
+        public long Heap { get; set; }
+
+        public int ReclaimCount { get; private set; }
+
+        public long WorkingSet { get; set; } = 42;
+
+        public long GetAvailablePhysicalBytes() => Available;
+
+        public long GetManagedHeapBytes() => Heap;
+
+        public long GetWorkingSetBytes() => WorkingSet;
+
+        public void RequestBackgroundReclaim() => ReclaimCount++;
+    }
+
+    private sealed class Harness
+    {
+        private long _now;
+
+        public Harness()
+        {
+            Dispatcher
+                .When(dispatcher => dispatcher.Dispatch(Arg.Any<object>()))
+                .Do(call =>
+                {
+                    if (call.Arg<object>() is MemoryIndicatorRecomputedAction action) { Dispatched.Add(action); }
+                });
+        }
+
+        public List<MemoryIndicatorRecomputedAction> Dispatched { get; } = [];
+
+        public IDispatcher Dispatcher { get; } = Substitute.For<IDispatcher>();
+
+        public FakeMeter Meter { get; } = new();
+
+        public void Advance(TimeSpan span) => _now += (long)(span.TotalSeconds * Stopwatch.Frequency);
+
+        public MemoryIndicatorEffect CreateEffect(
+            long? elevatedBytes = ElevatedBytes,
+            long? highBytes = HighBytes) =>
+            new(
+                Meter,
+                Dispatcher,
+                Substitute.For<ITraceLogger>(),
+                // A far-future interval keeps the internal re-arm from firing a real timer callback during the test;
+                // Tick() is driven manually and the dwell/deadline read the injected clock.
+                sampleInterval: TimeSpan.FromHours(1),
+                closeReclaimDelay: TimeSpan.FromSeconds(1.5),
+                levelDwell: TimeSpan.FromSeconds(2),
+                elevatedBytes: elevatedBytes,
+                highBytes: highBytes,
+                monotonicTimestampProvider: () => _now);
+    }
+
+    private sealed class IncrementingHeapMeter : IProcessMemoryMeter
+    {
+        private long _heap;
+
+        public long GetAvailablePhysicalBytes() => 0;
+
+        public long GetManagedHeapBytes() => Interlocked.Add(ref _heap, 1024 * 1024);
+
+        public long GetWorkingSetBytes() => 0;
+
+        public void RequestBackgroundReclaim() { }
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Memory/MemoryIndicatorEffectTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Memory/MemoryIndicatorEffectTests.cs
@@ -8,7 +8,6 @@ using EventLogExpert.Runtime.Memory;
 using NSubstitute;
 using System.Diagnostics;
 using IDispatcher = Fluxor.IDispatcher;
-using LogTableCloseLogAction = EventLogExpert.Runtime.LogTable.CloseLogAction;
 
 namespace EventLogExpert.Runtime.Tests.Memory;
 
@@ -29,30 +28,6 @@ public sealed class MemoryIndicatorEffectTests
         effect.Tick();
 
         Assert.Empty(harness.Dispatched);
-    }
-
-    [Fact]
-    public void CloseHandshake_HasNoExpiryWindow_RegardlessOfOrderOrDelay()
-    {
-        var userFirst = new Harness();
-        using var userFirstEffect = userFirst.CreateEffect();
-        var logA = EventLogId.Create();
-        _ = userFirstEffect.HandleLogClosedByUser(new LogClosedByUserAction(logA, "A"), userFirst.Dispatcher);
-        userFirst.Advance(TimeSpan.FromSeconds(30)); // a slow unwind must not drop the pending intent
-        _ = userFirstEffect.HandleLogClosed(new LogTableCloseLogAction(logA), userFirst.Dispatcher);
-        userFirst.Advance(TimeSpan.FromSeconds(2));
-        userFirstEffect.Tick();
-        Assert.Equal(1, userFirst.Meter.ReclaimCount);
-
-        var terminalFirst = new Harness();
-        using var terminalFirstEffect = terminalFirst.CreateEffect();
-        var logB = EventLogId.Create();
-        _ = terminalFirstEffect.HandleLogClosed(new LogTableCloseLogAction(logB), terminalFirst.Dispatcher);
-        terminalFirst.Advance(TimeSpan.FromSeconds(30)); // a remembered terminal must not expire
-        _ = terminalFirstEffect.HandleLogClosedByUser(new LogClosedByUserAction(logB, "B"), terminalFirst.Dispatcher);
-        terminalFirst.Advance(TimeSpan.FromSeconds(2));
-        terminalFirstEffect.Tick();
-        Assert.Equal(1, terminalFirst.Meter.ReclaimCount);
     }
 
     [Fact]
@@ -233,37 +208,6 @@ public sealed class MemoryIndicatorEffectTests
     }
 
     [Fact]
-    public void TerminalClose_ThenUserClose_SchedulesReclaim()
-    {
-        var harness = new Harness();
-        using var effect = harness.CreateEffect();
-        var logId = EventLogId.Create();
-
-        // Production ordering for a loaded file log: the terminal close drains synchronously before the user marker is
-        // recorded. The handshake must reclaim regardless of order.
-        _ = effect.HandleLogClosed(new LogTableCloseLogAction(logId), harness.Dispatcher);
-        _ = effect.HandleLogClosedByUser(new LogClosedByUserAction(logId, "System"), harness.Dispatcher);
-        harness.Advance(TimeSpan.FromSeconds(2));
-        effect.Tick();
-
-        Assert.Equal(1, harness.Meter.ReclaimCount);
-    }
-
-    [Fact]
-    public void TerminalClose_WithoutAUserClose_DoesNotReclaim()
-    {
-        var harness = new Harness();
-        using var effect = harness.CreateEffect();
-
-        // A filter-driven XML reload dispatches the terminal close with no preceding LogClosedByUserAction.
-        _ = effect.HandleLogClosed(new LogTableCloseLogAction(EventLogId.Create()), harness.Dispatcher);
-        harness.Advance(TimeSpan.FromSeconds(2));
-        effect.Tick();
-
-        Assert.Equal(0, harness.Meter.ReclaimCount);
-    }
-
-    [Fact]
     public void Tick_QuantizesHeapToWholeMebibytes()
     {
         var harness = new Harness();
@@ -293,15 +237,15 @@ public sealed class MemoryIndicatorEffectTests
     }
 
     [Fact]
-    public void UserClose_ThenTerminalClose_SchedulesReclaim()
+    public void UserCloseCompleted_SchedulesReclaimOnce()
     {
         var harness = new Harness();
         using var effect = harness.CreateEffect();
-        var logId = EventLogId.Create();
 
-        _ = effect.HandleLogClosedByUser(new LogClosedByUserAction(logId, "System"), harness.Dispatcher);
-        _ = effect.HandleLogClosed(new LogTableCloseLogAction(logId), harness.Dispatcher);
+        _ = effect.HandleUserCloseCompleted(
+            new LogClosedByUserCompletedAction(EventLogId.Create()), harness.Dispatcher);
         harness.Advance(TimeSpan.FromSeconds(2)); // past the 1.5s deadline
+        effect.Tick();
         effect.Tick();
 
         Assert.Equal(1, harness.Meter.ReclaimCount);

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Memory/MemoryIndicatorPerfTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Memory/MemoryIndicatorPerfTests.cs
@@ -1,0 +1,66 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.Memory;
+using System.Diagnostics;
+
+namespace EventLogExpert.Runtime.Tests.Memory;
+
+/// <summary>
+///     Measures the steady-state overhead the advisory memory indicator adds in the normal (non-pressure) scenario.
+///     The governor's only per-sample work is a non-collecting managed-heap read; there is no forced GC on the
+///     sampling/load path (that is asserted deterministically in <see cref="MemoryIndicatorEffectTests" />). Run with
+///     detailed output to capture the numbers for the PR.
+/// </summary>
+public sealed class MemoryIndicatorPerfTests(ITestOutputHelper output)
+{
+    private const int Iterations = 200_000;
+
+    [Fact]
+    public void PerDispatchWorkingSetCost_IsMeasured()
+    {
+        var meter = new ProcessMemoryMeter();
+        const int Samples = 2_000;
+
+        for (var warmup = 0; warmup < 100; warmup++) { _ = meter.GetWorkingSetBytes(); }
+
+        long sink = 0;
+        var stopwatch = Stopwatch.StartNew();
+
+        for (var i = 0; i < Samples; i++) { sink += meter.GetWorkingSetBytes(); }
+
+        stopwatch.Stop();
+        double usPerCall = stopwatch.Elapsed.TotalMicroseconds / Samples;
+
+        // Working set is sampled only when a change is dispatched (not every tick), so this cost is incurred rarely.
+        output.WriteLine($"GetWorkingSetBytes (per-dispatch only): {usPerCall:F2} us/call over {Samples:N0} reads (sink={sink}).");
+
+        // Wide sanity bound only (Process.WorkingSet64 walks the system process list, so a loaded agent varies widely).
+        Assert.True(usPerCall < 50_000, $"per-dispatch working-set read unexpectedly slow: {usPerCall:F2} us/call.");
+    }
+
+    [Fact]
+    public void PerSampleReadCost_IsNegligibleAndNonCollecting()
+    {
+        var meter = new ProcessMemoryMeter();
+
+        for (var warmup = 0; warmup < 1_000; warmup++) { _ = meter.GetManagedHeapBytes(); }
+
+        long sink = 0;
+        int gen2Before = GC.CollectionCount(2);
+        var stopwatch = Stopwatch.StartNew();
+
+        for (var i = 0; i < Iterations; i++) { sink += meter.GetManagedHeapBytes(); }
+
+        stopwatch.Stop();
+        int inducedGen2 = GC.CollectionCount(2) - gen2Before;
+        double nsPerCall = stopwatch.Elapsed.TotalNanoseconds / Iterations;
+
+        output.WriteLine($"GetManagedHeapBytes: {nsPerCall:F1} ns/call over {Iterations:N0} reads; gen2 induced = {inducedGen2} (sink={sink}).");
+        output.WriteLine($"Steady state is one read per second, so the governor adds roughly {nsPerCall:F1} ns of work per second in the normal scenario.");
+
+        // Generous sanity bounds only (the deterministic no-forced-GC proof is in the effect tests); wide enough not to
+        // flake on a loaded CI agent.
+        Assert.True(nsPerCall < 100_000, $"per-sample read unexpectedly slow: {nsPerCall:F1} ns/call.");
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Memory/MemoryIndicatorReducerTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Memory/MemoryIndicatorReducerTests.cs
@@ -1,0 +1,23 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.Memory;
+
+namespace EventLogExpert.Runtime.Tests.Memory;
+
+public sealed class MemoryIndicatorReducerTests
+{
+    [Fact]
+    public void ReduceRecomputed_ReplacesTheProjectedValues()
+    {
+        var initial = new MemoryIndicatorState { UsedMebibytes = 1, WorkingSetBytes = 2, Level = MemoryUsageLevel.Normal };
+
+        var next = MemoryIndicatorReducer.ReduceRecomputed(
+            initial,
+            new MemoryIndicatorRecomputedAction(512, MemoryUsageLevel.High, 900_000_000));
+
+        Assert.Equal(512, next.UsedMebibytes);
+        Assert.Equal(MemoryUsageLevel.High, next.Level);
+        Assert.Equal(900_000_000, next.WorkingSetBytes);
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/StatusBar/StatusBarFormatterTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/StatusBar/StatusBarFormatterTests.cs
@@ -4,6 +4,7 @@
 using EventLogExpert.Eventing.Common.Channels;
 using EventLogExpert.Eventing.Common.EventLogs;
 using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.Runtime.Memory;
 using EventLogExpert.Runtime.StatusBar;
 using System.Collections.Immutable;
 
@@ -152,6 +153,21 @@ public sealed class StatusBarFormatterTests
     }
 
     [Fact]
+    public void FormatMemory_Elevated_AppendsTheLevelWord() =>
+        Assert.Equal("Memory: 1.0 GB \u00b7 Elevated", StatusBarFormatter.FormatMemory(1024, MemoryUsageLevel.Elevated));
+
+    [Fact]
+    public void FormatMemory_High_AppendsTheLevelWord() =>
+        Assert.Equal("Memory: 2.0 GB \u00b7 High", StatusBarFormatter.FormatMemory(2048, MemoryUsageLevel.High));
+
+    [Theory]
+    [InlineData(0, "Memory: 0 MB")]
+    [InlineData(512, "Memory: 512 MB")]
+    [InlineData(1536, "Memory: 1.5 GB")]
+    public void FormatMemory_Normal_ShowsValueWithoutTheLevelWord(long usedMebibytes, string expected) =>
+        Assert.Equal(expected, StatusBarFormatter.FormatMemory(usedMebibytes, MemoryUsageLevel.Normal));
+
+    [Fact]
     public void FormatSource_AllLogs_CountsOnlyStandaloneTabs()
     {
         var allLogs = Combined(LogTabGroupId.AllLogs);
@@ -191,6 +207,34 @@ public sealed class StatusBarFormatterTests
 
         Assert.Equal("Combined (3 logs)", StatusBarFormatter.FormatSource(active, [active], groups));
     }
+
+    [Theory]
+    [InlineData(MemoryUsageLevel.Normal, "Memory usage normal")]
+    [InlineData(MemoryUsageLevel.Elevated, "Memory usage elevated")]
+    [InlineData(MemoryUsageLevel.High, "Memory usage high")]
+    public void MemoryLevelAnnouncement_MapsBandToSpokenText(MemoryUsageLevel level, string expected) =>
+        Assert.Equal(expected, StatusBarFormatter.MemoryLevelAnnouncement(level));
+
+    [Theory]
+    [InlineData(MemoryUsageLevel.Normal, "")]
+    [InlineData(MemoryUsageLevel.Elevated, "status-bar-memory-elevated")]
+    [InlineData(MemoryUsageLevel.High, "status-bar-memory-high")]
+    public void MemoryLevelClass_MapsBandToModifier(MemoryUsageLevel level, string expected) =>
+        Assert.Equal(expected, StatusBarFormatter.MemoryLevelClass(level));
+
+    [Fact]
+    public void MemoryTooltip_DistinguishesManagedHeapFromWorkingSet()
+    {
+        var tooltip = StatusBarFormatter.MemoryTooltip(512, 900L * 1024 * 1024, MemoryUsageLevel.High);
+
+        Assert.Contains("Managed heap (app data): 512 MB", tooltip);
+        Assert.Contains("Process working set: 900 MB", tooltip);
+        Assert.Contains("Level: high.", tooltip);
+    }
+
+    [Fact]
+    public void MemoryTooltip_Normal_OmitsTheLevelSuffix() =>
+        Assert.DoesNotContain("Level:", StatusBarFormatter.MemoryTooltip(100, 200, MemoryUsageLevel.Normal));
 
     private static LogView Channel(string name) =>
         new(EventLogId.Create()) { LogName = name, LogPathType = LogPathType.Channel };

--- a/tests/Unit/EventLogExpert.Runtime.Tests/StatusBar/StatusBarSourceTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/StatusBar/StatusBarSourceTests.cs
@@ -7,6 +7,7 @@ using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.Runtime.FilterPane;
 using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.Runtime.Memory;
 using EventLogExpert.Runtime.StatusBar;
 using Fluxor;
 using NSubstitute;
@@ -79,6 +80,21 @@ public sealed class StatusBarSourceTests
 
         harness.RawCount = new RawEventCountState { ByLog = ImmutableDictionary.CreateRange([new KeyValuePair<EventLogId, ProviderResolutionCounts>(LogA, Counts(5))]) };
         harness.RaiseRawCount();
+
+        Assert.Equal(0, raised);
+    }
+
+    [Fact]
+    public void Changed_DoesNotFire_WhenTheMemoryFacetIsEquivalent()
+    {
+        var harness = new Harness();
+        harness.Memory = new MemoryIndicatorState { UsedMebibytes = 256, WorkingSetBytes = 10, Level = MemoryUsageLevel.Normal };
+        harness.RaiseMemory();
+        var raised = 0;
+        harness.Source.Changed += () => raised++;
+
+        harness.Memory = new MemoryIndicatorState { UsedMebibytes = 256, WorkingSetBytes = 10, Level = MemoryUsageLevel.Normal };
+        harness.RaiseMemory();
 
         Assert.Equal(0, raised);
     }
@@ -200,6 +216,19 @@ public sealed class StatusBarSourceTests
     }
 
     [Fact]
+    public void Changed_Fires_WhenTheMemoryFacetChanges()
+    {
+        var harness = new Harness();
+        var raised = 0;
+        harness.Source.Changed += () => raised++;
+
+        harness.Memory = harness.Memory with { UsedMebibytes = 256, Level = MemoryUsageLevel.Elevated };
+        harness.RaiseMemory();
+
+        Assert.Equal(1, raised);
+    }
+
+    [Fact]
     public void Construction_ReconcilesARawCountChangeBetweenSeedAndSubscribe_SoALaterUnchangedNotificationDoesNotRaise()
     {
         var populated = new RawEventCountState { ByLog = ImmutableDictionary<EventLogId, ProviderResolutionCounts>.Empty.Add(LogA, Counts(7)) };
@@ -232,6 +261,26 @@ public sealed class StatusBarSourceTests
     }
 
     [Fact]
+    public void Current_ProjectsMemoryFacets()
+    {
+        var harness = new Harness
+        {
+            Memory = new MemoryIndicatorState
+            {
+                UsedMebibytes = 512,
+                WorkingSetBytes = 900_000_000,
+                Level = MemoryUsageLevel.Elevated
+            }
+        };
+
+        var presentation = harness.Source.Current;
+
+        Assert.Equal(512, presentation.MemoryUsedMebibytes);
+        Assert.Equal(900_000_000, presentation.MemoryWorkingSetBytes);
+        Assert.Equal(MemoryUsageLevel.Elevated, presentation.MemoryLevel);
+    }
+
+    [Fact]
     public void Current_ReadsEveryBackingStateLive()
     {
         var harness = new Harness();
@@ -260,7 +309,7 @@ public sealed class StatusBarSourceTests
     }
 
     [Fact]
-    public void Dispose_UnsubscribesFromAllFiveStates()
+    public void Dispose_UnsubscribesFromAllSixStates()
     {
         var eventLog = Substitute.For<IState<EventLogState>>();
         eventLog.Value.Returns(new EventLogState());
@@ -272,7 +321,9 @@ public sealed class StatusBarSourceTests
         statusBar.Value.Returns(new StatusBarState());
         var logTable = Substitute.For<IState<LogTableState>>();
         logTable.Value.Returns(new LogTableState());
-        var source = new StatusBarSource(eventLog, filterPane, rawCount, statusBar, logTable, Substitute.For<ITraceLogger>());
+        var memory = Substitute.For<IState<MemoryIndicatorState>>();
+        memory.Value.Returns(new MemoryIndicatorState());
+        var source = new StatusBarSource(eventLog, filterPane, rawCount, statusBar, logTable, memory, Substitute.For<ITraceLogger>());
 
         source.Dispose();
 
@@ -281,6 +332,7 @@ public sealed class StatusBarSourceTests
         rawCount.Received().StateChanged -= Arg.Any<EventHandler>();
         statusBar.Received().StateChanged -= Arg.Any<EventHandler>();
         logTable.Received().StateChanged -= Arg.Any<EventHandler>();
+        memory.Received().StateChanged -= Arg.Any<EventHandler>();
     }
 
     [Fact]
@@ -303,15 +355,17 @@ public sealed class StatusBarSourceTests
         IState<FilterPaneState>? filterPane = null,
         IState<RawEventCountState>? rawCount = null,
         IState<StatusBarState>? statusBar = null,
-        IState<LogTableState>? logTable = null)
+        IState<LogTableState>? logTable = null,
+        IState<MemoryIndicatorState>? memory = null)
     {
         eventLog ??= StateOf(new EventLogState());
         filterPane ??= StateOf(new FilterPaneState());
         rawCount ??= StateOf(new RawEventCountState());
         statusBar ??= StateOf(new StatusBarState());
         logTable ??= StateOf(new LogTableState());
+        memory ??= StateOf(new MemoryIndicatorState());
 
-        return new StatusBarSource(eventLog, filterPane, rawCount, statusBar, logTable, Substitute.For<ITraceLogger>());
+        return new StatusBarSource(eventLog, filterPane, rawCount, statusBar, logTable, memory, Substitute.For<ITraceLogger>());
     }
 
     private static IState<TState> StateOf<TState>(TState value)
@@ -327,6 +381,7 @@ public sealed class StatusBarSourceTests
         private readonly IState<EventLogState> _eventLog = Substitute.For<IState<EventLogState>>();
         private readonly IState<FilterPaneState> _filterPane = Substitute.For<IState<FilterPaneState>>();
         private readonly IState<LogTableState> _logTable = Substitute.For<IState<LogTableState>>();
+        private readonly IState<MemoryIndicatorState> _memory = Substitute.For<IState<MemoryIndicatorState>>();
         private readonly IState<RawEventCountState> _rawCount = Substitute.For<IState<RawEventCountState>>();
         private readonly IState<StatusBarState> _statusBar = Substitute.For<IState<StatusBarState>>();
 
@@ -337,8 +392,9 @@ public sealed class StatusBarSourceTests
             _rawCount.Value.Returns(_ => RawCount);
             _statusBar.Value.Returns(_ => StatusBar);
             _logTable.Value.Returns(_ => LogTable);
+            _memory.Value.Returns(_ => Memory);
             Source = new StatusBarSource(
-                _eventLog, _filterPane, _rawCount, _statusBar, _logTable, Substitute.For<ITraceLogger>());
+                _eventLog, _filterPane, _rawCount, _statusBar, _logTable, _memory, Substitute.For<ITraceLogger>());
         }
 
         public EventLogState EventLog { get; set; } = new();
@@ -346,6 +402,8 @@ public sealed class StatusBarSourceTests
         public FilterPaneState FilterPane { get; set; } = new();
 
         public LogTableState LogTable { get; set; } = new();
+
+        public MemoryIndicatorState Memory { get; set; } = new();
 
         public RawEventCountState RawCount { get; set; } = new();
 
@@ -361,6 +419,9 @@ public sealed class StatusBarSourceTests
 
         public void RaiseLogTable() =>
             _logTable.StateChanged += Raise.Event<EventHandler>(_logTable, EventArgs.Empty);
+
+        public void RaiseMemory() =>
+            _memory.StateChanged += Raise.Event<EventHandler>(_memory, EventArgs.Empty);
 
         public void RaiseRawCount() =>
             _rawCount.StateChanged += Raise.Event<EventHandler>(_rawCount, EventArgs.Empty);

--- a/tests/Unit/EventLogExpert.UI.Tests/StatusBar/StatusBarTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/StatusBar/StatusBarTests.cs
@@ -9,6 +9,7 @@ using EventLogExpert.Filtering.Evaluation;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.Runtime.FilterLenses;
 using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.Runtime.Memory;
 using EventLogExpert.Runtime.Stats;
 using EventLogExpert.Runtime.StatusBar;
 using EventLogExpert.UI.LogTable.Resolution;
@@ -246,6 +247,82 @@ public sealed class StatusBarTests : BunitContext
     }
 
     [Fact]
+    public void MemoryChip_Elevated_RendersTheElevatedBandAndLevelWord()
+    {
+        _status = new StatusBarPresentation { MemoryLevel = MemoryUsageLevel.Elevated, MemoryUsedMebibytes = 100 };
+
+        var cut = Render<UI.StatusBar.StatusBar>();
+
+        var chip = cut.Find(".status-bar-memory");
+        Assert.Contains("status-bar-memory-elevated", chip.ClassList);
+        Assert.Contains("Elevated", chip.TextContent);
+        Assert.Equal("Memory usage elevated", cut.Find(".status-bar-memory-announce").TextContent);
+    }
+
+    [Fact]
+    public void MemoryChip_High_RendersTheHighBandAndLevelWord()
+    {
+        _status = new StatusBarPresentation { MemoryLevel = MemoryUsageLevel.High, MemoryUsedMebibytes = 100 };
+
+        var cut = Render<UI.StatusBar.StatusBar>();
+
+        var chip = cut.Find(".status-bar-memory");
+        Assert.Contains("status-bar-memory-high", chip.ClassList);
+        Assert.Contains("High", chip.TextContent);
+        Assert.Equal("Memory usage high", cut.Find(".status-bar-memory-announce").TextContent);
+    }
+
+    [Fact]
+    public void MemoryChip_Normal_RendersPlainTextWithoutABandClass()
+    {
+        _status = new StatusBarPresentation { MemoryLevel = MemoryUsageLevel.Normal, MemoryUsedMebibytes = 100 };
+
+        var cut = Render<UI.StatusBar.StatusBar>();
+
+        var chip = cut.Find(".status-bar-memory");
+        Assert.Contains("Memory: 100 MB", chip.TextContent);
+        Assert.DoesNotContain("status-bar-memory-elevated", chip.ClassList);
+        Assert.DoesNotContain("status-bar-memory-high", chip.ClassList);
+        Assert.Equal("Memory usage normal", cut.Find(".status-bar-memory-announce").TextContent);
+    }
+
+    [Fact]
+    public void MemoryChip_Tooltip_ReconcilesManagedHeapAndWorkingSet()
+    {
+        _status = new StatusBarPresentation
+        {
+            MemoryLevel = MemoryUsageLevel.Normal,
+            MemoryUsedMebibytes = 100,
+            MemoryWorkingSetBytes = 256L * 1024 * 1024
+        };
+
+        var cut = Render<UI.StatusBar.StatusBar>();
+
+        var tooltip = cut.Find(".status-bar-memory").GetAttribute("title");
+        Assert.Contains("Managed heap", tooltip);
+        Assert.Contains("Process working set", tooltip);
+    }
+
+    [Fact]
+    public void MemoryLevelChange_ThroughTheSource_RepaintsTheChipAndAnnouncement()
+    {
+        _status = new StatusBarPresentation { MemoryLevel = MemoryUsageLevel.Normal, MemoryUsedMebibytes = 100 };
+
+        var cut = Render<UI.StatusBar.StatusBar>();
+
+        Assert.DoesNotContain("status-bar-memory-high", cut.Find(".status-bar-memory").ClassList);
+
+        _status = new StatusBarPresentation { MemoryLevel = MemoryUsageLevel.High, MemoryUsedMebibytes = 900 };
+        cut.InvokeAsync(() => _statusBarSource.Changed += Raise.Event<Action>());
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("status-bar-memory-high", cut.Find(".status-bar-memory").ClassList);
+            Assert.Equal("Memory usage high", cut.Find(".status-bar-memory-announce").TextContent);
+        });
+    }
+
+    [Fact]
     public void MultiSelect_ShowsSelectedSuffix_SingleSelectDoesNot()
     {
         SetActiveLog(total: 500, shown: 500, filter: Unfiltered, selected: 3);
@@ -271,27 +348,6 @@ public sealed class StatusBarTests : BunitContext
         Assert.DoesNotContain("Loading: 100", cut.Markup);
         Assert.DoesNotContain("Loading: 50", cut.Markup);
         Assert.Contains("Failed: 2", cut.Markup);
-    }
-
-    [Fact]
-    public void NewEventsCounter_StaysVisibleWhileAnotherLogLoads()
-    {
-        var id = EventLogId.Create();
-        var channel = new LogView(id) { LogName = "Application", LogPathType = LogPathType.Channel };
-        _status = new StatusBarPresentation
-        {
-            Tabs = ImmutableList.Create(channel),
-            ActiveTabId = id,
-            RawEventCountsByLog = ImmutableDictionary<EventLogId, ProviderResolutionCounts>.Empty.Add(id, default),
-            NewEventBufferCount = 42,
-            LoadingActivities = ImmutableDictionary<StatusActivityId, LoadingProgress>.Empty
-                .Add(new StatusActivityId(Guid.NewGuid()), new LoadingProgress(500, 0))
-        };
-
-        var cut = Render<UI.StatusBar.StatusBar>();
-
-        Assert.Contains("Loading: 500", cut.Markup);
-        Assert.Contains("New Events: 42", cut.Markup);
     }
 
     [Fact]
@@ -325,6 +381,24 @@ public sealed class StatusBarTests : BunitContext
     }
 
     [Fact]
+    public void NewEventsButton_IsTheLastRightClusterItem_EvenWhenBufferFull()
+    {
+        SetChannelStatus(newEventCount: 1000, bufferFull: true);
+
+        var cut = Render<UI.StatusBar.StatusBar>();
+
+        var right = cut.Find(".status-bar-right");
+        var children = right.Children.ToList();
+        var memoryChip = right.QuerySelector(".status-bar-memory");
+        var newEventsButton = right.QuerySelector("button.status-bar-newevents");
+
+        Assert.NotNull(memoryChip);
+        Assert.NotNull(newEventsButton);
+        Assert.Equal(children.Count - 1, children.IndexOf(newEventsButton));
+        Assert.True(children.IndexOf(memoryChip) < children.IndexOf(newEventsButton));
+    }
+
+    [Fact]
     public void NewEventsButton_ZeroCount_IsRenderedAndEnabled()
     {
         SetChannelStatus(newEventCount: 0);
@@ -334,6 +408,27 @@ public sealed class StatusBarTests : BunitContext
         Assert.False(button.HasAttribute("disabled"));
         Assert.Contains("New Events: 0", button.TextContent);
         Assert.Equal("No new events to load", button.GetAttribute("title"));
+    }
+
+    [Fact]
+    public void NewEventsCounter_StaysVisibleWhileAnotherLogLoads()
+    {
+        var id = EventLogId.Create();
+        var channel = new LogView(id) { LogName = "Application", LogPathType = LogPathType.Channel };
+        _status = new StatusBarPresentation
+        {
+            Tabs = ImmutableList.Create(channel),
+            ActiveTabId = id,
+            RawEventCountsByLog = ImmutableDictionary<EventLogId, ProviderResolutionCounts>.Empty.Add(id, default),
+            NewEventBufferCount = 42,
+            LoadingActivities = ImmutableDictionary<StatusActivityId, LoadingProgress>.Empty
+                .Add(new StatusActivityId(Guid.NewGuid()), new LoadingProgress(500, 0))
+        };
+
+        var cut = Render<UI.StatusBar.StatusBar>();
+
+        Assert.Contains("Loading: 500", cut.Markup);
+        Assert.Contains("New Events: 42", cut.Markup);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Adds an advisory memory-usage indicator to the status bar: a `Memory: {managed}` chip showing the app's managed-heap usage, color-coded to amber (Elevated) / red (High) as usage climbs, so heavy multi-log sessions are visible at a glance.

## Behavior
- **Always-visible chip** at the left of the status-bar right cluster (the New Events indicator stays the far-right item). Normal renders as plain status-bar text; Elevated/High render as an AA-contrast colored fill plus the level word plus a `forced-colors` fallback, so the band is never conveyed by color alone. The chip is non-interactive; its tooltip reconciles managed heap vs. process working set.
- **Color bands** derive from 50% / 75% of the physical memory that was free to the app (available RAM), so they adapt to the machine and stay Normal through ordinary multi-GB sessions.
- **Cheap, fresh sampling:** a 1 Hz background sampler reads the managed heap with no forced GC on the sampling path, so idle GC frees and log closes are reflected. A user-initiated log close schedules one non-blocking background gen2 (off the UI thread) so the reclaim becomes visible; filter-driven XML reloads do not.
- **Close-log stewardship:** the within-log activity-correlation view cache is invalidated on close, guarded by the existing content token so a build completing after a close cannot repopulate it.

## Notes
- Supersedes the previously-held budget-governor approach: no automatic pause / partial-load and no forced `GC.Collect()` on load. Steady-state overhead is a ~20 ns managed-heap read per second.
- `MemoryUsageLevel` is the only new public type (it surfaces through the public `StatusBarPresentation`); every other new type is internal.

## Tests
New unit tests for the sampler (timer lifecycle, single-flight, 2 s level dwell, deadline-gated reclaim, order-independent close handshake, available-RAM threshold derivation, freshness, dispose safety), the reducer, the status-bar formatter/source projection, and the correlation-cache invalidation. Full `EventLogExpert.Runtime.Tests` suite passes (2672), UI `StatusBarTests` pass (27), and the MAUI head builds clean.
