### PR TITLE
Show loading progress percentage on the status bar chip

### DIFF
--- a/src/EventLogExpert.Runtime/EventLog/EventLogReaderFactory.cs
+++ b/src/EventLogExpert.Runtime/EventLog/EventLogReaderFactory.cs
@@ -15,4 +15,7 @@ internal sealed class EventLogReaderFactory : IEventLogReaderFactory
         bool reverseDirection = false,
         bool captureSelfDescribing = false) =>
         new EventLogReader(path, pathType, renderXml, reverseDirection, captureSelfDescribing);
+
+    public long? GetRecordCount(string path, LogPathType pathType) =>
+        EventLogSession.GlobalSession.GetLogInformation(path, pathType).RecordCount;
 }

--- a/src/EventLogExpert.Runtime/EventLog/IEventLogReaderFactory.cs
+++ b/src/EventLogExpert.Runtime/EventLog/IEventLogReaderFactory.cs
@@ -14,4 +14,6 @@ internal interface IEventLogReaderFactory
         bool renderXml = false,
         bool reverseDirection = false,
         bool captureSelfDescribing = false);
+
+    long? GetRecordCount(string path, LogPathType pathType);
 }

--- a/src/EventLogExpert.Runtime/EventLog/OpenLogEffects.cs
+++ b/src/EventLogExpert.Runtime/EventLog/OpenLogEffects.cs
@@ -44,6 +44,8 @@ internal sealed class OpenLogEffects(
 
     private static readonly int s_maxGlobalConcurrency = ConcurrencyLimits.MaxBackgroundIoParallelism;
     private static readonly TimeSpan s_partialDispatchInterval = TimeSpan.FromSeconds(3);
+    private static readonly SemaphoreSlim s_recordCountProbeGate = new(s_maxGlobalConcurrency);
+    private static readonly TimeSpan s_recordCountProbeTimeout = TimeSpan.FromSeconds(30);
     private static readonly PrioritySemaphore s_resolutionGate = new(s_maxGlobalConcurrency);
 
     private readonly LogCloseCoordinator _closeCoordinator = closeCoordinator;
@@ -278,6 +280,41 @@ internal sealed class OpenLogEffects(
         return Task.CompletedTask;
     }
 
+    internal async Task RunRecordCountProbeAsync(
+        StatusActivityId activityId,
+        string logName,
+        LogPathType pathType,
+        IDispatcher dispatcher,
+        CancellationToken token)
+    {
+        try
+        {
+            if (!await s_recordCountProbeGate.WaitAsync(s_recordCountProbeTimeout, token).ConfigureAwait(false))
+            {
+                return;
+            }
+
+            try
+            {
+                var count = await Task.Run(() => _readerFactory.GetRecordCount(logName, pathType), token).ConfigureAwait(false);
+
+                if (count is > 0)
+                {
+                    dispatcher.Dispatch(new SetLoadingTotalAction(activityId, count.Value));
+                }
+            }
+            finally
+            {
+                s_recordCountProbeGate.Release();
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (Exception ex)
+        {
+            _logger.Trace($"Record count unavailable for {logName}: {ex.Message}");
+        }
+    }
+
     private static string DescribeLog(OpenLogAction action) =>
         action.LogPathType == LogPathType.File ?
             $"{Path.GetFileName(action.LogName)} ({action.LogName})" :
@@ -379,6 +416,8 @@ internal sealed class OpenLogEffects(
 
             if (reader is null) { return; }
 
+            _ = RunRecordCountProbeAsync(activityId, action.LogName, action.LogPathType, dispatcher, token);
+
             var producerTask = Task.Run(async () =>
             {
                 long sequence = 0;
@@ -473,6 +512,8 @@ internal sealed class OpenLogEffects(
                                     }
                                     catch (Exception ex)
                                     {
+                                        Interlocked.Increment(ref failed);
+
                                         _logger.Warning($"Failed to resolve RecordId: {@event.RecordId}, {ex.Message}");
                                     }
                                 }

--- a/src/EventLogExpert.Runtime/StatusBar/Reducers.cs
+++ b/src/EventLogExpert.Runtime/StatusBar/Reducers.cs
@@ -34,21 +34,45 @@ public sealed class Reducers
     }
 
     [ReducerMethod]
+    public static StatusBarState ReduceSetLoadingTotal(StatusBarState state, SetLoadingTotalAction action)
+    {
+        // Only annotate an activity that is still loading; a probe that finishes after the load cleared must not
+        // resurrect a "Loading" entry. Preserving the same reference when unchanged suppresses a spurious StateChanged.
+        if (!state.EventsLoading.TryGetValue(action.ActivityId, out var existing) || existing.Total == action.Total)
+        {
+            return state;
+        }
+
+        return state with
+        {
+            EventsLoading = state.EventsLoading.SetItem(
+                action.ActivityId,
+                (existing.Loaded, existing.Failed, action.Total))
+        };
+    }
+
+    [ReducerMethod]
     public static StatusBarState
         ReduceSetResolverStatus(StatusBarState state, SetResolverStatusAction action) =>
         state with { ResolverStatus = action.ResolverStatus };
 
-    private static ImmutableDictionary<StatusActivityId, (int, int)> CommonLoadingReducer(
-        ImmutableDictionary<StatusActivityId, (int, int)> loadingEntries,
+    private static ImmutableDictionary<StatusActivityId, (int Loaded, int Failed, long? Total)> CommonLoadingReducer(
+        ImmutableDictionary<StatusActivityId, (int Loaded, int Failed, long? Total)> loadingEntries,
         StatusActivityId activityId,
         int count,
         int failedCount)
     {
-        if (loadingEntries.TryGetValue(activityId, out var existing) && existing == (count, failedCount))
+        if (loadingEntries.TryGetValue(activityId, out var existing))
         {
-            return loadingEntries;
+            if (existing.Loaded == count && existing.Failed == failedCount)
+            {
+                return loadingEntries;
+            }
+
+            // Preserve the probe-published Total when only the running counts change.
+            return loadingEntries.SetItem(activityId, (count, failedCount, existing.Total));
         }
 
-        return loadingEntries.SetItem(activityId, (count, failedCount));
+        return loadingEntries.SetItem(activityId, (count, failedCount, null));
     }
 }

--- a/src/EventLogExpert.Runtime/StatusBar/SetLoadingTotalAction.cs
+++ b/src/EventLogExpert.Runtime/StatusBar/SetLoadingTotalAction.cs
@@ -1,0 +1,6 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.StatusBar;
+
+public sealed record SetLoadingTotalAction(StatusActivityId ActivityId, long Total);

--- a/src/EventLogExpert.Runtime/StatusBar/StatusBarFormatter.cs
+++ b/src/EventLogExpert.Runtime/StatusBar/StatusBarFormatter.cs
@@ -72,16 +72,24 @@ public static class StatusBarFormatter
 
         var totalFailed = 0;
         var singleLoaded = 0;
+        var singleFailed = 0;
+        long? singleTotal = null;
 
         foreach (var progress in activities.Values)
         {
             totalFailed += progress.Failed;
             singleLoaded = progress.Loaded;
+            singleFailed = progress.Failed;
+            singleTotal = progress.Total;
         }
+
+        var percent = Percent(singleLoaded, singleFailed, singleTotal);
 
         var text = loadingCount switch
         {
+            1 when singleLoaded == 0 && percent is int failureOnlyPercent and > 0 => $"Loading... ({failureOnlyPercent}%)",
             1 when singleLoaded == 0 => "Loading...",
+            1 when percent is { } loadedPercent => $"Loading: {singleLoaded:N0} ({loadedPercent}%)",
             1 => $"Loading: {singleLoaded:N0}",
             _ => $"Loading {loadingCount:N0} logs..."
         };
@@ -186,4 +194,9 @@ public static class StatusBarFormatter
 
     private static string FormatMebibytes(long mebibytes) =>
         mebibytes >= 1024 ? $"{mebibytes / 1024.0:0.0} GB" : $"{mebibytes:N0} MB";
+
+    private static int? Percent(int loaded, int failed, long? total) =>
+        total is { } denominator and > 0 ?
+            (int)Math.Clamp(((long)loaded + failed) * 100 / denominator, 0L, 99L) :
+            null;
 }

--- a/src/EventLogExpert.Runtime/StatusBar/StatusBarPresentation.cs
+++ b/src/EventLogExpert.Runtime/StatusBar/StatusBarPresentation.cs
@@ -9,7 +9,7 @@ using System.Collections.Immutable;
 
 namespace EventLogExpert.Runtime.StatusBar;
 
-public readonly record struct LoadingProgress(int Loaded, int Failed);
+public readonly record struct LoadingProgress(int Loaded, int Failed, long? Total = null);
 
 public sealed record StatusBarPresentation
 {

--- a/src/EventLogExpert.Runtime/StatusBar/StatusBarSource.cs
+++ b/src/EventLogExpert.Runtime/StatusBar/StatusBarSource.cs
@@ -31,7 +31,7 @@ internal sealed class StatusBarSource : IStatusBarSource, IDisposable
     private (long UsedMebibytes, long WorkingSetBytes, MemoryUsageLevel Level) _memoryFacets;
     private bool _persistentFilterActive;
     private (int Total, ImmutableDictionary<EventLogId, ProviderResolutionCounts> ByLog) _rawCountFacets;
-    private (ImmutableDictionary<StatusActivityId, (int, int)> Loading, string Resolver) _statusFacets;
+    private (ImmutableDictionary<StatusActivityId, (int Loaded, int Failed, long? Total)> Loading, string Resolver) _statusFacets;
 
     public StatusBarSource(
         IState<EventLogState> eventLogState,
@@ -136,7 +136,7 @@ internal sealed class StatusBarSource : IStatusBarSource, IDisposable
             RawEventCountsByLog = rawCount.ByLog,
             LoadingActivities = statusBar.EventsLoading.ToImmutableDictionary(
                 pair => pair.Key,
-                pair => new LoadingProgress(pair.Value.Item1, pair.Value.Item2)),
+                pair => new LoadingProgress(pair.Value.Loaded, pair.Value.Failed, pair.Value.Total)),
             ResolverStatus = statusBar.ResolverStatus,
             Tabs = logTable.EventTables,
             Groups = logTable.Groups,
@@ -159,7 +159,7 @@ internal sealed class StatusBarSource : IStatusBarSource, IDisposable
     private static (int, ImmutableDictionary<EventLogId, ProviderResolutionCounts>) ProjectRawCount(RawEventCountState state) =>
         (state.Total, state.ByLog);
 
-    private static (ImmutableDictionary<StatusActivityId, (int, int)>, string) ProjectStatus(StatusBarState state) =>
+    private static (ImmutableDictionary<StatusActivityId, (int Loaded, int Failed, long? Total)>, string) ProjectStatus(StatusBarState state) =>
         (state.EventsLoading, state.ResolverStatus);
 
     private void OnEventLogChanged(object? sender, EventArgs e)

--- a/src/EventLogExpert.Runtime/StatusBar/StatusBarState.cs
+++ b/src/EventLogExpert.Runtime/StatusBar/StatusBarState.cs
@@ -9,7 +9,8 @@ namespace EventLogExpert.Runtime.StatusBar;
 [FeatureState(MaximumStateChangedNotificationsPerSecond = 1)]
 public sealed record StatusBarState
 {
-    public ImmutableDictionary<StatusActivityId, (int, int)> EventsLoading { get; init; } = ImmutableDictionary<StatusActivityId, (int, int)>.Empty;
+    public ImmutableDictionary<StatusActivityId, (int Loaded, int Failed, long? Total)> EventsLoading { get; init; } =
+        ImmutableDictionary<StatusActivityId, (int Loaded, int Failed, long? Total)>.Empty;
 
     public string ResolverStatus { get; init; } = string.Empty;
 }

--- a/tests/Integration/EventLogExpert.Eventing.IntegrationTests/Readers/EventLogReaderReverseTests.cs
+++ b/tests/Integration/EventLogExpert.Eventing.IntegrationTests/Readers/EventLogReaderReverseTests.cs
@@ -35,6 +35,23 @@ public sealed class EventLogReaderReverseTests
         AssertStrictlyOrdered(ids, ascending: true);
     }
 
+    [Fact]
+    public void GetLogInformation_WhileReverseReaderOpen_ReturnsRecordCount()
+    {
+        // The loading-percentage probe fetches the record count via a second EvtOpenLog while the load's reverse
+        // EvtQuery handle on the same file is still live. Prove that concurrent-handle combination yields a usable
+        // count, so the % shows for the primary (large .evtx) scenario rather than silently degrading to count-only.
+        using var fixture = new SmallEvtxFixture();
+        using var reader = new EventLogReader(fixture.FilePath, LogPathType.File, reverseDirection: true);
+
+        Assert.True(reader.IsValid);
+
+        var information = EventLogSession.GlobalSession.GetLogInformation(fixture.FilePath, LogPathType.File);
+
+        Assert.NotNull(information.RecordCount);
+        Assert.True(information.RecordCount > 0);
+    }
+
     [Theory]
     [InlineData(false)]
     [InlineData(true)]

--- a/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EffectsTests.cs
@@ -1407,6 +1407,28 @@ public sealed class EffectsTests
     }
 
     [Fact]
+    public async Task HandleOpenLog_WhenResolveThrows_ExcludesThrownRecordFromLoadedViaTheFailedPath()
+    {
+        const int total = 60;
+        var fakeFactory = new FakeEventLogReaderFactory(
+            new FakeEventLogReader(BuildReverseBatches(total, batchSize: 30), newestBookmark: "NEWEST"));
+
+        // One read record's resolver throws. A record that WAS read can only be dropped from the loaded set via the
+        // resolve-exception catch - which is exactly where it is counted as failed (loaded + failed is the loading
+        // percentage numerator, and failed drives the "Failed: N" badge). So its exclusion proves that path executed.
+        var (openLog, dispatcher, _) = CreateEagerLoadEffects(fakeFactory, throwOnResolve: recordId => recordId == 30);
+
+        await openLog.HandleOpenLog(new OpenLogAction(Constants.LogNameApplication, LogPathType.Channel), dispatcher);
+
+        var load = dispatcher.ReceivedCalls()
+            .Select(call => call.GetArguments()[0])
+            .OfType<LoadEventsAction>()
+            .Single();
+
+        Assert.Equal(total - 1, load.Events.Count);
+    }
+
+    [Fact]
     public async Task HandleRegisterLiveTail_WhenLogClosed_DoesNotRegisterWatcher()
     {
         var logData = new EventLogData(Constants.LogNameTestLog, LogPathType.Channel);
@@ -1759,7 +1781,8 @@ public sealed class EffectsTests
 
     private static (OpenLogEffects openLog, IDispatcher dispatcher, ILogWatcherService watcher) CreateEagerLoadEffects(
         IEventLogReaderFactory readerFactory,
-        Func<long?, int>? resolveDelayMs = null)
+        Func<long?, int>? resolveDelayMs = null,
+        Func<long?, bool>? throwOnResolve = null)
     {
         var logData = new EventLogData(Constants.LogNameApplication, LogPathType.Channel);
 
@@ -1777,6 +1800,11 @@ public sealed class EffectsTests
         resolver.ResolveEvent(Arg.Any<EventRecord>()).Returns(callInfo =>
         {
             var record = callInfo.ArgAt<EventRecord>(0);
+
+            if (throwOnResolve?.Invoke(record.RecordId) == true)
+            {
+                throw new InvalidOperationException($"Simulated resolve failure for record {record.RecordId}.");
+            }
 
             if (resolveDelayMs is not null)
             {

--- a/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EffectsTests.cs
@@ -1384,6 +1384,29 @@ public sealed class EffectsTests
     }
 
     [Fact]
+    public async Task HandleOpenLog_WhenRecordCountAvailable_DispatchesLoadingTotalFromProbe()
+    {
+        var fakeFactory = new FakeEventLogReaderFactory(
+            new FakeEventLogReader(BuildReverseBatches(60, batchSize: 30), newestBookmark: "NEWEST"))
+        {
+            RecordCount = 10_000
+        };
+
+        var (openLog, dispatcher, _) = CreateEagerLoadEffects(fakeFactory);
+
+        // The probe is fire-and-forget; synchronize on the observable dispatch so the assertion is deterministic and
+        // this test fails (via WaitAsync timeout) if the effect ever stops invoking the probe.
+        var totalDispatched = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        dispatcher.When(target => target.Dispatch(Arg.Any<SetLoadingTotalAction>()))
+            .Do(_ => totalDispatched.TrySetResult());
+
+        await openLog.HandleOpenLog(new OpenLogAction(Constants.LogNameApplication, LogPathType.Channel), dispatcher);
+        await totalDispatched.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+
+        dispatcher.Received(1).Dispatch(Arg.Is<SetLoadingTotalAction>(action => action != null && action.Total == 10_000));
+    }
+
+    [Fact]
     public async Task HandleRegisterLiveTail_WhenLogClosed_DoesNotRegisterWatcher()
     {
         var logData = new EventLogData(Constants.LogNameTestLog, LogPathType.Channel);
@@ -1518,6 +1541,77 @@ public sealed class EffectsTests
         mockDispatcher.Received(1)
             .Dispatch(Arg.Is<OpenLogAction>(a => a != null &&
                 a.LogName == Constants.LogNameLog2 && a.LogPathType == LogPathType.File));
+    }
+
+    [Fact]
+    public async Task RunRecordCountProbe_WhenGetRecordCountThrows_SwallowsAndDoesNotDispatch()
+    {
+        var fakeFactory = new FakeEventLogReaderFactory(
+            new FakeEventLogReader(BuildReverseBatches(0, batchSize: 30), newestBookmark: null))
+        {
+            ThrowOnGetRecordCount = true
+        };
+
+        var (openLog, dispatcher, _) = CreateEagerLoadEffects(fakeFactory);
+
+        await openLog.RunRecordCountProbeAsync(
+            StatusActivityId.Create(), Constants.LogNameApplication, LogPathType.Channel, dispatcher, CancellationToken.None);
+
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<SetLoadingTotalAction>());
+    }
+
+    [Fact]
+    public async Task RunRecordCountProbe_WithNullCount_DoesNotDispatch()
+    {
+        var fakeFactory = new FakeEventLogReaderFactory(
+            new FakeEventLogReader(BuildReverseBatches(0, batchSize: 30), newestBookmark: null))
+        {
+            RecordCount = null
+        };
+
+        var (openLog, dispatcher, _) = CreateEagerLoadEffects(fakeFactory);
+
+        await openLog.RunRecordCountProbeAsync(
+            StatusActivityId.Create(), Constants.LogNameApplication, LogPathType.Channel, dispatcher, CancellationToken.None);
+
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<SetLoadingTotalAction>());
+    }
+
+    [Fact]
+    public async Task RunRecordCountProbe_WithPositiveCount_DispatchesLoadingTotal()
+    {
+        var fakeFactory = new FakeEventLogReaderFactory(
+            new FakeEventLogReader(BuildReverseBatches(0, batchSize: 30), newestBookmark: null))
+        {
+            RecordCount = 10_000
+        };
+
+        var (openLog, dispatcher, _) = CreateEagerLoadEffects(fakeFactory);
+        var activityId = StatusActivityId.Create();
+
+        await openLog.RunRecordCountProbeAsync(
+            activityId, Constants.LogNameApplication, LogPathType.Channel, dispatcher, CancellationToken.None);
+
+        Assert.Equal(1, fakeFactory.GetRecordCountCallCount);
+        dispatcher.Received(1).Dispatch(
+            Arg.Is<SetLoadingTotalAction>(action => action != null && action.ActivityId == activityId && action.Total == 10_000));
+    }
+
+    [Fact]
+    public async Task RunRecordCountProbe_WithZeroCount_DoesNotDispatch()
+    {
+        var fakeFactory = new FakeEventLogReaderFactory(
+            new FakeEventLogReader(BuildReverseBatches(0, batchSize: 30), newestBookmark: null))
+        {
+            RecordCount = 0
+        };
+
+        var (openLog, dispatcher, _) = CreateEagerLoadEffects(fakeFactory);
+
+        await openLog.RunRecordCountProbeAsync(
+            StatusActivityId.Create(), Constants.LogNameApplication, LogPathType.Channel, dispatcher, CancellationToken.None);
+
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<SetLoadingTotalAction>());
     }
 
     private static List<LoadEventsPartialAction> AllPartialActions(IDispatcher dispatcher) =>
@@ -2112,7 +2206,13 @@ public sealed class EffectsTests
 
     private sealed class FakeEventLogReaderFactory(IEventLogReader reader) : IEventLogReaderFactory
     {
+        public int GetRecordCountCallCount { get; private set; }
+
+        public long? RecordCount { get; set; }
+
         public bool ReverseDirectionRequested { get; private set; }
+
+        public bool ThrowOnGetRecordCount { get; set; }
 
         public IEventLogReader CreateReader(string path, LogPathType pathType, bool renderXml = false, bool reverseDirection = false, bool captureSelfDescribing = false)
         {
@@ -2120,11 +2220,25 @@ public sealed class EffectsTests
 
             return reader;
         }
+
+        public long? GetRecordCount(string path, LogPathType pathType)
+        {
+            GetRecordCountCallCount++;
+
+            if (ThrowOnGetRecordCount)
+            {
+                throw new UnauthorizedAccessException("Simulated record-count failure.");
+            }
+
+            return RecordCount;
+        }
     }
 
     private sealed class ThrowingReaderFactory : IEventLogReaderFactory
     {
         public IEventLogReader CreateReader(string path, LogPathType pathType, bool renderXml = false, bool reverseDirection = false, bool captureSelfDescribing = false) =>
             throw new InvalidOperationException("Simulated reader creation failure.");
+
+        public long? GetRecordCount(string path, LogPathType pathType) => null;
     }
 }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/StatusBar/StatusBarFormatterTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/StatusBar/StatusBarFormatterTests.cs
@@ -96,6 +96,25 @@ public sealed class StatusBarFormatterTests
         Assert.Equal($"{1234:N0} events", StatusBarFormatter.FormatCounts(1234, 1234, isFiltered: false, selectedCount: 0));
 
     [Fact]
+    public void FormatLoading_FailureOnlyProgressRoundingToZero_StaysPending()
+    {
+        var summary = StatusBarFormatter.FormatLoading(Loading(new LoadingProgress(0, 3, 10_000)));
+
+        Assert.NotNull(summary);
+        Assert.Equal("Loading...", summary.Value.Text);
+    }
+
+    [Fact]
+    public void FormatLoading_FailureOnlyProgressWithTotal_ShowsPercentWithoutZeroCount()
+    {
+        var summary = StatusBarFormatter.FormatLoading(Loading(new LoadingProgress(0, 50_000, 100_000)));
+
+        Assert.NotNull(summary);
+        Assert.Equal("Loading... (50%)", summary.Value.Text);
+        Assert.DoesNotContain("Loading: 0", summary.Value.Text);
+    }
+
+    [Fact]
     public void FormatLoading_ManyActivities_GroupsLogCountAndSumsFailedEvents()
     {
         var progresses = Enumerable.Range(0, 1500)
@@ -112,6 +131,34 @@ public sealed class StatusBarFormatterTests
     [Fact]
     public void FormatLoading_NoActivities_ReturnsNull() =>
         Assert.Null(StatusBarFormatter.FormatLoading(Loading()));
+
+    [Fact]
+    public void FormatLoading_NonPositiveTotal_FallsBackToCountOnly()
+    {
+        var summary = StatusBarFormatter.FormatLoading(Loading(new LoadingProgress(4_500, 0, 0)));
+
+        Assert.NotNull(summary);
+        Assert.Equal($"Loading: {4500:N0}", summary.Value.Text);
+    }
+
+    [Fact]
+    public void FormatLoading_PercentClampsAtNinetyNineBeforeCompletion()
+    {
+        var summary = StatusBarFormatter.FormatLoading(Loading(new LoadingProgress(1_000_000, 0, 1_000_000)));
+
+        Assert.NotNull(summary);
+        Assert.Equal($"Loading: {1000000:N0} (99%)", summary.Value.Text);
+    }
+
+    [Fact]
+    public void FormatLoading_PercentUsesLoadedPlusFailed()
+    {
+        // 4000 loaded + 1000 failed = 5000 processed of 10000 = 50%; the displayed count stays the loaded tally.
+        var summary = StatusBarFormatter.FormatLoading(Loading(new LoadingProgress(4_000, 1_000, 10_000)));
+
+        Assert.NotNull(summary);
+        Assert.Equal($"Loading: {4000:N0} (50%)", summary.Value.Text);
+    }
 
     [Fact]
     public void FormatLoading_SingleActivityAtZero_ShowsPendingText()
@@ -133,6 +180,15 @@ public sealed class StatusBarFormatterTests
     }
 
     [Fact]
+    public void FormatLoading_SingleActivityWithTotal_AppendsPercent()
+    {
+        var summary = StatusBarFormatter.FormatLoading(Loading(new LoadingProgress(4_500, 0, 10_000)));
+
+        Assert.NotNull(summary);
+        Assert.Equal($"Loading: {4500:N0} (45%)", summary.Value.Text);
+    }
+
+    [Fact]
     public void FormatLoading_SingleFailedOnlyActivity_StaysPendingAndReportsFailures()
     {
         var summary = StatusBarFormatter.FormatLoading(Loading(new LoadingProgress(0, 3)));
@@ -140,6 +196,16 @@ public sealed class StatusBarFormatterTests
         Assert.NotNull(summary);
         Assert.Equal("Loading...", summary.Value.Text);
         Assert.Equal(3, summary.Value.FailedEvents);
+    }
+
+    [Fact]
+    public void FormatLoading_TinyCorruptDenominator_ClampsInsteadOfOverflowing()
+    {
+        // (long)50_000_000 * 100 / 2 = 2.5e9 (> int.MaxValue): clamping in long space yields 99, never a wrapped value.
+        var summary = StatusBarFormatter.FormatLoading(Loading(new LoadingProgress(50_000_000, 0, 2)));
+
+        Assert.NotNull(summary);
+        Assert.Equal($"Loading: {50000000:N0} (99%)", summary.Value.Text);
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Runtime.Tests/StatusBar/StatusBarSourceTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/StatusBar/StatusBarSourceTests.cs
@@ -54,7 +54,7 @@ public sealed class StatusBarSourceTests
         var harness = new Harness();
         harness.StatusBar = harness.StatusBar with
         {
-            EventsLoading = ImmutableDictionary<StatusActivityId, (int, int)>.Empty.Add(Activity, (12, 3))
+            EventsLoading = ImmutableDictionary<StatusActivityId, (int, int, long?)>.Empty.Add(Activity, (12, 3, null))
         };
         harness.RaiseStatusBar();
         var raised = 0;
@@ -62,7 +62,7 @@ public sealed class StatusBarSourceTests
 
         harness.StatusBar = harness.StatusBar with
         {
-            EventsLoading = ImmutableDictionary.CreateRange([new KeyValuePair<StatusActivityId, (int, int)>(Activity, (12, 3))])
+            EventsLoading = ImmutableDictionary.CreateRange([new KeyValuePair<StatusActivityId, (int, int, long?)>(Activity, (12, 3, null))])
         };
         harness.RaiseStatusBar();
 
@@ -122,7 +122,7 @@ public sealed class StatusBarSourceTests
 
         harness.StatusBar = harness.StatusBar with
         {
-            EventsLoading = ImmutableDictionary<StatusActivityId, (int, int)>.Empty.Add(Activity, (12, 3))
+            EventsLoading = ImmutableDictionary<StatusActivityId, (int, int, long?)>.Empty.Add(Activity, (12, 3, null))
         };
         harness.RaiseStatusBar();
 
@@ -144,6 +144,28 @@ public sealed class StatusBarSourceTests
 
         Assert.Equal(1, raised);
         Assert.Equal(LogA, harness.Source.Current.ActiveTabId);
+    }
+
+    [Fact]
+    public void Changed_Fires_WhenOnlyTotalChanges_AndProjectsTotal()
+    {
+        var harness = new Harness();
+        harness.StatusBar = harness.StatusBar with
+        {
+            EventsLoading = ImmutableDictionary<StatusActivityId, (int, int, long?)>.Empty.Add(Activity, (12, 3, null))
+        };
+        harness.RaiseStatusBar();
+        var raised = 0;
+        harness.Source.Changed += () => raised++;
+
+        harness.StatusBar = harness.StatusBar with
+        {
+            EventsLoading = ImmutableDictionary<StatusActivityId, (int, int, long?)>.Empty.Add(Activity, (12, 3, 10_000))
+        };
+        harness.RaiseStatusBar();
+
+        Assert.Equal(1, raised);
+        Assert.Equal(10_000, harness.Source.Current.LoadingActivities[Activity].Total);
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Runtime.Tests/StatusBar/StatusBarStoreTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/StatusBar/StatusBarStoreTests.cs
@@ -88,7 +88,7 @@ public sealed class StatusBarReducerTests
 
         var state = new StatusBarState
         {
-            EventsLoading = ImmutableDictionary<StatusActivityId, (int, int)>.Empty.Add(activityId, (100, 5))
+            EventsLoading = ImmutableDictionary<StatusActivityId, (int, int, long?)>.Empty.Add(activityId, (100, 5, null))
         };
 
         var action = new ClearStatusAction(activityId);
@@ -106,7 +106,7 @@ public sealed class StatusBarReducerTests
 
         var state = new StatusBarState
         {
-            EventsLoading = ImmutableDictionary<StatusActivityId, (int, int)>.Empty.Add(existingActivityId, (100, 5))
+            EventsLoading = ImmutableDictionary<StatusActivityId, (int, int, long?)>.Empty.Add(existingActivityId, (100, 5, null))
         };
 
         var action = new ClearStatusAction(nonExistingActivityId);
@@ -122,9 +122,9 @@ public sealed class StatusBarReducerTests
     {
         var state = new StatusBarState
         {
-            EventsLoading = ImmutableDictionary<StatusActivityId, (int, int)>.Empty
-                .Add(StatusActivityId.Create(), (100, 5))
-                .Add(StatusActivityId.Create(), (200, 10)),
+            EventsLoading = ImmutableDictionary<StatusActivityId, (int, int, long?)>.Empty
+                .Add(StatusActivityId.Create(), (100, 5, null))
+                .Add(StatusActivityId.Create(), (200, 10, null)),
             ResolverStatus = "Processing..."
         };
 
@@ -135,13 +135,28 @@ public sealed class StatusBarReducerTests
     }
 
     [Fact]
+    public void ReduceSetEventsLoading_AfterTotalSet_PreservesTotal()
+    {
+        var activityId = StatusActivityId.Create();
+
+        var state = new StatusBarState
+        {
+            EventsLoading = ImmutableDictionary<StatusActivityId, (int, int, long?)>.Empty.Add(activityId, (50, 2, 10_000))
+        };
+
+        var result = Reducers.ReduceSetEventsLoading(state, new SetEventsLoadingAction(activityId, 100, 5));
+
+        Assert.Equal((100, 5, (long?)10_000), result.EventsLoading[activityId]);
+    }
+
+    [Fact]
     public void ReduceSetEventsLoading_WithExistingActivity_ShouldUpdateActivity()
     {
         var activityId = StatusActivityId.Create();
 
         var state = new StatusBarState
         {
-            EventsLoading = ImmutableDictionary<StatusActivityId, (int, int)>.Empty.Add(activityId, (50, 2))
+            EventsLoading = ImmutableDictionary<StatusActivityId, (int, int, long?)>.Empty.Add(activityId, (50, 2, null))
         };
 
         var action = new SetEventsLoadingAction(activityId, 100, 5);
@@ -149,7 +164,7 @@ public sealed class StatusBarReducerTests
         var result = Reducers.ReduceSetEventsLoading(state, action);
 
         Assert.Single(result.EventsLoading);
-        Assert.Equal((100, 5), result.EventsLoading[activityId]);
+        Assert.Equal((100, 5, (long?)null), result.EventsLoading[activityId]);
     }
 
     [Fact]
@@ -161,9 +176,9 @@ public sealed class StatusBarReducerTests
 
         var state = new StatusBarState
         {
-            EventsLoading = ImmutableDictionary<StatusActivityId, (int, int)>.Empty
-                .Add(activityId1, (100, 5))
-                .Add(activityId2, (200, 10))
+            EventsLoading = ImmutableDictionary<StatusActivityId, (int, int, long?)>.Empty
+                .Add(activityId1, (100, 5, null))
+                .Add(activityId2, (200, 10, null))
         };
 
         var action = new SetEventsLoadingAction(activityId3, 300, 15);
@@ -187,7 +202,7 @@ public sealed class StatusBarReducerTests
 
         Assert.Single(result.EventsLoading);
         Assert.True(result.EventsLoading.ContainsKey(activityId));
-        Assert.Equal((100, 5), result.EventsLoading[activityId]);
+        Assert.Equal((100, 5, (long?)null), result.EventsLoading[activityId]);
     }
 
     [Fact]
@@ -197,7 +212,7 @@ public sealed class StatusBarReducerTests
 
         var state = new StatusBarState
         {
-            EventsLoading = ImmutableDictionary<StatusActivityId, (int, int)>.Empty.Add(activityId, (100, 5))
+            EventsLoading = ImmutableDictionary<StatusActivityId, (int, int, long?)>.Empty.Add(activityId, (100, 5, null))
         };
 
         var action = new SetEventsLoadingAction(activityId, 100, 5);
@@ -219,7 +234,51 @@ public sealed class StatusBarReducerTests
         var result = Reducers.ReduceSetEventsLoading(state, action);
 
         Assert.Single(result.EventsLoading);
-        Assert.Equal((0, 0), result.EventsLoading[activityId]);
+        Assert.Equal((0, 0, (long?)null), result.EventsLoading[activityId]);
+    }
+
+    [Fact]
+    public void ReduceSetLoadingTotal_WithAbsentActivity_ReturnsSameState()
+    {
+        var state = new StatusBarState
+        {
+            EventsLoading = ImmutableDictionary<StatusActivityId, (int, int, long?)>.Empty.Add(StatusActivityId.Create(), (50, 2, null))
+        };
+
+        var result = Reducers.ReduceSetLoadingTotal(state, new SetLoadingTotalAction(StatusActivityId.Create(), 10_000));
+
+        Assert.Same(state, result);
+    }
+
+    [Fact]
+    public void ReduceSetLoadingTotal_WithEqualTotal_ReturnsSameState()
+    {
+        var activityId = StatusActivityId.Create();
+
+        var state = new StatusBarState
+        {
+            EventsLoading = ImmutableDictionary<StatusActivityId, (int, int, long?)>.Empty.Add(activityId, (50, 2, 10_000))
+        };
+
+        var result = Reducers.ReduceSetLoadingTotal(state, new SetLoadingTotalAction(activityId, 10_000));
+
+        Assert.Same(state, result);
+    }
+
+    [Fact]
+    public void ReduceSetLoadingTotal_WithPresentActivity_SetsTotalPreservingCounts()
+    {
+        var activityId = StatusActivityId.Create();
+
+        var state = new StatusBarState
+        {
+            EventsLoading = ImmutableDictionary<StatusActivityId, (int, int, long?)>.Empty.Add(activityId, (50, 2, null))
+        };
+
+        var result = Reducers.ReduceSetLoadingTotal(state, new SetLoadingTotalAction(activityId, 10_000));
+
+        Assert.Single(result.EventsLoading);
+        Assert.Equal((50, 2, (long?)10_000), result.EventsLoading[activityId]);
     }
 
     [Fact]
@@ -271,21 +330,21 @@ public sealed class StatusBarIntegrationTests
             new SetEventsLoadingAction(activityId, 100, 0));
 
         Assert.Single(state.EventsLoading);
-        Assert.Equal((100, 0), state.EventsLoading[activityId]);
+        Assert.Equal((100, 0, (long?)null), state.EventsLoading[activityId]);
 
         state = Reducers.ReduceSetEventsLoading(
             state,
             new SetEventsLoadingAction(activityId, 75, 2));
 
         Assert.Single(state.EventsLoading);
-        Assert.Equal((75, 2), state.EventsLoading[activityId]);
+        Assert.Equal((75, 2, (long?)null), state.EventsLoading[activityId]);
 
         state = Reducers.ReduceSetEventsLoading(
             state,
             new SetEventsLoadingAction(activityId, 50, 5));
 
         Assert.Single(state.EventsLoading);
-        Assert.Equal((50, 5), state.EventsLoading[activityId]);
+        Assert.Equal((50, 5, (long?)null), state.EventsLoading[activityId]);
 
         state = Reducers.ReduceClearStatus(
             state,
@@ -303,9 +362,9 @@ public sealed class StatusBarIntegrationTests
 
         var state = new StatusBarState
         {
-            EventsLoading = ImmutableDictionary<StatusActivityId, (int, int)>.Empty
-                .Add(activity1, (100, 5))
-                .Add(activity2, (200, 10))
+            EventsLoading = ImmutableDictionary<StatusActivityId, (int, int, long?)>.Empty
+                .Add(activity1, (100, 5, null))
+                .Add(activity2, (200, 10, null))
         };
 
         state = Reducers.ReduceClearStatus(state, new ClearStatusAction(nonExisting));
@@ -320,10 +379,10 @@ public sealed class StatusBarIntegrationTests
     {
         var state = new StatusBarState
         {
-            EventsLoading = ImmutableDictionary<StatusActivityId, (int, int)>.Empty
-                .Add(StatusActivityId.Create(), (100, 5))
-                .Add(StatusActivityId.Create(), (200, 10))
-                .Add(StatusActivityId.Create(), (300, 15)),
+            EventsLoading = ImmutableDictionary<StatusActivityId, (int, int, long?)>.Empty
+                .Add(StatusActivityId.Create(), (100, 5, null))
+                .Add(StatusActivityId.Create(), (200, 10, null))
+                .Add(StatusActivityId.Create(), (300, 15, null)),
             ResolverStatus = "Processing multiple activities..."
         };
 
@@ -384,7 +443,7 @@ public sealed class StatusBarIntegrationTests
             new SetEventsLoadingAction(activity1, 50, 0));
 
         Assert.Equal(2, state.EventsLoading.Count);
-        Assert.Equal((50, 0), state.EventsLoading[activity1]);
+        Assert.Equal((50, 0, (long?)null), state.EventsLoading[activity1]);
 
         state = Reducers.ReduceClearStatus(state, new ClearStatusAction(activity1));
         Assert.Single(state.EventsLoading);
@@ -412,9 +471,9 @@ public sealed class StatusBarIntegrationTests
             new SetEventsLoadingAction(activity3, 150, 5));
 
         Assert.Equal(3, state.EventsLoading.Count);
-        Assert.Equal((100, 0), state.EventsLoading[activity1]);
-        Assert.Equal((200, 10), state.EventsLoading[activity2]);
-        Assert.Equal((150, 5), state.EventsLoading[activity3]);
+        Assert.Equal((100, 0, (long?)null), state.EventsLoading[activity1]);
+        Assert.Equal((200, 10, (long?)null), state.EventsLoading[activity2]);
+        Assert.Equal((150, 5, (long?)null), state.EventsLoading[activity3]);
     }
 
     [Fact]
@@ -432,7 +491,7 @@ public sealed class StatusBarIntegrationTests
         state = Reducers.ReduceClearStatus(state, new ClearStatusAction(firstActivity));
 
         Assert.Single(state.EventsLoading);
-        Assert.Equal((50, 0), state.EventsLoading[secondActivity]);
+        Assert.Equal((50, 0, (long?)null), state.EventsLoading[secondActivity]);
         Assert.False(state.EventsLoading.ContainsKey(firstActivity));
     }
 

--- a/tests/Unit/EventLogExpert.UI.Tests/StatusBar/StatusBarTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/StatusBar/StatusBarTests.cs
@@ -517,6 +517,20 @@ public sealed class StatusBarTests : BunitContext
     }
 
     [Fact]
+    public void SingleLoadingActivityWithTotal_RendersPercent()
+    {
+        _status = new StatusBarPresentation
+        {
+            LoadingActivities = ImmutableDictionary<StatusActivityId, LoadingProgress>.Empty
+                .Add(new StatusActivityId(Guid.NewGuid()), new LoadingProgress(4_500, 0, 10_000))
+        };
+
+        var cut = Render<UI.StatusBar.StatusBar>();
+
+        Assert.Contains($"Loading: {4500:N0} (45%)", cut.Markup);
+    }
+
+    [Fact]
     public void SingleLoadingActivity_GroupsLargeFailedCount()
     {
         _status = new StatusBarPresentation


### PR DESCRIPTION
## SummaryAdds a live completion percentage to the status-bar loading chip while a log loads (for example `Loading: 45,000 (45%)`), so long loads of large logs show real progress instead of only a running count.## How it works- Denominator: the log's `RecordCount`, fetched at open time via a new `IEventLogReaderFactory.GetRecordCount` (a thin reuse of the existing public `EventLogSession.GetLogInformation`).- Numerator: records processed (`resolved + failed`), so the percentage converges even on logs with unresolvable events.- The count is fetched by a fire-and-forget, concurrency-gated probe (`RunRecordCountProbeAsync`) that publishes a total-only `SetLoadingTotalAction`. It never gates or strands the load; a wedged native open simply yields no percentage. The reducer no-ops if the activity already cleared and preserves the total across running-count updates.- The formatter clamps the percentage to 0..99 in `long` space (it never asserts 100%, and never renders `Loading: 0`); it falls back to count-only when no usable denominator is known.- Shown for both file logs and live channels (live channels are approximate but bounded and graceful).## Behavior change to noteThe status bar's "Failed: N" badge now counts events that throw during resolution. Previously those events vanished silently (counted as neither loaded nor failed). Counting them as failed is what makes the percentage converge and is arguably more correct, but it is a user-visible change to that badge.## Testing- Runtime.Tests: 2690 passed (+17: formatter percentage cases, reducer preserve/no-op, source projection, four probe direct-await cases, and a fire-and-forget wiring test).- UI.Tests: 1543 passed (+1: chip renders `(45%)`).- New Eventing integration test covering a second `EvtOpenLog` while a reverse `EvtQuery` on the same file is live (container-gated like all integration tests).- MAUI head builds clean.## Quality gateA multi-model review panel (rubber-duck plus code-review across Claude, GPT, and Gemini families, plus an author-framing-free red-team pass) reviewed both the design and the final diff and reached unanimous approval with zero blocking findings.

---
AB#63710011