### PR TITLE
Add a priority-aware CPU-work scheduler and route analytics through it

### DIFF
--- a/src/EventLogExpert.Runtime/ActivityCorrelation/ActivityCorrelationService.cs
+++ b/src/EventLogExpert.Runtime/ActivityCorrelation/ActivityCorrelationService.cs
@@ -3,12 +3,13 @@
 
 using EventLogExpert.Eventing.Common.EventLogs;
 using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Runtime.Concurrency;
 using EventLogExpert.Runtime.LogTable;
 using Fluxor;
 
 namespace EventLogExpert.Runtime.ActivityCorrelation;
 
-internal sealed class ActivityCorrelationService(IState<RawEventStoreState> rawStore)
+internal sealed class ActivityCorrelationService(IState<RawEventStoreState> rawStore, ICpuWorkScheduler cpuScheduler)
     : IActivityCorrelationService, IActivityCorrelationCacheControl
 {
     private const int MaxEventsPerActivity = 200;
@@ -16,6 +17,7 @@ internal sealed class ActivityCorrelationService(IState<RawEventStoreState> rawS
     private const int SharedPreviewCap = 25;
 
     private readonly Lock _cacheGate = new();
+    private readonly ICpuWorkScheduler _cpuScheduler = cpuScheduler;
     private readonly IState<RawEventStoreState> _rawStore = rawStore;
 
     private CachedView? _cache;
@@ -46,7 +48,10 @@ internal sealed class ActivityCorrelationService(IState<RawEventStoreState> rawS
             }
         }
 
-        var view = await Task.Run(() => BuildCore(store, focusedEvent, token, cancellationToken), cancellationToken);
+        var view = await _cpuScheduler.RunAsync(
+            correlationToken => BuildCore(store, focusedEvent, token, correlationToken),
+            CpuWorkPriority.UserInitiated,
+            cancellationToken);
 
         // Cache only if the snapshot is still current: a close or content change during the build must not repopulate
         // the neighborhood of a log that is no longer open. TryGetContentToken reads the live store, and the check runs

--- a/src/EventLogExpert.Runtime/Concurrency/ConcurrencyLimits.cs
+++ b/src/EventLogExpert.Runtime/Concurrency/ConcurrencyLimits.cs
@@ -3,13 +3,28 @@
 
 namespace EventLogExpert.Runtime.Concurrency;
 
-/// <summary>Shared concurrency limits for background, I/O-bound work across the runtime.</summary>
+/// <summary>Shared concurrency limits for background I/O-bound and CPU-bound work across the runtime.</summary>
 internal static class ConcurrencyLimits
 {
+    /// <summary>
+    ///     Interactive headroom reserved within <see cref="MaxCpuParallelism" />: while interactive work is present,
+    ///     background CPU work is held back by this many slots so a find scan is never queued behind the full analytics
+    ///     fan-out. Clamped to the valid range by <see cref="CpuWorkScheduler" />.
+    /// </summary>
+    internal static int CpuInteractiveReserve { get; } = 2;
+
     /// <summary>
     ///     Max degree of parallelism for background I/O-bound work (live-log resolution, exported-log folder scans).
     ///     Capped at one below the processor count and floored at 1, so a burst of concurrent file opens leaves a core for the
     ///     UI and never saturates the disk. Centralized here so every I/O fan-out shares one policy.
     /// </summary>
     internal static int MaxBackgroundIoParallelism { get; } = Math.Max(1, Environment.ProcessorCount - 1);
+
+    /// <summary>
+    ///     Concurrently-running CPU-bound analytics items admitted through <see cref="CpuWorkScheduler" />, set to the
+    ///     processor count. The scheduler is work-conserving, so a single log's background work still uses every core while
+    ///     the interactive reserve engages only when the user interacts. Separate from
+    ///     <see cref="MaxBackgroundIoParallelism" /> (CPU and I/O fan-outs are governed independently).
+    /// </summary>
+    internal static int MaxCpuParallelism { get; } = Environment.ProcessorCount;
 }

--- a/src/EventLogExpert.Runtime/Concurrency/CpuWorkPriority.cs
+++ b/src/EventLogExpert.Runtime/Concurrency/CpuWorkPriority.cs
@@ -1,0 +1,23 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Concurrency;
+
+/// <summary>Admission priority for CPU-bound work submitted to <see cref="ICpuWorkScheduler" />.</summary>
+public enum CpuWorkPriority
+{
+    /// <summary>Latency-critical work the user awaits keystroke-by-keystroke (find); admitted first, protected by the reserve.</summary>
+    Interactive,
+
+    /// <summary>
+    ///     User-initiated work with a visible spinner (modals, click-driven correlation); beats <see cref="Bulk" />, but
+    ///     not the interactive reserve.
+    /// </summary>
+    UserInitiated,
+
+    /// <summary>
+    ///     Always-on background analytics; yields to higher priorities and, while interactive work is present, runs only
+    ///     within the non-reserved budget.
+    /// </summary>
+    Bulk,
+}

--- a/src/EventLogExpert.Runtime/Concurrency/CpuWorkScheduler.cs
+++ b/src/EventLogExpert.Runtime/Concurrency/CpuWorkScheduler.cs
@@ -1,0 +1,161 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Concurrency;
+
+/// <summary>
+///     Bounded, priority-aware admission gate for CPU-bound work. At most <c>totalBudget</c> items run at once,
+///     admitted Interactive → UserInitiated → Bulk. While interactive work is present or queued, non-interactive work is
+///     admitted only below <c>totalBudget - reserve</c>, reserving headroom for an arriving interactive item; with no
+///     interactive work the reserve collapses so background work uses the whole budget (a single un-interacted log takes
+///     no throughput hit). The guarantee is admission, not preemption: already-running work is never suspended, so the
+///     non-interactive count can briefly exceed <c>totalBudget - reserve</c> right after an interactive item arrives.
+///     Reuses the thread pool; mirrors the reserved-headroom / cancellation model of <see cref="PrioritySemaphore" />.
+/// </summary>
+internal sealed class CpuWorkScheduler : ICpuWorkScheduler
+{
+    private readonly Queue<TaskCompletionSource> _bulkWaiters = new();
+    private readonly Lock _gate = new();
+    private readonly Queue<TaskCompletionSource> _interactiveWaiters = new();
+    private readonly int _reserve;
+    private readonly int _totalBudget;
+    private readonly Queue<TaskCompletionSource> _userInitiatedWaiters = new();
+
+    private int _maxObserved;
+    private int _nonInteractiveRunning;
+    private int _running;
+
+    internal CpuWorkScheduler(int totalBudget, int reserve)
+    {
+        _totalBudget = Math.Max(1, totalBudget);
+        _reserve = Math.Clamp(reserve, 0, _totalBudget - 1);
+    }
+
+    /// <summary>High-water mark of concurrently-running items; test-only.</summary>
+    internal int MaxObserved { get { lock (_gate) { return _maxObserved; } } }
+
+    /// <summary>Currently-running item count; test-only.</summary>
+    internal int Running { get { lock (_gate) { return _running; } } }
+
+    /// <summary>Queued (interactive, userInitiated, bulk) waiter counts; test-only.</summary>
+    internal (int Interactive, int UserInitiated, int Bulk) WaiterCounts
+    {
+        get { lock (_gate) { return (_interactiveWaiters.Count, _userInitiatedWaiters.Count, _bulkWaiters.Count); } }
+    }
+
+    public async Task<T> RunAsync<T>(Func<CancellationToken, T> work, CpuWorkPriority priority, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(work);
+
+        if (!Enum.IsDefined(priority)) { throw new ArgumentOutOfRangeException(nameof(priority), priority, "Unknown CPU work priority."); }
+
+        // Validation throws before any permit is taken, so nothing leaks.
+        await AcquireAsync(priority, cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            // Admission (not the pool) bounds concurrency; Task.Run just offloads. The token drives both in-flight and
+            // pre-start cancellation.
+            return await Task.Run(() => work(cancellationToken), cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            Release(priority);
+        }
+    }
+
+    private Task AcquireAsync(CpuWorkPriority priority, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested) { return Task.FromCanceled(cancellationToken); }
+
+        lock (_gate)
+        {
+            if (CanAdmit(priority))
+            {
+                Occupy(priority);
+
+                return Task.CompletedTask;
+            }
+
+            var waiter = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            if (cancellationToken.CanBeCanceled)
+            {
+                // Register before enqueueing so a throwing Register can't strand a waiter that later steals a permit;
+                // pass the token through so a queued cancel carries the caller's token (like Task.Run(work, token)).
+                CancellationTokenRegistration registration = cancellationToken.Register(
+                    static (state, token) => ((TaskCompletionSource)state!).TrySetCanceled(token),
+                    waiter);
+
+                // Dispose the registration once the wait settles (granted or canceled) so it isn't retained.
+                waiter.Task.ContinueWith(
+                    static (_, state) => ((CancellationTokenRegistration)state!).Dispose(),
+                    registration,
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+            }
+
+            WaitersFor(priority).Enqueue(waiter);
+
+            return waiter.Task;
+        }
+    }
+
+    private bool CanAdmit(CpuWorkPriority priority)
+    {
+        if (_running >= _totalBudget) { return false; }
+
+        return priority == CpuWorkPriority.Interactive || _nonInteractiveRunning < _totalBudget - EffectiveReserve();
+    }
+
+    private int EffectiveReserve() =>
+        _running - _nonInteractiveRunning > 0 || _interactiveWaiters.Count > 0 ? _reserve : 0;
+
+    private void Occupy(CpuWorkPriority priority)
+    {
+        _running++;
+
+        if (_running > _maxObserved) { _maxObserved = _running; }
+
+        if (priority != CpuWorkPriority.Interactive) { _nonInteractiveRunning++; }
+    }
+
+    private void Release(CpuWorkPriority priority)
+    {
+        lock (_gate)
+        {
+            Unoccupy(priority);
+
+            // Wake in strict priority order; RunContinuationsAsynchronously keeps a woken continuation off this locked stack.
+            WakeWaiters(_interactiveWaiters, CpuWorkPriority.Interactive);
+            WakeWaiters(_userInitiatedWaiters, CpuWorkPriority.UserInitiated);
+            WakeWaiters(_bulkWaiters, CpuWorkPriority.Bulk);
+        }
+    }
+
+    private void Unoccupy(CpuWorkPriority priority)
+    {
+        _running--;
+
+        if (priority != CpuWorkPriority.Interactive) { _nonInteractiveRunning--; }
+    }
+
+    private Queue<TaskCompletionSource> WaitersFor(CpuWorkPriority priority) => priority switch
+    {
+        CpuWorkPriority.Interactive => _interactiveWaiters,
+        CpuWorkPriority.UserInitiated => _userInitiatedWaiters,
+        _ => _bulkWaiters,
+    };
+
+    private void WakeWaiters(Queue<TaskCompletionSource> waiters, CpuWorkPriority priority)
+    {
+        while (waiters.Count > 0 && CanAdmit(priority))
+        {
+            Occupy(priority);
+
+            // A canceled waiter refuses the grant; roll the permit back and keep draining so it isn't lost.
+            if (!waiters.Dequeue().TrySetResult()) { Unoccupy(priority); }
+        }
+    }
+}

--- a/src/EventLogExpert.Runtime/Concurrency/ICpuWorkScheduler.cs
+++ b/src/EventLogExpert.Runtime/Concurrency/ICpuWorkScheduler.cs
@@ -1,0 +1,20 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Concurrency;
+
+/// <summary>
+///     Process-wide admission gate for CPU-bound work: bounds how many items run at once and admits them by
+///     <see cref="CpuWorkPriority" /> so background analytics neither starve interactive work nor oversubscribe the cores.
+///     Reuses the thread pool; only admission is governed.
+/// </summary>
+public interface ICpuWorkScheduler
+{
+    /// <summary>
+    ///     Runs <paramref name="work" /> on the thread pool once admitted at <paramref name="priority" />, passing it
+    ///     <paramref name="cancellationToken" />; the token also drops the request if canceled before admission (throwing like
+    ///     a canceled <see cref="Task.Run{TResult}(Func{TResult}, CancellationToken)" />). The delegate must be leaf CPU work
+    ///     and must not call back into the scheduler.
+    /// </summary>
+    Task<T> RunAsync<T>(Func<CancellationToken, T> work, CpuWorkPriority priority, CancellationToken cancellationToken = default);
+}

--- a/src/EventLogExpert.Runtime/DependencyInjection/RuntimeServiceCollectionExtensions.cs
+++ b/src/EventLogExpert.Runtime/DependencyInjection/RuntimeServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ using EventLogExpert.Runtime.Common.AppTitle;
 using EventLogExpert.Runtime.Common.Clipboard;
 using EventLogExpert.Runtime.Common.Files;
 using EventLogExpert.Runtime.Common.Versioning;
+using EventLogExpert.Runtime.Concurrency;
 using EventLogExpert.Runtime.Database;
 using EventLogExpert.Runtime.DatabaseTools;
 using EventLogExpert.Runtime.DatabaseTools.Elevation;
@@ -144,6 +145,8 @@ public static class RuntimeServiceCollectionExtensions
             services.AddSingleton<IFilterPaneQueries, FilterPaneQueries>();
 
             // Coordinators and concurrency
+            services.AddSingleton<ICpuWorkScheduler>(static _ =>
+                new CpuWorkScheduler(ConcurrencyLimits.MaxCpuParallelism, ConcurrencyLimits.CpuInteractiveReserve));
             services.AddSingleton<LogCloseCoordinator>();
             services.AddSingleton<EventLogConcurrencyState>();
             services.AddSingleton<XmlFilterMatchCache>();

--- a/src/EventLogExpert.Runtime/EventLog/FilteringEffects.cs
+++ b/src/EventLogExpert.Runtime/EventLog/FilteringEffects.cs
@@ -6,6 +6,7 @@ using EventLogExpert.Eventing.Common.EventLogs;
 using EventLogExpert.Eventing.Common.Events;
 using EventLogExpert.Filtering.Evaluation;
 using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.Concurrency;
 using EventLogExpert.Runtime.LogTable;
 using Fluxor;
 using Microsoft.Extensions.DependencyInjection;
@@ -21,10 +22,12 @@ internal sealed class FilteringEffects(
     IXmlFilterMatcher matcher,
     XmlFilterMatchCache matchCache,
     EventLogConcurrencyState concurrencyState,
+    ICpuWorkScheduler cpuScheduler,
     [FromKeyedServices(LogCategories.EventLog)] ITraceLogger logger)
 {
     private readonly Lock _computeGate = new();
     private readonly EventLogConcurrencyState _concurrencyState = concurrencyState;
+    private readonly ICpuWorkScheduler _cpuScheduler = cpuScheduler;
     private readonly IState<EventLogState> _eventLogState = eventLogState;
     private readonly LiveTailIngestCoordinator _liveTailCoordinator = liveTailCoordinator;
     private readonly ITraceLogger _logger = logger;
@@ -184,8 +187,12 @@ internal sealed class FilteringEffects(
 
                     IEventColumnReader reader = store.CreateReader(info.Id);
 
-                    matches[info.Id] = await Task.Run(
-                        () => _matcher.ComputeMatch(reader, filter, name, info.Type, computeCts.Token));
+                    // Bulk: this on-demand XML match is background analytics that must yield to interactive find. Passing
+                    // computeCts.Token now also drops a superseded queued match (OperationCanceledException, already treated as Superseded), unlike the prior token-less Task.Run.
+                    matches[info.Id] = await _cpuScheduler.RunAsync(
+                        matchToken => _matcher.ComputeMatch(reader, filter, name, info.Type, matchToken),
+                        CpuWorkPriority.Bulk,
+                        computeCts.Token);
 
                     recomputed = true;
                 }

--- a/src/EventLogExpert.UI/LogTable/Histogram/HistogramPane.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/Histogram/HistogramPane.razor.cs
@@ -4,6 +4,7 @@
 using EventLogExpert.Eventing.Common.EventLogs;
 using EventLogExpert.Filtering.Persistence;
 using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.Concurrency;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.Runtime.FilterLenses;
 using EventLogExpert.Runtime.FilterPane;
@@ -72,6 +73,8 @@ public sealed partial class HistogramPane
     private long _windowStartTicks;
 
     [Inject] private IActiveEventLogSource ActiveEventLog { get; init; } = null!;
+
+    [Inject] private ICpuWorkScheduler CpuScheduler { get; init; } = null!;
 
     [Inject] private IHistogramDimensionRequestSource DimensionRequest { get; init; } = null!;
 
@@ -890,19 +893,19 @@ public sealed partial class HistogramPane
 
         try
         {
-            data = await Task.Run(() =>
+            data = await CpuScheduler.RunAsync(histogramToken =>
             {
-                token.ThrowIfCancellationRequested();
+                histogramToken.ThrowIfCancellationRequested();
 
                 if (useHighlightTie)
                 {
-                    byte[] highlightWinners = view.EnsureHighlightWinners(tieHighlightFilters, tiePlanKey, token);
+                    byte[] highlightWinners = view.EnsureHighlightWinners(tieHighlightFilters, tiePlanKey, histogramToken);
 
-                    return HistogramBuilder.BuildWithHighlightTie(view, dimension, HistogramConstants.MaxBuckets, highlightWinners, token);
+                    return HistogramBuilder.BuildWithHighlightTie(view, dimension, HistogramConstants.MaxBuckets, highlightWinners, histogramToken);
                 }
 
-                return HistogramBuilder.Build(view, dimension, HistogramConstants.MaxBuckets, token);
-            }, token);
+                return HistogramBuilder.Build(view, dimension, HistogramConstants.MaxBuckets, histogramToken);
+            }, CpuWorkPriority.Bulk, token);
         }
         catch (OperationCanceledException) { return; }
         catch (Exception e)

--- a/src/EventLogExpert.UI/LogTable/LogTablePane.Find.cs
+++ b/src/EventLogExpert.UI/LogTable/LogTablePane.Find.cs
@@ -3,6 +3,7 @@
 
 using EventLogExpert.Eventing.Common.EventLogs;
 using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Runtime.Concurrency;
 using EventLogExpert.Runtime.LogTable;
 using EventLogExpert.UI.LogTable.Find;
 using EventLogExpert.UI.LogTable.Grouping;
@@ -411,8 +412,8 @@ public sealed partial class LogTablePane
 
         try
         {
-            (matches, matchTicks) = await Task.Run(
-                () =>
+            (matches, matchTicks) = await CpuScheduler.RunAsync(
+                findToken =>
                 {
                     var found = new List<EventLocator>();
                     var foundTicks = new List<long>();
@@ -420,7 +421,7 @@ public sealed partial class LogTablePane
 
                     for (int start = 0; start < total; start += FindChunkSize)
                     {
-                        token.ThrowIfCancellationRequested();
+                        findToken.ThrowIfCancellationRequested();
 
                         int count = Math.Min(FindChunkSize, total - start);
                         IReadOnlyList<DisplayRow> slice = view.Slice(start, count);
@@ -437,6 +438,7 @@ public sealed partial class LogTablePane
 
                     return (found, foundTicks);
                 },
+                CpuWorkPriority.Interactive,
                 token);
         }
         catch (OperationCanceledException) { return; }

--- a/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
@@ -10,6 +10,7 @@ using EventLogExpert.Filtering.Persistence;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Runtime.Common.Clipboard;
 using EventLogExpert.Runtime.Common.Display;
+using EventLogExpert.Runtime.Concurrency;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.Runtime.FilterLenses;
 using EventLogExpert.Runtime.FilterPane;
@@ -80,6 +81,8 @@ public sealed partial class LogTablePane
     [Inject] private IClipboardService ClipboardService { get; init; } = null!;
 
     [Inject] private ILogTableColumnDefaultsProvider ColumnDefaults { get; init; } = null!;
+
+    [Inject] private ICpuWorkScheduler CpuScheduler { get; init; } = null!;
 
     [Inject] private IEventLogCommands EventLogCommands { get; init; } = null!;
 

--- a/src/EventLogExpert.UI/LogTable/Resolution/ResolutionCoverageModal.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/Resolution/ResolutionCoverageModal.razor.cs
@@ -4,6 +4,7 @@
 using EventLogExpert.Eventing.Common.Events;
 using EventLogExpert.Filtering.Common.Filtering;
 using EventLogExpert.Runtime.Common.Clipboard;
+using EventLogExpert.Runtime.Concurrency;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.Runtime.FilterLenses;
 using EventLogExpert.Runtime.LogTable;
@@ -51,6 +52,8 @@ public sealed partial class ResolutionCoverageModal : ModalBase<bool>
     [Inject] private IClipboardService ClipboardService { get; init; } = null!;
 
     [Inject] private IResolutionCoverageService CoverageService { get; init; } = null!;
+
+    [Inject] private ICpuWorkScheduler CpuScheduler { get; init; } = null!;
 
     [Inject] private IFilterAppliedSource FilterApplied { get; init; } = null!;
 
@@ -115,7 +118,9 @@ public sealed partial class ResolutionCoverageModal : ModalBase<bool>
         try
         {
             IEventColumnView view = _view;
-            _report = await Task.Run(() => CoverageService.Build(view, _cts.Token), _cts.Token);
+            // UserInitiated: user opened this modal and is watching its spinner. Do NOT add ConfigureAwait(false) - the
+            // continuation mutates _report and calls StateHasChanged() without InvokeAsync, so it must resume on the Blazor dispatcher.
+            _report = await CpuScheduler.RunAsync(reportToken => CoverageService.Build(view, reportToken), CpuWorkPriority.UserInitiated, _cts.Token);
         }
         catch (OperationCanceledException) { }
         catch (Exception)
@@ -355,7 +360,9 @@ public sealed partial class ResolutionCoverageModal : ModalBase<bool>
 
         try
         {
-            detail = await Task.Run(() => CoverageService.BuildProviderDetail(view, provider, linked.Token), linked.Token);
+            // UserInitiated: user-driven provider expand. Do NOT add ConfigureAwait(false) - the continuation mutates
+            // detail state and renders without InvokeAsync, so it must resume on the Blazor dispatcher.
+            detail = await CpuScheduler.RunAsync(detailToken => CoverageService.BuildProviderDetail(view, provider, detailToken), CpuWorkPriority.UserInitiated, linked.Token);
         }
         catch (OperationCanceledException) { return; }
         catch (Exception) { failed = true; }

--- a/src/EventLogExpert.UI/LogTable/Stats/StatsDetailModal.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/Stats/StatsDetailModal.razor.cs
@@ -1,6 +1,7 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Runtime.Concurrency;
 using EventLogExpert.Runtime.FilterLenses;
 using EventLogExpert.Runtime.LogTable;
 using EventLogExpert.Runtime.Stats;
@@ -31,6 +32,8 @@ public sealed partial class StatsDetailModal : ModalBase<bool>
 
     [EditorRequired]
     [Parameter] public IEventColumnView View { get; set; } = null!;
+
+    [Inject] private ICpuWorkScheduler CpuScheduler { get; init; } = null!;
 
     [Inject] private IFilterLensCommands FilterLensCommands { get; init; } = null!;
 
@@ -64,8 +67,10 @@ public sealed partial class StatsDetailModal : ModalBase<bool>
 
         try
         {
-            DimensionStats stats = await Task.Run(
-                () => StatsService.BuildDimension(View, Dimension, MaxRows, _cts.Token), _cts.Token);
+            // UserInitiated: user opened this modal and is watching its spinner. Do NOT add ConfigureAwait(false) - the
+            // continuation mutates state and the finally calls StateHasChanged() without InvokeAsync, so it must resume on the Blazor dispatcher.
+            DimensionStats stats = await CpuScheduler.RunAsync(
+                detailToken => StatsService.BuildDimension(View, Dimension, MaxRows, detailToken), CpuWorkPriority.UserInitiated, _cts.Token);
 
             _all = stats.Top;
             _distinct = stats.DistinctCount;

--- a/src/EventLogExpert.UI/LogTable/Stats/StatsPane.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/Stats/StatsPane.razor.cs
@@ -4,6 +4,7 @@
 using EventLogExpert.Eventing.Common.EventLogs;
 using EventLogExpert.Eventing.Common.Events;
 using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.Concurrency;
 using EventLogExpert.Runtime.FilterLenses;
 using EventLogExpert.Runtime.LogTable;
 using EventLogExpert.Runtime.LogTable.OrderedView;
@@ -70,6 +71,8 @@ public sealed partial class StatsPane
     private DotNetObjectReference<StatsPane>? _selfRef;
     private SeverityStats? _severity;
     private ViewContentToken _severityToken = ViewContentToken.Empty;
+
+    [Inject] private ICpuWorkScheduler CpuScheduler { get; init; } = null!;
 
     [Inject] private IFilterLensCommands FilterLensCommands { get; init; } = null!;
 
@@ -363,7 +366,7 @@ public sealed partial class StatsPane
         try
         {
             SeverityStats severity =
-                await Task.Run(() => StatsService.BuildSeverity(view, cancellationToken), cancellationToken);
+                await CpuScheduler.RunAsync(scanToken => StatsService.BuildSeverity(view, scanToken), CpuWorkPriority.Bulk, cancellationToken);
 
             if (!await PublishAsync(scanVersion, tab, contentToken, () =>
                 {
@@ -377,8 +380,9 @@ public sealed partial class StatsPane
 
             foreach ((StatsDimension dimension, int topN) in requests)
             {
-                DimensionStats stats = await Task.Run(
-                    () => StatsService.BuildDimension(view, dimension, topN, cancellationToken),
+                DimensionStats stats = await CpuScheduler.RunAsync(
+                    scanToken => StatsService.BuildDimension(view, dimension, topN, scanToken),
+                    CpuWorkPriority.Bulk,
                     cancellationToken);
 
                 if (!await PublishAsync(scanVersion, tab, contentToken, () =>

--- a/tests/Unit/EventLogExpert.Runtime.Tests/ActivityCorrelation/ActivityCorrelationServiceTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/ActivityCorrelation/ActivityCorrelationServiceTests.cs
@@ -6,6 +6,7 @@ using EventLogExpert.Eventing.Common.EventLogs;
 using EventLogExpert.Eventing.Common.Events;
 using EventLogExpert.Runtime.ActivityCorrelation;
 using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.Runtime.Tests.TestUtils;
 using Fluxor;
 using NSubstitute;
 using System.Collections.Immutable;
@@ -293,7 +294,7 @@ public sealed class ActivityCorrelationServiceTests
     {
         var storeState = Substitute.For<IState<RawEventStoreState>>();
         storeState.Value.Returns(new RawEventStoreState());
-        var service = new ActivityCorrelationService(storeState);
+        var service = new ActivityCorrelationService(storeState, new ImmediateCpuWorkScheduler());
 
         var view = await service.BuildAsync(Locator(1, 0), Ct);
 
@@ -431,6 +432,6 @@ public sealed class ActivityCorrelationServiceTests
             ByLog = ImmutableDictionary<EventLogId, EventColumnStore>.Empty.Add(s_logId, store)
         });
 
-        return (new ActivityCorrelationService(storeState), storeState);
+        return (new ActivityCorrelationService(storeState, new ImmediateCpuWorkScheduler()), storeState);
     }
 }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Concurrency/CpuWorkSchedulerTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Concurrency/CpuWorkSchedulerTests.cs
@@ -1,0 +1,386 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.Concurrency;
+
+namespace EventLogExpert.Runtime.Tests.Concurrency;
+
+public sealed class CpuWorkSchedulerTests
+{
+    private static int Sink;
+
+    [Fact(Timeout = 30000)]
+    public async Task Constructor_ClampsReserveBelowBudget_LeavingOneNonInteractiveSlot()
+    {
+        // reserve 5 on budget 2 clamps to 1; without the clamp the non-interactive cap would go negative and admit none.
+        var scheduler = new CpuWorkScheduler(totalBudget: 2, reserve: 5);
+        var gates = new List<Gate>();
+
+        try
+        {
+            Gate interactive = Submit(scheduler, CpuWorkPriority.Interactive);
+            gates.Add(interactive);
+            await interactive.Started;
+
+            gates.Add(Submit(scheduler, CpuWorkPriority.Bulk));
+            gates.Add(Submit(scheduler, CpuWorkPriority.Bulk));
+
+            Assert.Equal(2, scheduler.Running);
+            Assert.Equal(1, scheduler.WaiterCounts.Bulk);
+        }
+        finally { await ReleaseAllAsync(gates); }
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task RunAsync_AdmitsUpToBudget_AndQueuesTheRest()
+    {
+        var scheduler = new CpuWorkScheduler(totalBudget: 2, reserve: 0);
+        var gates = new List<Gate>();
+
+        try
+        {
+            for (int i = 0; i < 4; i++) { gates.Add(Submit(scheduler, CpuWorkPriority.Bulk)); }
+
+            Assert.Equal(2, scheduler.Running);
+            Assert.Equal(2, scheduler.WaiterCounts.Bulk);
+            Assert.Equal(2, scheduler.MaxObserved);
+        }
+        finally { await ReleaseAllAsync(gates); }
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task RunAsync_CancelingQueuedWaiter_DropsItWithoutRunningWork_AndConservesBudget()
+    {
+        var scheduler = new CpuWorkScheduler(totalBudget: 1, reserve: 0);
+        var gates = new List<Gate>();
+        int queuedRan = 0;
+
+        try
+        {
+            Gate running = Submit(scheduler, CpuWorkPriority.Bulk);
+            gates.Add(running);
+            await running.Started;
+
+            using var cts = new CancellationTokenSource();
+            Task queued = scheduler.RunAsync(_ => Interlocked.Exchange(ref queuedRan, 1), CpuWorkPriority.Bulk, cts.Token);
+            Assert.Equal(1, scheduler.WaiterCounts.Bulk);
+
+            await cts.CancelAsync();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => queued);
+
+            Assert.Equal(0, Volatile.Read(ref queuedRan));
+
+            // The canceled waiter never consumed the permit: after the running item finishes, a fresh acquire admits.
+            running.Release();
+            Gate next = Submit(scheduler, CpuWorkPriority.Bulk);
+            gates.Add(next);
+            await next.Started;
+            Assert.Equal(1, scheduler.Running);
+        }
+        finally { await ReleaseAllAsync(gates); }
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task RunAsync_InteractiveWork_MayUseTheReservedSlot()
+    {
+        var scheduler = new CpuWorkScheduler(totalBudget: 4, reserve: 2);
+        var gates = new List<Gate>();
+
+        try
+        {
+            Gate firstInteractive = Submit(scheduler, CpuWorkPriority.Interactive);
+            gates.Add(firstInteractive);
+            await firstInteractive.Started;
+
+            for (int i = 0; i < 2; i++) { gates.Add(Submit(scheduler, CpuWorkPriority.Bulk)); }
+
+            Assert.Equal(3, scheduler.Running);
+
+            Gate secondInteractive = Submit(scheduler, CpuWorkPriority.Interactive);
+            gates.Add(secondInteractive);
+            await secondInteractive.Started;
+
+            // Interactive is only bounded by the total budget, so it takes the reserved slot rather than queuing.
+            Assert.Equal(4, scheduler.Running);
+            Assert.Equal((0, 0, 0), scheduler.WaiterCounts);
+        }
+        finally { await ReleaseAllAsync(gates); }
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task RunAsync_OnRelease_AdmitsQueuedInteractiveBeforeQueuedBulk()
+    {
+        var scheduler = new CpuWorkScheduler(totalBudget: 2, reserve: 0);
+        var gates = new List<Gate>();
+
+        try
+        {
+            Gate runningA = Submit(scheduler, CpuWorkPriority.Bulk);
+            Gate runningB = Submit(scheduler, CpuWorkPriority.Bulk);
+            gates.Add(runningA);
+            gates.Add(runningB);
+            await Task.WhenAll(runningA.Started, runningB.Started);
+
+            Gate queuedBulk = Submit(scheduler, CpuWorkPriority.Bulk);
+            Gate queuedInteractive = Submit(scheduler, CpuWorkPriority.Interactive);
+            gates.Add(queuedBulk);
+            gates.Add(queuedInteractive);
+            Assert.Equal((1, 0, 1), scheduler.WaiterCounts);
+
+            runningA.Release();
+            await queuedInteractive.Started;
+
+            // The freed slot went to the interactive waiter; the bulk waiter is still queued.
+            Assert.Equal(2, scheduler.Running);
+            Assert.Equal(1, scheduler.WaiterCounts.Bulk);
+            Assert.False(queuedBulk.Started.IsCompleted);
+        }
+        finally { await ReleaseAllAsync(gates); }
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task RunAsync_OnRelease_AdmitsQueuedUserInitiatedBeforeBulk()
+    {
+        var scheduler = new CpuWorkScheduler(totalBudget: 1, reserve: 0);
+        var gates = new List<Gate>();
+
+        try
+        {
+            Gate running = Submit(scheduler, CpuWorkPriority.Bulk);
+            gates.Add(running);
+            await running.Started;
+
+            Gate queuedBulk = Submit(scheduler, CpuWorkPriority.Bulk);
+            Gate queuedUserInitiated = Submit(scheduler, CpuWorkPriority.UserInitiated);
+            gates.Add(queuedBulk);
+            gates.Add(queuedUserInitiated);
+
+            running.Release();
+            await queuedUserInitiated.Started;
+
+            Assert.Equal(1, scheduler.Running);
+            Assert.Equal(1, scheduler.WaiterCounts.Bulk);
+            Assert.False(queuedBulk.Started.IsCompleted);
+        }
+        finally { await ReleaseAllAsync(gates); }
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task RunAsync_UnderConcurrentMixedLoad_NeverExceedsBudget_AndConservesBudget()
+    {
+        const int budget = 4;
+        var scheduler = new CpuWorkScheduler(budget, reserve: 2);
+
+        async Task Worker(int seed)
+        {
+            var seededRandom = new Random(seed);
+
+            for (int i = 0; i < 1500; i++)
+            {
+                CpuWorkPriority priority = (CpuWorkPriority)seededRandom.Next(3);
+                using var cts = new CancellationTokenSource();
+
+                if (seededRandom.Next(5) == 0) { cts.CancelAfter(TimeSpan.FromMilliseconds(seededRandom.Next(3))); }
+
+                try { await scheduler.RunAsync(_ => Interlocked.Increment(ref Sink), priority, cts.Token); }
+                catch (OperationCanceledException) { }
+            }
+        }
+
+        await Task.WhenAll(Enumerable.Range(0, 8).Select(seed => Task.Run(() => Worker(seed))))
+            .WaitAsync(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+
+        // Budget is conserved (no permit leaked); canceled waiters may linger in a queue until a later release drains
+        // them (design limitation #4, as with PrioritySemaphore), so waiter counts are not asserted zero here.
+        Assert.True(scheduler.MaxObserved <= budget, $"observed {scheduler.MaxObserved} exceeded budget {budget}");
+        Assert.Equal(0, scheduler.Running);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task RunAsync_UserInitiated_CannotConsumeTheInteractiveReserve()
+    {
+        var scheduler = new CpuWorkScheduler(totalBudget: 3, reserve: 2);
+        var gates = new List<Gate>();
+
+        try
+        {
+            Gate interactive = Submit(scheduler, CpuWorkPriority.Interactive);
+            gates.Add(interactive);
+            await interactive.Started;
+
+            gates.Add(Submit(scheduler, CpuWorkPriority.UserInitiated));
+            gates.Add(Submit(scheduler, CpuWorkPriority.UserInitiated));
+
+            // budget - reserve = 1 non-interactive slot; the second user-initiated item queues behind the reserve.
+            Assert.Equal(2, scheduler.Running);
+            Assert.Equal(1, scheduler.WaiterCounts.UserInitiated);
+        }
+        finally { await ReleaseAllAsync(gates); }
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task RunAsync_WhenLastInteractiveCompletes_AdmitsHeldBackBulk()
+    {
+        var scheduler = new CpuWorkScheduler(totalBudget: 3, reserve: 2);
+        var gates = new List<Gate>();
+
+        try
+        {
+            Gate interactive = Submit(scheduler, CpuWorkPriority.Interactive);
+            gates.Add(interactive);
+            await interactive.Started;
+
+            Gate runningBulk = Submit(scheduler, CpuWorkPriority.Bulk);
+            Gate heldBulkA = Submit(scheduler, CpuWorkPriority.Bulk);
+            Gate heldBulkB = Submit(scheduler, CpuWorkPriority.Bulk);
+            gates.Add(runningBulk);
+            gates.Add(heldBulkA);
+            gates.Add(heldBulkB);
+            await runningBulk.Started;
+            Assert.Equal(2, scheduler.WaiterCounts.Bulk);
+
+            // Completing the only interactive item collapses the reserve; the held-back bulk must wake.
+            interactive.Release();
+            await Task.WhenAll(heldBulkA.Started, heldBulkB.Started);
+
+            Assert.Equal(3, scheduler.Running);
+            Assert.Equal(0, scheduler.WaiterCounts.Bulk);
+        }
+        finally { await ReleaseAllAsync(gates); }
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task RunAsync_WhenNoInteractiveWork_BulkUsesEntireBudget()
+    {
+        // Work-conserving: with no interactive work present the reserve collapses, so bulk fills the whole budget.
+        var scheduler = new CpuWorkScheduler(totalBudget: 4, reserve: 2);
+        var gates = new List<Gate>();
+
+        try
+        {
+            for (int i = 0; i < 4; i++) { gates.Add(Submit(scheduler, CpuWorkPriority.Bulk)); }
+
+            Assert.Equal(4, scheduler.Running);
+            Assert.Equal(4, scheduler.MaxObserved);
+            Assert.Equal(0, scheduler.WaiterCounts.Bulk);
+        }
+        finally { await ReleaseAllAsync(gates); }
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task RunAsync_WhenWorkThrows_ReleasesBudget()
+    {
+        var scheduler = new CpuWorkScheduler(totalBudget: 1, reserve: 0);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            scheduler.RunAsync<int>(_ => throw new InvalidOperationException("boom"), CpuWorkPriority.Bulk, TestContext.Current.CancellationToken));
+
+        Assert.Equal(0, scheduler.Running);
+
+        // The faulted item released its slot, so the scheduler still admits new work.
+        var gates = new List<Gate>();
+        try
+        {
+            Gate next = Submit(scheduler, CpuWorkPriority.Bulk);
+            gates.Add(next);
+            await next.Started;
+            Assert.Equal(1, scheduler.Running);
+        }
+        finally { await ReleaseAllAsync(gates); }
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task RunAsync_WhileInteractivePresent_HoldsReservedHeadroomForInteractive()
+    {
+        var scheduler = new CpuWorkScheduler(totalBudget: 4, reserve: 2);
+        var gates = new List<Gate>();
+
+        try
+        {
+            Gate interactive = Submit(scheduler, CpuWorkPriority.Interactive);
+            gates.Add(interactive);
+            await interactive.Started;
+
+            for (int i = 0; i < 4; i++) { gates.Add(Submit(scheduler, CpuWorkPriority.Bulk)); }
+
+            // 1 interactive + (budget - reserve = 2) bulk running; the remaining 2 bulk queue behind the reserve.
+            Assert.Equal(3, scheduler.Running);
+            Assert.Equal(2, scheduler.WaiterCounts.Bulk);
+        }
+        finally { await ReleaseAllAsync(gates); }
+    }
+
+    [Fact]
+    public async Task RunAsync_WithNullWork_ThrowsArgumentNull()
+    {
+        var scheduler = new CpuWorkScheduler(totalBudget: 1, reserve: 0);
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            scheduler.RunAsync<int>(null!, CpuWorkPriority.Bulk, TestContext.Current.CancellationToken));
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task RunAsync_WithPreCanceledToken_DoesNotRunWork_OrConsumeBudget()
+    {
+        var scheduler = new CpuWorkScheduler(totalBudget: 2, reserve: 0);
+        using var canceled = new CancellationTokenSource();
+        await canceled.CancelAsync();
+        int ran = 0;
+
+        await Assert.ThrowsAsync<TaskCanceledException>(() =>
+            scheduler.RunAsync(_ => Interlocked.Exchange(ref ran, 1), CpuWorkPriority.Bulk, canceled.Token));
+
+        Assert.Equal(0, Volatile.Read(ref ran));
+        Assert.Equal(0, scheduler.Running);
+    }
+
+    [Fact]
+    public async Task RunAsync_WithUndefinedPriority_ThrowsArgumentOutOfRange()
+    {
+        var scheduler = new CpuWorkScheduler(totalBudget: 1, reserve: 0);
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            scheduler.RunAsync(_ => 0, (CpuWorkPriority)999, TestContext.Current.CancellationToken));
+    }
+
+    private static async Task ReleaseAllAsync(List<Gate> gates)
+    {
+        foreach (Gate item in gates) { item.Release(); }
+
+        // Await completion so blocked pool threads are freed before the next test and no permit lingers.
+        await Task.WhenAll(gates.Select(item => item.Completion)).WaitAsync(TimeSpan.FromSeconds(10));
+    }
+
+    private static Gate Submit(CpuWorkScheduler scheduler, CpuWorkPriority priority)
+    {
+        var item = new Gate();
+        item.Bind(scheduler.RunAsync(item.Work, priority));
+
+        return item;
+    }
+
+    // A work item that signals when its delegate begins and then blocks until the test releases it, letting the test
+    // inspect admission state deterministically while the item "runs".
+    private sealed class Gate
+    {
+        private readonly ManualResetEventSlim _release = new(false);
+        private readonly TaskCompletionSource _started = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private Task _completion = Task.CompletedTask;
+
+        public Task Completion => _completion;
+
+        public Task Started => _started.Task;
+
+        public void Bind(Task completion) => _completion = completion;
+
+        public void Release() => _release.Set();
+
+        public int Work(CancellationToken cancellationToken)
+        {
+            _started.TrySetResult();
+            _release.Wait(cancellationToken);
+
+            return 0;
+        }
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/DependencyInjection/RuntimeServiceCollectionExtensionsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/DependencyInjection/RuntimeServiceCollectionExtensionsTests.cs
@@ -16,6 +16,7 @@ using EventLogExpert.Runtime.Common.Identity;
 using EventLogExpert.Runtime.Common.Restart;
 using EventLogExpert.Runtime.Common.Threading;
 using EventLogExpert.Runtime.Common.Versioning;
+using EventLogExpert.Runtime.Concurrency;
 using EventLogExpert.Runtime.Database;
 using EventLogExpert.Runtime.DatabaseTools;
 using EventLogExpert.Runtime.DatabaseTools.Elevation;
@@ -157,6 +158,7 @@ public sealed class RuntimeServiceCollectionExtensionsTests
     }
 
     [Theory]
+    [InlineData(typeof(ICpuWorkScheduler))]
     [InlineData(typeof(IEventLogCommands))]
     [InlineData(typeof(IFilterLibraryCommands))]
     [InlineData(typeof(IFilterPaneCommands))]

--- a/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EffectsTests.cs
@@ -15,6 +15,7 @@ using EventLogExpert.Runtime.Database;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.Runtime.LogTable;
 using EventLogExpert.Runtime.StatusBar;
+using EventLogExpert.Runtime.Tests.TestUtils;
 using EventLogExpert.Runtime.Tests.TestUtils.Constants;
 using Fluxor;
 using Microsoft.Extensions.DependencyInjection;
@@ -1579,6 +1580,7 @@ public sealed class EffectsTests
             new XmlFilterMatcher(),
             new XmlFilterMatchCache(),
             concurrencyState,
+            new ImmediateCpuWorkScheduler(),
             logger);
 
         var openLog = new OpenLogEffects(

--- a/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/FilteringEffectsXmlMatchTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/FilteringEffectsXmlMatchTests.cs
@@ -8,6 +8,7 @@ using EventLogExpert.Filtering.Persistence;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.Runtime.Tests.TestUtils;
 using Fluxor;
 using NSubstitute;
 using System.Collections.Immutable;
@@ -423,6 +424,7 @@ public sealed class FilteringEffectsXmlMatchTests
                 Matcher,
                 MatchCache,
                 ConcurrencyState,
+                new ImmediateCpuWorkScheduler(),
                 logger);
         }
 

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/XmlFilterWiringParityTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/XmlFilterWiringParityTests.cs
@@ -11,6 +11,7 @@ using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.Runtime.LogTable;
 using EventLogExpert.Runtime.LogTable.OrderedView;
 using EventLogExpert.Runtime.Tests.LogTable.TestSupport;
+using EventLogExpert.Runtime.Tests.TestUtils;
 using Fluxor;
 using NSubstitute;
 using System.Collections.Concurrent;
@@ -186,6 +187,7 @@ public sealed class XmlFilterWiringParityTests
                 Matcher,
                 MatchCache,
                 ConcurrencyState,
+                new ImmediateCpuWorkScheduler(),
                 logger);
 
             Bridge = new OrderedViewDispatchBridge(Dispatcher, Writer);

--- a/tests/Unit/EventLogExpert.Runtime.Tests/TestUtils/ImmediateCpuWorkScheduler.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/TestUtils/ImmediateCpuWorkScheduler.cs
@@ -1,0 +1,16 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.Concurrency;
+
+namespace EventLogExpert.Runtime.Tests.TestUtils;
+
+/// <summary>
+///     Pass-through <see cref="ICpuWorkScheduler" /> test double: offloads each item to the thread pool with no
+///     admission limit (pre-scheduler <c>Task.Run</c> behavior).
+/// </summary>
+internal sealed class ImmediateCpuWorkScheduler : ICpuWorkScheduler
+{
+    public Task<T> RunAsync<T>(Func<CancellationToken, T> work, CpuWorkPriority priority, CancellationToken cancellationToken = default) =>
+        Task.Run(() => work(cancellationToken), cancellationToken);
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/Histogram/HistogramPaneTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/Histogram/HistogramPaneTests.cs
@@ -16,6 +16,7 @@ using EventLogExpert.Runtime.Settings;
 using EventLogExpert.UI.Inputs;
 using EventLogExpert.UI.LogTable.Find;
 using EventLogExpert.UI.LogTable.Histogram;
+using EventLogExpert.UI.Tests.TestUtils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
@@ -70,6 +71,7 @@ public sealed class HistogramPaneTests : BunitContext
         _highlightSelector.ComputePredicatePlanKey(Arg.Any<ImmutableList<SavedFilter>>()).Returns(0);
         _settings.TimeZoneInfo.Returns(TimeZoneInfo.Utc);
 
+        Services.AddImmediateCpuWorkScheduler();
         Services.AddSingleton(_activeEventLog);
         Services.AddSingleton(_viewSource);
         Services.AddSingleton(_dimensionRequest);

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneBusyTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneBusyTests.cs
@@ -53,6 +53,7 @@ public sealed class LogTablePaneBusyTests : BunitContext
         _selectedEvents.Current.Returns(ImmutableList<SelectionEntry>.Empty);
 
         Services.AddLogTablePaneDependencies();
+        Services.AddImmediateCpuWorkScheduler();
         Services.AddSingleton(_columnDefaults);
         Services.AddSingleton(_eventLogCommands);
         Services.AddSingleton(_filterPaneState);

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneFindTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneFindTests.cs
@@ -64,6 +64,7 @@ public sealed class LogTablePaneFindTests : BunitContext
             .Do(_ => _selectionDispatched = true);
 
         Services.AddLogTablePaneDependencies();
+        Services.AddImmediateCpuWorkScheduler();
         Services.AddSingleton(_columnDefaults);
         Services.AddSingleton(_eventLogCommands);
         Services.AddSingleton(_filterPaneState);

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneGroupingTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneGroupingTests.cs
@@ -61,6 +61,7 @@ public sealed class LogTablePaneGroupingTests : BunitContext
         _selectedEvents.Current.Returns(ImmutableList<SelectionEntry>.Empty);
 
         Services.AddLogTablePaneDependencies();
+        Services.AddImmediateCpuWorkScheduler();
         Services.AddSingleton(_columnDefaults);
         Services.AddSingleton(_eventLogCommands);
         Services.AddSingleton(_filterPaneState);

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneIndicatorTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneIndicatorTests.cs
@@ -54,6 +54,7 @@ public sealed class LogTablePaneIndicatorTests : BunitContext
         _selectedEvents.Current.Returns(ImmutableList<SelectionEntry>.Empty);
 
         Services.AddLogTablePaneDependencies();
+        Services.AddImmediateCpuWorkScheduler();
         Services.AddSingleton(_columnDefaults);
         Services.AddSingleton(_eventLogCommands);
         Services.AddSingleton(_filterPaneState);

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneSelectionTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneSelectionTests.cs
@@ -71,6 +71,7 @@ public sealed class LogTablePaneSelectionTests : BunitContext
             });
 
         Services.AddLogTablePaneDependencies();
+        Services.AddImmediateCpuWorkScheduler();
         Services.AddSingleton(_columnDefaults);
         Services.AddSingleton(_eventLogCommands);
         Services.AddSingleton(_filterPaneState);

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneViewSourceTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneViewSourceTests.cs
@@ -75,6 +75,7 @@ public sealed class LogTablePaneViewSourceTests : BunitContext
             });
 
         Services.AddLogTablePaneDependencies();
+        Services.AddImmediateCpuWorkScheduler();
         Services.AddSingleton(_columnDefaults);
         Services.AddSingleton(_eventLogCommands);
         Services.AddSingleton(_filterPaneState);

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/Resolution/ResolutionCoverageModalTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/Resolution/ResolutionCoverageModalTests.cs
@@ -45,6 +45,7 @@ public sealed class ResolutionCoverageModalTests : BunitContext
         _presentation = PresentationWith(PresentationState.Current);
         _viewSource.Current.Returns(_ => _presentation);
 
+        Services.AddImmediateCpuWorkScheduler();
         Services.AddSingleton(_clipboard);
         Services.AddSingleton(_coverageService);
         Services.AddSingleton(_filterApplied);

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/Stats/StatsPaneTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/Stats/StatsPaneTests.cs
@@ -11,6 +11,7 @@ using EventLogExpert.Runtime.LogTable.OrderedView;
 using EventLogExpert.Runtime.Stats;
 using EventLogExpert.UI.LogTable.Stats;
 using EventLogExpert.UI.Modal;
+using EventLogExpert.UI.Tests.TestUtils;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using System.Collections.Immutable;
@@ -43,6 +44,7 @@ public sealed class StatsPaneTests : BunitContext
         JSInterop.Mode = JSRuntimeMode.Loose;
         JSInterop.SetupModule("./_content/EventLogExpert.UI/LogTable/Stats/StatsPane.razor.js");
 
+        Services.AddImmediateCpuWorkScheduler();
         Services.AddSingleton(_lensCommands);
         Services.AddSingleton(_lensSource);
         Services.AddSingleton(_modalCoordinator);

--- a/tests/Unit/EventLogExpert.UI.Tests/TestUtils/CpuWorkSchedulerTestExtensions.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/TestUtils/CpuWorkSchedulerTestExtensions.cs
@@ -1,0 +1,26 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Runtime.Concurrency;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EventLogExpert.UI.Tests.TestUtils;
+
+internal static class CpuWorkSchedulerTestExtensions
+{
+    private sealed class ImmediateCpuWorkScheduler : ICpuWorkScheduler
+    {
+        public Task<T> RunAsync<T>(Func<CancellationToken, T> work, CpuWorkPriority priority, CancellationToken cancellationToken = default) =>
+            Task.Run(() => work(cancellationToken), cancellationToken);
+    }
+
+    extension(IServiceCollection services)
+    {
+        /// <summary>
+        ///     Registers a pass-through <see cref="ICpuWorkScheduler" /> (no admission limit) so components under test behave
+        ///     as with the pre-scheduler <c>Task.Run</c>.
+        /// </summary>
+        public void AddImmediateCpuWorkScheduler() =>
+            services.AddSingleton<ICpuWorkScheduler>(new ImmediateCpuWorkScheduler());
+    }
+}


### PR DESCRIPTION
## Summary

Adds `ICpuWorkScheduler`, a shared process-wide admission gate for CPU-bound
analytics, and routes the seven CPU-bound `Task.Run` analytics sites through it.
Background analytics no longer compete on equal footing with latency-critical
interactive work or oversubscribe the cores.

## How it works

- **Priority tiers:** `Interactive` (find) > `UserInitiated` (stats-detail and
  resolution-coverage modals, click-driven activity correlation) > `Bulk` (stats
  panes, histogram, on-demand XML filter-match).
- **Bounded admission:** at most `ProcessorCount` items run at once; execution
  still reuses the thread pool (only admission is governed).
- **Work-conserving reserve:** a 2-slot interactive reserve engages only while
  interactive work is present. With none, the reserve collapses so a single
  un-interacted log's background work still uses every core and takes no
  throughput hit.
- **Admission, not preemption:** running work is never suspended; the guarantee
  is that an arriving find scan is never queued behind the full analytics fan-out.
- The XML filter-match site now passes its cancellation token, so a superseded
  queued match is dropped (already surfaced as `Superseded`).

## Behavior change to note

Under heavy multi-log analytics load, background stats/histogram/XML-match work is
admitted after interactive find rather than concurrently. Single-log behavior is
unchanged (no-op).

## Testing

- Runtime.Tests: 2689 passed (+15 `CpuWorkScheduler` tests: admission math,
  priority wake-order, reserve collapse, cancellation, reserve clamping).
- UI.Tests: 1542 passed.
- Build clean under `TreatWarningsAsErrors`.
- Validated on real multi-log workloads: the scheduler holds find p95 latency flat
  while the baseline degrades 2-4x, at <=4% throughput cost; single-log is a no-op.
