### PR TITLE
Default Light/Dark to a neutral palette; add opt-in Modern themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A Windows Event Log viewer for tech support and IT professionals.
 * Live event channels with auto-discovery (admin-only channels disabled when not elevated), `Continuously Update`, and a `Load New Events` buffered mode.
 * Provider Databases — load `.db` files captured on another machine so its `.evtx` files resolve descriptions and task categories correctly.
 * In-line description previews in the table; on-demand event XML in the Details pane.
-* Configurable Ctrl+C copy mode (`Default`, `Simple`, `XML`, `Full`); System / Light / Dark theme.
+* Configurable Ctrl+C copy mode (`Default`, `Simple`, `XML`, `Full`); System / Light / Dark themes (neutral Event Viewer-style) plus opt-in Modern Light / Modern Dark (blue-accent) themes.
 * In-app Release Notes and Debug Log viewer; opt-in pre-release update channel.
 
 For more information, check our [docs](docs/Home.md).

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -41,7 +41,7 @@ When `True`, the Details pane re-expands every time the selection changes, even 
 
 ### Theme
 
-`Follow System` (default), `Light`, or `Dark`. `Follow System` tracks the current Windows app-mode preference and switches with it.
+`Follow System` (default), `Light`, `Dark`, `Modern Light`, or `Modern Dark`. `Follow System` tracks the current Windows app-mode preference and switches with it. The default `Light`/`Dark` themes use a clean, neutral Microsoft Management Console / Windows Event Viewer-style palette — neutral gray chrome, black/gray body text, and blue selection. The `Modern` themes are an opt-in alternative that render the app's original blue-accent identity (accent-colored body text and brighter blue bars).
 
 ### Keyboard Copy Behavior
 

--- a/src/EventLogExpert.Localization/Resources/SharedResource.resx
+++ b/src/EventLogExpert.Localization/Resources/SharedResource.resx
@@ -142,6 +142,12 @@
   <data name="Settings_Theme_Dark" xml:space="preserve">
     <value>Dark</value>
   </data>
+  <data name="Settings_Theme_ModernLight" xml:space="preserve">
+    <value>Modern Light</value>
+  </data>
+  <data name="Settings_Theme_ModernDark" xml:space="preserve">
+    <value>Modern Dark</value>
+  </data>
   <!-- Keyboard-copy-format dropdown options (map to EventCopyFormat). Xml/Markdown are format proper nouns translators may leave as-is. -->
   <data name="Settings_CopyFormat_Default" xml:space="preserve">
     <value>Default</value>

--- a/src/EventLogExpert.Runtime/Settings/Theme.cs
+++ b/src/EventLogExpert.Runtime/Settings/Theme.cs
@@ -7,5 +7,7 @@ public enum Theme
 {
     System,
     Light,
-    Dark
+    Dark,
+    ModernLight,
+    ModernDark
 }

--- a/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.css
+++ b/src/EventLogExpert.UI/DatabaseTools/Tabs/ManageDatabasesTab.razor.css
@@ -136,6 +136,27 @@
     font-size: .9rem;
 }
 
+/* Buttons on the statusbar-colored save/bulk strips: white on-bar text + the white --focus-on-statusbar
+   ring so they clear WCAG AA on the navy/steel (and Modern blue) bars, where their accent/semantic text
+   and an accent focus ring would be too low-contrast. */
+.manage-databases-save-strip ::deep .button,
+.manage-databases-bulk-strip ::deep .button {
+    color: var(--text-on-statusbar);
+}
+
+.manage-databases-save-strip ::deep .button:focus-visible,
+.manage-databases-bulk-strip ::deep .button:focus-visible {
+    outline-color: var(--focus-on-statusbar);
+}
+
+/* Override the global brightness:hover (which dims the white text below AA on the dark bars) with a
+   darkening overlay, so the text stays full white. */
+.manage-databases-save-strip ::deep .button:hover,
+.manage-databases-bulk-strip ::deep .button:hover {
+    filter: none;
+    background-color: color-mix(in srgb, var(--clr-black) 20%, transparent);
+}
+
 @keyframes manage-databases-bulk-strip-fade-in {
     from { opacity: 0; transform: translateY(8px); }
     to { opacity: 1; transform: translateY(0); }

--- a/src/EventLogExpert.UI/Layout/MainLayout.razor.css
+++ b/src/EventLogExpert.UI/Layout/MainLayout.razor.css
@@ -11,4 +11,6 @@
     text-decoration: none;
 
     &:focus { top: 0; }
+
+    &:focus-visible { outline-color: var(--focus-on-statusbar); }
 }

--- a/src/EventLogExpert.UI/Layout/MainLayout.razor.js
+++ b/src/EventLogExpert.UI/Layout/MainLayout.razor.js
@@ -2,12 +2,13 @@
 // // Licensed under the MIT License.
 
 // Theme application. Called from MainLayout on first render and whenever
-// the user changes the Theme setting. Accepts "system", "light", or "dark"
-// (case-insensitive). For "system", the data-theme attribute is removed so
-// that the CSS prefers-color-scheme media query takes over.
+// the user changes the Theme setting. Accepts "system", "light", "dark",
+// "modernlight", or "moderndark" (case-insensitive). For "system", the
+// data-theme attribute is removed so that the CSS prefers-color-scheme media
+// query takes over.
 export function setTheme(theme) {
     const value = (theme || "system").toString().toLowerCase();
-    if (value === "light" || value === "dark") {
+    if (value === "light" || value === "dark" || value === "modernlight" || value === "moderndark") {
         document.documentElement.setAttribute("data-theme", value);
     } else {
         document.documentElement.removeAttribute("data-theme");

--- a/src/EventLogExpert.UI/LogTable/Resolution/ResolutionCoverageModal.razor.css
+++ b/src/EventLogExpert.UI/LogTable/Resolution/ResolutionCoverageModal.razor.css
@@ -125,7 +125,7 @@
     position: sticky;
     top: 0;
     font-weight: 600;
-    background: var(--background-color, #1e1e1e);
+    background: var(--background-darkgray);
     border-bottom: 1px solid var(--border-color, rgba(128, 128, 128, 0.3));
 }
 
@@ -362,7 +362,7 @@
     position: sticky;
     top: 0;
     font-weight: 600;
-    background: var(--background-color, #1e1e1e);
+    background: var(--background-darkgray);
 }
 
 .resolution-detail-idrow button {

--- a/src/EventLogExpert.UI/Menu/MenuBar.razor.css
+++ b/src/EventLogExpert.UI/Menu/MenuBar.razor.css
@@ -28,6 +28,6 @@
 .menu-bar ::deep .menu-bar-item:focus-visible {
     background-color: var(--menu-hover-overlay);
     color: var(--text-on-statusbar);
-    outline: 2px solid var(--clr-lightblue);
+    outline: 2px solid var(--focus-on-statusbar);
     outline-offset: -2px;
 }

--- a/src/EventLogExpert.UI/Modal/ModalChrome.razor.css
+++ b/src/EventLogExpert.UI/Modal/ModalChrome.razor.css
@@ -4,7 +4,7 @@ dialog {
     max-width: var(--modal-max-width, none);
     overflow: hidden;
 
-    color: var(--clr-lightblue);
+    color: var(--text-primary);
     border-color: var(--clr-statusbar);
     background-color: var(--background-dark);
 }
@@ -44,7 +44,7 @@ dialog:not(:modal) {
     white-space: nowrap;
     text-overflow: ellipsis;
     font-size: var(--font-size-lg);
-    color: var(--clr-lightblue);
+    color: var(--text-primary);
 }
 
 .dialog-header ::deep .dialog-close {
@@ -97,7 +97,7 @@ dialog[data-body-layout="content"] .dialog-body {
     max-height: calc(100vh - 2rem);
     padding: 1.25rem 1.5rem;
 
-    color: var(--clr-lightblue);
+    color: var(--text-primary);
     background-color: var(--background-dark);
     border: 1px solid var(--clr-statusbar);
     border-radius: .25rem;
@@ -112,7 +112,7 @@ dialog[data-body-layout="content"] .dialog-body {
     white-space: nowrap;
     text-overflow: ellipsis;
     font-size: var(--font-size-lg);
-    color: var(--clr-lightblue);
+    color: var(--text-primary);
 }
 
 .inline-alert-message {

--- a/src/EventLogExpert.UI/wwwroot/Banner/banner.css
+++ b/src/EventLogExpert.UI/wwwroot/Banner/banner.css
@@ -14,6 +14,22 @@
     box-shadow: var(--shadow-modal);
 }
 
+/* Focus rings on banner controls use the banner variant's own AA-contrasted foreground token, so they
+   stay visible even on controls (e.g. plain buttons) that set their own text color - currentColor would
+   otherwise pick up the control's accent, which is too low-contrast on the fill. */
+.banner-error :focus-visible,
+.banner-critical :focus-visible,
+.banner-warning :focus-visible,
+.banner-attention :focus-visible {
+    outline-color: var(--clr-on-status-fill);
+}
+
+.banner-info :focus-visible,
+.banner-upgrade-progress :focus-visible,
+.banner-export-progress :focus-visible {
+    outline-color: var(--text-on-statusbar);
+}
+
 .banner-error,
 .banner-critical {
     background-color: var(--clr-red);

--- a/src/EventLogExpert.UI/wwwroot/app.css
+++ b/src/EventLogExpert.UI/wwwroot/app.css
@@ -10,14 +10,14 @@
 
     /* Theme-aware palette. light-dark(lightValue, darkValue) resolves based on
        the element's used color-scheme. */
-    --clr-lightblue:    light-dark(#155A9E, #9CDCFE);
+    --clr-lightblue:    light-dark(#0A4C8C, #6FB2F5);
     --clr-lightgray:    light-dark(#4A4A4A, #A4B9C0);
-    --clr-red:          light-dark(#C0392B, #EF523B);
+    --clr-red:          light-dark(#A02020, #FF7059);
     --text-error:       light-dark(#A02020, var(--clr-red));
-    --clr-green:        light-dark(#1E7E34, #5AC358);
-    --clr-yellow:       light-dark(#8A6D00, #F8C84B);
+    --clr-green:        light-dark(#14622A, #5AC358);
+    --clr-yellow:       light-dark(#6A5300, #F8C84B);
     --clr-placeholder:  light-dark(#6B6B6B, #A3A1A1);
-    --clr-statusbar:    light-dark(#2E50C0, #3C64E7);
+    --clr-statusbar:    light-dark(#0A246A, #4472C4);
 
     /* Find highlight: highlighter-yellow background fill for the current match's inline marks; #1A1A1A text clears WCAG AA on both themes. */
     --clr-find:    light-dark(#FFE066, #F8C84B);
@@ -30,19 +30,16 @@
     --clr-status-fill-high:     light-dark(#C0392B, #EF523B);
     --clr-on-status-high:       light-dark(#FFF, #1A1A1A);
 
-    --background-dark:     light-dark(#E0E0E0, #222222);
-    --background-darkgray: light-dark(#CECECE, #353535);
+    --background-dark:     light-dark(#F0F0F0, #222222);
+    --background-darkgray: light-dark(#E1E1E1, #353535);
 
-    /* Shared accent for Toggle + OptionSelect. Light is darkened from --clr-lightblue
-       so the on-state hits WCAG 1.4.3 AA against --background-darkgray (#14599D on
-       #CECECE = 4.53:1; dark #9CDCFE on #353535 = 8.23:1). */
-    --toggle-accent: light-dark(#14599D, var(--clr-lightblue));
+    --toggle-accent: light-dark(#0A4C8C, #6FB2F5);
 
     /* Recessed surface used for content wells (e.g. the trash strip exposed
        behind a database row when it slides aside). Always darker than
        --background-dark in both schemes so the well reads as cut into the
        surrounding chrome rather than lifted on top of it. */
-    --surface-inset:       light-dark(#C8C8C8, #161616);
+    --surface-inset:       light-dark(#D0D0D0, #161616);
 
     /* Shared menu metrics. The menu bar height drives the MenuHost overlay offset so
        the bar strip stays clickable while a menu is open. */
@@ -61,19 +58,22 @@
        (--highlight-light* colors). */
     --clr-on-light-highlight: light-dark(#1A1A1A, var(--background-darkgray));
     /* Always-dark text used on the dark-mode branch of the Mid+Dark highlight
-       tiers. The re-toned dark-mode hexes sit at L_rel >= 0.22 where #353535
-       (--clr-on-light-highlight dark branch) only reaches ~3.2:1; #1A1A1A
-       clears 4.5:1 from the WCAG floor up. */
+       tiers. */
     --clr-on-dark-highlight: #1A1A1A;
-    /* Default body text color. Component CSS should reference this rather than
-       hardcoding white/black. */
-    --text-primary: var(--clr-lightblue);
+    /* Default body text color, decoupled from the accent so the default (neutral)
+       themes read as black/gray while selection and links stay blue. Component CSS
+       should reference this rather than hardcoding white/black. */
+    --text-primary: light-dark(#1A1A1A, #DCDCDC);
     /* Inverted text for badges / scrollbar thumbs that always appear on the
        statusbar (blue) background. */
     --text-on-statusbar: var(--clr-white);
     --clr-on-status-fill: light-dark(var(--clr-white), #1A1A1A);
+    /* Focus-ring color for controls that sit ON the statusbar-colored bars (e.g. the menu bar).
+       White in every theme: an accent ring is too low-contrast on the Modern themes' blue bars
+       (~1.01:1), so those themes intentionally inherit this rather than override it. */
+    --focus-on-statusbar: var(--clr-white);
     /* Muted/secondary text (disabled menu items, shortcut hints, etc.). */
-    --text-secondary: light-dark(#555, var(--clr-lightgray));
+    --text-secondary: light-dark(#454545, #B0B0B0);
 
     /* Surface chrome tokens. Shadow color components are extracted so the
        light/dark variant can swap while the geometry stays in one place. */
@@ -112,20 +112,35 @@
 
 :root[data-theme="dark"]  { color-scheme: dark; }
 
-/* -----------------------------------------------------------------------------
-   Highlight palette.
-   Adding or removing a color requires only updating this block (and the
-   matching enum / serialization). All consumers (table rows, color box,
-   color dropdown items) read --hl-bg / --hl-fg from these declarations.
+/* Modern Light: blue body text on medium gray, royal-blue bars. */
+:root[data-theme="modernlight"] {
+    color-scheme: light;
 
-   Light-tier rules use a single hex (passes WCAG AA in both themes with
-   --clr-on-light-highlight). Mid+Dark tier rules use light-dark() so each
-   theme gets a hex that clears 4.5:1 with its mode-appropriate text color
-   (white in light, --clr-on-dark-highlight in dark). Dark-mode hexes are
-   re-toned to L_rel >= 0.22 (WCAG SC 1.4.11 floor vs odd row #353535) using
-   a hue-locked white/black-mix derivation that preserves original hue within
-   +/-8 deg.
-   -------------------------------------------------------------------------- */
+    --background-dark: #E0E0E0;
+    --background-darkgray: #CECECE;
+    --surface-inset: #C8C8C8;
+
+    --clr-lightblue: #14599D;
+    --clr-statusbar: #2E50C0;
+    --toggle-accent: #14599D;
+
+    --text-primary: var(--clr-lightblue);
+    --text-secondary: #555;
+}
+
+/* Modern Dark: backgrounds already match the neutral base dark, so only the blue
+   chrome + accent-colored text are restored. */
+:root[data-theme="moderndark"] {
+    color-scheme: dark;
+
+    --clr-lightblue: #9CDCFE;
+    --clr-statusbar: #3C64E7;
+    --toggle-accent: var(--clr-lightblue);
+
+    --text-primary: var(--clr-lightblue);
+    --text-secondary: var(--clr-lightgray);
+}
+
 [data-highlight="lightred"]     { --hl-bg: #EE8F86; --hl-fg: var(--clr-on-light-highlight); }
 [data-highlight="red"]          { --hl-bg: light-dark(#D03B2D, #FF6769); --hl-fg: light-dark(var(--clr-white), var(--clr-on-dark-highlight)); }
 [data-highlight="darkred"]      { --hl-bg: light-dark(#73190E, #FF1A09); --hl-fg: light-dark(var(--clr-white), var(--clr-on-dark-highlight)); }
@@ -356,13 +371,14 @@ input[type="text"].input.dialog-input { padding: .25rem 0; }
     .input.filter-datetime::-webkit-calendar-picker-indicator { filter: invert(1); }
 
 /* In light mode the page is bright, so the icon is naturally dark - don't
-   re-invert it. Applies to explicit light and system-light only. */
-:root[data-theme="light"] .input.filter-datetime::-webkit-calendar-picker-indicator {
+   re-invert it. Applies to explicit light / modern-light and system-light only. */
+:root[data-theme="light"] .input.filter-datetime::-webkit-calendar-picker-indicator,
+:root[data-theme="modernlight"] .input.filter-datetime::-webkit-calendar-picker-indicator {
     filter: none;
 }
 
 @media (prefers-color-scheme: light) {
-    :root:not([data-theme="dark"]):not([data-theme="light"]) .input.filter-datetime::-webkit-calendar-picker-indicator {
+    :root:not([data-theme="dark"]):not([data-theme="light"]):not([data-theme="moderndark"]):not([data-theme="modernlight"]) .input.filter-datetime::-webkit-calendar-picker-indicator {
         filter: none;
     }
 }
@@ -432,7 +448,6 @@ input[type="text"].input.dialog-input { padding: .25rem 0; }
     background: color-mix(in srgb, var(--clr-statusbar) 10%, transparent);
 }
 
-/* Compact icon-only buttons. Maintain WCAG 2.5.5 AA 24x24 hit target. */
 .button.icon-button {
     display: inline-flex;
     align-items: center;

--- a/src/EventLogExpert/App.xaml
+++ b/src/EventLogExpert/App.xaml
@@ -6,7 +6,7 @@
     <Application.Resources>
         <ResourceDictionary>
 
-            <Color x:Key="PageBackgroundColor">#3C64E7</Color>
+            <Color x:Key="PageBackgroundColor">#222222</Color>
             <Color x:Key="PrimaryTextColor">#FFF</Color>
 
             <Style TargetType="NavigationPage">

--- a/src/EventLogExpert/App.xaml.cs
+++ b/src/EventLogExpert/App.xaml.cs
@@ -36,6 +36,7 @@ public sealed partial class App : Application
 
         ApplyNativeTheme(_settings.Theme);
         _settings.ThemeChanged += OnThemeChanged;
+        RequestedThemeChanged += OnRequestedThemeChanged;
 
         _mainPage = new MainPage(
             filterLibraryCommands,
@@ -65,13 +66,44 @@ public sealed partial class App : Application
         return window;
     }
 
-    private void ApplyNativeTheme(Theme theme) =>
+    // Keep the native page background (briefly visible before the WebView paints, and as the window
+    // backdrop) matched to the active theme so it never flashes an off-theme color. Split from
+    // ApplyNativeTheme so the OS-theme-change handler can refresh it WITHOUT re-setting UserAppTheme.
+    private void ApplyNativeBackground(Theme theme)
+    {
+        var backgroundHex = theme switch
+        {
+            Theme.ModernLight => "#E0E0E0",
+            Theme.ModernDark => "#222222",
+            Theme.Light => "#F0F0F0",
+            Theme.Dark => "#222222",
+            _ => RequestedTheme == AppTheme.Dark ? "#222222" : "#F0F0F0",
+        };
+
+        Resources["PageBackgroundColor"] = Color.FromArgb(backgroundHex);
+    }
+
+    private void ApplyNativeTheme(Theme theme)
+    {
         UserAppTheme = theme switch
         {
-            Theme.Light => AppTheme.Light,
-            Theme.Dark => AppTheme.Dark,
+            Theme.Light or Theme.ModernLight => AppTheme.Light,
+            Theme.Dark or Theme.ModernDark => AppTheme.Dark,
             _ => AppTheme.Unspecified,
         };
+
+        ApplyNativeBackground(theme);
+    }
+
+    private void OnRequestedThemeChanged(object? sender, AppThemeChangedEventArgs e) =>
+        // Following the OS (Theme.System): a Windows light/dark switch changes RequestedTheme without
+        // raising ISettingsService.ThemeChanged, so refresh only the native backdrop (not UserAppTheme,
+        // which would re-enter this event) so it keeps tracking the OS. The Theme re-check runs on the UI
+        // thread so an explicit-theme change made while this callback is queued is not overwritten.
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            if (_settings.Theme == Theme.System) { ApplyNativeBackground(Theme.System); }
+        });
 
     private void OnThemeChanged() =>
         // ThemeChanged may be raised from non-UI threads (Blazor JSInterop /

--- a/src/EventLogExpert/MainPage.xaml.cs
+++ b/src/EventLogExpert/MainPage.xaml.cs
@@ -87,8 +87,8 @@ public sealed partial class MainPage : ContentPage, IDisposable
         // Align WebView2's prefers-color-scheme with the user's Theme so "System" follows the OS and explicit Light/Dark stays consistent.
         _coreWebView?.Profile.PreferredColorScheme = theme switch
         {
-            Theme.Light => CoreWebView2PreferredColorScheme.Light,
-            Theme.Dark => CoreWebView2PreferredColorScheme.Dark,
+            Theme.Light or Theme.ModernLight => CoreWebView2PreferredColorScheme.Light,
+            Theme.Dark or Theme.ModernDark => CoreWebView2PreferredColorScheme.Dark,
             _ => CoreWebView2PreferredColorScheme.Auto,
         };
     }
@@ -157,12 +157,13 @@ public sealed partial class MainPage : ContentPage, IDisposable
 
         ApplyWebViewTheme(_settings.Theme);
 
-        var themeSettings = _settings.Theme switch
-        {
-            Theme.Light => "light",
-            Theme.Dark => "dark",
-            _ => null,
-        };
+        // Match MainLayout.razor.js: the data-theme attribute is the lowercased enum name for every
+        // explicit theme (e.g. "modernlight"), and absent for System so the CSS prefers-color-scheme
+        // rules take over. Keeping this derived (rather than a per-value switch) avoids drift as themes
+        // are added.
+        var themeSettings = _settings.Theme == Theme.System ?
+            null :
+            _settings.Theme.ToString().ToLowerInvariant();
 
         var resolvedCulture = ContentCulture.Resolve(CultureInfo.CurrentUICulture, ContentCulture.SupportedUiCultures);
         var script = DocumentInitScript.Build(themeSettings, ContentCulture.DirectionOf(resolvedCulture), resolvedCulture.Name);

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Settings/SettingsServiceTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Settings/SettingsServiceTests.cs
@@ -596,6 +596,8 @@ public sealed class SettingsServiceTests
     [InlineData(Theme.System)]
     [InlineData(Theme.Light)]
     [InlineData(Theme.Dark)]
+    [InlineData(Theme.ModernLight)]
+    [InlineData(Theme.ModernDark)]
     public void Theme_WhenSetToEachValue_ShouldPersistCorrectly(Theme theme)
     {
         // Arrange

--- a/tests/Unit/EventLogExpert.UI.Tests/Common/Interop/DocumentInitScriptTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Common/Interop/DocumentInitScriptTests.cs
@@ -1,6 +1,7 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Runtime.Settings;
 using EventLogExpert.UI.Common.Interop;
 
 namespace EventLogExpert.UI.Tests.Common.Interop;
@@ -19,6 +20,16 @@ public sealed class DocumentInitScriptTests
             script);
     }
 
+    [Theory]
+    [InlineData("modernlight")]
+    [InlineData("moderndark")]
+    public void Build_WithModernTheme_EmbedsThemeAttribute(string theme)
+    {
+        var script = DocumentInitScript.Build(theme, "ltr", "en");
+
+        Assert.Contains($"root.setAttribute('data-theme','{theme}');", script);
+    }
+
     [Fact]
     public void Build_WithTheme_SetsThemeDirAndLang()
     {
@@ -29,5 +40,21 @@ public sealed class DocumentInitScriptTests
             "root.setAttribute('data-theme','dark');root.setAttribute('dir','rtl');root.setAttribute('lang','ar');" +
             "return true;}if(!apply()){document.addEventListener('DOMContentLoaded',apply);}})();",
             script);
+    }
+
+    [Fact]
+    public void EveryExplicitTheme_MapsToASupportedDataThemeAttribute()
+    {
+        // The data-theme attribute the app writes (MainPage pre-render + MainLayout.razor.js setTheme)
+        // is the lowercased enum name for every non-System theme. Keep this closed set in lockstep with
+        // the CSS palette blocks in app.css and the JS allowlist in MainLayout.razor.js.
+        string[] supported = ["light", "dark", "modernlight", "moderndark"];
+
+        foreach (var theme in Enum.GetValues<Theme>())
+        {
+            if (theme == Theme.System) { continue; }
+
+            Assert.Contains(theme.ToString().ToLowerInvariant(), supported);
+        }
     }
 }


### PR DESCRIPTION
## Summary
Changes the default **Light / Dark / System** themes to a clean, neutral Microsoft Management Console / Windows Event Viewer-style palette — neutral gray chrome, black/gray body text, and theme-tuned blue bars and selection. The app's original blue-accent design (accent-colored body text, royal-blue bars) is preserved as two opt-in themes, **Modern Light** and **Modern Dark**.

## Motivation
For a dense event-log data grid read in long sessions, neutral body text is lower cognitive load and more legible than saturated accent-blue text (which can read like links and compete with severity/selection colors), and it matches what users expect coming from the Windows Event Viewer. The distinctive blue identity remains available as an opt-in.

## Changes
- `Theme` enum gains `ModernLight` and `ModernDark`.
- `app.css`: the base palette is now neutral (via `light-dark()`); the blue design moves to `[data-theme="modernlight"|"moderndark"]` override blocks. The dark backgrounds are unchanged, so the tuned highlight-row palette is preserved and Modern Dark matches the previously-shipped Dark.
- Re-tuned the shared status colors (`--clr-red/green/yellow`) so warning/error/success **text** clears WCAG AA on secondary surfaces in both light and dark modes — a pre-existing gap the neutral surfaces surfaced (fills, which carry their own on-fill text, are unaffected).
- Native theme wiring (`App.xaml.cs`, `MainPage.xaml.cs`), the theme JS allowlist, and localized labels updated. The native window background now tracks the active theme (removing a startup color flash) and refreshes on OS light/dark changes while following System.
- Docs (`Settings.md`, `README.md`) updated.

## Accessibility
Every foreground/background pair clears WCAG AA (>= 4.5:1 text, >= 3:1 UI) in all five themes. Along with the status-color re-tune above, this fixed contrast in shared components: coverage-modal sticky headers, statusbar-strip button text, and focus rings on statusbar-colored controls (menu bar, banners, skip link, database strips). Modern Light/Dark closely reproduce the original blue design, with small AA adjustments to Modern Light (accent `#14599D`, white on-bar focus ring).

## Testing
- .NET MAUI app builds clean.
- Unit tests green: Runtime 65/65, UI 15/15 (theme persistence, localized-label resolution, and a `data-theme` attribute-contract guard covering all five themes).
