### PR TITLE
Fix large-log load UI freeze and harden live-tail watcher

### DIFF
--- a/src/EventLogExpert.Runtime/EventLog/AddEventAction.cs
+++ b/src/EventLogExpert.Runtime/EventLog/AddEventAction.cs
@@ -1,8 +1,9 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Eventing.Common.EventLogs;
 using EventLogExpert.Eventing.Common.Events;
 
 namespace EventLogExpert.Runtime.EventLog;
 
-internal sealed record AddEventAction(ResolvedEvent NewEvent);
+internal sealed record AddEventAction(ResolvedEvent NewEvent, EventLogId SourceLogId);

--- a/src/EventLogExpert.Runtime/EventLog/FilteringEffects.cs
+++ b/src/EventLogExpert.Runtime/EventLog/FilteringEffects.cs
@@ -45,8 +45,11 @@ internal sealed class FilteringEffects(
     [EffectMethod]
     public Task HandleAddEvent(AddEventAction action, IDispatcher dispatcher)
     {
+        // Drop a stale watcher's event: SourceLogId is the id the event's watcher was created for; if the open log
+        // under that name is now a different id (a same-name reopen), routing it here would misattribute it.
         if (!_eventLogState.Value.ContinuouslyUpdate ||
-            !_eventLogState.Value.OpenLogs.TryGetValue(action.NewEvent.OwningLog, out var owningLog))
+            !_eventLogState.Value.OpenLogs.TryGetValue(action.NewEvent.OwningLog, out var owningLog) ||
+            owningLog.Id != action.SourceLogId)
         {
             return Task.CompletedTask;
         }

--- a/src/EventLogExpert.Runtime/EventLog/ILogWatcherService.cs
+++ b/src/EventLogExpert.Runtime/EventLog/ILogWatcherService.cs
@@ -1,13 +1,15 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Eventing.Common.EventLogs;
+
 namespace EventLogExpert.Runtime.EventLog;
 
 public interface ILogWatcherService
 {
-    void AddLog(string logName, string? bookmark, bool renderXml = false);
+    void AddLog(string logName, EventLogId logId, string? bookmark, bool renderXml = false);
 
     Task RemoveAllAsync();
 
-    Task RemoveLogAsync(string logName);
+    Task RemoveLogAsync(string logName, EventLogId logId);
 }

--- a/src/EventLogExpert.Runtime/EventLog/LogWatcherService.cs
+++ b/src/EventLogExpert.Runtime/EventLog/LogWatcherService.cs
@@ -16,8 +16,8 @@ internal sealed class LogWatcherService : ILogWatcherService
     private readonly ITraceLogger _debugLogger;
     private readonly IDispatcher _dispatcher;
     private readonly List<string> _logsToWatch = [];
+    private readonly Dictionary<EventLogId, Task> _pendingDisposals = [];
     private readonly Dictionary<string, bool> _renderXmlByLog = [];
-    private readonly Dictionary<EventLogId, Task> _retiringWatchers = [];
     private readonly IServiceScopeFactory _serviceScopeFactory;
     private readonly Dictionary<string, EventLogId> _watchedLogIds = [];
     private readonly Dictionary<string, EventLogWatcher> _watchers = [];
@@ -39,8 +39,9 @@ internal sealed class LogWatcherService : ILogWatcherService
         {
             if (isFull)
             {
-                // Fire-and-forget: nothing downstream waits for the old per-event resolver scopes to finish disposing.
-                _ = StopAllWatchersAsync();
+                // Fire-and-forget stop; observe the aggregate so a disposal fault is logged, not an unobserved
+                // ThreadPool exception (observing the constituents does not observe the WhenAll aggregate).
+                ObserveFault(StopAllWatchersAsync());
             }
             else
             {
@@ -57,9 +58,9 @@ internal sealed class LogWatcherService : ILogWatcherService
             {
                 if (existingId == logId) { return; }
 
-                // Retire under the detach's lock so a concurrent close of the old id never sees a gap with neither
-                // the watcher nor its disposal.
-                if (DetachWatcher(logName) is { } staleWatcher) { RetireWatcher(existingId, logName, staleWatcher); }
+                // Register the displaced watcher's disposal under the detach's lock so a concurrent close of the old
+                // id never sees a gap with neither the watcher nor its disposal.
+                if (DetachWatcher(logName) is { } staleWatcher) { RegisterPendingDisposal(existingId, logName, staleWatcher); }
             }
 
             _watchedLogIds[logName] = logId;
@@ -78,47 +79,39 @@ internal sealed class LogWatcherService : ILogWatcherService
 
     public Task RemoveAllAsync()
     {
-        List<(string Name, EventLogWatcher Watcher)> detached = [];
-        List<Task> retiring;
-
         using (_watchersLock.EnterScope())
         {
-            // Snapshot: DetachWatcher mutates _logsToWatch below.
+            // Register every live watcher's disposal so close-all (and any concurrent single close) awaits it.
+            // DetachWatcher clears _watchedLogIds, so capture the id first; snapshot the names before iterating.
             foreach (var logName in _logsToWatch.ToArray())
             {
-                if (DetachWatcher(logName) is { } watcher) { detached.Add((logName, watcher)); }
+                var id = _watchedLogIds.TryGetValue(logName, out var watchedId) ? watchedId : default;
+
+                if (DetachWatcher(logName) is { } watcher) { RegisterPendingDisposal(id, logName, watcher); }
             }
 
-            // Also await any watcher already being disposed by a same-name replacement.
-            retiring = [.. _retiringWatchers.Values];
+            // Await every in-flight disposal (just-registered plus any prior replacement/buffer-full stop); the
+            // settlement continuation removes each on success.
+            return Task.WhenAll(_pendingDisposals.Values);
         }
-
-        List<Task> disposals = [];
-
-        foreach (var (name, watcher) in detached) { disposals.Add(DisposeWatcherAsync(name, watcher)); }
-
-        disposals.AddRange(retiring);
-
-        return Task.WhenAll(disposals);
     }
 
     public Task RemoveLogAsync(string logName, EventLogId logId)
     {
-        EventLogWatcher? watcher;
-
         using (_watchersLock.EnterScope())
         {
-            // A stale close for a prior open must not drop a same-name log reopened under a new id.
-            if (!_watchedLogIds.TryGetValue(logName, out var watchedId) || watchedId != logId)
+            // Register the live watcher's disposal (when this id is still the watched one) so a concurrent close-all
+            // sees it too; a stale close for a prior id just awaits any disposal already tracked for it.
+            if (_watchedLogIds.TryGetValue(logName, out var watchedId) && watchedId == logId &&
+                DetachWatcher(logName) is { } watcher)
             {
-                // If this id's watcher was displaced by a reopen, await its disposal so close still releases its handles.
-                return _retiringWatchers.TryGetValue(logId, out var retiring) ? retiring : Task.CompletedTask;
+                RegisterPendingDisposal(logId, logName, watcher);
             }
 
-            watcher = DetachWatcher(logName);
+            // Await whatever disposal is in flight for this id without claiming it; the settlement continuation
+            // removes it on success or retains a fault for a later close to observe.
+            return _pendingDisposals.TryGetValue(logId, out var pending) ? pending : Task.CompletedTask;
         }
-
-        return watcher is null ? Task.CompletedTask : DisposeWatcherAsync(logName, watcher);
     }
 
     // Call under _watchersLock; the caller disposes the returned watcher OFF the lock (deadlock rule).
@@ -134,21 +127,14 @@ internal sealed class LogWatcherService : ILogWatcherService
     }
 
     // Off-thread: EventLogWatcher.Unsubscribe blocks on in-flight callbacks that take _watchersLock, so disposing
-    // under the lock would deadlock.
+    // under the lock would deadlock. Faults propagate: an awaiting close (or the pending-disposal observer) must
+    // see a teardown failure rather than a false success.
     private Task DisposeWatcherAsync(string logName, EventLogWatcher watcher) =>
         Task.Run(() =>
         {
-            try
-            {
-                watcher.Dispose();
+            watcher.Dispose();
 
-                _debugLogger.Debug($"{nameof(LogWatcherService)} disposed the watcher for log {logName}.");
-            }
-            catch (Exception ex)
-            {
-                // Never fault: a fire-and-forget caller would surface an unobserved throw as an unhandled ThreadPool exception.
-                _debugLogger.Warning($"{nameof(LogWatcherService)} failed to dispose the watcher for log {logName}: {ex.Message}");
-            }
+            _debugLogger.Debug($"{nameof(LogWatcherService)} disposed the watcher for log {logName}.");
         });
 
     private bool IsWatching()
@@ -158,28 +144,47 @@ internal sealed class LogWatcherService : ILogWatcherService
         return _watchers.Keys.Count > 0;
     }
 
-    // Call under _watchersLock. Record the disposal BEFORE scheduling it so a concurrent close of the retired id can
-    // await teardown without leaking the entry.
-    private void RetireWatcher(EventLogId retiredId, string logName, EventLogWatcher watcher)
+    private void ObserveFault(Task task) =>
+        task.ContinueWith(
+            faulted => _debugLogger.Warning(
+                $"{nameof(LogWatcherService)} watcher teardown faulted: {faulted.Exception?.GetBaseException().Message}"),
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+
+    // Call under _watchersLock; the blocking Dispose runs off-lock (deadlock rule). Tracks the disposal by id so a
+    // later close awaits it, chaining onto any in-flight disposal for the same id (a buffer-full stop reuses the id).
+    // Success self-removes; a fault is RETAINED (a later close sees it, not a false CompletedTask) and logged.
+    private Task RegisterPendingDisposal(EventLogId id, string logName, EventLogWatcher watcher)
     {
-        var retirement = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        _retiringWatchers[retiredId] = retirement.Task;
+        var disposal = DisposeWatcherAsync(logName, watcher);
+        var tracked = _pendingDisposals.TryGetValue(id, out var existing) ? Task.WhenAll(existing, disposal) : disposal;
+        _pendingDisposals[id] = tracked;
 
-        _ = CompleteWhenDisposedAsync();
-
-        async Task CompleteWhenDisposedAsync()
-        {
-            try
+        tracked.ContinueWith(
+            completed =>
             {
-                await DisposeWatcherAsync(logName, watcher);
-            }
-            finally
-            {
-                using (_watchersLock.EnterScope()) { _retiringWatchers.Remove(retiredId); }
+                using (_watchersLock.EnterScope())
+                {
+                    if (completed.IsCompletedSuccessfully &&
+                        _pendingDisposals.TryGetValue(id, out var current) &&
+                        ReferenceEquals(current, completed))
+                    {
+                        _pendingDisposals.Remove(id);
+                    }
+                }
 
-                retirement.TrySetResult();
-            }
-        }
+                if (completed.IsFaulted)
+                {
+                    _debugLogger.Warning(
+                        $"{nameof(LogWatcherService)} failed to dispose a retired watcher for log {logName}: {completed.Exception?.GetBaseException().Message}");
+                }
+            },
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+
+        return tracked;
     }
 
     private void StartWatching()
@@ -197,6 +202,10 @@ internal sealed class LogWatcherService : ILogWatcherService
         using var scope = _watchersLock.EnterScope();
 
         if (_watchers.ContainsKey(logName)) { return; }
+
+        // The id the watcher is created for; stamped on every dispatched event so a stale watcher's events are
+        // dropped by the reopened log (they carry the old id) instead of being misrouted to it.
+        var watcherLogId = _watchedLogIds.TryGetValue(logName, out var currentId) ? currentId : default;
 
         bool renderXml = _renderXmlByLog.TryGetValue(logName, out var flag) && flag;
 
@@ -232,7 +241,7 @@ internal sealed class LogWatcherService : ILogWatcherService
                 return;
             }
 
-            _dispatcher.Dispatch(new AddEventAction(eventResolver.ResolveEvent(eventArgs)));
+            _dispatcher.Dispatch(new AddEventAction(eventResolver.ResolveEvent(eventArgs), watcherLogId));
         };
 
         // Enabling reads every event since the last bookmark; do it off the UI thread.
@@ -266,13 +275,14 @@ internal sealed class LogWatcherService : ILogWatcherService
 
     private Task StopWatchingAsync(string logName)
     {
-        EventLogWatcher? watcher;
+        using var scope = _watchersLock.EnterScope();
 
-        using (_watchersLock.EnterScope())
-        {
-            if (!_watchers.Remove(logName, out watcher)) { return Task.CompletedTask; }
-        }
+        if (!_watchers.Remove(logName, out var watcher)) { return Task.CompletedTask; }
 
-        return DisposeWatcherAsync(logName, watcher);
+        // The log stays watched (it can resume when the buffer clears), so track the disposal under its id: a close
+        // before it completes must still await the teardown. Reuses the id, so RegisterPendingDisposal chains.
+        var id = _watchedLogIds.TryGetValue(logName, out var watchedId) ? watchedId : default;
+
+        return RegisterPendingDisposal(id, logName, watcher);
     }
 }

--- a/src/EventLogExpert.Runtime/EventLog/LogWatcherService.cs
+++ b/src/EventLogExpert.Runtime/EventLog/LogWatcherService.cs
@@ -1,6 +1,7 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Eventing.Common.EventLogs;
 using EventLogExpert.Eventing.Readers;
 using EventLogExpert.Eventing.Resolvers;
 using EventLogExpert.Logging.Abstractions;
@@ -16,7 +17,9 @@ internal sealed class LogWatcherService : ILogWatcherService
     private readonly IDispatcher _dispatcher;
     private readonly List<string> _logsToWatch = [];
     private readonly Dictionary<string, bool> _renderXmlByLog = [];
+    private readonly Dictionary<EventLogId, Task> _retiringWatchers = [];
     private readonly IServiceScopeFactory _serviceScopeFactory;
+    private readonly Dictionary<string, EventLogId> _watchedLogIds = [];
     private readonly Dictionary<string, EventLogWatcher> _watchers = [];
     private readonly Lock _watchersLock = new();
 
@@ -36,9 +39,7 @@ internal sealed class LogWatcherService : ILogWatcherService
         {
             if (isFull)
             {
-                // Buffer-full is a state change, not a coordinated delete: fire-and-forget
-                // is fine because nothing downstream is waiting for the old per-event
-                // resolver scopes to finish disposing.
+                // Fire-and-forget: nothing downstream waits for the old per-event resolver scopes to finish disposing.
                 _ = StopAllWatchersAsync();
             }
             else
@@ -48,84 +49,137 @@ internal sealed class LogWatcherService : ILogWatcherService
         };
     }
 
-    public void AddLog(string logName, string? bookmark, bool renderXml = false)
+    public void AddLog(string logName, EventLogId logId, string? bookmark, bool renderXml = false)
     {
-        using var scope = _watchersLock.EnterScope();
-
-        if (_logsToWatch.Contains(logName))
+        using (_watchersLock.EnterScope())
         {
-            throw new InvalidOperationException(
-                $"Attempted to add log {logName} which is already present in {nameof(LogWatcherService)}.");
-        }
+            if (_watchedLogIds.TryGetValue(logName, out var existingId))
+            {
+                if (existingId == logId) { return; }
 
-        _logsToWatch.Add(logName);
-        _bookmarks.Add(logName, bookmark);
-        _renderXmlByLog[logName] = renderXml;
+                // Retire under the detach's lock so a concurrent close of the old id never sees a gap with neither
+                // the watcher nor its disposal.
+                if (DetachWatcher(logName) is { } staleWatcher) { RetireWatcher(existingId, logName, staleWatcher); }
+            }
 
-        // If this is the first log added, or if we're already watching
-        // other logs, then we need to start watching this one.
-        //
-        // If we have _logsToWatch but no watchers, that means StopAllWatchersAsync()
-        // was called due to a full buffer. In that case we do not want to
-        // start watching the new log.
-        if (_logsToWatch.Count == 1 || IsWatching())
-        {
-            StartWatching(logName);
+            _watchedLogIds[logName] = logId;
+
+            if (!_logsToWatch.Contains(logName)) { _logsToWatch.Add(logName); }
+
+            _bookmarks[logName] = bookmark;
+            _renderXmlByLog[logName] = renderXml;
+
+            if (_logsToWatch.Count == 1 || IsWatching())
+            {
+                StartWatching(logName);
+            }
         }
     }
 
     public Task RemoveAllAsync()
     {
-        List<string> logNames;
+        List<(string Name, EventLogWatcher Watcher)> detached = [];
+        List<Task> retiring;
 
         using (_watchersLock.EnterScope())
         {
-            // Snapshot the names before iterating so RemoveLogAsync can mutate
-            // _logsToWatch without invalidating our enumerator.
-            logNames = [.. _logsToWatch];
+            // Snapshot: DetachWatcher mutates _logsToWatch below.
+            foreach (var logName in _logsToWatch.ToArray())
+            {
+                if (DetachWatcher(logName) is { } watcher) { detached.Add((logName, watcher)); }
+            }
+
+            // Also await any watcher already being disposed by a same-name replacement.
+            retiring = [.. _retiringWatchers.Values];
         }
 
-        var tasks = new List<Task>(logNames.Count);
+        List<Task> disposals = [];
 
-        foreach (var logName in logNames)
-        {
-            tasks.Add(RemoveLogAsync(logName));
-        }
+        foreach (var (name, watcher) in detached) { disposals.Add(DisposeWatcherAsync(name, watcher)); }
 
-        return Task.WhenAll(tasks);
+        disposals.AddRange(retiring);
+
+        return Task.WhenAll(disposals);
     }
 
-    public Task RemoveLogAsync(string logName)
+    public Task RemoveLogAsync(string logName, EventLogId logId)
     {
         EventLogWatcher? watcher;
 
         using (_watchersLock.EnterScope())
         {
-            _logsToWatch.Remove(logName);
-            _bookmarks.Remove(logName);
-            _renderXmlByLog.Remove(logName);
+            // A stale close for a prior open must not drop a same-name log reopened under a new id.
+            if (!_watchedLogIds.TryGetValue(logName, out var watchedId) || watchedId != logId)
+            {
+                // If this id's watcher was displaced by a reopen, await its disposal so close still releases its handles.
+                return _retiringWatchers.TryGetValue(logId, out var retiring) ? retiring : Task.CompletedTask;
+            }
 
-            if (!_watchers.Remove(logName, out watcher)) { return Task.CompletedTask; }
+            watcher = DetachWatcher(logName);
         }
 
-        // Always dispose on a background thread to avoid a deadlock if this is
-        // called on the UI thread. EventLogWatcher.Unsubscribe blocks until all
-        // in-flight ReadAndRaiseEvents callbacks have completed (so the per-event
-        // service scopes — and the SQLite handles they hold — are released
-        // before this Task completes).
-        return Task.Run(() =>
-        {
-            watcher.Dispose();
-
-            _debugLogger.Debug($"{nameof(LogWatcherService)} disposed the old watcher for log {logName}.");
-        });
+        return watcher is null ? Task.CompletedTask : DisposeWatcherAsync(logName, watcher);
     }
+
+    // Call under _watchersLock; the caller disposes the returned watcher OFF the lock (deadlock rule).
+    private EventLogWatcher? DetachWatcher(string logName)
+    {
+        _logsToWatch.Remove(logName);
+        _bookmarks.Remove(logName);
+        _renderXmlByLog.Remove(logName);
+        _watchedLogIds.Remove(logName);
+        _watchers.Remove(logName, out var watcher);
+
+        return watcher;
+    }
+
+    // Off-thread: EventLogWatcher.Unsubscribe blocks on in-flight callbacks that take _watchersLock, so disposing
+    // under the lock would deadlock.
+    private Task DisposeWatcherAsync(string logName, EventLogWatcher watcher) =>
+        Task.Run(() =>
+        {
+            try
+            {
+                watcher.Dispose();
+
+                _debugLogger.Debug($"{nameof(LogWatcherService)} disposed the watcher for log {logName}.");
+            }
+            catch (Exception ex)
+            {
+                // Never fault: a fire-and-forget caller would surface an unobserved throw as an unhandled ThreadPool exception.
+                _debugLogger.Warning($"{nameof(LogWatcherService)} failed to dispose the watcher for log {logName}: {ex.Message}");
+            }
+        });
 
     private bool IsWatching()
     {
         using var scope = _watchersLock.EnterScope();
 
         return _watchers.Keys.Count > 0;
+    }
+
+    // Call under _watchersLock. Record the disposal BEFORE scheduling it so a concurrent close of the retired id can
+    // await teardown without leaking the entry.
+    private void RetireWatcher(EventLogId retiredId, string logName, EventLogWatcher watcher)
+    {
+        var retirement = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _retiringWatchers[retiredId] = retirement.Task;
+
+        _ = CompleteWhenDisposedAsync();
+
+        async Task CompleteWhenDisposedAsync()
+        {
+            try
+            {
+                await DisposeWatcherAsync(logName, watcher);
+            }
+            finally
+            {
+                using (_watchersLock.EnterScope()) { _retiringWatchers.Remove(retiredId); }
+
+                retirement.TrySetResult();
+            }
+        }
     }
 
     private void StartWatching()
@@ -170,11 +224,8 @@ internal sealed class LogWatcherService : ILogWatcherService
 
             using var scope = _watchersLock.EnterScope();
 
-            // Guard against stale callbacks: a watcher being disposed asynchronously
-            // can still be mid-loop processing buffered events with the old renderXml
-            // setting. If the active watcher for this log is no longer this instance,
-            // discard the event so it doesn't pollute the re-opened log with the
-            // wrong XML state.
+            // Drop events from a watcher being disposed asynchronously: it may still be mid-loop with the old
+            // renderXml and would pollute the reopened log.
             if (!_watchers.TryGetValue(logName, out var activeWatcher) ||
                 !ReferenceEquals(activeWatcher, watcher))
             {
@@ -184,9 +235,7 @@ internal sealed class LogWatcherService : ILogWatcherService
             _dispatcher.Dispatch(new AddEventAction(eventResolver.ResolveEvent(eventArgs)));
         };
 
-        // When the watcher is enabled, it reads all the events since the
-        // last bookmark. Do this on a background thread so we don't tie
-        // up the UI.
+        // Enabling reads every event since the last bookmark; do it off the UI thread.
         Task.Run(() =>
         {
             watcher.Enabled = true;
@@ -201,7 +250,7 @@ internal sealed class LogWatcherService : ILogWatcherService
 
         using (_watchersLock.EnterScope())
         {
-            // Snapshot keys before iterating; StopWatchingAsync mutates the dict.
+            // Snapshot: StopWatchingAsync mutates _watchers below.
             logNames = [.. _watchers.Keys];
         }
 
@@ -224,11 +273,6 @@ internal sealed class LogWatcherService : ILogWatcherService
             if (!_watchers.Remove(logName, out watcher)) { return Task.CompletedTask; }
         }
 
-        return Task.Run(() =>
-        {
-            watcher.Dispose();
-
-            _debugLogger.Debug($"{nameof(LogWatcherService)} disposed the old watcher for log {logName}.");
-        });
+        return DisposeWatcherAsync(logName, watcher);
     }
 }

--- a/src/EventLogExpert.Runtime/EventLog/OpenLogEffects.cs
+++ b/src/EventLogExpert.Runtime/EventLog/OpenLogEffects.cs
@@ -82,7 +82,16 @@ internal sealed class OpenLogEffects(
         _concurrencyState.ClearAllLoadedWithXml();
         _closeCoordinator.ClearAllPendingRestore();
 
-        await _logWatcherService.RemoveAllAsync();
+        try
+        {
+            await _logWatcherService.RemoveAllAsync();
+        }
+        catch (Exception ex)
+        {
+            // Log-and-proceed: a watcher teardown fault should not surface as an unhandled effect exception; the
+            // close-all state was already cleared above.
+            _logger.Error($"{nameof(HandleCloseAll)}: watcher teardown faulted: {ex.Message}");
+        }
     }
 
     [EffectMethod]
@@ -112,7 +121,17 @@ internal sealed class OpenLogEffects(
                 }
             }
 
-            await _logWatcherService.RemoveLogAsync(action.LogName, action.LogId);
+            try
+            {
+                await _logWatcherService.RemoveLogAsync(action.LogName, action.LogId);
+            }
+            catch (Exception ex)
+            {
+                // A watcher teardown fault must not strand the rest of the close (state cleanup, CloseLogAction,
+                // reopen-waiter signal). Proceed and log; a leaked native handle is not actionable here since a
+                // reopen builds a fresh reader.
+                _logger.Error($"{nameof(HandleCloseLog)}: watcher teardown for '{action.LogName}' faulted: {ex.Message}");
+            }
 
             if (!(_eventLogState.Value.OpenLogs.TryGetValue(action.LogName, out var activeLog) && activeLog.Id != action.LogId))
             {

--- a/src/EventLogExpert.Runtime/EventLog/OpenLogEffects.cs
+++ b/src/EventLogExpert.Runtime/EventLog/OpenLogEffects.cs
@@ -112,9 +112,10 @@ internal sealed class OpenLogEffects(
                 }
             }
 
+            await _logWatcherService.RemoveLogAsync(action.LogName, action.LogId);
+
             if (!(_eventLogState.Value.OpenLogs.TryGetValue(action.LogName, out var activeLog) && activeLog.Id != action.LogId))
             {
-                await _logWatcherService.RemoveLogAsync(action.LogName);
                 _closeCoordinator.ClearPendingRestore(action.LogName);
                 _xmlResolver.ClearXmlCacheForLog(action.LogName);
             }
@@ -243,6 +244,19 @@ internal sealed class OpenLogEffects(
                 loadComplete.TrySetResult();
             }
         }
+    }
+
+    [EffectMethod]
+    public Task HandleRegisterLiveTail(RegisterLiveTailAction action, IDispatcher dispatcher)
+    {
+        // Register only if this exact log is still open, so a close that drained first is not undone by a late register.
+        if (_eventLogState.Value.OpenLogs.TryGetValue(action.LogData.Name, out var active) &&
+            active.Id == action.LogData.Id)
+        {
+            _logWatcherService.AddLog(action.LogData.Name, action.LogData.Id, action.Bookmark, action.RenderXml);
+        }
+
+        return Task.CompletedTask;
     }
 
     private static string DescribeLog(OpenLogAction action) =>
@@ -534,11 +548,16 @@ internal sealed class OpenLogEffects(
                 _concurrencyState.MarkLoadedWithXml(logData.Id);
             }
 
-            dispatcher.Dispatch(new LoadEventsAction(logData, events.AsReadOnly()));
+            // Offload the O(N) LoadEventsAction reducers (EventColumnStore.Build + counts) via Task.Run so they run
+            // off the UI thread instead of freezing it; a concurrent Fluxor drain can still strand them (guaranteed
+            // off-thread build deferred).
+            await Task.Run(() => dispatcher.Dispatch(new LoadEventsAction(logData, events.AsReadOnly())));
 
             if (action.LogPathType == LogPathType.Channel)
             {
-                _logWatcherService.AddLog(action.LogName, lastEvent, renderXml);
+                // Route via an action so HandleRegisterLiveTail re-checks OpenLogs; a concurrent close can't leave a
+                // watcher on a closed log.
+                dispatcher.Dispatch(new RegisterLiveTailAction(logData, lastEvent, renderXml));
             }
 
             dispatcher.Dispatch(new SetResolverStatusAction(string.Empty));

--- a/src/EventLogExpert.Runtime/EventLog/Reducers.cs
+++ b/src/EventLogExpert.Runtime/EventLog/Reducers.cs
@@ -21,7 +21,11 @@ internal sealed class Reducers
     [ReducerMethod]
     public static EventLogState ReduceAddEvent(EventLogState state, AddEventAction action)
     {
-        if (state.ContinuouslyUpdate || !state.OpenLogs.ContainsKey(action.NewEvent.OwningLog))
+        // Same id-guard as the live path (HandleAddEvent): a stale watcher's event (SourceLogId) must not be buffered
+        // into a same-name log reopened under a new id, which the paused-buffer flush re-attributes by name.
+        if (state.ContinuouslyUpdate ||
+            !state.OpenLogs.TryGetValue(action.NewEvent.OwningLog, out var owningLog) ||
+            owningLog.Id != action.SourceLogId)
         {
             return state;
         }

--- a/src/EventLogExpert.Runtime/EventLog/Reducers.cs
+++ b/src/EventLogExpert.Runtime/EventLog/Reducers.cs
@@ -124,31 +124,6 @@ internal sealed class Reducers
     }
 
     [ReducerMethod]
-    public static EventLogState ReduceLoadEventsPartial(EventLogState state, LoadEventsPartialAction action)
-    {
-        if (!state.OpenLogs.TryGetValue(action.LogData.Name, out var existingLog) ||
-            existingLog.Id != action.LogData.Id ||
-            action.LogData.Type != LogPathType.File)
-        {
-            return state;
-        }
-
-        var existingSet = state.NamesByLog.TryGetValue(action.LogData.Name, out var current) ? current : s_emptyNames;
-
-        var newSet = existingSet.Union(DistinctLogNames(action.Events));
-
-        if (ReferenceEquals(newSet, existingSet)) { return state; }
-
-        var newNamesByLog = state.NamesByLog.SetItem(action.LogData.Name, newSet);
-
-        return state with
-        {
-            NamesByLog = newNamesByLog,
-            LoadedLogNames = RecomputeLoadedLogNames(newNamesByLog, state.LoadedLogNames)
-        };
-    }
-
-    [ReducerMethod]
     public static EventLogState ReduceNewEventBufferConsumed(EventLogState state, NewEventBufferConsumedAction action)
     {
         if (action.ConsumedEvents.Count == 0) { return state; }

--- a/src/EventLogExpert.Runtime/EventLog/RegisterLiveTailAction.cs
+++ b/src/EventLogExpert.Runtime/EventLog/RegisterLiveTailAction.cs
@@ -1,0 +1,8 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.EventLogs;
+
+namespace EventLogExpert.Runtime.EventLog;
+
+internal sealed record RegisterLiveTailAction(EventLogData LogData, string? Bookmark, bool RenderXml);

--- a/src/EventLogExpert.Runtime/LogTable/Reducers.cs
+++ b/src/EventLogExpert.Runtime/LogTable/Reducers.cs
@@ -176,16 +176,6 @@ internal sealed class Reducers
     }
 
     [ReducerMethod]
-    public static LogTableState ReduceLoadEventsPartial(LogTableState state, LoadEventsPartialAction action)
-    {
-        if (action.Events.Count == 0) { return state; }
-
-        var tables = LatchComputerNameForLog(state.EventTables, action.LogData.Id, action.Events);
-
-        return ReferenceEquals(tables, state.EventTables) ? state : state with { EventTables = tables };
-    }
-
-    [ReducerMethod]
     public static LogTableState ReduceMoveTabToGroup(LogTableState state, MoveTabToGroupAction action)
     {
         var tab = state.EventTables.FirstOrDefault(table => table.Id == action.TabId);

--- a/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EffectsTests.cs
@@ -58,7 +58,7 @@ public sealed class EffectsTests
 
         pending.Enqueue(new IngestRawEventsAction(rawByLog, RawIngestMode.Prepend));
         pending.Enqueue(new NewEventBufferConsumedAction(snapshot));
-        pending.Enqueue(new AddEventAction(eventB));
+        pending.Enqueue(new AddEventAction(eventB, logData.Id));
 
         while (pending.Count > 0)
         {
@@ -91,7 +91,7 @@ public sealed class EffectsTests
 
         var newEvent = FilterEventBuilder.CreateTestEvent(100, logName: Constants.LogNameTestLog);
 
-        await effects.HandleAddEvent(new AddEventAction(newEvent), mockDispatcher);
+        await effects.HandleAddEvent(new AddEventAction(newEvent, logData.Id), mockDispatcher);
 
         mockDispatcher.DidNotReceive().Dispatch(Arg.Any<object>());
     }
@@ -123,7 +123,7 @@ public sealed class EffectsTests
         var pending = CaptureDispatchQueue(mockDispatcher);
         var newEvent = FilterEventBuilder.CreateTestEvent(100, logName: Constants.LogNameTestLog);
 
-        await effects.HandleAddEvent(new AddEventAction(newEvent), mockDispatcher);
+        await effects.HandleAddEvent(new AddEventAction(newEvent, logData.Id), mockDispatcher);
         await DrainDispatchQueueAsync(pending, effects, mockDispatcher, () => rawState, r => rawState = r);
 
         mockDispatcher.DidNotReceive().Dispatch(Arg.Any<NewEventBufferConsumedAction>());
@@ -143,7 +143,7 @@ public sealed class EffectsTests
 
         var newEvent = FilterEventBuilder.CreateTestEvent(100, logName: Constants.LogNameTestLog);
 
-        await effects.HandleAddEvent(new AddEventAction(newEvent), mockDispatcher);
+        await effects.HandleAddEvent(new AddEventAction(newEvent, logData.Id), mockDispatcher);
 
         mockDispatcher.Received(1).Dispatch(Arg.Is<IngestRawEventsAction>(a => a != null &&
             a.Mode == RawIngestMode.Prepend && a.EventsByLog.ContainsKey(logData.Id)));
@@ -171,7 +171,7 @@ public sealed class EffectsTests
         var (effects, mockDispatcher, _) = CreateEffectsWithMutableState(() => state, () => rawState);
 
         var newEvent = FilterEventBuilder.CreateTestEvent(100, logName: Constants.LogNameTestLog);
-        var action = new AddEventAction(newEvent);
+        var action = new AddEventAction(newEvent, logData.Id);
 
         await effects.HandleAddEvent(action, mockDispatcher);
 
@@ -184,9 +184,38 @@ public sealed class EffectsTests
     {
         var (effects, mockDispatcher) = CreateEffects();
         var newEvent = FilterEventBuilder.CreateTestEvent(100, logName: Constants.LogNameTestLog);
-        var action = new AddEventAction(newEvent);
+        var action = new AddEventAction(newEvent, EventLogId.Create());
 
         await effects.HandleAddEvent(action, mockDispatcher);
+
+        mockDispatcher.DidNotReceive().Dispatch(Arg.Any<object>());
+    }
+
+    [Fact]
+    public async Task HandleAddEvent_WhenSourceLogIdMismatchesOpenLog_ShouldNotDispatch()
+    {
+        // A stale watcher's event (old id) must not be routed into a same-name log reopened under a new id.
+        var reopenedId = EventLogId.Create();
+
+        var state = new EventLogState
+        {
+            ContinuouslyUpdate = true,
+            OpenLogs = ImmutableDictionary<string, OpenLogInfo>.Empty
+                .Add(Constants.LogNameTestLog, new OpenLogInfo(reopenedId, LogPathType.Channel)),
+            NewEventBuffer = [],
+            AppliedFilter = new Filter(null, [])
+        };
+
+        var rawState = new RawEventStoreState
+        {
+            ByLog = ImmutableDictionary<EventLogId, EventColumnStore>.Empty.Add(reopenedId, EventColumnStore.Empty)
+        };
+
+        var (effects, mockDispatcher, _) = CreateEffectsWithMutableState(() => state, () => rawState);
+
+        var staleEvent = FilterEventBuilder.CreateTestEvent(100, logName: Constants.LogNameTestLog);
+
+        await effects.HandleAddEvent(new AddEventAction(staleEvent, EventLogId.Create()), mockDispatcher);
 
         mockDispatcher.DidNotReceive().Dispatch(Arg.Any<object>());
     }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EffectsTests.cs
@@ -258,7 +258,7 @@ public sealed class EffectsTests
         var mockFilterService = Substitute.For<IFilterService>();
         var mockLogWatcher = Substitute.For<ILogWatcherService>();
         var watcherCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        mockLogWatcher.RemoveLogAsync(Arg.Any<string>()).Returns(watcherCompletion.Task);
+        mockLogWatcher.RemoveLogAsync(Arg.Any<string>(), Arg.Any<EventLogId>()).Returns(watcherCompletion.Task);
         mockLogWatcher.RemoveAllAsync().Returns(Task.CompletedTask);
 
         var mockServiceScopeFactory = Substitute.For<IServiceScopeFactory>();
@@ -324,7 +324,7 @@ public sealed class EffectsTests
         var (effects, mockDispatcher, mockLogWatcher, _, _) = CreateEffectsWithServices(activeLogs: activeLogs, appliedFilter: XmlContainsFilter());
 
         var watcherCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        mockLogWatcher.RemoveLogAsync(Arg.Any<string>()).Returns(watcherCompletion.Task);
+        mockLogWatcher.RemoveLogAsync(Arg.Any<string>(), Arg.Any<EventLogId>()).Returns(watcherCompletion.Task);
 
         var closeTasks = new List<Task>();
 
@@ -418,7 +418,7 @@ public sealed class EffectsTests
         var (effects, mockDispatcher, mockLogWatcher, _, _) = CreateEffectsWithServices(activeLogs: activeLogs, appliedFilter: XmlContainsFilter());
 
         var watcherCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        mockLogWatcher.RemoveLogAsync(Arg.Any<string>()).Returns(watcherCompletion.Task);
+        mockLogWatcher.RemoveLogAsync(Arg.Any<string>(), Arg.Any<EventLogId>()).Returns(watcherCompletion.Task);
 
         var closeTasks = new List<Task>();
 
@@ -540,7 +540,7 @@ public sealed class EffectsTests
         var (effects, mockDispatcher, mockLogWatcher, _, _) = CreateEffectsWithServices(activeLogs: activeLogs, appliedFilter: XmlContainsFilter());
 
         var watcherCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        mockLogWatcher.RemoveLogAsync(Arg.Any<string>()).Returns(watcherCompletion.Task);
+        mockLogWatcher.RemoveLogAsync(Arg.Any<string>(), Arg.Any<EventLogId>()).Returns(watcherCompletion.Task);
 
         var closeTasks = new List<Task>();
 
@@ -648,7 +648,7 @@ public sealed class EffectsTests
         var (effects, mockDispatcher, mockLogWatcher, _, _) = CreateEffectsWithServices();
 
         var watcherTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        mockLogWatcher.RemoveLogAsync(Arg.Any<string>()).Returns(watcherTcs.Task);
+        mockLogWatcher.RemoveLogAsync(Arg.Any<string>(), Arg.Any<EventLogId>()).Returns(watcherTcs.Task);
 
         var logId = EventLogId.Create();
         var action = new CloseLogAction(logId, Constants.LogNameTestLog);
@@ -714,7 +714,7 @@ public sealed class EffectsTests
 
         await effects.HandleCloseLog(action, mockDispatcher);
 
-        await mockLogWatcher.Received(1).RemoveLogAsync(Constants.LogNameTestLog);
+        await mockLogWatcher.Received(1).RemoveLogAsync(Constants.LogNameTestLog, logId);
 
         mockDispatcher.Received(1)
             .Dispatch(Arg.Is<Runtime.LogTable.CloseLogAction>(a => a != null &&
@@ -1049,11 +1049,12 @@ public sealed class EffectsTests
     {
         var fakeFactory = new FakeEventLogReaderFactory(new FakeEventLogReader([], newestBookmark: null));
 
-        var (openLog, dispatcher, watcher) = CreateEagerLoadEffects(fakeFactory);
+        var (openLog, dispatcher, _) = CreateEagerLoadEffects(fakeFactory);
 
         await openLog.HandleOpenLog(new OpenLogAction(Constants.LogNameApplication, LogPathType.Channel), dispatcher);
 
-        watcher.Received(1).AddLog(Constants.LogNameApplication, null, Arg.Any<bool>());
+        dispatcher.Received(1).Dispatch(Arg.Is<RegisterLiveTailAction>(a => a != null &&
+            a.LogData.Name == Constants.LogNameApplication && a.Bookmark == null));
         Assert.Empty(SingleFinalEvents(dispatcher));
     }
 
@@ -1188,11 +1189,12 @@ public sealed class EffectsTests
         var fakeFactory = new FakeEventLogReaderFactory(
             new FakeEventLogReader(BuildReverseBatches(50, batchSize: 30), newestBookmark: "NEWEST_BOOKMARK"));
 
-        var (openLog, dispatcher, watcher) = CreateEagerLoadEffects(fakeFactory);
+        var (openLog, dispatcher, _) = CreateEagerLoadEffects(fakeFactory);
 
         await openLog.HandleOpenLog(new OpenLogAction(Constants.LogNameApplication, LogPathType.Channel), dispatcher);
 
-        watcher.Received(1).AddLog(Constants.LogNameApplication, "NEWEST_BOOKMARK", Arg.Any<bool>());
+        dispatcher.Received(1).Dispatch(Arg.Is<RegisterLiveTailAction>(a => a != null &&
+            a.LogData.Name == Constants.LogNameApplication && a.Bookmark == "NEWEST_BOOKMARK"));
 
         Assert.True(fakeFactory.ReverseDirectionRequested);
     }
@@ -1247,7 +1249,8 @@ public sealed class EffectsTests
         dispatcher.Received().Dispatch(Arg.Is<SetResolverStatusAction>(a => a != null &&
             a.ResolverStatus.Contains("Error") && a.ResolverStatus.Contains(Constants.LogNameApplication)));
         Assert.Empty(dispatcher.ReceivedCalls().Select(call => call.GetArguments()[0]).OfType<LoadEventsAction>());
-        watcher.DidNotReceive().AddLog(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
+        watcher.DidNotReceive().AddLog(Arg.Any<string>(), Arg.Any<EventLogId>(), Arg.Any<string>(), Arg.Any<bool>());
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<RegisterLiveTailAction>());
     }
 
     [Fact]
@@ -1348,6 +1351,50 @@ public sealed class EffectsTests
         dispatcher.Received(1).Dispatch(Arg.Any<ClearStatusAction>());
         dispatcher.Received().Dispatch(Arg.Any<CloseLogAction>());
         dispatcher.Received().Dispatch(Arg.Is<SetResolverStatusAction>(action => action != null && action.ResolverStatus.Contains("Error")));
+    }
+
+    [Fact]
+    public async Task HandleRegisterLiveTail_WhenLogClosed_DoesNotRegisterWatcher()
+    {
+        var logData = new EventLogData(Constants.LogNameTestLog, LogPathType.Channel);
+        var (effects, _, watcher, _, _) = CreateEffectsWithServices();
+
+        await effects.OpenLog.HandleRegisterLiveTail(
+            new RegisterLiveTailAction(logData, "BOOKMARK", RenderXml: true),
+            Substitute.For<IDispatcher>());
+
+        watcher.DidNotReceive().AddLog(Arg.Any<string>(), Arg.Any<EventLogId>(), Arg.Any<string>(), Arg.Any<bool>());
+    }
+
+    [Fact]
+    public async Task HandleRegisterLiveTail_WhenLogReplacedByNewerId_DoesNotRegisterWatcher()
+    {
+        var openLogData = new EventLogData(Constants.LogNameTestLog, LogPathType.Channel);
+        var activeLogs = ImmutableDictionary<string, EventLogData>.Empty.Add(Constants.LogNameTestLog, openLogData);
+        var (effects, _, watcher, _, _) = CreateEffectsWithServices(activeLogs: activeLogs);
+
+        var staleLogData = new EventLogData(Constants.LogNameTestLog, LogPathType.Channel);
+        Assert.NotEqual(openLogData.Id, staleLogData.Id);
+
+        await effects.OpenLog.HandleRegisterLiveTail(
+            new RegisterLiveTailAction(staleLogData, "BOOKMARK", RenderXml: true),
+            Substitute.For<IDispatcher>());
+
+        watcher.DidNotReceive().AddLog(Arg.Any<string>(), Arg.Any<EventLogId>(), Arg.Any<string>(), Arg.Any<bool>());
+    }
+
+    [Fact]
+    public async Task HandleRegisterLiveTail_WhenLogStillOpenWithSameId_RegistersWatcher()
+    {
+        var logData = new EventLogData(Constants.LogNameTestLog, LogPathType.Channel);
+        var activeLogs = ImmutableDictionary<string, EventLogData>.Empty.Add(Constants.LogNameTestLog, logData);
+        var (effects, _, watcher, _, _) = CreateEffectsWithServices(activeLogs: activeLogs);
+
+        await effects.OpenLog.HandleRegisterLiveTail(
+            new RegisterLiveTailAction(logData, "BOOKMARK", RenderXml: true),
+            Substitute.For<IDispatcher>());
+
+        watcher.Received(1).AddLog(Constants.LogNameTestLog, logData.Id, "BOOKMARK", true);
     }
 
     [Fact]
@@ -1629,7 +1676,7 @@ public sealed class EffectsTests
         databaseService.InitialClassificationTask.Returns(Task.CompletedTask);
 
         var watcher = Substitute.For<ILogWatcherService>();
-        watcher.RemoveLogAsync(Arg.Any<string>()).Returns(Task.CompletedTask);
+        watcher.RemoveLogAsync(Arg.Any<string>(), Arg.Any<EventLogId>()).Returns(Task.CompletedTask);
         watcher.RemoveAllAsync().Returns(Task.CompletedTask);
 
         var dispatcher = Substitute.For<IDispatcher>();
@@ -1683,7 +1730,7 @@ public sealed class EffectsTests
 
         var mockLogger = Substitute.For<ITraceLogger>();
         var mockLogWatcherService = Substitute.For<ILogWatcherService>();
-        mockLogWatcherService.RemoveLogAsync(Arg.Any<string>()).Returns(Task.CompletedTask);
+        mockLogWatcherService.RemoveLogAsync(Arg.Any<string>(), Arg.Any<EventLogId>()).Returns(Task.CompletedTask);
         mockLogWatcherService.RemoveAllAsync().Returns(Task.CompletedTask);
         var mockResolverCache = Substitute.For<IEventResolverCache>();
 
@@ -1870,7 +1917,7 @@ public sealed class EffectsTests
 
         var mockLogger = Substitute.For<ITraceLogger>();
         var mockLogWatcherService = Substitute.For<ILogWatcherService>();
-        mockLogWatcherService.RemoveLogAsync(Arg.Any<string>()).Returns(Task.CompletedTask);
+        mockLogWatcherService.RemoveLogAsync(Arg.Any<string>(), Arg.Any<EventLogId>()).Returns(Task.CompletedTask);
         mockLogWatcherService.RemoveAllAsync().Returns(Task.CompletedTask);
         var mockResolverCache = Substitute.For<IEventResolverCache>();
 

--- a/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EventLogLoadedLogNamesReducersTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EventLogLoadedLogNamesReducersTests.cs
@@ -127,19 +127,6 @@ public sealed class EventLogLoadedLogNamesReducersTests
     }
 
     [Fact]
-    public void ReduceLoadEventsPartial_File_UnionsPerLogNames()
-    {
-        var state = Reducers.ReduceOpenLog(new EventLogState(), new OpenLogAction(FileA, LogPathType.File));
-        var logData = new EventLogData(FileA, LogPathType.File) { Id = state.OpenLogs[FileA].Id };
-
-        state = Reducers.ReduceLoadEvents(state, new LoadEventsAction(logData, EventsWithLogNames("Security")));
-        state = Reducers.ReduceLoadEventsPartial(state, new LoadEventsPartialAction(logData, EventsWithLogNames("Setup")));
-
-        Assert.Equal(["Security", "Setup"], state.NamesByLog[FileA].OrderBy(name => name, StringComparer.Ordinal));
-        Assert.Equal(["Security", "Setup"], state.LoadedLogNames.OrderBy(name => name, StringComparer.Ordinal));
-    }
-
-    [Fact]
     public void ReduceOpenLog_AfterClose_ReopensWithSeededNames()
     {
         var state = Reducers.ReduceOpenLog(new EventLogState(), new OpenLogAction(ChannelName, LogPathType.Channel));

--- a/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EventLogReducerRegistrationTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EventLogReducerRegistrationTests.cs
@@ -24,18 +24,20 @@ public sealed class EventLogReducerRegistrationTests
 
         var feature = provider.GetRequiredService<IFeature<EventLogState>>();
 
+        var logId = EventLogId.Create();
+
         feature.RestoreState(feature.State with
         {
             ContinuouslyUpdate = false,
             OpenLogs = ImmutableDictionary<string, OpenLogInfo>.Empty
-                .Add(Constants.LogNameTestLog, new OpenLogInfo(EventLogId.Create(), LogPathType.Channel))
+                .Add(Constants.LogNameTestLog, new OpenLogInfo(logId, LogPathType.Channel))
         });
 
         var first = FilterEventBuilder.CreateTestEvent(100, owningLog: Constants.LogNameTestLog);
         var second = FilterEventBuilder.CreateTestEvent(200, owningLog: Constants.LogNameTestLog);
 
-        feature.ReceiveDispatchNotificationFromStore(new AddEventAction(first));
-        feature.ReceiveDispatchNotificationFromStore(new AddEventAction(second));
+        feature.ReceiveDispatchNotificationFromStore(new AddEventAction(first, logId));
+        feature.ReceiveDispatchNotificationFromStore(new AddEventAction(second, logId));
 
         Assert.Equal(2, feature.State.NewEventBuffer.Count);
         Assert.Same(second, feature.State.NewEventBuffer[0]);

--- a/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EventLogStoreTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EventLogStoreTests.cs
@@ -30,8 +30,8 @@ public sealed class EventLogStoreTests
         };
 
         // Act: buffer two events additively (newest first).
-        state = Reducers.ReduceAddEvent(state, new AddEventAction(FilterEventBuilder.CreateTestEvent(100, logName: Constants.LogNameTestLog)));
-        state = Reducers.ReduceAddEvent(state, new AddEventAction(FilterEventBuilder.CreateTestEvent(200, logName: Constants.LogNameTestLog)));
+        state = Reducers.ReduceAddEvent(state, new AddEventAction(FilterEventBuilder.CreateTestEvent(100, logName: Constants.LogNameTestLog), logData.Id));
+        state = Reducers.ReduceAddEvent(state, new AddEventAction(FilterEventBuilder.CreateTestEvent(200, logName: Constants.LogNameTestLog), logData.Id));
 
         // Assert
         Assert.Equal(2, state.NewEventBuffer.Count);
@@ -276,8 +276,8 @@ public sealed class EventLogStoreTests
 
         // Act: each add composes against current state, so the second cannot clobber the first (the pre-fix whole-buffer
         // effect write could).
-        state = Reducers.ReduceAddEvent(state, new AddEventAction(first));
-        state = Reducers.ReduceAddEvent(state, new AddEventAction(second));
+        state = Reducers.ReduceAddEvent(state, new AddEventAction(first, logData.Id));
+        state = Reducers.ReduceAddEvent(state, new AddEventAction(second, logData.Id));
 
         // Assert
         Assert.Equal(2, state.NewEventBuffer.Count);
@@ -299,7 +299,7 @@ public sealed class EventLogStoreTests
 
         // Act
         var result = Reducers.ReduceAddEvent(
-            state, new AddEventAction(FilterEventBuilder.CreateTestEvent(100, logName: Constants.LogNameTestLog)));
+            state, new AddEventAction(FilterEventBuilder.CreateTestEvent(100, logName: Constants.LogNameTestLog), logData.Id));
 
         // Assert: buffering is the live-tail effect's job when continuously updating, not the reducer's.
         Assert.Same(state, result);
@@ -314,7 +314,7 @@ public sealed class EventLogStoreTests
 
         // Act
         var result = Reducers.ReduceAddEvent(
-            state, new AddEventAction(FilterEventBuilder.CreateTestEvent(100, logName: Constants.LogNameTestLog)));
+            state, new AddEventAction(FilterEventBuilder.CreateTestEvent(100, logName: Constants.LogNameTestLog), EventLogId.Create()));
 
         // Assert
         Assert.Same(state, result);
@@ -341,12 +341,34 @@ public sealed class EventLogStoreTests
         var newEvent = FilterEventBuilder.CreateTestEvent(9999, logName: Constants.LogNameTestLog);
 
         // Act
-        var result = Reducers.ReduceAddEvent(state, new AddEventAction(newEvent));
+        var result = Reducers.ReduceAddEvent(state, new AddEventAction(newEvent, logData.Id));
 
         // Assert: prepended (newest first) and the full flag recomputed.
         Assert.Equal(EventLogState.MaxNewEvents, result.NewEventBuffer.Count);
         Assert.Same(newEvent, result.NewEventBuffer[0]);
         Assert.True(result.NewEventBufferIsFull);
+    }
+
+    [Fact]
+    public void ReduceAddEvent_WhenSourceLogIdMismatchesOpenLog_DoesNotBuffer()
+    {
+        // A stale watcher's event (old id) must not be buffered into a same-name log reopened under a new id.
+        var reopenedId = EventLogId.Create();
+        var staleId = EventLogId.Create();
+
+        var state = new EventLogState
+        {
+            ContinuouslyUpdate = false,
+            OpenLogs = ImmutableDictionary<string, OpenLogInfo>.Empty
+                .Add(Constants.LogNameTestLog, new OpenLogInfo(reopenedId, LogPathType.Channel))
+        };
+
+        var staleEvent = FilterEventBuilder.CreateTestEvent(100, logName: Constants.LogNameTestLog);
+
+        var result = Reducers.ReduceAddEvent(state, new AddEventAction(staleEvent, staleId));
+
+        Assert.Same(state, result);
+        Assert.Empty(result.NewEventBuffer);
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EventLogStoreTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EventLogStoreTests.cs
@@ -515,45 +515,6 @@ public sealed class EventLogStoreTests
     }
 
     [Fact]
-    public void ReduceLoadEventsPartial_WhenLogIdDoesNotMatch_ShouldReturnStateUnchanged()
-    {
-        // Arrange
-        var state = new EventLogState();
-
-        state = Reducers.ReduceOpenLog(state,
-            new OpenLogAction(Constants.LogNameTestLog, LogPathType.Channel));
-
-        var staleLogData = new EventLogData(Constants.LogNameTestLog, LogPathType.Channel);
-        var events = ImmutableArray.Create(FilterEventBuilder.CreateTestEvent(100));
-
-        // Act: stale partial with mismatched ID
-        var newState = Reducers.ReduceLoadEventsPartial(state,
-            new LoadEventsPartialAction(staleLogData, events));
-
-        // Assert: state unchanged, original log preserved with its ID
-        var originalId = state.OpenLogs[Constants.LogNameTestLog].Id;
-        Assert.NotEqual(originalId, staleLogData.Id);
-        Assert.Same(state, newState);
-        Assert.Equal(originalId, newState.OpenLogs[Constants.LogNameTestLog].Id);
-    }
-
-    [Fact]
-    public void ReduceLoadEventsPartial_WhenLogNotInOpenLogs_ShouldReturnStateUnchanged()
-    {
-        // Arrange: no logs open
-        var state = new EventLogState();
-        var logData = new EventLogData(Constants.LogNameTestLog, LogPathType.Channel);
-        var events = ImmutableArray.Create(FilterEventBuilder.CreateTestEvent(100));
-
-        // Act
-        var newState = Reducers.ReduceLoadEventsPartial(state,
-            new LoadEventsPartialAction(logData, events));
-
-        // Assert
-        Assert.Same(state, newState);
-    }
-
-    [Fact]
     public void ReduceLoadEvents_WhenLogIdDoesNotMatch_ShouldReturnStateUnchanged()
     {
         // Arrange: open a log, then create stale logData with a different ID

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/LogTableStoreTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/LogTableStoreTests.cs
@@ -13,7 +13,6 @@ using System.Collections.Immutable;
 using ApplyFilterAction = EventLogExpert.Runtime.EventLog.ApplyFilterAction;
 using CloseLogAction = EventLogExpert.Runtime.LogTable.CloseLogAction;
 using LoadEventsAction = EventLogExpert.Runtime.EventLog.LoadEventsAction;
-using LoadEventsPartialAction = EventLogExpert.Runtime.EventLog.LoadEventsPartialAction;
 using Reducers = EventLogExpert.Runtime.LogTable.Reducers;
 
 namespace EventLogExpert.Runtime.Tests.LogTable;
@@ -175,40 +174,6 @@ public sealed class LogTableStoreTests
     }
 
     [Fact]
-    public void LogView_ComputerName_WhenAlreadyLatched_ShouldNotBeOverwrittenByRawLoad()
-    {
-        var logData = new EventLogData(Constants.LogNameTestLog, LogPathType.Channel);
-        var state = new LogTableState();
-        state = Reducers.ReduceAddTable(state, new AddTableAction(logData));
-
-        state = Reducers.ReduceLoadEventsPartial(
-            state,
-            new LoadEventsPartialAction(
-                logData,
-                [
-                    new(Constants.LogNameTestLog, LogPathType.Channel)
-                    {
-                        Id = 10, RecordId = 1, ComputerName = FilterTestConstants.EventComputerServer01
-                    }
-                ]));
-
-        state = Reducers.ReduceLoadEvents(
-            state,
-            new LoadEventsAction(
-                logData,
-                [
-                    new(Constants.LogNameTestLog, LogPathType.Channel)
-                    {
-                        Id = 11, RecordId = 2, ComputerName = FilterTestConstants.EventComputerServer02
-                    }
-                ]));
-
-        Assert.Equal(
-            FilterTestConstants.EventComputerServer01,
-            state.EventTables.First(t => t.Id == logData.Id).ComputerName);
-    }
-
-    [Fact]
     public void LogView_ComputerName_WhenIngestTargetsCombinedTab_ShouldNotLatch()
     {
         var combinedId = EventLogId.Create();
@@ -257,6 +222,42 @@ public sealed class LogTableStoreTests
     }
 
     [Fact]
+    public void LogView_ComputerName_WhenLatchedByLiveTailIngest_ShouldNotBeOverwrittenByFinalLoad()
+    {
+        var logData = new EventLogData(Constants.LogNameTestLog, LogPathType.Channel);
+        var state = new LogTableState();
+        state = Reducers.ReduceAddTable(state, new AddTableAction(logData));
+
+        var byLog = new Dictionary<EventLogId, IReadOnlyList<ResolvedEvent>>
+        {
+            [logData.Id] =
+            [
+                new(Constants.LogNameTestLog, LogPathType.Channel)
+                {
+                    Id = 10, RecordId = 1, ComputerName = FilterTestConstants.EventComputerServer01
+                }
+            ]
+        };
+
+        state = Reducers.ReduceIngestRawEvents(state, new IngestRawEventsAction(byLog, RawIngestMode.Append));
+
+        state = Reducers.ReduceLoadEvents(
+            state,
+            new LoadEventsAction(
+                logData,
+                [
+                    new(Constants.LogNameTestLog, LogPathType.Channel)
+                    {
+                        Id = 11, RecordId = 2, ComputerName = FilterTestConstants.EventComputerServer02
+                    }
+                ]));
+
+        Assert.Equal(
+            FilterTestConstants.EventComputerServer01,
+            state.EventTables.First(t => t.Id == logData.Id).ComputerName);
+    }
+
+    [Fact]
     public void LogView_ComputerName_WhenLiveTailIngestArrives_ShouldLatch()
     {
         var logData = new EventLogData(Constants.LogNameTestLog, LogPathType.Channel);
@@ -289,28 +290,6 @@ public sealed class LogTableStoreTests
         var computerName = model.ComputerName;
 
         Assert.Equal(string.Empty, computerName);
-    }
-
-    [Fact]
-    public void LogView_ComputerName_WhenPartialRawLoadArrives_ShouldLatchBeforeFinalize()
-    {
-        var logData = new EventLogData(Constants.LogNameTestLog, LogPathType.Channel);
-        var state = new LogTableState();
-        state = Reducers.ReduceAddTable(state, new AddTableAction(logData));
-
-        var partial = new List<ResolvedEvent>
-        {
-            new(Constants.LogNameTestLog, LogPathType.Channel)
-            {
-                Id = 10, RecordId = 1, ComputerName = FilterTestConstants.EventComputerServer01
-            }
-        };
-
-        state = Reducers.ReduceLoadEventsPartial(state, new LoadEventsPartialAction(logData, partial));
-
-        Assert.Equal(
-            FilterTestConstants.EventComputerServer01,
-            state.EventTables.First(t => t.Id == logData.Id).ComputerName);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fixes the UI freeze when loading a large event log, and hardens the live-tail watcher lifecycle against close/reopen races. Three scoped parts:

- **Part 1 — load-hang fix.** The final `LoadEventsAction` dispatch in the open-log completion is now wrapped in `await Task.Run(...)`, so the O(N) reducers (`EventColumnStore.Build` + the count updates) run off the UI thread instead of freezing it while a large log finalizes. (A concurrent Fluxor drain can still strand the reducers; a guaranteed off-thread build is deferred follow-up.)
- **Part 3 — defer the O(N) partial reducers.** Removed the per-partial `ReduceLoadEventsPartial` reducers for `NamesByLog` (EventLog) and `ComputerName` (LogTable). The final `LoadEventsAction` already recomputes both from all events, so the end-state is identical; the `RawEventCount` partial stays live to avoid a "0 events" flash. The partial action itself still drives the raw-store/count reducers and the ordered-view/presence effects.
- **Watcher id-hardening.** `ILogWatcherService.AddLog`/`RemoveLogAsync` now take an `EventLogId`. `LogWatcherService` tracks watched logs by id (`_watchedLogIds`): a same-id `AddLog` is a no-op, a different-id one replaces the stale watcher, and `RemoveLogAsync` is id-conditional so a stale close cannot drop a same-name log reopened under a new id. Live-tail registration is routed through a new `RegisterLiveTailAction` + id-guarded `HandleRegisterLiveTail` effect (serialized with close in the Fluxor drain). Watcher disposal is always off-lock (deadlock rule), and a displaced watcher's disposal is recorded in a retired-disposal registry so a superseded close still awaits its teardown.

## Validation

- Full solution build: 0 warnings / 0 errors
- `EventLogExpert.Runtime.Tests`: 2671 passed
- `EventLogExpert.UI.Tests`: 1542 passed
- MAUI Windows (ARM64) head build: 0/0

## Tests

- Added `HandleRegisterLiveTail` effect tests (registers when the log is still open at the same id; skips on a newer id; skips when closed) and tightened the close-log test to assert the exact `EventLogId`.
- Added a reducer test that a live-tail-latched `ComputerName` is not overwritten by a later full load.
- Removed the tests that exercised the now-deleted partial reducers (removed behavior); the final-action end-state remains covered by existing reducer tests.