### PR TITLE
Localize the filter editor and typed draft-build failures

### DIFF
--- a/src/EventLogExpert.Filtering/Drafts/FilterDraft.cs
+++ b/src/EventLogExpert.Filtering/Drafts/FilterDraft.cs
@@ -140,14 +140,15 @@ public sealed class FilterDraft
 
     /// <summary>
     ///     Builds a <see cref="SavedFilter" /> from this draft per <see cref="Mode" />. Returns <see langword="false" />
-    ///     with a populated <paramref name="error" /> when the draft cannot be saved (empty input, incomplete Basic predicate,
-    ///     or compile failure on the resulting text). Pure (does not mutate the draft) so the caller can surface the error
-    ///     inline and let the user repair.
+    ///     with a populated <paramref name="failure" /> when the draft cannot be saved. Pure (does not mutate the draft) so
+    ///     the caller can surface the error inline and let the user repair.
     /// </summary>
-    public bool TryBuildSavedFilter([NotNullWhen(true)] out SavedFilter? saved, out string error)
+    public bool TryBuildSavedFilter(
+        [NotNullWhen(true)] out SavedFilter? saved,
+        [NotNullWhen(false)] out FilterDraftBuildFailure? failure)
     {
         saved = null;
-        error = string.Empty;
+        failure = null;
 
         string text;
         BasicFilter? basicFilter;
@@ -156,7 +157,7 @@ public sealed class FilterDraft
         {
             if (!HasMeaningfulStructure)
             {
-                error = "Cannot save an empty filter";
+                failure = new FilterDraftBuildFailure.EmptyFilter();
                 return false;
             }
 
@@ -164,7 +165,7 @@ public sealed class FilterDraft
 
             if (!BasicFilterFormatter.TryFormat(draftBasic, true, out var formatted))
             {
-                error = "All predicates must be complete before saving.";
+                failure = new FilterDraftBuildFailure.InvalidBasicStructure();
 
                 return false;
             }
@@ -180,14 +181,14 @@ public sealed class FilterDraft
 
         if (string.IsNullOrWhiteSpace(text))
         {
-            error = "Cannot save an empty filter";
+            failure = new FilterDraftBuildFailure.EmptyFilter();
 
             return false;
         }
 
         if (!FilterCompiler.TryCompile(text, out var compiled, out var compileError))
         {
-            error = compileError;
+            failure = new FilterDraftBuildFailure.CompilerDiagnostic(compileError);
 
             return false;
         }

--- a/src/EventLogExpert.Filtering/Drafts/FilterDraftBuildFailure.cs
+++ b/src/EventLogExpert.Filtering/Drafts/FilterDraftBuildFailure.cs
@@ -1,0 +1,18 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Filtering.Drafts;
+
+public abstract record FilterDraftBuildFailure
+{
+    private FilterDraftBuildFailure() { }
+
+    public sealed record CompilerDiagnostic(string Message) : FilterDraftBuildFailure
+    {
+        public string Message { get; init; } = Message ?? throw new ArgumentNullException(nameof(Message));
+    }
+
+    public sealed record EmptyFilter : FilterDraftBuildFailure;
+
+    public sealed record InvalidBasicStructure : FilterDraftBuildFailure;
+}

--- a/src/EventLogExpert.Localization/Resources/SharedResource.resx
+++ b/src/EventLogExpert.Localization/Resources/SharedResource.resx
@@ -1398,6 +1398,337 @@
   <data name="FilterLens_RemoveAria" xml:space="preserve">
     <value>Remove lens: {0}</value>
   </data>
+  <!-- Filter editor chrome, dialogs, actions, and predicate summaries. -->
+  <data name="FilterEditor_ModeLabel" xml:space="preserve">
+    <value>Filter mode</value>
+  </data>
+  <data name="FilterEditor_Mode_Advanced" xml:space="preserve">
+    <value>Advanced</value>
+  </data>
+  <data name="FilterEditor_Mode_Basic" xml:space="preserve">
+    <value>Basic</value>
+  </data>
+  <data name="FilterEditor_Mode_Recent" xml:space="preserve">
+    <value>Recent</value>
+  </data>
+  <data name="FilterEditor_AdvancedExpression_ExcludeAria" xml:space="preserve">
+    <value>Exclude Expression</value>
+  </data>
+  <data name="FilterEditor_AdvancedExpression_IncludeAria" xml:space="preserve">
+    <value>Expression</value>
+  </data>
+  <data name="FilterEditor_Recent_TagFilterAria" xml:space="preserve">
+    <value>Filter recent options by tag</value>
+  </data>
+  <data name="FilterEditor_Recent_AllTags" xml:space="preserve">
+    <value>All tags</value>
+  </data>
+  <data name="FilterEditor_Recent_SelectAria" xml:space="preserve">
+    <value>Recent Filter</value>
+  </data>
+  <data name="FilterEditor_Recent_FavoriteAria" xml:space="preserve">
+    <value>Favorite</value>
+  </data>
+  <data name="FilterEditor_Recent_ReadOnlyAria" xml:space="preserve">
+    <value>Recent filter (read-only)</value>
+  </data>
+  <data name="FilterEditor_Recent_EmptyNoMatches" xml:space="preserve">
+    <value>No recent filters match the selected tags - clear tags to see all</value>
+  </data>
+  <data name="FilterEditor_Recent_EmptyNoneAvailable" xml:space="preserve">
+    <value>No recent options available here</value>
+  </data>
+  <data name="FilterEditor_Announcement_FilterDiscarded" xml:space="preserve">
+    <value>Filter discarded</value>
+  </data>
+  <data name="FilterEditor_Announcement_EditCancelled" xml:space="preserve">
+    <value>Edit cancelled</value>
+  </data>
+  <data name="FilterEditor_Announcement_EditingFilter" xml:space="preserve">
+    <value>Editing filter</value>
+  </data>
+  <data name="FilterEditor_Announcement_SetToExclude" xml:space="preserve">
+    <value>Filter set to Exclude</value>
+  </data>
+  <data name="FilterEditor_Announcement_SetToInclude" xml:space="preserve">
+    <value>Filter set to Include</value>
+  </data>
+  <data name="FilterEditor_Announcement_FilterRemoved" xml:space="preserve">
+    <value>Filter removed</value>
+  </data>
+  <data name="FilterEditor_Announcement_FilterSaved" xml:space="preserve">
+    <value>Filter saved</value>
+  </data>
+  <data name="FilterEditor_Announcement_FilterDisabled" xml:space="preserve">
+    <value>Filter disabled</value>
+  </data>
+  <data name="FilterEditor_Announcement_FilterEnabled" xml:space="preserve">
+    <value>Filter enabled</value>
+  </data>
+  <data name="FilterEditor_Announcement_SwitchedToAdvanced" xml:space="preserve">
+    <value>Switched to Advanced filter mode</value>
+  </data>
+  <data name="FilterEditor_Announcement_SwitchedToBasic" xml:space="preserve">
+    <value>Switched to Basic filter mode</value>
+  </data>
+  <data name="FilterEditor_Announcement_SwitchedToRecent" xml:space="preserve">
+    <value>Switched to Recent filter mode</value>
+  </data>
+  <data name="FilterEditor_ModeSwitch_Title" xml:space="preserve">
+    <value>Switch Filter Mode</value>
+  </data>
+  <data name="FilterEditor_ModeSwitch_Message_ToRecent" xml:space="preserve">
+    <value>Switching to Recent will discard the current filter contents. Continue?</value>
+  </data>
+  <data name="FilterEditor_ModeSwitch_Message_ToBasic" xml:space="preserve">
+    <value>Switching to Basic will discard the current expression because it cannot be represented in the Basic editor. Continue?</value>
+  </data>
+  <data name="FilterEditor_ModeSwitch_Message_ToAdvanced" xml:space="preserve">
+    <value>Switching to Advanced will drop incomplete predicates from the Basic editor. Continue?</value>
+  </data>
+  <data name="FilterEditor_ModeSwitch_Message_Generic" xml:space="preserve">
+    <value>Switching modes will discard the current filter contents. Continue?</value>
+  </data>
+  <data name="FilterEditor_Action_Continue" xml:space="preserve">
+    <value>Continue</value>
+  </data>
+  <data name="FilterEditor_RowHeader_ExcludedAria" xml:space="preserve">
+    <value>Filter '{0}' is excluded; activate to include</value>
+    <comment>{0} is the filter expression text authored by the user or loaded from the library.</comment>
+  </data>
+  <data name="FilterEditor_RowHeader_IncludedAria" xml:space="preserve">
+    <value>Filter '{0}' is included; activate to exclude</value>
+    <comment>{0} is the filter expression text authored by the user or loaded from the library.</comment>
+  </data>
+  <data name="FilterEditor_ExcludeToggle_TitleExcluded" xml:space="preserve">
+    <value>Excluded — click to include</value>
+  </data>
+  <data name="FilterEditor_ExcludeToggle_TitleIncluded" xml:space="preserve">
+    <value>Included — click to exclude</value>
+  </data>
+  <data name="FilterEditor_RowHeader_NoFilterSpecified" xml:space="preserve">
+    <value>No Filter Specified</value>
+  </data>
+  <data name="FilterEditor_RowAction_CopyScenarioAria_Unnamed" xml:space="preserve">
+    <value>Copy filter as scenario JSON</value>
+  </data>
+  <data name="FilterEditor_RowAction_CopyScenarioAria_Named" xml:space="preserve">
+    <value>Copy filter '{0}' as scenario JSON</value>
+    <comment>{0} is the filter expression text authored by the user or loaded from the library.</comment>
+  </data>
+  <data name="FilterEditor_RowAction_CopyScenarioTitle" xml:space="preserve">
+    <value>Copy as scenario JSON</value>
+  </data>
+  <data name="FilterEditor_RowAction_EditAria_Unnamed" xml:space="preserve">
+    <value>Edit filter</value>
+  </data>
+  <data name="FilterEditor_RowAction_EditAria_Named" xml:space="preserve">
+    <value>Edit filter '{0}'</value>
+    <comment>{0} is the filter expression text authored by the user or loaded from the library.</comment>
+  </data>
+  <data name="FilterEditor_RowAction_EditTitle" xml:space="preserve">
+    <value>Edit filter</value>
+  </data>
+  <data name="FilterEditor_RowAction_RemoveAria_Unnamed" xml:space="preserve">
+    <value>Remove filter</value>
+  </data>
+  <data name="FilterEditor_RowAction_RemoveAria_Named" xml:space="preserve">
+    <value>Remove filter '{0}'</value>
+    <comment>{0} is the filter expression text authored by the user or loaded from the library.</comment>
+  </data>
+  <data name="FilterEditor_RowAction_RemoveTitle" xml:space="preserve">
+    <value>Remove filter</value>
+  </data>
+  <data name="FilterEditor_RowAction_EnableToggleLabel" xml:space="preserve">
+    <value>Enable filter</value>
+  </data>
+  <data name="FilterEditor_EditPanel_ExcludedAria" xml:space="preserve">
+    <value>Filter is excluded; activate to include</value>
+  </data>
+  <data name="FilterEditor_EditPanel_IncludedAria" xml:space="preserve">
+    <value>Filter is included; activate to exclude</value>
+  </data>
+  <data name="FilterEditor_HighlightColor_Aria" xml:space="preserve">
+    <value>Highlight Color</value>
+  </data>
+  <data name="FilterEditor_HighlightColor_IncludeOnlyDescription" xml:space="preserve">
+    <value>Color applies in Include mode only.</value>
+  </data>
+  <data name="FilterEditor_Action_Save" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="FilterEditor_Action_CancelEdit_Aria" xml:space="preserve">
+    <value>Cancel edit</value>
+  </data>
+  <data name="FilterEditor_Action_CancelEdit_Title" xml:space="preserve">
+    <value>Cancel edit</value>
+  </data>
+  <data name="FilterEditor_Action_RemoveFilter_Aria" xml:space="preserve">
+    <value>Remove filter</value>
+  </data>
+  <data name="FilterEditor_Action_RemoveFilter_Title" xml:space="preserve">
+    <value>Remove filter</value>
+  </data>
+  <data name="FilterEditor_PredicateJoin_OrAria" xml:space="preserve">
+    <value>Joining with OR; click to switch to AND</value>
+  </data>
+  <data name="FilterEditor_PredicateJoin_AndAria" xml:space="preserve">
+    <value>Joining with AND; click to switch to OR</value>
+  </data>
+  <data name="FilterEditor_PredicateJoin_OrTitle" xml:space="preserve">
+    <value>OR</value>
+  </data>
+  <data name="FilterEditor_PredicateJoin_AndTitle" xml:space="preserve">
+    <value>AND</value>
+  </data>
+  <data name="FilterEditor_PredicateJoin_OrLabel" xml:space="preserve">
+    <value>OR</value>
+  </data>
+  <data name="FilterEditor_PredicateJoin_AndLabel" xml:space="preserve">
+    <value>AND</value>
+  </data>
+  <data name="FilterEditor_Predicate_DoneAria" xml:space="preserve">
+    <value>Done editing predicate</value>
+  </data>
+  <data name="FilterEditor_Predicate_DoneTitle" xml:space="preserve">
+    <value>Done</value>
+  </data>
+  <data name="FilterEditor_Predicate_DoneDisabledTitle" xml:space="preserve">
+    <value>Complete the predicate before continuing</value>
+  </data>
+  <data name="FilterEditor_Predicate_RemoveAria" xml:space="preserve">
+    <value>Remove predicate: {0}</value>
+    <comment>{0} is the localized predicate summary shown in the predicate chip.</comment>
+  </data>
+  <data name="FilterEditor_Predicate_RemoveTitle" xml:space="preserve">
+    <value>Remove predicate</value>
+  </data>
+  <data name="FilterEditor_Predicate_EditAria" xml:space="preserve">
+    <value>Edit predicate: {0}</value>
+    <comment>{0} is the localized predicate summary shown in the predicate chip.</comment>
+  </data>
+  <data name="FilterEditor_Predicate_EditTitle" xml:space="preserve">
+    <value>Edit predicate</value>
+  </data>
+  <data name="FilterEditor_PredicateSummary_Operator_In" xml:space="preserve">
+    <value>in</value>
+  </data>
+  <data name="FilterEditor_PredicateSummary_Operator_Contains" xml:space="preserve">
+    <value>contains</value>
+  </data>
+  <data name="FilterEditor_PredicateSummary_Operator_NotContains" xml:space="preserve">
+    <value>doesn't contain</value>
+  </data>
+  <data name="FilterEditor_PredicateSummary_ValueCount_Many" xml:space="preserve">
+    <value>{0} values</value>
+    <comment>{0} is the raw count of selected values; do not add number grouping.</comment>
+  </data>
+  <data name="FilterEditor_PredicateSummary" xml:space="preserve">
+    <value>{0} {1} {2}</value>
+    <comment>{0} is the filter property token, {1} is the localized operator, and {2} is the value text or raw value count.</comment>
+  </data>
+  <data name="FilterEditor_PredicateList_AddAria" xml:space="preserve">
+    <value>Add predicate</value>
+  </data>
+  <data name="FilterEditor_PredicateList_AddTitle" xml:space="preserve">
+    <value>Add predicate</value>
+  </data>
+  <data name="FilterEditor_PredicateList_AddDisabledAria" xml:space="preserve">
+    <value>Complete the current predicate before adding another</value>
+  </data>
+  <data name="FilterEditor_PredicateList_AddDisabledTitle" xml:space="preserve">
+    <value>Complete the current predicate before adding another</value>
+  </data>
+  <data name="FilterEditor_SaveError_EmptyFilter" xml:space="preserve">
+    <value>Cannot save an empty filter</value>
+  </data>
+  <data name="FilterEditor_SaveError_IncompletePredicates" xml:space="preserve">
+    <value>All predicates must be complete before saving.</value>
+  </data>
+  <data name="FilterEditor_HighlightColorOption_None" xml:space="preserve">
+    <value>None</value>
+  </data>
+  <data name="FilterEditor_HighlightColorOption_LightRed" xml:space="preserve">
+    <value>LightRed</value>
+  </data>
+  <data name="FilterEditor_HighlightColorOption_Red" xml:space="preserve">
+    <value>Red</value>
+  </data>
+  <data name="FilterEditor_HighlightColorOption_DarkRed" xml:space="preserve">
+    <value>DarkRed</value>
+  </data>
+  <data name="FilterEditor_HighlightColorOption_LightOrange" xml:space="preserve">
+    <value>LightOrange</value>
+  </data>
+  <data name="FilterEditor_HighlightColorOption_Orange" xml:space="preserve">
+    <value>Orange</value>
+  </data>
+  <data name="FilterEditor_HighlightColorOption_DarkOrange" xml:space="preserve">
+    <value>DarkOrange</value>
+  </data>
+  <data name="FilterEditor_HighlightColorOption_LightYellow" xml:space="preserve">
+    <value>LightYellow</value>
+  </data>
+  <data name="FilterEditor_HighlightColorOption_Yellow" xml:space="preserve">
+    <value>Yellow</value>
+  </data>
+  <data name="FilterEditor_HighlightColorOption_DarkYellow" xml:space="preserve">
+    <value>DarkYellow</value>
+  </data>
+  <data name="FilterEditor_HighlightColorOption_LightGreen" xml:space="preserve">
+    <value>LightGreen</value>
+  </data>
+  <data name="FilterEditor_HighlightColorOption_Green" xml:space="preserve">
+    <value>Green</value>
+  </data>
+  <data name="FilterEditor_HighlightColorOption_DarkGreen" xml:space="preserve">
+    <value>DarkGreen</value>
+  </data>
+  <data name="FilterEditor_HighlightColorOption_LightTeal" xml:space="preserve">
+    <value>LightTeal</value>
+  </data>
+  <data name="FilterEditor_HighlightColorOption_Teal" xml:space="preserve">
+    <value>Teal</value>
+  </data>
+  <data name="FilterEditor_HighlightColorOption_DarkTeal" xml:space="preserve">
+    <value>DarkTeal</value>
+  </data>
+  <data name="FilterEditor_HighlightColorOption_LightBlue" xml:space="preserve">
+    <value>LightBlue</value>
+  </data>
+  <data name="FilterEditor_HighlightColorOption_Blue" xml:space="preserve">
+    <value>Blue</value>
+  </data>
+  <data name="FilterEditor_HighlightColorOption_DarkBlue" xml:space="preserve">
+    <value>DarkBlue</value>
+  </data>
+  <data name="FilterEditor_HighlightColorOption_LightPurple" xml:space="preserve">
+    <value>LightPurple</value>
+  </data>
+  <data name="FilterEditor_HighlightColorOption_Purple" xml:space="preserve">
+    <value>Purple</value>
+  </data>
+  <data name="FilterEditor_HighlightColorOption_DarkPurple" xml:space="preserve">
+    <value>DarkPurple</value>
+  </data>
+  <data name="FilterEditor_HighlightColorOption_LightMagenta" xml:space="preserve">
+    <value>LightMagenta</value>
+  </data>
+  <data name="FilterEditor_HighlightColorOption_Magenta" xml:space="preserve">
+    <value>Magenta</value>
+  </data>
+  <data name="FilterEditor_HighlightColorOption_DarkMagenta" xml:space="preserve">
+    <value>DarkMagenta</value>
+  </data>
+  <data name="FilterEditor_HighlightColorOption_LightPink" xml:space="preserve">
+    <value>LightPink</value>
+  </data>
+  <data name="FilterEditor_HighlightColorOption_Pink" xml:space="preserve">
+    <value>Pink</value>
+  </data>
+  <data name="FilterEditor_HighlightColorOption_DarkPink" xml:space="preserve">
+    <value>DarkPink</value>
+  </data>
   <!-- Filter comparison editor: operator dropdown (FilterEditor_Comparison_* map to ComparisonOperatorSelect.ComparisonKind) + value-picker visually-hidden labels and placeholders. -->
   <data name="FilterEditor_Comparison_Equals" xml:space="preserve">
     <value>Equals</value>

--- a/src/EventLogExpert.UI/FilterEditor/Editing/FilterEditPanel.razor
+++ b/src/EventLogExpert.UI/FilterEditor/Editing/FilterEditPanel.razor
@@ -3,22 +3,23 @@
     <div class="filter-edit-panel @CssClass">
         <div class="filter-edit-panel-row">
             <div class="filter-edit-panel-content">
-                <Button aria-label="@(filter.IsExcluded ? "Filter is excluded; activate to include" : "Filter is included; activate to exclude")"
-                    aria-pressed="@(filter.IsExcluded ? "true" : "false")"
-                    CssClass="filter-exclude-toggle"
-                    data-excluded="@(filter.IsExcluded ? "true" : "false")"
+                <Button CssClass="filter-exclude-toggle"
                     IconClass="@(filter.IsExcluded ? "bi bi-slash-circle-fill" : "bi bi-slash-circle")"
                     IconOnly
                     OnClick="@(() => OnExclusionChanged.InvokeAsync(!filter.IsExcluded))"
-                    title="@(filter.IsExcluded ? "Excluded \u2014 click to include" : "Included \u2014 click to exclude")" />
+                    aria-label="@(filter.IsExcluded ? Localizer["FilterEditor_EditPanel_ExcludedAria"] : Localizer["FilterEditor_EditPanel_IncludedAria"])"
+                    aria-pressed="@(filter.IsExcluded ? "true" : "false")"
+                    data-excluded="@(filter.IsExcluded ? "true" : "false")"
+                    title="@(filter.IsExcluded ? Localizer["FilterEditor_ExcludeToggle_TitleExcluded"] : Localizer["FilterEditor_ExcludeToggle_TitleIncluded"])" />
 
                 <div class="color-picker-wrapper" data-filter-excluded="@(filter.IsExcluded ? "true" : "false")">
                     <ValueSelect AriaDescribedBy="@(filter.IsExcluded ? _colorDescriptionId : null)"
-                        AriaLabel="Highlight Color"
-                        @bind-Value="filter.Color"
+                        AriaLabel="@Localizer["FilterEditor_HighlightColor_Aria"]"
                         CssClass="input color-dropdown"
                         DataHighlight="@filter.Color.ToCssName()"
-                        T="HighlightColor">
+                        T="HighlightColor"
+                        ToStringFunc="@(color => color is { } value ? FilterEditorHighlightColorLocalizer.Label(Localizer, value) : string.Empty)"
+                        @bind-Value="filter.Color">
                         @foreach (var item in Enum.GetValues<HighlightColor>())
                         {
                             <ValueSelectItem CssClass="color-dropdown-item"
@@ -29,7 +30,7 @@
                     </ValueSelect>
                     @if (filter.IsExcluded)
                     {
-                        <span class="visually-hidden" id="@_colorDescriptionId">Color applies in Include mode only.</span>
+                        <span class="visually-hidden" id="@_colorDescriptionId">@Localizer["FilterEditor_HighlightColor_IncludeOnlyDescription"]</span>
                     }
                 </div>
 
@@ -39,21 +40,21 @@
             </div>
 
             <div class="filter-edit-panel-actions">
-                <PrimaryButton IconClass="bi bi-check-circle" OnClick="OnSave">Save</PrimaryButton>
+                <PrimaryButton IconClass="bi bi-check-circle" OnClick="OnSave">@Localizer["FilterEditor_Action_Save"]</PrimaryButton>
 
-                <Button aria-label="Cancel edit"
-                    IconClass="bi bi-x-circle"
+                <Button IconClass="bi bi-x-circle"
                     IconOnly
                     OnClick="OnCancel"
-                    title="Cancel edit" />
+                    aria-label="@Localizer["FilterEditor_Action_CancelEdit_Aria"]"
+                    title="@Localizer["FilterEditor_Action_CancelEdit_Title"]" />
 
                 @if (!IsPending)
                 {
-                    <DangerButton aria-label="Remove filter"
-                        IconClass="bi bi-dash-circle"
+                    <DangerButton IconClass="bi bi-dash-circle"
                         IconOnly
                         OnClick="OnRemove"
-                        title="Remove filter" />
+                        aria-label="@Localizer["FilterEditor_Action_RemoveFilter_Aria"]"
+                        title="@Localizer["FilterEditor_Action_RemoveFilter_Title"]" />
                 }
             </div>
         </div>

--- a/src/EventLogExpert.UI/FilterEditor/Editing/FilterEditPanel.razor.cs
+++ b/src/EventLogExpert.UI/FilterEditor/Editing/FilterEditPanel.razor.cs
@@ -2,8 +2,10 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Filtering.Drafts;
+using EventLogExpert.Localization;
 using EventLogExpert.UI.Common;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
 
 namespace EventLogExpert.UI.FilterEditor.Editing;
 
@@ -33,4 +35,6 @@ public sealed partial class FilterEditPanel : ComponentBase
     [Parameter] public EventCallback OnRemove { get; set; }
 
     [Parameter] public EventCallback OnSave { get; set; }
+
+    [Inject] private IStringLocalizer<SharedResource> Localizer { get; init; } = null!;
 }

--- a/src/EventLogExpert.UI/FilterEditor/Editing/FilterPredicateEditor.razor
+++ b/src/EventLogExpert.UI/FilterEditor/Editing/FilterPredicateEditor.razor
@@ -1,49 +1,49 @@
 @if (IsEditing)
 {
     <div class="filter-predicate-editing">
-        <ChromelessButton aria-label="@(Value.JoinWithAny ? "Joining with OR; click to switch to AND" : "Joining with AND; click to switch to OR")"
-            CssClass="filter-predicate-and-or"
-            data-mode="@(Value.JoinWithAny ? "or" : "and")"
+        <ChromelessButton CssClass="filter-predicate-and-or"
             OnClick="OnAndOrClick"
+            aria-label="@JoinerAriaLabel"
+            data-mode="@(Value.JoinWithAny ? "or" : "and")"
             @ref="_editorFirstInput"
-            title="@(Value.JoinWithAny ? "OR" : "AND")">
-            @(Value.JoinWithAny ? "OR" : "AND")
+            title="@JoinerTitle">
+            @JoinerLabel
         </ChromelessButton>
 
         <FilterComparisonEditor Comparison="Value.Comparison"
             Id="@ComponentId.For(Value.Id, ComponentIdScope.Predicate).Value"
             OnChanged="OnComparisonChanged" />
 
-        <Button aria-label="Done editing predicate"
-            Disabled="@(!Value.IsComplete)"
+        <Button Disabled="@(!Value.IsComplete)"
             IconClass="bi bi-check-circle"
             IconOnly
             OnClick="OnDoneClick"
-            title="@(Value.IsComplete ? "Done" : "Complete the predicate before continuing")" />
+            aria-label="@Localizer["FilterEditor_Predicate_DoneAria"]"
+            title="@(Value.IsComplete ? Localizer["FilterEditor_Predicate_DoneTitle"] : Localizer["FilterEditor_Predicate_DoneDisabledTitle"])" />
 
-        <DangerButton aria-label="@($"Remove predicate: {SummaryText}")"
-            IconClass="bi bi-x-circle"
+        <DangerButton IconClass="bi bi-x-circle"
             IconOnly
             OnClick="OnRemoveChip"
-            title="Remove predicate" />
+            aria-label="@Localizer["FilterEditor_Predicate_RemoveAria", SummaryText]"
+            title="@Localizer["FilterEditor_Predicate_RemoveTitle"]" />
     </div>
 }
 else
 {
     <div class="filter-predicate">
-        <ChromelessButton aria-label="@($"Edit predicate: {SummaryText}")"
-            CssClass="filter-predicate-edit"
+        <ChromelessButton CssClass="filter-predicate-edit"
             OnClick="OnEditChip"
+            aria-label="@Localizer["FilterEditor_Predicate_EditAria", SummaryText]"
             @ref="_chipEditButton"
-            title="Edit predicate">
+            title="@Localizer["FilterEditor_Predicate_EditTitle"]">
             <span class="filter-predicate-joiner">@JoinerLabel</span>
             <span class="filter-predicate-summary">@SummaryText</span>
         </ChromelessButton>
 
-        <ChromelessButton aria-label="@($"Remove predicate: {SummaryText}")"
-            CssClass="filter-predicate-remove"
+        <ChromelessButton CssClass="filter-predicate-remove"
             IconClass="bi bi-x-circle"
             OnClick="OnRemoveChip"
-            title="Remove predicate" />
+            aria-label="@Localizer["FilterEditor_Predicate_RemoveAria", SummaryText]"
+            title="@Localizer["FilterEditor_Predicate_RemoveTitle"]" />
     </div>
 }

--- a/src/EventLogExpert.UI/FilterEditor/Editing/FilterPredicateEditor.razor.cs
+++ b/src/EventLogExpert.UI/FilterEditor/Editing/FilterPredicateEditor.razor.cs
@@ -3,9 +3,11 @@
 
 using EventLogExpert.Filtering.Common.Filtering;
 using EventLogExpert.Filtering.Drafts;
+using EventLogExpert.Localization;
 using EventLogExpert.UI.Focus;
 using EventLogExpert.UI.Inputs;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
 
 namespace EventLogExpert.UI.FilterEditor.Editing;
 
@@ -31,7 +33,22 @@ public sealed partial class FilterPredicateEditor : ComponentBase
 
     [Parameter][EditorRequired] public FilterPredicateDraft Value { get; set; } = null!;
 
-    private string JoinerLabel => Value.JoinWithAny ? "OR" : "AND";
+    private string JoinerAriaLabel =>
+        Value.JoinWithAny ?
+            Localizer["FilterEditor_PredicateJoin_OrAria"] :
+            Localizer["FilterEditor_PredicateJoin_AndAria"];
+
+    private string JoinerLabel =>
+        Value.JoinWithAny ?
+            Localizer["FilterEditor_PredicateJoin_OrLabel"] :
+            Localizer["FilterEditor_PredicateJoin_AndLabel"];
+
+    private string JoinerTitle =>
+        Value.JoinWithAny ?
+            Localizer["FilterEditor_PredicateJoin_OrTitle"] :
+            Localizer["FilterEditor_PredicateJoin_AndTitle"];
+
+    [Inject] private IStringLocalizer<SharedResource> Localizer { get; init; } = null!;
 
     private string SummaryText
     {
@@ -41,24 +58,24 @@ public sealed partial class FilterPredicateEditor : ComponentBase
 
             string opLabel = (cmp.Operator, cmp.MatchMode) switch
             {
-                (ComparisonOperator.Equals, MatchMode.Many) => "in",
+                (ComparisonOperator.Equals, MatchMode.Many) => Localizer["FilterEditor_PredicateSummary_Operator_In"],
                 (ComparisonOperator.Equals, _) => "==",
-                (ComparisonOperator.Contains, _) => "contains",
+                (ComparisonOperator.Contains, _) => Localizer["FilterEditor_PredicateSummary_Operator_Contains"],
                 (ComparisonOperator.NotEqual, _) => "!=",
-                (ComparisonOperator.NotContains, _) => "doesn't contain",
+                (ComparisonOperator.NotContains, _) => Localizer["FilterEditor_PredicateSummary_Operator_NotContains"],
                 _ => "?"
             };
 
-            string valueLabel = cmp.MatchMode == MatchMode.Many
-                ? cmp.Values.Count switch
+            string valueLabel = cmp.MatchMode == MatchMode.Many ?
+                cmp.Values.Count switch
                 {
                     0 => "?",
                     1 => cmp.Values[0],
-                    var count => $"{count} values"
-                }
-                : string.IsNullOrEmpty(cmp.Value) ? "?" : cmp.Value;
+                    var count => Localizer["FilterEditor_PredicateSummary_ValueCount_Many", count]
+                } :
+                string.IsNullOrEmpty(cmp.Value) ? "?" : cmp.Value;
 
-            return $"{cmp.Property} {opLabel} {valueLabel}";
+            return Localizer["FilterEditor_PredicateSummary", cmp.Property.ToString(), opLabel, valueLabel];
         }
     }
 

--- a/src/EventLogExpert.UI/FilterEditor/Editing/FilterPredicateList.razor
+++ b/src/EventLogExpert.UI/FilterEditor/Editing/FilterPredicateList.razor
@@ -3,22 +3,22 @@
         @foreach (var predicate in Predicates)
         {
             <FilterPredicateEditor IsEditing="@(_editingPredicateId == predicate.Id)"
-                @key="predicate.Id"
                 OnChanged="StateHasChanged"
                 OnDone="CollapseEditor"
                 OnEdit="@(() => StartEditing(predicate.Id))"
                 OnRemove="@(() => RemovePredicate(predicate.Id))"
-                @ref="_editorRefs[predicate.Id]"
-                Value="predicate" />
+                Value="predicate"
+                @key="predicate.Id"
+                @ref="_editorRefs[predicate.Id]" />
         }
 
-        <Button aria-label="@(CanAddPredicate ? "Add predicate" : "Complete the current predicate before adding another")"
-            CssClass="add-filter-predicate-button"
+        <Button CssClass="add-filter-predicate-button"
             Disabled="@(!CanAddPredicate)"
             IconClass="bi bi-plus-circle"
             IconOnly
             OnClick="AddPredicate"
+            aria-label="@AddPredicateAriaLabel"
             @ref="_addButton"
-            title="@(CanAddPredicate ? "Add predicate" : "Complete the current predicate before adding another")" />
+            title="@AddPredicateTitle" />
     </span>
 </div>

--- a/src/EventLogExpert.UI/FilterEditor/Editing/FilterPredicateList.razor.cs
+++ b/src/EventLogExpert.UI/FilterEditor/Editing/FilterPredicateList.razor.cs
@@ -3,9 +3,11 @@
 
 using EventLogExpert.Filtering.Drafts;
 using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Localization;
 using EventLogExpert.UI.Focus;
 using EventLogExpert.UI.Inputs;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
 
 namespace EventLogExpert.UI.FilterEditor.Editing;
 
@@ -21,6 +23,16 @@ public sealed partial class FilterPredicateList : ComponentBase
 
     [Parameter][EditorRequired] public List<FilterPredicateDraft> Predicates { get; set; } = null!;
 
+    private string AddPredicateAriaLabel =>
+        CanAddPredicate ?
+            Localizer["FilterEditor_PredicateList_AddAria"] :
+            Localizer["FilterEditor_PredicateList_AddDisabledAria"];
+
+    private string AddPredicateTitle =>
+        CanAddPredicate ?
+            Localizer["FilterEditor_PredicateList_AddTitle"] :
+            Localizer["FilterEditor_PredicateList_AddDisabledTitle"];
+
     /// <summary>
     ///     The Add (+) button is gated when ANY existing predicate is incomplete, so the user must finish (or remove)
     ///     in-flight predicates before introducing another. Mirrors the per-row Done gate in
@@ -28,6 +40,8 @@ public sealed partial class FilterPredicateList : ComponentBase
     ///     <see cref="FilterPredicateDraft.IsComplete" /> / the formatter's strict-mode save guard.
     /// </summary>
     private bool CanAddPredicate => Predicates.TrueForAll(p => p.IsComplete);
+
+    [Inject] private IStringLocalizer<SharedResource> Localizer { get; init; } = null!;
 
     /// <summary>
     ///     Post-render focus restoration: after the chip&lt;-&gt;editor swap unmounts the previously focused button, move
@@ -39,16 +53,16 @@ public sealed partial class FilterPredicateList : ComponentBase
     {
         PruneStaleEditorRefs();
 
-        if (_focusEditorAfterRender is { } editingId
-            && _editorRefs.TryGetValue(editingId, out var editor)
-            && editor is not null)
+        if (_focusEditorAfterRender is { } editingId &&
+            _editorRefs.TryGetValue(editingId, out var editor) &&
+            editor is not null)
         {
             _focusEditorAfterRender = null;
             await editor.FocusEditorFirstInputAsync();
         }
-        else if (_focusChipAfterRender is { } chipId
-            && _editorRefs.TryGetValue(chipId, out var chipEditor)
-            && chipEditor is not null)
+        else if (_focusChipAfterRender is { } chipId &&
+            _editorRefs.TryGetValue(chipId, out var chipEditor) &&
+            chipEditor is not null)
         {
             _focusChipAfterRender = null;
             await chipEditor.FocusChipEditButtonAsync();

--- a/src/EventLogExpert.UI/FilterEditor/FilterEditorAnnouncements.cs
+++ b/src/EventLogExpert.UI/FilterEditor/FilterEditorAnnouncements.cs
@@ -1,0 +1,44 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Evaluation;
+using EventLogExpert.Localization;
+using Microsoft.Extensions.Localization;
+
+namespace EventLogExpert.UI.FilterEditor;
+
+internal static class FilterEditorAnnouncements
+{
+    public static string EditCancelled(IStringLocalizer<SharedResource> localizer) =>
+        localizer["FilterEditor_Announcement_EditCancelled"];
+
+    public static string EditingFilter(IStringLocalizer<SharedResource> localizer) =>
+        localizer["FilterEditor_Announcement_EditingFilter"];
+
+    public static string FilterDiscarded(IStringLocalizer<SharedResource> localizer) =>
+        localizer["FilterEditor_Announcement_FilterDiscarded"];
+
+    public static string FilterEnabledState(IStringLocalizer<SharedResource> localizer, bool newIsEnabled) =>
+        newIsEnabled ?
+            localizer["FilterEditor_Announcement_FilterEnabled"] :
+            localizer["FilterEditor_Announcement_FilterDisabled"];
+
+    public static string FilterRemoved(IStringLocalizer<SharedResource> localizer) =>
+        localizer["FilterEditor_Announcement_FilterRemoved"];
+
+    public static string FilterSaved(IStringLocalizer<SharedResource> localizer) =>
+        localizer["FilterEditor_Announcement_FilterSaved"];
+
+    public static string FilterSetTo(IStringLocalizer<SharedResource> localizer, bool isExcluded) =>
+        isExcluded ?
+            localizer["FilterEditor_Announcement_SetToExclude"] :
+            localizer["FilterEditor_Announcement_SetToInclude"];
+
+    public static string SwitchedToMode(IStringLocalizer<SharedResource> localizer, FilterMode mode) => mode switch
+    {
+        FilterMode.Advanced => localizer["FilterEditor_Announcement_SwitchedToAdvanced"],
+        FilterMode.Basic => localizer["FilterEditor_Announcement_SwitchedToBasic"],
+        FilterMode.Cached => localizer["FilterEditor_Announcement_SwitchedToRecent"],
+        _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
+    };
+}

--- a/src/EventLogExpert.UI/FilterEditor/FilterEditorCore.razor
+++ b/src/EventLogExpert.UI/FilterEditor/FilterEditorCore.razor
@@ -7,22 +7,22 @@
     OnRemove="RemoveHandler"
     OnSave="SaveHandler"
     OnToggleEnabled="ToggleEnabledHandler"
-    @ref="_shellRef"
-    Value="Value">
+    Value="Value"
+    @ref="_shellRef">
     <ModeSelector>
         @if (Filter is { } filter)
         {
             <span class="filter-row-mode">
-                <label class="visually-hidden" id="@($"{Id}_Mode")">Filter mode</label>
+                <label class="visually-hidden" id="@($"{Id}_Mode")">@Localizer["FilterEditor_ModeLabel"]</label>
                 <ValueSelect AriaLabelledBy="@($"{Id}_Mode")"
                     CssClass="input filter-dropdown filter-mode-dropdown"
                     T="FilterMode"
-                    ToStringFunc="@(GetFilterModeDisplayLabel)"
+                    ToStringFunc="@(mode => mode is { } value ? FilterEditorModeLocalizer.Display(Localizer, value) : string.Empty)"
                     Value="filter.Mode"
                     ValueChanged="TryChangeModeAsync">
                     @foreach (var mode in GetAvailableModes(filter))
                     {
-                        <ValueSelectItem T="FilterMode" Value="mode">@GetFilterModeDisplayLabel(mode)</ValueSelectItem>
+                        <ValueSelectItem T="FilterMode" Value="mode">@FilterEditorModeLocalizer.Display(Localizer, mode)</ValueSelectItem>
                     }
                 </ValueSelect>
             </span>
@@ -41,7 +41,7 @@
                     break;
                 case FilterMode.Advanced:
                     <span class="filter-row-text">
-                        <input aria-label="@(filter.IsExcluded ? "Exclude Expression" : "Expression")"
+                        <input aria-label="@(filter.IsExcluded ? Localizer["FilterEditor_AdvancedExpression_ExcludeAria"] : Localizer["FilterEditor_AdvancedExpression_IncludeAria"])"
                             class="advanced-filter input"
                             id="@Id"
                             @oninput="OnAdvancedTextInput"
@@ -54,14 +54,14 @@
                     <span class="filter-row-cached">
                         @if (AvailableCachedTags is { Count: > 0 } cachedTags)
                         {
-                            <ValueSelect AriaLabel="Filter recent options by tag"
+                            <ValueSelect AriaLabel="@Localizer["FilterEditor_Recent_TagFilterAria"]"
                                 CssClass="input filter-multiselect-dropdown"
-                                EmptyText="All tags"
+                                EmptyText="@Localizer["FilterEditor_Recent_AllTags"]"
                                 IsMultiSelect="true"
                                 T="string"
                                 Values="_selectedTags"
                                 ValuesChanged="OnSelectedTagsChanged">
-                                <ValueSelectItem ClearItem T="string">All tags</ValueSelectItem>
+                                <ValueSelectItem ClearItem T="string">@Localizer["FilterEditor_Recent_AllTags"]</ValueSelectItem>
                                 @foreach (var tag in cachedTags)
                                 {
                                     <ValueSelectItem T="string" Value="@tag">@tag</ValueSelectItem>
@@ -71,7 +71,7 @@
 
                         @if (VisibleCachedOptions is { Count: > 0 } options)
                         {
-                            <ValueSelect AriaLabel="Recent Filter"
+                            <ValueSelect AriaLabel="@Localizer["FilterEditor_Recent_SelectAria"]"
                                 CssClass="input cache-dropdown"
                                 T="string"
                                 Value="filter.ComparisonText"
@@ -81,7 +81,7 @@
                                     <ValueSelectItem T="string" Value="option.Value">
                                         @if (option.IsFavorite)
                                         {
-                                            <i aria-label="Favorite" class="bi bi-star-fill cached-favorite-icon"></i>
+                                            <i aria-label="@Localizer["FilterEditor_Recent_FavoriteAria"]" class="bi bi-star-fill cached-favorite-icon"></i>
                                         }
                                         else
                                         {
@@ -94,7 +94,7 @@
                         }
                         else
                         {
-                            <input aria-label="Recent filter (read-only)"
+                            <input aria-label="@Localizer["FilterEditor_Recent_ReadOnlyAria"]"
                                 class="advanced-filter input"
                                 readonly
                                 type="text"

--- a/src/EventLogExpert.UI/FilterEditor/FilterEditorCore.razor.cs
+++ b/src/EventLogExpert.UI/FilterEditor/FilterEditorCore.razor.cs
@@ -4,11 +4,13 @@
 using EventLogExpert.Filtering.Drafts;
 using EventLogExpert.Filtering.Evaluation;
 using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Localization;
 using EventLogExpert.Runtime.Alerts;
 using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.UI.Common;
 using EventLogExpert.UI.FilterEditor.Rows;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
 
 namespace EventLogExpert.UI.FilterEditor;
 
@@ -49,14 +51,16 @@ public sealed partial class FilterEditorCore : ComponentBase
 
     private string CachedEmptyHint =>
         _selectedTags.Count > 0 ?
-            "No recent filters match the selected tags - clear tags to see all" :
-            "No recent options available here";
+            Localizer["FilterEditor_Recent_EmptyNoMatches"] :
+            Localizer["FilterEditor_Recent_EmptyNoneAvailable"];
 
     private string ErrorMessage { get; set; } = string.Empty;
 
     private FilterDraft? Filter { get; set; }
 
     private bool IsPending => Value is null && PendingDraft is not null;
+
+    [Inject] private IStringLocalizer<SharedResource> Localizer { get; init; } = null!;
 
     private IReadOnlyList<CachedFilterOption> VisibleCachedOptions =>
         FilterCachedByTags(CachedOptions ?? [], _selectedTags, Filter?.ComparisonText);
@@ -111,12 +115,6 @@ public sealed partial class FilterEditorCore : ComponentBase
         base.OnParametersSet();
     }
 
-    private static string GetFilterModeDisplayLabel(FilterMode mode) => mode switch
-    {
-        FilterMode.Cached => "Recent",
-        _ => mode.ToString(),
-    };
-
     private async Task CancelHandler()
     {
         ErrorMessage = string.Empty;
@@ -124,13 +122,13 @@ public sealed partial class FilterEditorCore : ComponentBase
 
         if (IsPending)
         {
-            AnnouncementService.Announce("Filter discarded");
+            AnnouncementService.Announce(FilterEditorAnnouncements.FilterDiscarded(Localizer));
             await OnPendingDiscard.InvokeAsync();
 
             return;
         }
 
-        AnnouncementService.Announce("Edit cancelled");
+        AnnouncementService.Announce(FilterEditorAnnouncements.EditCancelled(Localizer));
     }
 
     // Local edit transition: never add OnEdit/OnCancel host callbacks (WebView2 render bug).
@@ -141,18 +139,16 @@ public sealed partial class FilterEditorCore : ComponentBase
         ErrorMessage = string.Empty;
         Filter = FilterDraft.FromSavedFilter(savedFilter);
 
-        AnnouncementService.Announce("Editing filter");
+        AnnouncementService.Announce(FilterEditorAnnouncements.EditingFilter(Localizer));
 
         return Task.CompletedTask;
     }
 
     private async Task ExclusionHandler(bool isExcluded)
     {
-        string label = isExcluded ? "Exclude" : "Include";
-
         if (Filter is not null)
         {
-            AnnouncementService.Announce($"Filter set to {label}");
+            AnnouncementService.Announce(FilterEditorAnnouncements.FilterSetTo(Localizer, isExcluded));
             Filter.IsExcluded = isExcluded;
             await InvokeAsync(StateHasChanged);
 
@@ -161,7 +157,7 @@ public sealed partial class FilterEditorCore : ComponentBase
 
         if (Value is not null)
         {
-            AnnouncementService.Announce($"Filter set to {label}");
+            AnnouncementService.Announce(FilterEditorAnnouncements.FilterSetTo(Localizer, isExcluded));
             await OnExclusionChanged.InvokeAsync(isExcluded);
         }
     }
@@ -207,7 +203,7 @@ public sealed partial class FilterEditorCore : ComponentBase
     {
         if (IsPending)
         {
-            AnnouncementService.Announce("Filter discarded");
+            AnnouncementService.Announce(FilterEditorAnnouncements.FilterDiscarded(Localizer));
             await OnPendingDiscard.InvokeAsync();
 
             return;
@@ -215,7 +211,7 @@ public sealed partial class FilterEditorCore : ComponentBase
 
         if (Value is null) { return; }
 
-        AnnouncementService.Announce("Filter removed");
+        AnnouncementService.Announce(FilterEditorAnnouncements.FilterRemoved(Localizer));
         await OnRemove.InvokeAsync();
     }
 
@@ -223,9 +219,15 @@ public sealed partial class FilterEditorCore : ComponentBase
     {
         if (Filter is null) { return; }
 
-        if (!Filter.TryBuildSavedFilter(out var saved, out string error))
+        if (!Filter.TryBuildSavedFilter(out var saved, out var failure))
         {
-            ErrorMessage = error;
+            ErrorMessage = failure switch
+            {
+                FilterDraftBuildFailure.EmptyFilter => Localizer["FilterEditor_SaveError_EmptyFilter"],
+                FilterDraftBuildFailure.InvalidBasicStructure => Localizer["FilterEditor_SaveError_IncompletePredicates"],
+                FilterDraftBuildFailure.CompilerDiagnostic diagnostic => diagnostic.Message,
+                _ => throw new ArgumentOutOfRangeException(nameof(failure), failure, null)
+            };
 
             return;
         }
@@ -233,7 +235,7 @@ public sealed partial class FilterEditorCore : ComponentBase
         Filter = null;
         ErrorMessage = string.Empty;
 
-        AnnouncementService.Announce("Filter saved");
+        AnnouncementService.Announce(FilterEditorAnnouncements.FilterSaved(Localizer));
 
         if (IsPending)
         {
@@ -249,8 +251,7 @@ public sealed partial class FilterEditorCore : ComponentBase
     {
         if (Value is not { } savedFilter) { return; }
 
-        string newState = savedFilter.IsEnabled ? "disabled" : "enabled";
-        AnnouncementService.Announce($"Filter {newState}");
+        AnnouncementService.Announce(FilterEditorAnnouncements.FilterEnabledState(Localizer, !savedFilter.IsEnabled));
         await OnToggleEnabled.InvokeAsync();
     }
 
@@ -262,22 +263,13 @@ public sealed partial class FilterEditorCore : ComponentBase
 
         if (Filter.WouldLoseDataSwitchingTo(target))
         {
-            string message = (Filter.Mode, target) switch
-            {
-                (_, FilterMode.Cached) =>
-                    "Switching to Recent will discard the current filter contents. Continue?",
-                (FilterMode.Advanced, FilterMode.Basic) or (FilterMode.Cached, FilterMode.Basic) =>
-                    "Switching to Basic will discard the current expression because it cannot be represented in the Basic editor. Continue?",
-                (FilterMode.Basic, FilterMode.Advanced) =>
-                    "Switching to Advanced will drop incomplete predicates from the Basic editor. Continue?",
-                _ => "Switching modes will discard the current filter contents. Continue?",
-            };
+            string message = FilterEditorModeSwitchLocalizer.ConfirmationMessage(Localizer, Filter.Mode, target);
 
             bool accepted = await AlertDialogService.ShowAlert(
-                "Switch Filter Mode",
+                Localizer["FilterEditor_ModeSwitch_Title"],
                 message,
-                "Continue",
-                "Cancel");
+                Localizer["FilterEditor_Action_Continue"],
+                Localizer["Modal_Cancel"]);
 
             if (!accepted)
             {
@@ -287,7 +279,7 @@ public sealed partial class FilterEditorCore : ComponentBase
             }
         }
 
-        AnnouncementService.Announce($"Switched to {GetFilterModeDisplayLabel(target)} filter mode");
+        AnnouncementService.Announce(FilterEditorAnnouncements.SwitchedToMode(Localizer, target));
         Filter.ApplyModeSwitch(target);
         ErrorMessage = string.Empty;
     }

--- a/src/EventLogExpert.UI/FilterEditor/FilterEditorHighlightColorLocalizer.cs
+++ b/src/EventLogExpert.UI/FilterEditor/FilterEditorHighlightColorLocalizer.cs
@@ -1,0 +1,44 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Localization;
+using Microsoft.Extensions.Localization;
+
+namespace EventLogExpert.UI.FilterEditor;
+
+internal static class FilterEditorHighlightColorLocalizer
+{
+    public static string Label(IStringLocalizer<SharedResource> localizer, HighlightColor color) => color switch
+    {
+        HighlightColor.None => localizer["FilterEditor_HighlightColorOption_None"],
+        HighlightColor.LightRed => localizer["FilterEditor_HighlightColorOption_LightRed"],
+        HighlightColor.Red => localizer["FilterEditor_HighlightColorOption_Red"],
+        HighlightColor.DarkRed => localizer["FilterEditor_HighlightColorOption_DarkRed"],
+        HighlightColor.LightOrange => localizer["FilterEditor_HighlightColorOption_LightOrange"],
+        HighlightColor.Orange => localizer["FilterEditor_HighlightColorOption_Orange"],
+        HighlightColor.DarkOrange => localizer["FilterEditor_HighlightColorOption_DarkOrange"],
+        HighlightColor.LightYellow => localizer["FilterEditor_HighlightColorOption_LightYellow"],
+        HighlightColor.Yellow => localizer["FilterEditor_HighlightColorOption_Yellow"],
+        HighlightColor.DarkYellow => localizer["FilterEditor_HighlightColorOption_DarkYellow"],
+        HighlightColor.LightGreen => localizer["FilterEditor_HighlightColorOption_LightGreen"],
+        HighlightColor.Green => localizer["FilterEditor_HighlightColorOption_Green"],
+        HighlightColor.DarkGreen => localizer["FilterEditor_HighlightColorOption_DarkGreen"],
+        HighlightColor.LightTeal => localizer["FilterEditor_HighlightColorOption_LightTeal"],
+        HighlightColor.Teal => localizer["FilterEditor_HighlightColorOption_Teal"],
+        HighlightColor.DarkTeal => localizer["FilterEditor_HighlightColorOption_DarkTeal"],
+        HighlightColor.LightBlue => localizer["FilterEditor_HighlightColorOption_LightBlue"],
+        HighlightColor.Blue => localizer["FilterEditor_HighlightColorOption_Blue"],
+        HighlightColor.DarkBlue => localizer["FilterEditor_HighlightColorOption_DarkBlue"],
+        HighlightColor.LightPurple => localizer["FilterEditor_HighlightColorOption_LightPurple"],
+        HighlightColor.Purple => localizer["FilterEditor_HighlightColorOption_Purple"],
+        HighlightColor.DarkPurple => localizer["FilterEditor_HighlightColorOption_DarkPurple"],
+        HighlightColor.LightMagenta => localizer["FilterEditor_HighlightColorOption_LightMagenta"],
+        HighlightColor.Magenta => localizer["FilterEditor_HighlightColorOption_Magenta"],
+        HighlightColor.DarkMagenta => localizer["FilterEditor_HighlightColorOption_DarkMagenta"],
+        HighlightColor.LightPink => localizer["FilterEditor_HighlightColorOption_LightPink"],
+        HighlightColor.Pink => localizer["FilterEditor_HighlightColorOption_Pink"],
+        HighlightColor.DarkPink => localizer["FilterEditor_HighlightColorOption_DarkPink"],
+        _ => throw new ArgumentOutOfRangeException(nameof(color), color, null)
+    };
+}

--- a/src/EventLogExpert.UI/FilterEditor/FilterEditorModeLocalizer.cs
+++ b/src/EventLogExpert.UI/FilterEditor/FilterEditorModeLocalizer.cs
@@ -1,0 +1,19 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Evaluation;
+using EventLogExpert.Localization;
+using Microsoft.Extensions.Localization;
+
+namespace EventLogExpert.UI.FilterEditor;
+
+internal static class FilterEditorModeLocalizer
+{
+    public static string Display(IStringLocalizer<SharedResource> localizer, FilterMode mode) => mode switch
+    {
+        FilterMode.Advanced => localizer["FilterEditor_Mode_Advanced"],
+        FilterMode.Basic => localizer["FilterEditor_Mode_Basic"],
+        FilterMode.Cached => localizer["FilterEditor_Mode_Recent"],
+        _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
+    };
+}

--- a/src/EventLogExpert.UI/FilterEditor/FilterEditorModeSwitchLocalizer.cs
+++ b/src/EventLogExpert.UI/FilterEditor/FilterEditorModeSwitchLocalizer.cs
@@ -1,0 +1,28 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Evaluation;
+using EventLogExpert.Localization;
+using Microsoft.Extensions.Localization;
+
+namespace EventLogExpert.UI.FilterEditor;
+
+internal static class FilterEditorModeSwitchLocalizer
+{
+    public static string ConfirmationMessage(
+        IStringLocalizer<SharedResource> localizer,
+        FilterMode current,
+        FilterMode target) => (current, target) switch
+        {
+            (FilterMode.Advanced, FilterMode.Cached) => localizer["FilterEditor_ModeSwitch_Message_ToRecent"],
+            (FilterMode.Basic, FilterMode.Cached) => localizer["FilterEditor_ModeSwitch_Message_ToRecent"],
+            (FilterMode.Cached, FilterMode.Cached) => localizer["FilterEditor_ModeSwitch_Message_ToRecent"],
+            (FilterMode.Advanced, FilterMode.Basic) => localizer["FilterEditor_ModeSwitch_Message_ToBasic"],
+            (FilterMode.Cached, FilterMode.Basic) => localizer["FilterEditor_ModeSwitch_Message_ToBasic"],
+            (FilterMode.Basic, FilterMode.Advanced) => localizer["FilterEditor_ModeSwitch_Message_ToAdvanced"],
+            (FilterMode.Cached, FilterMode.Advanced) => localizer["FilterEditor_ModeSwitch_Message_Generic"],
+            (FilterMode.Advanced, FilterMode.Advanced) => localizer["FilterEditor_ModeSwitch_Message_Generic"],
+            (FilterMode.Basic, FilterMode.Basic) => localizer["FilterEditor_ModeSwitch_Message_Generic"],
+            _ => throw new ArgumentOutOfRangeException(nameof(current), current, null)
+        };
+}

--- a/src/EventLogExpert.UI/FilterEditor/Rows/FilterRowActions.razor
+++ b/src/EventLogExpert.UI/FilterEditor/Rows/FilterRowActions.razor
@@ -3,26 +3,26 @@
     <div class="filter-row-actions">
         @if (ShowScenarioCopy)
         {
-            <Button aria-label="@($"Copy {DescribeFilter(savedFilter)} as scenario JSON")"
-                IconClass="bi bi-filetype-json"
+            <Button IconClass="bi bi-filetype-json"
                 IconOnly
                 OnClick="@(() => CopyScenarioJsonAsync(savedFilter))"
-                title="Copy as scenario JSON" />
+                aria-label="@CopyScenarioAriaLabel(savedFilter)"
+                title="@Localizer["FilterEditor_RowAction_CopyScenarioTitle"]" />
         }
-        <Button aria-label="@($"Edit {DescribeFilter(savedFilter)}")"
-            IconClass="bi bi-funnel"
+        <Button IconClass="bi bi-funnel"
             IconOnly
             OnClick="OnEdit"
+            aria-label="@EditAriaLabel(savedFilter)"
             @ref="_editButton"
-            title="Edit filter" />
+            title="@Localizer["FilterEditor_RowAction_EditTitle"]" />
 
-        <DangerButton aria-label="@($"Remove {DescribeFilter(savedFilter)}")"
-            IconClass="bi bi-dash-circle"
+        <DangerButton IconClass="bi bi-dash-circle"
             IconOnly
             OnClick="OnRemove"
-            title="Remove filter" />
+            aria-label="@RemoveAriaLabel(savedFilter)"
+            title="@Localizer["FilterEditor_RowAction_RemoveTitle"]" />
 
-        <span class="visually-hidden" id="@_enableToggleLabelId">Enable filter</span>
+        <span class="visually-hidden" id="@_enableToggleLabelId">@Localizer["FilterEditor_RowAction_EnableToggleLabel"]</span>
 
         <Toggle AriaLabelledBy="@EnableToggleAriaLabelledBy"
             Value="savedFilter.IsEnabled"

--- a/src/EventLogExpert.UI/FilterEditor/Rows/FilterRowActions.razor.cs
+++ b/src/EventLogExpert.UI/FilterEditor/Rows/FilterRowActions.razor.cs
@@ -2,10 +2,12 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Localization;
 using EventLogExpert.UI.Common;
 using EventLogExpert.UI.Focus;
 using EventLogExpert.UI.Inputs;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
 
 namespace EventLogExpert.UI.FilterEditor.Rows;
 
@@ -28,17 +30,31 @@ public sealed partial class FilterRowActions : ComponentBase
     [Parameter] public SavedFilter? Value { get; set; }
 
     private string EnableToggleAriaLabelledBy =>
-        string.IsNullOrEmpty(FilterLabelId)
-            ? _enableToggleLabelId
-            : $"{FilterLabelId} {_enableToggleLabelId}";
+        string.IsNullOrEmpty(FilterLabelId) ?
+            _enableToggleLabelId :
+            $"{FilterLabelId} {_enableToggleLabelId}";
+
+    [Inject] private IStringLocalizer<SharedResource> Localizer { get; init; } = null!;
 
     private bool ShowScenarioCopy => AuthoringContext is { Enabled: true };
 
     internal ValueTask FocusEditAsync() => _editButton is { } button ? ElementFocus.SafelyAsync(button.Element) : ValueTask.CompletedTask;
 
-    private static string DescribeFilter(SavedFilter filter) =>
-        string.IsNullOrWhiteSpace(filter.ComparisonText) ? "filter" : $"filter '{filter.ComparisonText}'";
+    private string CopyScenarioAriaLabel(SavedFilter filter) =>
+        string.IsNullOrWhiteSpace(filter.ComparisonText) ?
+            Localizer["FilterEditor_RowAction_CopyScenarioAria_Unnamed"] :
+            Localizer["FilterEditor_RowAction_CopyScenarioAria_Named", filter.ComparisonText];
 
     private Task CopyScenarioJsonAsync(SavedFilter savedFilter) =>
         AuthoringContext?.CopyAsync(savedFilter) ?? Task.CompletedTask;
+
+    private string EditAriaLabel(SavedFilter filter) =>
+        string.IsNullOrWhiteSpace(filter.ComparisonText) ?
+            Localizer["FilterEditor_RowAction_EditAria_Unnamed"] :
+            Localizer["FilterEditor_RowAction_EditAria_Named", filter.ComparisonText];
+
+    private string RemoveAriaLabel(SavedFilter filter) =>
+        string.IsNullOrWhiteSpace(filter.ComparisonText) ?
+            Localizer["FilterEditor_RowAction_RemoveAria_Unnamed"] :
+            Localizer["FilterEditor_RowAction_RemoveAria_Named", filter.ComparisonText];
 }

--- a/src/EventLogExpert.UI/FilterEditor/Rows/FilterRowHeader.razor
+++ b/src/EventLogExpert.UI/FilterEditor/Rows/FilterRowHeader.razor
@@ -1,14 +1,14 @@
 @if (Value is { } savedFilter)
 {
     <div class="filter-row-header">
-        <Button aria-label="@(savedFilter.IsExcluded ? $"Filter '{savedFilter.ComparisonText}' is excluded; activate to include" : $"Filter '{savedFilter.ComparisonText}' is included; activate to exclude")"
-            aria-pressed="@(savedFilter.IsExcluded ? "true" : "false")"
-            CssClass="filter-exclude-toggle"
-            data-excluded="@(savedFilter.IsExcluded ? "true" : "false")"
+        <Button CssClass="filter-exclude-toggle"
             IconClass="@(savedFilter.IsExcluded ? "bi bi-slash-circle-fill" : "bi bi-slash-circle")"
             IconOnly
             OnClick="@(() => OnExclusionChanged.InvokeAsync(!savedFilter.IsExcluded))"
-            title="@(savedFilter.IsExcluded ? "Excluded \u2014 click to include" : "Included \u2014 click to exclude")" />
+            aria-label="@(savedFilter.IsExcluded ? Localizer["FilterEditor_RowHeader_ExcludedAria", savedFilter.ComparisonText] : Localizer["FilterEditor_RowHeader_IncludedAria", savedFilter.ComparisonText])"
+            aria-pressed="@(savedFilter.IsExcluded ? "true" : "false")"
+            data-excluded="@(savedFilter.IsExcluded ? "true" : "false")"
+            title="@(savedFilter.IsExcluded ? Localizer["FilterEditor_ExcludeToggle_TitleExcluded"] : Localizer["FilterEditor_ExcludeToggle_TitleIncluded"])" />
 
         <div aria-hidden="true"
             class="color-box"
@@ -18,7 +18,7 @@
 
         @if (string.IsNullOrWhiteSpace(savedFilter.ComparisonText))
         {
-            <span class="filter-row-header-text" id="@FilterLabelId">No Filter Specified</span>
+            <span class="filter-row-header-text" id="@FilterLabelId">@Localizer["FilterEditor_RowHeader_NoFilterSpecified"]</span>
         }
         else
         {

--- a/src/EventLogExpert.UI/FilterEditor/Rows/FilterRowHeader.razor.cs
+++ b/src/EventLogExpert.UI/FilterEditor/Rows/FilterRowHeader.razor.cs
@@ -2,7 +2,9 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Localization;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
 
 namespace EventLogExpert.UI.FilterEditor.Rows;
 
@@ -18,4 +20,6 @@ public sealed partial class FilterRowHeader : ComponentBase
     [Parameter] public EventCallback<bool> OnExclusionChanged { get; set; }
 
     [Parameter] public SavedFilter? Value { get; set; }
+
+    [Inject] private IStringLocalizer<SharedResource> Localizer { get; init; } = null!;
 }

--- a/tests/Unit/EventLogExpert.Filtering.Tests/Drafts/FilterDraftModeTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/Drafts/FilterDraftModeTests.cs
@@ -286,14 +286,16 @@ public sealed class FilterDraftModeTests
     [Fact]
     public void TryBuildSavedFilter_AdvancedMode_CompileFailure_ReturnsCompileError()
     {
+        const string expectedDiagnostic = "Unterminated string literal. (position 10).";
         FilterDraft draft = new()
-            { Mode = FilterMode.Advanced, ComparisonText = "Id ===== ###" };
+            { Mode = FilterMode.Advanced, ComparisonText = "Source == \"unterminated" };
 
-        bool ok = draft.TryBuildSavedFilter(out SavedFilter? saved, out string error);
+        bool ok = draft.TryBuildSavedFilter(out SavedFilter? saved, out FilterDraftBuildFailure? failure);
 
         Assert.False(ok);
         Assert.Null(saved);
-        Assert.False(string.IsNullOrEmpty(error));
+        var diagnostic = Assert.IsType<FilterDraftBuildFailure.CompilerDiagnostic>(failure);
+        Assert.Equal(expectedDiagnostic, diagnostic.Message);
     }
 
     [Fact]
@@ -304,10 +306,11 @@ public sealed class FilterDraftModeTests
         FilterDraft draft = new()
             { Mode = FilterMode.Advanced, ComparisonText = FilterTestConstants.FilterIdEquals100 };
 
-        bool ok = draft.TryBuildSavedFilter(out SavedFilter? saved, out string error);
+        bool ok = draft.TryBuildSavedFilter(out SavedFilter? saved, out FilterDraftBuildFailure? failure);
 
-        Assert.True(ok, error);
+        Assert.True(ok, failure?.ToString());
         Assert.NotNull(saved);
+        Assert.Null(failure);
         Assert.Equal(FilterMode.Advanced, saved.Mode);
         Assert.Null(saved.BasicFilter);
     }
@@ -318,11 +321,11 @@ public sealed class FilterDraftModeTests
         FilterDraft draft = new()
             { Mode = FilterMode.Advanced, ComparisonText = string.Empty };
 
-        bool ok = draft.TryBuildSavedFilter(out SavedFilter? saved, out string error);
+        bool ok = draft.TryBuildSavedFilter(out SavedFilter? saved, out FilterDraftBuildFailure? failure);
 
         Assert.False(ok);
         Assert.Null(saved);
-        Assert.False(string.IsNullOrEmpty(error));
+        Assert.IsType<FilterDraftBuildFailure.EmptyFilter>(failure);
     }
 
     [Fact]
@@ -330,11 +333,11 @@ public sealed class FilterDraftModeTests
     {
         FilterDraft draft = new() { Mode = FilterMode.Basic };
 
-        bool ok = draft.TryBuildSavedFilter(out SavedFilter? saved, out string error);
+        bool ok = draft.TryBuildSavedFilter(out SavedFilter? saved, out FilterDraftBuildFailure? failure);
 
         Assert.False(ok);
         Assert.Null(saved);
-        Assert.False(string.IsNullOrEmpty(error));
+        Assert.IsType<FilterDraftBuildFailure.EmptyFilter>(failure);
     }
 
     [Fact]
@@ -366,11 +369,11 @@ public sealed class FilterDraftModeTests
             JoinWithAny = false
         });
 
-        bool ok = draft.TryBuildSavedFilter(out SavedFilter? saved, out string error);
+        bool ok = draft.TryBuildSavedFilter(out SavedFilter? saved, out FilterDraftBuildFailure? failure);
 
         Assert.False(ok);
         Assert.Null(saved);
-        Assert.False(string.IsNullOrEmpty(error));
+        Assert.IsType<FilterDraftBuildFailure.InvalidBasicStructure>(failure);
     }
 
     [Fact]
@@ -388,10 +391,11 @@ public sealed class FilterDraftModeTests
             }
         };
 
-        bool ok = draft.TryBuildSavedFilter(out SavedFilter? saved, out string error);
+        bool ok = draft.TryBuildSavedFilter(out SavedFilter? saved, out FilterDraftBuildFailure? failure);
 
-        Assert.True(ok, error);
+        Assert.True(ok, failure?.ToString());
         Assert.NotNull(saved);
+        Assert.Null(failure);
         Assert.Equal(FilterMode.Basic, saved.Mode);
         Assert.NotNull(saved.BasicFilter);
         Assert.Equal("Id == 100", saved.ComparisonText);
@@ -403,11 +407,11 @@ public sealed class FilterDraftModeTests
         FilterDraft draft = new()
             { Mode = FilterMode.Cached, ComparisonText = string.Empty };
 
-        bool ok = draft.TryBuildSavedFilter(out SavedFilter? saved, out string error);
+        bool ok = draft.TryBuildSavedFilter(out SavedFilter? saved, out FilterDraftBuildFailure? failure);
 
         Assert.False(ok);
         Assert.Null(saved);
-        Assert.False(string.IsNullOrEmpty(error));
+        Assert.IsType<FilterDraftBuildFailure.EmptyFilter>(failure);
     }
 
     [Fact]
@@ -416,10 +420,11 @@ public sealed class FilterDraftModeTests
         FilterDraft draft = new()
             { Mode = FilterMode.Cached, ComparisonText = FilterTestConstants.FilterIdEquals100 };
 
-        bool ok = draft.TryBuildSavedFilter(out SavedFilter? saved, out string error);
+        bool ok = draft.TryBuildSavedFilter(out SavedFilter? saved, out FilterDraftBuildFailure? failure);
 
-        Assert.True(ok, error);
+        Assert.True(ok, failure?.ToString());
         Assert.NotNull(saved);
+        Assert.Null(failure);
         Assert.Equal(FilterMode.Cached, saved.Mode);
         Assert.Null(saved.BasicFilter);
     }

--- a/tests/Unit/EventLogExpert.Filtering.Tests/Drafts/FilterDraftTests.cs
+++ b/tests/Unit/EventLogExpert.Filtering.Tests/Drafts/FilterDraftTests.cs
@@ -279,7 +279,8 @@ public sealed class FilterDraftModelTests
             }
         };
 
-        Assert.True(draft.TryBuildSavedFilter(out var saved, out _));
+        Assert.True(draft.TryBuildSavedFilter(out var saved, out var failure), failure?.ToString());
+        Assert.Null(failure);
 
         // Both the compiled text AND the stored Basic model must be free of the degenerate empty value (no drift).
         Assert.DoesNotContain("\"\"", saved.ComparisonText);

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterEditor/FilterEditorCoreTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterEditor/FilterEditorCoreTests.cs
@@ -5,10 +5,13 @@ using Bunit;
 using EventLogExpert.Filtering.Drafts;
 using EventLogExpert.Filtering.Evaluation;
 using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Localization;
 using EventLogExpert.Runtime.Alerts;
 using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.UI.FilterEditor;
+using EventLogExpert.UI.Tests.TestUtils;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using NSubstitute;
 using System.Reflection;
 
@@ -23,6 +26,7 @@ public sealed class FilterEditorCoreTests : BunitContext
     {
         Services.AddSingleton(_alerts);
         Services.AddSingleton(_announcements);
+        Services.AddSingleton<IStringLocalizer<SharedResource>>(new MarkerLocalizer());
 
         JSInterop.Mode = JSRuntimeMode.Loose;
     }
@@ -67,7 +71,7 @@ public sealed class FilterEditorCoreTests : BunitContext
         Assert.Equal("Level == 4", readOnlyInput.GetAttribute("value"));
 
         var hint = component.Find(".filter-row-hint");
-        Assert.Contains("No recent options", hint.TextContent);
+        Assert.Contains("[[FilterEditor_Recent_EmptyNoneAvailable]]", hint.TextContent);
     }
 
     [Fact]
@@ -80,7 +84,7 @@ public sealed class FilterEditorCoreTests : BunitContext
             .Add(p => p.PendingDraft, draft)
             .Add(p => p.CachedOptions, options));
 
-        Assert.Empty(component.FindAll("[aria-label='Filter recent options by tag']"));
+        Assert.Empty(component.FindAll("[aria-label='[[FilterEditor_Recent_TagFilterAria]]']"));
     }
 
     [Fact]
@@ -93,7 +97,7 @@ public sealed class FilterEditorCoreTests : BunitContext
             .Add(p => p.PendingDraft, draft)
             .Add(p => p.CachedOptions, options));
 
-        Assert.NotNull(component.Find("[aria-label='Filter recent options by tag']"));
+        Assert.NotNull(component.Find("[aria-label='[[FilterEditor_Recent_TagFilterAria]]']"));
     }
 
     [Fact]
@@ -107,15 +111,15 @@ public sealed class FilterEditorCoreTests : BunitContext
 
         Assert.False(component.Instance.IsEditing);
 
-        component.Find("button[title='Edit filter']").Click();
+        component.Find("button[title='[[FilterEditor_RowAction_EditTitle]]']").Click();
 
         Assert.True(component.Instance.IsEditing);
-        _announcements.Received(1).Announce("Editing filter");
+        _announcements.Received(1).Announce("[[FilterEditor_Announcement_EditingFilter]]");
 
-        component.Find("button[aria-label='Cancel edit']").Click();
+        component.Find("button[aria-label='[[FilterEditor_Action_CancelEdit_Aria]]']").Click();
 
         Assert.False(component.Instance.IsEditing);
-        _announcements.Received(1).Announce("Edit cancelled");
+        _announcements.Received(1).Announce("[[FilterEditor_Announcement_EditCancelled]]");
     }
 
     [Fact]
@@ -180,14 +184,14 @@ public sealed class FilterEditorCoreTests : BunitContext
             .Add(p => p.CachedOptions, new List<CachedFilterOption>()));
 
         var initialItems = component.Find(".filter-row-mode .dropdown-list").QuerySelectorAll("[role='option']");
-        Assert.DoesNotContain(initialItems, item => item.TextContent.Contains("Recent"));
+        Assert.DoesNotContain(initialItems, item => item.TextContent.Contains("[[FilterEditor_Mode_Recent]]"));
 
         component.Render(parameters => parameters
             .Add(p => p.PendingDraft, draft)
             .Add(p => p.CachedOptions, new List<CachedFilterOption> { new("Level == 4", IsFavorite: true, Tags: []) }));
 
         var updatedItems = component.Find(".filter-row-mode .dropdown-list").QuerySelectorAll("[role='option']");
-        Assert.Contains(updatedItems, item => item.TextContent.Contains("Recent"));
+        Assert.Contains(updatedItems, item => item.TextContent.Contains("[[FilterEditor_Mode_Recent]]"));
     }
 
     [Fact]
@@ -202,7 +206,7 @@ public sealed class FilterEditorCoreTests : BunitContext
         var modeListbox = component.Find(".filter-row-mode .dropdown-list");
         var items = modeListbox.QuerySelectorAll("[role='option']");
 
-        Assert.Contains(items, item => item.TextContent.Contains("Recent"));
+        Assert.Contains(items, item => item.TextContent.Contains("[[FilterEditor_Mode_Recent]]"));
     }
 
     [Fact]
@@ -217,7 +221,7 @@ public sealed class FilterEditorCoreTests : BunitContext
         var modeListbox = component.Find(".filter-row-mode .dropdown-list");
         var items = modeListbox.QuerySelectorAll("[role='option']");
 
-        Assert.DoesNotContain(items, item => item.TextContent.Contains("Recent"));
+        Assert.DoesNotContain(items, item => item.TextContent.Contains("[[FilterEditor_Mode_Recent]]"));
     }
 
     [Fact]
@@ -236,9 +240,9 @@ public sealed class FilterEditorCoreTests : BunitContext
         var modeListbox = component.Find(".filter-row-mode .dropdown-list");
         var items = modeListbox.QuerySelectorAll("[role='option']");
 
-        Assert.Contains(items, item => item.TextContent.Contains("Basic"));
-        Assert.Contains(items, item => item.TextContent.Contains("Advanced"));
-        Assert.Contains(items, item => item.TextContent.Contains("Recent"));
+        Assert.Contains(items, item => item.TextContent.Contains("[[FilterEditor_Mode_Basic]]"));
+        Assert.Contains(items, item => item.TextContent.Contains("[[FilterEditor_Mode_Advanced]]"));
+        Assert.Contains(items, item => item.TextContent.Contains("[[FilterEditor_Mode_Recent]]"));
     }
 
     [Fact]
@@ -253,7 +257,7 @@ public sealed class FilterEditorCoreTests : BunitContext
         var modeListbox = component.Find(".filter-row-mode .dropdown-list");
         var items = modeListbox.QuerySelectorAll("[role='option']");
 
-        Assert.Contains(items, item => item.TextContent.Contains("Recent"));
+        Assert.Contains(items, item => item.TextContent.Contains("[[FilterEditor_Mode_Recent]]"));
     }
 
     [Fact]
@@ -268,7 +272,7 @@ public sealed class FilterEditorCoreTests : BunitContext
         var modeListbox = component.Find(".filter-row-mode .dropdown-list");
         var items = modeListbox.QuerySelectorAll("[role='option']");
 
-        Assert.DoesNotContain(items, item => item.TextContent.Contains("Recent"));
+        Assert.DoesNotContain(items, item => item.TextContent.Contains("[[FilterEditor_Mode_Recent]]"));
     }
 
     [Fact]
@@ -294,6 +298,19 @@ public sealed class FilterEditorCoreTests : BunitContext
     }
 
     [Fact]
+    public void OnParametersSet_BothValueAndPendingDraftNull_ThrowsInvalidOperationException()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            Render<FilterEditorCore>(parameters => parameters
+                .Add(p => p.Value, null)
+                .Add(p => p.PendingDraft, null)));
+
+        Assert.Contains("requires either", ex.Message);
+        Assert.Contains("Value", ex.Message);
+        Assert.Contains("PendingDraft", ex.Message);
+    }
+
+    [Fact]
     public void OnParametersSet_BothValueAndPendingDraft_DropsDraftPendingToSavedTransition()
     {
         var draft = new FilterDraft { Mode = FilterMode.Advanced, ComparisonText = "Id == 1" };
@@ -309,19 +326,6 @@ public sealed class FilterEditorCoreTests : BunitContext
             .Add(p => p.PendingDraft, draft));
 
         Assert.False(component.Instance.IsEditing);
-    }
-
-    [Fact]
-    public void OnParametersSet_BothValueAndPendingDraftNull_ThrowsInvalidOperationException()
-    {
-        var ex = Assert.Throws<InvalidOperationException>(() =>
-            Render<FilterEditorCore>(parameters => parameters
-                .Add(p => p.Value, null)
-                .Add(p => p.PendingDraft, null)));
-
-        Assert.Contains("requires either", ex.Message);
-        Assert.Contains("Value", ex.Message);
-        Assert.Contains("PendingDraft", ex.Message);
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterEditor/FilterEditorLocalizerWiringTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterEditor/FilterEditorLocalizerWiringTests.cs
@@ -1,0 +1,616 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using EventLogExpert.Filtering.Common.Filtering;
+using EventLogExpert.Filtering.Drafts;
+using EventLogExpert.Filtering.Evaluation;
+using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Localization;
+using EventLogExpert.Runtime.Alerts;
+using EventLogExpert.Runtime.Announcement;
+using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.UI.FilterEditor;
+using EventLogExpert.UI.FilterEditor.Comparison;
+using EventLogExpert.UI.FilterEditor.Editing;
+using EventLogExpert.UI.FilterEditor.Rows;
+using EventLogExpert.UI.Tests.TestUtils;
+using Fluxor;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using NSubstitute;
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Xml.Linq;
+
+namespace EventLogExpert.UI.Tests.FilterEditor;
+
+public sealed class FilterEditorLocalizerWiringTests : BunitContext
+{
+    private readonly IAlertDialogService _alerts = Substitute.For<IAlertDialogService>();
+    private readonly IAnnouncementService _announcements = Substitute.For<IAnnouncementService>();
+
+    public FilterEditorLocalizerWiringTests()
+    {
+        var eventLogState = Substitute.For<IState<EventLogState>>();
+        eventLogState.Value.Returns(new EventLogState());
+        Services.AddSingleton(eventLogState);
+
+        var eventLogQueries = Substitute.For<IEventLogQueries>();
+        eventLogQueries.GetPropertyValues(default).ReturnsForAnyArgs(ImmutableArray<string>.Empty);
+        eventLogQueries.GetEventDataFieldNames().Returns(ImmutableArray<string>.Empty);
+        eventLogQueries.GetUserDataFieldNames().Returns(ImmutableArray<string>.Empty);
+        eventLogQueries.GetEventDataFieldValues(default!).ReturnsForAnyArgs(ImmutableArray<string>.Empty);
+        eventLogQueries.GetUserDataFieldValues(default!).ReturnsForAnyArgs(ImmutableArray<string>.Empty);
+        Services.AddSingleton(eventLogQueries);
+
+        Services.AddSingleton(_alerts);
+        Services.AddSingleton(_announcements);
+        Services.AddSingleton<IStringLocalizer<SharedResource>>(new MarkerLocalizer());
+        Services.AddFluxor(options => options.ScanAssemblies(typeof(FilterComparisonEditor).Assembly));
+        JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    [Fact]
+    public void CoreAdvancedExpressionAndCachedEmptyStates_RouteStateSpecificMarkers()
+    {
+        var include = RenderCore(new FilterDraft { Mode = FilterMode.Advanced, IsExcluded = false });
+        Assert.Equal(
+            "[[FilterEditor_AdvancedExpression_IncludeAria]]",
+            include.Find("input.advanced-filter").GetAttribute("aria-label"));
+
+        var exclude = RenderCore(new FilterDraft { Mode = FilterMode.Advanced, IsExcluded = true });
+        Assert.Equal(
+            "[[FilterEditor_AdvancedExpression_ExcludeAria]]",
+            exclude.Find("input.advanced-filter").GetAttribute("aria-label"));
+
+        var noOptions = RenderCore(new FilterDraft { Mode = FilterMode.Cached, ComparisonText = "Level == 4" }, cachedOptions: []);
+        Assert.Equal(
+            "[[FilterEditor_Recent_ReadOnlyAria]]",
+            noOptions.Find(".filter-row-cached input[readonly]").GetAttribute("aria-label"));
+
+        var noMatches = RenderCore(
+            new FilterDraft { Mode = FilterMode.Cached, ComparisonText = "Id == 1" },
+            cachedOptions:
+            [
+                new CachedFilterOption("Level == 4", false, ["network"]),
+                new CachedFilterOption("Source == x", false, ["database"])
+            ]);
+        SelectedTags(noMatches).AddRange(["network", "database"]);
+        noMatches.Render();
+
+        Assert.Equal("[[FilterEditor_Recent_EmptyNoMatches]]", noMatches.Find(".filter-row-hint").TextContent);
+    }
+
+    [Fact]
+    public void CoreAndRows_RouteChromeThroughLocalizerAndKeepDataVerbatim()
+    {
+        var draft = new FilterDraft { Mode = FilterMode.Cached, ComparisonText = "Level == 4" };
+        var component = RenderCore(
+            draft,
+            cachedOptions: [new CachedFilterOption("Level == 4", true, ["network"])]);
+
+        Assert.Contains("[[FilterEditor_ModeLabel]]", component.Markup);
+        Assert.Contains("[[FilterEditor_Recent_TagFilterAria]]", component.Markup);
+        Assert.Contains("[[FilterEditor_Recent_AllTags]]", component.Markup);
+        Assert.Contains("[[FilterEditor_Recent_SelectAria]]", component.Markup);
+        Assert.Contains("[[FilterEditor_Recent_FavoriteAria]]", component.Markup);
+
+        var tagOption = component.FindAll("[role='option']")
+            .Single(option => option.TextContent.Trim() == "network");
+        Assert.Equal("network", tagOption.TextContent.Trim());
+        Assert.Equal("Level == 4", component.Find(".cached-option-text").TextContent);
+        Assert.DoesNotContain("[[network]]", component.Markup);
+        Assert.DoesNotContain("[[Level == 4]]", component.Markup);
+    }
+
+    [Fact]
+    public async Task CoreAnnouncements_RouteEveryHandlerThroughMarkerLocalizer()
+    {
+        await InvokeAsync(RenderCore(new FilterDraft { Mode = FilterMode.Advanced }), "CancelHandler");
+        _announcements.Received(1).Announce("[[FilterEditor_Announcement_FilterDiscarded]]");
+
+        _announcements.ClearReceivedCalls();
+        await InvokeAsync(RenderCore(new FilterDraft { Mode = FilterMode.Advanced }), "RemoveHandler");
+        _announcements.Received(1).Announce("[[FilterEditor_Announcement_FilterDiscarded]]");
+
+        _announcements.ClearReceivedCalls();
+        var savedCore = RenderCore(value: MakeSavedFilter("Id == 1"));
+        await InvokeAsync(savedCore, "EditHandler");
+        _announcements.Received(1).Announce("[[FilterEditor_Announcement_EditingFilter]]");
+
+        _announcements.ClearReceivedCalls();
+        await InvokeAsync(savedCore, "CancelHandler");
+        _announcements.Received(1).Announce("[[FilterEditor_Announcement_EditCancelled]]");
+
+        _announcements.ClearReceivedCalls();
+        await InvokeAsync(RenderCore(value: MakeSavedFilter("Id == 1")), "ExclusionHandler", true);
+        _announcements.Received(1).Announce("[[FilterEditor_Announcement_SetToExclude]]");
+
+        _announcements.ClearReceivedCalls();
+        await InvokeAsync(RenderCore(value: MakeSavedFilter("Id == 1")), "ExclusionHandler", false);
+        _announcements.Received(1).Announce("[[FilterEditor_Announcement_SetToInclude]]");
+
+        _announcements.ClearReceivedCalls();
+        await InvokeAsync(RenderCore(new FilterDraft { Mode = FilterMode.Advanced }), "ExclusionHandler", true);
+        _announcements.Received(1).Announce("[[FilterEditor_Announcement_SetToExclude]]");
+
+        _announcements.ClearReceivedCalls();
+        await InvokeAsync(RenderCore(new FilterDraft { Mode = FilterMode.Advanced }), "ExclusionHandler", false);
+        _announcements.Received(1).Announce("[[FilterEditor_Announcement_SetToInclude]]");
+
+        _announcements.ClearReceivedCalls();
+        await InvokeAsync(RenderCore(value: MakeSavedFilter("Id == 1")), "RemoveHandler");
+        _announcements.Received(1).Announce("[[FilterEditor_Announcement_FilterRemoved]]");
+
+        _announcements.ClearReceivedCalls();
+        await InvokeAsync(RenderCore(new FilterDraft { Mode = FilterMode.Advanced, ComparisonText = "Id == 1" }), "SaveHandler");
+        _announcements.Received(1).Announce("[[FilterEditor_Announcement_FilterSaved]]");
+
+        _announcements.ClearReceivedCalls();
+        await InvokeAsync(RenderCore(value: MakeSavedFilter("Id == 1", isEnabled: true)), "ToggleEnabledHandler");
+        _announcements.Received(1).Announce("[[FilterEditor_Announcement_FilterDisabled]]");
+
+        _announcements.ClearReceivedCalls();
+        await InvokeAsync(RenderCore(value: MakeSavedFilter("Id == 1", isEnabled: false)), "ToggleEnabledHandler");
+        _announcements.Received(1).Announce("[[FilterEditor_Announcement_FilterEnabled]]");
+
+        _announcements.ClearReceivedCalls();
+        await InvokeAsync(RenderCore(new FilterDraft { Mode = FilterMode.Basic, Comparison = { Value = "1" } }), "TryChangeModeAsync", FilterMode.Advanced);
+        _announcements.Received(1).Announce("[[FilterEditor_Announcement_SwitchedToAdvanced]]");
+
+        _announcements.ClearReceivedCalls();
+        await InvokeAsync(RenderCore(new FilterDraft { Mode = FilterMode.Advanced }), "TryChangeModeAsync", FilterMode.Basic);
+        _announcements.Received(1).Announce("[[FilterEditor_Announcement_SwitchedToBasic]]");
+
+        _announcements.ClearReceivedCalls();
+        await InvokeAsync(RenderCore(new FilterDraft { Mode = FilterMode.Cached }), "TryChangeModeAsync", FilterMode.Cached);
+        _announcements.DidNotReceive().Announce(Arg.Any<string>());
+
+        _announcements.ClearReceivedCalls();
+        await InvokeAsync(RenderCore(new FilterDraft { Mode = FilterMode.Advanced }), "TryChangeModeAsync", FilterMode.Cached);
+        _announcements.Received(1).Announce("[[FilterEditor_Announcement_SwitchedToRecent]]");
+    }
+
+    [Fact]
+    public async Task CoreModeSwitchDialog_UsesLocalizedMarkersForLossySwitch()
+    {
+        _alerts.ShowAlert(default!, default!, default!, (string)default!).ReturnsForAnyArgs(true);
+        var component = RenderCore(new FilterDraft { Mode = FilterMode.Advanced, ComparisonText = "Id ===== ###" });
+
+        await InvokeAsync(component, "TryChangeModeAsync", FilterMode.Basic);
+
+        await _alerts.Received().ShowAlert(
+            "[[FilterEditor_ModeSwitch_Title]]",
+            "[[FilterEditor_ModeSwitch_Message_ToBasic]]",
+            "[[FilterEditor_Action_Continue]]",
+            "[[Modal_Cancel]]");
+    }
+
+    [Fact]
+    public async Task CoreSaveErrors_LocalizeTypedFailuresButPreserveCompilerDiagnostics()
+    {
+        var empty = RenderCore(new FilterDraft { Mode = FilterMode.Advanced, ComparisonText = string.Empty });
+        await InvokeAsync(empty, "SaveHandler");
+        Assert.Contains("[[FilterEditor_SaveError_EmptyFilter]]", empty.Markup);
+
+        var incomplete = RenderCore(new FilterDraft { Mode = FilterMode.Basic, Predicates = [new FilterPredicateDraft()] });
+        await InvokeAsync(incomplete, "SaveHandler");
+        Assert.Contains("[[FilterEditor_SaveError_IncompletePredicates]]", incomplete.Markup);
+
+        var diagnosticDraft = new FilterDraft { Mode = FilterMode.Advanced, ComparisonText = "Source == \"unterminated" };
+        Assert.False(diagnosticDraft.TryBuildSavedFilter(out _, out var failure));
+        var expectedDiagnostic = Assert.IsType<FilterDraftBuildFailure.CompilerDiagnostic>(failure).Message;
+
+        var diagnostic = RenderCore(diagnosticDraft);
+        await InvokeAsync(diagnostic, "SaveHandler");
+        var error = diagnostic.Find(".advanced-filter-error");
+        Assert.Equal(expectedDiagnostic, error.TextContent);
+        Assert.DoesNotContain("[[", error.TextContent);
+    }
+
+    [Fact]
+    public void FilterEditPanel_RoutesActionsAndHighlightColorsThroughLocalizer()
+    {
+        var component = Render<FilterEditPanel>(parameters => parameters
+            .Add(panel => panel.Filter, new FilterDraft { Mode = FilterMode.Advanced, Color = HighlightColor.LightRed }));
+
+        Assert.Contains("[[FilterEditor_EditPanel_IncludedAria]]", component.Markup);
+        Assert.Contains("[[FilterEditor_ExcludeToggle_TitleIncluded]]", component.Markup);
+        Assert.Contains("[[FilterEditor_HighlightColor_Aria]]", component.Markup);
+        Assert.Contains("[[FilterEditor_HighlightColorOption_LightRed]]", component.Markup);
+        Assert.Contains("data-highlight=\"lightred\"", component.Markup);
+        Assert.Contains("[[FilterEditor_Action_Save]]", component.Markup);
+        Assert.Contains("[[FilterEditor_Action_CancelEdit_Aria]]", component.Markup);
+        Assert.Equal(
+            "[[FilterEditor_Action_CancelEdit_Title]]",
+            component.Find("button[aria-label='[[FilterEditor_Action_CancelEdit_Aria]]']").GetAttribute("title"));
+        Assert.Contains("[[FilterEditor_Action_RemoveFilter_Aria]]", component.Markup);
+        Assert.Equal(
+            "[[FilterEditor_Action_RemoveFilter_Title]]",
+            component.Find("button[aria-label='[[FilterEditor_Action_RemoveFilter_Aria]]']").GetAttribute("title"));
+
+        var excluded = Render<FilterEditPanel>(parameters => parameters
+            .Add(panel => panel.Filter, new FilterDraft { Mode = FilterMode.Advanced, IsExcluded = true }));
+
+        Assert.Contains("[[FilterEditor_EditPanel_ExcludedAria]]", excluded.Markup);
+        Assert.Contains("[[FilterEditor_ExcludeToggle_TitleExcluded]]", excluded.Markup);
+        Assert.Contains("[[FilterEditor_HighlightColor_IncludeOnlyDescription]]", excluded.Markup);
+    }
+
+    [Fact]
+    public void FilterEditorAnnouncements_RouteEveryBranch()
+    {
+        MarkerLocalizer localizer = new();
+
+        Assert.Equal("[[FilterEditor_Announcement_FilterDiscarded]]", FilterEditorAnnouncements.FilterDiscarded(localizer));
+        Assert.Equal("[[FilterEditor_Announcement_EditCancelled]]", FilterEditorAnnouncements.EditCancelled(localizer));
+        Assert.Equal("[[FilterEditor_Announcement_EditingFilter]]", FilterEditorAnnouncements.EditingFilter(localizer));
+        Assert.Equal("[[FilterEditor_Announcement_SetToExclude]]", FilterEditorAnnouncements.FilterSetTo(localizer, true));
+        Assert.Equal("[[FilterEditor_Announcement_SetToInclude]]", FilterEditorAnnouncements.FilterSetTo(localizer, false));
+        Assert.Equal("[[FilterEditor_Announcement_FilterRemoved]]", FilterEditorAnnouncements.FilterRemoved(localizer));
+        Assert.Equal("[[FilterEditor_Announcement_FilterSaved]]", FilterEditorAnnouncements.FilterSaved(localizer));
+        Assert.Equal("[[FilterEditor_Announcement_FilterEnabled]]", FilterEditorAnnouncements.FilterEnabledState(localizer, true));
+        Assert.Equal("[[FilterEditor_Announcement_FilterDisabled]]", FilterEditorAnnouncements.FilterEnabledState(localizer, false));
+        Assert.Equal("[[FilterEditor_Announcement_SwitchedToAdvanced]]", FilterEditorAnnouncements.SwitchedToMode(localizer, FilterMode.Advanced));
+        Assert.Equal("[[FilterEditor_Announcement_SwitchedToBasic]]", FilterEditorAnnouncements.SwitchedToMode(localizer, FilterMode.Basic));
+        Assert.Equal("[[FilterEditor_Announcement_SwitchedToRecent]]", FilterEditorAnnouncements.SwitchedToMode(localizer, FilterMode.Cached));
+        Assert.Throws<ArgumentOutOfRangeException>(() => FilterEditorAnnouncements.SwitchedToMode(localizer, (FilterMode)999));
+    }
+
+    [Fact]
+    public void FilterEditorHighlightColorLocalizer_RoutesEveryColorAndThrowsForUnknownColor()
+    {
+        MarkerLocalizer localizer = new();
+
+        foreach (HighlightColor color in Enum.GetValues<HighlightColor>())
+        {
+            Assert.Equal($"[[FilterEditor_HighlightColorOption_{color}]]", FilterEditorHighlightColorLocalizer.Label(localizer, color));
+        }
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            FilterEditorHighlightColorLocalizer.Label(localizer, (HighlightColor)999));
+    }
+
+    [Theory]
+    [InlineData(FilterMode.Advanced, "[[FilterEditor_Mode_Advanced]]")]
+    [InlineData(FilterMode.Basic, "[[FilterEditor_Mode_Basic]]")]
+    [InlineData(FilterMode.Cached, "[[FilterEditor_Mode_Recent]]")]
+    public void FilterEditorModeLocalizer_Display_RoutesDefinedModes(FilterMode mode, string expected)
+    {
+        Assert.Equal(expected, FilterEditorModeLocalizer.Display(new MarkerLocalizer(), mode));
+    }
+
+    [Fact]
+    public void FilterEditorModeLocalizer_Display_ThrowsForUnknownMode()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            FilterEditorModeLocalizer.Display(new MarkerLocalizer(), (FilterMode)999));
+    }
+
+    [Fact]
+    public void FilterEditorModeLocalizer_Map_CoversEveryModeWithCustomCachedMapping()
+    {
+        Dictionary<FilterMode, string> expected = new()
+        {
+            [FilterMode.Advanced] = "[[FilterEditor_Mode_Advanced]]",
+            [FilterMode.Basic] = "[[FilterEditor_Mode_Basic]]",
+            [FilterMode.Cached] = "[[FilterEditor_Mode_Recent]]"
+        };
+
+        Assert.Equal(Enum.GetValues<FilterMode>().Length, expected.Count);
+        foreach ((FilterMode mode, string label) in expected)
+        {
+            Assert.Equal(label, FilterEditorModeLocalizer.Display(new MarkerLocalizer(), mode));
+        }
+    }
+
+    [Fact]
+    public void HighlightColorOptionResourceFamily_MatchesEnumMembers()
+    {
+        var keys = LoadSharedResourceData()
+            .Where(element => element.Attribute("name")?.Value.StartsWith("FilterEditor_HighlightColorOption_", StringComparison.Ordinal) == true)
+            .Select(element => element.Attribute("name")!.Value["FilterEditor_HighlightColorOption_".Length..])
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        var members = Enum.GetNames<HighlightColor>().Order(StringComparer.Ordinal).ToArray();
+
+        Assert.Equal(members, keys);
+    }
+
+    [Theory]
+    [InlineData(FilterMode.Advanced, FilterMode.Cached, "[[FilterEditor_ModeSwitch_Message_ToRecent]]")]
+    [InlineData(FilterMode.Basic, FilterMode.Cached, "[[FilterEditor_ModeSwitch_Message_ToRecent]]")]
+    [InlineData(FilterMode.Cached, FilterMode.Cached, "[[FilterEditor_ModeSwitch_Message_ToRecent]]")]
+    [InlineData(FilterMode.Advanced, FilterMode.Basic, "[[FilterEditor_ModeSwitch_Message_ToBasic]]")]
+    [InlineData(FilterMode.Cached, FilterMode.Basic, "[[FilterEditor_ModeSwitch_Message_ToBasic]]")]
+    [InlineData(FilterMode.Basic, FilterMode.Advanced, "[[FilterEditor_ModeSwitch_Message_ToAdvanced]]")]
+    [InlineData(FilterMode.Cached, FilterMode.Advanced, "[[FilterEditor_ModeSwitch_Message_Generic]]")]
+    [InlineData(FilterMode.Advanced, FilterMode.Advanced, "[[FilterEditor_ModeSwitch_Message_Generic]]")]
+    [InlineData(FilterMode.Basic, FilterMode.Basic, "[[FilterEditor_ModeSwitch_Message_Generic]]")]
+    public void ModeSwitchConfirmation_RoutesEveryDefinedTuple(FilterMode current, FilterMode target, string expected)
+    {
+        Assert.Equal(expected, FilterEditorModeSwitchLocalizer.ConfirmationMessage(new MarkerLocalizer(), current, target));
+    }
+
+    [Fact]
+    public void ModeSwitchConfirmation_ThrowsForUnknownMode()
+    {
+        MarkerLocalizer localizer = new();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            FilterEditorModeSwitchLocalizer.ConfirmationMessage(localizer, (FilterMode)999, FilterMode.Cached));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            FilterEditorModeSwitchLocalizer.ConfirmationMessage(localizer, FilterMode.Advanced, (FilterMode)999));
+    }
+
+    [Fact]
+    public void PredicateChip_RoutesEditAndRemoveThroughLocalizer()
+    {
+        var predicate = new FilterPredicateDraft { Comparison = { Value = "1" } };
+        var component = RenderPredicate(predicate, isEditing: false);
+
+        Assert.Contains("[[FilterEditor_Predicate_EditAria([[FilterEditor_PredicateSummary(Id|==|1)]])]]", component.Markup);
+        Assert.Contains("[[FilterEditor_Predicate_EditTitle]]", component.Markup);
+        Assert.Contains("[[FilterEditor_Predicate_RemoveAria([[FilterEditor_PredicateSummary(Id|==|1)]])]]", component.Markup);
+        Assert.Contains("[[FilterEditor_Predicate_RemoveTitle]]", component.Markup);
+    }
+
+    [Fact]
+    public void PredicateEditor_RoutesButtonsThroughLocalizer()
+    {
+        var predicate = new FilterPredicateDraft { JoinWithAny = true };
+        var component = RenderPredicate(predicate, isEditing: true);
+
+        Assert.Contains("[[FilterEditor_PredicateJoin_OrAria]]", component.Markup);
+        Assert.Contains("[[FilterEditor_PredicateJoin_OrTitle]]", component.Markup);
+        Assert.Contains("[[FilterEditor_PredicateJoin_OrLabel]]", component.Markup);
+        Assert.Contains("[[FilterEditor_Predicate_DoneAria]]", component.Markup);
+        Assert.Contains("[[FilterEditor_Predicate_DoneDisabledTitle]]", component.Markup);
+        Assert.Contains("[[FilterEditor_Predicate_RemoveAria([[FilterEditor_PredicateSummary(Id|==|?)]])]]", component.Markup);
+        Assert.Contains("[[FilterEditor_Predicate_RemoveTitle]]", component.Markup);
+
+        var andPredicate = new FilterPredicateDraft { JoinWithAny = false };
+        var andComponent = RenderPredicate(andPredicate, isEditing: true);
+
+        Assert.Contains("[[FilterEditor_PredicateJoin_AndAria]]", andComponent.Markup);
+        Assert.Contains("[[FilterEditor_PredicateJoin_AndTitle]]", andComponent.Markup);
+        Assert.Contains("[[FilterEditor_PredicateJoin_AndLabel]]", andComponent.Markup);
+
+        andPredicate.Comparison.Value = "1";
+        andComponent.Render();
+        Assert.Contains("[[FilterEditor_Predicate_DoneTitle]]", andComponent.Markup);
+    }
+
+    [Fact]
+    public void PredicateList_RoutesAddButtonThroughLocalizer()
+    {
+        var enabled = Render<FilterPredicateList>(parameters => parameters.Add(list => list.Predicates, []));
+        Assert.Contains("[[FilterEditor_PredicateList_AddAria]]", enabled.Markup);
+        Assert.Contains("[[FilterEditor_PredicateList_AddTitle]]", enabled.Markup);
+
+        var disabled = Render<FilterPredicateList>(parameters => parameters.Add(list => list.Predicates, [new FilterPredicateDraft()]));
+        Assert.Contains("[[FilterEditor_PredicateList_AddDisabledAria]]", disabled.Markup);
+        Assert.Contains("[[FilterEditor_PredicateList_AddDisabledTitle]]", disabled.Markup);
+    }
+
+    [Fact]
+    public void PredicateSummaryResource_PreservesSpaces()
+    {
+        var data = LoadSharedResourceData()
+            .Single(element => element.Attribute("name")?.Value == "FilterEditor_PredicateSummary");
+
+        Assert.Equal("preserve", data.Attribute(XNamespace.Xml + "space")?.Value);
+    }
+
+    [Theory]
+    [InlineData(0, "?")]
+    [InlineData(1, "alpha")]
+    [InlineData(2, "[[FilterEditor_PredicateSummary_ValueCount_Many(2)]]")]
+    [InlineData(1500, "[[FilterEditor_PredicateSummary_ValueCount_Many(1500)]]")]
+    public void PredicateSummary_ManyValueCounts_UseRequiredDisplayBranches(int count, string expectedValueLabel)
+    {
+        List<string> values = count switch
+        {
+            0 => [],
+            1 => ["alpha"],
+            _ => [.. Enumerable.Range(0, count).Select(index => $"v{index}")]
+        };
+        var predicate = new FilterPredicateDraft
+        {
+            Comparison =
+            {
+                Property = EventProperty.Id,
+                Operator = ComparisonOperator.Equals,
+                MatchMode = MatchMode.Many,
+                Values = values
+            }
+        };
+
+        var component = RenderPredicate(predicate, isEditing: false);
+
+        Assert.Contains($"[[FilterEditor_PredicateSummary(Id|[[FilterEditor_PredicateSummary_Operator_In]]|{expectedValueLabel})]]", component.Markup);
+    }
+
+    [Theory]
+    [InlineData(ComparisonOperator.Equals, MatchMode.Many, "a|b", "[[FilterEditor_PredicateSummary(TaskCategory|[[FilterEditor_PredicateSummary_Operator_In]]|[[FilterEditor_PredicateSummary_ValueCount_Many(2)]])]]")]
+    [InlineData(ComparisonOperator.Contains, MatchMode.Single, "abc", "[[FilterEditor_PredicateSummary(TaskCategory|[[FilterEditor_PredicateSummary_Operator_Contains]]|abc)]]")]
+    [InlineData(ComparisonOperator.NotContains, MatchMode.Single, "abc", "[[FilterEditor_PredicateSummary(TaskCategory|[[FilterEditor_PredicateSummary_Operator_NotContains]]|abc)]]")]
+    [InlineData(ComparisonOperator.Equals, MatchMode.Single, "abc", "[[FilterEditor_PredicateSummary(TaskCategory|==|abc)]]")]
+    [InlineData(ComparisonOperator.NotEqual, MatchMode.Single, "abc", "[[FilterEditor_PredicateSummary(TaskCategory|!=|abc)]]")]
+    public void PredicateSummary_RoutesLocalizedPartsAndKeepsExpressionTokens(
+        ComparisonOperator comparisonOperator,
+        MatchMode matchMode,
+        string value,
+        string expectedSummary)
+    {
+        var predicate = new FilterPredicateDraft
+        {
+            Comparison =
+            {
+                Property = EventProperty.TaskCategory,
+                Operator = comparisonOperator,
+                MatchMode = matchMode,
+                Value = value,
+                Values = [.. value.Split('|')]
+            }
+        };
+
+        var component = RenderPredicate(predicate, isEditing: false);
+
+        Assert.Contains(expectedSummary, component.Markup);
+        Assert.DoesNotContain("[[FilterLens_Property_TaskCategory]]", component.Markup);
+    }
+
+    [Fact]
+    public void PredicateSummary_UnknownOperator_UsesRawQuestionMarkOperator()
+    {
+        var predicate = new FilterPredicateDraft
+        {
+            Comparison =
+            {
+                Property = EventProperty.TaskCategory,
+                Operator = (ComparisonOperator)999,
+                MatchMode = MatchMode.Single,
+                Value = "abc"
+            }
+        };
+
+        var component = RenderPredicate(predicate, isEditing: false);
+
+        Assert.Contains("[[FilterEditor_PredicateSummary(TaskCategory|?|abc)]]", component.Markup);
+        Assert.DoesNotContain("[[?]]", component.Markup);
+    }
+
+    [Fact]
+    public void RowActionsScenarioCopy_RoutesNamedAndUnnamedBranchesThroughLocalizer()
+    {
+        var context = new ScenarioAuthoringRowContext(Enabled: true, _ => Task.CompletedTask);
+        var named = Render<FilterRowActions>(parameters => parameters
+            .Add(actions => actions.Value, MakeSavedFilter("Id == 1"))
+            .AddCascadingValue(context));
+
+        Assert.Contains("[[FilterEditor_RowAction_CopyScenarioAria_Named(Id == 1)]]", named.Markup);
+        Assert.Contains("[[FilterEditor_RowAction_CopyScenarioTitle]]", named.Markup);
+
+        var unnamed = Render<FilterRowActions>(parameters => parameters
+            .Add(actions => actions.Value, MakeSavedFilter(string.Empty))
+            .AddCascadingValue(context));
+
+        Assert.Contains("[[FilterEditor_RowAction_CopyScenarioAria_Unnamed]]", unnamed.Markup);
+    }
+
+    [Fact]
+    public void RowHeaderAndActions_RouteBothNamedAndUnnamedBranchesThroughLocalizer()
+    {
+        var named = Render<FilterRowShell>(parameters => parameters.Add(shell => shell.Value, MakeSavedFilter("Id == 1")));
+
+        Assert.Contains("[[FilterEditor_RowHeader_IncludedAria(Id == 1)]]", named.Markup);
+        Assert.Contains("[[FilterEditor_ExcludeToggle_TitleIncluded]]", named.Markup);
+        Assert.Contains("Id == 1", named.Markup);
+        Assert.Contains("[[FilterEditor_RowAction_EditAria_Named(Id == 1)]]", named.Markup);
+        Assert.Contains("[[FilterEditor_RowAction_EditTitle]]", named.Markup);
+        Assert.Contains("[[FilterEditor_RowAction_RemoveAria_Named(Id == 1)]]", named.Markup);
+        Assert.Contains("[[FilterEditor_RowAction_RemoveTitle]]", named.Markup);
+        Assert.Contains("[[FilterEditor_RowAction_EnableToggleLabel]]", named.Markup);
+
+        var unnamed = Render<FilterRowShell>(parameters => parameters.Add(shell => shell.Value, MakeSavedFilter(string.Empty)));
+
+        Assert.Contains("[[FilterEditor_RowHeader_NoFilterSpecified]]", unnamed.Markup);
+        Assert.Contains("[[FilterEditor_RowAction_EditAria_Unnamed]]", unnamed.Markup);
+        Assert.Contains("[[FilterEditor_RowAction_RemoveAria_Unnamed]]", unnamed.Markup);
+
+        var excluded = Render<FilterRowShell>(parameters =>
+            parameters.Add(shell => shell.Value, MakeSavedFilter("Id == 2", isExcluded: true)));
+
+        Assert.Contains("[[FilterEditor_RowHeader_ExcludedAria(Id == 2)]]", excluded.Markup);
+        Assert.Contains("[[FilterEditor_ExcludeToggle_TitleExcluded]]", excluded.Markup);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        DirectoryInfo? directory = new(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "EventLogExpert.slnx")))
+        {
+            directory = directory.Parent;
+        }
+
+        Assert.NotNull(directory);
+        return directory.FullName;
+    }
+
+    private static async Task InvokeAsync(IRenderedComponent<FilterEditorCore> component, string methodName, params object[] arguments)
+    {
+        var method = typeof(FilterEditorCore).GetMethod(
+            methodName,
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        var result = component.InvokeAsync(() => method.Invoke(component.Instance, arguments));
+        var value = await result;
+
+        switch (value)
+        {
+            case Task task:
+                await task;
+                break;
+            case ValueTask valueTask:
+                await valueTask;
+                break;
+        }
+
+        component.Render();
+    }
+
+    private static IEnumerable<XElement> LoadSharedResourceData()
+    {
+        string root = FindRepositoryRoot();
+        string path = Path.Combine(root, "src", "EventLogExpert.Localization", "Resources", "SharedResource.resx");
+        return XDocument.Load(path).Root!.Elements("data");
+    }
+
+    private static SavedFilter MakeSavedFilter(string text, bool isEnabled = true, bool isExcluded = false) =>
+        new()
+        {
+            ComparisonText = text,
+            Compiled = null,
+            IsEnabled = isEnabled,
+            IsExcluded = isExcluded,
+        };
+
+    private static List<string> SelectedTags(IRenderedComponent<FilterEditorCore> component)
+    {
+        var field = typeof(FilterEditorCore).GetField(
+            "_selectedTags",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+
+        var selectedTags = Assert.IsType<List<string>>(field.GetValue(component.Instance));
+        return selectedTags;
+    }
+
+    private IRenderedComponent<FilterEditorCore> RenderCore(
+        FilterDraft? draft = null,
+        SavedFilter? value = null,
+        IReadOnlyList<CachedFilterOption>? cachedOptions = null) =>
+        Render<FilterEditorCore>(parameters =>
+        {
+            if (draft is not null)
+            {
+                parameters.Add(core => core.PendingDraft, draft);
+            }
+
+            if (value is not null)
+            {
+                parameters.Add(core => core.Value, value);
+            }
+
+            parameters.Add(core => core.CachedOptions, cachedOptions);
+        });
+
+    private IRenderedComponent<FilterPredicateEditor> RenderPredicate(FilterPredicateDraft predicate, bool isEditing) =>
+        Render<FilterPredicateEditor>(parameters => parameters
+            .Add(editor => editor.Value, predicate)
+            .Add(editor => editor.IsEditing, isEditing));
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterEditor/FilterPredicateEditorAccessibilityTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterEditor/FilterPredicateEditorAccessibilityTests.cs
@@ -4,12 +4,15 @@
 using Bunit;
 using EventLogExpert.Filtering.Common.Filtering;
 using EventLogExpert.Filtering.Drafts;
+using EventLogExpert.Localization;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.UI.Common;
 using EventLogExpert.UI.FilterEditor.Comparison;
 using EventLogExpert.UI.FilterEditor.Editing;
+using EventLogExpert.UI.Tests.TestUtils;
 using Fluxor;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using NSubstitute;
 using System.Collections.Immutable;
 
@@ -28,7 +31,7 @@ public sealed class FilterPredicateEditorAccessibilityTests : BunitContext
         Services.AddSingleton(eventLogQueries);
 
         Services.AddFluxor(options => options.ScanAssemblies(typeof(FilterComparisonEditor).Assembly));
-        Services.AddEventLogLocalization();
+        Services.AddSingleton<IStringLocalizer<SharedResource>>(new MarkerLocalizer());
 
         JSInterop.Mode = JSRuntimeMode.Loose;
     }
@@ -69,7 +72,7 @@ public sealed class FilterPredicateEditorAccessibilityTests : BunitContext
 
         var options = component.FindAll("[role=option]").Select(option => option.TextContent.Trim()).ToList();
 
-        Assert.Contains("User ID", options);
+        Assert.Contains("[[FilterLens_Property_UserId]]", options);
     }
 
     [Fact]
@@ -83,7 +86,7 @@ public sealed class FilterPredicateEditorAccessibilityTests : BunitContext
 
         var options = component.FindAll("[role=option]").Select(option => option.TextContent.Trim()).ToList();
 
-        Assert.Contains("User", options);
-        Assert.DoesNotContain("User ID", options);
+        Assert.Contains("[[FilterLens_Property_UserDisplayName]]", options);
+        Assert.DoesNotContain("[[FilterLens_Property_UserId]]", options);
     }
 }

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterEditor/FilterRowOrderingTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterEditor/FilterRowOrderingTests.cs
@@ -3,13 +3,16 @@
 
 using Bunit;
 using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Localization;
 using EventLogExpert.Runtime.Alerts;
 using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.Runtime.FilterLibrary;
 using EventLogExpert.Runtime.FilterPane;
 using EventLogExpert.UI.FilterEditor;
+using EventLogExpert.UI.Tests.TestUtils;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using NSubstitute;
 using System.Collections.Immutable;
 
@@ -27,6 +30,7 @@ public sealed class FilterRowOrderingTests : BunitContext
         Services.AddSingleton(Substitute.For<IAlertDialogService>());
         Services.AddSingleton(Substitute.For<IAnnouncementService>());
         Services.AddSingleton(Substitute.For<IEventLogQueries>());
+        Services.AddSingleton<IStringLocalizer<SharedResource>>(new MarkerLocalizer());
         JSInterop.Mode = JSRuntimeMode.Loose;
 
         var cut = Render<FilterRow>(parameters => parameters.Add(p => p.Value, SavedFilter.TryCreate("Level == 4")!));

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterEditor/Rows/FilterRowActionsScenarioTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterEditor/Rows/FilterRowActionsScenarioTests.cs
@@ -4,14 +4,23 @@
 using AngleSharp.Dom;
 using Bunit;
 using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Localization;
 using EventLogExpert.UI.FilterEditor;
 using EventLogExpert.UI.FilterEditor.Rows;
+using EventLogExpert.UI.Tests.TestUtils;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 
 namespace EventLogExpert.UI.Tests.FilterEditor.Rows;
 
 public sealed class FilterRowActionsScenarioTests : BunitContext
 {
+    public FilterRowActionsScenarioTests()
+    {
+        Services.AddSingleton<IStringLocalizer<SharedResource>>(new MarkerLocalizer());
+    }
+
     [Fact]
     public void AuthoringDisabled_RendersNoCopyButton()
     {
@@ -59,7 +68,7 @@ public sealed class FilterRowActionsScenarioTests : BunitContext
 
     private static IElement? FindScenarioButton(IRenderedComponent<FilterRowActions> component) =>
         component.FindAll("button")
-            .FirstOrDefault(button => button.GetAttribute("aria-label")?.Contains("scenario JSON") == true);
+            .FirstOrDefault(button => button.GetAttribute("aria-label")?.Contains("FilterEditor_RowAction_CopyScenarioAria") == true);
 
     private static SavedFilter MakeSavedFilter() =>
         new()

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterEditor/Rows/FilterRowShellTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterEditor/Rows/FilterRowShellTests.cs
@@ -3,13 +3,22 @@
 
 using Bunit;
 using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Localization;
 using EventLogExpert.UI.FilterEditor.Rows;
+using EventLogExpert.UI.Tests.TestUtils;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 
 namespace EventLogExpert.UI.Tests.FilterEditor.Rows;
 
 public sealed class FilterRowShellTests : BunitContext
 {
+    public FilterRowShellTests()
+    {
+        Services.AddSingleton<IStringLocalizer<SharedResource>>(new MarkerLocalizer());
+    }
+
     [Fact]
     public void SavedFilter_AllButtons_HaveTypeButton()
     {
@@ -74,6 +83,7 @@ public sealed class FilterRowShellTests : BunitContext
         var referencedTexts = labelIds!.Split(' ', StringSplitOptions.RemoveEmptyEntries)
             .Select(id => component.Find($"#{id}").TextContent);
         Assert.Contains(referencedTexts, text => text.Contains(savedFilter.ComparisonText));
+        Assert.Contains(referencedTexts, text => text == "[[FilterEditor_RowAction_EnableToggleLabel]]");
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterLibrary/LibraryEntryFilterEditorTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterLibrary/LibraryEntryFilterEditorTests.cs
@@ -4,11 +4,14 @@
 using Bunit;
 using EventLogExpert.Filtering.Evaluation;
 using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Localization;
 using EventLogExpert.Runtime.Alerts;
 using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.Runtime.FilterLibrary;
 using EventLogExpert.UI.FilterLibrary;
+using EventLogExpert.UI.Tests.TestUtils;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using NSubstitute;
 using System.Collections.Immutable;
 
@@ -25,6 +28,7 @@ public sealed class LibraryEntryFilterEditorTests : BunitContext
         Services.AddSingleton(_alerts);
         Services.AddSingleton(_announcements);
         Services.AddSingleton(_commands);
+        Services.AddSingleton<IStringLocalizer<SharedResource>>(new MarkerLocalizer());
 
         JSInterop.Mode = JSRuntimeMode.Loose;
     }

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterLibrary/LibraryFilterRowTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterLibrary/LibraryFilterRowTests.cs
@@ -5,12 +5,15 @@ using Bunit;
 using EventLogExpert.Filtering.Drafts;
 using EventLogExpert.Filtering.Evaluation;
 using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Localization;
 using EventLogExpert.Runtime.Alerts;
 using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.Runtime.FilterPane;
 using EventLogExpert.UI.FilterLibrary;
+using EventLogExpert.UI.Tests.TestUtils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using NSubstitute;
 
 namespace EventLogExpert.UI.Tests.FilterLibrary;
@@ -24,6 +27,7 @@ public sealed class LibraryFilterRowTests : BunitContext
     {
         Services.AddSingleton(_alerts);
         Services.AddSingleton(_announcements);
+        Services.AddSingleton<IStringLocalizer<SharedResource>>(new MarkerLocalizer());
 
         JSInterop.Mode = JSRuntimeMode.Loose;
     }

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterLibrary/LibrarySavedTabHeaderTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterLibrary/LibrarySavedTabHeaderTests.cs
@@ -3,13 +3,16 @@
 
 using Bunit;
 using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Localization;
 using EventLogExpert.Runtime.Alerts;
 using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.Runtime.FilterLibrary;
 using EventLogExpert.UI.FilterLibrary;
+using EventLogExpert.UI.Tests.TestUtils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using NSubstitute;
 
 namespace EventLogExpert.UI.Tests.FilterLibrary;
@@ -25,6 +28,7 @@ public sealed class LibrarySavedTabHeaderTests : BunitContext
         Services.AddSingleton(_announcements);
         Services.AddSingleton(_commands);
         Services.AddSingleton(Substitute.For<IAlertDialogService>());
+        Services.AddSingleton<IStringLocalizer<SharedResource>>(new MarkerLocalizer());
 
         var libraryEntries = Substitute.For<ILibraryEntriesSource>();
         libraryEntries.Current.Returns(_ => _libraryState.Entries);


### PR DESCRIPTION
Localizes the Filter Editor UI to `IStringLocalizer<SharedResource>` (roadmap increment **L3**), under a strict byte-identical en-US contract (the app looks pixel-identical in en-US).

## What changed
- **~80 Filter Editor strings** keyed across Core + Rows/ + Editing/ + predicate summary (buttons, `aria-label`/`title` split per rubric #18, mode labels, live-region announcements, the mode-switch confirm dialog).
- **Typed `FilterDraftBuildFailure` domain union** ({EmptyFilter, InvalidBasicStructure, CompilerDiagnostic(Message)}) replaces `TryBuildSavedFilter`'s `out string error`; the UI switches it totally (localized keys + the compiler diagnostic passed through verbatim).
- **Typed state/mode announcements** (no English fragment interpolation): enabled/disabled, set-to-exclude/include, switched-to-mode all select complete per-variant sentence keys.
- **Highlight-color localizer** with byte-identical values (`LightRed`, not `Light red`) wired via `ToStringFunc`; per-component `@inject` across the 6 components.

## Verification
- Release build **0W/0E** (incl. MAUI head); unit suite **7,941/0**.
- en-US **byte-identical** (resx additive; no existing value changed).
- Design panel converged **4/4 DESIGN_READY** (3 rounds); post-code panel **6/6 LGTM** (8 test-vacuity gaps caught + fixed test-only).

## Recorded residuals (by design)
- Compiler-diagnostic text (Class A) + `ScenarioAuthoringService` warning → future typed-error / **L12** increments.
- Predicate property display (`Id`→`Event ID`) → **L13**.

Tests assert behavior (marker routing, DOM, receipt matrix, typed-switch coverage), not UI copy; no byte-identity value-pin tripwire (per the established test-architecture directive).
