### PR TITLE
Add localization infrastructure with FindBar pilot

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,6 +16,7 @@
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Localization" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <PackageVersion Include="System.CommandLine" Version="2.0.10" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.10" />

--- a/src/EventLogExpert.UI/Common/Interop/DocumentInitScript.cs
+++ b/src/EventLogExpert.UI/Common/Interop/DocumentInitScript.cs
@@ -1,0 +1,27 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.UI.Common.Interop;
+
+/// <summary>
+///     Builds the self-contained CoreWebView2 document-created script (runs before HTML parse, so it can't call
+///     app.js) that sets the root element's theme/dir/lang from trusted, closed-set values embedded unescaped.
+/// </summary>
+public static class DocumentInitScript
+{
+    public static string Build(string? themeAttribute, string direction, string language)
+    {
+        ArgumentNullException.ThrowIfNull(direction);
+        ArgumentNullException.ThrowIfNull(language);
+
+        var themeStatement = themeAttribute is null ?
+            "root.removeAttribute('data-theme');" :
+            $"root.setAttribute('data-theme','{themeAttribute}');";
+
+        return
+            "(function(){var root=document.documentElement;if(!root){return;}" +
+            themeStatement +
+            $"root.setAttribute('dir','{direction}');root.setAttribute('lang','{language}');" +
+            "})();";
+    }
+}

--- a/src/EventLogExpert.UI/Common/Interop/DocumentInitScript.cs
+++ b/src/EventLogExpert.UI/Common/Interop/DocumentInitScript.cs
@@ -6,6 +6,8 @@ namespace EventLogExpert.UI.Common.Interop;
 /// <summary>
 ///     Builds the self-contained CoreWebView2 document-created script (runs before HTML parse, so it can't call
 ///     app.js) that sets the root element's theme/dir/lang from trusted, closed-set values embedded unescaped.
+///     Defers to DOMContentLoaded when documentElement is not yet available, since document-created scripts can
+///     precede the root.
 /// </summary>
 public static class DocumentInitScript
 {
@@ -19,9 +21,9 @@ public static class DocumentInitScript
             $"root.setAttribute('data-theme','{themeAttribute}');";
 
         return
-            "(function(){var root=document.documentElement;if(!root){return;}" +
+            "(function(){function apply(){var root=document.documentElement;if(!root){return false;}" +
             themeStatement +
-            $"root.setAttribute('dir','{direction}');root.setAttribute('lang','{language}');" +
-            "})();";
+            $"root.setAttribute('dir','{direction}');root.setAttribute('lang','{language}');return true;" +
+            "}if(!apply()){document.addEventListener('DOMContentLoaded',apply);}})();";
     }
 }

--- a/src/EventLogExpert.UI/DependencyInjection/EventLogLocalizationServiceCollectionExtensions.cs
+++ b/src/EventLogExpert.UI/DependencyInjection/EventLogLocalizationServiceCollectionExtensions.cs
@@ -1,0 +1,24 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+public static class EventLogLocalizationServiceCollectionExtensions
+{
+    extension(IServiceCollection services)
+    {
+        /// <summary>
+        ///     Registers <see cref="Microsoft.Extensions.Localization.IStringLocalizer{T}" /> against the <c>Resources/</c>
+        ///     RESX; omits logging deliberately since TryAdd-ing a fallback <c>ILoggerFactory</c> could clobber the host's real
+        ///     one by registration order (the host/bUnit/guard-test supply it).
+        /// </summary>
+        public IServiceCollection AddEventLogLocalization()
+        {
+            ArgumentNullException.ThrowIfNull(services);
+
+            services.AddLocalization(options => options.ResourcesPath = "Resources");
+
+            return services;
+        }
+    }
+}

--- a/src/EventLogExpert.UI/EventLogExpert.UI.csproj
+++ b/src/EventLogExpert.UI/EventLogExpert.UI.csproj
@@ -2,12 +2,16 @@
 
   <PropertyGroup>
     <RootNamespace>EventLogExpert.UI</RootNamespace>
+    <!-- The SDK emits [assembly: NeutralResourcesLanguage("en")]; the neutral SharedResource.resx is embedded in this
+         assembly (not a satellite), so this is the authoritative "en" for the supported-culture drift-guard test. -->
+    <NeutralLanguage>en</NeutralLanguage>
   </PropertyGroup>
 
   <ItemGroup>
     <!-- Blazor Web component + JSInterop references, formerly pulled in transitively through Fluxor.Blazor.Web. The UI no
          longer consumes Fluxor, so this is now a direct reference at the version the net10 MAUI head already runs. -->
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
+    <PackageReference Include="Microsoft.Extensions.Localization" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EventLogExpert.UI/Globalization/ContentCulture.cs
+++ b/src/EventLogExpert.UI/Globalization/ContentCulture.cs
@@ -1,0 +1,45 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using System.Globalization;
+
+namespace EventLogExpert.UI.Globalization;
+
+/// <summary>
+///     Resolves the renderable content culture and its layout direction from the RESOLVED (not raw OS) culture, so an
+///     RTL OS never mirrors the English layout until a translation ships.
+/// </summary>
+public static class ContentCulture
+{
+    /// <summary>
+    ///     Cultures with a shipped translation; grows ONLY with a translation + the RTL prerequisite bundle (a
+    ///     drift-guard test enforces alignment with the embedded satellites).
+    /// </summary>
+    public static readonly IReadOnlySet<string> SupportedUiCultures =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "en" };
+
+    /// <summary>The BCP-47 layout direction for <paramref name="culture" />: <c>"rtl"</c> or <c>"ltr"</c>.</summary>
+    public static string DirectionOf(CultureInfo culture)
+    {
+        ArgumentNullException.ThrowIfNull(culture);
+
+        return culture.TextInfo.IsRightToLeft ? "rtl" : "ltr";
+    }
+
+    /// <summary>
+    ///     The nearest supported culture for <paramref name="current" /> (walking parents, terminating at the invariant
+    ///     culture), else the neutral <c>en</c>.
+    /// </summary>
+    public static CultureInfo Resolve(CultureInfo current, IReadOnlySet<string> supported)
+    {
+        ArgumentNullException.ThrowIfNull(current);
+        ArgumentNullException.ThrowIfNull(supported);
+
+        for (var candidate = current; candidate.Name.Length > 0; candidate = candidate.Parent)
+        {
+            if (supported.Contains(candidate.Name)) { return candidate; }
+        }
+
+        return CultureInfo.GetCultureInfo("en");
+    }
+}

--- a/src/EventLogExpert.UI/LogTable/Find/FindBar.razor
+++ b/src/EventLogExpert.UI/LogTable/Find/FindBar.razor
@@ -3,18 +3,18 @@
 <div class="find-bar" @onkeydown="HandleRootKeyDown" role="search">
     <div class="find-main">
         <div class="find-inputbox">
-            <input aria-label="Find in events"
+            <input aria-label="@Localizer["FindBar_FindInEvents"]"
                 class="find-input"
                 @oninput="OnInput"
                 @onkeydown="HandleInputKeyDown"
-                placeholder="Find in events"
+                placeholder="@Localizer["FindBar_FindInEvents"]"
                 @ref="_input"
                 spellcheck="false"
                 type="text"
                 value="@Query" />
             <span class="find-inline">
                 <span aria-live="polite" class="find-count">@CountText</span>
-                <button aria-label="Previous match"
+                <button aria-label="@Localizer["FindBar_PreviousMatch"]"
                     class="find-nav"
                     disabled="@NavDisabled"
                     @onclick="OnPrevious"
@@ -22,7 +22,7 @@
                     type="button">
                     <i aria-hidden="true" class="bi bi-chevron-up"></i>
                 </button>
-                <button aria-label="Next match"
+                <button aria-label="@Localizer["FindBar_NextMatch"]"
                     class="find-nav"
                     disabled="@NavDisabled"
                     @onclick="OnNext"
@@ -32,16 +32,16 @@
                 </button>
             </span>
         </div>
-        <span aria-live="polite" class="find-wrap">@WrapAnnouncement</span>
+        <span aria-live="polite" class="find-wrap">@WrapText</span>
         <button aria-controls="@(_optionsOpen ? "find-options" : null)"
             aria-expanded="@(_optionsOpen ? "true" : "false")"
-            aria-label="Search options"
+            aria-label="@Localizer["FindBar_SearchOptions"]"
             class="find-options-toggle @(OptionsActive ? "is-active" : null)"
             @onclick="ToggleOptions"
             type="button">
             <i aria-hidden="true" class="bi bi-sliders"></i>
         </button>
-        <button aria-label="Close find"
+        <button aria-label="@Localizer["FindBar_Close"]"
             class="find-close"
             @onclick="OnClose"
             type="button">
@@ -52,11 +52,11 @@
     {
         <div class="find-options" id="find-options">
             <div class="flex-center-aligned-row">
-                <label for="find-opt-case">Match case</label>
+                <label for="find-opt-case">@Localizer["FindBar_MatchCase"]</label>
                 <Toggle Id="find-opt-case" Value="CaseSensitive" ValueChanged="OnCaseChanged" />
             </div>
             <div class="flex-center-aligned-row">
-                <label for="find-opt-word">Match whole word</label>
+                <label for="find-opt-word">@Localizer["FindBar_MatchWholeWord"]</label>
                 <Toggle Id="find-opt-word" Value="WholeWord" ValueChanged="OnWholeWordChanged" />
             </div>
         </div>

--- a/src/EventLogExpert.UI/LogTable/Find/FindBar.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/Find/FindBar.razor.cs
@@ -4,7 +4,9 @@
 using EventLogExpert.UI.Common.Interop;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.Localization;
 using Microsoft.JSInterop;
+using System.Globalization;
 
 namespace EventLogExpert.UI.LogTable.Find;
 
@@ -56,20 +58,40 @@ public sealed partial class FindBar : IAsyncDisposable
     public EventCallback<bool> WholeWordChanged { get; set; }
 
     [Parameter]
-    public string WrapAnnouncement { get; set; } = string.Empty;
+    public FindWrapState WrapAnnouncement { get; set; }
 
-    private string CountText =>
-        Query.Length == 0 ? string.Empty :
-        IsScanning ? "Searching\u2026" :
-        MatchCount == 0 ? "No results" :
-        $"{CurrentOrdinal}/{MatchCount}";
+    private string CountText
+    {
+        get
+        {
+            if (Query.Length == 0) { return string.Empty; }
+            if (IsScanning) { return Localizer["FindBar_Searching"]; }
+            if (MatchCount == 0) { return Localizer["FindBar_NoResults"]; }
+
+            return string.Format(
+                CultureInfo.CurrentCulture,
+                Localizer["FindBar_CountFormat"],
+                CurrentOrdinal.ToString("N0", CultureInfo.CurrentCulture),
+                MatchCount.ToString("N0", CultureInfo.CurrentCulture));
+        }
+    }
 
     [Inject]
     private IJSRuntime JSRuntime { get; init; } = null!;
 
+    [Inject]
+    private IStringLocalizer<SharedResource> Localizer { get; init; } = null!;
+
     private bool NavDisabled => IsScanning || MatchCount == 0;
 
     private bool OptionsActive => CaseSensitive || WholeWord;
+
+    private string WrapText => WrapAnnouncement switch
+    {
+        FindWrapState.WrappedToFirst => Localizer["FindBar_WrapToFirst"],
+        FindWrapState.WrappedToLast => Localizer["FindBar_WrapToLast"],
+        _ => string.Empty,
+    };
 
     public async ValueTask DisposeAsync()
     {

--- a/src/EventLogExpert.UI/LogTable/Find/FindWrapState.cs
+++ b/src/EventLogExpert.UI/LogTable/Find/FindWrapState.cs
@@ -1,0 +1,15 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.UI.LogTable.Find;
+
+/// <summary>
+///     Whether find navigation wrapped; FindBar maps this to the localized announcement so the component owns the
+///     text it renders.
+/// </summary>
+public enum FindWrapState
+{
+    None,
+    WrappedToFirst,
+    WrappedToLast,
+}

--- a/src/EventLogExpert.UI/LogTable/LogTablePane.Find.cs
+++ b/src/EventLogExpert.UI/LogTable/LogTablePane.Find.cs
@@ -38,7 +38,7 @@ public sealed partial class LogTablePane
     private bool _findScanning;
     private bool _findScrollToCurrentOnRender;
     private bool _findWholeWord;
-    private string _findWrapAnnouncement = string.Empty;
+    private FindWrapState _findWrapAnnouncement;
 
     [Inject]
     private IFindCoordinator FindCoordinator { get; init; } = null!;
@@ -96,7 +96,7 @@ public sealed partial class LogTablePane
         _findCurrentKey = null;
         _findCurrentLocator = null;
         _findScanning = false;
-        _findWrapAnnouncement = string.Empty;
+        _findWrapAnnouncement = FindWrapState.None;
 
         FindMarkerSource.Clear();
     }
@@ -301,7 +301,7 @@ public sealed partial class LogTablePane
         _findMatches = matches;
         _findMatchSet = new HashSet<EventLocator>(matches);
         _findScanning = false;
-        _findWrapAnnouncement = string.Empty;
+        _findWrapAnnouncement = FindWrapState.None;
 
         ResolveCurrentMatchAfterScan(priorLocator);
         _findScrollToCurrentOnRender = _findCurrentIndex >= 0;
@@ -489,7 +489,7 @@ public sealed partial class LogTablePane
         }
 
         _findScanning = true;
-        _findWrapAnnouncement = string.Empty;
+        _findWrapAnnouncement = FindWrapState.None;
 
         var cts = new CancellationTokenSource();
         _findDebounceCts = cts;
@@ -586,9 +586,10 @@ public sealed partial class LogTablePane
         int previousIndex = _findCurrentIndex < 0 ? (direction > 0 ? -1 : 0) : _findCurrentIndex;
         int next = (previousIndex + direction + _findMatches.Count) % _findMatches.Count;
 
-        _findWrapAnnouncement = direction > 0 && next <= previousIndex ? "Wrapped to first match"
-            : direction < 0 && next >= previousIndex ? "Wrapped to last match"
-            : string.Empty;
+        _findWrapAnnouncement = direction > 0 && next <= previousIndex ?
+            FindWrapState.WrappedToFirst :
+                direction < 0 && next >= previousIndex ?
+                    FindWrapState.WrappedToLast : FindWrapState.None;
 
         SetCurrentMatchIndex(next);
         _findScrollToCurrentOnRender = true;

--- a/src/EventLogExpert.UI/Resources/SharedResource.qps-ploc.resx
+++ b/src/EventLogExpert.UI/Resources/SharedResource.qps-ploc.resx
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- Pseudo-locale CANARY: proves satellite emit/load/fallback. DEDICATED Canary_* keys (no component uses them), so a qps-Ploc machine still renders real strings via neutral fallback. -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Canary_Probe1" xml:space="preserve">
+    <value>[qps-ploc] canary probe one</value>
+  </data>
+  <data name="Canary_Probe2" xml:space="preserve">
+    <value>[qps-ploc] canary probe two</value>
+  </data>
+</root>

--- a/src/EventLogExpert.UI/Resources/SharedResource.resx
+++ b/src/EventLogExpert.UI/Resources/SharedResource.resx
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- Neutral (English) FindBar strings. Numbers are formatted in code and passed as strings, so values carry no format specifiers. -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="FindBar_Close" xml:space="preserve">
+    <value>Close find</value>
+  </data>
+  <data name="FindBar_CountFormat" xml:space="preserve">
+    <value>{0}/{1}</value>
+    <comment>Current-match / total-match count. {0} and {1} are pre-formatted numbers; do not add format specifiers.</comment>
+  </data>
+  <data name="FindBar_FindInEvents" xml:space="preserve">
+    <value>Find in events</value>
+  </data>
+  <data name="FindBar_MatchCase" xml:space="preserve">
+    <value>Match case</value>
+  </data>
+  <data name="FindBar_MatchWholeWord" xml:space="preserve">
+    <value>Match whole word</value>
+  </data>
+  <data name="FindBar_NextMatch" xml:space="preserve">
+    <value>Next match</value>
+  </data>
+  <data name="FindBar_NoResults" xml:space="preserve">
+    <value>No results</value>
+  </data>
+  <data name="FindBar_PreviousMatch" xml:space="preserve">
+    <value>Previous match</value>
+  </data>
+  <data name="FindBar_Searching" xml:space="preserve">
+    <value>Searching…</value>
+  </data>
+  <data name="FindBar_SearchOptions" xml:space="preserve">
+    <value>Search options</value>
+  </data>
+  <data name="FindBar_WrapToFirst" xml:space="preserve">
+    <value>Wrapped to first match</value>
+  </data>
+  <data name="FindBar_WrapToLast" xml:space="preserve">
+    <value>Wrapped to last match</value>
+  </data>
+</root>

--- a/src/EventLogExpert.UI/SharedResource.cs
+++ b/src/EventLogExpert.UI/SharedResource.cs
@@ -1,0 +1,10 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.UI;
+
+/// <summary>
+///     Shared string-resource marker; MUST stay at the assembly root namespace or the localizer base name doubles the
+///     <c>Resources</c> segment and every lookup breaks.
+/// </summary>
+internal sealed class SharedResource;

--- a/src/EventLogExpert.UI/_Imports.razor
+++ b/src/EventLogExpert.UI/_Imports.razor
@@ -2,6 +2,7 @@
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.Extensions.Localization
 
 @using EventLogExpert.Filtering.Common.Filtering
 @using EventLogExpert.Filtering.Drafts

--- a/src/EventLogExpert/MainPage.xaml.cs
+++ b/src/EventLogExpert/MainPage.xaml.cs
@@ -164,7 +164,6 @@ public sealed partial class MainPage : ContentPage, IDisposable
             _ => null,
         };
 
-        // dir/lang from the RESOLVED content culture (today en/ltr); one pre-document-created script (proven timing, null-guarded).
         var resolvedCulture = ContentCulture.Resolve(CultureInfo.CurrentUICulture, ContentCulture.SupportedUiCultures);
         var script = DocumentInitScript.Build(themeSettings, ContentCulture.DirectionOf(resolvedCulture), resolvedCulture.Name);
 

--- a/src/EventLogExpert/MainPage.xaml.cs
+++ b/src/EventLogExpert/MainPage.xaml.cs
@@ -9,10 +9,13 @@ using EventLogExpert.Runtime.Common.AppTitle;
 using EventLogExpert.Runtime.FilterLibrary;
 using EventLogExpert.Runtime.LogTable;
 using EventLogExpert.Runtime.Settings;
+using EventLogExpert.UI.Common.Interop;
+using EventLogExpert.UI.Globalization;
 using Fluxor;
 using Microsoft.AspNetCore.Components.WebView;
 using Microsoft.Web.WebView2.Core;
 using System.Collections.Immutable;
+using System.Globalization;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Storage;
 using DataPackageOperation = Windows.ApplicationModel.DataTransfer.DataPackageOperation;
@@ -60,10 +63,7 @@ public sealed partial class MainPage : ContentPage, IDisposable
         logTableCommands.LoadColumns();
         filterLibraryCommands.LoadLibrary();
 
-        // Eager subscription so cold-launch args buffered by ActivationBootstrap drain even when
-        // WebView2 is missing and BlazorWebViewInitialized never fires; the StartConsumingAsync
-        // call in BlazorWebViewInitialized is idempotent (guarded by Interlocked) so a second
-        // call from there is safe.
+        // Eager so ActivationBootstrap's buffered cold-launch args drain even if WebView2 is missing; StartConsumingAsync is Interlocked-idempotent, so the BlazorWebViewInitialized call is safe.
         _ = _activationDispatcher.StartConsumingAsync(
             _menuActionService.OpenLogsBatchAsync,
             _consumerCts.Token);
@@ -84,9 +84,7 @@ public sealed partial class MainPage : ContentPage, IDisposable
 
     private void ApplyWebViewTheme(Theme theme)
     {
-        // Keep WebView2's prefers-color-scheme aligned with the user's choice so the "System" path
-        // (data-theme attribute removed) actually follows the OS, and so explicit Light/Dark stays
-        // consistent across the page.
+        // Align WebView2's prefers-color-scheme with the user's Theme so "System" follows the OS and explicit Light/Dark stays consistent.
         _coreWebView?.Profile.PreferredColorScheme = theme switch
         {
             Theme.Light => CoreWebView2PreferredColorScheme.Light,
@@ -159,16 +157,16 @@ public sealed partial class MainPage : ContentPage, IDisposable
 
         ApplyWebViewTheme(_settings.Theme);
 
-        var themeAttr = _settings.Theme switch
+        var themeSettings = _settings.Theme switch
         {
             Theme.Light => "light",
             Theme.Dark => "dark",
             _ => null,
         };
 
-        var script = themeAttr is null
-            ? "document.documentElement.removeAttribute('data-theme');"
-            : $"document.documentElement.setAttribute('data-theme','{themeAttr}');";
+        // dir/lang from the RESOLVED content culture (today en/ltr); one pre-document-created script (proven timing, null-guarded).
+        var resolvedCulture = ContentCulture.Resolve(CultureInfo.CurrentUICulture, ContentCulture.SupportedUiCultures);
+        var script = DocumentInitScript.Build(themeSettings, ContentCulture.DirectionOf(resolvedCulture), resolvedCulture.Name);
 
         _ = _coreWebView.AddScriptToExecuteOnDocumentCreatedAsync(script);
     }
@@ -188,7 +186,6 @@ public sealed partial class MainPage : ContentPage, IDisposable
     }
 
     private void OnThemeChanged() =>
-        // ThemeChanged may be raised from non-UI threads; marshal to the UI thread before touching
-        // WebView2's profile.
+        // ThemeChanged may fire off the UI thread; marshal to the UI thread before touching WebView2's profile.
         MainThread.BeginInvokeOnMainThread(() => ApplyWebViewTheme(_settings.Theme));
 }

--- a/src/EventLogExpert/MauiProgram.cs
+++ b/src/EventLogExpert/MauiProgram.cs
@@ -96,6 +96,7 @@ public static class MauiProgram
         builder.Services.AddEventLogRuntime();
         builder.Services.AddElevatedDatabaseToolsRunner();
         builder.Services.AddEventLogUIServices();
+        builder.Services.AddEventLogLocalization();
 
         builder.Services.AddMauiPreferenceAdapters();
         builder.Services.AddMauiPlatformAdapters();

--- a/tests/Unit/EventLogExpert.UI.Tests/Common/Interop/DocumentInitScriptTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Common/Interop/DocumentInitScriptTests.cs
@@ -13,19 +13,21 @@ public sealed class DocumentInitScriptTests
         var script = DocumentInitScript.Build(null, "ltr", "en");
 
         Assert.Equal(
-            "(function(){var root=document.documentElement;if(!root){return;}" +
-            "root.removeAttribute('data-theme');root.setAttribute('dir','ltr');root.setAttribute('lang','en');})();",
+            "(function(){function apply(){var root=document.documentElement;if(!root){return false;}" +
+            "root.removeAttribute('data-theme');root.setAttribute('dir','ltr');root.setAttribute('lang','en');" +
+            "return true;}if(!apply()){document.addEventListener('DOMContentLoaded',apply);}})();",
             script);
     }
 
     [Fact]
-    public void Build_WithTheme_SetsThemeDirAndLangBehindTheRootNullGuard()
+    public void Build_WithTheme_SetsThemeDirAndLang()
     {
         var script = DocumentInitScript.Build("dark", "rtl", "ar");
 
         Assert.Equal(
-            "(function(){var root=document.documentElement;if(!root){return;}" +
-            "root.setAttribute('data-theme','dark');root.setAttribute('dir','rtl');root.setAttribute('lang','ar');})();",
+            "(function(){function apply(){var root=document.documentElement;if(!root){return false;}" +
+            "root.setAttribute('data-theme','dark');root.setAttribute('dir','rtl');root.setAttribute('lang','ar');" +
+            "return true;}if(!apply()){document.addEventListener('DOMContentLoaded',apply);}})();",
             script);
     }
 }

--- a/tests/Unit/EventLogExpert.UI.Tests/Common/Interop/DocumentInitScriptTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Common/Interop/DocumentInitScriptTests.cs
@@ -1,0 +1,31 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.UI.Common.Interop;
+
+namespace EventLogExpert.UI.Tests.Common.Interop;
+
+public sealed class DocumentInitScriptTests
+{
+    [Fact]
+    public void Build_NullTheme_RemovesThemeAttribute()
+    {
+        var script = DocumentInitScript.Build(null, "ltr", "en");
+
+        Assert.Equal(
+            "(function(){var root=document.documentElement;if(!root){return;}" +
+            "root.removeAttribute('data-theme');root.setAttribute('dir','ltr');root.setAttribute('lang','en');})();",
+            script);
+    }
+
+    [Fact]
+    public void Build_WithTheme_SetsThemeDirAndLangBehindTheRootNullGuard()
+    {
+        var script = DocumentInitScript.Build("dark", "rtl", "ar");
+
+        Assert.Equal(
+            "(function(){var root=document.documentElement;if(!root){return;}" +
+            "root.setAttribute('data-theme','dark');root.setAttribute('dir','rtl');root.setAttribute('lang','ar');})();",
+            script);
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/EventLogExpert.UI.Tests.csproj
+++ b/tests/Unit/EventLogExpert.UI.Tests/EventLogExpert.UI.Tests.csproj
@@ -10,6 +10,8 @@
     <!-- The UI no longer references Fluxor. The Fluxor-boundary architecture test still names FluxorComponent / IState /
          IStateSelection / IActionSubscriber to assert their ABSENCE from the converted surfaces, so it needs Fluxor here. -->
     <PackageReference Include="Fluxor.Blazor.Web" />
+    <!-- Guard/canary localization tests resolve IStringLocalizer against the production RESX config. -->
+    <PackageReference Include="Microsoft.Extensions.Localization" />
   </ItemGroup>
 
   <!-- The independent array-of-structs display-view oracles (AosReferenceView / AosReferenceCombinedView) live in

--- a/tests/Unit/EventLogExpert.UI.Tests/Localization/LocalizationInfraTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Localization/LocalizationInfraTests.cs
@@ -1,0 +1,144 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.UI.Globalization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Globalization;
+using System.Reflection;
+using System.Resources;
+using System.Text.RegularExpressions;
+
+namespace EventLogExpert.UI.Tests.Localization;
+
+/// <summary>
+///     Culture-agnostic localization-infra tests (config guard, resolver, drift guard, no-pin guard);
+///     culture-MUTATING tests live in <c>FindBarCultureTests</c>.
+/// </summary>
+public sealed class LocalizationInfraTests
+{
+    [Fact]
+    public void Localizer_KnownKey_ResolvesToNeutralValue()
+    {
+        var result = BuildLocalizer()["FindBar_NoResults"];
+
+        Assert.False(result.ResourceNotFound);
+        Assert.Equal("No results", result.Value);
+    }
+
+    [Fact]
+    public void Localizer_MissingKey_ReportsNotFoundAndEchoesKey()
+    {
+        var result = BuildLocalizer()["FindBar_ThisKeyDoesNotExist"];
+
+        Assert.True(result.ResourceNotFound);
+        Assert.Equal("FindBar_ThisKeyDoesNotExist", result.Value);
+    }
+
+    [Fact]
+    public void ProductionSource_NeverPinsThreadCulture()
+    {
+        var sourceRoot = Path.Combine(FindRepositoryRoot(), "src");
+
+        // Matches pins (=, ??=; not ==/!=), not reads: only assignments would break OS-culture-following.
+        var pinPattern = new Regex(
+            @"(CurrentCulture|CurrentUICulture|DefaultThreadCurrentCulture|DefaultThreadCurrentUICulture)\s*(\?\?)?=(?!=)",
+            RegexOptions.Compiled);
+
+        var offenders = Directory
+            .EnumerateFiles(sourceRoot, "*.*", SearchOption.AllDirectories)
+            .Where(path => (path.EndsWith(".cs", StringComparison.OrdinalIgnoreCase) ||
+                path.EndsWith(".razor", StringComparison.OrdinalIgnoreCase)) &&
+                !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase) &&
+                !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase))
+            .Where(path => pinPattern.IsMatch(File.ReadAllText(path)))
+            .Select(path => Path.GetRelativePath(sourceRoot, path))
+            .ToList();
+
+        Assert.True(
+            offenders.Count == 0,
+            $"Production code must not pin thread culture (it follows the OS). Offending files: {string.Join(", ", offenders)}");
+    }
+
+    [Fact]
+    public void Resolve_InvariantCulture_TerminatesAtNeutral()
+    {
+        var resolved = ContentCulture.Resolve(CultureInfo.InvariantCulture, ContentCulture.SupportedUiCultures);
+
+        Assert.Equal("en", resolved.Name);
+        Assert.Equal("ltr", ContentCulture.DirectionOf(resolved));
+    }
+
+    [Fact]
+    public void Resolve_SupportedRtlCulture_ReturnsThatCultureRtl()
+    {
+        // Once a culture is in the supported set, its own direction is honored.
+        var supported = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "en", "ar" };
+
+        var resolved = ContentCulture.Resolve(CultureInfo.GetCultureInfo("ar-SA"), supported);
+
+        Assert.Equal("ar", resolved.Name);
+        Assert.Equal("rtl", ContentCulture.DirectionOf(resolved));
+    }
+
+    [Theory]
+    [InlineData("en-US", "en", "ltr")]
+    [InlineData("en-GB", "en", "ltr")]
+    [InlineData("en", "en", "ltr")]
+    [InlineData("ar-SA", "en", "ltr")] // unsupported RTL OS -> neutral en/ltr today (no regression)
+    [InlineData("zh-Hans-CN", "en", "ltr")]
+    public void Resolve_UnsupportedCulture_FallsBackToNeutralLtr(string current, string expectedName, string expectedDir)
+    {
+        var resolved = ContentCulture.Resolve(
+            CultureInfo.GetCultureInfo(current),
+            ContentCulture.SupportedUiCultures);
+
+        Assert.Equal(expectedName, resolved.Name);
+        Assert.Equal(expectedDir, ContentCulture.DirectionOf(resolved));
+    }
+
+    [Fact]
+    public void SupportedUiCultures_MatchesEmbeddedSatellites_ExcludingCanary()
+    {
+        // Neutral comes from the assembly's [NeutralResourcesLanguage] so changing/removing it fails this guard, not silently passes.
+        var neutralAttribute = typeof(SharedResource).Assembly.GetCustomAttribute<NeutralResourcesLanguageAttribute>();
+        Assert.NotNull(neutralAttribute);
+        var neutral = CultureInfo.GetCultureInfo(neutralAttribute.CultureName).Name;
+
+        var canary = CultureInfo.GetCultureInfo("qps-ploc").Name;
+        var satelliteCultures = Directory.GetDirectories(AppContext.BaseDirectory)
+            .Where(directory => File.Exists(Path.Combine(directory, "EventLogExpert.UI.resources.dll")))
+            .Select(directory => CultureInfo.GetCultureInfo(Path.GetFileName(directory)).Name)
+            .Where(name => !string.Equals(name, canary, StringComparison.OrdinalIgnoreCase))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var expected = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { neutral };
+        expected.UnionWith(satelliteCultures);
+
+        Assert.True(
+            ContentCulture.SupportedUiCultures.SetEquals(expected),
+            $"SupportedUiCultures [{string.Join(", ", ContentCulture.SupportedUiCultures)}] must equal " +
+            $"neutral-plus-non-canary-satellites [{string.Join(", ", expected)}]. Ship a translation's culture here " +
+            "ONLY after the RTL prerequisite bundle lands.");
+    }
+
+    // Resolves the localizer from a bare container: the production extension plus the ILoggerFactory it needs (as the host supplies in production).
+    private static IStringLocalizer<SharedResource> BuildLocalizer() =>
+        new ServiceCollection()
+            .AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance)
+            .AddEventLogLocalization()
+            .BuildServiceProvider()
+            .GetRequiredService<IStringLocalizer<SharedResource>>();
+
+    private static string FindRepositoryRoot()
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory); directory is not null; directory = directory.Parent)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "EventLogExpert.slnx"))) { return directory.FullName; }
+        }
+
+        throw new InvalidOperationException("Could not locate the repository root (EventLogExpert.slnx) from the test output.");
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/FindBarCultureTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/FindBarCultureTests.cs
@@ -1,0 +1,72 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using EventLogExpert.UI.LogTable.Find;
+using EventLogExpert.UI.Tests.TestUtils;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using System.Globalization;
+
+namespace EventLogExpert.UI.Tests.LogTable;
+
+/// <summary>
+///     FindBar tests that MUTATE thread culture (qps-Ploc canary, de-DE formatting); each restores culture
+///     synchronously and the class is serialized via <see cref="CultureSensitiveCollection" />.
+/// </summary>
+[Collection(CultureSensitiveCollection.Name)]
+public sealed class FindBarCultureTests : BunitContext
+{
+    public FindBarCultureTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        JSInterop.SetupModule("./_content/EventLogExpert.UI/LogTable/Find/FindBar.razor.js");
+        Services.AddEventLogLocalization();
+    }
+
+    [Fact]
+    public void Canary_UnderPseudoLocale_LoadsSatellite_AndRealKeysFallBackToNeutral()
+    {
+        var priorUiCulture = CultureInfo.CurrentUICulture;
+
+        try
+        {
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("qps-ploc");
+            var localizer = Services.GetRequiredService<IStringLocalizer<SharedResource>>();
+
+            var canary = localizer["Canary_Probe1"];
+            Assert.False(canary.ResourceNotFound);
+            Assert.Equal("[qps-ploc] canary probe one", canary.Value);
+
+            // A real key is absent from the canary satellite -> neutral English, proving a qps-Ploc machine never renders pseudo UI.
+            Assert.Equal("No results", localizer["FindBar_NoResults"].Value);
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = priorUiCulture;
+        }
+    }
+
+    [Fact]
+    public void Count_UnderNonInvariantCulture_UsesLocaleGroupSeparators()
+    {
+        var priorCulture = CultureInfo.CurrentCulture;
+
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+
+            var cut = Render<FindBar>(parameters => parameters
+                .Add(component => component.Query, "x")
+                .Add(component => component.IsScanning, false)
+                .Add(component => component.MatchCount, 5678)
+                .Add(component => component.CurrentOrdinal, 1234));
+
+            Assert.Equal("1.234/5.678", cut.Find(".find-count").TextContent.Trim());
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = priorCulture;
+        }
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/FindBarTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/FindBarTests.cs
@@ -4,6 +4,7 @@
 using Bunit;
 using EventLogExpert.UI.LogTable.Find;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace EventLogExpert.UI.Tests.LogTable;
 
@@ -13,6 +14,7 @@ public sealed class FindBarTests : BunitContext
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
         JSInterop.SetupModule("./_content/EventLogExpert.UI/LogTable/Find/FindBar.razor.js");
+        Services.AddEventLogLocalization();
     }
 
     [Fact]
@@ -129,6 +131,20 @@ public sealed class FindBarTests : BunitContext
         cut.Find(".find-input").Input("error");
 
         Assert.Equal("error", typed);
+    }
+
+    [Fact]
+    public void LocalizedStrings_RenderFromResources()
+    {
+        var cut = Render<FindBar>(parameters => parameters.Add(component => component.Query, "x"));
+
+        Assert.Equal("Find in events", cut.Find(".find-input").GetAttribute("aria-label"));
+        Assert.Equal("Find in events", cut.Find(".find-input").GetAttribute("placeholder"));
+
+        cut.Find(".find-options-toggle").Click();
+
+        Assert.Equal("Match case", cut.Find("label[for=find-opt-case]").TextContent);
+        Assert.Equal("Match whole word", cut.Find("label[for=find-opt-word]").TextContent);
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneBusyTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneBusyTests.cs
@@ -21,7 +21,8 @@ using System.Globalization;
 
 namespace EventLogExpert.UI.Tests.LogTable;
 
-public sealed class LogTablePaneBusyTests : BunitContext
+[Collection(CultureSensitiveCollection.Name)]
+public sealed class LogTablePaneBusyTests : CultureSensitiveBunitContext
 {
     private const string LogName = "Application";
 

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneFindTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneFindTests.cs
@@ -23,7 +23,8 @@ using System.Reflection;
 
 namespace EventLogExpert.UI.Tests.LogTable;
 
-public sealed class LogTablePaneFindTests : BunitContext
+[Collection(CultureSensitiveCollection.Name)]
+public sealed class LogTablePaneFindTests : CultureSensitiveBunitContext
 {
     private const string LogName = "Application";
 

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneGroupingTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneGroupingTests.cs
@@ -24,7 +24,8 @@ using System.Globalization;
 
 namespace EventLogExpert.UI.Tests.LogTable;
 
-public sealed class LogTablePaneGroupingTests : BunitContext
+[Collection(CultureSensitiveCollection.Name)]
+public sealed class LogTablePaneGroupingTests : CultureSensitiveBunitContext
 {
     private const string LogName = "Application";
 

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneIndicatorTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneIndicatorTests.cs
@@ -21,7 +21,8 @@ using System.Globalization;
 
 namespace EventLogExpert.UI.Tests.LogTable;
 
-public sealed class LogTablePaneIndicatorTests : BunitContext
+[Collection(CultureSensitiveCollection.Name)]
+public sealed class LogTablePaneIndicatorTests : CultureSensitiveBunitContext
 {
     private const string LogName = "Application";
 

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneSelectionTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneSelectionTests.cs
@@ -23,7 +23,8 @@ using System.Security.Principal;
 
 namespace EventLogExpert.UI.Tests.LogTable;
 
-public sealed class LogTablePaneSelectionTests : BunitContext
+[Collection(CultureSensitiveCollection.Name)]
+public sealed class LogTablePaneSelectionTests : CultureSensitiveBunitContext
 {
     private const string LogName = "Application";
 

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneViewSourceTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneViewSourceTests.cs
@@ -22,7 +22,8 @@ using System.Globalization;
 
 namespace EventLogExpert.UI.Tests.LogTable;
 
-public sealed class LogTablePaneViewSourceTests : BunitContext
+[Collection(CultureSensitiveCollection.Name)]
+public sealed class LogTablePaneViewSourceTests : CultureSensitiveBunitContext
 {
     private const string LogName = "Application";
 
@@ -533,8 +534,7 @@ public sealed class LogTablePaneViewSourceTests : BunitContext
     [Fact]
     public void SelectionReveal_WhenTheTargetIsNotInTheView_DiscardsWithoutScrolling()
     {
-        // A one-shot (WaitForView=false) reveal whose target is filtered out of the current settled view is discarded
-        // rather than left pending - contrast with the reload reveal above, which lingers until the row appears.
+        // A one-shot (WaitForView=false) reveal whose target is filtered out of the settled view is discarded, not left pending (unlike the reload reveal above).
         var target = new EventLocator(_logId, 0, 2);
         SetCommittedState(_logId, [_logId], Event(1, "Alpha"), Event(2, "Beta"), Event(3, "Gamma"));
         _viewSource.Current.Returns(DisplayViewTestFactory.Presentation(_logId, [Event(1, "Alpha"), Event(2, "Beta")]));

--- a/tests/Unit/EventLogExpert.UI.Tests/TestUtils/CultureSensitiveBunitContext.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/TestUtils/CultureSensitiveBunitContext.cs
@@ -1,0 +1,22 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using System.Globalization;
+
+namespace EventLogExpert.UI.Tests.TestUtils;
+
+/// <summary>
+///     bUnit context that restores the construction-time thread culture on dispose, so a ctor's
+///     <see cref="CultureInfo.InvariantCulture" /> pin cannot leak onto a pooled thread.
+/// </summary>
+public abstract class CultureSensitiveBunitContext : BunitContext
+{
+    private readonly CultureInfo _originalCulture = CultureInfo.CurrentCulture;
+
+    protected override void Dispose(bool disposing)
+    {
+        CultureInfo.CurrentCulture = _originalCulture;
+        base.Dispose(disposing);
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/TestUtils/CultureSensitiveCollection.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/TestUtils/CultureSensitiveCollection.cs
@@ -1,0 +1,14 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.UI.Tests.TestUtils;
+
+/// <summary>
+///     Serializes culture-mutating test classes (<c>DisableParallelization</c>) so a pinned/forced culture cannot
+///     leak into a culture-sensitive assertion on a pooled thread.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class CultureSensitiveCollection
+{
+    public const string Name = "culture-sensitive";
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/TestUtils/LogTablePaneDependenciesExtensions.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/TestUtils/LogTablePaneDependenciesExtensions.cs
@@ -25,6 +25,8 @@ internal static class LogTablePaneDependenciesExtensions
     {
         public IServiceCollection AddLogTablePaneDependencies()
         {
+            services.AddEventLogLocalization();
+
             services.AddSingleton(Substitute.For<IAlertDialogService>());
             services.AddSingleton(Substitute.For<IClipboardService>());
             services.AddSingleton(Substitute.For<IFilterLensCommands>());


### PR DESCRIPTION
## Summary

Adds localization infrastructure (IStringLocalizer + RESX + locale-aware formatting + RTL direction resolution) that **follows the OS culture with no in-app language setting**, plus a single pilot surface (FindBar) migrated end-to-end to prove the wiring. Bulk string migration is deferred.

Scope decided up front: **infra + one pilot surface**, follow the OS culture (no picker), bulk migration deferred.

## Infrastructure
- `Microsoft.Extensions.Localization` 10.0.10 + an `AddEventLogLocalization()` DI extension.
- `SharedResource` marker at the root `EventLogExpert.UI` namespace with `ResourcesPath="Resources"`, so the manifest resolves to `EventLogExpert.UI.Resources.SharedResource` (avoids the double-`Resources` segment footgun).
- Neutral English `SharedResource.resx` + a `qps-ploc` pseudo-loc canary satellite (dedicated `Canary_*` keys, always embedded).
- `<NeutralLanguage>en</NeutralLanguage>` for correct satellite / main-assembly behavior.
- `ContentCulture` resolver: `SupportedUiCultures` (`{en}`), a parent-walk `Resolve`, and `DirectionOf` (ltr/rtl) for future RTL.
- `DocumentInitScript.Build(...)` — an extracted, testable WebView document-init script builder (theme + dir + lang) replacing the inline string in `MainPage.xaml.cs`.

## FindBar pilot
- All FindBar user-facing strings → `@Localizer[...]`.
- Match count uses culture-aware `:N0` formatting.
- Wrap announcement string → a `FindWrapState` enum (`None` / `WrappedToFirst` / `WrappedToLast`), localized at render.

## Tests (UI.Tests 1556 → 1558)
- Guard/config, resolver edge cases (invariant / en-GB / zh-Hans / ar-SA), a satellite drift guard, and a no-hardcoded-pin source scan.
- Culture-sensitive FindBar tests (qps-Ploc canary + de-DE count formatting) with a culture-restoring bUnit context and a non-parallel collection.
- `DocumentInitScript` pin tests (null-theme + with-theme).

## Regression risk / follow-ups
- Every OS culture resolves to `en` / `ltr` today (`SupportedUiCultures = {en}`), so runtime behavior is identical to the previous static `<html lang="en">` — **zero v1 regression risk**.
- RTL robustness (mutation-observer / awaiting doc-created) and any `CurrentUICulture` OS-display-language bootstrap are documented follow-ups, needed only before shipping a non-English locale.
