### PR TITLE
Localize the Settings modal and shared dialog chrome

### DIFF
--- a/src/EventLogExpert.UI/Globalization/ContentCulture.cs
+++ b/src/EventLogExpert.UI/Globalization/ContentCulture.cs
@@ -1,6 +1,7 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using System.Collections.Frozen;
 using System.Globalization;
 
 namespace EventLogExpert.UI.Globalization;
@@ -15,8 +16,8 @@ public static class ContentCulture
     ///     Cultures with a shipped translation; grows ONLY with a translation + the RTL prerequisite bundle (a
     ///     drift-guard test enforces alignment with the embedded satellites).
     /// </summary>
-    public static readonly IReadOnlySet<string> SupportedUiCultures =
-        new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "en" };
+    public static readonly FrozenSet<string> SupportedUiCultures =
+        new[] { "en" }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>The BCP-47 layout direction for <paramref name="culture" />: <c>"rtl"</c> or <c>"ltr"</c>.</summary>
     public static string DirectionOf(CultureInfo culture)

--- a/src/EventLogExpert.UI/Inputs/ValueSelect.razor
+++ b/src/EventLogExpert.UI/Inputs/ValueSelect.razor
@@ -1,5 +1,9 @@
 @typeparam T
 @inherits InputComponent<T>
+@{
+    // Evaluate once per render; DisplayString runs the converter (and a string.Join for multi-select).
+    var displayString = DisplayString;
+}
 
 <div class="dropdown-input" @onkeydown="HandleKeyDown" @ref="_selectComponent">
     <input aria-activedescendant="@HighlightedItem?.ItemId"
@@ -20,8 +24,9 @@
         readonly="@(!IsInput || IsMultiSelect)"
         role="combobox"
         tabindex="0"
+        title="@displayString"
         type="text"
-        value="@DisplayString" />
+        value="@displayString" />
 
     <div aria-multiselectable="@(IsMultiSelect ? "true" : null)" class="dropdown-list" id="@_itemId" role="listbox" tabindex="-1">
         <CascadingValue Value="this">

--- a/src/EventLogExpert.UI/Modal/ModalChrome.razor
+++ b/src/EventLogExpert.UI/Modal/ModalChrome.razor
@@ -1,4 +1,4 @@
-<dialog aria-label="@(string.IsNullOrEmpty(Title) ? (string.IsNullOrEmpty(AriaLabel) ? "Dialog" : AriaLabel) : null)"
+<dialog aria-label="@(string.IsNullOrEmpty(Title) ? (string.IsNullOrEmpty(AriaLabel) ? Localizer["Modal_DialogAriaFallback"] : AriaLabel) : null)"
     aria-labelledby="@(string.IsNullOrEmpty(Title) ? null : _titleId)"
     aria-modal="true"
     class="@DialogClass"
@@ -22,7 +22,7 @@
 
                 @if (ShowCloseButton)
                 {
-                    <Button aria-label="@(string.IsNullOrEmpty(CloseButtonAriaLabel) ? "Close" : CloseButtonAriaLabel)"
+                    <Button aria-label="@EffectiveCloseButtonAriaLabel"
                         CssClass="dialog-close"
                         Disabled="@HasInlineAlert"
                         IconClass="bi bi-x"
@@ -49,7 +49,7 @@
                     <Button autofocus
                         Disabled="@(HasInlineAlert || FooterDisabled)"
                         OnClick="HandleCloseButtonAsync">
-                        @CloseLabel
+                        @EffectiveCloseLabel
                     </Button>
 
                     break;
@@ -58,11 +58,11 @@
                     <div class="button-group">
                         <PrimaryButton Disabled="@(HasInlineAlert || FooterDisabled)"
                             OnClick="HandleSaveAsync">
-                            @SaveLabel
+                            @EffectiveSaveLabel
                         </PrimaryButton>
                         <Button Disabled="@(HasInlineAlert || FooterDisabled)"
                             OnClick="HandleCancelButtonAsync">
-                            @CancelLabel
+                            @EffectiveCancelLabel
                         </Button>
                     </div>
                     break;
@@ -71,18 +71,18 @@
                     <div class="button-group">
                         <Button Disabled="@(HasInlineAlert || FooterDisabled)"
                             OnClick="HandleImportAsync">
-                            @ImportLabel
+                            @EffectiveImportLabel
                         </Button>
                         <Button Disabled="@(HasInlineAlert || FooterDisabled)"
                             OnClick="HandleExportAsync">
-                            @ExportLabel
+                            @EffectiveExportLabel
                         </Button>
                     </div>
 
                     <Button autofocus
                         Disabled="@(HasInlineAlert || FooterDisabled)"
                         OnClick="HandleCloseButtonAsync">
-                        @CloseLabel
+                        @EffectiveCloseLabel
                     </Button>
 
                     break;
@@ -91,7 +91,7 @@
                     <Button autofocus
                         Disabled="@(HasInlineAlert || FooterDisabled)"
                         OnClick="HandleAcceptAsync">
-                        @AcceptLabel
+                        @EffectiveAcceptLabel
                     </Button>
 
                     break;
@@ -100,12 +100,12 @@
                     <PrimaryButton autofocus
                         Disabled="@(HasInlineAlert || FooterDisabled || AcceptDisabled)"
                         OnClick="HandleAcceptAsync">
-                        @AcceptLabel
+                        @EffectiveAcceptLabel
                     </PrimaryButton>
 
                     <Button Disabled="@(HasInlineAlert || FooterDisabled)"
                         OnClick="HandleCancelButtonAsync">
-                        @CancelLabel
+                        @EffectiveCancelLabel
                     </Button>
 
                     break;
@@ -121,7 +121,7 @@
         <div aria-hidden="true" class="inline-alert-overlay"></div>
 
         <section aria-describedby="@_inlineAlertMessageId"
-            aria-label="@(string.IsNullOrEmpty(InlineAlert!.Title) ? "Alert" : null)"
+            aria-label="@(string.IsNullOrEmpty(InlineAlert!.Title) ? Localizer["Modal_AlertAriaFallback"].Value : null)"
             aria-labelledby="@(string.IsNullOrEmpty(InlineAlert!.Title) ? null : _inlineAlertTitleId)"
             aria-modal="true"
             class="inline-alert"

--- a/src/EventLogExpert.UI/Modal/ModalChrome.razor.cs
+++ b/src/EventLogExpert.UI/Modal/ModalChrome.razor.cs
@@ -7,6 +7,7 @@ using EventLogExpert.UI.Common;
 using EventLogExpert.UI.Common.Interop;
 using EventLogExpert.UI.Inputs;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
 using Microsoft.JSInterop;
 
 namespace EventLogExpert.UI.Modal;
@@ -34,23 +35,23 @@ public sealed partial class ModalChrome : ComponentBase, IAsyncDisposable
 
     [Parameter] public bool AcceptDisabled { get; set; }
 
-    [Parameter] public string AcceptLabel { get; set; } = "OK";
+    [Parameter] public string? AcceptLabel { get; set; }
 
     [Parameter] public string? AriaLabel { get; set; }
 
     [Parameter] public ModalBodyLayout BodyLayout { get; set; } = ModalBodyLayout.Content;
 
-    [Parameter] public string CancelLabel { get; set; } = "Cancel";
+    [Parameter] public string? CancelLabel { get; set; }
 
     [Parameter] public RenderFragment? ChildContent { get; set; }
 
-    [Parameter] public string CloseButtonAriaLabel { get; set; } = "Close";
+    [Parameter] public string? CloseButtonAriaLabel { get; set; }
 
-    [Parameter] public string CloseLabel { get; set; } = "Close";
+    [Parameter] public string? CloseLabel { get; set; }
 
     [Parameter] public string? DialogClass { get; set; }
 
-    [Parameter] public string ExportLabel { get; set; } = "Export";
+    [Parameter] public string? ExportLabel { get; set; }
 
     [Parameter] public RenderFragment? ExtraFooterContent { get; set; }
 
@@ -60,7 +61,7 @@ public sealed partial class ModalChrome : ComponentBase, IAsyncDisposable
 
     [Parameter] public string? Height { get; set; }
 
-    [Parameter] public string ImportLabel { get; set; } = "Import";
+    [Parameter] public string? ImportLabel { get; set; }
 
     [Parameter] public InlineAlertRequest? InlineAlert { get; set; }
 
@@ -84,7 +85,7 @@ public sealed partial class ModalChrome : ComponentBase, IAsyncDisposable
 
     [Parameter] public EventCallback OnSave { get; set; }
 
-    [Parameter] public string SaveLabel { get; set; } = "Save";
+    [Parameter] public string? SaveLabel { get; set; }
 
     [Parameter] public bool ShowCloseButton { get; set; }
 
@@ -110,9 +111,26 @@ public sealed partial class ModalChrome : ComponentBase, IAsyncDisposable
         }
     }
 
+    private string EffectiveAcceptLabel => string.IsNullOrEmpty(AcceptLabel) ? Localizer["Modal_Accept"] : AcceptLabel;
+
+    private string EffectiveCancelLabel => string.IsNullOrEmpty(CancelLabel) ? Localizer["Modal_Cancel"] : CancelLabel;
+
+    private string EffectiveCloseButtonAriaLabel =>
+        string.IsNullOrEmpty(CloseButtonAriaLabel) ? Localizer["Modal_Close"] : CloseButtonAriaLabel;
+
+    private string EffectiveCloseLabel => string.IsNullOrEmpty(CloseLabel) ? Localizer["Modal_Close"] : CloseLabel;
+
+    private string EffectiveExportLabel => string.IsNullOrEmpty(ExportLabel) ? Localizer["Modal_Export"] : ExportLabel;
+
+    private string EffectiveImportLabel => string.IsNullOrEmpty(ImportLabel) ? Localizer["Modal_Import"] : ImportLabel;
+
+    private string EffectiveSaveLabel => string.IsNullOrEmpty(SaveLabel) ? Localizer["Modal_Save"] : SaveLabel;
+
     private bool HasInlineAlert => InlineAlert is not null;
 
     [Inject] private IJSRuntime JSRuntime { get; init; } = null!;
+
+    [Inject] private IStringLocalizer<SharedResource> Localizer { get; init; } = null!;
 
     private string? ValidationError
     {

--- a/src/EventLogExpert.UI/Resources/SharedResource.resx
+++ b/src/EventLogExpert.UI/Resources/SharedResource.resx
@@ -96,4 +96,127 @@
   <data name="FindBar_WrapToLast" xml:space="preserve">
     <value>Wrapped to last match</value>
   </data>
+  <!-- Settings modal. Field labels keep their trailing colon in the value (locale-controlled punctuation); the two toggle rows add a bare aria/title variant. -->
+  <data name="Settings_AriaLabel" xml:space="preserve">
+    <value>Settings</value>
+  </data>
+  <data name="Settings_TimeZoneLabel" xml:space="preserve">
+    <value>Time Zone:</value>
+  </data>
+  <data name="Settings_ThemeLabel" xml:space="preserve">
+    <value>Theme:</value>
+  </data>
+  <data name="Settings_KeyboardCopyLabel" xml:space="preserve">
+    <value>Keyboard Copy Behavior:</value>
+  </data>
+  <data name="Settings_LoggingLevelLabel" xml:space="preserve">
+    <value>Logging Level:</value>
+  </data>
+  <data name="Settings_VerboseResolutionLabel" xml:space="preserve">
+    <value>Verbose Event Resolution Logging:</value>
+  </data>
+  <data name="Settings_ExpandDisplayPaneLabel" xml:space="preserve">
+    <value>Expand Display Pane On Selection Change:</value>
+  </data>
+  <data name="Settings_ExpandDisplayPaneAriaLabel" xml:space="preserve">
+    <value>Expand Display Pane On Selection Change</value>
+    <comment>Toggle accessible name; the colon-suffixed visible label is Settings_ExpandDisplayPaneLabel.</comment>
+  </data>
+  <data name="Settings_PreReleaseLabel" xml:space="preserve">
+    <value>Pre-release Builds:</value>
+  </data>
+  <data name="Settings_PreReleaseAriaLabel" xml:space="preserve">
+    <value>Pre-release Builds</value>
+    <comment>Toggle accessible name; the colon-suffixed visible label is Settings_PreReleaseLabel.</comment>
+  </data>
+  <data name="Settings_SavedAnnouncement" xml:space="preserve">
+    <value>Settings saved</value>
+  </data>
+  <!-- Theme dropdown options. -->
+  <data name="Settings_Theme_System" xml:space="preserve">
+    <value>Follow System</value>
+  </data>
+  <data name="Settings_Theme_Light" xml:space="preserve">
+    <value>Light</value>
+  </data>
+  <data name="Settings_Theme_Dark" xml:space="preserve">
+    <value>Dark</value>
+  </data>
+  <!-- Keyboard-copy-format dropdown options (map to EventCopyFormat). Xml/Markdown are format proper nouns translators may leave as-is. -->
+  <data name="Settings_CopyFormat_Default" xml:space="preserve">
+    <value>Default</value>
+  </data>
+  <data name="Settings_CopyFormat_Simple" xml:space="preserve">
+    <value>Simple</value>
+  </data>
+  <data name="Settings_CopyFormat_Xml" xml:space="preserve">
+    <value>Xml</value>
+    <comment>Format proper noun; typically not translated.</comment>
+  </data>
+  <data name="Settings_CopyFormat_Full" xml:space="preserve">
+    <value>Full</value>
+  </data>
+  <data name="Settings_CopyFormat_Markdown" xml:space="preserve">
+    <value>Markdown</value>
+    <comment>Format proper noun; typically not translated.</comment>
+  </data>
+  <!-- Logging-level dropdown options. These map 1:1 to Microsoft.Extensions.Logging.LogLevel members; translating them hurts log/support correlation. -->
+  <data name="Settings_LogLevel_Trace" xml:space="preserve">
+    <value>Trace</value>
+    <comment>Microsoft.Extensions.Logging.LogLevel member; may stay untranslated to preserve log correlation.</comment>
+  </data>
+  <data name="Settings_LogLevel_Debug" xml:space="preserve">
+    <value>Debug</value>
+    <comment>Microsoft.Extensions.Logging.LogLevel member; may stay untranslated to preserve log correlation.</comment>
+  </data>
+  <data name="Settings_LogLevel_Information" xml:space="preserve">
+    <value>Information</value>
+    <comment>Microsoft.Extensions.Logging.LogLevel member; may stay untranslated to preserve log correlation.</comment>
+  </data>
+  <data name="Settings_LogLevel_Warning" xml:space="preserve">
+    <value>Warning</value>
+    <comment>Microsoft.Extensions.Logging.LogLevel member; may stay untranslated to preserve log correlation.</comment>
+  </data>
+  <data name="Settings_LogLevel_Error" xml:space="preserve">
+    <value>Error</value>
+    <comment>Microsoft.Extensions.Logging.LogLevel member; may stay untranslated to preserve log correlation.</comment>
+  </data>
+  <data name="Settings_LogLevel_Critical" xml:space="preserve">
+    <value>Critical</value>
+    <comment>Microsoft.Extensions.Logging.LogLevel member; may stay untranslated to preserve log correlation.</comment>
+  </data>
+  <data name="Settings_LogLevel_None" xml:space="preserve">
+    <value>None</value>
+    <comment>Microsoft.Extensions.Logging.LogLevel member; may stay untranslated to preserve log correlation.</comment>
+  </data>
+  <!-- Shared modal-chrome default button labels + aria fallbacks. Used when a caller omits the label parameter. -->
+  <data name="Modal_Save" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="Modal_Cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="Modal_Close" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="Modal_Import" xml:space="preserve">
+    <value>Import</value>
+  </data>
+  <data name="Modal_Export" xml:space="preserve">
+    <value>Export</value>
+  </data>
+  <data name="Modal_Accept" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="Modal_Exit" xml:space="preserve">
+    <value>Exit</value>
+  </data>
+  <data name="Modal_DialogAriaFallback" xml:space="preserve">
+    <value>Dialog</value>
+    <comment>Accessible name for a titleless dialog with no explicit AriaLabel.</comment>
+  </data>
+  <data name="Modal_AlertAriaFallback" xml:space="preserve">
+    <value>Alert</value>
+    <comment>Accessible name for a titleless inline alert.</comment>
+  </data>
 </root>

--- a/src/EventLogExpert.UI/Settings/SettingsModal.razor
+++ b/src/EventLogExpert.UI/Settings/SettingsModal.razor
@@ -2,9 +2,9 @@
 @using Microsoft.Extensions.Logging
 @inherits ModalBase<bool>
 
-<ModalChrome AriaLabel="Settings"
+<ModalChrome AriaLabel="@Localizer["Settings_AriaLabel"]"
     BodyLayout="ModalBodyLayout.Flex"
-    CancelLabel="Exit"
+    CancelLabel="@Localizer["Modal_Exit"]"
     Footer="FooterPreset.SaveCancel"
     Height="60%"
     InlineAlert="@CurrentInlineAlert"
@@ -13,39 +13,38 @@
     OnInlineAlertResolved="HandleInlineAlertResolvedAsync"
     OnSave="OnSaveAsync"
     @ref="ChromeRef"
-    SaveLabel="Save"
     StackFooterExtra="true">
     <ChildContent>
         <div class="settings-form">
             <div class="flex-column-scroll">
                 <div class="flex-center-aligned-row tz-row">
-                    <label for="settings-timezone">Time Zone:</label>
-                    <ValueSelect @bind-Value="_timeZoneId" CssClass="input timezone-dropdown" Id="settings-timezone" T="string">
-                        @foreach (var item in TimeZoneInfo.GetSystemTimeZones())
+                    <label for="settings-timezone">@Localizer["Settings_TimeZoneLabel"]</label>
+                    <ValueSelect @bind-Value="_timeZoneId" CssClass="input timezone-dropdown" Id="settings-timezone" T="string" ToStringFunc="GetTimeZoneDisplay">
+                        @foreach (var item in _timeZones)
                         {
-                            <ValueSelectItem T="string" Value="item.Id">@item.DisplayName</ValueSelectItem>
+                            <ValueSelectItem T="string" Value="item.Id" />
                         }
                     </ValueSelect>
                 </div>
 
                 <div class="flex-center-aligned-row">
-                    <text>Expand Display Pane On Selection Change:</text>
-                    <Toggle AriaLabel="Expand Display Pane On Selection Change" @bind-Value="_showDisplayPaneOnSelectionChange" />
+                    <text>@Localizer["Settings_ExpandDisplayPaneLabel"]</text>
+                    <Toggle AriaLabel="@Localizer["Settings_ExpandDisplayPaneAriaLabel"]" @bind-Value="_showDisplayPaneOnSelectionChange" />
                 </div>
 
                 <div class="flex-center-aligned-row">
-                    <label for="settings-theme">Theme:</label>
-                    <ValueSelect @bind-Value="_theme" CssClass="input filter-dropdown" Id="settings-theme" T="Theme">
+                    <label for="settings-theme">@Localizer["Settings_ThemeLabel"]</label>
+                    <ValueSelect @bind-Value="_theme" CssClass="input filter-dropdown" Id="settings-theme" T="Theme" ToStringFunc="GetThemeDisplay">
                         @foreach (Theme item in Enum.GetValues(typeof(Theme)))
                         {
-                            <ValueSelectItem T="Theme" Value="item">@(item == Theme.System ? "Follow System" : item.ToString())</ValueSelectItem>
+                            <ValueSelectItem T="Theme" Value="item" />
                         }
                     </ValueSelect>
                 </div>
 
                 <div class="flex-center-aligned-row">
-                    <label for="settings-copy-format">Keyboard Copy Behavior:</label>
-                    <ValueSelect @bind-Value="_copyFormat" CssClass="input filter-dropdown" Id="settings-copy-format" T="EventCopyFormat">
+                    <label for="settings-copy-format">@Localizer["Settings_KeyboardCopyLabel"]</label>
+                    <ValueSelect @bind-Value="_copyFormat" CssClass="input filter-dropdown" Id="settings-copy-format" T="EventCopyFormat" ToStringFunc="GetCopyFormatDisplay">
                         @foreach (EventCopyFormat item in Enum.GetValues(typeof(EventCopyFormat)))
                         {
                             <ValueSelectItem T="EventCopyFormat" Value="item" />
@@ -54,8 +53,8 @@
                 </div>
 
                 <div class="flex-center-aligned-row">
-                    <label for="settings-log-level">Logging Level:</label>
-                    <ValueSelect @bind-Value="_logLevel" CssClass="input filter-dropdown" Id="settings-log-level" T="LogLevel">
+                    <label for="settings-log-level">@Localizer["Settings_LoggingLevelLabel"]</label>
+                    <ValueSelect @bind-Value="_logLevel" CssClass="input filter-dropdown" Id="settings-log-level" T="LogLevel" ToStringFunc="GetLogLevelDisplay">
                         @foreach (LogLevel item in Enum.GetValues(typeof(LogLevel)))
                         {
                             <ValueSelectItem T="LogLevel" Value="item" />
@@ -64,7 +63,7 @@
                 </div>
 
                 <div class="flex-center-aligned-row">
-                    <label for="settings-verbose-resolution">Verbose Event Resolution Logging:</label>
+                    <label for="settings-verbose-resolution">@Localizer["Settings_VerboseResolutionLabel"]</label>
                     <Toggle @bind-Value="_verboseResolution" Id="settings-verbose-resolution" />
                 </div>
             </div>
@@ -73,8 +72,8 @@
 
     <ExtraFooterContent>
         <div class="flex-center-aligned-row">
-            <text>Pre-release Builds:</text>
-            <Toggle AriaLabel="Pre-release Builds" @bind-Value="_isPreReleaseEnabled" />
+            <text>@Localizer["Settings_PreReleaseLabel"]</text>
+            <Toggle AriaLabel="@Localizer["Settings_PreReleaseAriaLabel"]" @bind-Value="_isPreReleaseEnabled" />
         </div>
     </ExtraFooterContent>
 </ModalChrome>

--- a/src/EventLogExpert.UI/Settings/SettingsModal.razor.cs
+++ b/src/EventLogExpert.UI/Settings/SettingsModal.razor.cs
@@ -7,6 +7,7 @@ using EventLogExpert.Runtime.DetailsPane;
 using EventLogExpert.Runtime.Settings;
 using EventLogExpert.UI.Modal;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 
 namespace EventLogExpert.UI.Settings;
@@ -18,12 +19,16 @@ public sealed partial class SettingsModal : ModalBase<bool>
     private LogLevel _logLevel;
     private bool _showDisplayPaneOnSelectionChange;
     private Theme _theme;
+    private Dictionary<string, string> _timeZoneDisplay = new();
     private string _timeZoneId = string.Empty;
+    private IReadOnlyList<TimeZoneInfo> _timeZones = [];
     private bool _verboseResolution;
 
     [Inject] private IAnnouncementService AnnouncementService { get; init; } = null!;
 
     [Inject] private IDetailsPanePreferencesProvider DetailsPanePreferences { get; init; } = null!;
+
+    [Inject] private IStringLocalizer<SharedResource> Localizer { get; init; } = null!;
 
     [Inject] private ISettingsService Settings { get; init; } = null!;
 
@@ -35,6 +40,16 @@ public sealed partial class SettingsModal : ModalBase<bool>
 
     protected override void OnInitialized()
     {
+        // One GetSystemTimeZones() snapshot drives both the ordered dropdown list and the id->DisplayName lookup;
+        // per-instance (not static) because DisplayName is culture-sensitive.
+        _timeZones = TimeZoneInfo.GetSystemTimeZones();
+        _timeZoneDisplay = new Dictionary<string, string>(_timeZones.Count);
+
+        foreach (var timeZone in _timeZones)
+        {
+            _timeZoneDisplay[timeZone.Id] = timeZone.DisplayName;
+        }
+
         LoadFromSettings();
         base.OnInitialized();
     }
@@ -43,10 +58,19 @@ public sealed partial class SettingsModal : ModalBase<bool>
     {
         SaveSettings();
 
-        AnnouncementService.Announce("Settings saved");
+        AnnouncementService.Announce(Localizer["Settings_SavedAnnouncement"]);
 
         await CompleteAsync(true);
     }
+
+    private string GetCopyFormatDisplay(EventCopyFormat value) => Localizer[$"Settings_CopyFormat_{value}"];
+
+    private string GetLogLevelDisplay(LogLevel value) => Localizer[$"Settings_LogLevel_{value}"];
+
+    private string GetThemeDisplay(Theme value) => Localizer[$"Settings_Theme_{value}"];
+
+    private string GetTimeZoneDisplay(string? id) =>
+        string.IsNullOrEmpty(id) ? string.Empty : (_timeZoneDisplay.TryGetValue(id, out var name) ? name : id);
 
     private void LoadFromSettings()
     {

--- a/src/EventLogExpert.UI/wwwroot/app.css
+++ b/src/EventLogExpert.UI/wwwroot/app.css
@@ -324,7 +324,7 @@ input[type="text"].input.dialog-input { padding: .25rem 0; }
 
 .input.filter-mode-dropdown { width: 90px; }
 
-.input.timezone-dropdown { width: 350px; }
+.input.timezone-dropdown { width: 420px; }
 
 .input.cache-dropdown,
 .input.advanced-filter {

--- a/tests/Unit/EventLogExpert.UI.Tests/Modal/ModalChromeTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Modal/ModalChromeTests.cs
@@ -103,6 +103,87 @@ public sealed class ModalChromeTests : BunitContext
         Assert.False(cycleState.ModalContentDisplayed);
     }
 
+    [Theory]
+    [InlineData(FooterPreset.Dismiss)]
+    [InlineData(FooterPreset.AcceptCancel)]
+    public void ModalChrome_AcceptDefault_LocalizesToOk(FooterPreset footer)
+    {
+        var component = Render<ModalChrome>(parameters => parameters
+            .Add(p => p.Title, "Test")
+            .Add(p => p.Footer, footer)
+            .AddChildContent("<p>body</p>"));
+
+        var labels = component.FindAll(".footer-group button").Select(button => button.TextContent.Trim()).ToList();
+        Assert.Contains("OK", labels);
+    }
+
+    [Fact]
+    public void ModalChrome_CloseButton_AriaLabelDefaultsToLocalizedClose()
+    {
+        var component = Render<ModalChrome>(parameters => parameters
+            .Add(p => p.Title, "Test")
+            .Add(p => p.ShowCloseButton, true)
+            .AddChildContent("<p>body</p>"));
+
+        Assert.Equal("Close", component.Find(".dialog-close").GetAttribute("aria-label"));
+    }
+
+    [Fact]
+    public void ModalChrome_ImportExportCloseDefaults_Localize()
+    {
+        var component = Render<ModalChrome>(parameters => parameters
+            .Add(p => p.Title, "Test")
+            .Add(p => p.Footer, FooterPreset.ImportExportClose)
+            .AddChildContent("<p>body</p>"));
+
+        var labels = component.FindAll(".footer-group button").Select(button => button.TextContent.Trim()).ToList();
+        Assert.Contains("Import", labels);
+        Assert.Contains("Export", labels);
+        Assert.Contains("Close", labels);
+    }
+
+    [Fact]
+    public void ModalChrome_InlineAlertWithoutTitle_AriaFallsBackToLocalizedAlert()
+    {
+        var alert = new InlineAlertRequest(
+            Title: "",
+            Message: "Something happened",
+            AcceptLabel: "OK",
+            CancelLabel: "Cancel",
+            IsPrompt: false,
+            PromptInitialValue: null);
+
+        var component = Render<ModalChrome>(parameters => parameters
+            .Add(p => p.Title, "Test")
+            .Add(p => p.InlineAlert, alert)
+            .AddChildContent("<p>body</p>"));
+
+        Assert.Equal("Alert", component.Find("section.inline-alert").GetAttribute("aria-label"));
+    }
+
+    [Fact]
+    public void ModalChrome_NoTitleNoAriaLabel_DialogAriaFallsBackToLocalized()
+    {
+        var component = Render<ModalChrome>(parameters => parameters
+            .Add(p => p.Footer, FooterPreset.None)
+            .AddChildContent("<p>body</p>"));
+
+        Assert.Equal("Dialog", component.Find("dialog").GetAttribute("aria-label"));
+    }
+
+    [Fact]
+    public void ModalChrome_SaveCancelDefaults_LocalizeToSaveAndCancel()
+    {
+        var component = Render<ModalChrome>(parameters => parameters
+            .Add(p => p.Title, "Test")
+            .Add(p => p.Footer, FooterPreset.SaveCancel)
+            .AddChildContent("<p>body</p>"));
+
+        var labels = component.FindAll(".footer-group button").Select(button => button.TextContent.Trim()).ToList();
+        Assert.Contains("Save", labels);
+        Assert.Contains("Cancel", labels);
+    }
+
     [Fact]
     public void Render_BannerHostWrapper_DoesNotHaveInertAttributeWhenNoInlineAlert()
     {
@@ -179,25 +260,6 @@ public sealed class ModalChromeTests : BunitContext
     }
 
     [Fact]
-    public void Render_InlineAlertWithoutSecondaryActionLabel_RendersNoSecondaryButton()
-    {
-        var alert = new InlineAlertRequest(
-            Title: "Confirm",
-            Message: "Are you sure?",
-            AcceptLabel: "Yes",
-            CancelLabel: "No",
-            IsPrompt: false,
-            PromptInitialValue: null);
-
-        var component = Render<ModalChrome>(parameters => parameters
-            .Add(p => p.Title, "Test")
-            .Add(p => p.InlineAlert, alert)
-            .AddChildContent("<p>body</p>"));
-
-        Assert.Equal(2, component.FindAll(".inline-alert-buttons button").Count);
-    }
-
-    [Fact]
     public void Render_InlineAlertWithSecondaryActionLabel_RendersSecondaryButton()
     {
         var alert = new InlineAlertRequest(
@@ -220,15 +282,22 @@ public sealed class ModalChromeTests : BunitContext
     }
 
     [Fact]
-    public void Render_WhenFooterPresetNone_RendersNoBuiltInButtons()
+    public void Render_InlineAlertWithoutSecondaryActionLabel_RendersNoSecondaryButton()
     {
+        var alert = new InlineAlertRequest(
+            Title: "Confirm",
+            Message: "Are you sure?",
+            AcceptLabel: "Yes",
+            CancelLabel: "No",
+            IsPrompt: false,
+            PromptInitialValue: null);
+
         var component = Render<ModalChrome>(parameters => parameters
             .Add(p => p.Title, "Test")
-            .Add(p => p.Footer, FooterPreset.None)
+            .Add(p => p.InlineAlert, alert)
             .AddChildContent("<p>body</p>"));
 
-        var footerGroup = component.Find(".footer-group");
-        Assert.Empty(footerGroup.QuerySelectorAll("button"));
+        Assert.Equal(2, component.FindAll(".inline-alert-buttons button").Count);
     }
 
     [Fact]
@@ -257,5 +326,17 @@ public sealed class ModalChromeTests : BunitContext
         var footerGroup = component.Find(".footer-group");
         var buttons = footerGroup.QuerySelectorAll("button");
         Assert.Equal(3, buttons.Length);
+    }
+
+    [Fact]
+    public void Render_WhenFooterPresetNone_RendersNoBuiltInButtons()
+    {
+        var component = Render<ModalChrome>(parameters => parameters
+            .Add(p => p.Title, "Test")
+            .Add(p => p.Footer, FooterPreset.None)
+            .AddChildContent("<p>body</p>"));
+
+        var footerGroup = component.Find(".footer-group");
+        Assert.Empty(footerGroup.QuerySelectorAll("button"));
     }
 }

--- a/tests/Unit/EventLogExpert.UI.Tests/Settings/SettingsModalCultureTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Settings/SettingsModalCultureTests.cs
@@ -1,0 +1,62 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using EventLogExpert.Runtime.Announcement;
+using EventLogExpert.Runtime.DetailsPane;
+using EventLogExpert.Runtime.Settings;
+using EventLogExpert.UI.Modal;
+using EventLogExpert.UI.Settings;
+using EventLogExpert.UI.Tests.TestUtils;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using NSubstitute;
+using System.Globalization;
+
+namespace EventLogExpert.UI.Tests.Settings;
+
+/// <summary>
+///     SettingsModal test that MUTATES thread UI culture (qps-Ploc); the base context restores both cultures on
+///     dispose and the class is serialized via <see cref="CultureSensitiveCollection" />.
+/// </summary>
+[Collection(CultureSensitiveCollection.Name)]
+public sealed class SettingsModalCultureTests : CultureSensitiveBunitContext
+{
+    private readonly IAnnouncementService _announcementService = Substitute.For<IAnnouncementService>();
+    private readonly IDetailsPanePreferencesProvider _detailsPanePreferences = Substitute.For<IDetailsPanePreferencesProvider>();
+    private readonly IModalCoordinator _modalCoordinator = Substitute.For<IModalCoordinator>();
+    private readonly IModalService _modalService = Substitute.For<IModalService>();
+    private readonly ISettingsService _settings = Substitute.For<ISettingsService>();
+
+    public SettingsModalCultureTests()
+    {
+        Services.AddBannerHostDependencies();
+        Services.AddMenuMocks();
+
+        _modalService.ActiveModalId.Returns(new ModalId(1L));
+        _settings.TimeZoneId.Returns(string.Empty);
+
+        Services.AddSingleton(_announcementService);
+        Services.AddSingleton(_detailsPanePreferences);
+        Services.AddSingleton(_modalCoordinator);
+        Services.AddSingleton(_modalService);
+        Services.AddSingleton(_settings);
+
+        JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    [Fact]
+    public void SettingsModal_UnderPseudoLocale_LoadsSatelliteButRendersEnglish()
+    {
+        CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("qps-ploc");
+
+        // Positive control: the qps-Ploc satellite IS loaded, so "assert English" below is not vacuous.
+        var localizer = Services.GetRequiredService<IStringLocalizer<SharedResource>>();
+        Assert.Equal("[qps-ploc] canary probe one", localizer["Canary_Probe1"].Value);
+
+        // Real Settings keys are absent from the canary satellite -> neutral English (a qps-Ploc machine never renders pseudo UI).
+        var component = Render<SettingsModal>();
+        Assert.Equal("Time Zone:", component.Find("label[for='settings-timezone']").TextContent.Trim());
+        Assert.Equal("Settings", component.Find("dialog").GetAttribute("aria-label"));
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/Settings/SettingsModalTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Settings/SettingsModalTests.cs
@@ -3,12 +3,16 @@
 
 using Bunit;
 using EventLogExpert.Runtime.Announcement;
+using EventLogExpert.Runtime.Common.Clipboard;
 using EventLogExpert.Runtime.DetailsPane;
 using EventLogExpert.Runtime.Settings;
 using EventLogExpert.UI.Modal;
 using EventLogExpert.UI.Settings;
 using EventLogExpert.UI.Tests.TestUtils;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 
 namespace EventLogExpert.UI.Tests.Settings;
@@ -37,6 +41,29 @@ public sealed class SettingsModalTests : BunitContext
         Services.AddSingleton(_settings);
 
         JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    [Fact]
+    public void SettingsModal_EnumOptionKeys_AllResolveInResources()
+    {
+        var localizer = Services.GetRequiredService<IStringLocalizer<SharedResource>>();
+
+        foreach (var value in Enum.GetValues<Theme>())
+        {
+            Assert.False(localizer[$"Settings_Theme_{value}"].ResourceNotFound, $"Missing Settings_Theme_{value}");
+        }
+
+        foreach (var value in Enum.GetValues<EventCopyFormat>())
+        {
+            Assert.False(localizer[$"Settings_CopyFormat_{value}"].ResourceNotFound, $"Missing Settings_CopyFormat_{value}");
+        }
+
+        foreach (var value in Enum.GetValues<LogLevel>())
+        {
+            Assert.False(localizer[$"Settings_LogLevel_{value}"].ResourceNotFound, $"Missing Settings_LogLevel_{value}");
+        }
+
+        Assert.Equal("Follow System", localizer[$"Settings_Theme_{Theme.System}"].Value);
     }
 
     [Fact]
@@ -80,6 +107,64 @@ public sealed class SettingsModalTests : BunitContext
     }
 
     [Fact]
+    public void SettingsModal_ResolvesAllResourceKeys_NoRawKeyLeaksIntoMarkup()
+    {
+        // A missing key makes IStringLocalizer echo the key name; ids/classes use hyphens (settings-timezone, modal-title),
+        // so a raw "Settings_" or "Modal_" in the markup is an unresolved-key leak on any label, aria, or dropdown option.
+        var component = Render<SettingsModal>();
+
+        Assert.DoesNotContain("Settings_", component.Markup);
+        Assert.DoesNotContain("Modal_", component.Markup);
+    }
+
+    [Fact]
+    public async Task SettingsModal_ThemeDropdown_ClosedDisplayIsLocalized_AndUpdatesOnSelection()
+    {
+        _settings.Theme.Returns(Theme.Light);
+        var component = Render<SettingsModal>();
+
+        Assert.Equal("Light", component.Find("#settings-theme").GetAttribute("value"));
+
+        // ValueSelectItem wires @onmousedown (not onclick), so Click() would be a no-op here.
+        var systemOption = component.FindAll("[role='option']")
+            .Single(option => option.TextContent.Trim() == "Follow System");
+        await systemOption.MouseDownAsync(new MouseEventArgs());
+
+        Assert.Equal("Follow System", component.Find("#settings-theme").GetAttribute("value"));
+    }
+
+    [Fact]
+    public void SettingsModal_TimeZoneClosedDisplay_EmptyIdRendersEmpty()
+    {
+        _settings.TimeZoneId.Returns(string.Empty);
+
+        var component = Render<SettingsModal>();
+
+        Assert.Equal(string.Empty, component.Find("#settings-timezone").GetAttribute("value"));
+    }
+
+    [Fact]
+    public void SettingsModal_TimeZoneClosedDisplay_FallsBackToRawIdForUnknownId()
+    {
+        _settings.TimeZoneId.Returns("Not A Real Time Zone Id");
+
+        var component = Render<SettingsModal>();
+
+        Assert.Equal("Not A Real Time Zone Id", component.Find("#settings-timezone").GetAttribute("value"));
+    }
+
+    [Fact]
+    public void SettingsModal_TimeZoneClosedDisplay_ShowsDisplayNameForKnownId()
+    {
+        var zone = TimeZoneInfo.GetSystemTimeZones()[0];
+        _settings.TimeZoneId.Returns(zone.Id);
+
+        var component = Render<SettingsModal>();
+
+        Assert.Equal(zone.DisplayName, component.Find("#settings-timezone").GetAttribute("value"));
+    }
+
+    [Fact]
     public void SettingsModal_TimeZoneInput_HasLabelForAssociation()
     {
         var component = Render<SettingsModal>();
@@ -88,6 +173,18 @@ public sealed class SettingsModalTests : BunitContext
         Assert.Equal("Time Zone:", label.TextContent.Trim());
         var input = component.Find("#settings-timezone");
         Assert.Equal("settings-timezone", input.Id);
+    }
+
+    [Fact]
+    public void SettingsModal_ToggleRows_UseBareAriaLabels_ButColonInVisibleText()
+    {
+        var component = Render<SettingsModal>();
+
+        Assert.Contains("Expand Display Pane On Selection Change:", component.Markup);
+        Assert.Single(component.FindAll("[aria-label='Expand Display Pane On Selection Change']"));
+
+        Assert.Contains("Pre-release Builds:", component.Markup);
+        Assert.Single(component.FindAll("[aria-label='Pre-release Builds']"));
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.UI.Tests/TestUtils/BannerHostDependenciesExtensions.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/TestUtils/BannerHostDependenciesExtensions.cs
@@ -15,6 +15,8 @@ internal static class BannerHostDependenciesExtensions
     {
         public void AddBannerHostDependencies()
         {
+            services.AddEventLogLocalization();
+
             var attention = Substitute.For<IAttentionBannerService>();
             attention.AttentionEntries.Returns([]);
             attention.AttentionDismissed.Returns(false);

--- a/tests/Unit/EventLogExpert.UI.Tests/TestUtils/CultureSensitiveBunitContext.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/TestUtils/CultureSensitiveBunitContext.cs
@@ -7,16 +7,18 @@ using System.Globalization;
 namespace EventLogExpert.UI.Tests.TestUtils;
 
 /// <summary>
-///     bUnit context that restores the construction-time thread culture on dispose, so a ctor's
-///     <see cref="CultureInfo.InvariantCulture" /> pin cannot leak onto a pooled thread.
+///     bUnit context that restores the construction-time thread <see cref="CultureInfo.CurrentCulture" /> AND
+///     <see cref="CultureInfo.CurrentUICulture" /> on dispose, so a ctor's culture pin cannot leak onto a pooled thread.
 /// </summary>
 public abstract class CultureSensitiveBunitContext : BunitContext
 {
     private readonly CultureInfo _originalCulture = CultureInfo.CurrentCulture;
+    private readonly CultureInfo _originalUiCulture = CultureInfo.CurrentUICulture;
 
     protected override void Dispose(bool disposing)
     {
         CultureInfo.CurrentCulture = _originalCulture;
+        CultureInfo.CurrentUICulture = _originalUiCulture;
         base.Dispose(disposing);
     }
 }


### PR DESCRIPTION
## Summary

The second incremental UI-surface localization migration (after the merged FindBar pilot in #701), plus a held infra hardening. Follows the OS culture with no in-app language setting; **English is byte-identical today**.

Two commits:
1. **Freeze `SupportedUiCultures`** to a `FrozenSet<string>` — a held follow-up from the infra PR (#701) that closes a cast-and-mutate bypass of the satellite drift guard.
2. **Localize SettingsModal + the shared ModalChrome.**

## SettingsModal + ModalChrome localization

**RESX (`SharedResource.resx`):** `Settings_*` field labels (colon kept **in the value** for locale-controlled punctuation) + bare `*AriaLabel` keys for the two toggle rows; Theme / Keyboard-Copy / Logging-Level dropdown option values (with do-not-translate `<comment>`s on the format proper nouns and the `LogLevel` members); `Modal_*` shared button defaults (Save/Cancel/Close/Import/Export/Accept/Exit) + Dialog/Alert aria fallbacks.

**ModalChrome** (shared dialog chrome): the 7 hardcoded default label params become `string?`, resolved via `string.IsNullOrEmpty(x) ? Localizer["Modal_X"] : x`, so every modal that relies on the defaults is now localizable (English-invariant; all 10 callers audited). Injects `IStringLocalizer<SharedResource>`.

**SettingsModal:** all labels / aria / the "Settings saved" announcement -> `@Localizer`; the three enum dropdowns use the existing `ToStringFunc` hook (method groups) so **both** the option list and the closed/selected display are localized consistently. This also **fixes two latent inconsistencies**: Theme showed "Follow System" in the list but "System" when closed, and TimeZone showed the friendly name in the list but the raw Id when closed. The id->DisplayName map is built once per instance from a single `GetSystemTimeZones()` snapshot (unknown id falls back to the raw id; empty -> "").

**ValueSelect:** adds a `title="@DisplayString"` tooltip (evaluated once per render) so the now-longer selected value is discoverable; the timezone dropdown is widened.

## Non-regression
Every OS culture resolves to `en` today (`SupportedUiCultures = {en}`), so all lookups return the neutral English values -- the UI is byte-identical except the two intentional closed-display consistency fixes. No in-app language setting; bulk migration of the remaining surfaces continues incrementally.

## Tests
- Enum key-contract (`ResourceNotFound` over `Enum.GetValues<T>()`), closed-display selection (`MouseDownAsync`, strictly-changing Light -> "Follow System"), TimeZone known/unknown/empty, ModalChrome default fall-through + Dialog/Alert/Close aria fallbacks, a qps-Ploc culture test (positive canary control, then English), and a missing-key markup guard.
- Shared test infra: `AddBannerHostDependencies()` now registers localization (all modal-hosting fixtures); `CultureSensitiveBunitContext` restores both `CurrentCulture` and `CurrentUICulture`.
- UI.Tests 1574/1574; MAUI head builds clean.

Governed by adversarial pre-impl (3-round) + post-code (2-round, incl. a fresh red-team) panels, profile=full, unanimous.
