### PR TITLE
Localize the menu bar and shared close-all confirmation

### DIFF
--- a/src/EventLogExpert.UI/Common/CloseAllLogsConfirmation.cs
+++ b/src/EventLogExpert.UI/Common/CloseAllLogsConfirmation.cs
@@ -2,11 +2,16 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Runtime.Alerts;
+using Microsoft.Extensions.Localization;
 
 namespace EventLogExpert.UI.Common;
 
 internal static class CloseAllLogsConfirmation
 {
-    public static Task<bool> ConfirmAsync(IAlertDialogService dialog) =>
-        dialog.ShowAlert("Close all logs", "Close all open logs? This cannot be undone.", "Close all", "Cancel");
+    public static Task<bool> ConfirmAsync(IAlertDialogService dialog, IStringLocalizer<SharedResource> localizer) =>
+        dialog.ShowAlert(
+            localizer["CloseAllLogs_Title"],
+            localizer["CloseAllLogs_Body"],
+            localizer["CloseAllLogs_Confirm"],
+            localizer["Modal_Cancel"]);
 }

--- a/src/EventLogExpert.UI/LogTable/LogTabBar.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/LogTabBar.razor.cs
@@ -12,6 +12,7 @@ using EventLogExpert.UI.Common.Interop;
 using EventLogExpert.UI.Menu;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.Localization;
 using Microsoft.JSInterop;
 
 namespace EventLogExpert.UI.LogTable;
@@ -29,6 +30,8 @@ public sealed partial class LogTabBar
     [Inject] private IEventLogCommands EventLogCommands { get; init; } = null!;
 
     [Inject] private IJSRuntime JSRuntime { get; init; } = null!;
+
+    [Inject] private IStringLocalizer<SharedResource> Localizer { get; init; } = null!;
 
     [Inject] private ILogTableCommands LogTableCommands { get; init; } = null!;
 
@@ -285,7 +288,7 @@ public sealed partial class LogTabBar
 
     private async Task ConfirmCloseAllLogsAsync()
     {
-        if (await CloseAllLogsConfirmation.ConfirmAsync(AlertDialogService))
+        if (await CloseAllLogsConfirmation.ConfirmAsync(AlertDialogService, Localizer))
         {
             EventLogCommands.CloseAllLogs();
         }

--- a/src/EventLogExpert.UI/Menu/MenuBar.razor
+++ b/src/EventLogExpert.UI/Menu/MenuBar.razor
@@ -1,6 +1,6 @@
 @inherits AppStateComponentBase
 
-<nav aria-label="Main menu" aria-orientation="horizontal" class="menu-bar" @ref="_menuBarRootRef" role="menubar">
+<nav aria-label="@Localizer["Menu_MainMenuAria"]" aria-orientation="horizontal" class="menu-bar" @ref="_menuBarRootRef" role="menubar">
     @for (int index = 0; index < _bars.Count; index++)
     {
         var bar = _bars[index];
@@ -8,16 +8,16 @@
         bool isActive = IsActive(bar);
         bool isFocused = capturedIndex == _focusedBarIndex;
 
-        <ChromelessButton aria-expanded="@isActive.ToString().ToLowerInvariant()"
-            aria-haspopup="menu"
-            CssClass="@($"menu-bar-item{(isActive ? " active" : string.Empty)}")"
-            @key="bar.Label"
+        <ChromelessButton CssClass="@($"menu-bar-item{(isActive ? " active" : string.Empty)}")"
             OnClick="@(async _ => await OnBarClick(bar, capturedIndex))"
             OnKeyDown="@(async args => await OnBarKeyDown(args, capturedIndex))"
             OnMouseEnter="@(async _ => await OnBarHover(bar, capturedIndex))"
+            StopPropagation="true"
+            aria-expanded="@isActive.ToString().ToLowerInvariant()"
+            aria-haspopup="menu"
+            @key="capturedIndex"
             @ref="_barElements[capturedIndex]"
             role="menuitem"
-            StopPropagation="true"
             tabindex="@(isFocused ? 0 : -1)">
             @bar.Label
         </ChromelessButton>

--- a/src/EventLogExpert.UI/Menu/MenuBar.razor.cs
+++ b/src/EventLogExpert.UI/Menu/MenuBar.razor.cs
@@ -18,6 +18,7 @@ using EventLogExpert.UI.Common.Interop;
 using EventLogExpert.UI.Inputs;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.Localization;
 using Microsoft.JSInterop;
 using System.Text;
 
@@ -25,8 +26,6 @@ namespace EventLogExpert.UI.Menu;
 
 public sealed partial class MenuBar
 {
-    private const string GroupDisabledReason = "Group events first (column header > Group By)";
-
     private readonly List<TopLevel> _bars = [];
 
     private ChromelessButton?[] _barElements = [];
@@ -50,9 +49,13 @@ public sealed partial class MenuBar
 
     [Inject] private IFilterPaneQueries FilterPaneQueries { get; init; } = null!;
 
+    private string GroupDisabledReason => Localizer["Menu_GroupDisabledReason"];
+
     [Inject] private IHistogramVisibilitySource HistogramVisibility { get; init; } = null!;
 
     [Inject] private IJSRuntime JSRuntime { get; init; } = null!;
+
+    [Inject] private IStringLocalizer<SharedResource> Localizer { get; init; } = null!;
 
     [Inject] private ILogTableQueries LogTableQueries { get; init; } = null!;
 
@@ -96,7 +99,14 @@ public sealed partial class MenuBar
                 await _scrollSuppressorModule.InvokeVoidAsync(
                     "suppress",
                     _menuBarRootRef,
-                    new[] { new { selector = "[role='menuitem']", keys = new[] { "ArrowRight", "ArrowLeft", "Home", "End", "ArrowDown", "ArrowUp" } } });
+                    new[]
+                    {
+                        new
+                        {
+                            selector = "[role='menuitem']",
+                            keys = new[] { "ArrowRight", "ArrowLeft", "Home", "End", "ArrowDown", "ArrowUp" }
+                        }
+                    });
             }
             catch (JSDisconnectedException) { }
             catch (JSException) { }
@@ -119,32 +129,27 @@ public sealed partial class MenuBar
         base.OnInitialized();
     }
 
-    private static string? ReadinessStatusText(ChannelReadiness readiness) =>
-        readiness.Access == ChannelAccess.RequiresElevation
-            ? "(elevate)"
-            : readiness.Enablement == ChannelEnablement.Disabled ? "(disabled)" : null;
-
     private IReadOnlyList<MenuItem> BuildEdit()
     {
         var defaultCopyFormat = Settings.CopyFormat;
 
         return
         [
-            MenuItem.Item("Copy Selected",
+            MenuItem.Item(Localizer["Menu_Edit_CopySelected"],
                 () => Actions.CopySelectedAsync(EventCopyFormat.Default),
-                defaultCopyFormat == EventCopyFormat.Default ? "Ctrl+C" : null),
-            MenuItem.Item("Copy Selected (Simple)",
+                defaultCopyFormat == EventCopyFormat.Default ? Localizer["Menu_Shortcut_Copy"].Value : null),
+            MenuItem.Item(Localizer["Menu_Edit_CopySelectedSimple"],
                 () => Actions.CopySelectedAsync(EventCopyFormat.Simple),
-                defaultCopyFormat == EventCopyFormat.Simple ? "Ctrl+C" : null),
-            MenuItem.Item("Copy Selected (XML)",
+                defaultCopyFormat == EventCopyFormat.Simple ? Localizer["Menu_Shortcut_Copy"].Value : null),
+            MenuItem.Item(Localizer["Menu_Edit_CopySelectedXml"],
                 () => Actions.CopySelectedAsync(EventCopyFormat.Xml),
-                defaultCopyFormat == EventCopyFormat.Xml ? "Ctrl+C" : null),
-            MenuItem.Item("Copy Selected (Full)",
+                defaultCopyFormat == EventCopyFormat.Xml ? Localizer["Menu_Shortcut_Copy"].Value : null),
+            MenuItem.Item(Localizer["Menu_Edit_CopySelectedFull"],
                 () => Actions.CopySelectedAsync(EventCopyFormat.Full),
-                defaultCopyFormat == EventCopyFormat.Full ? "Ctrl+C" : null),
-            MenuItem.Item("Copy Selected (Markdown)",
+                defaultCopyFormat == EventCopyFormat.Full ? Localizer["Menu_Shortcut_Copy"].Value : null),
+            MenuItem.Item(Localizer["Menu_Edit_CopySelectedMarkdown"],
                 () => Actions.CopySelectedAsync(EventCopyFormat.Markdown),
-                defaultCopyFormat == EventCopyFormat.Markdown ? "Ctrl+C" : null),
+                defaultCopyFormat == EventCopyFormat.Markdown ? Localizer["Menu_Shortcut_Copy"].Value : null),
         ];
     }
 
@@ -154,34 +159,42 @@ public sealed partial class MenuBar
 
         return
         [
-            MenuItem.SubMenu("Open", BuildOpenSubMenu(false)),
-            MenuItem.SubMenu("Combine", BuildOpenSubMenu(true), hasActiveLogs),
+            MenuItem.SubMenu(Localizer["Menu_File_Open"], BuildOpenSubMenu(false)),
+            MenuItem.SubMenu(Localizer["Menu_File_Combine"], BuildOpenSubMenu(true), hasActiveLogs),
             MenuItem.Separator(),
-            MenuItem.Item("Close All", ConfirmCloseAllLogsAsync, isEnabled: hasActiveLogs),
+            MenuItem.Item(Localizer["Menu_File_CloseAll"], ConfirmCloseAllLogsAsync, isEnabled: hasActiveLogs),
             MenuItem.Separator(),
-            MenuItem.Item("Export to CSV", () => Actions.ExportEventsAsync(ExportFormat.Csv), isEnabled: hasActiveLogs),
-            MenuItem.Item("Export to JSON", () => Actions.ExportEventsAsync(ExportFormat.Json), isEnabled: hasActiveLogs),
-            MenuItem.Item("Exit", Actions.Exit),
+            MenuItem.Item(Localizer["Menu_File_ExportCsv"],
+                () => Actions.ExportEventsAsync(ExportFormat.Csv),
+                isEnabled: hasActiveLogs),
+            MenuItem.Item(Localizer["Menu_File_ExportJson"],
+                () => Actions.ExportEventsAsync(ExportFormat.Json),
+                isEnabled: hasActiveLogs),
+            MenuItem.Item(Localizer["Menu_File_Exit"], Actions.Exit),
         ];
     }
 
     private IReadOnlyList<MenuItem> BuildHelp() =>
     [
-        MenuItem.Item("Docs", () => Actions.OpenDocsAsync()),
-        MenuItem.Item("Submit an Issue", () => Actions.OpenIssueAsync()),
-        MenuItem.Item("Check for Updates", () => Actions.CheckForUpdatesAsync()),
-        MenuItem.Item("Release Notes", () => Actions.ShowReleaseNotesAsync()),
-        MenuItem.Item("View Logs", () => Actions.ShowDebugLogsAsync()),
+        MenuItem.Item(Localizer["Menu_Help_Docs"], () => Actions.OpenDocsAsync()),
+        MenuItem.Item(Localizer["Menu_Help_SubmitIssue"], () => Actions.OpenIssueAsync()),
+        MenuItem.Item(Localizer["Menu_Help_CheckForUpdates"], () => Actions.CheckForUpdatesAsync()),
+        MenuItem.Item(Localizer["Menu_Help_ReleaseNotes"], () => Actions.ShowReleaseNotesAsync()),
+        MenuItem.Item(Localizer["Menu_Help_ViewLogs"], () => Actions.ShowDebugLogsAsync()),
     ];
 
     private IReadOnlyList<MenuItem> BuildOpenSubMenu(bool combineLog)
     {
         return
         [
-            MenuItem.Item("File", () => Actions.OpenFileAsync(combineLog), combineLog ? null : "Ctrl+O"),
-            MenuItem.Item("Folder", () => Actions.OpenFolderAsync(combineLog, includeSubfolders: true)),
-            MenuItem.Item("Folder (top level only)", () => Actions.OpenFolderAsync(combineLog, includeSubfolders: false)),
-            MenuItem.SubMenu("Live",
+            MenuItem.Item(Localizer["Menu_Open_File"],
+                () => Actions.OpenFileAsync(combineLog),
+                combineLog ? null : Localizer["Menu_Shortcut_Open"].Value),
+            MenuItem.Item(Localizer["Menu_Open_Folder"],
+                () => Actions.OpenFolderAsync(combineLog, includeSubfolders: true)),
+            MenuItem.Item(Localizer["Menu_Open_FolderTopLevel"],
+                () => Actions.OpenFolderAsync(combineLog, includeSubfolders: false)),
+            MenuItem.SubMenu(Localizer["Menu_Open_Live"],
             [
                 MenuItem.Item(LogChannelNames.ApplicationLog,
                     () => Actions.OpenLiveLogAsync(LogChannelNames.ApplicationLog, combineLog),
@@ -193,7 +206,7 @@ public sealed partial class MenuBar
                     () => Actions.OpenLiveLogAsync(LogChannelNames.SecurityLog, combineLog),
                     statusText: ReadinessStatusText(LogChannelNames.SecurityLog)),
                 MenuItem.AsyncSubMenu(
-                    "Other Logs",
+                    Localizer["Menu_Open_OtherLogs"],
                     async () => BuildOtherLogsTree(await GetOtherLogReadinessAsync(), combineLog)),
             ]),
         ];
@@ -214,6 +227,7 @@ public sealed partial class MenuBar
             if (path.Count == 0) { continue; }
 
             var log = path[^1];
+
             var logMenuItem = MenuItem.Item(log,
                 () => Actions.OpenLiveLogAsync(logName, combineLog),
                 statusText: ReadinessStatusText(readiness));
@@ -253,18 +267,18 @@ public sealed partial class MenuBar
 
     private IReadOnlyList<MenuItem> BuildTools() =>
     [
-        MenuItem.Item("Databases...", () => Actions.OpenDatabaseToolsAsync()),
+        MenuItem.Item(Localizer["Menu_Tools_Databases"], () => Actions.OpenDatabaseToolsAsync()),
         MenuItem.Separator(),
-        MenuItem.Item("Settings", () => Actions.OpenSettingsAsync()),
+        MenuItem.Item(Localizer["Menu_Tools_Settings"], () => Actions.OpenSettingsAsync()),
     ];
 
     private List<TopLevel> BuildTopLevel() =>
     [
-        new("File", BuildFile),
-        new("Edit", BuildEdit),
-        new("View", BuildView),
-        new("Tools", BuildTools),
-        new("Help", BuildHelp),
+        new(Localizer["Menu_File"], BuildFile),
+        new(Localizer["Menu_Edit"], BuildEdit),
+        new(Localizer["Menu_View"], BuildView),
+        new(Localizer["Menu_Tools"], BuildTools),
+        new(Localizer["Menu_Help"], BuildHelp),
     ];
 
     private IReadOnlyList<MenuItem> BuildView()
@@ -279,48 +293,48 @@ public sealed partial class MenuBar
         return
         [
             MenuItem.Item(
-                "Show All Events",
+                Localizer["Menu_View_ShowAllEvents"],
                 Actions.ToggleShowAllEvents,
-                "Ctrl+H",
+                Localizer["Menu_Shortcut_ShowAll"],
                 !isFilterEnabled),
-            MenuItem.Item("Load New Events", Actions.LoadNewEvents),
+            MenuItem.Item(Localizer["Menu_View_LoadNewEvents"], Actions.LoadNewEvents),
             MenuItem.Item(
-                "Continuously Update",
+                Localizer["Menu_View_ContinuouslyUpdate"],
                 () => Actions.SetContinuouslyUpdate(!isContinuouslyUpdating),
                 isChecked: isContinuouslyUpdating),
             MenuItem.Separator(),
             MenuItem.Item(
-                "Group Descending",
+                Localizer["Menu_View_GroupDescending"],
                 Actions.ToggleGroupSortDirection,
                 isChecked: isGroupDescending,
                 isEnabled: isGrouping,
                 disabledReason: isGrouping ? null : GroupDisabledReason),
             MenuItem.Item(
-                "Expand All Groups",
+                Localizer["Menu_View_ExpandAllGroups"],
                 () => Actions.SetAllGroupsCollapsed(false),
                 isEnabled: isGrouping,
                 disabledReason: isGrouping ? null : GroupDisabledReason),
             MenuItem.Item(
-                "Collapse All Groups",
+                Localizer["Menu_View_CollapseAllGroups"],
                 () => Actions.SetAllGroupsCollapsed(true),
                 isEnabled: isGrouping,
                 disabledReason: isGrouping ? null : GroupDisabledReason),
             MenuItem.Separator(),
             MenuItem.Item(
-                "Timeline",
+                Localizer["Menu_View_Timeline"],
                 () => Actions.SetHistogramVisible(!isHistogramVisible),
                 isChecked: isHistogramVisible),
             MenuItem.Item(
-                "Resolution & Coverage",
+                Localizer["Menu_View_ResolutionCoverage"],
                 () => Actions.ShowResolutionCoverageAsync(),
                 isEnabled: hasActiveLogs,
-                disabledReason: hasActiveLogs ? null : "Open a log to view resolution coverage."),
+                disabledReason: hasActiveLogs ? null : Localizer["Menu_ResolutionCoverageDisabledReason"].Value),
         ];
     }
 
     private async Task ConfirmCloseAllLogsAsync()
     {
-        if (await CloseAllLogsConfirmation.ConfirmAsync(AlertDialogService))
+        if (await CloseAllLogsConfirmation.ConfirmAsync(AlertDialogService, Localizer))
         {
             await Actions.CloseAllLogsAsync();
         }
@@ -329,6 +343,7 @@ public sealed partial class MenuBar
     private async Task<IReadOnlyList<ChannelReadiness>> GetOtherLogReadinessAsync()
     {
         var snapshot = await ChannelReadinessService.GetReadinessAsync();
+
         var logNames = snapshot
             .Select(channel => channel.Channel)
             .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
@@ -339,13 +354,12 @@ public sealed partial class MenuBar
         var readinessByChannel = new Dictionary<string, ChannelReadiness>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var channel in snapshot) { readinessByChannel[channel.Channel] = channel; }
+
         foreach (var channel in readiness) { readinessByChannel[channel.Channel] = channel; }
 
         _readinessByChannel = readinessByChannel;
 
-        return readiness
-            .OrderBy(channel => channel.Channel, StringComparer.OrdinalIgnoreCase)
-            .ToList();
+        return [.. readiness.OrderBy(channel => channel.Channel, StringComparer.OrdinalIgnoreCase)];
     }
 
     private void InvalidatePendingOpen() => Interlocked.Increment(ref _openRequestId);
@@ -456,7 +470,8 @@ public sealed partial class MenuBar
         var requestId = Interlocked.Increment(ref _openRequestId);
 
         _menuAnchorModule ??= await JSRuntime.InvokeAsync<IJSObjectReference>(
-            "import", "./_content/EventLogExpert.UI/Menu/MenuAnchor.js");
+            "import",
+            "./_content/EventLogExpert.UI/Menu/MenuAnchor.js");
 
         if (_barElements[index] is not { } barButton) { return; }
 
@@ -476,6 +491,7 @@ public sealed partial class MenuBar
         try
         {
             var readiness = await ChannelReadinessService.GetReadinessAsync();
+
             _readinessByChannel = readiness.ToDictionary(
                 channel => channel.Channel,
                 StringComparer.OrdinalIgnoreCase);
@@ -488,10 +504,13 @@ public sealed partial class MenuBar
         }
     }
 
+    private string? ReadinessStatusText(ChannelReadiness readiness) =>
+        readiness.Access == ChannelAccess.RequiresElevation ? Localizer["Menu_Status_Elevate"].Value :
+        readiness.Enablement == ChannelEnablement.Disabled ? Localizer["Menu_Status_Disabled"].Value : null;
+
     private string? ReadinessStatusText(string channel) =>
-        _readinessByChannel.TryGetValue(channel, out var readiness)
-            ? ReadinessStatusText(readiness)
-            : null;
+        _readinessByChannel.TryGetValue(channel, out var readiness) ?
+            ReadinessStatusText(readiness) : null;
 
     private sealed record TopLevel(string Label, Func<IReadOnlyList<MenuItem>> BuildItems);
 }

--- a/src/EventLogExpert.UI/Menu/MenuHost.razor
+++ b/src/EventLogExpert.UI/Menu/MenuHost.razor
@@ -4,7 +4,7 @@
         @onclick="HandleOverlayClick"
         @oncontextmenu="HandleOverlayClick"
         @oncontextmenu:preventDefault="true">
-        <div aria-label="Menu"
+        <div aria-label="@Localizer["Menu_PopupAria"]"
             class="menu-host-popup"
             id="menu-host-popup"
             @onclick:stopPropagation

--- a/src/EventLogExpert.UI/Menu/MenuHost.razor.cs
+++ b/src/EventLogExpert.UI/Menu/MenuHost.razor.cs
@@ -4,6 +4,7 @@
 using EventLogExpert.UI.Common.Interop;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.Localization;
 using Microsoft.JSInterop;
 using System.Globalization;
 
@@ -20,6 +21,8 @@ public sealed partial class MenuHost : IAsyncDisposable
     private bool IsActive => ReferenceEquals(Registry.ActiveHost, this);
 
     [Inject] private IJSRuntime JSRuntime { get; init; } = null!;
+
+    [Inject] private IStringLocalizer<SharedResource> Localizer { get; init; } = null!;
 
     [Inject] private IMenuService MenuService { get; init; } = null!;
 

--- a/src/EventLogExpert.UI/Menu/MenuRenderer.razor
+++ b/src/EventLogExpert.UI/Menu/MenuRenderer.razor
@@ -80,7 +80,7 @@
                             @if (_resolvedChildren is null)
                             {
                                 <ul aria-busy="true"
-                                    aria-label="Loading"
+                                    aria-label="@Localizer["Menu_LoadingAria"]"
                                     aria-orientation="vertical"
                                     class="menu-list"
                                     role="menu">
@@ -89,7 +89,7 @@
                                         role="menuitem"
                                         tabindex="-1">
                                         <span class="menu-check"></span>
-                                        <span class="menu-label">Loading...</span>
+                                        <span class="menu-label">@Localizer["Menu_Loading"]</span>
                                     </li>
                                 </ul>
                             }

--- a/src/EventLogExpert.UI/Menu/MenuRenderer.razor.cs
+++ b/src/EventLogExpert.UI/Menu/MenuRenderer.razor.cs
@@ -4,6 +4,7 @@
 using EventLogExpert.UI.Common.Interop;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.Localization;
 using Microsoft.JSInterop;
 
 namespace EventLogExpert.UI.Menu;
@@ -16,8 +17,9 @@ public sealed partial class MenuRenderer : IAsyncDisposable
     private static long s_rendererIdCounter;
 
     private readonly long _rendererId = Interlocked.Increment(ref s_rendererIdCounter);
-    private int _focusedIndex = -1;
+
     private bool _focusOnNextRender;
+    private int _focusedIndex = -1;
     private ElementReference[] _itemElements = [];
     private IJSObjectReference? _menuOverlayModule;
     private MenuItem? _openItem;
@@ -45,6 +47,8 @@ public sealed partial class MenuRenderer : IAsyncDisposable
     [Parameter] public bool SuppressInitialFocus { get; set; }
 
     [Inject] private IJSRuntime JSRuntime { get; init; } = null!;
+
+    [Inject] private IStringLocalizer<SharedResource> Localizer { get; init; } = null!;
 
     public async ValueTask DisposeAsync()
     {

--- a/src/EventLogExpert.UI/Resources/SharedResource.resx
+++ b/src/EventLogExpert.UI/Resources/SharedResource.resx
@@ -578,4 +578,183 @@
     <value>Office</value>
     <comment>Office is a product name; keep verbatim.</comment>
   </data>
+  <!-- Menu bar: top-level bars. -->
+  <data name="Menu_File" xml:space="preserve">
+    <value>File</value>
+  </data>
+  <data name="Menu_Edit" xml:space="preserve">
+    <value>Edit</value>
+  </data>
+  <data name="Menu_View" xml:space="preserve">
+    <value>View</value>
+  </data>
+  <data name="Menu_Tools" xml:space="preserve">
+    <value>Tools</value>
+  </data>
+  <data name="Menu_Help" xml:space="preserve">
+    <value>Help</value>
+  </data>
+  <!-- Menu bar: File menu. -->
+  <data name="Menu_File_Open" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="Menu_File_Combine" xml:space="preserve">
+    <value>Combine</value>
+  </data>
+  <data name="Menu_File_CloseAll" xml:space="preserve">
+    <value>Close All</value>
+  </data>
+  <data name="Menu_File_ExportCsv" xml:space="preserve">
+    <value>Export to CSV</value>
+    <comment>CSV is a file-format proper noun; keep verbatim.</comment>
+  </data>
+  <data name="Menu_File_ExportJson" xml:space="preserve">
+    <value>Export to JSON</value>
+    <comment>JSON is a file-format proper noun; keep verbatim.</comment>
+  </data>
+  <data name="Menu_File_Exit" xml:space="preserve">
+    <value>Exit</value>
+  </data>
+  <!-- Menu bar: File > Open / Combine submenu (shared by both). -->
+  <data name="Menu_Open_File" xml:space="preserve">
+    <value>File</value>
+  </data>
+  <data name="Menu_Open_Folder" xml:space="preserve">
+    <value>Folder</value>
+  </data>
+  <data name="Menu_Open_FolderTopLevel" xml:space="preserve">
+    <value>Folder (top level only)</value>
+    <comment>Opens logs in the selected folder only, without traversing subfolders.</comment>
+  </data>
+  <data name="Menu_Open_Live" xml:space="preserve">
+    <value>Live</value>
+  </data>
+  <data name="Menu_Open_OtherLogs" xml:space="preserve">
+    <value>Other Logs</value>
+  </data>
+  <!-- Menu bar: Edit menu. Copy formats are whole-string labels; the format names in parentheses are proper nouns. -->
+  <data name="Menu_Edit_CopySelected" xml:space="preserve">
+    <value>Copy Selected</value>
+  </data>
+  <data name="Menu_Edit_CopySelectedSimple" xml:space="preserve">
+    <value>Copy Selected (Simple)</value>
+  </data>
+  <data name="Menu_Edit_CopySelectedXml" xml:space="preserve">
+    <value>Copy Selected (XML)</value>
+    <comment>XML is a format proper noun; keep verbatim.</comment>
+  </data>
+  <data name="Menu_Edit_CopySelectedFull" xml:space="preserve">
+    <value>Copy Selected (Full)</value>
+  </data>
+  <data name="Menu_Edit_CopySelectedMarkdown" xml:space="preserve">
+    <value>Copy Selected (Markdown)</value>
+    <comment>Markdown is a format proper noun; keep verbatim.</comment>
+  </data>
+  <!-- Menu bar: View menu. -->
+  <data name="Menu_View_ShowAllEvents" xml:space="preserve">
+    <value>Show All Events</value>
+  </data>
+  <data name="Menu_View_LoadNewEvents" xml:space="preserve">
+    <value>Load New Events</value>
+  </data>
+  <data name="Menu_View_ContinuouslyUpdate" xml:space="preserve">
+    <value>Continuously Update</value>
+  </data>
+  <data name="Menu_View_GroupDescending" xml:space="preserve">
+    <value>Group Descending</value>
+  </data>
+  <data name="Menu_View_ExpandAllGroups" xml:space="preserve">
+    <value>Expand All Groups</value>
+  </data>
+  <data name="Menu_View_CollapseAllGroups" xml:space="preserve">
+    <value>Collapse All Groups</value>
+  </data>
+  <data name="Menu_View_Timeline" xml:space="preserve">
+    <value>Timeline</value>
+  </data>
+  <data name="Menu_View_ResolutionCoverage" xml:space="preserve">
+    <value>Resolution &amp; Coverage</value>
+    <comment>Also used as the Resolution &amp; Coverage modal title (ResolutionCoverageModal); keep consistent if that surface is localized later.</comment>
+  </data>
+  <!-- Menu bar: Tools menu. -->
+  <data name="Menu_Tools_Databases" xml:space="preserve">
+    <value>Databases...</value>
+  </data>
+  <data name="Menu_Tools_Settings" xml:space="preserve">
+    <value>Settings</value>
+  </data>
+  <!-- Menu bar: Help menu. -->
+  <data name="Menu_Help_Docs" xml:space="preserve">
+    <value>Docs</value>
+  </data>
+  <data name="Menu_Help_SubmitIssue" xml:space="preserve">
+    <value>Submit an Issue</value>
+  </data>
+  <data name="Menu_Help_CheckForUpdates" xml:space="preserve">
+    <value>Check for Updates</value>
+  </data>
+  <data name="Menu_Help_ReleaseNotes" xml:space="preserve">
+    <value>Release Notes</value>
+    <comment>Also used as the Release Notes modal accessible name (ReleaseNotesModal); keep consistent if that surface is localized later.</comment>
+  </data>
+  <data name="Menu_Help_ViewLogs" xml:space="preserve">
+    <value>View Logs</value>
+  </data>
+  <!-- Menu bar: live-log readiness status badges, appended after a channel/log name. -->
+  <data name="Menu_Status_Elevate" xml:space="preserve">
+    <value>(elevate)</value>
+    <comment>Status badge shown after a log/channel name; indicates the log requires administrator elevation to open.</comment>
+  </data>
+  <data name="Menu_Status_Disabled" xml:space="preserve">
+    <value>(disabled)</value>
+    <comment>Status badge shown after a log/channel name; indicates the log is currently disabled.</comment>
+  </data>
+  <!-- Menu bar: disabled-item reasons. -->
+  <data name="Menu_GroupDisabledReason" xml:space="preserve">
+    <value>Group events first (column header &gt; Group By)</value>
+    <comment>'&gt;' is a UI breadcrumb meaning 'then'; 'column header' and 'Group By' are UI navigation labels.</comment>
+  </data>
+  <data name="Menu_ResolutionCoverageDisabledReason" xml:space="preserve">
+    <value>Open a log to view resolution coverage.</value>
+  </data>
+  <!-- Menu bar: keyboard shortcut hints (display only; do not drive the binding). -->
+  <data name="Menu_Shortcut_Copy" xml:space="preserve">
+    <value>Ctrl+C</value>
+    <comment>Keyboard shortcut hint (display only; does not drive the binding). The letter C is the physical key - keep it; translate only the modifier word if your locale does (e.g. Strg).</comment>
+  </data>
+  <data name="Menu_Shortcut_Open" xml:space="preserve">
+    <value>Ctrl+O</value>
+    <comment>Keyboard shortcut hint (display only; does not drive the binding). The letter O is the physical key - keep it; translate only the modifier word if your locale does (e.g. Strg).</comment>
+  </data>
+  <data name="Menu_Shortcut_ShowAll" xml:space="preserve">
+    <value>Ctrl+H</value>
+    <comment>Keyboard shortcut hint (display only; does not drive the binding). The letter H is the physical key - keep it; translate only the modifier word if your locale does (e.g. Strg).</comment>
+  </data>
+  <!-- Menu bar: aria/chrome. -->
+  <data name="Menu_MainMenuAria" xml:space="preserve">
+    <value>Main menu</value>
+    <comment>Accessible name for the persistent top menu bar.</comment>
+  </data>
+  <data name="Menu_PopupAria" xml:space="preserve">
+    <value>Menu</value>
+    <comment>Accessible name for a transient dropdown menu popup (distinct from the persistent top menu bar).</comment>
+  </data>
+  <data name="Menu_LoadingAria" xml:space="preserve">
+    <value>Loading</value>
+    <comment>Accessible name for a submenu that is still loading its items.</comment>
+  </data>
+  <data name="Menu_Loading" xml:space="preserve">
+    <value>Loading...</value>
+    <comment>Placeholder text shown while an async submenu loads.</comment>
+  </data>
+  <!-- Shared close-all-logs confirmation dialog (used by the File menu and the log tab bar). -->
+  <data name="CloseAllLogs_Title" xml:space="preserve">
+    <value>Close all logs</value>
+  </data>
+  <data name="CloseAllLogs_Body" xml:space="preserve">
+    <value>Close all open logs? This cannot be undone.</value>
+  </data>
+  <data name="CloseAllLogs_Confirm" xml:space="preserve">
+    <value>Close all</value>
+  </data>
 </root>

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTabBarTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTabBarTests.cs
@@ -81,6 +81,7 @@ public sealed class LogTabBarTests : BunitContext
         Services.AddSingleton(_queries);
         Services.AddSingleton(_source);
         Services.AddSingleton(_traceLogger);
+        Services.AddEventLogLocalization();
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.UI.Tests/Menu/MenuBarGroupingTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Menu/MenuBarGroupingTests.cs
@@ -48,6 +48,7 @@ public sealed class MenuBarGroupingTests : BunitContext
         Services.AddSingleton(_readinessService);
         Services.AddSingleton(_settings);
         Services.AddSingleton(_versionProvider);
+        Services.AddEventLogLocalization();
 
         JSInterop.Mode = JSRuntimeMode.Loose;
         JSInterop.SetupModule("./_content/EventLogExpert.UI/Menu/MenuAnchor.js")

--- a/tests/Unit/EventLogExpert.UI.Tests/Menu/MenuBarLocalizerWiringTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Menu/MenuBarLocalizerWiringTests.cs
@@ -1,0 +1,175 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Readers;
+using EventLogExpert.Runtime.Alerts;
+using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.FilterPane;
+using EventLogExpert.Runtime.Histogram;
+using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.Runtime.Menu;
+using EventLogExpert.Runtime.Scenarios;
+using EventLogExpert.Runtime.Settings;
+using EventLogExpert.UI.Menu;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using NSubstitute;
+using System.Collections.Immutable;
+
+namespace EventLogExpert.UI.Tests.Menu;
+
+/// <summary>
+///     Proves the Menu bar actually CONSULTS the localizer (rather than emitting a reverted hardcoded English
+///     literal) by substituting a sentinel localizer that returns <c>[[key]]</c>. A label wired to <c>Localizer[...]</c>
+///     renders the sentinel; a data value (channel name) renders verbatim. Byte-identity of the real values is pinned
+///     separately by <see cref="MenuLocalizationTests.ResourceValue_IsByteIdenticalEnglish" />.
+/// </summary>
+public sealed class MenuBarLocalizerWiringTests : BunitContext
+{
+    private readonly IMenuActionService _actions = Substitute.For<IMenuActionService>();
+    private readonly IAlertDialogService _alertDialogService = Substitute.For<IAlertDialogService>();
+    private readonly IEventLogQueries _eventLogQueries = Substitute.For<IEventLogQueries>();
+    private readonly IFilterPaneQueries _filterPaneQueries = Substitute.For<IFilterPaneQueries>();
+    private readonly IHistogramVisibilitySource _histogramVisibility = Substitute.For<IHistogramVisibilitySource>();
+    private readonly ILogTableQueries _logTableQueries = Substitute.For<ILogTableQueries>();
+    private readonly IMenuService _menuService = Substitute.For<IMenuService>();
+    private readonly IChannelReadinessService _readinessService = Substitute.For<IChannelReadinessService>();
+    private readonly ISettingsService _settings = Substitute.For<ISettingsService>();
+
+    public MenuBarLocalizerWiringTests()
+    {
+        Services.AddSingleton(_actions);
+        Services.AddSingleton(_alertDialogService);
+        Services.AddSingleton(_eventLogQueries);
+        Services.AddSingleton(_filterPaneQueries);
+        Services.AddSingleton(_histogramVisibility);
+        Services.AddSingleton(_logTableQueries);
+        Services.AddSingleton(_menuService);
+        Services.AddSingleton(_readinessService);
+        Services.AddSingleton(_settings);
+        Services.AddSingleton<IStringLocalizer<SharedResource>>(new SentinelLocalizer());
+
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        JSInterop.SetupModule("./_content/EventLogExpert.UI/Menu/MenuAnchor.js")
+            .Setup<MenuAnchorRect>("getMenuElementRect", _ => true)
+            .SetResult(new MenuAnchorRect(0, 0, 0, 0, 0, 0));
+        _readinessService.GetReadinessAsync(Arg.Any<CancellationToken>()).Returns([]);
+        _readinessService.GetReadinessAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+            .Returns(call => ReadinessFor(call.Arg<IEnumerable<string>>()!));
+    }
+
+    [Fact]
+    public async Task ItemLabelsDisabledReasonAndStatus_AreDrivenByTheLocalizer_WhileChannelNamesStayVerbatim()
+    {
+        _readinessService.GetReadinessAsync(Arg.Any<CancellationToken>())
+            .Returns(
+            [
+                new ChannelReadiness(LogChannelNames.ApplicationLog, ChannelPresence.Present, ChannelEnablement.Enabled)
+                {
+                    Access = ChannelAccess.RequiresElevation
+                }
+            ]);
+        _logTableQueries.IsGrouping().Returns(false);
+
+        var fileItems = await OpenMenu("[[Menu_File]]");
+        Assert.Contains(fileItems, item => item.Label == "[[Menu_File_Exit]]");
+
+        var viewItems = await OpenMenu("[[Menu_View]]");
+        var groupDescending = viewItems.Single(item => item.Label == "[[Menu_View_GroupDescending]]");
+        Assert.Equal("[[Menu_GroupDisabledReason]]", groupDescending.DisabledReason);
+
+        var openItems = fileItems.Single(item => item.Label == "[[Menu_File_Open]]").Children!;
+        var liveItems = openItems.Single(item => item.Label == "[[Menu_Open_Live]]").Children!;
+        var application = liveItems.Single(item => item.Label == LogChannelNames.ApplicationLog);
+
+        Assert.Equal("[[Menu_Status_Elevate]]", application.StatusText);
+        // The channel name is data: had it been routed through the localizer it would render "[[Application]]".
+        Assert.Equal(LogChannelNames.ApplicationLog, application.Label);
+    }
+
+    [Fact]
+    public async Task OtherLogsTree_FolderAndLeafNames_StayVerbatim_UnderSentinelLocalizer()
+    {
+        const string sentinelChannel = "Microsoft-Windows-ZzzSentinelFolder/ZzzSentinelLeaf";
+        _readinessService.GetReadinessAsync(Arg.Any<CancellationToken>())
+            .Returns([new ChannelReadiness(sentinelChannel, ChannelPresence.Present, ChannelEnablement.Unknown)]);
+
+        var fileItems = await OpenMenu("[[Menu_File]]");
+        var openItems = fileItems.Single(item => item.Label == "[[Menu_File_Open]]").Children!;
+        var liveItems = openItems.Single(item => item.Label == "[[Menu_Open_Live]]").Children!;
+        var otherLogs = liveItems.Single(item => item.ChildrenLoader is not null);
+        var tree = await otherLogs.ChildrenLoader!();
+
+        var labels = new List<string>();
+        CollectLabels(tree, labels);
+
+        // Under the sentinel localizer a localized string renders "[[key]]"; folder/leaf names staying raw proves
+        // BuildOtherLogsTree never routes dynamic channel data through the localizer.
+        Assert.Contains("Microsoft", labels);
+        Assert.Contains("Windows", labels);
+        Assert.Contains("ZzzSentinelFolder", labels);
+        Assert.Contains("ZzzSentinelLeaf", labels);
+        Assert.DoesNotContain(labels, label => label.StartsWith("[[", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void TopLevelBarsAndAria_AreDrivenByTheLocalizer()
+    {
+        var cut = Render<MenuBar>();
+
+        var labels = cut.FindAll("button.menu-bar-item").Select(button => button.TextContent.Trim()).ToList();
+
+        Assert.Equal(
+            new[] { "[[Menu_File]]", "[[Menu_Edit]]", "[[Menu_View]]", "[[Menu_Tools]]", "[[Menu_Help]]" },
+            labels);
+        Assert.Equal("[[Menu_MainMenuAria]]", cut.Find("nav.menu-bar").GetAttribute("aria-label"));
+    }
+
+    private static void CollectLabels(IReadOnlyList<MenuItem> items, List<string> labels)
+    {
+        foreach (var item in items)
+        {
+            if (item.IsSeparator) { continue; }
+
+            labels.Add(item.Label);
+
+            if (item.Children is { } children) { CollectLabels(children, labels); }
+        }
+    }
+
+    private static ImmutableArray<ChannelReadiness> ReadinessFor(IEnumerable<string> channels) =>
+    [
+        .. channels.Select(channel => new ChannelReadiness(channel, ChannelPresence.Present, ChannelEnablement.Unknown))
+    ];
+
+    private async Task<IReadOnlyList<MenuItem>> OpenMenu(string barLabel)
+    {
+        IReadOnlyList<MenuItem>? items = null;
+        _menuService
+            .When(menu => menu.OpenAt(
+                Arg.Any<double>(), Arg.Any<double>(), Arg.Any<IReadOnlyList<MenuItem>>(),
+                Arg.Any<bool>(), Arg.Any<bool>()))
+            .Do(call => items = call.Arg<IReadOnlyList<MenuItem>>());
+
+        var cut = Render<MenuBar>();
+        await cut.FindAll("button.menu-bar-item")
+            .Single(button => button.TextContent.Trim() == barLabel)
+            .ClickAsync(new MouseEventArgs());
+
+        Assert.NotNull(items);
+
+        return items!;
+    }
+
+    private sealed class SentinelLocalizer : IStringLocalizer<SharedResource>
+    {
+        public LocalizedString this[string name] => new(name, $"[[{name}]]", resourceNotFound: false);
+
+        public LocalizedString this[string name, params object[] arguments] => new(name, $"[[{name}]]", resourceNotFound: false);
+
+        public IEnumerable<LocalizedString> GetAllStrings(bool includeParentCultures) => [];
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/Menu/MenuCultureTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Menu/MenuCultureTests.cs
@@ -1,0 +1,51 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using EventLogExpert.UI.Tests.TestUtils;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using System.Globalization;
+
+namespace EventLogExpert.UI.Tests.Menu;
+
+/// <summary>
+///     Menu tests that MUTATE thread UI culture (qps-Ploc canary). Restores culture synchronously and is serialized
+///     via <see cref="CultureSensitiveCollection" />. Proves a pseudo-locale machine loads the canary satellite yet real
+///     Menu_*/CloseAllLogs_* keys FALL BACK to neutral English.
+/// </summary>
+[Collection(CultureSensitiveCollection.Name)]
+public sealed class MenuCultureTests : BunitContext
+{
+    public MenuCultureTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddEventLogLocalization();
+    }
+
+    [Fact]
+    public void Canary_UnderPseudoLocale_LoadsSatellite_AndRealMenuKeysFallBackToNeutral()
+    {
+        var priorUiCulture = CultureInfo.CurrentUICulture;
+
+        try
+        {
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("qps-ploc");
+            var localizer = Services.GetRequiredService<IStringLocalizer<SharedResource>>();
+
+            var canary = localizer["Canary_Probe1"];
+            Assert.False(canary.ResourceNotFound);
+            Assert.Equal("[qps-ploc] canary probe one", canary.Value);
+
+            // Real Menu keys are absent from the canary satellite -> neutral English (no pseudo Menu UI on a qps-Ploc machine).
+            Assert.Equal("File", localizer["Menu_File"].Value);
+            Assert.Equal("Show All Events", localizer["Menu_View_ShowAllEvents"].Value);
+            Assert.Equal("Resolution & Coverage", localizer["Menu_View_ResolutionCoverage"].Value);
+            Assert.Equal("Close all logs", localizer["CloseAllLogs_Title"].Value);
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = priorUiCulture;
+        }
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/Menu/MenuHostHandoffTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Menu/MenuHostHandoffTests.cs
@@ -6,6 +6,7 @@ using EventLogExpert.UI.Menu;
 using EventLogExpert.UI.Modal;
 using EventLogExpert.UI.Tests.TestUtils;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using TestContext = Xunit.TestContext;
 
 namespace EventLogExpert.UI.Tests.Menu;
@@ -27,6 +28,21 @@ public sealed class MenuHostHandoffTests : BunitContext
         Services.AddBannerHostDependencies();
         Services.AddSingleton<IMenuService>(_menuService);
         Services.AddEventLogUIServices();
+    }
+
+    [Fact]
+    public async Task OpenMenu_PopupHasLocalizedAriaLabel()
+    {
+        var localizer = Services.GetRequiredService<IStringLocalizer<SharedResource>>();
+
+        var modal = Render<ModalChrome>(parameters => parameters
+            .Add(p => p.Title, "host")
+            .AddChildContent("<p>1</p>"));
+
+        await modal.InvokeAsync(() => _menuService.Open(MakeItems()));
+
+        modal.WaitForAssertion(() =>
+            Assert.Equal(localizer["Menu_PopupAria"].Value, modal.Find("div.menu-host-popup").GetAttribute("aria-label")));
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.UI.Tests/Menu/MenuLocalizationTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Menu/MenuLocalizationTests.cs
@@ -1,0 +1,413 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Readers;
+using EventLogExpert.Runtime.Alerts;
+using EventLogExpert.Runtime.Common.Clipboard;
+using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.FilterPane;
+using EventLogExpert.Runtime.Histogram;
+using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.Runtime.Menu;
+using EventLogExpert.Runtime.Scenarios;
+using EventLogExpert.Runtime.Settings;
+using EventLogExpert.UI.Menu;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using NSubstitute;
+using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+using System.Xml.Linq;
+
+namespace EventLogExpert.UI.Tests.Menu;
+
+/// <summary>
+///     Localization coverage for the Menu bar: top-level + item labels resolve, the tree carries no leaked resource
+///     keys (items never reach the DOM in tests, so the guard walks the captured <see cref="MenuItem" /> tree), aria
+///     chrome + status badges + disabled reasons are localized, channel names stay verbatim data, and every authored
+///     Menu_*/CloseAllLogs_* key is referenced in source (orphan guard).
+/// </summary>
+public sealed class MenuLocalizationTests : BunitContext
+{
+    private readonly IMenuActionService _actions = Substitute.For<IMenuActionService>();
+    private readonly IAlertDialogService _alertDialogService = Substitute.For<IAlertDialogService>();
+    private readonly IEventLogQueries _eventLogQueries = Substitute.For<IEventLogQueries>();
+    private readonly IFilterPaneQueries _filterPaneQueries = Substitute.For<IFilterPaneQueries>();
+    private readonly IHistogramVisibilitySource _histogramVisibility = Substitute.For<IHistogramVisibilitySource>();
+    private readonly ILogTableQueries _logTableQueries = Substitute.For<ILogTableQueries>();
+    private readonly IMenuService _menuService = Substitute.For<IMenuService>();
+    private readonly IChannelReadinessService _readinessService = Substitute.For<IChannelReadinessService>();
+    private readonly ISettingsService _settings = Substitute.For<ISettingsService>();
+
+    public MenuLocalizationTests()
+    {
+        Services.AddSingleton(_actions);
+        Services.AddSingleton(_alertDialogService);
+        Services.AddSingleton(_eventLogQueries);
+        Services.AddSingleton(_filterPaneQueries);
+        Services.AddSingleton(_histogramVisibility);
+        Services.AddSingleton(_logTableQueries);
+        Services.AddSingleton(_menuService);
+        Services.AddSingleton(_readinessService);
+        Services.AddSingleton(_settings);
+        Services.AddEventLogLocalization();
+
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        JSInterop.SetupModule("./_content/EventLogExpert.UI/Menu/MenuAnchor.js")
+            .Setup<MenuAnchorRect>("getMenuElementRect", _ => true)
+            .SetResult(new MenuAnchorRect(0, 0, 0, 0, 0, 0));
+        _readinessService.GetReadinessAsync(Arg.Any<CancellationToken>()).Returns([]);
+        _readinessService.GetReadinessAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+            .Returns(call => ReadinessFor(call.Arg<IEnumerable<string>>()!));
+    }
+
+    private IStringLocalizer<SharedResource> Localizer =>
+        Services.GetRequiredService<IStringLocalizer<SharedResource>>();
+
+    public static IEnumerable<object[]> AllMenuKeys() =>
+    [
+        ["Menu_File", "File"], ["Menu_Edit", "Edit"], ["Menu_View", "View"], ["Menu_Tools", "Tools"], ["Menu_Help", "Help"],
+        ["Menu_File_Open", "Open"], ["Menu_File_Combine", "Combine"], ["Menu_File_CloseAll", "Close All"],
+        ["Menu_File_ExportCsv", "Export to CSV"], ["Menu_File_ExportJson", "Export to JSON"], ["Menu_File_Exit", "Exit"],
+        ["Menu_Open_File", "File"], ["Menu_Open_Folder", "Folder"], ["Menu_Open_FolderTopLevel", "Folder (top level only)"],
+        ["Menu_Open_Live", "Live"], ["Menu_Open_OtherLogs", "Other Logs"],
+        ["Menu_Edit_CopySelected", "Copy Selected"], ["Menu_Edit_CopySelectedSimple", "Copy Selected (Simple)"],
+        ["Menu_Edit_CopySelectedXml", "Copy Selected (XML)"], ["Menu_Edit_CopySelectedFull", "Copy Selected (Full)"],
+        ["Menu_Edit_CopySelectedMarkdown", "Copy Selected (Markdown)"],
+        ["Menu_View_ShowAllEvents", "Show All Events"], ["Menu_View_LoadNewEvents", "Load New Events"],
+        ["Menu_View_ContinuouslyUpdate", "Continuously Update"], ["Menu_View_GroupDescending", "Group Descending"],
+        ["Menu_View_ExpandAllGroups", "Expand All Groups"], ["Menu_View_CollapseAllGroups", "Collapse All Groups"],
+        ["Menu_View_Timeline", "Timeline"], ["Menu_View_ResolutionCoverage", "Resolution & Coverage"],
+        ["Menu_Tools_Databases", "Databases..."], ["Menu_Tools_Settings", "Settings"],
+        ["Menu_Help_Docs", "Docs"], ["Menu_Help_SubmitIssue", "Submit an Issue"], ["Menu_Help_CheckForUpdates", "Check for Updates"],
+        ["Menu_Help_ReleaseNotes", "Release Notes"], ["Menu_Help_ViewLogs", "View Logs"],
+        ["Menu_Status_Elevate", "(elevate)"], ["Menu_Status_Disabled", "(disabled)"],
+        ["Menu_GroupDisabledReason", "Group events first (column header > Group By)"],
+        ["Menu_ResolutionCoverageDisabledReason", "Open a log to view resolution coverage."],
+        ["Menu_Shortcut_Copy", "Ctrl+C"], ["Menu_Shortcut_Open", "Ctrl+O"], ["Menu_Shortcut_ShowAll", "Ctrl+H"],
+        ["Menu_MainMenuAria", "Main menu"], ["Menu_PopupAria", "Menu"], ["Menu_LoadingAria", "Loading"], ["Menu_Loading", "Loading..."],
+        ["CloseAllLogs_Title", "Close all logs"], ["CloseAllLogs_Body", "Close all open logs? This cannot be undone."],
+        ["CloseAllLogs_Confirm", "Close all"],
+    ];
+
+    [Fact]
+    public void AllMenuKeys_TheoryData_CoversEveryMenuResourceKey()
+    {
+        var (resxPath, _) = LocateUiSource();
+
+        if (resxPath is null) { return; }
+
+        var resxKeys = XDocument.Load(resxPath)
+            .Root!.Elements("data")
+            .Select(data => (string?)data.Attribute("name"))
+            .Where(name => name is not null &&
+                (name.StartsWith("Menu_", StringComparison.Ordinal) ||
+                 name.StartsWith("CloseAllLogs_", StringComparison.Ordinal)))
+            .Select(name => name!)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToList();
+
+        var theoryKeys = AllMenuKeys()
+            .Select(row => (string)row[0])
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToList();
+
+        // Guards against value-pin coverage rot: a future Menu_*/CloseAllLogs_* key must be added to AllMenuKeys.
+        Assert.Equal(resxKeys, theoryKeys);
+    }
+
+    [Fact]
+    public async Task CloseAllConfirmation_UsesLocalizedStrings()
+    {
+        _logTableQueries.HasActiveLogs().Returns(true);
+
+        var closeAll = Item(await OpenMenu(Localizer["Menu_File"].Value), Localizer["Menu_File_CloseAll"].Value);
+        await closeAll.OnClickAsync!();
+
+        await _alertDialogService.Received(1).ShowAlert(
+            Localizer["CloseAllLogs_Title"].Value,
+            Localizer["CloseAllLogs_Body"].Value,
+            Localizer["CloseAllLogs_Confirm"].Value,
+            Localizer["Modal_Cancel"].Value);
+    }
+
+    [Fact]
+    public async Task CopyShortcutHint_IsLocalized_ByteIdentical()
+    {
+        _settings.CopyFormat.Returns(EventCopyFormat.Default);
+
+        var editItems = await OpenMenu(Localizer["Menu_Edit"].Value);
+        var copyDefault = editItems.Single(item => item.Label == Localizer["Menu_Edit_CopySelected"].Value);
+
+        Assert.Equal(Localizer["Menu_Shortcut_Copy"].Value, copyDefault.Shortcut);
+        Assert.Equal("Ctrl+C", copyDefault.Shortcut);
+    }
+
+    [Fact]
+    public async Task EveryMenuItem_DoesNotLeakResourceKeys()
+    {
+        foreach (var bar in new[] { "File", "Edit", "View", "Tools", "Help" })
+        {
+            var items = await OpenMenu(Localizer[$"Menu_{bar}"].Value);
+            await AssertNoLeakedKeys(items);
+        }
+    }
+
+    [Fact]
+    public void EveryMenuResourceKey_IsReferencedInSource()
+    {
+        var (resxPath, uiSourceRoot) = LocateUiSource();
+
+        if (resxPath is null || uiSourceRoot is null) { return; }
+
+        var keys = XDocument.Load(resxPath)
+            .Root!.Elements("data")
+            .Select(data => (string?)data.Attribute("name"))
+            .Where(name => name is not null &&
+                (name.StartsWith("Menu_", StringComparison.Ordinal) ||
+                 name.StartsWith("CloseAllLogs_", StringComparison.Ordinal)))
+            .Select(name => name!)
+            .ToList();
+
+        var source = string.Join(
+            "\n",
+            Directory.EnumerateFiles(uiSourceRoot, "*.cs", SearchOption.AllDirectories)
+                .Concat(Directory.EnumerateFiles(uiSourceRoot, "*.razor", SearchOption.AllDirectories))
+                .Select(File.ReadAllText));
+
+        var orphans = keys
+            .Where(key => !source.Contains($"\"{key}\"", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.True(orphans.Count == 0, $"Authored-but-unreferenced Menu_*/CloseAllLogs_* RESX keys: {string.Join(", ", orphans)}");
+    }
+
+    [Fact]
+    public async Task GroupDisabledReason_IsLocalized()
+    {
+        _logTableQueries.IsGrouping().Returns(false);
+
+        var item = Item(await OpenMenu(Localizer["Menu_View"].Value), Localizer["Menu_View_GroupDescending"].Value);
+
+        Assert.False(item.IsEnabled);
+        Assert.Equal(Localizer["Menu_GroupDisabledReason"].Value, item.DisabledReason);
+    }
+
+    [Fact]
+    public async Task LiveChannelNames_RenderVerbatim_NotLocalized()
+    {
+        var liveItems = await OpenLiveSubmenu();
+        var labels = liveItems.Where(item => !item.IsSeparator && item.ChildrenLoader is null)
+            .Select(item => item.Label)
+            .ToList();
+
+        // Channel names are Windows proper nouns passed through as data, never routed through the localizer.
+        Assert.Equal(
+            new[] { LogChannelNames.ApplicationLog, LogChannelNames.SystemLog, LogChannelNames.SecurityLog },
+            labels);
+    }
+
+    [Theory]
+    [InlineData(ChannelAccess.RequiresElevation, ChannelEnablement.Enabled, "Menu_Status_Elevate")]
+    [InlineData(ChannelAccess.Accessible, ChannelEnablement.Disabled, "Menu_Status_Disabled")]
+    public async Task LiveChannelStatusBadges_AreLocalized(ChannelAccess access, ChannelEnablement enablement, string key)
+    {
+        _readinessService.GetReadinessAsync(Arg.Any<CancellationToken>())
+            .Returns(
+            [
+                new ChannelReadiness(LogChannelNames.ApplicationLog, ChannelPresence.Present, enablement)
+                {
+                    Access = access
+                }
+            ]);
+
+        var liveItems = await OpenLiveSubmenu();
+        var application = liveItems.Single(item => item.Label == LogChannelNames.ApplicationLog);
+
+        Assert.Equal(Localizer[key].Value, application.StatusText);
+    }
+
+    [Fact]
+    public void MainMenuAria_IsLocalized()
+    {
+        var cut = Render<MenuBar>();
+
+        Assert.Equal(Localizer["Menu_MainMenuAria"].Value, cut.Find("nav.menu-bar").GetAttribute("aria-label"));
+    }
+
+    [Fact]
+    public async Task OtherLogsTree_FolderAndLeafNames_RenderVerbatim_NotLocalized()
+    {
+        const string sentinelChannel = "Microsoft-Windows-ZzzSentinelFolder/ZzzSentinelLeaf";
+        _readinessService.GetReadinessAsync(Arg.Any<CancellationToken>())
+            .Returns([new ChannelReadiness(sentinelChannel, ChannelPresence.Present, ChannelEnablement.Unknown)]);
+
+        var liveItems = await OpenLiveSubmenu();
+        var otherLogs = liveItems.Single(item => item.ChildrenLoader is not null);
+        var tree = await otherLogs.ChildrenLoader!();
+
+        var labels = new List<string>();
+        CollectLabels(tree, labels);
+
+        // GetMenuPath("Microsoft-Windows-ZzzSentinelFolder/ZzzSentinelLeaf") -> Microsoft > Windows > ZzzSentinelFolder > ZzzSentinelLeaf.
+        // Every folder + leaf segment is system data rendered verbatim, never routed through the localizer.
+        Assert.Contains("Microsoft", labels);
+        Assert.Contains("Windows", labels);
+        Assert.Contains("ZzzSentinelFolder", labels);
+        Assert.Contains("ZzzSentinelLeaf", labels);
+        Assert.DoesNotContain(labels, label => label.Contains("Menu_", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task RenderedMenuItems_DoNotLeakResourceKeysToTheDom()
+    {
+        foreach (var bar in new[] { "File", "Edit", "View", "Tools", "Help" })
+        {
+            var items = await OpenMenu(Localizer[$"Menu_{bar}"].Value);
+            var rendered = Render<MenuRenderer>(parameters => parameters.Add(panel => panel.Items, items));
+
+            Assert.DoesNotContain("Menu_", rendered.Markup);
+            Assert.DoesNotContain("CloseAllLogs_", rendered.Markup);
+        }
+    }
+
+    [Fact]
+    public async Task RepresentativeItemLabels_ResolveToLocalizedValues()
+    {
+        var fileItems = await OpenMenu(Localizer["Menu_File"].Value);
+        Assert.Contains(fileItems, item => item.Label == Localizer["Menu_File_ExportCsv"].Value);
+        Assert.Contains(fileItems, item => item.Label == Localizer["Menu_File_Exit"].Value);
+
+        var helpItems = await OpenMenu(Localizer["Menu_Help"].Value);
+        Assert.Contains(helpItems, item => item.Label == Localizer["Menu_Help_SubmitIssue"].Value);
+
+        var viewItems = await OpenMenu(Localizer["Menu_View"].Value);
+        Assert.Contains(viewItems, item => item.Label == Localizer["Menu_View_ResolutionCoverage"].Value);
+    }
+
+    [Fact]
+    public async Task ResolutionCoverageDisabledReason_IsLocalized()
+    {
+        _logTableQueries.HasActiveLogs().Returns(false);
+
+        var item = Item(await OpenMenu(Localizer["Menu_View"].Value), Localizer["Menu_View_ResolutionCoverage"].Value);
+
+        Assert.False(item.IsEnabled);
+        Assert.Equal(Localizer["Menu_ResolutionCoverageDisabledReason"].Value, item.DisabledReason);
+    }
+
+    [Theory]
+    [MemberData(nameof(AllMenuKeys))]
+    public void ResourceValue_IsByteIdenticalEnglish(string key, string expected) =>
+        Assert.Equal(expected, Localizer[key].Value);
+
+    [Fact]
+    public void TopLevelBars_AreLocalized()
+    {
+        var cut = Render<MenuBar>();
+
+        var labels = cut.FindAll("button.menu-bar-item").Select(button => button.TextContent.Trim()).ToList();
+
+        Assert.Equal(
+            new[]
+            {
+                Localizer["Menu_File"].Value,
+                Localizer["Menu_Edit"].Value,
+                Localizer["Menu_View"].Value,
+                Localizer["Menu_Tools"].Value,
+                Localizer["Menu_Help"].Value,
+            },
+            labels);
+        Assert.DoesNotContain("Menu_", cut.Markup);
+    }
+
+    private static void AssertFieldsClean(string? value)
+    {
+        if (value is null) { return; }
+
+        Assert.DoesNotContain("Menu_", value);
+        Assert.DoesNotContain("CloseAllLogs_", value);
+    }
+
+    private static void CollectLabels(IReadOnlyList<MenuItem> items, List<string> labels)
+    {
+        foreach (var item in items)
+        {
+            if (item.IsSeparator) { continue; }
+
+            labels.Add(item.Label);
+
+            if (item.Children is { } children) { CollectLabels(children, labels); }
+        }
+    }
+
+    private static MenuItem Item(IReadOnlyList<MenuItem> items, string label) =>
+        items.Single(item => item.Label == label);
+
+    private static (string? ResxPath, string? UiSourceRoot) LocateUiSource([CallerFilePath] string testFilePath = "")
+    {
+        var directory = Path.GetDirectoryName(testFilePath);
+
+        while (directory is not null && !Directory.Exists(Path.Combine(directory, "src", "EventLogExpert.UI")))
+        {
+            directory = Path.GetDirectoryName(directory);
+        }
+
+        if (directory is null) { return (null, null); }
+
+        var uiRoot = Path.Combine(directory, "src", "EventLogExpert.UI");
+        var resx = Path.Combine(uiRoot, "Resources", "SharedResource.resx");
+
+        return (File.Exists(resx) ? resx : null, Directory.Exists(uiRoot) ? uiRoot : null);
+    }
+
+    private static ImmutableArray<ChannelReadiness> ReadinessFor(IEnumerable<string> channels) =>
+    [
+        .. channels.Select(channel => new ChannelReadiness(channel, ChannelPresence.Present, ChannelEnablement.Unknown))
+    ];
+
+    private async Task AssertNoLeakedKeys(IReadOnlyList<MenuItem> items)
+    {
+        foreach (var item in items)
+        {
+            AssertFieldsClean(item.Label);
+            AssertFieldsClean(item.StatusText);
+            AssertFieldsClean(item.DisabledReason);
+            AssertFieldsClean(item.Shortcut);
+
+            if (item.Children is { } children) { await AssertNoLeakedKeys(children); }
+
+            if (item.ChildrenLoader is { } loader) { await AssertNoLeakedKeys(await loader()); }
+        }
+    }
+
+    private async Task<IReadOnlyList<MenuItem>> OpenLiveSubmenu()
+    {
+        var fileItems = await OpenMenu(Localizer["Menu_File"].Value);
+        var openItems = Item(fileItems, Localizer["Menu_File_Open"].Value).Children!;
+
+        return Item(openItems, Localizer["Menu_Open_Live"].Value).Children!;
+    }
+
+    private async Task<IReadOnlyList<MenuItem>> OpenMenu(string barLabel)
+    {
+        IReadOnlyList<MenuItem>? items = null;
+        _menuService
+            .When(menu => menu.OpenAt(
+                Arg.Any<double>(), Arg.Any<double>(), Arg.Any<IReadOnlyList<MenuItem>>(),
+                Arg.Any<bool>(), Arg.Any<bool>()))
+            .Do(call => items = call.Arg<IReadOnlyList<MenuItem>>());
+
+        var cut = Render<MenuBar>();
+        await cut.FindAll("button.menu-bar-item")
+            .Single(button => button.TextContent.Trim() == barLabel)
+            .ClickAsync(new MouseEventArgs());
+
+        Assert.NotNull(items);
+
+        return items!;
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/Menu/MenuRendererTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Menu/MenuRendererTests.cs
@@ -4,6 +4,8 @@
 using Bunit;
 using EventLogExpert.UI.Menu;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 
 namespace EventLogExpert.UI.Tests.Menu;
 
@@ -12,6 +14,29 @@ public sealed class MenuRendererTests : BunitContext
     public MenuRendererTests()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddEventLogLocalization();
+    }
+
+    [Fact]
+    public async Task AsyncSubmenu_WhileLoading_RendersLocalizedLoadingChrome()
+    {
+        var localizer = Services.GetRequiredService<IStringLocalizer<SharedResource>>();
+        var gate = new TaskCompletionSource<IReadOnlyList<MenuItem>>();
+        var items = new[] { MenuItem.AsyncSubMenu("Parent", () => gate.Task) };
+
+        var component = Render<MenuRenderer>(parameters => parameters.Add(p => p.Items, items));
+
+        var activateTask = component.Find("li.menu-item").ClickAsync(new());
+
+        component.WaitForAssertion(() =>
+        {
+            var busy = component.Find("ul[aria-busy='true']");
+            Assert.Equal(localizer["Menu_LoadingAria"].Value, busy.GetAttribute("aria-label"));
+            Assert.Equal(localizer["Menu_Loading"].Value, busy.QuerySelector(".menu-label")!.TextContent);
+        });
+
+        gate.SetResult([]);
+        await activateTask;
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Fourth incremental UI-surface localization (after FindBar #701, SettingsModal + ModalChrome #702, Dashboard #703). Moves all user-facing English on the **menu bar** behind `IStringLocalizer<SharedResource>`. Neutral English is byte-identical to today; only the string source moves to RESX.

Scope: **UI-layer-full** — the menu bar components and the shared close-all confirmation.

## Changes
- **`Menu/MenuBar.razor(.cs)`**: all top-level bars + menu-item labels (File/Edit/View/Tools/Help and their items), the two readiness status badges (`(elevate)`/`(disabled)`), the two disabled-item reasons, and the `Main menu` aria-label now resolve through RESX. The `GroupDisabledReason` const became an instance property; the static `ReadinessStatusText(ChannelReadiness)` became instance (both need the injected localizer). `@key="bar.Label"` → `@key="capturedIndex"` (a localized string is not a safe render key).
- **`Menu/MenuHost.razor(.cs)`** and **`Menu/MenuRenderer.razor(.cs)`**: the popup aria-label (`Menu`), the async-submenu busy aria-label (`Loading`), and its `Loading...` placeholder now resolve through RESX.
- **`Common/CloseAllLogsConfirmation.cs`**: now takes an `IStringLocalizer<SharedResource>` and resolves its title/body/confirm from RESX (reusing `Modal_Cancel`). It is shared chrome with **two callers** — `MenuBar` and `LogTabBar` — both updated; `LogTabBar` gains an injected localizer (its own labels stay English, a future increment).
- **`Resources/SharedResource.resx`**: ~48 new keys. Menu keys use the `Menu_*` prefix; the shared confirmation uses a neutral `CloseAllLogs_*` prefix (referenced cross-surface). Translator `<comment>`s mark file-format proper nouns (CSV/JSON/XML/Markdown), the status badges, the `>` breadcrumb in the group-disabled reason, the aria distinctions, and cross-surface reuse (Resolution & Coverage / Release Notes).

### Notable decisions
- **Keyboard-shortcut hints are localized** as whole-string keys (`Menu_Shortcut_Copy`="Ctrl+C" etc.). They are display-only and do **not** drive the bindings (those are physical key codes in `KeyboardShortcutService`), so localizing the hint cannot desync the binding; the letter is marked do-not-translate.
- **Not localized (data):** channel names (Application/System/Security) and the entire dynamic "Other Logs" tree (folder + leaf names from `GetMenuPath`) — Windows proper nouns.

## Tests
- `MenuLocalizationTests` (new): a tree-walk resource-key leak guard (menu items never reach the DOM in tests), representative label/status/disabled-reason resolution, a `[Theory]` byte-pinning all ~50 values to hardcoded English + a completeness guard vs the RESX, the "Other Logs" tree building, and the `CloseAllLogs_*` confirmation wiring.
- `MenuBarLocalizerWiringTests` (new): a sentinel localizer returning `[[key]]` proves the components actually consult the localizer, while channel names and the Other-Logs tree render verbatim.
- `MenuCultureTests` (new): qps-Ploc canary positive control, then real keys fall back to neutral English.
- `MenuHostHandoffTests` / `MenuRendererTests`: added popup-aria and async-loading-chrome DOM assertions.
- The three affected fixtures register `AddEventLogLocalization()`.

## Validation
- Full `EventLogExpert.UI.Tests`: **1669/1669**.
- MAUI head (ARM64) build: **0 warnings / 0 errors**.
- No em-dashes; English output byte-identical to pre-change.
