### PR TITLE
Localize Dashboard empty-state welcome screen

### DIFF
--- a/src/EventLogExpert.UI/Common/EnableChannelConfirmation.cs
+++ b/src/EventLogExpert.UI/Common/EnableChannelConfirmation.cs
@@ -2,25 +2,32 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Runtime.Alerts;
+using Microsoft.Extensions.Localization;
 
 namespace EventLogExpert.UI.Common;
 
 internal static class EnableChannelConfirmation
 {
-    public static Task<bool> ConfirmAsync(IAlertDialogService dialog, string channelName, bool isAnalyticOrDebug)
+    public static Task<bool> ConfirmAsync(
+        IAlertDialogService dialog,
+        IStringLocalizer<SharedResource> localizer,
+        string channelName,
+        bool isAnalyticOrDebug)
     {
         var message =
-            $"Enable the \"{channelName}\" log?\n\n" +
-            "This changes Windows event logging for the whole computer and stays in effect until it is disabled again. " +
-            "Only events generated after enabling are collected - events that occurred while the log was disabled cannot be recovered.";
+            localizer["Dashboard_EnableConfirm_Prompt", channelName] + "\n\n" +
+            localizer["Dashboard_EnableConfirm_Body"];
 
         if (isAnalyticOrDebug)
         {
-            message +=
-                "\n\nThis is an analytic or debug log: enabling it can clear the records it already holds, and Windows may " +
-                "keep collecting to it while refusing to open it for live viewing until it is disabled again.";
+            message += "\n\n" + localizer["Dashboard_EnableConfirm_AnalyticNote"];
         }
 
-        return dialog.ShowAlert("Enable log", message, "Enable", "Cancel");
+        return dialog.ShowAlert(
+            localizer["Dashboard_Alert_EnableLog"],
+            message,
+            localizer["Dashboard_EnableButton"],
+            localizer["Modal_Cancel"]);
     }
 }
+

--- a/src/EventLogExpert.UI/Common/ScenarioGroupLocalizer.cs
+++ b/src/EventLogExpert.UI/Common/ScenarioGroupLocalizer.cs
@@ -1,0 +1,19 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Scenarios.Catalog;
+using Microsoft.Extensions.Localization;
+
+namespace EventLogExpert.UI.Common;
+
+/// <summary>
+///     Localizes <see cref="ScenarioGroup" /> display names for the Dashboard. Shared by the category tabs (
+///     <c>EmptyStateDashboard</c>) and the scenario-detail eyebrow (<c>ScenarioDetail</c>), which live in different
+///     components, so this cannot be a private member of either. The English values mirror
+///     <see cref="ScenarioGroupDisplay.DisplayName" /> (a drift-guard test pins them equal).
+/// </summary>
+internal static class ScenarioGroupLocalizer
+{
+    internal static string GroupDisplay(IStringLocalizer<SharedResource> localizer, ScenarioGroup group) =>
+        localizer[$"Dashboard_Group_{group}"];
+}

--- a/src/EventLogExpert.UI/Dashboard/EmptyStateDashboard.razor
+++ b/src/EventLogExpert.UI/Dashboard/EmptyStateDashboard.razor
@@ -6,7 +6,7 @@
             <span aria-hidden="true" class="empty-dashboard__brand-mark"><i class="bi bi-journal-text"></i></span>
             <div>
                 <h1 class="empty-dashboard__title" id="empty-dashboard-title">EventLogExpert</h1>
-                <p class="empty-dashboard__lead">Open a log to get started, or jump straight into a common investigation.</p>
+                <p class="empty-dashboard__lead">@Localizer["Dashboard_Lead"]</p>
             </div>
         </div>
         <div class="empty-dashboard__masthead-actions">
@@ -17,7 +17,7 @@
                     <span class="empty-dashboard__chip-text">@FolderScanStatusText()</span>
                     @if (!_openingLogs && !_cancelRequested)
                     {
-                        <Button OnClick="CancelFolderScan" aria-label="@FolderScanCancelLabel()" @ref="_cancelScanButton">Cancel</Button>
+                        <Button OnClick="CancelFolderScan" aria-label="@FolderScanCancelLabel()" @ref="_cancelScanButton">@Localizer["Dashboard_Cancel"]</Button>
                     }
                 </div>
             }
@@ -25,39 +25,47 @@
             {
                 <div class="empty-dashboard__chip" role="status">
                     <i aria-hidden="true" class="bi bi-funnel"></i>
-                    <span class="empty-dashboard__chip-text">A filter is still applied and will affect your next open.</span>
-                    <Button Disabled="@_isBusy" OnClick="ClearFilter">Clear filter</Button>
+                    <span class="empty-dashboard__chip-text">@Localizer["Dashboard_FilterStillApplied"]</span>
+                    <Button Disabled="@_isBusy" OnClick="ClearFilter">@Localizer["Dashboard_ClearFilter"]</Button>
                 </div>
             }
             <ChromelessButton CssClass="empty-dashboard__utility" Disabled="@_isBusy" IconClass="bi bi-database-gear" OnClick="OpenDatabaseToolsAsync">
-                <span>Manage databases...</span>
+                <span>@Localizer["Dashboard_ManageDatabases"]</span>
             </ChromelessButton>
         </div>
     </header>
 
     <section aria-labelledby="empty-dashboard-quickstart-heading" class="empty-dashboard__section">
-        <h2 class="empty-dashboard__heading" id="empty-dashboard-quickstart-heading">Quick Launch</h2>
+        <h2 class="empty-dashboard__heading" id="empty-dashboard-quickstart-heading">@Localizer["Dashboard_QuickLaunch"]</h2>
+        @{
+            var openApplicationSystemLabel = Localizer["Dashboard_Open_ApplicationSystem"];
+            var openApplicationLabel = Localizer["Dashboard_Open_Application"];
+            var openSystemLabel = Localizer["Dashboard_Open_System"];
+            var openSecurityLabel = Localizer["Dashboard_Open_Security"];
+            var openLogFileLabel = Localizer["Dashboard_Open_LogFile"];
+            var openFolderLabel = Localizer["Dashboard_Open_Folder"];
+        }
         <div class="empty-dashboard__launchbar">
             <ChromelessButton CssClass="empty-dashboard__launch empty-dashboard__launch--primary"
                 Disabled="@_isBusy"
                 IconClass="bi bi-collection"
                 OnClick="OpenApplicationAndSystemAsync"
-                aria-label="Open Application + System (live)">
-                <span>Application + System (live)</span>
+                aria-label="@(Localizer["Dashboard_OpenAria", openApplicationSystemLabel])">
+                <span>@openApplicationSystemLabel</span>
             </ChromelessButton>
             <ChromelessButton CssClass="empty-dashboard__launch"
                 Disabled="@_isBusy"
                 IconClass="bi bi-window"
                 OnClick="OpenApplicationAsync"
-                aria-label="Open Application (live)">
-                <span>Application (live)</span>
+                aria-label="@(Localizer["Dashboard_OpenAria", openApplicationLabel])">
+                <span>@openApplicationLabel</span>
             </ChromelessButton>
             <ChromelessButton CssClass="empty-dashboard__launch"
                 Disabled="@_isBusy"
                 IconClass="bi bi-pc-display"
                 OnClick="OpenSystemAsync"
-                aria-label="Open System (live)">
-                <span>System (live)</span>
+                aria-label="@(Localizer["Dashboard_OpenAria", openSystemLabel])">
+                <span>@openSystemLabel</span>
             </ChromelessButton>
             @if (!SecurityRequiresElevation)
             {
@@ -65,8 +73,8 @@
                     Disabled="@_isBusy"
                     IconClass="bi bi-shield-lock"
                     OnClick="OpenSecurityAsync"
-                    aria-label="Open Security (live)">
-                    <span>Security (live)</span>
+                    aria-label="@(Localizer["Dashboard_OpenAria", openSecurityLabel])">
+                    <span>@openSecurityLabel</span>
                 </ChromelessButton>
             }
             else
@@ -75,20 +83,20 @@
                     IconClass="bi bi-shield-lock"
                     aria-describedby="@ElevationReasonId"
                     aria-disabled="true"
-                    aria-label="Open Security (live)">
-                    <span>Security (live)</span>
+                    aria-label="@(Localizer["Dashboard_OpenAria", openSecurityLabel])">
+                    <span>@openSecurityLabel</span>
                 </ChromelessButton>
             }
             <span aria-hidden="true" class="empty-dashboard__launch-divider"></span>
-            <ChromelessButton CssClass="empty-dashboard__launch" Disabled="@_isBusy" IconClass="bi bi-file-earmark-text" OnClick="OpenFileAsync" aria-label="Open Log file...">
-                <span>Log file...</span>
+            <ChromelessButton CssClass="empty-dashboard__launch" Disabled="@_isBusy" IconClass="bi bi-file-earmark-text" OnClick="OpenFileAsync" aria-label="@(Localizer["Dashboard_OpenAria", openLogFileLabel])">
+                <span>@openLogFileLabel</span>
             </ChromelessButton>
-            <ChromelessButton CssClass="empty-dashboard__launch" Disabled="@_isBusy" IconClass="bi bi-folder2-open" OnClick="OpenFolderAsync" aria-label="Open Folder...">
-                <span>Folder...</span>
+            <ChromelessButton CssClass="empty-dashboard__launch" Disabled="@_isBusy" IconClass="bi bi-folder2-open" OnClick="OpenFolderAsync" aria-label="@(Localizer["Dashboard_OpenAria", openFolderLabel])">
+                <span>@openFolderLabel</span>
             </ChromelessButton>
             <label class="empty-dashboard__subfolders">
-                <input type="checkbox" @bind="_includeSubfolders" disabled="@_isBusy" />
-                <span>Include subfolders</span>
+                <input @bind="_includeSubfolders" disabled="@_isBusy" type="checkbox" />
+                <span>@Localizer["Dashboard_IncludeSubfolders"]</span>
             </label>
         </div>
     </section>
@@ -96,15 +104,15 @@
     <div class="empty-dashboard__catalog">
         @if (_splashScenarios is null)
         {
-            <p class="empty-dashboard__loading">Loading scenarios...</p>
+            <p class="empty-dashboard__loading">@Localizer["Dashboard_LoadingScenarios"]</p>
         }
         else if (_categories.Count == 0)
         {
-            <p class="empty-dashboard__empty" role="status">No scenarios are available.</p>
+            <p class="empty-dashboard__empty" role="status">@Localizer["Dashboard_NoScenarios"]</p>
         }
         else
         {
-            <SidebarTabs TTab="SplashCategory" TablistAriaLabel="Scenario categories" Tabs="_tabs" @bind-ActiveTab="_activeCategory" @ref="_sidebarTabs">
+            <SidebarTabs TTab="SplashCategory" TablistAriaLabel="@Localizer["Dashboard_ScenarioCategoriesAria"].Value" Tabs="_tabs" @bind-ActiveTab="_activeCategory" @ref="_sidebarTabs">
                 <TabContent Context="category">
                     <ScenarioBrowserPanel CanEnableChannels="ChannelEnable.CanEnable"
                         GetChannelReadiness="GetChannelReadiness"
@@ -125,5 +133,5 @@
         }
     </div>
 
-    <span class="empty-dashboard__sr-only" id="@ElevationReasonId">Access denied (Needs elevation)</span>
+    <span class="empty-dashboard__sr-only" id="@ElevationReasonId">@Localizer["Dashboard_AccessDeniedElevation"]</span>
 </section>

--- a/src/EventLogExpert.UI/Dashboard/EmptyStateDashboard.razor.cs
+++ b/src/EventLogExpert.UI/Dashboard/EmptyStateDashboard.razor.cs
@@ -17,6 +17,7 @@ using EventLogExpert.UI.Focus;
 using EventLogExpert.UI.Inputs;
 using EventLogExpert.UI.Modal;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
 using System.Collections.Frozen;
 using System.Collections.Immutable;
 
@@ -81,6 +82,8 @@ public sealed partial class EmptyStateDashboard : AppStateComponentBase
     [Inject] private IFilterAppliedSource FilterAppliedSource { get; init; } = null!;
 
     [Inject] private IFilterPaneCommands FilterCommands { get; init; } = null!;
+
+    [Inject] private IStringLocalizer<SharedResource> Localizer { get; init; } = null!;
 
     [Inject] private IScenarioLaunchService ScenarioLaunch { get; init; } = null!;
 
@@ -189,78 +192,6 @@ public sealed partial class EmptyStateDashboard : AppStateComponentBase
                 .SelectMany(static scenario => scenario.Channels.Concat(scenario.OptionalChannels))
                 .Distinct(StringComparer.OrdinalIgnoreCase);
 
-    private static string DescribeEnableFailure(string channel, ChannelEnableResult result) => result.Outcome switch
-    {
-        ChannelEnableOutcome.AccessDenied =>
-            $"Enabling \"{channel}\" was denied. Administrator rights are required, and the log's security settings must allow the change.",
-        ChannelEnableOutcome.NotFound => $"The \"{channel}\" log is not registered on this computer.",
-        ChannelEnableOutcome.NotElevated => $"Run EventLogExpert as administrator to enable \"{channel}\".",
-        _ => $"The \"{channel}\" log could not be enabled (error {result.Win32Error})."
-    };
-
-    private static string? DescribeFolderLaunch(ScenarioDefinition scenario, ScenarioFolderLaunchResult result)
-    {
-        var scanNote = result.Unreadable > 0 ? $" {FolderFilesWord(result.Unreadable)} could not be inspected." : string.Empty;
-
-        return result.Outcome switch
-        {
-            ScenarioFolderOutcome.Cancelled => null,
-            ScenarioFolderOutcome.Error => result.Message ?? "The selected folder could not be opened.",
-            ScenarioFolderOutcome.NoMatchingLogs => $"No {scenario.Name} logs were found in the selected folder.",
-            ScenarioFolderOutcome.NoLogsOpened =>
-                $"Matched {FolderLogsWord(result.Matched)} for {scenario.Name} but none could be loaded " +
-                $"({result.Empty} empty, {result.Failed} failed).{scanNote}",
-            ScenarioFolderOutcome.Completed =>
-                $"Opened {FolderLogsWord(result.Opened)} for {scenario.Name}.{FolderMissingNote(result.MissingChannels)}{scanNote}",
-            _ => null
-        };
-    }
-
-    private static string DescribeLaunch(ScenarioDefinition scenario, ScenarioLaunchResult result)
-    {
-        if (!result.ChannelOutcomes.IsDefaultOrEmpty)
-        {
-            var failedOutcomes = result.ChannelOutcomes
-                .Where(outcome => outcome.Outcome is ChannelLaunchOutcome.AccessDenied
-                    or ChannelLaunchOutcome.NotPresent
-                    or ChannelLaunchOutcome.Failed)
-                .Select(DescribeLaunchOutcome)
-                .ToList();
-
-            if (failedOutcomes.Count > 0)
-            {
-                return $"{scenario.Name} could not open every required channel. {string.Join(" ", failedOutcomes)}";
-            }
-        }
-
-        if (result.Opened == 0)
-        {
-            return $"No channels could be opened for {scenario.Name}.";
-        }
-
-        return result.Failed > 0
-            ? $"Opened {scenario.Name}; {result.Failed} {(result.Failed == 1 ? "channel" : "channels")} unavailable."
-            : $"Opened {scenario.Name}.";
-    }
-
-    private static string DescribeLaunchOutcome(ChannelOutcome outcome) => outcome.Outcome switch
-    {
-        ChannelLaunchOutcome.AccessDenied =>
-            $"{outcome.Channel}: access denied - needs elevation, or open from a saved .evtx.",
-        ChannelLaunchOutcome.NotPresent =>
-            $"{outcome.Channel}: not present on this computer - open from a saved .evtx.",
-        ChannelLaunchOutcome.Failed =>
-            $"{outcome.Channel}: failed to open - open from a saved .evtx.",
-        _ => $"{outcome.Channel}: {outcome.Outcome}."
-    };
-
-    private static string FolderFilesWord(int count) => count == 1 ? "1 file" : $"{count} files";
-
-    private static string FolderLogsWord(int count) => count == 1 ? "1 log" : $"{count} logs";
-
-    private static string FolderMissingNote(ImmutableArray<string> missing) =>
-        missing.IsDefaultOrEmpty ? string.Empty : $" Not found: {string.Join(", ", missing)}.";
-
     private static bool HasReactiveFolderFallback(ScenarioLaunchResult result) =>
         !result.ChannelOutcomes.IsDefaultOrEmpty &&
         result.ChannelOutcomes.Any(outcome => outcome.Outcome is ChannelLaunchOutcome.AccessDenied
@@ -287,13 +218,79 @@ public sealed partial class EmptyStateDashboard : AppStateComponentBase
 
     private void ClearFilter() => FilterCommands.ClearAllFilters();
 
+    private string DescribeEnableFailure(string channel, ChannelEnableResult result) => result.Outcome switch
+    {
+        ChannelEnableOutcome.AccessDenied => Localizer["Dashboard_EnableFail_AccessDenied", channel],
+        ChannelEnableOutcome.NotFound => Localizer["Dashboard_EnableFail_NotFound", channel],
+        ChannelEnableOutcome.NotElevated => Localizer["Dashboard_EnableFail_NotElevated", channel],
+        _ => Localizer["Dashboard_EnableFail_Unknown", channel, result.Win32Error]
+    };
+
+    private string? DescribeFolderLaunch(ScenarioDefinition scenario, ScenarioFolderLaunchResult result)
+    {
+        var scanNote = result.Unreadable > 0
+            ? Localizer["Dashboard_ScanNote", FolderFilesWord(result.Unreadable)].Value
+            : string.Empty;
+
+        return result.Outcome switch
+        {
+            ScenarioFolderOutcome.Cancelled => null,
+            ScenarioFolderOutcome.Error => result.Message ?? Localizer["Dashboard_FolderError"].Value,
+            ScenarioFolderOutcome.NoMatchingLogs => Localizer["Dashboard_FolderNoMatching", scenario.Name].Value,
+            ScenarioFolderOutcome.NoLogsOpened =>
+                Localizer["Dashboard_FolderNoneLoaded", FolderLogsWord(result.Matched), scenario.Name, result.Empty, result.Failed].Value +
+                scanNote,
+            ScenarioFolderOutcome.Completed =>
+                Localizer["Dashboard_FolderCompleted", FolderLogsWord(result.Opened), scenario.Name].Value +
+                FolderMissingNote(result.MissingChannels) + scanNote,
+            _ => null
+        };
+    }
+
+    private string DescribeLaunch(ScenarioDefinition scenario, ScenarioLaunchResult result)
+    {
+        if (!result.ChannelOutcomes.IsDefaultOrEmpty)
+        {
+            var failedOutcomes = result.ChannelOutcomes
+                .Where(outcome => outcome.Outcome is ChannelLaunchOutcome.AccessDenied
+                    or ChannelLaunchOutcome.NotPresent
+                    or ChannelLaunchOutcome.Failed)
+                .Select(DescribeLaunchOutcome)
+                .ToList();
+
+            if (failedOutcomes.Count > 0)
+            {
+                return Localizer["Dashboard_Launch_CouldNotOpenAll", scenario.Name, string.Join(" ", failedOutcomes)];
+            }
+        }
+
+        if (result.Opened == 0)
+        {
+            return Localizer["Dashboard_Launch_NoneOpened", scenario.Name];
+        }
+
+        return result.Failed > 0 ?
+            Localizer["Dashboard_Launch_OpenedWithUnavailable",
+                scenario.Name,
+                Plural(result.Failed, "Dashboard_Channel_One", "Dashboard_Channel_Many")] :
+            Localizer["Dashboard_Launch_Opened", scenario.Name];
+    }
+
+    private string DescribeLaunchOutcome(ChannelOutcome outcome) => outcome.Outcome switch
+    {
+        ChannelLaunchOutcome.AccessDenied => Localizer["Dashboard_Outcome_AccessDenied", outcome.Channel],
+        ChannelLaunchOutcome.NotPresent => Localizer["Dashboard_Outcome_NotPresent", outcome.Channel],
+        ChannelLaunchOutcome.Failed => Localizer["Dashboard_Outcome_Failed", outcome.Channel],
+        _ => Localizer["Dashboard_Outcome_Other", outcome.Channel, outcome.Outcome]
+    };
+
     private Task EnableChannelAsync(string channel) =>
         RunGuardedAsync(async () =>
         {
             bool isAnalyticOrDebug = _readinessByChannel.TryGetValue(channel, out var current)
                 && current.Access == ChannelAccess.NotEvaluated;
 
-            if (!await EnableChannelConfirmation.ConfirmAsync(AlertDialogService, channel, isAnalyticOrDebug))
+            if (!await EnableChannelConfirmation.ConfirmAsync(AlertDialogService, Localizer, channel, isAnalyticOrDebug))
             {
                 return;
             }
@@ -302,7 +299,7 @@ public sealed partial class EmptyStateDashboard : AppStateComponentBase
 
             if (result.Outcome is not (ChannelEnableOutcome.Enabled or ChannelEnableOutcome.AlreadyEnabled))
             {
-                await AlertDialogService.ShowErrorAlert("Enable log", DescribeEnableFailure(channel, result));
+                await AlertDialogService.ShowErrorAlert(Localizer["Dashboard_Alert_EnableLog"], DescribeEnableFailure(channel, result));
 
                 return;
             }
@@ -313,36 +310,48 @@ public sealed partial class EmptyStateDashboard : AppStateComponentBase
                 || refreshed.Enablement != ChannelEnablement.Enabled)
             {
                 await AlertDialogService.ShowAlert(
-                    "Enable log",
-                    $"\"{channel}\" was enabled, but its status could not be confirmed. Refresh to re-check.",
-                    "OK");
+                    Localizer["Dashboard_Alert_EnableLog"],
+                    Localizer["Dashboard_EnabledUnconfirmed", channel],
+                    Localizer["Modal_Accept"]);
             }
         });
 
     private IEnumerable<ScenarioDefinition> FavoriteScenarios() =>
-        _splashScenarios is null
-            ? []
-            : _splashScenarios
-                .Where(IsFavored)
-                .OrderBy(scenario => scenario.Priority)
-                .ThenBy(scenario => scenario.Order);
+        _splashScenarios is null ? [] : _splashScenarios.Where(IsFavored)
+            .OrderBy(scenario => scenario.Priority)
+            .ThenBy(scenario => scenario.Order);
+
+    private string FolderFilesWord(int count) => Plural(count, "Dashboard_File_One", "Dashboard_File_Many");
+
+    private string FolderLogsWord(int count) => Plural(count, "Dashboard_Log_One", "Dashboard_Log_Many");
+
+    private string FolderMissingNote(ImmutableArray<string> missing) =>
+        missing.IsDefaultOrEmpty ? string.Empty : Localizer["Dashboard_MissingNote", string.Join(", ", missing)].Value;
 
     private string FolderScanCancelLabel() =>
-        _folderScanLabel is { } label ? $"Cancel folder scan for {label}" : "Cancel folder scan";
+        _folderScanLabel is { } label ?
+            Localizer["Dashboard_ScanCancel_Labeled", label].Value :
+            Localizer["Dashboard_ScanCancel"].Value;
 
     private string FolderScanStatusText()
     {
         if (_openingLogs)
         {
-            return _folderScanLabel is { } openingLabel ? $"Opening logs for {openingLabel}..." : "Opening logs...";
+            return _folderScanLabel is { } openingLabel ?
+                Localizer["Dashboard_ScanStatus_OpeningLabeled", openingLabel] :
+                Localizer["Dashboard_ScanStatus_Opening"];
         }
 
         if (_cancelRequested)
         {
-            return _folderScanLabel is { } cancellingLabel ? $"Cancelling folder scan for {cancellingLabel}..." : "Cancelling folder scan...";
+            return _folderScanLabel is { } cancellingLabel ?
+                Localizer["Dashboard_ScanStatus_CancellingLabeled", cancellingLabel] :
+                Localizer["Dashboard_ScanStatus_Cancelling"];
         }
 
-        return _folderScanLabel is { } scanningLabel ? $"Scanning {scanningLabel} folder for logs..." : "Scanning folder for logs...";
+        return _folderScanLabel is { } scanningLabel ?
+            Localizer["Dashboard_ScanStatus_ScanningLabeled", scanningLabel] :
+            Localizer["Dashboard_ScanStatus_Scanning"];
     }
 
     private IReadOnlyList<ChannelReadiness> GetChannelReadiness(ScenarioDefinition scenario) =>
@@ -370,9 +379,9 @@ public sealed partial class EmptyStateDashboard : AppStateComponentBase
             if (HasReactiveFolderFallback(result))
             {
                 await AlertDialogService.ShowErrorAlert(
-                    "Launch scenario",
+                    Localizer["Dashboard_Alert_LaunchScenario"],
                     message,
-                    "Open from folder",
+                    Localizer["Dashboard_OpenFromFolder"],
                     () => LaunchScenarioFromFolderAsync(scenario, includeSubfolders: true));
             }
             else
@@ -429,10 +438,10 @@ public sealed partial class EmptyStateDashboard : AppStateComponentBase
             case ScenarioFolderOutcome.Error:
                 if (scanStarted) { RestoreFocusAfterScan(); }
 
-                await AlertDialogService.ShowErrorAlert("Open from folder", message);
+                await AlertDialogService.ShowErrorAlert(Localizer["Dashboard_Alert_OpenFromFolder"], message);
                 break;
             default:
-                await AlertDialogService.ShowAlert("Open from folder", message, "OK");
+                await AlertDialogService.ShowAlert(Localizer["Dashboard_Alert_OpenFromFolder"], message, Localizer["Modal_Accept"]);
                 break;
         }
 
@@ -550,6 +559,11 @@ public sealed partial class EmptyStateDashboard : AppStateComponentBase
 
     private Task OpenSystemAsync() => RunGuardedAsync(() => Actions.OpenLiveLogAsync(LogChannelNames.SystemLog, false));
 
+    // English 2-form pluralization (count picks singular). Correct for English only; locales with more than two plural
+    // categories, or a different singular boundary, need a CLDR/ICU provider (see the design "Known limitations").
+    private string Plural(int count, string oneKey, string manyKey) =>
+        count == 1 ? Localizer[oneKey, count] : Localizer[manyKey, count];
+
     private IReadOnlyList<ChannelReadiness> ReadinessFor(IEnumerable<string> channels) =>
     [
         .. channels.Select(channel =>
@@ -566,11 +580,11 @@ public sealed partial class EmptyStateDashboard : AppStateComponentBase
         {
             List<ScenarioDefinition> favorites = [.. FavoriteScenarios()];
 
-            if (favorites.Count > 0) { categories.Add((SplashCategory.Favorites, "Favorites", favorites)); }
+            if (favorites.Count > 0) { categories.Add((SplashCategory.Favorites, Localizer["Dashboard_Category_Favorites"].Value, favorites)); }
 
             List<ScenarioDefinition> recommended = [.. StarterScenarios()];
 
-            if (recommended.Count > 0) { categories.Add((SplashCategory.Recommended, "Recommended", recommended)); }
+            if (recommended.Count > 0) { categories.Add((SplashCategory.Recommended, Localizer["Dashboard_Category_Recommended"].Value, recommended)); }
 
             foreach (ScenarioGroup group in Enum.GetValues<ScenarioGroup>())
             {
@@ -586,7 +600,7 @@ public sealed partial class EmptyStateDashboard : AppStateComponentBase
 
                 if (groupScenarios.Count == 0) { continue; }
 
-                categories.Add((category, group.DisplayName(), groupScenarios));
+                categories.Add((category, ScenarioGroupLocalizer.GroupDisplay(Localizer, group), groupScenarios));
             }
         }
 

--- a/src/EventLogExpert.UI/Dashboard/ScenarioBrowserPanel.razor
+++ b/src/EventLogExpert.UI/Dashboard/ScenarioBrowserPanel.razor
@@ -1,11 +1,11 @@
 <div class="scenario-browser" @ref="_scenarioBrowserRootRef">
     @if (Scenarios.Count == 0)
     {
-        <p class="scenario-browser__empty" role="status">No scenarios available in this category.</p>
+        <p class="scenario-browser__empty" role="status">@Localizer["Dashboard_NoScenariosInCategory"]</p>
     }
     else
     {
-        <ul aria-label="Scenarios" class="scenario-browser__list" @onkeydown="OnListKeyDownAsync" role="listbox">
+        <ul aria-label="@(Localizer["Dashboard_ScenariosListAria"])" class="scenario-browser__list" @onkeydown="OnListKeyDownAsync" role="listbox">
             @foreach (var scenario in Scenarios)
             {
                 <li aria-selected="@(IsSelected(scenario) ? "true" : "false")"

--- a/src/EventLogExpert.UI/Dashboard/ScenarioBrowserPanel.razor.cs
+++ b/src/EventLogExpert.UI/Dashboard/ScenarioBrowserPanel.razor.cs
@@ -6,6 +6,7 @@ using EventLogExpert.Scenarios.Catalog;
 using EventLogExpert.UI.Common.Interop;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.Localization;
 using Microsoft.JSInterop;
 
 namespace EventLogExpert.UI.Dashboard;
@@ -49,6 +50,8 @@ public sealed partial class ScenarioBrowserPanel : IAsyncDisposable
     [Parameter] public ScenarioDefinition? Selected { get; set; }
 
     [Inject] private IJSRuntime JSRuntime { get; init; } = null!;
+
+    [Inject] private IStringLocalizer<SharedResource> Localizer { get; init; } = null!;
 
     public async ValueTask DisposeAsync()
     {

--- a/src/EventLogExpert.UI/Dashboard/ScenarioDetail.razor
+++ b/src/EventLogExpert.UI/Dashboard/ScenarioDetail.razor
@@ -1,6 +1,5 @@
 @using EventLogExpert.Eventing.Readers
 @using EventLogExpert.Runtime.Scenarios
-@using EventLogExpert.Scenarios.Catalog
 @{
     RenderFragment StatusTags(ChannelReadiness readiness) =>
         @<text>
@@ -11,20 +10,20 @@
              }
              @if (readiness.Access == ChannelAccess.RequiresElevation)
              {
-                 <span class="scenario-detail__status">Access denied (Needs elevation)</span>
+                 <span class="scenario-detail__status">@Localizer["Dashboard_AccessDeniedElevation"]</span>
              }
     </text>;
 }
 <div aria-labelledby="@_nameId" class="scenario-detail" role="region">
     <p class="scenario-detail__eyebrow">
         <i aria-hidden="true" class="bi @EmptyStateDashboard.ScenarioIcon(Scenario.Group)"></i>
-        <span>@Scenario.Group.DisplayName()</span>
+        <span>@ScenarioGroupLocalizer.GroupDisplay(Localizer, Scenario.Group)</span>
     </p>
     <h3 class="scenario-detail__name" id="@_nameId">@Scenario.Name</h3>
     <p class="scenario-detail__purpose">@Scenario.Purpose</p>
     <div class="scenario-detail__facts">
         <div class="scenario-detail__fact">
-            <span class="scenario-detail__fact-label">Logs</span>
+            <span class="scenario-detail__fact-label">@Localizer["Dashboard_LogsLabel"]</span>
             @foreach (var readiness in DisplayReadiness)
             {
                 <span class="scenario-detail__channel-readiness">
@@ -38,14 +37,14 @@
                                 disabled="@IsBusy"
                                 @onclick="() => OnEnableChannel.InvokeAsync(readiness.Channel)"
                                 type="button">
-                                Enable channel
+                                @Localizer["Dashboard_EnableChannel"]
                             </button>
                         }
                         else
                         {
                             <span class="scenario-detail__enable-hint">
                                 <i aria-hidden="true" class="bi bi-shield-lock"></i>
-                                This instance is not elevated. Close it, start EventLogExpert as administrator, then return to enable this channel.
+                                @Localizer["Dashboard_NotElevatedHint"]
                             </span>
                         }
                     }
@@ -53,7 +52,7 @@
             }
             @if (DisplayOptionalReadiness.Count > 0)
             {
-                <span class="scenario-detail__fact-muted">Also if present:</span>
+                <span class="scenario-detail__fact-muted">@Localizer["Dashboard_AlsoIfPresent"]</span>
 
                 @foreach (var readiness in DisplayOptionalReadiness)
                 {
@@ -67,7 +66,7 @@
         @if (FilterLines.Count > 0)
         {
             <div class="scenario-detail__fact">
-                <span class="scenario-detail__fact-label">Filters</span>
+                <span class="scenario-detail__fact-label">@Localizer["Dashboard_FiltersLabel"]</span>
                 @foreach (var line in FilterLines)
                 {
                     <span class="scenario-detail__filter">
@@ -84,20 +83,20 @@
     @if (IsDisabled && !IsLivePresent)
     {
         <p class="scenario-detail__unavailable" id="@_offlineId">
-            One or more of these logs are not on this computer. Use Open from folder to analyze an exported copy.
+            @Localizer["Dashboard_LogsNotOnComputer"]
         </p>
     }
     else if (IsDisabled)
     {
         <p class="scenario-detail__unavailable" id="@_offlineId">
-            Live access to one or more of these logs is blocked. Use Open from folder to analyze an exported copy.
+            @Localizer["Dashboard_LiveAccessBlocked"]
         </p>
     }
     <div class="scenario-detail__actions">
         <ChromelessButton CssClass="scenario-detail__star"
             IconClass="@(IsFavored ? "bi bi-star-fill" : "bi bi-star")"
             OnClick="OnToggleFavorite"
-            aria-label="@(IsFavored ? $"Remove {Scenario.Name} from favorites" : $"Add {Scenario.Name} to favorites")"
+            aria-label="@(IsFavored ? Localizer["Dashboard_RemoveFavoriteAria", Scenario.Name].Value : Localizer["Dashboard_AddFavoriteAria", Scenario.Name].Value)"
             aria-pressed="@(IsFavored ? "true" : "false")" />
         <ChromelessButton CssClass="scenario-detail__launch"
             Disabled="@IsBusy"
@@ -105,18 +104,18 @@
             OnClick="LaunchAsync"
             aria-describedby="@(IsDisabled ? _offlineId : null)"
             aria-disabled="@(IsDisabled ? "true" : "false")">
-            <span>Launch</span>
+            <span>@Localizer["Dashboard_Launch"]</span>
         </ChromelessButton>
         <ChromelessButton CssClass="scenario-detail__open-folder"
             Disabled="@IsBusy"
             IconClass="bi bi-folder2-open"
             OnClick="LaunchFromFolderAsync"
-            aria-label="@($"Open {Scenario.Name} from a folder of exported logs")">
-            <span>Open from folder</span>
+            aria-label="@(Localizer["Dashboard_OpenFromFolderAria", Scenario.Name].Value)">
+            <span>@Localizer["Dashboard_OpenFromFolder"]</span>
         </ChromelessButton>
         <label class="scenario-detail__subfolders">
-            <input type="checkbox" @bind="_includeSubfolders" disabled="@IsBusy" />
-            <span>Include subfolders</span>
+            <input @bind="_includeSubfolders" disabled="@IsBusy" type="checkbox" />
+            <span>@Localizer["Dashboard_IncludeSubfolders"]</span>
         </label>
     </div>
 </div>

--- a/src/EventLogExpert.UI/Dashboard/ScenarioDetail.razor.cs
+++ b/src/EventLogExpert.UI/Dashboard/ScenarioDetail.razor.cs
@@ -8,6 +8,7 @@ using EventLogExpert.Runtime.Scenarios;
 using EventLogExpert.Scenarios.Catalog;
 using EventLogExpert.UI.Common;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
 
 namespace EventLogExpert.UI.Dashboard;
 
@@ -69,31 +70,19 @@ public sealed partial class ScenarioDetail
             {
                 if (!BasicFilterFormatter.TryFormat(row.Filter, out var text)) { continue; }
 
-                lines.Add(new FilterLine(row.IsExcluded ? $"Exclude {text}" : text, row.Color));
+                lines.Add(new FilterLine(row.IsExcluded ? Localizer["Dashboard_ExcludePrefix", text].Value : text, row.Color));
             }
 
             return lines;
         }
     }
 
-    private static string EnablementLabel(ChannelEnablement enablement) => enablement switch
-    {
-        ChannelEnablement.Enabled => "Enabled",
-        ChannelEnablement.Disabled => "Disabled",
-        _ => "Enablement unknown"
-    };
+    [Inject] private IStringLocalizer<SharedResource> Localizer { get; init; } = null!;
 
     private static bool IsSystemChannel(string channel) =>
         string.Equals(channel, LogChannelNames.ApplicationLog, StringComparison.OrdinalIgnoreCase) ||
         string.Equals(channel, LogChannelNames.SystemLog, StringComparison.OrdinalIgnoreCase) ||
         string.Equals(channel, LogChannelNames.SecurityLog, StringComparison.OrdinalIgnoreCase);
-
-    private static string PresenceLabel(ChannelPresence presence) => presence switch
-    {
-        ChannelPresence.Present => "Present",
-        ChannelPresence.Absent => "Not present",
-        _ => "Presence unknown"
-    };
 
     // A disabled required channel can be enabled in place only when it is actually present and is not one of the classic
     // system logs (Application/System/Security), which Windows does not allow toggling.
@@ -101,6 +90,13 @@ public sealed partial class ScenarioDetail
         readiness.Presence == ChannelPresence.Present &&
         readiness.Enablement == ChannelEnablement.Disabled &&
         !IsSystemChannel(readiness.Channel);
+
+    private string EnablementLabel(ChannelEnablement enablement) => enablement switch
+    {
+        ChannelEnablement.Enabled => Localizer["Dashboard_Enablement_Enabled"],
+        ChannelEnablement.Disabled => Localizer["Dashboard_Enablement_Disabled"],
+        _ => Localizer["Dashboard_Enablement_Unknown"]
+    };
 
     private async Task LaunchAsync()
     {
@@ -115,6 +111,13 @@ public sealed partial class ScenarioDetail
 
         await OnLaunchFromFolder.InvokeAsync(_includeSubfolders);
     }
+
+    private string PresenceLabel(ChannelPresence presence) => presence switch
+    {
+        ChannelPresence.Present => Localizer["Dashboard_Presence_Present"],
+        ChannelPresence.Absent => Localizer["Dashboard_Presence_Absent"],
+        _ => Localizer["Dashboard_Presence_Unknown"]
+    };
 
     private readonly record struct FilterLine(string Text, HighlightColor Color);
 }

--- a/src/EventLogExpert.UI/Resources/SharedResource.resx
+++ b/src/EventLogExpert.UI/Resources/SharedResource.resx
@@ -219,4 +219,363 @@
     <value>Alert</value>
     <comment>Accessible name for a titleless inline alert.</comment>
   </data>
+  <!-- Dashboard (empty-state welcome screen): masthead + Quick Launch. -->
+  <data name="Dashboard_Lead" xml:space="preserve">
+    <value>Open a log to get started, or jump straight into a common investigation.</value>
+  </data>
+  <data name="Dashboard_FilterStillApplied" xml:space="preserve">
+    <value>A filter is still applied and will affect your next open.</value>
+  </data>
+  <data name="Dashboard_ClearFilter" xml:space="preserve">
+    <value>Clear filter</value>
+  </data>
+  <data name="Dashboard_ManageDatabases" xml:space="preserve">
+    <value>Manage databases...</value>
+  </data>
+  <data name="Dashboard_QuickLaunch" xml:space="preserve">
+    <value>Quick Launch</value>
+  </data>
+  <data name="Dashboard_Open_ApplicationSystem" xml:space="preserve">
+    <value>Application + System (live)</value>
+    <comment>Quick-launch label. "Application"/"System" are Windows event-log channel names - keep verbatim; "(live)" is UI text.</comment>
+  </data>
+  <data name="Dashboard_Open_Application" xml:space="preserve">
+    <value>Application (live)</value>
+    <comment>Quick-launch label. "Application" is a Windows event-log channel name - keep verbatim; "(live)" is UI text.</comment>
+  </data>
+  <data name="Dashboard_Open_System" xml:space="preserve">
+    <value>System (live)</value>
+    <comment>Quick-launch label. "System" is a Windows event-log channel name - keep verbatim; "(live)" is UI text.</comment>
+  </data>
+  <data name="Dashboard_Open_Security" xml:space="preserve">
+    <value>Security (live)</value>
+    <comment>Quick-launch label. "Security" is a Windows event-log channel name - keep verbatim; "(live)" is UI text.</comment>
+  </data>
+  <data name="Dashboard_Open_LogFile" xml:space="preserve">
+    <value>Log file...</value>
+  </data>
+  <data name="Dashboard_Open_Folder" xml:space="preserve">
+    <value>Folder...</value>
+  </data>
+  <data name="Dashboard_OpenAria" xml:space="preserve">
+    <value>Open {0}</value>
+    <comment>Accessible name for a Quick Launch button; {0} is the button's visible label.</comment>
+  </data>
+  <data name="Dashboard_IncludeSubfolders" xml:space="preserve">
+    <value>Include subfolders</value>
+  </data>
+  <data name="Dashboard_LoadingScenarios" xml:space="preserve">
+    <value>Loading scenarios...</value>
+  </data>
+  <data name="Dashboard_NoScenarios" xml:space="preserve">
+    <value>No scenarios are available.</value>
+  </data>
+  <data name="Dashboard_ScenarioCategoriesAria" xml:space="preserve">
+    <value>Scenario categories</value>
+  </data>
+  <data name="Dashboard_AccessDeniedElevation" xml:space="preserve">
+    <value>Access denied (Needs elevation)</value>
+  </data>
+  <data name="Dashboard_Cancel" xml:space="preserve">
+    <value>Cancel</value>
+    <comment>Visible label of the folder-scan chip button; its accessible name is Dashboard_ScanCancel/_Labeled.</comment>
+  </data>
+  <!-- Dashboard: scenario browser + detail. -->
+  <data name="Dashboard_NoScenariosInCategory" xml:space="preserve">
+    <value>No scenarios available in this category.</value>
+  </data>
+  <data name="Dashboard_ScenariosListAria" xml:space="preserve">
+    <value>Scenarios</value>
+  </data>
+  <data name="Dashboard_LogsLabel" xml:space="preserve">
+    <value>Logs</value>
+  </data>
+  <data name="Dashboard_EnableChannel" xml:space="preserve">
+    <value>Enable channel</value>
+  </data>
+  <data name="Dashboard_NotElevatedHint" xml:space="preserve">
+    <value>This instance is not elevated. Close it, start EventLogExpert as administrator, then return to enable this channel.</value>
+  </data>
+  <data name="Dashboard_AlsoIfPresent" xml:space="preserve">
+    <value>Also if present:</value>
+  </data>
+  <data name="Dashboard_FiltersLabel" xml:space="preserve">
+    <value>Filters</value>
+  </data>
+  <data name="Dashboard_LogsNotOnComputer" xml:space="preserve">
+    <value>One or more of these logs are not on this computer. Use Open from folder to analyze an exported copy.</value>
+  </data>
+  <data name="Dashboard_LiveAccessBlocked" xml:space="preserve">
+    <value>Live access to one or more of these logs is blocked. Use Open from folder to analyze an exported copy.</value>
+  </data>
+  <data name="Dashboard_AddFavoriteAria" xml:space="preserve">
+    <value>Add {0} to favorites</value>
+    <comment>Accessible name for the favorite toggle; {0} is the scenario name (catalog data, not translated).</comment>
+  </data>
+  <data name="Dashboard_RemoveFavoriteAria" xml:space="preserve">
+    <value>Remove {0} from favorites</value>
+    <comment>Accessible name for the favorite toggle; {0} is the scenario name (catalog data, not translated).</comment>
+  </data>
+  <data name="Dashboard_Launch" xml:space="preserve">
+    <value>Launch</value>
+  </data>
+  <data name="Dashboard_OpenFromFolder" xml:space="preserve">
+    <value>Open from folder</value>
+  </data>
+  <data name="Dashboard_OpenFromFolderAria" xml:space="preserve">
+    <value>Open {0} from a folder of exported logs</value>
+    <comment>Accessible name; {0} is the scenario name (catalog data, not translated).</comment>
+  </data>
+  <data name="Dashboard_Presence_Present" xml:space="preserve">
+    <value>Present</value>
+  </data>
+  <data name="Dashboard_Presence_Absent" xml:space="preserve">
+    <value>Not present</value>
+  </data>
+  <data name="Dashboard_Presence_Unknown" xml:space="preserve">
+    <value>Presence unknown</value>
+  </data>
+  <data name="Dashboard_Enablement_Enabled" xml:space="preserve">
+    <value>Enabled</value>
+  </data>
+  <data name="Dashboard_Enablement_Disabled" xml:space="preserve">
+    <value>Disabled</value>
+  </data>
+  <data name="Dashboard_Enablement_Unknown" xml:space="preserve">
+    <value>Enablement unknown</value>
+  </data>
+  <data name="Dashboard_ExcludePrefix" xml:space="preserve">
+    <value>Exclude {0}</value>
+    <comment>{0} is the formatted filter text (catalog data, not translated).</comment>
+  </data>
+  <!-- Dashboard: dynamic enable-failure messages. -->
+  <data name="Dashboard_EnableFail_AccessDenied" xml:space="preserve">
+    <value>Enabling "{0}" was denied. Administrator rights are required, and the log's security settings must allow the change.</value>
+    <comment>{0} is the channel name (data, not translated).</comment>
+  </data>
+  <data name="Dashboard_EnableFail_NotFound" xml:space="preserve">
+    <value>The "{0}" log is not registered on this computer.</value>
+    <comment>{0} is the channel name (data, not translated).</comment>
+  </data>
+  <data name="Dashboard_EnableFail_NotElevated" xml:space="preserve">
+    <value>Run EventLogExpert as administrator to enable "{0}".</value>
+    <comment>{0} is the channel name (data, not translated).</comment>
+  </data>
+  <data name="Dashboard_EnableFail_Unknown" xml:space="preserve">
+    <value>The "{0}" log could not be enabled (error {1}).</value>
+    <comment>{0} is the channel name (data); {1} is a raw Win32 error code (diagnostic, not translated).</comment>
+  </data>
+  <!-- Dashboard: folder-launch outcome messages (base sentence + appended note fragments). -->
+  <data name="Dashboard_FolderError" xml:space="preserve">
+    <value>The selected folder could not be opened.</value>
+  </data>
+  <data name="Dashboard_FolderNoMatching" xml:space="preserve">
+    <value>No {0} logs were found in the selected folder.</value>
+    <comment>{0} is the scenario name (data, not translated).</comment>
+  </data>
+  <data name="Dashboard_FolderNoneLoaded" xml:space="preserve">
+    <value>Matched {0} for {1} but none could be loaded ({2} empty, {3} failed).</value>
+    <comment>{0} is a log-count phrase (e.g. "3 logs"); {1} is the scenario name (data); {2},{3} are raw counts.</comment>
+  </data>
+  <data name="Dashboard_FolderCompleted" xml:space="preserve">
+    <value>Opened {0} for {1}.</value>
+    <comment>{0} is a log-count phrase (e.g. "3 logs"); {1} is the scenario name (data).</comment>
+  </data>
+  <data name="Dashboard_ScanNote" xml:space="preserve">
+    <value> {0} could not be inspected.</value>
+    <comment>Fragment appended after a folder-launch sentence; the leading space is intentional. {0} is a file-count phrase (e.g. "2 files").</comment>
+  </data>
+  <data name="Dashboard_MissingNote" xml:space="preserve">
+    <value> Not found: {0}.</value>
+    <comment>Fragment appended after a folder-launch sentence; the leading space is intentional. {0} is a comma-joined list of channel names (data, not translated).</comment>
+  </data>
+  <!-- Dashboard: live-launch outcome messages. -->
+  <data name="Dashboard_Launch_CouldNotOpenAll" xml:space="preserve">
+    <value>{0} could not open every required channel. {1}</value>
+    <comment>{0} is the scenario name (data); {1} is one or more space-joined per-channel outcome sentences.</comment>
+  </data>
+  <data name="Dashboard_Launch_NoneOpened" xml:space="preserve">
+    <value>No channels could be opened for {0}.</value>
+    <comment>{0} is the scenario name (data, not translated).</comment>
+  </data>
+  <data name="Dashboard_Launch_OpenedWithUnavailable" xml:space="preserve">
+    <value>Opened {0}; {1} unavailable.</value>
+    <comment>{0} is the scenario name (data); {1} is a channel-count phrase (e.g. "1 channel").</comment>
+  </data>
+  <data name="Dashboard_Launch_Opened" xml:space="preserve">
+    <value>Opened {0}.</value>
+    <comment>{0} is the scenario name (data, not translated).</comment>
+  </data>
+  <data name="Dashboard_Outcome_AccessDenied" xml:space="preserve">
+    <value>{0}: access denied - needs elevation, or open from a saved .evtx.</value>
+    <comment>{0} is the channel name (data, not translated).</comment>
+  </data>
+  <data name="Dashboard_Outcome_NotPresent" xml:space="preserve">
+    <value>{0}: not present on this computer - open from a saved .evtx.</value>
+    <comment>{0} is the channel name (data, not translated).</comment>
+  </data>
+  <data name="Dashboard_Outcome_Failed" xml:space="preserve">
+    <value>{0}: failed to open - open from a saved .evtx.</value>
+    <comment>{0} is the channel name (data, not translated).</comment>
+  </data>
+  <data name="Dashboard_Outcome_Other" xml:space="preserve">
+    <value>{0}: {1}.</value>
+    <comment>{0} is the channel name (data); {1} is a raw enum outcome identifier (diagnostic, not translated).</comment>
+  </data>
+  <!-- Dashboard: 2-form plural phrases (English count-picks-singular; see design "Known localization limitations"). -->
+  <data name="Dashboard_File_One" xml:space="preserve">
+    <value>1 file</value>
+  </data>
+  <data name="Dashboard_File_Many" xml:space="preserve">
+    <value>{0} files</value>
+    <comment>{0} is the count (2 or more).</comment>
+  </data>
+  <data name="Dashboard_Log_One" xml:space="preserve">
+    <value>1 log</value>
+  </data>
+  <data name="Dashboard_Log_Many" xml:space="preserve">
+    <value>{0} logs</value>
+    <comment>{0} is the count (2 or more).</comment>
+  </data>
+  <data name="Dashboard_Channel_One" xml:space="preserve">
+    <value>1 channel</value>
+  </data>
+  <data name="Dashboard_Channel_Many" xml:space="preserve">
+    <value>{0} channels</value>
+    <comment>{0} is the count (2 or more).</comment>
+  </data>
+  <!-- Dashboard: folder-scan chip status + cancel accessible names. -->
+  <data name="Dashboard_ScanCancel_Labeled" xml:space="preserve">
+    <value>Cancel folder scan for {0}</value>
+    <comment>{0} is the scenario name (data, not translated).</comment>
+  </data>
+  <data name="Dashboard_ScanCancel" xml:space="preserve">
+    <value>Cancel folder scan</value>
+  </data>
+  <data name="Dashboard_ScanStatus_OpeningLabeled" xml:space="preserve">
+    <value>Opening logs for {0}...</value>
+    <comment>{0} is the scenario name (data, not translated).</comment>
+  </data>
+  <data name="Dashboard_ScanStatus_Opening" xml:space="preserve">
+    <value>Opening logs...</value>
+  </data>
+  <data name="Dashboard_ScanStatus_CancellingLabeled" xml:space="preserve">
+    <value>Cancelling folder scan for {0}...</value>
+    <comment>{0} is the scenario name (data, not translated).</comment>
+  </data>
+  <data name="Dashboard_ScanStatus_Cancelling" xml:space="preserve">
+    <value>Cancelling folder scan...</value>
+  </data>
+  <data name="Dashboard_ScanStatus_ScanningLabeled" xml:space="preserve">
+    <value>Scanning {0} folder for logs...</value>
+    <comment>{0} is the scenario name (data, not translated).</comment>
+  </data>
+  <data name="Dashboard_ScanStatus_Scanning" xml:space="preserve">
+    <value>Scanning folder for logs...</value>
+  </data>
+  <!-- Dashboard: alert dialog titles + confirmation. -->
+  <data name="Dashboard_Alert_EnableLog" xml:space="preserve">
+    <value>Enable log</value>
+  </data>
+  <data name="Dashboard_Alert_LaunchScenario" xml:space="preserve">
+    <value>Launch scenario</value>
+  </data>
+  <data name="Dashboard_Alert_OpenFromFolder" xml:space="preserve">
+    <value>Open from folder</value>
+  </data>
+  <data name="Dashboard_EnabledUnconfirmed" xml:space="preserve">
+    <value>"{0}" was enabled, but its status could not be confirmed. Refresh to re-check.</value>
+    <comment>{0} is the channel name (data, not translated).</comment>
+  </data>
+  <data name="Dashboard_EnableButton" xml:space="preserve">
+    <value>Enable</value>
+  </data>
+  <data name="Dashboard_EnableConfirm_Prompt" xml:space="preserve">
+    <value>Enable the "{0}" log?</value>
+    <comment>{0} is the channel name (data, not translated).</comment>
+  </data>
+  <data name="Dashboard_EnableConfirm_Body" xml:space="preserve">
+    <value>This changes Windows event logging for the whole computer and stays in effect until it is disabled again. Only events generated after enabling are collected - events that occurred while the log was disabled cannot be recovered.</value>
+  </data>
+  <data name="Dashboard_EnableConfirm_AnalyticNote" xml:space="preserve">
+    <value>This is an analytic or debug log: enabling it can clear the records it already holds, and Windows may keep collecting to it while refusing to open it for live viewing until it is disabled again.</value>
+  </data>
+  <!-- Dashboard: category tab names. Favorites/Recommended are UI; the ScenarioGroup names below mirror ScenarioGroupDisplay.DisplayName() (a drift-guard test pins them equal). -->
+  <data name="Dashboard_Category_Favorites" xml:space="preserve">
+    <value>Favorites</value>
+  </data>
+  <data name="Dashboard_Category_Recommended" xml:space="preserve">
+    <value>Recommended</value>
+  </data>
+  <data name="Dashboard_Group_SystemHealth" xml:space="preserve">
+    <value>System Health</value>
+  </data>
+  <data name="Dashboard_Group_Applications" xml:space="preserve">
+    <value>Applications</value>
+  </data>
+  <data name="Dashboard_Group_Security" xml:space="preserve">
+    <value>Security</value>
+  </data>
+  <data name="Dashboard_Group_ThreatsAndIncidentResponse" xml:space="preserve">
+    <value>Threats and Incident Response</value>
+  </data>
+  <data name="Dashboard_Group_Network" xml:space="preserve">
+    <value>Network</value>
+  </data>
+  <data name="Dashboard_Group_Storage" xml:space="preserve">
+    <value>Storage</value>
+  </data>
+  <data name="Dashboard_Group_UpdatesAndPolicy" xml:space="preserve">
+    <value>Updates and Policy</value>
+  </data>
+  <data name="Dashboard_Group_ActiveDirectory" xml:space="preserve">
+    <value>Active Directory</value>
+    <comment>Active Directory is a product name; keep verbatim.</comment>
+  </data>
+  <data name="Dashboard_Group_DnsServer" xml:space="preserve">
+    <value>DNS Server</value>
+    <comment>DNS is a technology acronym; keep verbatim.</comment>
+  </data>
+  <data name="Dashboard_Group_DhcpServer" xml:space="preserve">
+    <value>DHCP Server</value>
+    <comment>DHCP is a technology acronym; keep verbatim.</comment>
+  </data>
+  <data name="Dashboard_Group_NpsAndRras" xml:space="preserve">
+    <value>NPS and RRAS</value>
+    <comment>NPS and RRAS are Windows role acronyms; keep verbatim.</comment>
+  </data>
+  <data name="Dashboard_Group_Wins" xml:space="preserve">
+    <value>WINS</value>
+    <comment>WINS is a Windows service acronym; keep verbatim.</comment>
+  </data>
+  <data name="Dashboard_Group_WebAndIis" xml:space="preserve">
+    <value>Web and IIS</value>
+    <comment>IIS is a product acronym; keep verbatim.</comment>
+  </data>
+  <data name="Dashboard_Group_VirtualizationAndClustering" xml:space="preserve">
+    <value>Virtualization and Clustering</value>
+  </data>
+  <data name="Dashboard_Group_FilePrintAndStorage" xml:space="preserve">
+    <value>File, Print, and Storage</value>
+  </data>
+  <data name="Dashboard_Group_SqlServer" xml:space="preserve">
+    <value>SQL Server</value>
+    <comment>SQL Server is a product name; keep verbatim.</comment>
+  </data>
+  <data name="Dashboard_Group_Exchange" xml:space="preserve">
+    <value>Exchange</value>
+    <comment>Exchange is a product name; keep verbatim.</comment>
+  </data>
+  <data name="Dashboard_Group_SharePoint" xml:space="preserve">
+    <value>SharePoint</value>
+    <comment>SharePoint is a product name; keep verbatim.</comment>
+  </data>
+  <data name="Dashboard_Group_DefenderForEndpoint" xml:space="preserve">
+    <value>Defender for Endpoint</value>
+    <comment>Defender for Endpoint is a product name; keep verbatim.</comment>
+  </data>
+  <data name="Dashboard_Group_Office" xml:space="preserve">
+    <value>Office</value>
+    <comment>Office is a product name; keep verbatim.</comment>
+  </data>
 </root>

--- a/tests/Unit/EventLogExpert.UI.Tests/Dashboard/DashboardCultureTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Dashboard/DashboardCultureTests.cs
@@ -1,0 +1,51 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using EventLogExpert.UI.Tests.TestUtils;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using System.Globalization;
+
+namespace EventLogExpert.UI.Tests.Dashboard;
+
+/// <summary>
+///     Dashboard tests that MUTATE thread UI culture (qps-Ploc canary). Restores culture synchronously and is
+///     serialized via <see cref="CultureSensitiveCollection" />. Proves a pseudo-locale machine loads the canary satellite
+///     yet real Dashboard keys FALL BACK to neutral English (the satellite carries only the dedicated canary probes).
+/// </summary>
+[Collection(CultureSensitiveCollection.Name)]
+public sealed class DashboardCultureTests : BunitContext
+{
+    public DashboardCultureTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddEventLogLocalization();
+    }
+
+    [Fact]
+    public void Canary_UnderPseudoLocale_LoadsSatellite_AndRealDashboardKeysFallBackToNeutral()
+    {
+        var priorUiCulture = CultureInfo.CurrentUICulture;
+
+        try
+        {
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("qps-ploc");
+            var localizer = Services.GetRequiredService<IStringLocalizer<SharedResource>>();
+
+            var canary = localizer["Canary_Probe1"];
+            Assert.False(canary.ResourceNotFound);
+            Assert.Equal("[qps-ploc] canary probe one", canary.Value);
+
+            // Real Dashboard keys are absent from the canary satellite -> neutral English, proving a qps-Ploc machine
+            // never renders pseudo Dashboard UI.
+            Assert.Equal("Quick Launch", localizer["Dashboard_QuickLaunch"].Value);
+            Assert.Equal("Launch", localizer["Dashboard_Launch"].Value);
+            Assert.Equal("System Health", localizer["Dashboard_Group_SystemHealth"].Value);
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = priorUiCulture;
+        }
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/Dashboard/DashboardLocalizationTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Dashboard/DashboardLocalizationTests.cs
@@ -1,0 +1,196 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using EventLogExpert.Scenarios.Catalog;
+using EventLogExpert.UI.Common;
+using EventLogExpert.UI.Dashboard;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using System.Runtime.CompilerServices;
+using System.Xml.Linq;
+
+namespace EventLogExpert.UI.Tests.Dashboard;
+
+/// <summary>
+///     Localization coverage for the Dashboard surface: the group-name drift guard, count-inclusive plurals, the
+///     localized-label render + resource-key-leak guards, and the data-vs-UI boundary (catalog data renders verbatim). The
+///     exclude-filter prefix (localized) with verbatim formatter text is covered by
+///     <see cref="ScenarioDetailTests.Filters_WhenExcluded_PrefixesExclude" />, and the diagnostic <c>result.Message</c>
+///     pass-through by <see cref="EmptyStateDashboardTests.DetailOpenFromFolder_WhenError_ShowsErrorAlert" />.
+/// </summary>
+public sealed class DashboardLocalizationTests : BunitContext
+{
+    public DashboardLocalizationTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddEventLogLocalization();
+    }
+
+    private IStringLocalizer<SharedResource> Localizer =>
+        Services.GetRequiredService<IStringLocalizer<SharedResource>>();
+
+    [Theory]
+    [InlineData("Dashboard_Presence_Present", "Present")]
+    [InlineData("Dashboard_Presence_Absent", "Not present")]
+    [InlineData("Dashboard_Presence_Unknown", "Presence unknown")]
+    [InlineData("Dashboard_Enablement_Enabled", "Enabled")]
+    [InlineData("Dashboard_Enablement_Disabled", "Disabled")]
+    [InlineData("Dashboard_Enablement_Unknown", "Enablement unknown")]
+    public void EnumLabelKeys_ResolveToEnglish(string key, string expected)
+    {
+        var localized = Localizer[key];
+
+        Assert.False(localized.ResourceNotFound, $"Missing RESX key {key}");
+        Assert.Equal(expected, localized.Value);
+    }
+
+    [Fact]
+    public void EveryDashboardResourceKey_IsReferencedInSource()
+    {
+        var (resxPath, uiSourceRoot) = LocateUiSource();
+
+        // No-op when the source tree is not alongside the test binary (e.g. a packaged run).
+        if (resxPath is null || uiSourceRoot is null) { return; }
+
+        var keys = XDocument.Load(resxPath)
+            .Root!.Elements("data")
+            .Select(data => (string?)data.Attribute("name"))
+            .Where(name => name is not null && name.StartsWith("Dashboard_", StringComparison.Ordinal))
+            .Select(name => name!)
+            .ToList();
+
+        var source = string.Join(
+            "\n",
+            Directory.EnumerateFiles(uiSourceRoot, "*.cs", SearchOption.AllDirectories)
+                .Concat(Directory.EnumerateFiles(uiSourceRoot, "*.razor", SearchOption.AllDirectories))
+                .Select(File.ReadAllText));
+
+        // Dashboard_Group_* are composed via $"Dashboard_Group_{group}" (and pinned by the drift-guard test above);
+        // every other Dashboard_* key must appear as a literal "key" reference in the component sources. This catches the
+        // authored-but-never-referenced failure the one-directional DoesNotContain("Dashboard_") guard cannot.
+        var orphans = keys
+            .Where(key => !key.StartsWith("Dashboard_Group_", StringComparison.Ordinal))
+            .Where(key => !source.Contains($"\"{key}\"", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.True(orphans.Count == 0, $"Authored-but-unreferenced Dashboard_* RESX keys: {string.Join(", ", orphans)}");
+    }
+
+    [Fact]
+    public void GroupDisplay_ForEveryScenarioGroup_ResolvesAndEqualsDisplayName()
+    {
+        var localizer = Localizer;
+
+        foreach (var group in Enum.GetValues<ScenarioGroup>())
+        {
+            var localized = localizer[$"Dashboard_Group_{group}"];
+
+            Assert.False(localized.ResourceNotFound, $"Missing RESX key Dashboard_Group_{group}");
+            Assert.Equal(group.DisplayName(), localized.Value);
+            Assert.Equal(ScenarioGroupLocalizer.GroupDisplay(localizer, group), localized.Value);
+        }
+    }
+
+    [Theory]
+    [InlineData("Dashboard_File_One", "Dashboard_File_Many", "1 file", "2 files")]
+    [InlineData("Dashboard_Log_One", "Dashboard_Log_Many", "1 log", "2 logs")]
+    [InlineData("Dashboard_Channel_One", "Dashboard_Channel_Many", "1 channel", "2 channels")]
+    public void PluralKeys_AreCountInclusive(string oneKey, string manyKey, string singular, string plural)
+    {
+        var localizer = Localizer;
+
+        Assert.Equal(singular, localizer[oneKey].Value);
+        Assert.Equal(plural, localizer[manyKey, 2].Value);
+    }
+
+    [Fact]
+    public void ScenarioBrowserPanel_EmptyState_IsLocalized_AndDoesNotLeakResourceKeys()
+    {
+        var cut = Render<ScenarioBrowserPanel>(parameters => parameters
+            .Add(panel => panel.Scenarios, Array.Empty<ScenarioDefinition>()));
+
+        var markup = cut.Markup;
+
+        Assert.Contains("No scenarios available in this category.", markup);
+        Assert.DoesNotContain("Dashboard_", markup);
+    }
+
+    [Fact]
+    public void ScenarioBrowserPanel_ListAria_IsLocalized()
+    {
+        var cut = Render<ScenarioBrowserPanel>(parameters => parameters
+            .Add(panel => panel.Scenarios, [Scenario()])
+            .Add(panel => panel.IsFavored, _ => false)
+            .Add(panel => panel.IsScenarioDisabled, _ => false));
+
+        Assert.Equal("Scenarios", cut.Find("ul[role='listbox']").GetAttribute("aria-label"));
+    }
+
+    [Fact]
+    public void ScenarioDetail_LeavesCatalogDataVerbatim()
+    {
+        var scenario = Scenario() with
+        {
+            Name = "Zzz Sentinel Scenario",
+            Purpose = "Zzz Sentinel Purpose",
+            Channels = ["Zzz-Sentinel-Channel"]
+        };
+
+        var cut = Render<ScenarioDetail>(parameters => parameters
+            .Add(detail => detail.Scenario, scenario));
+
+        var markup = cut.Markup;
+
+        Assert.Contains("Zzz Sentinel Scenario", markup);
+        Assert.Contains("Zzz Sentinel Purpose", markup);
+        Assert.Contains("Zzz-Sentinel-Channel", markup);
+
+        // The favorite aria composes the (data) scenario name into a localized "Add {0} to favorites" format.
+        Assert.Contains("Add Zzz Sentinel Scenario to favorites", markup);
+    }
+
+    [Fact]
+    public void ScenarioDetail_RendersLocalizedLabels_AndDoesNotLeakResourceKeys()
+    {
+        var cut = Render<ScenarioDetail>(parameters => parameters
+            .Add(detail => detail.Scenario, Scenario()));
+
+        var markup = cut.Markup;
+
+        Assert.Contains("System Health", markup); // ScenarioGroup.SystemHealth eyebrow
+        Assert.Contains("Logs", markup);
+        Assert.Contains("Launch", markup);
+        Assert.Contains("Open from folder", markup);
+        Assert.Contains("Include subfolders", markup);
+        Assert.DoesNotContain("Dashboard_", markup);
+    }
+
+    private static (string? ResxPath, string? UiSourceRoot) LocateUiSource([CallerFilePath] string testFilePath = "")
+    {
+        var directory = Path.GetDirectoryName(testFilePath);
+
+        while (directory is not null && !Directory.Exists(Path.Combine(directory, "src", "EventLogExpert.UI")))
+        {
+            directory = Path.GetDirectoryName(directory);
+        }
+
+        if (directory is null) { return (null, null); }
+
+        var uiRoot = Path.Combine(directory, "src", "EventLogExpert.UI");
+        var resx = Path.Combine(uiRoot, "Resources", "SharedResource.resx");
+
+        return (File.Exists(resx) ? resx : null, Directory.Exists(uiRoot) ? uiRoot : null);
+    }
+
+    private static ScenarioDefinition Scenario() =>
+        new()
+        {
+            Id = "application-crashes",
+            Name = "Application crashes",
+            Purpose = "Purpose",
+            Group = ScenarioGroup.SystemHealth,
+            Channels = ["System"],
+            Filters = []
+        };
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/Dashboard/EmptyStateDashboardTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Dashboard/EmptyStateDashboardTests.cs
@@ -16,6 +16,7 @@ using EventLogExpert.Runtime.Scenarios.Favorites;
 using EventLogExpert.Scenarios.Catalog;
 using EventLogExpert.UI.Dashboard;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using NSubstitute;
 using System.Collections.Immutable;
 
@@ -67,6 +68,7 @@ public sealed class EmptyStateDashboardTests : BunitContext
         Services.AddSingleton(_scenarioQuery);
         Services.AddSingleton(_channelReadinessService);
         Services.AddSingleton(_channelEnable);
+        Services.AddEventLogLocalization();
         JSInterop.Mode = JSRuntimeMode.Loose;
     }
 
@@ -128,6 +130,17 @@ public sealed class EmptyStateDashboardTests : BunitContext
         var cut = Render<EmptyStateDashboard>();
 
         Assert.Empty(cut.FindAll(".empty-dashboard__chip"));
+    }
+
+    [Fact]
+    public void Dashboard_DoesNotLeakResourceKeys()
+    {
+        _scenarioQuery.GetSplashScenarios().Returns([Scenario("application-crashes", "Application crashes")]);
+
+        var cut = Render<EmptyStateDashboard>();
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(ActiveDetailLaunch)));
+
+        Assert.DoesNotContain("Dashboard_", cut.Markup);
     }
 
     [Fact]
@@ -226,6 +239,23 @@ public sealed class EmptyStateDashboardTests : BunitContext
         Assert.Contains("not on this computer", offlineNote.TextContent, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Theory]
+    [InlineData(1, "Opened Application crashes; 1 channel unavailable.")]
+    [InlineData(2, "Opened Application crashes; 2 channels unavailable.")]
+    public void DetailLaunch_WhenChannelsUnavailable_AnnouncesCountInclusivePlural(int failed, string expected)
+    {
+        _scenarioLaunch.LaunchAsync(Arg.Any<ScenarioDefinition>(), Arg.Any<DateFilter?>(), Arg.Any<bool>())
+            .Returns(new ScenarioLaunchResult(1, 0, failed));
+        _scenarioQuery.GetSplashScenarios().Returns([Scenario("application-crashes", "Application crashes")]);
+
+        var cut = Render<EmptyStateDashboard>();
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(ActiveDetailLaunch)));
+
+        cut.Find(ActiveDetailLaunch).Click();
+
+        cut.WaitForAssertion(() => _announcer.Received(1).Announce(expected));
+    }
+
     [Fact]
     public void DetailLaunch_WhenLaunchOpensNothing_AnnouncesFailure()
     {
@@ -313,6 +343,29 @@ public sealed class EmptyStateDashboardTests : BunitContext
 
         cut.WaitForAssertion(() => _scenarioLaunch.Received(1).LaunchFromFolderAsync(
             Arg.Any<ScenarioDefinition>(), Arg.Any<DateFilter?>(), true, Arg.Any<CancellationToken>(), Arg.Any<Func<ScenarioFolderPhase, Task>?>()));
+    }
+
+    [Fact]
+    public void DetailOpenFromFolder_WhenCompletedWithMissingAndUnreadable_AnnouncesFullComposedSentence()
+    {
+        _scenarioLaunch.LaunchFromFolderAsync(Arg.Any<ScenarioDefinition>(), Arg.Any<DateFilter?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>(), Arg.Any<Func<ScenarioFolderPhase, Task>?>())
+            .Returns(new ScenarioFolderLaunchResult
+            {
+                Outcome = ScenarioFolderOutcome.Completed,
+                Opened = 2,
+                Matched = 3,
+                Unreadable = 1,
+                MissingChannels = ["Setup"]
+            });
+        _scenarioQuery.GetSplashScenarios().Returns([Scenario("application-crashes", "Application crashes")]);
+
+        var cut = Render<EmptyStateDashboard>();
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(ActiveDetailOpenFolder)));
+
+        cut.Find(ActiveDetailOpenFolder).Click();
+
+        cut.WaitForAssertion(() => _announcer.Received(1).Announce(
+            "Opened 2 logs for Application crashes. Not found: Setup. 1 file could not be inspected."));
     }
 
     [Fact]
@@ -515,6 +568,94 @@ public sealed class EmptyStateDashboardTests : BunitContext
         RaiseFavoritesChanged(cut);
 
         cut.WaitForAssertion(() => Assert.Equal("true", cut.Find(ActiveDetailStar).GetAttribute("aria-pressed")));
+    }
+
+    [Fact]
+    public void FolderScan_CancellingStatus_IsLocalized()
+    {
+        var release = new TaskCompletionSource<ScenarioFolderLaunchResult>();
+        _scenarioLaunch
+            .LaunchFromFolderAsync(Arg.Any<ScenarioDefinition>(), Arg.Any<DateFilter?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>(), Arg.Any<Func<ScenarioFolderPhase, Task>?>())
+            .Returns(async ci =>
+            {
+                await ci.Arg<Func<ScenarioFolderPhase, Task>>()!(ScenarioFolderPhase.Scanning);
+
+                return await release.Task;
+            });
+        _scenarioQuery.GetSplashScenarios().Returns([Scenario("application-crashes", "Application crashes")]);
+        var localizer = Services.GetRequiredService<IStringLocalizer<SharedResource>>();
+
+        var cut = Render<EmptyStateDashboard>();
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(ActiveDetailOpenFolder)));
+        cut.Find(ActiveDetailOpenFolder).Click();
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".empty-dashboard__chip--scanning button")));
+        cut.Find(".empty-dashboard__chip--scanning button").Click();
+
+        cut.WaitForAssertion(() => Assert.Equal(
+            localizer["Dashboard_ScanStatus_CancellingLabeled", "Application crashes"].Value,
+            cut.Find(".empty-dashboard__chip--scanning .empty-dashboard__chip-text").TextContent.Trim()));
+
+        release.SetResult(ScenarioFolderLaunchResult.Cancelled);
+    }
+
+    [Fact]
+    public void FolderScan_OpeningStatus_IsLocalized()
+    {
+        var release = new TaskCompletionSource<ScenarioFolderLaunchResult>();
+        _scenarioLaunch
+            .LaunchFromFolderAsync(Arg.Any<ScenarioDefinition>(), Arg.Any<DateFilter?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>(), Arg.Any<Func<ScenarioFolderPhase, Task>?>())
+            .Returns(async ci =>
+            {
+                var onPhase = ci.Arg<Func<ScenarioFolderPhase, Task>>()!;
+                await onPhase(ScenarioFolderPhase.Scanning);
+                await onPhase(ScenarioFolderPhase.Opening);
+
+                return await release.Task;
+            });
+        _scenarioQuery.GetSplashScenarios().Returns([Scenario("application-crashes", "Application crashes")]);
+        var localizer = Services.GetRequiredService<IStringLocalizer<SharedResource>>();
+
+        var cut = Render<EmptyStateDashboard>();
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(ActiveDetailOpenFolder)));
+        cut.Find(ActiveDetailOpenFolder).Click();
+
+        cut.WaitForAssertion(() => Assert.Equal(
+            localizer["Dashboard_ScanStatus_OpeningLabeled", "Application crashes"].Value,
+            cut.Find(".empty-dashboard__chip--scanning .empty-dashboard__chip-text").TextContent.Trim()));
+
+        release.SetResult(new ScenarioFolderLaunchResult { Outcome = ScenarioFolderOutcome.Completed, Opened = 1, Matched = 1 });
+    }
+
+    [Fact]
+    public void FolderScan_ScanningStatusAndCancelAria_AreLocalized()
+    {
+        var release = new TaskCompletionSource<ScenarioFolderLaunchResult>();
+        _scenarioLaunch
+            .LaunchFromFolderAsync(Arg.Any<ScenarioDefinition>(), Arg.Any<DateFilter?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>(), Arg.Any<Func<ScenarioFolderPhase, Task>?>())
+            .Returns(async ci =>
+            {
+                await ci.Arg<Func<ScenarioFolderPhase, Task>>()!(ScenarioFolderPhase.Scanning);
+
+                return await release.Task;
+            });
+        _scenarioQuery.GetSplashScenarios().Returns([Scenario("application-crashes", "Application crashes")]);
+        var localizer = Services.GetRequiredService<IStringLocalizer<SharedResource>>();
+
+        var cut = Render<EmptyStateDashboard>();
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(ActiveDetailOpenFolder)));
+        cut.Find(ActiveDetailOpenFolder).Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Equal(
+                localizer["Dashboard_ScanStatus_ScanningLabeled", "Application crashes"].Value,
+                cut.Find(".empty-dashboard__chip--scanning .empty-dashboard__chip-text").TextContent.Trim());
+            Assert.Equal(
+                localizer["Dashboard_ScanCancel_Labeled", "Application crashes"].Value,
+                cut.Find(".empty-dashboard__chip--scanning button").GetAttribute("aria-label"));
+        });
+
+        release.SetResult(ScenarioFolderLaunchResult.Cancelled);
     }
 
     [Fact]
@@ -862,6 +1003,22 @@ public sealed class EmptyStateDashboardTests : BunitContext
         FindLaunch(cut, "Open Log file...").Click();
 
         cut.WaitForAssertion(() => _actions.Received(1).OpenFileAsync(false));
+    }
+
+    [Fact]
+    public void QuickLaunch_RendersLocalizedLabelsAndArias()
+    {
+        _scenarioQuery.GetSplashScenarios().Returns([Scenario("application-crashes", "Application crashes")]);
+
+        var cut = Render<EmptyStateDashboard>();
+
+        Assert.Contains("Quick Launch", cut.Markup);
+
+        var primary = cut.Find(".empty-dashboard__launch--primary");
+        Assert.Equal("Open Application + System (live)", primary.GetAttribute("aria-label"));
+        Assert.Equal("Application + System (live)", primary.QuerySelector("span")!.TextContent.Trim());
+
+        Assert.Contains("Manage databases...", cut.Markup);
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.UI.Tests/Dashboard/ScenarioBrowserPanelTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Dashboard/ScenarioBrowserPanelTests.cs
@@ -5,12 +5,17 @@ using Bunit;
 using EventLogExpert.Scenarios.Catalog;
 using EventLogExpert.UI.Dashboard;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace EventLogExpert.UI.Tests.Dashboard;
 
 public sealed class ScenarioBrowserPanelTests : BunitContext
 {
-    public ScenarioBrowserPanelTests() => JSInterop.Mode = JSRuntimeMode.Loose;
+    public ScenarioBrowserPanelTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddEventLogLocalization();
+    }
 
     [Fact]
     public void Click_SelectsOption()

--- a/tests/Unit/EventLogExpert.UI.Tests/Dashboard/ScenarioDetailTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Dashboard/ScenarioDetailTests.cs
@@ -9,12 +9,17 @@ using EventLogExpert.Filtering.Persistence;
 using EventLogExpert.Runtime.Scenarios;
 using EventLogExpert.Scenarios.Catalog;
 using EventLogExpert.UI.Dashboard;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace EventLogExpert.UI.Tests.Dashboard;
 
 public sealed class ScenarioDetailTests : BunitContext
 {
-    public ScenarioDetailTests() => JSInterop.Mode = JSRuntimeMode.Loose;
+    public ScenarioDetailTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddEventLogLocalization();
+    }
 
     [Fact]
     public void AdminBadge_WhenRequiresAdmin_IsAbsent()


### PR DESCRIPTION
## Summary
Third incremental UI-surface localization (after FindBar #701 and SettingsModal + ModalChrome #702). Moves all user-facing English on the **Dashboard empty-state welcome screen** behind `IStringLocalizer<SharedResource>`. Neutral English is byte-identical to today; only the string source moves to RESX.

Scope: **UI-layer-full** — the three Dashboard components + the shared enable-channel confirmation + scenario-group display names.

## Changes
- **Components** (`.razor` + `.razor.cs`): `EmptyStateDashboard`, `ScenarioDetail`, `ScenarioBrowserPanel` — masthead, Quick Launch (labels + arias), catalog states, category tabs, scenario detail (labels, status tags, filters, favorite/open-folder arias), enable-channel flow, dynamic status/announcement/alert messages, and folder-scan status/cancel text.
- **`Common/EnableChannelConfirmation.cs`**: now takes an `IStringLocalizer<SharedResource>` and composes the confirmation message from resources.
- **`Common/ScenarioGroupLocalizer.cs`** (new): shared helper mapping the 20 `ScenarioGroup` values to `Dashboard_Group_*` resources (values mirror `ScenarioGroupDisplay.DisplayName()`; a drift-guard test pins them equal).
- **`Resources/SharedResource.resx`**: +101 `Dashboard_*` keys with translator `<comment>`s on channel/product proper nouns and diagnostic placeholders.

### Localization specifics
- **Pluralization**: 2-form count-inclusive helper (`Plural(count, oneKey, manyKey)`) for files/logs/channels — correct for English; documented as needing a CLDR/ICU provider before shipping locales with other plural rules.
- **Composition**: folder/launch messages compose a localized base sentence + appended note fragments (each a complete resource; leading spaces preserved under `xml:space="preserve"`).
- **Data boundary**: scenario Name/Purpose, channel names, filter formatter text, and Runtime-authored `result.Message` render verbatim (never routed through the localizer).

## Tests
- `DashboardLocalizationTests` (new): group-name drift guard (all 20), count-inclusive plurals, enum-label keys, localized render + resource-key-leak guards, data-boundary sentinels, and an **orphan-key guard** (fails if any `Dashboard_*` key is authored but never referenced in source).
- `DashboardCultureTests` (new): qps-Ploc canary positive control, then real keys fall back to neutral English.
- `EmptyStateDashboardTests`: + quick-launch label/aria render, plural launch composition, and folder-scan status/cancel localized-equality.
- The 3 Dashboard fixtures now register `AddEventLogLocalization()`.

## Validation
- Full `EventLogExpert.UI.Tests`: **1598/1598**.
- MAUI head (ARM64) build: **0 warnings / 0 errors**.
- No em-dashes; English output byte-identical to pre-change.
