### PR TITLE
Fix live-tail restart gate for same-name log replacement

### DIFF
--- a/src/EventLogExpert.Runtime/EventLog/LogWatcherService.cs
+++ b/src/EventLogExpert.Runtime/EventLog/LogWatcherService.cs
@@ -54,6 +54,10 @@ internal sealed class LogWatcherService : ILogWatcherService
     {
         using (_watchersLock.EnterScope())
         {
+            // Capture before DetachWatcher, which transiently empties _watchers during a same-name replace.
+            bool wasEmpty = _logsToWatch.Count == 0;
+            bool wasWatching = IsWatching();
+
             if (_watchedLogIds.TryGetValue(logName, out var existingId))
             {
                 if (existingId == logId) { return; }
@@ -70,7 +74,7 @@ internal sealed class LogWatcherService : ILogWatcherService
             _bookmarks[logName] = bookmark;
             _renderXmlByLog[logName] = renderXml;
 
-            if (_logsToWatch.Count == 1 || IsWatching())
+            if (wasEmpty || wasWatching)
             {
                 StartWatching(logName);
             }


### PR DESCRIPTION
## Summary

Follow-up to PR #696. The post-merge Copilot review flagged a buffer-cap-bypass in `LogWatcherService.AddLog`: during the buffer-full stopped state (`StopAllWatchersAsync` clears `_watchers` but keeps `_logsToWatch`), replacing the sole watched log detaches then re-adds it, so the old `_logsToWatch.Count == 1` guard restarted live-tail even though the cap should keep it paused.

## Fix

Capture the watch-set state (`wasEmpty`, `wasWatching`) **before** `DetachWatcher` mutates the collections, and gate the watcher start on `wasEmpty || wasWatching`. This:

- Does **not** restart during the buffer-full stopped state (logs present, no watchers) on a same-name replace, so the cap is respected.
- **Does** restart when replacing a sole log that was actively being watched (the reopened watcher must start) — a case a naive post-mutation `IsWatching()` check would miss, since `DetachWatcher` transiently empties `_watchers`.
- Leaves the genuine-first-log and add-while-watching-others paths unchanged.

The buffer-clear resume path is unaffected (it runs through the no-arg `StartWatching()`, not `AddLog`).

## Validation

- Full solution build: 0 warnings / 0 errors
- `EventLogExpert.Runtime.Tests`: 2673 passed
- `EventLogExpert.UI.Tests`: 1542 passed
- MAUI Windows (ARM64) head build: 0/0

`LogWatcherService` wraps the sealed native `EventLogWatcher` with no test seam, so the start-gate cases were verified by state-machine reasoning across the three service states (idle / watching / buffer-full-stopped).