### PR TITLE
Localize the filter pane UI and scenario-export messages

### DIFF
--- a/src/EventLogExpert.Localization/Resources/SharedResource.resx
+++ b/src/EventLogExpert.Localization/Resources/SharedResource.resx
@@ -1775,4 +1775,279 @@
   <data name="Histogram_BinCursor" xml:space="preserve"><value>{0:g} to {1:g}: {2} {3}.</value></data>
   <data name="Histogram_BinCursor_Spike" xml:space="preserve"><value>{0:g} to {1:g}: {2} {3}, spike.</value></data>
   <data name="Histogram_BinCursor_Breakdown" xml:space="preserve"><value>{0:g} to {1:g}: {2} {3} ({4}).</value></data>
-  <data name="Histogram_BinCursor_Spike_Breakdown" xml:space="preserve"><value>{0:g} to {1:g}: {2} {3} ({4}), spike.</value></data></root>
+  <data name="Histogram_BinCursor_Spike_Breakdown" xml:space="preserve"><value>{0:g} to {1:g}: {2} {3} ({4}), spike.</value></data>  <!-- Filter pane localization. Counts remain raw and ungrouped for byte-identical en-US output. -->
+  <data name="FilterPane_AddBasicTitle" xml:space="preserve">
+    <value>Add Basic filter (use chevron for Advanced or Recent)</value>
+  </data>
+  <data name="FilterPane_Action_AddFilter" xml:space="preserve">
+    <value>Add Filter</value>
+  </data>
+  <data name="FilterPane_AddMenuAria" xml:space="preserve">
+    <value>Choose filter mode</value>
+  </data>
+  <data name="FilterPane_Action_AddExclusion" xml:space="preserve">
+    <value>Add Exclusion</value>
+  </data>
+  <data name="FilterPane_Action_AddDateFilter" xml:space="preserve">
+    <value>Add Date Filter</value>
+  </data>
+  <data name="FilterPane_Action_ApplyFilterSet" xml:space="preserve">
+    <value>Apply Filter Set</value>
+  </data>
+  <data name="FilterPane_Action_ApplyScenario" xml:space="preserve">
+    <value>Apply Scenario</value>
+  </data>
+  <data name="FilterPane_ActiveFilters" xml:space="preserve">
+    <value>[Active Filters: {0}]</value>
+    <comment>{0} is the raw, ungrouped active filter count.</comment>
+  </data>
+  <data name="FilterPane_SaveAsFilterSet_Aria" xml:space="preserve">
+    <value>Save as Filter Set</value>
+  </data>
+  <data name="FilterPane_SaveAsFilterSet_EmphasisLabel" xml:space="preserve">
+    <value>Save as Filter Set</value>
+  </data>
+  <data name="FilterPane_SaveAsFilterSet_TitleEnabled" xml:space="preserve">
+    <value>Save as Filter Set...</value>
+  </data>
+  <data name="FilterPane_SaveAsFilterSet_TitleDisabled" xml:space="preserve">
+    <value>No filters to save</value>
+  </data>
+  <data name="FilterPane_ClearAll_Aria" xml:space="preserve">
+    <value>Clear All Filters</value>
+  </data>
+  <data name="FilterPane_ClearAll_TitleEnabled" xml:space="preserve">
+    <value>Clear All Filters...</value>
+  </data>
+  <data name="FilterPane_ClearAll_TitleDisabled" xml:space="preserve">
+    <value>No filters to clear</value>
+  </data>
+  <data name="FilterPane_OpenLibrary_Aria" xml:space="preserve">
+    <value>Open Filter Library</value>
+  </data>
+  <data name="FilterPane_OpenLibrary_Title" xml:space="preserve">
+    <value>Open Filter Library</value>
+  </data>
+  <data name="FilterPane_CopyScenarioJson_Aria" xml:space="preserve">
+    <value>Copy scenario JSON</value>
+  </data>
+  <data name="FilterPane_CopyScenarioJson_Title" xml:space="preserve">
+    <value>Copy current filter rows as scenario-catalog JSON</value>
+  </data>
+  <data name="FilterPane_SaveScenarioJson_Aria" xml:space="preserve">
+    <value>Save scenario JSON</value>
+  </data>
+  <data name="FilterPane_SaveScenarioJson_Title" xml:space="preserve">
+    <value>Save current filter rows as scenario-catalog JSON...</value>
+  </data>
+  <data name="FilterPane_ScenarioExport_HintDisabled" xml:space="preserve">
+    <value>Enable a filter before exporting as a scenario.</value>
+  </data>
+  <data name="FilterPane_SaveFilterSet_HintDisabled" xml:space="preserve">
+    <value>Add a filter before saving as a Filter Set.</value>
+  </data>
+  <data name="FilterPane_ClearFilters_HintDisabled" xml:space="preserve">
+    <value>There are no filters to clear.</value>
+  </data>
+  <data name="FilterPane_FilterList_ExpandedAria" xml:space="preserve">
+    <value>Filters Expanded</value>
+  </data>
+  <data name="FilterPane_FilterList_CollapsedAria" xml:space="preserve">
+    <value>Filters Collapsed</value>
+  </data>
+  <data name="FilterPane_Date_AfterLabel" xml:space="preserve">
+    <value>After:</value>
+  </data>
+  <data name="FilterPane_Date_AfterAria" xml:space="preserve">
+    <value>After</value>
+  </data>
+  <data name="FilterPane_Date_BeforeLabel" xml:space="preserve">
+    <value>Before:</value>
+  </data>
+  <data name="FilterPane_Date_BeforeAria" xml:space="preserve">
+    <value>Before</value>
+  </data>
+  <data name="FilterPane_Date_QuickRangeLabel" xml:space="preserve">
+    <value>Quick range:</value>
+  </data>
+  <data name="FilterPane_Date_QuickRangeAria" xml:space="preserve">
+    <value>Quick date range</value>
+  </data>
+  <data name="FilterPane_Action_Apply" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="FilterPane_Action_Remove" xml:space="preserve">
+    <value>Remove</value>
+  </data>
+  <data name="FilterPane_Action_Edit" xml:space="preserve">
+    <value>Edit</value>
+  </data>
+  <data name="FilterPane_Action_Disable" xml:space="preserve">
+    <value>Disable</value>
+  </data>
+  <data name="FilterPane_Action_Enable" xml:space="preserve">
+    <value>Enable</value>
+  </data>
+  <data name="FilterPane_FilterSet_TagsLabel" xml:space="preserve">
+    <value>Tags:</value>
+  </data>
+  <data name="FilterPane_FilterSet_TagSelectAria" xml:space="preserve">
+    <value>Narrow filter sets by tag</value>
+  </data>
+  <data name="FilterPane_FilterSet_AllTags" xml:space="preserve">
+    <value>All tags</value>
+  </data>
+  <data name="FilterPane_FilterSet_Label" xml:space="preserve">
+    <value>Filter Set:</value>
+  </data>
+  <data name="FilterPane_FilterSet_SelectAria" xml:space="preserve">
+    <value>Filter Set</value>
+  </data>
+  <data name="FilterPane_FilterSetFilterCount_One" xml:space="preserve">
+    <value>{0} filter</value>
+    <comment>{0} is the raw, ungrouped filter count.</comment>
+  </data>
+  <data name="FilterPane_FilterSetFilterCount_Many" xml:space="preserve">
+    <value>{0} filters</value>
+    <comment>{0} is the raw, ungrouped filter count.</comment>
+  </data>
+  <data name="FilterPane_FilterSetDetail_WithTags" xml:space="preserve">
+    <value>{0} · {1}</value>
+    <comment>{0} is the localized filter count; {1} is the comma-joined tag list data.</comment>
+  </data>
+  <data name="FilterPane_FilterSetOptionTitle" xml:space="preserve">
+    <value>{0} ({1})</value>
+    <comment>{0} is the filter set name data; {1} is the localized filter-set detail.</comment>
+  </data>
+  <data name="FilterPane_FilterSetOptionMeta" xml:space="preserve">
+    <value>({0})</value>
+    <comment>{0} is the localized filter-set detail shown in the visible option row.</comment>
+  </data>
+  <data name="FilterPane_FilterSet_ReplaceAria" xml:space="preserve">
+    <value>Replace filters with selected filter set</value>
+  </data>
+  <data name="FilterPane_Action_Replace" xml:space="preserve">
+    <value>Replace</value>
+  </data>
+  <data name="FilterPane_FilterSetEmpty_WithSavableFilters" xml:space="preserve">
+    <value>No saved filter sets yet - use {0} on the right to create one from the current pane.</value>
+    <comment>{0} is the emphasized Save as Filter Set control name; translators may move it.</comment>
+  </data>
+  <data name="FilterPane_FilterSetEmpty_NoSavableFilters" xml:space="preserve">
+    <value>No saved filter sets yet. Add and apply filters first, then use {0} on the right to create one.</value>
+    <comment>{0} is the emphasized Save as Filter Set control name; translators may move it.</comment>
+  </data>
+  <data name="FilterPane_Action_Cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="FilterPane_Scenario_CategoryLabel" xml:space="preserve">
+    <value>Category:</value>
+  </data>
+  <data name="FilterPane_Scenario_CategoryAria" xml:space="preserve">
+    <value>Category</value>
+  </data>
+  <data name="FilterPane_Scenario_Label" xml:space="preserve">
+    <value>Scenario:</value>
+  </data>
+  <data name="FilterPane_Scenario_SelectAria" xml:space="preserve">
+    <value>Scenario</value>
+  </data>
+  <data name="FilterPane_Scenario_OptionTitle" xml:space="preserve">
+    <value>{0} - {1}</value>
+    <comment>{0} is the localized scenario category; {1} is scenario purpose data.</comment>
+  </data>
+  <data name="FilterPane_Scenario_ReplaceAria" xml:space="preserve">
+    <value>Replace filters with selected scenario</value>
+  </data>
+  <data name="FilterPane_Scenario_EmptyNoMatches" xml:space="preserve">
+    <value>No scenarios match the loaded logs.</value>
+  </data>
+  <data name="FilterPane_AddMenu_Basic" xml:space="preserve">
+    <value>Basic</value>
+  </data>
+  <data name="FilterPane_AddMenu_Advanced" xml:space="preserve">
+    <value>Advanced</value>
+  </data>
+  <data name="FilterPane_AddMenu_Recent" xml:space="preserve">
+    <value>Recent</value>
+  </data>
+  <data name="FilterPane_Announcement_LoadFailedRetryViaModal" xml:space="preserve">
+    <value>Filter library failed to load. Open Filter Library to retry.</value>
+  </data>
+  <data name="FilterPane_Announcement_LoadingTryAgain" xml:space="preserve">
+    <value>Filter library is still loading. Please try again.</value>
+  </data>
+  <data name="FilterPane_Announcement_RecentNoneAvailable" xml:space="preserve">
+    <value>No recent filters yet - apply a Basic or Advanced filter to populate.</value>
+  </data>
+  <data name="FilterPane_Announcement_SelectedFilterSetMissing" xml:space="preserve">
+    <value>Selected filter set no longer exists.</value>
+  </data>
+  <data name="FilterPane_Announcement_SelectedScenarioMissing" xml:space="preserve">
+    <value>Selected scenario no longer matches the loaded logs.</value>
+  </data>
+  <data name="FilterPane_ClearConfirm_Message_One" xml:space="preserve">
+    <value>Clear 1 filter? This cannot be undone.</value>
+  </data>
+  <data name="FilterPane_ClearConfirm_Message_Many" xml:space="preserve">
+    <value>Clear {0} filters? This cannot be undone.</value>
+    <comment>{0} is the raw, ungrouped filter count.</comment>
+  </data>
+  <data name="FilterPane_ClearConfirm_Title" xml:space="preserve">
+    <value>Clear All Filters</value>
+  </data>
+  <data name="FilterPane_Action_Clear" xml:space="preserve">
+    <value>Clear</value>
+  </data>
+  <data name="FilterPane_CopyFilterSuccess" xml:space="preserve">
+    <value>Filter copied to the clipboard as scenario JSON.</value>
+  </data>
+  <data name="FilterPane_CopyScenarioSuccess" xml:space="preserve">
+    <value>Scenario JSON copied to the clipboard.</value>
+  </data>
+  <data name="FilterPane_ExportScenario_Title" xml:space="preserve">
+    <value>Export scenario JSON</value>
+  </data>
+  <data name="FilterPane_ExportFailed_Title" xml:space="preserve">
+    <value>Export failed</value>
+  </data>
+  <data name="FilterPane_ScenarioSaved" xml:space="preserve">
+    <value>Scenario JSON saved to {0}.</value>
+    <comment>{0} is the file path data.</comment>
+  </data>
+  <!-- Scenario export wrapper localization. Warning details remain runtime-authored L12 typed-warning debt. -->
+  <data name="ScenarioExport_ChannelsGuidance" xml:space="preserve">
+    <value>Fill in channels[] before adding to the catalog.</value>
+  </data>
+  <data name="ScenarioExport_WithChannelsGuidance" xml:space="preserve">
+    <value>{0} {1}</value>
+    <comment>{0} is the success sentence; {1} is the channels guidance sentence.</comment>
+  </data>
+  <data name="ScenarioExport_WarningsTitle" xml:space="preserve">
+    <value>Scenario JSON exported with warnings</value>
+  </data>
+  <data name="ScenarioExport_WarningsBody" xml:space="preserve">
+    <value>{0}{1}{2}</value>
+    <comment>{0} is the success/guidance message; {1} is Environment.NewLine; {2} is joined warning detail data.</comment>
+  </data>
+  <data name="ScenarioExport_NotExportable_SingleFilter_WithDetail" xml:space="preserve">
+    <value>Could not export this filter: {0}</value>
+    <comment>{0} is joined warning detail data.</comment>
+  </data>
+  <data name="ScenarioExport_NotExportable_SingleFilter_BasicOnly" xml:space="preserve">
+    <value>Could not export this filter: only Basic filters can be exported as scenarios.</value>
+  </data>
+  <data name="ScenarioExport_NotExportable_CurrentFilters_WithDetail" xml:space="preserve">
+    <value>Could not export these filters: {0}</value>
+    <comment>{0} is joined warning detail data.</comment>
+  </data>
+  <data name="ScenarioExport_NotExportable_CurrentFilters_BasicOnly" xml:space="preserve">
+    <value>Could not export these filters: only Basic filters can be exported as scenarios.</value>
+  </data>
+  <data name="ScenarioExport_NotExportable_FilterSet_WithDetail" xml:space="preserve">
+    <value>Could not export this filter set: {0}</value>
+    <comment>{0} is joined warning detail data.</comment>
+  </data>
+  <data name="ScenarioExport_NotExportable_FilterSet_BasicOnly" xml:space="preserve">
+    <value>Could not export this filter set: only Basic filters can be exported as scenarios.</value>
+  </data></root>

--- a/src/EventLogExpert.UI/FilterEditor/ScenarioClipboardExporter.cs
+++ b/src/EventLogExpert.UI/FilterEditor/ScenarioClipboardExporter.cs
@@ -1,40 +1,44 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Localization;
 using EventLogExpert.Runtime.Alerts;
 using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.Runtime.Common.Clipboard;
 using EventLogExpert.Scenarios.Catalog;
+using Microsoft.Extensions.Localization;
 
 namespace EventLogExpert.UI.FilterEditor;
 
 internal sealed class ScenarioClipboardExporter
 {
-    private const string ChannelsGuidance = "Fill in channels[] before adding to the catalog.";
-
     private readonly IAlertDialogService _alertDialogService;
     private readonly IAnnouncementService _announcementService;
     private readonly IClipboardService _clipboardService;
+    private readonly IStringLocalizer<SharedResource> _localizer;
 
     public ScenarioClipboardExporter(
         IAnnouncementService announcementService,
         IAlertDialogService alertDialogService,
-        IClipboardService clipboardService)
+        IClipboardService clipboardService,
+        IStringLocalizer<SharedResource> localizer)
     {
         ArgumentNullException.ThrowIfNull(announcementService);
         ArgumentNullException.ThrowIfNull(alertDialogService);
         ArgumentNullException.ThrowIfNull(clipboardService);
+        ArgumentNullException.ThrowIfNull(localizer);
 
         _announcementService = announcementService;
         _alertDialogService = alertDialogService;
         _clipboardService = clipboardService;
+        _localizer = localizer;
     }
 
     public async Task AnnounceAsync(string success, IReadOnlyList<string> warnings)
     {
-        var message = warnings.Contains(ScenarioExporter.NoLiveChannelsWarning)
-            ? $"{success} {ChannelsGuidance}"
-            : success;
+        var message = warnings.Contains(ScenarioExporter.NoLiveChannelsWarning) ?
+            _localizer["ScenarioExport_WithChannelsGuidance", success, _localizer["ScenarioExport_ChannelsGuidance"]] :
+            success;
 
         var substantive = SubstantiveWarnings(warnings);
 
@@ -46,32 +50,48 @@ internal sealed class ScenarioClipboardExporter
         }
 
         await _alertDialogService.ShowAlert(
-            "Scenario JSON exported with warnings",
-            message + Environment.NewLine + string.Join(Environment.NewLine, substantive),
-            "OK");
+            _localizer["ScenarioExport_WarningsTitle"],
+            _localizer["ScenarioExport_WarningsBody", message, Environment.NewLine, string.Join(Environment.NewLine, substantive)],
+            _localizer["Modal_Accept"]);
     }
 
-    public async Task CopyAsync(ScenarioExportResult export, string success, string emptyNoun)
+    public async Task CopyAsync(ScenarioExportResult export, string success, ScenarioExportSubject subject)
     {
-        if (NotExportable(export, emptyNoun)) { return; }
+        if (NotExportable(export, subject)) { return; }
 
         await _clipboardService.CopyTextAsync(export.Json);
         await AnnounceAsync(success, export.Warnings);
     }
 
-    public bool NotExportable(ScenarioExportResult export, string emptyNoun)
+    public bool NotExportable(ScenarioExportResult export, ScenarioExportSubject subject)
     {
         if (export.EmittedRowCount > 0) { return false; }
 
         var detail = SubstantiveWarnings(export.Warnings);
 
-        _announcementService.Announce(detail.Count > 0
-            ? $"Could not export {emptyNoun}: {string.Join(" ", detail)}"
-            : $"Could not export {emptyNoun}: only Basic filters can be exported as scenarios.");
+        _announcementService.Announce(NotExportableMessage(subject, detail));
 
         return true;
     }
 
     private static IReadOnlyList<string> SubstantiveWarnings(IReadOnlyList<string> warnings) =>
         [.. warnings.Where(warning => warning != ScenarioExporter.NoLiveChannelsWarning)];
+
+    private string NotExportableMessage(ScenarioExportSubject subject, IReadOnlyList<string> detail) =>
+        (subject, detail.Count > 0) switch
+        {
+            (ScenarioExportSubject.SingleFilter, true) =>
+                _localizer["ScenarioExport_NotExportable_SingleFilter_WithDetail", string.Join(" ", detail)],
+            (ScenarioExportSubject.SingleFilter, false) =>
+                _localizer["ScenarioExport_NotExportable_SingleFilter_BasicOnly"],
+            (ScenarioExportSubject.CurrentFilters, true) =>
+                _localizer["ScenarioExport_NotExportable_CurrentFilters_WithDetail", string.Join(" ", detail)],
+            (ScenarioExportSubject.CurrentFilters, false) =>
+                _localizer["ScenarioExport_NotExportable_CurrentFilters_BasicOnly"],
+            (ScenarioExportSubject.FilterSet, true) =>
+                _localizer["ScenarioExport_NotExportable_FilterSet_WithDetail", string.Join(" ", detail)],
+            (ScenarioExportSubject.FilterSet, false) =>
+                _localizer["ScenarioExport_NotExportable_FilterSet_BasicOnly"],
+            _ => throw new ArgumentOutOfRangeException(nameof(subject), subject, null),
+        };
 }

--- a/src/EventLogExpert.UI/FilterEditor/ScenarioExportSubject.cs
+++ b/src/EventLogExpert.UI/FilterEditor/ScenarioExportSubject.cs
@@ -1,0 +1,11 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.UI.FilterEditor;
+
+internal enum ScenarioExportSubject
+{
+    SingleFilter,
+    CurrentFilters,
+    FilterSet,
+}

--- a/src/EventLogExpert.UI/FilterLibrary/FilterLibraryModal.razor.cs
+++ b/src/EventLogExpert.UI/FilterLibrary/FilterLibraryModal.razor.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Localization;
 using EventLogExpert.Runtime.Alerts;
 using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.Runtime.Common.Clipboard;
@@ -14,6 +15,7 @@ using EventLogExpert.UI.FilterEditor;
 using EventLogExpert.UI.Modal;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.Localization;
 using System.Collections.Immutable;
 using System.Security;
 
@@ -115,6 +117,8 @@ public sealed partial class FilterLibraryModal : ModalBase<bool>
     [Inject] private ILibraryEntriesSource LibraryEntries { get; init; } = null!;
 
     [Inject] private ILibraryLoadStatusSource LibraryLoadStatus { get; init; } = null!;
+
+    [Inject] private IStringLocalizer<SharedResource> Localizer { get; init; } = null!;
 
     private EventCallback<LibraryEntryId> OnCopyScenarioCallback =>
         ScenarioAuthoringOptions.Enabled ?
@@ -479,7 +483,11 @@ public sealed partial class FilterLibraryModal : ModalBase<bool>
             FilterLibraryCommands.LoadLibrary();
         }
 
-        _clipboardExporter = new ScenarioClipboardExporter(AnnouncementService, AlertDialogService, ClipboardService);
+        _clipboardExporter = new ScenarioClipboardExporter(
+            AnnouncementService,
+            AlertDialogService,
+            ClipboardService,
+            Localizer);
 
         _authoringContext = ScenarioAuthoringOptions.Enabled
             ? new ScenarioAuthoringRowContext(Enabled: true, CopyLibraryRowAsync)
@@ -548,7 +556,7 @@ public sealed partial class FilterLibraryModal : ModalBase<bool>
         _clipboardExporter.CopyAsync(
             ScenarioAuthoringService.ExportRows([filter], []),
             "Filter copied to the clipboard as scenario JSON.",
-            "this filter");
+            ScenarioExportSubject.SingleFilter);
 
     private LibraryEntryFilterSet? FindFilterSet(LibraryEntryId entryId) =>
         LibraryEntries.Current.FirstOrDefault(e => e.Id.Equals(entryId)) as LibraryEntryFilterSet;
@@ -607,7 +615,7 @@ public sealed partial class FilterLibraryModal : ModalBase<bool>
         await _clipboardExporter.CopyAsync(
             ScenarioAuthoringService.ExportRows([.. filterSet.Filters], []),
             $"'{filterSet.Name}' copied to the clipboard as scenario JSON.",
-            "this filter set");
+            ScenarioExportSubject.FilterSet);
     }
 
     private void HandleDelete(LibraryEntryId id) => FilterLibraryCommands.DeleteEntry(id);
@@ -663,7 +671,7 @@ public sealed partial class FilterLibraryModal : ModalBase<bool>
 
         var export = ScenarioAuthoringService.ExportRows([.. filterSet.Filters], []);
 
-        if (_clipboardExporter.NotExportable(export, "this filter set")) { return; }
+        if (_clipboardExporter.NotExportable(export, ScenarioExportSubject.FilterSet)) { return; }
 
         var suggested = $"{SanitizeForFileName(filterSet.Name)}-scenario-{DateTimeOffset.Now:yyyyMMdd}.json";
         var path = await FilePickerService.PickSaveAsync("Export scenario JSON", [".json"], suggestedFileName: suggested);

--- a/src/EventLogExpert.UI/FilterPane/FilterPane.razor
+++ b/src/EventLogExpert.UI/FilterPane/FilterPane.razor
@@ -9,114 +9,114 @@
                 IconClass="bi bi-plus-circle"
                 OnClick="AddBasicFilter"
                 @ref="_addFilterButton"
-                title="Add Basic filter (use chevron for Advanced or Recent)">
-                Add Filter
+                title="@Localizer["FilterPane_AddBasicTitle"]">
+                @Localizer["FilterPane_Action_AddFilter"]
             </Button>
-            <Button aria-controls="menu-host-popup"
-                aria-expanded="@(IsAddFilterMenuOpen ? "true" : "false")"
-                aria-haspopup="menu"
-                aria-label="Choose filter mode"
-                CssClass="split-button-chevron"
+            <Button CssClass="split-button-chevron"
                 IconClass="bi bi-caret-down-fill"
                 OnClick="OpenAddFilterMenuAsync"
+                aria-controls="menu-host-popup"
+                aria-expanded="@(IsAddFilterMenuOpen ? "true" : "false")"
+                aria-haspopup="menu"
+                aria-label="@Localizer["FilterPane_AddMenuAria"]"
                 @onkeydown="HandleAddFilterChevronKeyDownAsync"
                 @ref="_addFilterChevron" />
         </div>
 
         <Button IconClass="bi bi-plus-circle" OnClick="AddExclusion">
-            Add Exclusion
+            @Localizer["FilterPane_Action_AddExclusion"]
         </Button>
 
         @if (!IsDateFilterVisible)
         {
             <Button IconClass="bi bi-plus-circle" OnClick="AddDateFilter">
-                Add Date Filter
+                @Localizer["FilterPane_Action_AddDateFilter"]
             </Button>
         }
 
         <Button IconClass="bi bi-plus-circle" OnClick="OpenFilterSetPicker">
-            Apply Filter Set
+            @Localizer["FilterPane_Action_ApplyFilterSet"]
         </Button>
 
         @if (OpenLogsPresence.HasOpenLogs)
         {
-            <Button aria-controls="scenario-picker"
-                aria-expanded="@(IsScenarioPickerVisible ? "true" : "false")"
-                IconClass="bi bi-plus-circle"
-                OnClick="OpenScenarioPicker">
-                Apply Scenario
+            <Button IconClass="bi bi-plus-circle"
+                OnClick="OpenScenarioPicker"
+                aria-controls="scenario-picker"
+                aria-expanded="@(IsScenarioPickerVisible ? "true" : "false")">
+                @Localizer["FilterPane_Action_ApplyScenario"]
             </Button>
         }
     </div>
 
     @if (HasFilters && GetActiveFilters() > 0)
     {
-        <span class="filter-header-status">[Active Filters: @GetActiveFilters()]</span>
+        <span class="filter-header-status">@Localizer["FilterPane_ActiveFilters", GetActiveFilters()]</span>
     }
 
     <div class="filter-header-secondary">
-        <Button aria-describedby="@(HasSavableFilters ? null : "save-filters-empty-hint")"
-            aria-label="Save as Filter Set"
-            Disabled="@(!HasSavableFilters)"
+        <Button Disabled="@(!HasSavableFilters)"
             IconClass="bi bi-bookmark-plus"
             IconOnly
             OnClick="SaveFiltersAsFilterSetAsync"
-            title="@(HasSavableFilters ? "Save as Filter Set..." : "No filters to save")" />
+            aria-describedby="@(HasSavableFilters ? null : "save-filters-empty-hint")"
+            aria-label="@Localizer["FilterPane_SaveAsFilterSet_Aria"]"
+            title="@(HasSavableFilters ? Localizer["FilterPane_SaveAsFilterSet_TitleEnabled"] : Localizer["FilterPane_SaveAsFilterSet_TitleDisabled"])" />
 
-        <Button aria-describedby="@(HasClearableFilters ? null : "clear-filters-empty-hint")"
-            aria-label="Clear All Filters"
-            Disabled="@(!HasClearableFilters)"
+        <Button Disabled="@(!HasClearableFilters)"
             IconClass="bi bi-trash"
             IconOnly
             OnClick="ClearAllFiltersAsync"
-            title="@(HasClearableFilters ? "Clear All Filters..." : "No filters to clear")" />
+            aria-describedby="@(HasClearableFilters ? null : "clear-filters-empty-hint")"
+            aria-label="@Localizer["FilterPane_ClearAll_Aria"]"
+            title="@(HasClearableFilters ? Localizer["FilterPane_ClearAll_TitleEnabled"] : Localizer["FilterPane_ClearAll_TitleDisabled"])" />
 
-        <Button aria-label="Open Filter Library"
-            IconClass="bi bi-bookmarks"
+        <Button IconClass="bi bi-bookmarks"
             IconOnly
             OnClick="OpenFilterLibraryAsync"
-            title="Open Filter Library" />
+            aria-label="@Localizer["FilterPane_OpenLibrary_Aria"]"
+            title="@Localizer["FilterPane_OpenLibrary_Title"]" />
 
         @if (ScenarioAuthoringEnabled)
         {
             var hasEnabledFilters = HasEnabledFilters;
 
-            <Button aria-describedby="@(hasEnabledFilters ? null : "scenario-export-empty-hint")"
-                aria-label="Copy scenario JSON"
-                Disabled="@(!hasEnabledFilters)"
+            <Button Disabled="@(!hasEnabledFilters)"
                 IconClass="bi bi-clipboard-data"
                 IconOnly
                 OnClick="CopyScenarioJsonAsync"
-                title="Copy current filter rows as scenario-catalog JSON" />
+                aria-describedby="@(hasEnabledFilters ? null : "scenario-export-empty-hint")"
+                aria-label="@Localizer["FilterPane_CopyScenarioJson_Aria"]"
+                title="@Localizer["FilterPane_CopyScenarioJson_Title"]" />
 
-            <Button aria-describedby="@(hasEnabledFilters ? null : "scenario-export-empty-hint")"
-                aria-label="Save scenario JSON"
-                Disabled="@(!hasEnabledFilters)"
+            <Button Disabled="@(!hasEnabledFilters)"
                 IconClass="bi bi-filetype-json"
                 IconOnly
                 OnClick="SaveScenarioJsonAsync"
-                title="Save current filter rows as scenario-catalog JSON..." />
+                aria-describedby="@(hasEnabledFilters ? null : "scenario-export-empty-hint")"
+                aria-label="@Localizer["FilterPane_SaveScenarioJson_Aria"]"
+                title="@Localizer["FilterPane_SaveScenarioJson_Title"]" />
 
             <span class="visually-hidden" id="scenario-export-empty-hint">
-                Enable a filter before exporting as a scenario.
+                @Localizer["FilterPane_ScenarioExport_HintDisabled"]
             </span>
         }
 
         <span class="visually-hidden" id="save-filters-empty-hint">
-            Add a filter before saving as a Filter Set.
+            @Localizer["FilterPane_SaveFilterSet_HintDisabled"]
         </span>
         <span class="visually-hidden" id="clear-filters-empty-hint">
-            There are no filters to clear.
+            @Localizer["FilterPane_ClearFilters_HintDisabled"]
         </span>
 
         @if (HasFilters)
         {
-            <Button aria-label="@(_isFilterListVisible ? "Filters Expanded" : "Filters Collapsed")"
-                CssClass="menu-toggle"
-                data-rotate="@MenuState"
+            <Button CssClass="menu-toggle"
                 IconClass="bi bi-caret-up"
                 IconOnly
-                OnClick="ToggleMenu" />
+                OnClick="ToggleMenu"
+                aria-label="@(_isFilterListVisible ? Localizer["FilterPane_FilterList_ExpandedAria"] : Localizer["FilterPane_FilterList_CollapsedAria"])"
+                data-rotate="@MenuState" />
         }
     </div>
 </div>
@@ -124,51 +124,51 @@
 <div class="filter-set" data-toggle="@MenuState">
     @if (IsDateFilterVisible)
     {
-        <EditForm class="filter-form flex-row" EditContext="_editContext">
+        <EditForm EditContext="_editContext" class="filter-form flex-row">
             <span>
-                After:
-                <InputDate aria-label="After" @bind-Value="ModelAfter" class="filter-datetime input" disabled="@(!_canEditDate)" Type="InputDateType.DateTimeLocal" />
+                @Localizer["FilterPane_Date_AfterLabel"]
+                <InputDate Type="InputDateType.DateTimeLocal" aria-label="@Localizer["FilterPane_Date_AfterAria"]" @bind-Value="ModelAfter" class="filter-datetime input" disabled="@(!_canEditDate)" />
             </span>
             <span>
-                Before:
-                <InputDate aria-label="Before" @bind-Value="ModelBefore" class="filter-datetime input" disabled="@(!_canEditDate)" Type="InputDateType.DateTimeLocal" />
+                @Localizer["FilterPane_Date_BeforeLabel"]
+                <InputDate Type="InputDateType.DateTimeLocal" aria-label="@Localizer["FilterPane_Date_BeforeAria"]" @bind-Value="ModelBefore" class="filter-datetime input" disabled="@(!_canEditDate)" />
             </span>
 
             @if (_canEditDate)
             {
                 <span>
-                    Quick range:
-                    <DateRangeQuickPick AriaLabel="Quick date range" CssClass="input filter-datetime" OnRangeSelected="SetQuickDateRange" />
+                    @Localizer["FilterPane_Date_QuickRangeLabel"]
+                    <DateRangeQuickPick AriaLabel="@Localizer["FilterPane_Date_QuickRangeAria"]" CssClass="input filter-datetime" OnRangeSelected="SetQuickDateRange" />
                 </span>
 
                 <PrimaryButton IconClass="bi bi-check-circle" OnClick="ApplyDateFilter">
-                    Apply
+                    @Localizer["FilterPane_Action_Apply"]
                 </PrimaryButton>
 
                 <DangerButton IconClass="bi bi-dash-circle" OnClick="RemoveDateFilter">
-                    Remove
+                    @Localizer["FilterPane_Action_Remove"]
                 </DangerButton>
             }
             else
             {
                 <Button IconClass="bi bi-funnel" OnClick="EditDateFilter">
-                    Edit
+                    @Localizer["FilterPane_Action_Edit"]
                 </Button>
 
                 <DangerButton IconClass="bi bi-dash-circle" OnClick="RemoveDateFilter">
-                    Remove
+                    @Localizer["FilterPane_Action_Remove"]
                 </DangerButton>
 
                 @if (FilteredDateRange.Current?.IsEnabled is true)
                 {
                     <DangerButton IconClass="bi bi-dash-circle" OnClick="ToggleDateFilter">
-                        Disable
+                        @Localizer["FilterPane_Action_Disable"]
                     </DangerButton>
                 }
                 else
                 {
                     <PrimaryButton IconClass="bi bi-plus-circle" OnClick="ToggleDateFilter">
-                        Enable
+                        @Localizer["FilterPane_Action_Enable"]
                     </PrimaryButton>
                 }
             }
@@ -183,15 +183,15 @@
                 @if (AvailableFilterSetTags is { Count: > 0 } setTags)
                 {
                     <span>
-                        Tags:
-                        <ValueSelect AriaLabel="Narrow filter sets by tag"
+                        @Localizer["FilterPane_FilterSet_TagsLabel"]
+                        <ValueSelect AriaLabel="@Localizer["FilterPane_FilterSet_TagSelectAria"]"
                             CssClass="input filter-multiselect-dropdown"
-                            EmptyText="All tags"
+                            EmptyText="@Localizer["FilterPane_FilterSet_AllTags"]"
                             IsMultiSelect="true"
                             T="string"
                             Values="_filterSetTags"
                             ValuesChanged="OnFilterSetTagsChanged">
-                            <ValueSelectItem ClearItem T="string">All tags</ValueSelectItem>
+                            <ValueSelectItem ClearItem T="string">@Localizer["FilterPane_FilterSet_AllTags"]</ValueSelectItem>
                             @foreach (var tag in setTags)
                             {
                                 <ValueSelectItem T="string" Value="@tag">@tag</ValueSelectItem>
@@ -201,8 +201,8 @@
                 }
 
                 <span>
-                    Filter Set:
-                    <ValueSelect AriaLabel="Filter Set"
+                    @Localizer["FilterPane_FilterSet_Label"]
+                    <ValueSelect AriaLabel="@Localizer["FilterPane_FilterSet_SelectAria"]"
                         CssClass="input filter-set-dropdown"
                         T="LibraryEntryId"
                         ToStringFunc="@(GetFilterSetName)"
@@ -213,7 +213,7 @@
                             <ValueSelectItem T="LibraryEntryId" Value="filterSet.Id">
                                 <span class="filter-set-option-row" title="@FormatFilterSetLabel(filterSet)">
                                     <span class="filter-set-option-name">@filterSet.Name</span>
-                                    <span class="filter-set-option-meta">(@FormatFilterSetDetail(filterSet))</span>
+                                    <span class="filter-set-option-meta">@Localizer["FilterPane_FilterSetOptionMeta", FormatFilterSetDetail(filterSet)]</span>
                                 </span>
                             </ValueSelectItem>
                         }
@@ -221,34 +221,25 @@
                 </span>
 
                 <PrimaryButton Disabled="@(SelectedFilterSetId == default)" IconClass="bi bi-check-circle" OnClick="ApplyFilterSetSelection">
-                    Apply
+                    @Localizer["FilterPane_Action_Apply"]
                 </PrimaryButton>
 
-                <Button aria-label="Replace filters with selected filter set"
-                    Disabled="@(SelectedFilterSetId == default)"
+                <Button Disabled="@(SelectedFilterSetId == default)"
                     IconClass="bi bi-arrow-repeat"
-                    OnClick="ReplaceFilterSetSelection">
-                    Replace
+                    OnClick="ReplaceFilterSetSelection"
+                    aria-label="@Localizer["FilterPane_FilterSet_ReplaceAria"]">
+                    @Localizer["FilterPane_Action_Replace"]
                 </Button>
             }
             else
             {
                 <span class="filter-empty-state">
-                    @if (HasSavableFilters)
-                    {
-                        @:No saved filter sets yet - use <strong>Save as Filter Set</strong> on the right
-                        @:to create one from the current pane.
-                    }
-                    else
-                    {
-                        @:No saved filter sets yet. Add and apply filters first, then use
-                        @:<strong>Save as Filter Set</strong> on the right to create one.
-                    }
+                    @FilterSetEmptyState()
                 </span>
             }
 
             <DangerButton IconClass="bi bi-dash-circle" OnClick="CancelFilterSetPicker">
-                Cancel
+                @Localizer["FilterPane_Action_Cancel"]
             </DangerButton>
         </div>
     }
@@ -261,24 +252,24 @@
                 @if (ScenarioMatchGroups.Count > 1)
                 {
                     <span>
-                        Category:
-                        <ValueSelect AriaLabel="Category"
+                        @Localizer["FilterPane_Scenario_CategoryLabel"]
+                        <ValueSelect AriaLabel="@Localizer["FilterPane_Scenario_CategoryAria"]"
                             CssClass="input scenario-category-dropdown"
                             T="ScenarioGroup?"
-                            ToStringFunc="@(group => group?.DisplayName() ?? string.Empty)"
+                            ToStringFunc="FormatScenarioGroup"
                             Value="EffectiveScenarioGroup"
                             ValueChanged="OnScenarioGroupChanged">
                             @foreach (var match in ScenarioMatchGroups)
                             {
-                                <ValueSelectItem T="ScenarioGroup?" Value="match.Key">@match.Key.DisplayName()</ValueSelectItem>
+                                <ValueSelectItem T="ScenarioGroup?" Value="match.Key">@ScenarioGroupLocalizer.GroupDisplay(Localizer, match.Key)</ValueSelectItem>
                             }
                         </ValueSelect>
                     </span>
                 }
 
                 <span>
-                    Scenario:
-                    <ValueSelect AriaLabel="Scenario"
+                    @Localizer["FilterPane_Scenario_Label"]
+                    <ValueSelect AriaLabel="@Localizer["FilterPane_Scenario_SelectAria"]"
                         CssClass="input scenario-item-dropdown"
                         T="string"
                         ToStringFunc="@(GetScenarioName)"
@@ -287,7 +278,7 @@
                         @foreach (var scenario in VisibleScenarioMatches)
                         {
                             <ValueSelectItem T="string" Value="scenario.Id">
-                                <span class="filter-set-option-row" title="@($"{scenario.Group.DisplayName()} - {scenario.Purpose}")">
+                                <span class="filter-set-option-row" title="@Localizer["FilterPane_Scenario_OptionTitle", ScenarioGroupLocalizer.GroupDisplay(Localizer, scenario.Group), scenario.Purpose]">
                                     <span class="filter-set-option-name">@scenario.Name</span>
                                 </span>
                             </ValueSelectItem>
@@ -296,23 +287,23 @@
                 </span>
 
                 <PrimaryButton Disabled="@(ResolvedScenario is null)" IconClass="bi bi-check-circle" OnClick="ApplyScenarioSelection">
-                    Apply
+                    @Localizer["FilterPane_Action_Apply"]
                 </PrimaryButton>
 
-                <Button aria-label="Replace filters with selected scenario"
-                    Disabled="@(ResolvedScenario is null)"
+                <Button Disabled="@(ResolvedScenario is null)"
                     IconClass="bi bi-arrow-repeat"
-                    OnClick="ReplaceScenarioSelection">
-                    Replace
+                    OnClick="ReplaceScenarioSelection"
+                    aria-label="@Localizer["FilterPane_Scenario_ReplaceAria"]">
+                    @Localizer["FilterPane_Action_Replace"]
                 </Button>
             }
             else
             {
-                <span class="filter-empty-state" role="status">No scenarios match the loaded logs.</span>
+                <span class="filter-empty-state" role="status">@Localizer["FilterPane_Scenario_EmptyNoMatches"]</span>
             }
 
             <DangerButton IconClass="bi bi-dash-circle" OnClick="CancelScenarioPicker">
-                Cancel
+                @Localizer["FilterPane_Action_Cancel"]
             </DangerButton>
         </div>
     }
@@ -321,20 +312,20 @@
         @foreach (var item in ActiveFilters.Current)
         {
             <FilterRow Id="@ComponentId.For(item.Id, ComponentIdScope.PaneFilter).Value"
-                @key="item.Id"
                 OnDisposed="@OnRowDisposed"
                 OnRemoved="HandleRemovedFilter"
-                @ref="_rowRefs[item.Id]"
-                Value="item" />
+                Value="item"
+                @key="item.Id"
+                @ref="_rowRefs[item.Id]" />
         }
 
         @foreach (var draft in _pendingDrafts)
         {
             <FilterRow Id="@ComponentId.For(draft.Id, ComponentIdScope.PanePendingFilter).Value"
-                @key="draft.Id"
                 OnPendingDiscard="() => HandlePendingDiscard(draft)"
                 OnPendingSave="filter => HandlePendingSave(draft, filter)"
-                PendingDraft="draft" />
+                PendingDraft="draft"
+                @key="draft.Id" />
         }
     </CascadingValue>
 </div>

--- a/src/EventLogExpert.UI/FilterPane/FilterPane.razor.cs
+++ b/src/EventLogExpert.UI/FilterPane/FilterPane.razor.cs
@@ -4,6 +4,7 @@
 using EventLogExpert.Filtering.Drafts;
 using EventLogExpert.Filtering.Evaluation;
 using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Localization;
 using EventLogExpert.Runtime.Alerts;
 using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.Runtime.Common.Clipboard;
@@ -16,6 +17,7 @@ using EventLogExpert.Runtime.Menu;
 using EventLogExpert.Runtime.Scenarios;
 using EventLogExpert.Runtime.Settings;
 using EventLogExpert.Scenarios.Catalog;
+using EventLogExpert.UI.Common;
 using EventLogExpert.UI.Common.Interop;
 using EventLogExpert.UI.FilterEditor;
 using EventLogExpert.UI.Focus;
@@ -25,6 +27,7 @@ using EventLogExpert.UI.Modal;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.Localization;
 using Microsoft.JSInterop;
 using System.Collections.Immutable;
 using System.Security;
@@ -136,6 +139,8 @@ public sealed partial class FilterPane
 
     [Inject] private ILoadedLogNamesSource LoadedLogNames { get; init; } = null!;
 
+    [Inject] private IStringLocalizer<SharedResource> Localizer { get; init; } = null!;
+
     [Inject] private IMenuActionService MenuActions { get; init; } = null!;
 
     [Inject] private IMenuService MenuService { get; init; } = null!;
@@ -238,7 +243,8 @@ public sealed partial class FilterPane
     {
         if (ResolvedScenario is not { } scenario)
         {
-            AnnouncementService.Announce(FilterPaneAnnouncements.SelectedScenarioMissing);
+            AnnouncementService.Announce(FilterPaneAnnouncements.SelectedScenarioMissing(Localizer));
+
             return;
         }
 
@@ -247,10 +253,10 @@ public sealed partial class FilterPane
 
     internal IReadOnlyList<MenuItem> BuildAddFilterMenu() =>
     [
-        MenuItem.Item("Basic", AddBasicFilterFromMenu),
-        MenuItem.Item("Advanced", AddAdvancedFilterFromMenu),
+        MenuItem.Item(Localizer["FilterPane_AddMenu_Basic"], AddBasicFilterFromMenu),
+        MenuItem.Item(Localizer["FilterPane_AddMenu_Advanced"], AddAdvancedFilterFromMenu),
         MenuItem.Item(
-            "Recent",
+            Localizer["FilterPane_AddMenu_Recent"],
             AddRecentFilterFromMenu,
             isEnabled: HasRecentFilters,
             disabledReason: GetRecentDisabledReason()),
@@ -258,15 +264,18 @@ public sealed partial class FilterPane
 
     internal void EditDateFilter() => _canEditDate = true;
 
+    internal string FormatScenarioGroup(ScenarioGroup? group) =>
+        group is { } value ? ScenarioGroupLocalizer.GroupDisplay(Localizer, value) : string.Empty;
+
     internal string? GetRecentDisabledReason()
     {
         if (HasRecentFilters) { return null; }
 
-        if (LibraryLoadStatus.Current.LoadError) { return FilterPaneAnnouncements.LoadFailedRetryViaModal; }
+        if (LibraryLoadStatus.Current.LoadError) { return FilterPaneAnnouncements.LoadFailedRetryViaModal(Localizer); }
 
         return !LibraryLoadStatus.Current.IsLoaded ?
-            FilterPaneAnnouncements.LoadingTryAgain :
-            FilterPaneAnnouncements.RecentNoneAvailable;
+            FilterPaneAnnouncements.LoadingTryAgain(Localizer) :
+            FilterPaneAnnouncements.RecentNoneAvailable(Localizer);
     }
 
     internal void OnScenarioGroupChanged(ScenarioGroup? group)
@@ -281,24 +290,28 @@ public sealed partial class FilterPane
 
         if (LibraryLoadStatus.Current.LoadError)
         {
-            AnnouncementService.Announce(FilterPaneAnnouncements.LoadFailedRetryViaModal);
+            AnnouncementService.Announce(FilterPaneAnnouncements.LoadFailedRetryViaModal(Localizer));
+
             return;
         }
 
         if (!LibraryLoadStatus.Current.IsLoaded)
         {
-            AnnouncementService.Announce(FilterPaneAnnouncements.LoadingTryAgain);
+            AnnouncementService.Announce(FilterPaneAnnouncements.LoadingTryAgain(Localizer));
+
             return;
         }
 
         _filterSetTags.Clear();
         IsFilterSetPickerVisible = true;
-        SelectedFilterSetId = HasFilterSets
-            ? LibraryEntries.Current
-                .OfType<LibraryEntryFilterSet>()
+
+        SelectedFilterSetId = HasFilterSets ?
+            LibraryEntries.Current.OfType<LibraryEntryFilterSet>()
                 .OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase)
-                .First().Id
-            : default;
+                .First()
+                .Id :
+            default;
+        
         _isFilterListVisible = true;
     }
 
@@ -324,7 +337,8 @@ public sealed partial class FilterPane
     {
         if (ResolvedScenario is not { } scenario)
         {
-            AnnouncementService.Announce(FilterPaneAnnouncements.SelectedScenarioMissing);
+            AnnouncementService.Announce(FilterPaneAnnouncements.SelectedScenarioMissing(Localizer));
+
             return;
         }
 
@@ -337,7 +351,7 @@ public sealed partial class FilterPane
     {
         if (LibraryLoadStatus.Current.LoadError)
         {
-            AnnouncementService.Announce(FilterPaneAnnouncements.LoadFailedRetryViaModal);
+            AnnouncementService.Announce(FilterPaneAnnouncements.LoadFailedRetryViaModal(Localizer));
             CancelFilterSetPicker();
 
             return false;
@@ -345,7 +359,7 @@ public sealed partial class FilterPane
 
         if (!LibraryLoadStatus.Current.IsLoaded)
         {
-            AnnouncementService.Announce(FilterPaneAnnouncements.LoadingTryAgain);
+            AnnouncementService.Announce(FilterPaneAnnouncements.LoadingTryAgain(Localizer));
             CancelFilterSetPicker();
 
             return false;
@@ -358,7 +372,8 @@ public sealed partial class FilterPane
             return true;
         }
 
-        AnnouncementService.Announce(FilterPaneAnnouncements.SelectedFilterSetMissing);
+        AnnouncementService.Announce(FilterPaneAnnouncements.SelectedFilterSetMissing(Localizer));
+
         SelectedFilterSetId = filterSets
             .OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase)
             .FirstOrDefault()?.Id ?? default;
@@ -416,9 +431,9 @@ public sealed partial class FilterPane
         PruneStaleRowRefs();
         PruneStaleFilterSetTags();
 
-        if (_focusTargetAfterRemove is { } targetId
-            && _rowRefs.TryGetValue(targetId, out var target)
-            && target is not null)
+        if (_focusTargetAfterRemove is { } targetId &&
+            _rowRefs.TryGetValue(targetId, out var target) &&
+            target is not null)
         {
             _focusTargetAfterRemove = null;
             await target.FocusEditAsync();
@@ -502,29 +517,18 @@ public sealed partial class FilterPane
         Settings.TimeZoneChanged += UpdateFilterDateTimeZone;
         MenuService.StateChanged += OnMenuServiceStateChanged;
 
-        _clipboardExporter = new ScenarioClipboardExporter(AnnouncementService, AlertDialogService, ClipboardService);
+        _clipboardExporter = new ScenarioClipboardExporter(
+            AnnouncementService,
+            AlertDialogService,
+            ClipboardService,
+            Localizer);
 
-        _authoringContext = ScenarioAuthoringOptions.Enabled
-            ? new ScenarioAuthoringRowContext(Enabled: true, CopyActiveRowAsync)
-            : null;
+        _authoringContext = ScenarioAuthoringOptions.Enabled ?
+            new ScenarioAuthoringRowContext(Enabled: true, CopyActiveRowAsync) :
+            null;
 
         base.OnInitialized();
     }
-
-    private static string FormatFilterSetDetail(LibraryEntryFilterSet set)
-    {
-        var detail = $"{set.Filters.Count} filter{(set.Filters.Count == 1 ? string.Empty : "s")}";
-
-        if (set.Tags.Count > 0)
-        {
-            detail = $"{detail} · {string.Join(", ", set.Tags)}";
-        }
-
-        return detail;
-    }
-
-    private static string FormatFilterSetLabel(LibraryEntryFilterSet set) =>
-        $"{set.Name} ({FormatFilterSetDetail(set)})";
 
     private void AddAdvancedFilter()
     {
@@ -627,10 +631,14 @@ public sealed partial class FilterPane
             (IsDateFilterVisible ? 1 : 0);
 
         string message = count == 1 ?
-            "Clear 1 filter? This cannot be undone." :
-            $"Clear {count} filters? This cannot be undone.";
+            Localizer["FilterPane_ClearConfirm_Message_One"] :
+            Localizer["FilterPane_ClearConfirm_Message_Many", count];
 
-        bool confirmed = await AlertDialogService.ShowAlert("Clear All Filters", message, "Clear", "Cancel");
+        bool confirmed = await AlertDialogService.ShowAlert(
+            Localizer["FilterPane_ClearConfirm_Title"],
+            message,
+            Localizer["FilterPane_Action_Clear"],
+            Localizer["Modal_Cancel"]);
 
         if (confirmed) { FilterPaneCommands.ClearAllFilters(); }
     }
@@ -638,11 +646,14 @@ public sealed partial class FilterPane
     private Task CopyActiveRowAsync(SavedFilter filter) =>
         _clipboardExporter.CopyAsync(
             ScenarioAuthoringService.ExportRows([filter], CurrentChannelNames()),
-            "Filter copied to the clipboard as scenario JSON.",
-            "this filter");
+            Localizer["FilterPane_CopyFilterSuccess"],
+            ScenarioExportSubject.SingleFilter);
 
     private Task CopyScenarioJsonAsync() =>
-        _clipboardExporter.CopyAsync(ExportCurrentRows(), "Scenario JSON copied to the clipboard.", "these filters");
+        _clipboardExporter.CopyAsync(
+            ExportCurrentRows(),
+            Localizer["FilterPane_CopyScenarioSuccess"],
+            ScenarioExportSubject.CurrentFilters);
 
     private IReadOnlyList<string> CurrentChannelNames() => EventLogQueries.GetChannelNames();
 
@@ -650,6 +661,44 @@ public sealed partial class FilterPane
         ScenarioAuthoringService.ExportRows(
             [.. ActiveFilters.Current.Where(filter => filter.IsEnabled)],
             CurrentChannelNames());
+
+    private RenderFragment FilterSetEmptyState() => builder =>
+    {
+        string template = Localizer[
+            HasSavableFilters ?
+                "FilterPane_FilterSetEmpty_WithSavableFilters" :
+                "FilterPane_FilterSetEmpty_NoSavableFilters"];
+        const string Placeholder = "{0}";
+        int placeholderIndex = template.IndexOf(Placeholder, StringComparison.Ordinal);
+
+        if (placeholderIndex < 0)
+        {
+            builder.AddContent(0, template);
+
+            return;
+        }
+
+        builder.AddContent(1, template[..placeholderIndex]);
+        builder.OpenElement(2, "strong");
+        builder.AddContent(3, Localizer["FilterPane_SaveAsFilterSet_EmphasisLabel"]);
+        builder.CloseElement();
+        builder.AddContent(4, template[(placeholderIndex + Placeholder.Length)..]);
+    };
+
+    private string FormatFilterSetDetail(LibraryEntryFilterSet set)
+    {
+        int count = set.Filters.Count;
+        string detail = Localizer[
+            count == 1 ? "FilterPane_FilterSetFilterCount_One" : "FilterPane_FilterSetFilterCount_Many",
+            count];
+
+        return set.Tags.Count > 0 ?
+            Localizer["FilterPane_FilterSetDetail_WithTags", detail, string.Join(", ", set.Tags)] :
+            detail;
+    }
+
+    private string FormatFilterSetLabel(LibraryEntryFilterSet set) =>
+        Localizer["FilterPane_FilterSetOptionTitle", set.Name, FormatFilterSetDetail(set)];
 
     private int GetActiveFilters()
     {
@@ -794,9 +843,9 @@ public sealed partial class FilterPane
     {
         var export = ExportCurrentRows();
 
-        if (_clipboardExporter.NotExportable(export, "these filters")) { return; }
+        if (_clipboardExporter.NotExportable(export, ScenarioExportSubject.CurrentFilters)) { return; }
 
-        var path = await FilePickerService.PickSaveAsync("Export scenario JSON", [".json"], "scenario.json");
+        var path = await FilePickerService.PickSaveAsync(Localizer["FilterPane_ExportScenario_Title"], [".json"], "scenario.json");
 
         if (path is null) { return; }
 
@@ -807,12 +856,15 @@ public sealed partial class FilterPane
         catch (Exception exception)
             when (exception is IOException or UnauthorizedAccessException or SecurityException)
         {
-            await AlertDialogService.ShowAlert("Export failed", exception.Message, "OK");
+            await AlertDialogService.ShowAlert(
+                Localizer["FilterPane_ExportFailed_Title"],
+                exception.Message,
+                Localizer["Modal_Accept"]);
 
             return;
         }
 
-        await _clipboardExporter.AnnounceAsync($"Scenario JSON saved to {path}.", export.Warnings);
+        await _clipboardExporter.AnnounceAsync(Localizer["FilterPane_ScenarioSaved", path], export.Warnings);
     }
 
     private void ToggleDateFilter() => FilterPaneCommands.ToggleFilterDate();

--- a/src/EventLogExpert.UI/FilterPane/FilterPaneAnnouncements.cs
+++ b/src/EventLogExpert.UI/FilterPane/FilterPaneAnnouncements.cs
@@ -1,17 +1,25 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Localization;
+using Microsoft.Extensions.Localization;
+
 namespace EventLogExpert.UI.FilterPane;
 
 internal static class FilterPaneAnnouncements
 {
-    public const string LoadFailedRetryViaModal = "Filter library failed to load. Open Filter Library to retry.";
+    internal static string LoadFailedRetryViaModal(IStringLocalizer<SharedResource> localizer) =>
+        localizer["FilterPane_Announcement_LoadFailedRetryViaModal"];
 
-    public const string LoadingTryAgain = "Filter library is still loading. Please try again.";
+    internal static string LoadingTryAgain(IStringLocalizer<SharedResource> localizer) =>
+        localizer["FilterPane_Announcement_LoadingTryAgain"];
 
-    public const string RecentNoneAvailable = "No recent filters yet - apply a Basic or Advanced filter to populate.";
+    internal static string RecentNoneAvailable(IStringLocalizer<SharedResource> localizer) =>
+        localizer["FilterPane_Announcement_RecentNoneAvailable"];
 
-    public const string SelectedFilterSetMissing = "Selected filter set no longer exists.";
+    internal static string SelectedFilterSetMissing(IStringLocalizer<SharedResource> localizer) =>
+        localizer["FilterPane_Announcement_SelectedFilterSetMissing"];
 
-    public const string SelectedScenarioMissing = "Selected scenario no longer matches the loaded logs.";
+    internal static string SelectedScenarioMissing(IStringLocalizer<SharedResource> localizer) =>
+        localizer["FilterPane_Announcement_SelectedScenarioMissing"];
 }

--- a/tests/Unit/EventLogExpert.UI.Tests/Dashboard/DashboardLocalizationTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Dashboard/DashboardLocalizationTests.cs
@@ -34,7 +34,7 @@ public sealed class DashboardLocalizationTests : BunitContext
     {
         var localizer = Localizer;
 
-        // Cross-source drift guard: FilterPane renders ScenarioGroup.DisplayName() unlocalized while Dashboard renders Dashboard_Group_*; editing a Dashboard_Group_* value is a 3-place co-edit with ScenarioGroupDisplay.cs and ScenarioGroupDisplayTests.cs.
+        // Cross-source drift guard: scenario group displays route through Dashboard_Group_*; editing one is a co-edit with ScenarioGroupDisplay.cs and ScenarioGroupDisplayTests.cs.
         foreach (var group in Enum.GetValues<ScenarioGroup>())
         {
             var localized = localizer[$"Dashboard_Group_{group}"];

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterEditor/ScenarioClipboardExporterTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterEditor/ScenarioClipboardExporterTests.cs
@@ -6,6 +6,7 @@ using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.Runtime.Common.Clipboard;
 using EventLogExpert.Scenarios.Catalog;
 using EventLogExpert.UI.FilterEditor;
+using EventLogExpert.UI.Tests.TestUtils;
 using NSubstitute;
 using System.Collections.Immutable;
 
@@ -18,25 +19,41 @@ public sealed class ScenarioClipboardExporterTests
     private readonly IClipboardService _clipboard = Substitute.For<IClipboardService>();
 
     [Fact]
-    public async Task AnnounceAsync_WhenChannelsEmpty_AppendsChannelsGuidance()
+    public async Task AnnounceAsync_WhenChannelsEmptyAndSubstantiveWarnings_ShowsLocalizedBodyWithGuidanceAndLiteralWarningData()
+    {
+        const string Warning = "single-row color guardrail";
+
+        await CreateExporter().AnnounceAsync("Saved.", [ScenarioExporter.NoLiveChannelsWarning, Warning]);
+
+        await _alertDialog.Received(1).ShowAlert(
+            "[[ScenarioExport_WarningsTitle]]",
+            $"[[ScenarioExport_WarningsBody([[ScenarioExport_WithChannelsGuidance(Saved.|[[ScenarioExport_ChannelsGuidance]])]]|{Environment.NewLine}|{Warning})]]",
+            "[[Modal_Accept]]");
+        _announcements.DidNotReceive().Announce(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task AnnounceAsync_WhenChannelsEmpty_RoutesGuidanceThroughLocalizer()
     {
         await CreateExporter().AnnounceAsync(
             "Scenario JSON copied to the clipboard.",
             [ScenarioExporter.NoLiveChannelsWarning]);
 
         _announcements.Received(1).Announce(
-            "Scenario JSON copied to the clipboard. Fill in channels[] before adding to the catalog.");
+            "[[ScenarioExport_WithChannelsGuidance(Scenario JSON copied to the clipboard.|[[ScenarioExport_ChannelsGuidance]])]]");
     }
 
     [Fact]
-    public async Task AnnounceAsync_WhenSubstantiveWarnings_ShowsAlertNotAnnouncement()
+    public async Task AnnounceAsync_WhenSubstantiveWarnings_ShowsLocalizedAlertWithLiteralWarningData()
     {
-        await CreateExporter().AnnounceAsync("Saved.", ["single-row color guardrail"]);
+        const string Warning = "single-row color guardrail";
+
+        await CreateExporter().AnnounceAsync("Saved.", [Warning]);
 
         await _alertDialog.Received(1).ShowAlert(
-            "Scenario JSON exported with warnings",
-            Arg.Is<string>(message => message != null && message.Contains("single-row color guardrail")),
-            "OK");
+            "[[ScenarioExport_WarningsTitle]]",
+            $"[[ScenarioExport_WarningsBody(Saved.|{Environment.NewLine}|{Warning})]]",
+            "[[Modal_Accept]]");
         _announcements.DidNotReceive().Announce(Arg.Any<string>());
     }
 
@@ -45,7 +62,7 @@ public sealed class ScenarioClipboardExporterTests
     {
         var export = new ScenarioExportResult("{ }", ImmutableList<string>.Empty, EmittedRowCount: 1);
 
-        await CreateExporter().CopyAsync(export, "Copied.", "these filters");
+        await CreateExporter().CopyAsync(export, "Copied.", ScenarioExportSubject.CurrentFilters);
 
         await _clipboard.Received(1).CopyTextAsync("{ }");
         _announcements.Received(1).Announce("Copied.");
@@ -56,21 +73,25 @@ public sealed class ScenarioClipboardExporterTests
     {
         var export = new ScenarioExportResult(string.Empty, ImmutableList<string>.Empty, EmittedRowCount: 0);
 
-        await CreateExporter().CopyAsync(export, "Copied.", "this filter");
+        await CreateExporter().CopyAsync(export, "Copied.", ScenarioExportSubject.SingleFilter);
 
         await _clipboard.DidNotReceive().CopyTextAsync(Arg.Any<string>());
         _announcements.Received(1)
-            .Announce("Could not export this filter: only Basic filters can be exported as scenarios.");
+            .Announce("[[ScenarioExport_NotExportable_SingleFilter_BasicOnly]]");
     }
 
-    [Fact]
-    public void NotExportable_WhenNothingEmitted_AnnouncesAndReturnsTrue()
+    [Theory]
+    [InlineData("SingleFilter", "ScenarioExport_NotExportable_SingleFilter_BasicOnly")]
+    [InlineData("CurrentFilters", "ScenarioExport_NotExportable_CurrentFilters_BasicOnly")]
+    [InlineData("FilterSet", "ScenarioExport_NotExportable_FilterSet_BasicOnly")]
+    public void NotExportable_WhenNothingEmitted_RoutesSubjectBasicOnlyKey(
+        string subjectName,
+        string expectedKey)
     {
         var export = new ScenarioExportResult(string.Empty, ImmutableList<string>.Empty, EmittedRowCount: 0);
 
-        Assert.True(CreateExporter().NotExportable(export, "these filters"));
-        _announcements.Received(1)
-            .Announce("Could not export these filters: only Basic filters can be exported as scenarios.");
+        Assert.True(CreateExporter().NotExportable(export, Enum.Parse<ScenarioExportSubject>(subjectName)));
+        _announcements.Received(1).Announce($"[[{expectedKey}]]");
     }
 
     [Fact]
@@ -78,22 +99,24 @@ public sealed class ScenarioClipboardExporterTests
     {
         var export = new ScenarioExportResult("{}", ImmutableList<string>.Empty, EmittedRowCount: 2);
 
-        Assert.False(CreateExporter().NotExportable(export, "these filters"));
+        Assert.False(CreateExporter().NotExportable(export, ScenarioExportSubject.CurrentFilters));
         _announcements.DidNotReceive().Announce(Arg.Any<string>());
     }
 
-    [Fact]
-    public void NotExportable_WhenRowsSkipped_SurfacesSkippedCount()
+    [Theory]
+    [InlineData("SingleFilter", "ScenarioExport_NotExportable_SingleFilter_WithDetail")]
+    [InlineData("CurrentFilters", "ScenarioExport_NotExportable_CurrentFilters_WithDetail")]
+    [InlineData("FilterSet", "ScenarioExport_NotExportable_FilterSet_WithDetail")]
+    public void NotExportable_WhenRowsSkipped_RoutesSubjectDetailKeyWithLiteralWarningData(
+        string subjectName,
+        string expectedKey)
     {
-        var export = new ScenarioExportResult(
-            string.Empty,
-            ["3 row(s) skipped: not expressible as a Basic filter."],
-            EmittedRowCount: 0);
+        const string Warning = "3 row(s) skipped: not expressible as a Basic filter.";
+        var export = new ScenarioExportResult(string.Empty, [Warning], EmittedRowCount: 0);
 
-        Assert.True(CreateExporter().NotExportable(export, "these filters"));
-        _announcements.Received(1)
-            .Announce("Could not export these filters: 3 row(s) skipped: not expressible as a Basic filter.");
+        Assert.True(CreateExporter().NotExportable(export, Enum.Parse<ScenarioExportSubject>(subjectName)));
+        _announcements.Received(1).Announce($"[[{expectedKey}({Warning})]]");
     }
 
-    private ScenarioClipboardExporter CreateExporter() => new(_announcements, _alertDialog, _clipboard);
+    private ScenarioClipboardExporter CreateExporter() => new(_announcements, _alertDialog, _clipboard, new MarkerLocalizer());
 }

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterLibrary/FilterLibraryModalTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterLibrary/FilterLibraryModalTests.cs
@@ -3,6 +3,7 @@
 
 using Bunit;
 using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Localization;
 using EventLogExpert.Runtime.Alerts;
 using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.Runtime.Common.Clipboard;
@@ -10,12 +11,14 @@ using EventLogExpert.Runtime.Common.Files;
 using EventLogExpert.Runtime.FilterLibrary;
 using EventLogExpert.Runtime.FilterPane;
 using EventLogExpert.Runtime.Scenarios;
+using EventLogExpert.Scenarios.Catalog;
 using EventLogExpert.UI.FilterLibrary;
 using EventLogExpert.UI.Modal;
 using EventLogExpert.UI.Tests.TestUtils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using NSubstitute;
 using System.Collections.Immutable;
 using System.Reflection;
@@ -31,6 +34,7 @@ public sealed class FilterLibraryModalTests : BunitContext
     private readonly IModalCoordinator _modalCoordinator = Substitute.For<IModalCoordinator>();
     private readonly ModalId _modalId = new(1L);
     private readonly IModalService _modalService = Substitute.For<IModalService>();
+    private readonly IScenarioAuthoringService _scenarioAuthoring = Substitute.For<IScenarioAuthoringService>();
 
     public FilterLibraryModalTests()
     {
@@ -58,7 +62,7 @@ public sealed class FilterLibraryModalTests : BunitContext
         Services.AddSingleton(Substitute.For<ITagBulkUpdateFailedNotifier>());
 
         Services.AddSingleton(Substitute.For<IAlertDialogService>());
-        Services.AddSingleton(Substitute.For<IScenarioAuthoringService>());
+        Services.AddSingleton(_scenarioAuthoring);
         Services.AddSingleton(Substitute.For<IClipboardService>());
         Services.AddSingleton(new ScenarioAuthoringOptions(false));
 
@@ -632,6 +636,55 @@ public sealed class FilterLibraryModalTests : BunitContext
     }
 
     [Fact]
+    public async Task ScenarioExportCopyFilterSet_WhenNotExportable_RoutesFilterSetDetailSubject()
+    {
+        Services.AddSingleton<IStringLocalizer<SharedResource>>(new MarkerLocalizer());
+        Services.AddSingleton(new ScenarioAuthoringOptions(true));
+        const string warning = "3 row(s) skipped: not expressible as a Basic filter.";
+        _scenarioAuthoring.ExportRows(Arg.Any<IReadOnlyList<SavedFilter>>(), Arg.Any<IReadOnlyList<string>>())
+            .Returns(new ScenarioExportResult(string.Empty, [warning], EmittedRowCount: 0));
+        var filterSet = BuildFilterSet("Scenario Set");
+        SetState(new FilterLibraryState { Entries = [filterSet], IsLoaded = true });
+        var component = Render<FilterLibraryModal>();
+
+        await InvokePrivateTask(component.Instance, "HandleCopyScenarioAsync", filterSet.Id);
+
+        _announcements.Received(1).Announce(
+            "[[ScenarioExport_NotExportable_FilterSet_WithDetail(3 row(s) skipped: not expressible as a Basic filter.)]]");
+    }
+
+    [Fact]
+    public async Task ScenarioExportCopyLibraryRow_WhenNotExportable_RoutesSingleFilterSubject()
+    {
+        Services.AddSingleton<IStringLocalizer<SharedResource>>(new MarkerLocalizer());
+        Services.AddSingleton(new ScenarioAuthoringOptions(true));
+        _scenarioAuthoring.ExportRows(Arg.Any<IReadOnlyList<SavedFilter>>(), Arg.Any<IReadOnlyList<string>>())
+            .Returns(new ScenarioExportResult(string.Empty, ImmutableList<string>.Empty, EmittedRowCount: 0));
+        SetState(new FilterLibraryState { Entries = [], IsLoaded = true });
+        var component = Render<FilterLibraryModal>();
+
+        await InvokePrivateTask(component.Instance, "CopyLibraryRowAsync", SavedFilter.TryCreate("Level == 4")!);
+
+        _announcements.Received(1).Announce("[[ScenarioExport_NotExportable_SingleFilter_BasicOnly]]");
+    }
+
+    [Fact]
+    public async Task ScenarioExportSaveFilterSet_WhenNotExportable_RoutesFilterSetBasicOnlySubject()
+    {
+        Services.AddSingleton<IStringLocalizer<SharedResource>>(new MarkerLocalizer());
+        Services.AddSingleton(new ScenarioAuthoringOptions(true));
+        _scenarioAuthoring.ExportRows(Arg.Any<IReadOnlyList<SavedFilter>>(), Arg.Any<IReadOnlyList<string>>())
+            .Returns(new ScenarioExportResult(string.Empty, ImmutableList<string>.Empty, EmittedRowCount: 0));
+        var filterSet = BuildFilterSet("Scenario Set");
+        SetState(new FilterLibraryState { Entries = [filterSet], IsLoaded = true });
+        var component = Render<FilterLibraryModal>();
+
+        await InvokePrivateTask(component.Instance, "HandleSaveScenarioAsync", filterSet.Id);
+
+        _announcements.Received(1).Announce("[[ScenarioExport_NotExportable_FilterSet_BasicOnly]]");
+    }
+
+    [Fact]
     public async Task TabClick_SwitchesActiveTab()
     {
         SetState(new FilterLibraryState { IsLoaded = true });
@@ -1005,6 +1058,14 @@ public sealed class FilterLibraryModalTests : BunitContext
         };
     }
 
+    private static LibraryEntryFilterSet BuildFilterSet(string name) =>
+        new()
+        {
+            Name = name,
+            CreatedUtc = DateTimeOffset.UtcNow,
+            Filters = [SavedFilter.TryCreate("Level == 4")!],
+        };
+
     private static LibraryEntrySavedFilter BuildSavedFilter(string name) =>
         BuildFilterEntry(name) with { Origin = LibraryEntryOrigin.UserSaved };
 
@@ -1016,6 +1077,16 @@ public sealed class FilterLibraryModalTests : BunitContext
 
         Assert.NotNull(dict);
         return dict[tab];
+    }
+
+    private static async Task InvokePrivateTask(FilterLibraryModal modal, string methodName, params object[] arguments)
+    {
+        var task = (Task?)typeof(FilterLibraryModal)
+            .GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic)
+            ?.Invoke(modal, arguments);
+
+        Assert.NotNull(task);
+        await task;
     }
 
     private void SetState(FilterLibraryState state)

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterPane/FilterPaneLocalizerWiringTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterPane/FilterPaneLocalizerWiringTests.cs
@@ -1,0 +1,443 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using EventLogExpert.Filtering.Drafts;
+using EventLogExpert.Filtering.Evaluation;
+using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Localization;
+using EventLogExpert.Runtime.Alerts;
+using EventLogExpert.Runtime.Announcement;
+using EventLogExpert.Runtime.Common.Clipboard;
+using EventLogExpert.Runtime.Common.Files;
+using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.FilterLibrary;
+using EventLogExpert.Runtime.FilterPane;
+using EventLogExpert.Runtime.Menu;
+using EventLogExpert.Runtime.Scenarios;
+using EventLogExpert.Runtime.Settings;
+using EventLogExpert.Scenarios.Catalog;
+using EventLogExpert.UI.Tests.TestUtils;
+using Fluxor;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using NSubstitute;
+using System.Collections.Immutable;
+using System.Reflection;
+
+namespace EventLogExpert.UI.Tests.FilterPane;
+
+public sealed class FilterPaneLocalizerWiringTests : BunitContext
+{
+    private readonly IActiveFiltersSource _activeFilters = Substitute.For<IActiveFiltersSource>();
+    private readonly IAlertDialogService _alertDialog = Substitute.For<IAlertDialogService>();
+    private readonly IAnnouncementService _announcements = Substitute.For<IAnnouncementService>();
+    private readonly IClearAllFiltersNotifier _clearAllFiltersNotifier = Substitute.For<IClearAllFiltersNotifier>();
+    private readonly IClipboardService _clipboard = Substitute.For<IClipboardService>();
+    private readonly IEventLogQueries _eventLogQueries = Substitute.For<IEventLogQueries>();
+    private readonly IFilePickerService _filePicker = Substitute.For<IFilePickerService>();
+    private readonly IFilterLibraryCommands _filterLibraryCommands = Substitute.For<IFilterLibraryCommands>();
+    private readonly IFilterPaneCommands _filterPaneCommands = Substitute.For<IFilterPaneCommands>();
+    private readonly IFilterPromotedNotifier _filterPromotedNotifier = Substitute.For<IFilterPromotedNotifier>();
+    private readonly IFilteredDateRangeSource _filteredDateRange = Substitute.For<IFilteredDateRangeSource>();
+    private readonly ILibraryEntriesSource _libraryEntries = Substitute.For<ILibraryEntriesSource>();
+    private readonly ILibraryLoadStatusSource _libraryLoadStatus = Substitute.For<ILibraryLoadStatusSource>();
+    private readonly ILoadedLogNamesSource _loadedLogNames = Substitute.For<ILoadedLogNamesSource>();
+    private readonly IMenuActionService _menuActions = Substitute.For<IMenuActionService>();
+    private readonly IOpenLogsPresenceSource _openLogsPresence = Substitute.For<IOpenLogsPresenceSource>();
+    private readonly IScenarioApplyService _scenarioApply = Substitute.For<IScenarioApplyService>();
+    private readonly IScenarioAuthoringService _scenarioAuthoring = Substitute.For<IScenarioAuthoringService>();
+    private readonly IScenarioQueryService _scenarioQuery = Substitute.For<IScenarioQueryService>();
+    private readonly ISetFilterDateRangeSucceededNotifier _setFilterDateRangeSucceededNotifier = Substitute.For<ISetFilterDateRangeSucceededNotifier>();
+    private readonly ISettingsService _settings = Substitute.For<ISettingsService>();
+    private DateFilter? _dateFilter;
+
+    private ImmutableList<SavedFilter> _filters = [];
+    private ImmutableList<LibraryEntry> _library = [];
+    private LibraryLoadStatus _loadStatus = new(IsLoaded: true, LoadError: false);
+    private ImmutableHashSet<string> _loadedNames = ImmutableHashSet<string>.Empty;
+
+    public FilterPaneLocalizerWiringTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddBannerHostDependencies();
+        Services.AddMenuMocks();
+        Services.AddSingleton<IStringLocalizer<SharedResource>>(new MarkerLocalizer());
+        Services.AddSingleton(_activeFilters);
+        Services.AddSingleton(_alertDialog);
+        Services.AddSingleton(_announcements);
+        Services.AddSingleton(_clearAllFiltersNotifier);
+        Services.AddSingleton(_clipboard);
+        Services.AddSingleton(_eventLogQueries);
+        Services.AddSingleton(_filterLibraryCommands);
+        Services.AddSingleton(_filterPaneCommands);
+        Services.AddSingleton(_filterPromotedNotifier);
+        Services.AddSingleton(_filteredDateRange);
+        Services.AddSingleton(_filePicker);
+        Services.AddSingleton(_libraryEntries);
+        Services.AddSingleton(_libraryLoadStatus);
+        Services.AddSingleton(_loadedLogNames);
+        Services.AddSingleton(_menuActions);
+        Services.AddSingleton(_openLogsPresence);
+        Services.AddSingleton(_scenarioApply);
+        Services.AddSingleton(_scenarioAuthoring);
+        Services.AddSingleton(_scenarioQuery);
+        Services.AddSingleton(_setFilterDateRangeSucceededNotifier);
+        Services.AddSingleton(_settings);
+        Services.AddSingleton(new ScenarioAuthoringOptions(true));
+        Services.AddFluxor(options => options.ScanAssemblies(typeof(UI.FilterPane.FilterPane).Assembly));
+
+        _activeFilters.Current.Returns(_ => _filters);
+        _filteredDateRange.Current.Returns(_ => _dateFilter);
+        _libraryEntries.Current.Returns(_ => _library);
+        _libraryLoadStatus.Current.Returns(_ => _loadStatus);
+        _loadedLogNames.Current.Returns(_ => _loadedNames);
+        _openLogsPresence.HasOpenLogs.Returns(_ => _loadedNames.Count > 0);
+        _settings.TimeZoneInfo.Returns(TimeZoneInfo.Utc);
+        _eventLogQueries.GetChannelNames().Returns(["System"]);
+    }
+
+    [Fact]
+    public void ActiveFilterStatus_UsesRawUngroupedCount()
+    {
+        _filters = [.. Enumerable.Range(0, 1500).Select(index => SavedFilter.TryCreate($"Level == {index}")! with { IsEnabled = true })];
+
+        var component = Render<UI.FilterPane.FilterPane>();
+
+        Assert.Contains("[[FilterPane_ActiveFilters(1500)]]", component.Markup);
+    }
+
+    [Fact]
+    public void Announcements_RouteReceivedMessagesThroughLocalizer()
+    {
+        _loadStatus = new LibraryLoadStatus(IsLoaded: true, LoadError: true);
+        var component = Render<UI.FilterPane.FilterPane>();
+
+        component.Instance.OpenFilterSetPicker();
+        _announcements.Received(1).Announce("[[FilterPane_Announcement_LoadFailedRetryViaModal]]");
+
+        _loadStatus = new LibraryLoadStatus(IsLoaded: false, LoadError: false);
+        component.Instance.OpenFilterSetPicker();
+        _announcements.Received(1).Announce("[[FilterPane_Announcement_LoadingTryAgain]]");
+
+        _loadStatus = new LibraryLoadStatus(IsLoaded: true, LoadError: false);
+        Assert.Equal("[[FilterPane_Announcement_RecentNoneAvailable]]", component.Instance.GetRecentDisabledReason());
+
+        component.Instance.SelectedFilterSetId = new LibraryEntryId(Guid.NewGuid());
+        component.Instance.TryResolveSelectedFilterSet();
+        _announcements.Received(1).Announce("[[FilterPane_Announcement_SelectedFilterSetMissing]]");
+
+        component.Instance.OpenScenarioPicker();
+        component.Instance.ApplyScenarioSelection();
+        _announcements.Received(1).Announce("[[FilterPane_Announcement_SelectedScenarioMissing]]");
+    }
+
+    [Theory]
+    [InlineData(1, "[[FilterPane_ClearConfirm_Message_One]]")]
+    [InlineData(2, "[[FilterPane_ClearConfirm_Message_Many(2)]]")]
+    [InlineData(1500, "[[FilterPane_ClearConfirm_Message_Many(1500)]]")]
+    public async Task ClearConfirm_RoutesOneAndManyMessagesWithRawCounts(int count, string expectedMessage)
+    {
+        var component = Render<UI.FilterPane.FilterPane>();
+        AddPendingDrafts(component.Instance, count);
+
+        await InvokePrivateTask(component.Instance, "ClearAllFiltersAsync");
+
+        await _alertDialog.Received(1).ShowAlert(
+            "[[FilterPane_ClearConfirm_Title]]",
+            expectedMessage,
+            "[[FilterPane_Action_Clear]]",
+            "[[Modal_Cancel]]");
+    }
+
+    [Fact]
+    public void DateEditor_RoutesLabelsAriaAndActionsThroughLocalizer()
+    {
+        var component = Render<UI.FilterPane.FilterPane>();
+        component.Instance.EditDateFilter();
+        component.Render();
+
+        Assert.Contains("[[FilterPane_Date_AfterLabel]]", component.Markup);
+        Assert.Contains("[[FilterPane_Date_BeforeLabel]]", component.Markup);
+        Assert.Contains("[[FilterPane_Date_QuickRangeLabel]]", component.Markup);
+        Assert.Equal("[[FilterPane_Date_AfterAria]]", component.Find("input.filter-datetime").GetAttribute("aria-label"));
+        Assert.Contains("[[FilterPane_Date_QuickRangeAria]]", component.Markup);
+        Assert.Contains("[[FilterPane_Action_Apply]]", component.Markup);
+        Assert.Contains("[[FilterPane_Action_Remove]]", component.Markup);
+    }
+
+    [Fact]
+    public void FilterSetEmptyState_RendersBothBranchesWithStrongEmphasisAndEncodedTemplateText()
+    {
+        Services.AddSingleton<IStringLocalizer<SharedResource>>(new EmptyStateSentinelLocalizer());
+        var emptyComponent = Render<UI.FilterPane.FilterPane>();
+
+        emptyComponent.Instance.OpenFilterSetPicker();
+        emptyComponent.Render();
+
+        AssertEmptyStateBranch(emptyComponent, "NoSavableFilterPane_FilterSetEmpty_NoSavableFilters");
+
+        _filters = [SavedFilter.TryCreate("Level == 4")! with { IsEnabled = true }];
+        var savableComponent = Render<UI.FilterPane.FilterPane>();
+        savableComponent.Instance.OpenFilterSetPicker();
+        savableComponent.Render();
+
+        AssertEmptyStateBranch(savableComponent, "WithSavableFilterPane_FilterSetEmpty_WithSavableFilters");
+    }
+
+    [Fact]
+    public void FilterSetPicker_RoutesLabelsOptionMetaAndRawCountsThroughLocalizer()
+    {
+        var filterSet = BuildFilterSet("Data <Set>", ["tagA", "tagB"], 1500);
+        _library = [filterSet];
+        var component = Render<UI.FilterPane.FilterPane>();
+
+        component.Instance.OpenFilterSetPicker();
+        component.Render();
+
+        Assert.Contains("[[FilterPane_FilterSet_Label]]", component.Markup);
+        Assert.Equal("[[FilterPane_FilterSet_SelectAria]]", component.Find(".filter-set-dropdown").GetAttribute("aria-label"));
+        Assert.Contains("Data &lt;Set&gt;", component.Markup);
+        Assert.Contains("[[FilterPane_FilterSetFilterCount_Many(1500)]]", component.Markup);
+        Assert.Contains("[[FilterPane_FilterSetDetail_WithTags([[FilterPane_FilterSetFilterCount_Many(1500)]]|tagA, tagB)]]", component.Markup);
+        Assert.Contains("[[FilterPane_FilterSetOptionMeta([[FilterPane_FilterSetDetail_WithTags([[FilterPane_FilterSetFilterCount_Many(1500)]]|tagA, tagB)]])]]", component.Markup);
+        Assert.Equal("[[FilterPane_FilterSet_ReplaceAria]]", component.Find("button[aria-label='[[FilterPane_FilterSet_ReplaceAria]]']").GetAttribute("aria-label"));
+    }
+
+    [Theory]
+    [InlineData(1, "[[FilterPane_FilterSetFilterCount_One(1)]]")]
+    [InlineData(2, "[[FilterPane_FilterSetFilterCount_Many(2)]]")]
+    [InlineData(1500, "[[FilterPane_FilterSetFilterCount_Many(1500)]]")]
+    public void FilterSetPicker_RoutesOneManyAndLargeCountsThroughDistinctKeys(int count, string expectedCountMarker)
+    {
+        var filterSet = BuildFilterSet("Count Set", [], count);
+        _library = [filterSet];
+        var component = Render<UI.FilterPane.FilterPane>();
+
+        component.Instance.OpenFilterSetPicker();
+        component.Render();
+
+        Assert.Contains(expectedCountMarker, component.Markup);
+    }
+
+    [Fact]
+    public void HeaderChrome_RoutesActionsTitlesHintsAndRawActiveCountThroughLocalizer()
+    {
+        _filters = [SavedFilter.TryCreate("Level == 4")! with { IsEnabled = true }];
+        _loadedNames = ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, "System");
+
+        var component = Render<UI.FilterPane.FilterPane>();
+
+        Assert.Equal("[[FilterPane_AddBasicTitle]]", component.Find(".split-button-primary").GetAttribute("title"));
+        Assert.Contains("[[FilterPane_Action_AddFilter]]", component.Markup);
+        Assert.Equal("[[FilterPane_AddMenuAria]]", component.Find(".split-button-chevron").GetAttribute("aria-label"));
+        Assert.Contains("[[FilterPane_Action_AddExclusion]]", component.Markup);
+        Assert.Contains("[[FilterPane_Action_AddDateFilter]]", component.Markup);
+        Assert.Contains("[[FilterPane_Action_ApplyFilterSet]]", component.Markup);
+        Assert.Contains("[[FilterPane_Action_ApplyScenario]]", component.Markup);
+        Assert.Contains("[[FilterPane_ActiveFilters(1)]]", component.Markup);
+        Assert.Equal("[[FilterPane_SaveAsFilterSet_Aria]]", component.Find("button[title='[[FilterPane_SaveAsFilterSet_TitleEnabled]]']").GetAttribute("aria-label"));
+        Assert.Equal("[[FilterPane_ClearAll_Aria]]", component.Find("button[title='[[FilterPane_ClearAll_TitleEnabled]]']").GetAttribute("aria-label"));
+        Assert.Equal("[[FilterPane_OpenLibrary_Aria]]", component.Find("button[title='[[FilterPane_OpenLibrary_Title]]']").GetAttribute("aria-label"));
+        Assert.Equal("[[FilterPane_CopyScenarioJson_Aria]]", component.Find("button[title='[[FilterPane_CopyScenarioJson_Title]]']").GetAttribute("aria-label"));
+        Assert.Equal("[[FilterPane_SaveScenarioJson_Aria]]", component.Find("button[title='[[FilterPane_SaveScenarioJson_Title]]']").GetAttribute("aria-label"));
+        Assert.Contains("[[FilterPane_ScenarioExport_HintDisabled]]", component.Markup);
+        Assert.Contains("[[FilterPane_SaveFilterSet_HintDisabled]]", component.Markup);
+        Assert.Contains("[[FilterPane_ClearFilters_HintDisabled]]", component.Markup);
+    }
+
+    [Fact]
+    public void HeaderChrome_WhenStateChanges_RoutesBothEnabledAndDisabledTitleBranches()
+    {
+        var component = Render<UI.FilterPane.FilterPane>();
+
+        Assert.True(component.Find("button[aria-label='[[FilterPane_SaveAsFilterSet_Aria]]']").HasAttribute("disabled"));
+        Assert.Equal("[[FilterPane_SaveAsFilterSet_TitleDisabled]]", component.Find("button[aria-label='[[FilterPane_SaveAsFilterSet_Aria]]']").GetAttribute("title"));
+        Assert.True(component.Find("button[aria-label='[[FilterPane_ClearAll_Aria]]']").HasAttribute("disabled"));
+        Assert.Equal("[[FilterPane_ClearAll_TitleDisabled]]", component.Find("button[aria-label='[[FilterPane_ClearAll_Aria]]']").GetAttribute("title"));
+
+        _dateFilter = new DateFilter { IsEnabled = false };
+        _filteredDateRange.Changed += Raise.Event<Action>();
+        component.Render();
+
+        Assert.True(component.Find("button[aria-label='[[FilterPane_SaveAsFilterSet_Aria]]']").HasAttribute("disabled"));
+        Assert.Equal("save-filters-empty-hint", component.Find("button[aria-label='[[FilterPane_SaveAsFilterSet_Aria]]']").GetAttribute("aria-describedby"));
+        Assert.False(component.Find("button[aria-label='[[FilterPane_ClearAll_Aria]]']").HasAttribute("disabled"));
+        Assert.Equal("[[FilterPane_ClearAll_TitleEnabled]]", component.Find("button[aria-label='[[FilterPane_ClearAll_Aria]]']").GetAttribute("title"));
+
+        _filters = [SavedFilter.TryCreate("Level == 4")! with { IsEnabled = true }];
+        _activeFilters.Changed += Raise.Event<Action>();
+        component.Render();
+
+        Assert.False(component.Find("button[aria-label='[[FilterPane_SaveAsFilterSet_Aria]]']").HasAttribute("disabled"));
+        Assert.Equal("[[FilterPane_SaveAsFilterSet_TitleEnabled]]", component.Find("button[aria-label='[[FilterPane_SaveAsFilterSet_Aria]]']").GetAttribute("title"));
+    }
+
+    [Fact]
+    public async Task SaveScenario_WhenFileWriteFails_RoutesSaveDialogAndFailureAlertThroughLocalizer()
+    {
+        _filters = [SavedFilter.TryCreate("Level == 4")! with { IsEnabled = true }];
+        _scenarioAuthoring.ExportRows(Arg.Any<IReadOnlyList<SavedFilter>>(), Arg.Any<IReadOnlyList<string>>())
+            .Returns(new ScenarioExportResult("{}", ImmutableList<string>.Empty, EmittedRowCount: 1));
+        string missingDirectoryPath = Path.Combine("missing-scenario-export", Guid.NewGuid().ToString("N"), "scenario.json");
+        _filePicker.PickSaveAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<string?>())
+            .Returns(missingDirectoryPath);
+        var component = Render<UI.FilterPane.FilterPane>();
+
+        await InvokePrivateTask(component.Instance, "SaveScenarioJsonAsync");
+
+        await _filePicker.Received(1).PickSaveAsync("[[FilterPane_ExportScenario_Title]]", Arg.Is<IReadOnlyList<string>>(extensions => extensions != null && extensions.SequenceEqual(new[] { ".json" })), "scenario.json");
+        await _alertDialog.Received(1).ShowAlert(
+            "[[FilterPane_ExportFailed_Title]]",
+            Arg.Any<string>(),
+            "[[Modal_Accept]]");
+    }
+
+    [Fact]
+    public async Task SaveScenario_WhenFileWritten_RoutesSavedPathThroughLocalizer()
+    {
+        _filters = [SavedFilter.TryCreate("Level == 4")! with { IsEnabled = true }];
+        _scenarioAuthoring.ExportRows(Arg.Any<IReadOnlyList<SavedFilter>>(), Arg.Any<IReadOnlyList<string>>())
+            .Returns(new ScenarioExportResult("{}", ImmutableList<string>.Empty, EmittedRowCount: 1));
+        string path = Path.Combine(AppContext.BaseDirectory, "scenario-localizer-success.json");
+        _filePicker.PickSaveAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<string?>())
+            .Returns(path);
+        var component = Render<UI.FilterPane.FilterPane>();
+
+        try
+        {
+            await InvokePrivateTask(component.Instance, "SaveScenarioJsonAsync");
+
+            _announcements.Received(1).Announce($"[[FilterPane_ScenarioSaved({path})]]");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task ScenarioExportCallSites_RouteSingleFilterAndCurrentFiltersSubjects()
+    {
+        _filters = [SavedFilter.TryCreate("Level == 4")! with { IsEnabled = true }];
+        _scenarioAuthoring.ExportRows(Arg.Any<IReadOnlyList<SavedFilter>>(), Arg.Any<IReadOnlyList<string>>())
+            .Returns(
+                new ScenarioExportResult(string.Empty, ImmutableList<string>.Empty, EmittedRowCount: 0),
+                new ScenarioExportResult(string.Empty, ["skipped detail"], EmittedRowCount: 0),
+                new ScenarioExportResult(string.Empty, ImmutableList<string>.Empty, EmittedRowCount: 0));
+        var component = Render<UI.FilterPane.FilterPane>();
+
+        await InvokePrivateTask(component.Instance, "CopyActiveRowAsync", _filters[0]);
+        await InvokePrivateTask(component.Instance, "CopyScenarioJsonAsync");
+        await InvokePrivateTask(component.Instance, "SaveScenarioJsonAsync");
+
+        _announcements.Received(1).Announce("[[ScenarioExport_NotExportable_SingleFilter_BasicOnly]]");
+        _announcements.Received(1).Announce("[[ScenarioExport_NotExportable_CurrentFilters_WithDetail(skipped detail)]]");
+        _announcements.Received(1).Announce("[[ScenarioExport_NotExportable_CurrentFilters_BasicOnly]]");
+    }
+
+    [Fact]
+    public void ScenarioPicker_RoutesLabelsGroupDisplayOptionsAndNullFormatterThroughLocalizer()
+    {
+        _loadedNames = ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, "System");
+        _scenarioQuery.GetInAppScenarios(Arg.Any<IReadOnlyCollection<string>>())
+            .Returns([Scenario("sys", ScenarioGroup.SystemHealth), Scenario("sec", ScenarioGroup.Security)]);
+        var component = Render<UI.FilterPane.FilterPane>();
+
+        component.Instance.OpenScenarioPicker();
+        component.Render();
+
+        Assert.Equal(string.Empty, component.Instance.FormatScenarioGroup(null));
+        Assert.Equal("[[Dashboard_Group_Security]]", component.Instance.FormatScenarioGroup(ScenarioGroup.Security));
+        Assert.Contains("[[FilterPane_Scenario_CategoryLabel]]", component.Markup);
+        var categoryDropdown = component.Find(".scenario-category-dropdown");
+        Assert.Equal("[[FilterPane_Scenario_CategoryAria]]", categoryDropdown.GetAttribute("aria-label"));
+        Assert.Contains(
+            "[[Dashboard_Group_SystemHealth]]",
+            categoryDropdown.ParentElement!.QuerySelector(".dropdown-list")!.TextContent,
+            StringComparison.Ordinal);
+        Assert.Contains("[[FilterPane_Scenario_Label]]", component.Markup);
+        Assert.Equal("[[FilterPane_Scenario_SelectAria]]", component.Find(".scenario-item-dropdown").GetAttribute("aria-label"));
+        Assert.Contains("[[FilterPane_Scenario_OptionTitle([[Dashboard_Group_SystemHealth]]|Purpose sys)]]", component.Markup);
+        Assert.Contains("sys", component.Markup);
+        Assert.DoesNotContain("[[sys]]", component.Markup);
+    }
+
+    private static void AddPendingDrafts(UI.FilterPane.FilterPane pane, int count)
+    {
+        var drafts = (List<FilterDraft>)typeof(UI.FilterPane.FilterPane)
+            .GetField("_pendingDrafts", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(pane)!;
+
+        for (int index = 0; index < count; index++)
+        {
+            drafts.Add(new FilterDraft { Mode = FilterMode.Basic });
+        }
+    }
+
+    private static void AssertEmptyStateBranch(
+        IRenderedComponent<UI.FilterPane.FilterPane> component,
+        string expectedBranchMarker)
+    {
+        var empty = component.Find(".filter-empty-state");
+
+        Assert.Contains(expectedBranchMarker, empty.TextContent, StringComparison.Ordinal);
+        Assert.Single(empty.QuerySelectorAll("strong"));
+        Assert.Equal("[[FilterPane_SaveAsFilterSet_EmphasisLabel]]", empty.QuerySelector("strong")!.TextContent);
+        Assert.Contains($"{expectedBranchMarker}&lt;before&gt;&amp;", empty.InnerHtml, StringComparison.Ordinal);
+        Assert.Empty(empty.QuerySelectorAll("before"));
+        Assert.Empty(empty.QuerySelectorAll("after"));
+    }
+
+    private static LibraryEntryFilterSet BuildFilterSet(string name, ImmutableList<string> tags, int count) =>
+        new()
+        {
+            Name = name,
+            CreatedUtc = DateTimeOffset.UtcNow,
+            Filters = [.. Enumerable.Range(0, count).Select(index => SavedFilter.TryCreate($"Level == {index}")!)],
+            Tags = tags,
+        };
+
+    private static async Task InvokePrivateTask(UI.FilterPane.FilterPane pane, string methodName, params object[] arguments)
+    {
+        var task = (Task?)typeof(UI.FilterPane.FilterPane)
+            .GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic)
+            ?.Invoke(pane, arguments);
+
+        Assert.NotNull(task);
+        await task;
+    }
+
+    private static ScenarioDefinition Scenario(string id, ScenarioGroup group) =>
+        new()
+        {
+            Id = id,
+            Name = id,
+            Purpose = $"Purpose {id}",
+            Group = group,
+            Channels = ["System"],
+            Filters = [],
+        };
+
+    private sealed class EmptyStateSentinelLocalizer : IStringLocalizer<SharedResource>
+    {
+        private readonly MarkerLocalizer _inner = new();
+
+        public LocalizedString this[string name] => name switch
+        {
+            "FilterPane_FilterSetEmpty_NoSavableFilters" => new(
+                name,
+                "NoSavableFilterPane_FilterSetEmpty_NoSavableFilters<before>&{0}<after>",
+                resourceNotFound: false),
+            "FilterPane_FilterSetEmpty_WithSavableFilters" => new(
+                name,
+                "WithSavableFilterPane_FilterSetEmpty_WithSavableFilters<before>&{0}<after>",
+                resourceNotFound: false),
+            _ => _inner[name],
+        };
+
+        public LocalizedString this[string name, params object[] arguments] => _inner[name, arguments];
+
+        public IEnumerable<LocalizedString> GetAllStrings(bool includeParentCultures) => [];
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterPane/FilterPaneTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterPane/FilterPaneTests.cs
@@ -7,6 +7,7 @@ using EventLogExpert.Eventing.Common.Channels;
 using EventLogExpert.Eventing.Common.Events;
 using EventLogExpert.Filtering.Evaluation;
 using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Localization;
 using EventLogExpert.Runtime.Alerts;
 using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.Runtime.Common.Clipboard;
@@ -25,6 +26,7 @@ using EventLogExpert.UI.Tests.TestUtils;
 using Fluxor;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using NSubstitute;
 using System.Collections.Immutable;
 using System.Reflection;
@@ -120,6 +122,9 @@ public sealed class FilterPaneTests : BunitContext
         JSInterop.Mode = JSRuntimeMode.Loose;
     }
 
+    private IStringLocalizer<SharedResource> Localizer =>
+        Services.GetRequiredService<IStringLocalizer<SharedResource>>();
+
     [Fact]
     public void AddDateFilter_PreFillsModelFromEventLogQueriesRange()
     {
@@ -157,7 +162,7 @@ public sealed class FilterPaneTests : BunitContext
 
         component.Instance.ApplyFilterSetSelection();
 
-        _announcements.Received(1).Announce(FilterPaneAnnouncements.LoadFailedRetryViaModal);
+        _announcements.Received(1).Announce(FilterPaneAnnouncements.LoadFailedRetryViaModal(Localizer));
         _filterLibraryCommands.DidNotReceiveWithAnyArgs().ApplyEntry(default);
     }
 
@@ -176,7 +181,7 @@ public sealed class FilterPaneTests : BunitContext
 
         component.Instance.ApplyFilterSetSelection();
 
-        _announcements.Received(1).Announce(FilterPaneAnnouncements.SelectedFilterSetMissing);
+        _announcements.Received(1).Announce(FilterPaneAnnouncements.SelectedFilterSetMissing(Localizer));
         Assert.Equal(filterSetA.Id, component.Instance.SelectedFilterSetId);
         _filterLibraryCommands.DidNotReceiveWithAnyArgs().ApplyEntry(default);
     }
@@ -195,7 +200,7 @@ public sealed class FilterPaneTests : BunitContext
 
         component.Instance.ApplyFilterSetSelection();
 
-        _announcements.Received(1).Announce(FilterPaneAnnouncements.LoadingTryAgain);
+        _announcements.Received(1).Announce(FilterPaneAnnouncements.LoadingTryAgain(Localizer));
         _filterLibraryCommands.DidNotReceiveWithAnyArgs().ApplyEntry(default);
     }
 
@@ -275,7 +280,7 @@ public sealed class FilterPaneTests : BunitContext
 
         component.Instance.ApplyScenarioSelection();
 
-        _announcements.Received(1).Announce(FilterPaneAnnouncements.SelectedScenarioMissing);
+        _announcements.Received(1).Announce(FilterPaneAnnouncements.SelectedScenarioMissing(Localizer));
         _scenarioApply.DidNotReceiveWithAnyArgs().ApplyInApp(null!, false);
     }
 
@@ -356,7 +361,7 @@ public sealed class FilterPaneTests : BunitContext
 
         var component = Render<UI.FilterPane.FilterPane>();
         var copyButton = component.FindAll("button")
-            .First(button => button.GetAttribute("aria-label") == "Copy scenario JSON");
+            .First(button => button.GetAttribute("aria-label") == Localizer["FilterPane_CopyScenarioJson_Aria"]);
 
         await copyButton.ClickAsync(new MouseEventArgs());
 
@@ -435,13 +440,13 @@ public sealed class FilterPaneTests : BunitContext
         component.Instance.OpenFilterSetPicker();
         component.Render();
 
-        var replace = component.Find("button[aria-label='Replace filters with selected filter set']");
+        var replace = component.Find($"button[aria-label='{Localizer["FilterPane_FilterSet_ReplaceAria"]}']");
         Assert.False(replace.HasAttribute("disabled"));
 
         component.Instance.SelectedFilterSetId = default;
         component.Render();
 
-        Assert.True(component.Find("button[aria-label='Replace filters with selected filter set']").HasAttribute("disabled"));
+        Assert.True(component.Find($"button[aria-label='{Localizer["FilterPane_FilterSet_ReplaceAria"]}']").HasAttribute("disabled"));
     }
 
     [Fact]
@@ -491,7 +496,7 @@ public sealed class FilterPaneTests : BunitContext
 
         var reason = component.Instance.GetRecentDisabledReason();
 
-        Assert.Equal(FilterPaneAnnouncements.RecentNoneAvailable, reason);
+        Assert.Equal(FilterPaneAnnouncements.RecentNoneAvailable(Localizer), reason);
     }
 
     [Fact]
@@ -526,12 +531,13 @@ public sealed class FilterPaneTests : BunitContext
     }
 
     [Theory]
-    [InlineData(true, false, true, "Filter library failed to load. Open Filter Library to retry.")]
-    [InlineData(false, false, false, "Filter library is still loading. Please try again.")]
-    [InlineData(true, true, true, "Filter library failed to load. Open Filter Library to retry.")]
+    [InlineData(true, false, true, "[[FilterPane_Announcement_LoadFailedRetryViaModal]]")]
+    [InlineData(false, false, false, "[[FilterPane_Announcement_LoadingTryAgain]]")]
+    [InlineData(true, true, true, "[[FilterPane_Announcement_LoadFailedRetryViaModal]]")]
     public void GetRecentDisabledReason_WhenLoadErrorOrLoading_ReturnsContextSpecificMessage(
         bool isLoaded, bool hasEntries, bool loadError, string expectedReason)
     {
+        Services.AddSingleton<IStringLocalizer<SharedResource>>(new MarkerLocalizer());
         var entries = hasEntries
             ? ImmutableList.Create<LibraryEntry>(BuildSavedFilter("X", isFavorite: true))
             : ImmutableList<LibraryEntry>.Empty;
@@ -625,7 +631,7 @@ public sealed class FilterPaneTests : BunitContext
 
         component.Instance.OpenFilterSetPicker();
 
-        _announcements.Received(1).Announce(FilterPaneAnnouncements.LoadFailedRetryViaModal);
+        _announcements.Received(1).Announce(FilterPaneAnnouncements.LoadFailedRetryViaModal(Localizer));
     }
 
     [Fact]
@@ -653,7 +659,7 @@ public sealed class FilterPaneTests : BunitContext
 
         component.Instance.OpenFilterSetPicker();
 
-        _announcements.Received(1).Announce(FilterPaneAnnouncements.LoadingTryAgain);
+        _announcements.Received(1).Announce(FilterPaneAnnouncements.LoadingTryAgain(Localizer));
     }
 
     [Fact]
@@ -709,7 +715,7 @@ public sealed class FilterPaneTests : BunitContext
         var component = Render<UI.FilterPane.FilterPane>();
         await FindApplyScenarioButton(component)!.ClickAsync(new MouseEventArgs());
 
-        Assert.Contains("Category:", component.Find("#scenario-picker").TextContent);
+        Assert.NotNull(component.Find("#scenario-picker .scenario-category-dropdown"));
     }
 
     [Fact]
@@ -741,7 +747,7 @@ public sealed class FilterPaneTests : BunitContext
         var component = Render<UI.FilterPane.FilterPane>();
         await FindApplyScenarioButton(component)!.ClickAsync(new MouseEventArgs());
 
-        Assert.DoesNotContain("Category:", component.Find("#scenario-picker").TextContent);
+        Assert.Empty(component.FindAll("#scenario-picker .scenario-category-dropdown"));
     }
 
     [Fact]
@@ -756,7 +762,7 @@ public sealed class FilterPaneTests : BunitContext
         await FindApplyScenarioButton(component)!.ClickAsync(new MouseEventArgs());
 
         var status = component.Find("[role='status']");
-        Assert.Equal("No scenarios match the loaded logs.", status.TextContent);
+        Assert.Equal(Localizer["FilterPane_Scenario_EmptyNoMatches"], status.TextContent);
     }
 
     [Fact]
@@ -951,7 +957,7 @@ public sealed class FilterPaneTests : BunitContext
 
         component.Instance.ReplaceFilterSetSelection();
 
-        _announcements.Received(1).Announce(FilterPaneAnnouncements.LoadFailedRetryViaModal);
+        _announcements.Received(1).Announce(FilterPaneAnnouncements.LoadFailedRetryViaModal(Localizer));
         _filterLibraryCommands.DidNotReceiveWithAnyArgs().ReplaceWithEntry(default);
     }
 
@@ -969,7 +975,7 @@ public sealed class FilterPaneTests : BunitContext
 
         component.Instance.ReplaceFilterSetSelection();
 
-        _announcements.Received(1).Announce(FilterPaneAnnouncements.LoadingTryAgain);
+        _announcements.Received(1).Announce(FilterPaneAnnouncements.LoadingTryAgain(Localizer));
         _filterLibraryCommands.DidNotReceiveWithAnyArgs().ReplaceWithEntry(default);
     }
 
@@ -996,8 +1002,8 @@ public sealed class FilterPaneTests : BunitContext
     {
         var component = Render<UI.FilterPane.FilterPane>();
 
-        Assert.True(component.Find("button[aria-label='Save as Filter Set']").HasAttribute("disabled"));
-        Assert.True(component.Find("button[aria-label='Clear All Filters']").HasAttribute("disabled"));
+        Assert.True(component.Find($"button[aria-label='{Localizer["FilterPane_SaveAsFilterSet_Aria"]}']").HasAttribute("disabled"));
+        Assert.True(component.Find($"button[aria-label='{Localizer["FilterPane_ClearAll_Aria"]}']").HasAttribute("disabled"));
     }
 
     [Fact]
@@ -1019,11 +1025,11 @@ public sealed class FilterPaneTests : BunitContext
 
         var component = Render<UI.FilterPane.FilterPane>();
         var saveButton = component.FindAll("button")
-            .First(button => button.GetAttribute("aria-label") == "Save scenario JSON");
+            .First(button => button.GetAttribute("aria-label") == Localizer["FilterPane_SaveScenarioJson_Aria"]);
 
         await saveButton.ClickAsync(new MouseEventArgs());
 
-        await alertDialog.Received(1).ShowAlert("Export failed", Arg.Any<string>(), "OK");
+        await alertDialog.Received(1).ShowAlert(Localizer["FilterPane_ExportFailed_Title"], Arg.Any<string>(), Localizer["Modal_Accept"]);
     }
 
     [Fact]
@@ -1052,8 +1058,8 @@ public sealed class FilterPaneTests : BunitContext
 
         var component = Render<UI.FilterPane.FilterPane>();
 
-        Assert.True(component.Find("button[aria-label='Copy scenario JSON']").HasAttribute("disabled"));
-        Assert.True(component.Find("button[aria-label='Save scenario JSON']").HasAttribute("disabled"));
+        Assert.True(component.Find($"button[aria-label='{Localizer["FilterPane_CopyScenarioJson_Aria"]}']").HasAttribute("disabled"));
+        Assert.True(component.Find($"button[aria-label='{Localizer["FilterPane_SaveScenarioJson_Aria"]}']").HasAttribute("disabled"));
     }
 
     [Fact]
@@ -1105,8 +1111,8 @@ public sealed class FilterPaneTests : BunitContext
         });
         component.Render();
 
-        Assert.Contains("2024-06-08", component.Find("input[aria-label='After']").GetAttribute("value"));
-        Assert.Contains("2024-06-15", component.Find("input[aria-label='Before']").GetAttribute("value"));
+        Assert.Contains("2024-06-08", component.Find($"input[aria-label='{Localizer["FilterPane_Date_AfterAria"]}']").GetAttribute("value"));
+        Assert.Contains("2024-06-15", component.Find($"input[aria-label='{Localizer["FilterPane_Date_BeforeAria"]}']").GetAttribute("value"));
         _filterPaneCommands.DidNotReceiveWithAnyArgs().SetFilterDateRange(null);
     }
 
@@ -1138,7 +1144,7 @@ public sealed class FilterPaneTests : BunitContext
         new("file", LogPathType.File) { LogName = logName };
 
     private static IElement? FindApplyScenarioButton(IRenderedComponent<UI.FilterPane.FilterPane> component) =>
-        component.FindAll("button").FirstOrDefault(button => button.TextContent.Contains("Apply Scenario"));
+        component.FindAll("button").FirstOrDefault(button => button.GetAttribute("aria-controls") == "scenario-picker");
 
     private static bool GetCanEditDate(IRenderedComponent<UI.FilterPane.FilterPane> component) =>
         (bool)typeof(UI.FilterPane.FilterPane)


### PR DESCRIPTION
Localizes the Filter Pane UI to `IStringLocalizer<SharedResource>` (roadmap increment **L2**), under a strict byte-identical en-US contract (the app looks pixel-identical in en-US).

## What changed
- **~65 Filter Pane UI strings** keyed to 86 new `FilterPane_*` / `ScenarioExport_*` resources (buttons, `aria-label`/`title` split per rubric #18, section labels, empty-states, live-region announcements).
- **Typed `ScenarioExportSubject` boundary** replaces English noun fragments with complete, translator-safe per-subject sentence keys selected via a literal-key switch (evicts the rubric #6 concatenation anti-pattern).
- **Raw counts preserved** (no `N0` grouping) for byte-identity; **`RenderFragment`** (not `MarkupString`) for the `<strong>` empty-states (HTML-encoded); **`ScenarioGroupLocalizer.GroupDisplay`** routing at the 3 category sites (byte-safe via the existing drift-guard); `FilterPaneAnnouncements` -> static localizer methods.
- Shared `ScenarioClipboardExporter` localized (also consumed by Filter Library).

## Verification
- Release build 0W/0E (incl. MAUI head); unit suite 7,901/0.
- en-US byte-identical (resx additive; no existing value changed).
- Design panel converged 4/4 DESIGN_READY (3 rounds); post-code panel 6/6 LGTM.

## Recorded residuals (by design)
- Filter Library chrome + its caller-composed export strings stay English -> L8.
- Runtime scenario-export warning text (Class A) -> L12 typed-warning debt.

Tests assert behavior (marker routing, DOM, subject selection), not UI copy, per the established test architecture.
