### PR TITLE
Localize the log table, context menu, and copied-event labels

### DIFF
--- a/src/EventLogExpert.Localization/Resources/SharedResource.resx
+++ b/src/EventLogExpert.Localization/Resources/SharedResource.resx
@@ -1732,6 +1732,259 @@
   <data name="FilterEditor_HighlightColorOption_DarkPink" xml:space="preserve">
     <value>DarkPink</value>
   </data>
+  <!-- Log table, context menu, event-copy, and tab-bar localization. -->
+  <data name="Table_Aria" xml:space="preserve">
+    <value>Event Log Table</value>
+  </data>
+  <data name="Table_ToggleSortAria" xml:space="preserve">
+    <value>Toggle sort direction</value>
+  </data>
+  <data name="Table_ColumnHeader_Description" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="Table_ColumnHeader_DateAndTime" xml:space="preserve">
+    <value>Date and Time</value>
+  </data>
+  <data name="Table_ColumnHeader_DateAndTimeWithZone" xml:space="preserve">
+    <value>Date and Time {0}</value>
+    <comment>{0} is the abbreviated time-zone display token shown by Windows.</comment>
+  </data>
+  <data name="Table_LoadingEvents" xml:space="preserve">
+    <value>Loading events…</value>
+  </data>
+  <data name="Table_ReorderingEvents" xml:space="preserve">
+    <value>Reordering events…</value>
+  </data>
+  <data name="Table_FaultPrefix" xml:space="preserve">
+    <value>These events could not be prepared.</value>
+  </data>
+  <data name="Table_FaultPrefixWithCause" xml:space="preserve">
+    <value>These events could not be prepared. {0}</value>
+    <comment>{0} is a technical fault cause and should remain verbatim.</comment>
+  </data>
+  <data name="LogTable_GroupValueNone" xml:space="preserve">
+    <value>(none)</value>
+  </data>
+  <data name="LogTable_GroupByNone" xml:space="preserve">
+    <value>(none)</value>
+  </data>
+  <data name="LogTable_ExcludeEventsBefore" xml:space="preserve">
+    <value>Exclude Events Before</value>
+  </data>
+  <data name="LogTable_ExcludeEventsAfter" xml:space="preserve">
+    <value>Exclude Events After</value>
+  </data>
+  <data name="LogTable_ShowRelatedByActivityId" xml:space="preserve">
+    <value>Show Related by Activity ID</value>
+  </data>
+  <data name="LogTable_ShowSharingRelatedActivityId" xml:space="preserve">
+    <value>Show Events Sharing Related Activity ID</value>
+  </data>
+  <data name="LogTable_ShowParentActivity" xml:space="preserve">
+    <value>Show Parent Activity</value>
+  </data>
+  <data name="LogTable_NoActivityIdReason" xml:space="preserve">
+    <value>This event has no Activity ID.</value>
+  </data>
+  <data name="LogTable_NoRelatedActivityIdReason" xml:space="preserve">
+    <value>This event has no Related Activity ID.</value>
+  </data>
+  <data name="LogTable_ShowEventsNearTime" xml:space="preserve">
+    <value>Show Events Near This Time</value>
+  </data>
+  <data name="LogTable_NearTime_30Seconds" xml:space="preserve">
+    <value>±30 Seconds</value>
+  </data>
+  <data name="LogTable_NearTime_1Minute" xml:space="preserve">
+    <value>±1 Minute</value>
+  </data>
+  <data name="LogTable_NearTime_5Minutes" xml:space="preserve">
+    <value>±5 Minutes</value>
+  </data>
+  <data name="LogTable_NearTime_15Minutes" xml:space="preserve">
+    <value>±15 Minutes</value>
+  </data>
+  <data name="LogTable_NearTime_1Hour" xml:space="preserve">
+    <value>±1 Hour</value>
+  </data>
+  <data name="LogTable_MoreFields" xml:space="preserve">
+    <value>More Fields</value>
+  </data>
+  <data name="LogTable_Include" xml:space="preserve">
+    <value>Include</value>
+  </data>
+  <data name="LogTable_Exclude" xml:space="preserve">
+    <value>Exclude</value>
+  </data>
+  <data name="LogTable_ExpandGroup" xml:space="preserve">
+    <value>Expand Group</value>
+  </data>
+  <data name="LogTable_CollapseGroup" xml:space="preserve">
+    <value>Collapse Group</value>
+  </data>
+  <data name="LogTable_SelectGroup" xml:space="preserve">
+    <value>Select Group</value>
+  </data>
+  <data name="LogTable_OrderBy" xml:space="preserve">
+    <value>Order By</value>
+  </data>
+  <data name="LogTable_GroupBy" xml:space="preserve">
+    <value>Group By</value>
+  </data>
+  <data name="LogTable_ResetColumnDefaults" xml:space="preserve">
+    <value>Reset Column Defaults</value>
+  </data>
+  <data name="LogTable_NoCellValue" xml:space="preserve">
+    <value>No value in this cell to filter on</value>
+  </data>
+  <data name="CellFilter_IncludeWhereEquals" xml:space="preserve">
+    <value>Include only where {0} = '{1}'</value>
+    <comment>{0} is the event-table column label; {1} is the cell value.</comment>
+  </data>
+  <data name="CellFilter_IncludeWhereHas" xml:space="preserve">
+    <value>Include only where {0} has '{1}'</value>
+    <comment>{0} is the event-table column label; {1} is the cell value.</comment>
+  </data>
+  <data name="CellFilter_ExcludeWhereEquals" xml:space="preserve">
+    <value>Exclude where {0} = '{1}'</value>
+    <comment>{0} is the event-table column label; {1} is the cell value.</comment>
+  </data>
+  <data name="CellFilter_ExcludeWhereHas" xml:space="preserve">
+    <value>Exclude where {0} has '{1}'</value>
+    <comment>{0} is the event-table column label; {1} is the cell value.</comment>
+  </data>
+  <data name="CellFilter_IncludeWhereNoValue" xml:space="preserve">
+    <value>Include only where {0}</value>
+    <comment>{0} is the event-table column label.</comment>
+  </data>
+  <data name="CellFilter_ExcludeWhereNoValue" xml:space="preserve">
+    <value>Exclude where {0}</value>
+    <comment>{0} is the event-table column label.</comment>
+  </data>
+  <data name="Copy_Full_LogName" xml:space="preserve">
+    <value>Log Name: {0}</value>
+  </data>
+  <data name="Copy_Full_Source" xml:space="preserve">
+    <value>Source: {0}</value>
+  </data>
+  <data name="Copy_Full_Date" xml:space="preserve">
+    <value>Date: {0}</value>
+  </data>
+  <data name="Copy_Full_EventId" xml:space="preserve">
+    <value>Event ID: {0}</value>
+  </data>
+  <data name="Copy_Full_TaskCategory" xml:space="preserve">
+    <value>Task Category: {0}</value>
+  </data>
+  <data name="Copy_Full_Level" xml:space="preserve">
+    <value>Level: {0}</value>
+  </data>
+  <data name="Copy_Full_Keywords" xml:space="preserve">
+    <value>Keywords: {0}</value>
+  </data>
+  <data name="Copy_Full_User" xml:space="preserve">
+    <value>User: {0}</value>
+  </data>
+  <data name="Copy_Full_UserSid" xml:space="preserve">
+    <value>User SID: {0}</value>
+  </data>
+  <data name="Copy_Full_Computer" xml:space="preserve">
+    <value>Computer: {0}</value>
+  </data>
+  <data name="Copy_Full_DescriptionHeader" xml:space="preserve">
+    <value>Description:</value>
+  </data>
+  <data name="Copy_Full_EventXmlHeader" xml:space="preserve">
+    <value>Event Xml:</value>
+  </data>
+  <data name="Copy_Markdown_DescriptionHeader" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="TabBar_ExpandGroupAria" xml:space="preserve">
+    <value>Expand group</value>
+  </data>
+  <data name="TabBar_CollapseGroupAria" xml:space="preserve">
+    <value>Collapse group</value>
+  </data>
+  <data name="TabBar_CloseGroup" xml:space="preserve">
+    <value>Close group</value>
+  </data>
+  <data name="TabBar_CloseLogAria" xml:space="preserve">
+    <value>Close log</value>
+  </data>
+  <data name="TabBar_LoadingAria" xml:space="preserve">
+    <value>Loading</value>
+  </data>
+  <data name="TabBar_Tooltip_File" xml:space="preserve">
+    <value>Log File: {0}&#xA;Log Name: {1}&#xA;Computer Name: {2}</value>
+    <comment>{0} is the log file path; {1} is the log name; {2} is the computer name.</comment>
+  </data>
+  <data name="TabBar_Tooltip_Live" xml:space="preserve">
+    <value>Live Log: {0}&#xA;Computer Name: {1}</value>
+    <comment>{0} is the log name; {1} is the computer name.</comment>
+  </data>
+  <data name="TabBar_Menu_CloseAllLogs" xml:space="preserve">
+    <value>Close all logs</value>
+  </data>
+  <data name="TabBar_Menu_Rename" xml:space="preserve">
+    <value>Rename…</value>
+  </data>
+  <data name="TabBar_Menu_Expand" xml:space="preserve">
+    <value>Expand</value>
+  </data>
+  <data name="TabBar_Menu_Collapse" xml:space="preserve">
+    <value>Collapse</value>
+  </data>
+  <data name="TabBar_Menu_MoveToGroup" xml:space="preserve">
+    <value>Move to group</value>
+  </data>
+  <data name="TabBar_Menu_RemoveFromGroup" xml:space="preserve">
+    <value>Remove from group</value>
+  </data>
+  <data name="TabBar_Menu_Close" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="TabBar_Menu_CloseOthersInGroup" xml:space="preserve">
+    <value>Close others in group</value>
+  </data>
+  <data name="TabBar_Menu_NoOtherTabsInGroupReason" xml:space="preserve">
+    <value>No other tabs in this group</value>
+  </data>
+  <data name="TabBar_Menu_NewGroup" xml:space="preserve">
+    <value>New group…</value>
+  </data>
+  <data name="TabBar_Menu_NewGroupFromTab" xml:space="preserve">
+    <value>New group from tab…</value>
+  </data>
+  <data name="TabBar_Menu_CloseOtherTabs" xml:space="preserve">
+    <value>Close other tabs</value>
+  </data>
+  <data name="TabBar_Menu_NoOtherTabsToCloseReason" xml:space="preserve">
+    <value>No other tabs to close</value>
+  </data>
+  <data name="TabBar_TabName_Combined" xml:space="preserve">
+    <value>Combined</value>
+  </data>
+  <data name="TabBar_TabName_Empty" xml:space="preserve">
+    <value>(Empty) {0}</value>
+    <comment>{0} is the tab name.</comment>
+  </data>
+  <data name="TabBar_TabName_Live" xml:space="preserve">
+    <value>{0} - {1}</value>
+    <comment>{0} is the log name; {1} is the computer name.</comment>
+  </data>
+  <data name="TabBar_Prompt_NewGroupTitle" xml:space="preserve">
+    <value>New group</value>
+  </data>
+  <data name="TabBar_Prompt_RenameGroupTitle" xml:space="preserve">
+    <value>Rename group</value>
+  </data>
+  <data name="TabBar_Prompt_GroupNameLabel" xml:space="preserve">
+    <value>Group name:</value>
+  </data>
+  <data name="TabBar_Prompt_GroupNameRequired" xml:space="preserve">
+    <value>Group name is required.</value>
+  </data>
   <!-- Filter comparison editor: operator dropdown (FilterEditor_Comparison_* map to ComparisonOperatorSelect.ComparisonKind) + value-picker visually-hidden labels and placeholders. -->
   <data name="FilterEditor_Comparison_Equals" xml:space="preserve">
     <value>Equals</value>

--- a/src/EventLogExpert.Runtime/Common/Clipboard/EventCopyFormatter.cs
+++ b/src/EventLogExpert.Runtime/Common/Clipboard/EventCopyFormatter.cs
@@ -13,9 +13,12 @@ using System.Xml.Linq;
 
 namespace EventLogExpert.Runtime.Common.Clipboard;
 
-internal sealed class EventCopyFormatter(IEventDetailResolver detailResolver, IEventXmlResolver xmlResolver)
-    : IEventCopyFormatter
+internal sealed class EventCopyFormatter(
+    IEventDetailResolver detailResolver,
+    IEventXmlResolver xmlResolver,
+    IEventCopyText copyText) : IEventCopyFormatter
 {
+    private readonly IEventCopyText _copyText = copyText;
     private readonly IEventDetailResolver _detailResolver = detailResolver;
     private readonly IEventXmlResolver _xmlResolver = xmlResolver;
 
@@ -90,7 +93,29 @@ internal sealed class EventCopyFormatter(IEventDetailResolver detailResolver, IE
         return stringToCopy.ToString();
     }
 
-    private static void AppendFormattedEvent(
+    private static string EscapeMarkdownCell(string? value) =>
+        (value ?? string.Empty)
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\r", " ", StringComparison.Ordinal)
+            .Replace("\n", " ", StringComparison.Ordinal)
+            .Replace("|", "\\|", StringComparison.Ordinal);
+
+    private static string FormatXmlForCopy(string xml)
+    {
+        try
+        {
+            return XElement.Parse(xml).ToString();
+        }
+        catch (XmlException)
+        {
+            return xml;
+        }
+    }
+
+    private static string GetColumnText(ColumnName column, ResolvedEvent @event, TimeZoneInfo timeZone) =>
+        EventTableColumnFormatter.GetCellText(@event, column, timeZone);
+
+    private void AppendFormattedEvent(
         StringBuilder builder,
         EventCopyFormat format,
         ResolvedEvent @event,
@@ -121,24 +146,24 @@ internal sealed class EventCopyFormatter(IEventDetailResolver detailResolver, IE
                 break;
             case EventCopyFormat.Full:
             default:
-                builder.AppendLine($"Log Name: {@event.LogName}");
-                builder.AppendLine($"Source: {@event.Source}");
-                builder.AppendLine($"Date: {@event.TimeCreated.ConvertTimeZone(request.TimeZone)}");
-                builder.AppendLine($"Event ID: {@event.Id}");
-                builder.AppendLine($"Task Category: {@event.TaskCategory}");
-                builder.AppendLine($"Level: {@event.Level}");
-                builder.AppendLine($"Keywords: {@event.KeywordsDisplayName}");
-                builder.AppendLine($"User: {@event.UserDisplayName}");
+                builder.AppendLine(_copyText.FieldLine(EventCopyFullField.LogName, @event.LogName));
+                builder.AppendLine(_copyText.FieldLine(EventCopyFullField.Source, @event.Source));
+                builder.AppendLine(_copyText.FieldLine(EventCopyFullField.Date, @event.TimeCreated.ConvertTimeZone(request.TimeZone).ToString()));
+                builder.AppendLine(_copyText.FieldLine(EventCopyFullField.EventId, @event.Id.ToString()));
+                builder.AppendLine(_copyText.FieldLine(EventCopyFullField.TaskCategory, @event.TaskCategory));
+                builder.AppendLine(_copyText.FieldLine(EventCopyFullField.Level, @event.Level));
+                builder.AppendLine(_copyText.FieldLine(EventCopyFullField.Keywords, @event.KeywordsDisplayName));
+                builder.AppendLine(_copyText.FieldLine(EventCopyFullField.User, @event.UserDisplayName));
 
                 if (@event.UserId is { } userId && !string.Equals(userId.Value, @event.UserDisplayName, StringComparison.Ordinal))
                 {
-                    builder.AppendLine($"User SID: {userId.Value}");
+                    builder.AppendLine(_copyText.FieldLine(EventCopyFullField.UserSid, userId.Value));
                 }
 
-                builder.AppendLine($"Computer: {@event.ComputerName}");
-                builder.AppendLine("Description:");
+                builder.AppendLine(_copyText.FieldLine(EventCopyFullField.Computer, @event.ComputerName));
+                builder.AppendLine(_copyText.FieldLine(EventCopyFullField.DescriptionHeader, string.Empty));
                 builder.AppendLine(@event.Description);
-                builder.AppendLine("Event Xml:");
+                builder.AppendLine(_copyText.FieldLine(EventCopyFullField.EventXmlHeader, string.Empty));
 
                 if (!string.IsNullOrEmpty(xml))
                 {
@@ -149,21 +174,22 @@ internal sealed class EventCopyFormatter(IEventDetailResolver detailResolver, IE
         }
     }
 
-    private static string BuildMarkdownTable(IReadOnlyList<ResolvedEvent> events, EventCopyRequest request)
+    private string BuildMarkdownTable(IReadOnlyList<ResolvedEvent> events, EventCopyRequest request)
     {
         var enabled = request.EnabledColumns;
         var order = request.ColumnOrder;
-        var columns = (order.IsEmpty
-                ? enabled.Where(column => column.Value).Select(column => column.Key).OrderBy(column => column)
-                : order.Where(column => enabled.TryGetValue(column, out bool isEnabled) && isEnabled))
-            .ToList();
+
+        var columns =
+            (order.IsEmpty ?
+                enabled.Where(column => column.Value).Select(column => column.Key).OrderBy(column => column) :
+                order.Where(column => enabled.TryGetValue(column, out bool isEnabled) && isEnabled)).ToList();
 
         StringBuilder builder = new();
 
         builder.Append("| ");
         foreach (var column in columns) { builder.Append(EscapeMarkdownCell(column.ToFullString())).Append(" | "); }
 
-        builder.AppendLine("Description |");
+        builder.Append(EscapeMarkdownCell(_copyText.MarkdownDescriptionHeader)).AppendLine(" |");
 
         builder.Append('|');
         for (int separator = 0; separator <= columns.Count; separator++) { builder.Append(" --- |"); }
@@ -181,14 +207,7 @@ internal sealed class EventCopyFormatter(IEventDetailResolver detailResolver, IE
         return builder.ToString().TrimEnd();
     }
 
-    private static string EscapeMarkdownCell(string? value) =>
-        (value ?? string.Empty)
-            .Replace("\\", "\\\\", StringComparison.Ordinal)
-            .Replace("\r", " ", StringComparison.Ordinal)
-            .Replace("\n", " ", StringComparison.Ordinal)
-            .Replace("|", "\\|", StringComparison.Ordinal);
-
-    private static string FormatEventForCopy(EventCopyFormat format, ResolvedEvent @event, string xml, EventCopyRequest request)
+    private string FormatEventForCopy(EventCopyFormat format, ResolvedEvent @event, string xml, EventCopyRequest request)
     {
         if (format == EventCopyFormat.Xml)
         {
@@ -201,21 +220,6 @@ internal sealed class EventCopyFormatter(IEventDetailResolver detailResolver, IE
 
         return builder.ToString();
     }
-
-    private static string FormatXmlForCopy(string xml)
-    {
-        try
-        {
-            return XElement.Parse(xml).ToString();
-        }
-        catch (XmlException)
-        {
-            return xml;
-        }
-    }
-
-    private static string GetColumnText(ColumnName column, ResolvedEvent @event, TimeZoneInfo timeZone) =>
-        EventTableColumnFormatter.GetCellText(@event, column, timeZone);
 
     private ResolvedEvent? ResolveEntry(SelectionEntry? entry)
     {

--- a/src/EventLogExpert.Runtime/Common/Clipboard/EventCopyFullField.cs
+++ b/src/EventLogExpert.Runtime/Common/Clipboard/EventCopyFullField.cs
@@ -1,0 +1,20 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Common.Clipboard;
+
+public enum EventCopyFullField
+{
+    LogName,
+    Source,
+    Date,
+    EventId,
+    TaskCategory,
+    Level,
+    Keywords,
+    User,
+    UserSid,
+    Computer,
+    DescriptionHeader,
+    EventXmlHeader
+}

--- a/src/EventLogExpert.Runtime/Common/Clipboard/IEventCopyText.cs
+++ b/src/EventLogExpert.Runtime/Common/Clipboard/IEventCopyText.cs
@@ -1,0 +1,11 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Common.Clipboard;
+
+public interface IEventCopyText
+{
+    string MarkdownDescriptionHeader { get; }
+
+    string FieldLine(EventCopyFullField field, string value);
+}

--- a/src/EventLogExpert.UI/DependencyInjection/UIServiceCollectionExtensions.cs
+++ b/src/EventLogExpert.UI/DependencyInjection/UIServiceCollectionExtensions.cs
@@ -1,7 +1,9 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Runtime.Common.Clipboard;
 using EventLogExpert.UI.Keyboard;
+using EventLogExpert.UI.LogTable;
 using EventLogExpert.UI.LogTable.Find;
 using EventLogExpert.UI.Menu;
 using EventLogExpert.UI.Modal;
@@ -21,6 +23,7 @@ public static class UIServiceCollectionExtensions
             services.AddSingleton<IFindCoordinator, FindCoordinator>();
             services.AddSingleton<IFindMarkerSource, FindMarkerSource>();
             services.AddSingleton<KeyboardShortcutService>();
+            services.AddSingleton<IEventCopyText, EventCopyText>();
 
             services.TryAddSingleton<IMenuService, MenuService>();
             services.TryAddSingleton<IModalCoordinator, ModalCoordinator>();

--- a/src/EventLogExpert.UI/LogTable/EventCopyText.cs
+++ b/src/EventLogExpert.UI/LogTable/EventCopyText.cs
@@ -1,0 +1,30 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Localization;
+using EventLogExpert.Runtime.Common.Clipboard;
+using Microsoft.Extensions.Localization;
+
+namespace EventLogExpert.UI.LogTable;
+
+internal sealed class EventCopyText(IStringLocalizer<SharedResource> localizer) : IEventCopyText
+{
+    public string MarkdownDescriptionHeader => localizer["Copy_Markdown_DescriptionHeader"];
+
+    public string FieldLine(EventCopyFullField field, string value) => field switch
+    {
+        EventCopyFullField.LogName => localizer["Copy_Full_LogName", value],
+        EventCopyFullField.Source => localizer["Copy_Full_Source", value],
+        EventCopyFullField.Date => localizer["Copy_Full_Date", value],
+        EventCopyFullField.EventId => localizer["Copy_Full_EventId", value],
+        EventCopyFullField.TaskCategory => localizer["Copy_Full_TaskCategory", value],
+        EventCopyFullField.Level => localizer["Copy_Full_Level", value],
+        EventCopyFullField.Keywords => localizer["Copy_Full_Keywords", value],
+        EventCopyFullField.User => localizer["Copy_Full_User", value],
+        EventCopyFullField.UserSid => localizer["Copy_Full_UserSid", value],
+        EventCopyFullField.Computer => localizer["Copy_Full_Computer", value],
+        EventCopyFullField.DescriptionHeader => localizer["Copy_Full_DescriptionHeader"],
+        EventCopyFullField.EventXmlHeader => localizer["Copy_Full_EventXmlHeader"],
+        _ => throw new ArgumentOutOfRangeException(nameof(field), field, null)
+    };
+}

--- a/src/EventLogExpert.UI/LogTable/LogTabBar.razor
+++ b/src/EventLogExpert.UI/LogTable/LogTabBar.razor
@@ -37,10 +37,10 @@
                         @oncontextmenu:stopPropagation="true"
                         title="@GetTabTooltip(group.Header)">
                         <button aria-expanded="@(group.Group.IsCollapsed ? "false" : "true")"
-                            aria-label="@(group.Group.IsCollapsed ? "Expand group" : "Collapse group")"
+                            aria-label="@(group.Group.IsCollapsed ? Localizer["TabBar_ExpandGroupAria"] : Localizer["TabBar_CollapseGroupAria"])"
                             class="chevron"
                             @onclick="() => ToggleCollapse(group.Group)"
-                            title="@(group.Group.IsCollapsed ? "Expand group" : "Collapse group")"
+                            title="@(group.Group.IsCollapsed ? Localizer["TabBar_ExpandGroupAria"] : Localizer["TabBar_CollapseGroupAria"])"
                             type="button">
                             <i class="bi bi-chevron-@(group.Group.IsCollapsed ? "down" : "right")"></i>
                         </button>
@@ -50,13 +50,13 @@
                             tabindex="0">
                             @GetTabName(presentation, group.Header)
                         </span>
-                        <i aria-label="Close group"
+                        <i aria-label="@Localizer["TabBar_CloseGroup"]"
                             class="bi bi-x"
                             @onclick="() => CloseGroup(group.Group)"
                             @onkeydown="e => OnCloseGroupKeyDown(e, group.Group)"
                             role="button"
                             tabindex="0"
-                            title="Close group">
+                            title="@Localizer["TabBar_CloseGroup"]">
                         </i>
                     </div>
                     @foreach (var member in VisibleMembers(presentation, group))
@@ -72,18 +72,18 @@
                                 tabindex="@(member.IsLoading ? -1 : 0)">
                                 @if (member.IsLoading)
                                 {
-                                    <i aria-label="Loading" class="loader-spin spinner-border" role="status"></i>
+                                    <i aria-label="@Localizer["TabBar_LoadingAria"]" class="loader-spin spinner-border" role="status"></i>
                                     @:&nbsp;
                                 }
                                 @GetTabName(presentation, member)
                             </span>
-                            <i aria-label="Close log"
+                            <i aria-label="@Localizer["TabBar_CloseLogAria"]"
                                 class="bi bi-x"
                                 @onkeydown="e => OnCloseLogKeyDown(e, member)"
                                 @onmousedown="e => OnCloseLogMouseDown(e, member)"
                                 role="button"
                                 tabindex="0"
-                                title="Close log">
+                                title="@Localizer["TabBar_CloseLogAria"]">
                             </i>
                         </div>
                     }
@@ -102,18 +102,18 @@
                         tabindex="@(standalone.Tab.IsLoading ? -1 : 0)">
                         @if (standalone.Tab.IsLoading)
                         {
-                            <i aria-label="Loading" class="loader-spin spinner-border" role="status"></i>
+                            <i aria-label="@Localizer["TabBar_LoadingAria"]" class="loader-spin spinner-border" role="status"></i>
                             @:&nbsp;
                         }
                         @GetTabName(presentation, standalone.Tab)
                     </span>
-                    <i aria-label="Close log"
+                    <i aria-label="@Localizer["TabBar_CloseLogAria"]"
                         class="bi bi-x"
                         @onkeydown="e => OnCloseLogKeyDown(e, standalone.Tab)"
                         @onmousedown="e => OnCloseLogMouseDown(e, standalone.Tab)"
                         role="button"
                         tabindex="0"
-                        title="Close log">
+                        title="@Localizer["TabBar_CloseLogAria"]">
                     </i>
                 </div>
             }

--- a/src/EventLogExpert.UI/LogTable/LogTabBar.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/LogTabBar.razor.cs
@@ -184,36 +184,24 @@ public sealed partial class LogTabBar
         string? disabledReason = null) =>
         MenuItem.Item(label, onClickAsync, isEnabled: isEnabled, isDanger: true, disabledReason: disabledReason);
 
-    private static string GetTabTooltip(LogView table)
-    {
-        if (table.IsCombined) { return string.Empty; }
-
-        return table.LogPathType == LogPathType.File
-            ? $"Log File: {table.FileName}\n" +
-                $"Log Name: {table.LogName}\n" +
-                $"Computer Name: {table.ComputerName}"
-            : $"Live Log: {table.LogName}\n" +
-                $"Computer Name: {table.ComputerName}";
-    }
-
     private static IReadOnlyList<LogView> VisibleMembers(LogTabBarPresentation presentation, GroupRow row) =>
-        row.Group.IsCollapsed
-            ? [.. row.Members.Where(member => member.Id == presentation.ActiveTabId)]
-            : row.Members;
+        row.Group.IsCollapsed ?
+            [.. row.Members.Where(member => member.Id == presentation.ActiveTabId)] :
+            row.Members;
 
     private IReadOnlyList<MenuItem> BuildAllLogsMenu() =>
     [
-        DangerItem("Close all logs", ConfirmCloseAllLogsAsync),
+        DangerItem(Localizer["TabBar_Menu_CloseAllLogs"].Value, ConfirmCloseAllLogsAsync),
     ];
 
     private IReadOnlyList<MenuItem> BuildGroupHeaderMenu(LogTabGroup group) =>
     [
-        MenuItem.Item("Rename\u2026", () => PromptRenameAsync(group)),
+        MenuItem.Item(Localizer["TabBar_Menu_Rename"].Value, () => PromptRenameAsync(group)),
         MenuItem.Item(
-            group.IsCollapsed ? "Expand" : "Collapse",
+            group.IsCollapsed ? Localizer["TabBar_Menu_Expand"].Value : Localizer["TabBar_Menu_Collapse"].Value,
             () => LogTableCommands.SetTabGroupCollapsed(group.Id, !group.IsCollapsed)),
         MenuItem.Separator(),
-        DangerItem("Close group", () => LogTableCommands.CloseGroup(group.Id)),
+        DangerItem(Localizer["TabBar_CloseGroup"].Value, () => LogTableCommands.CloseGroup(group.Id)),
     ];
 
     private IReadOnlyList<MenuItem> BuildMemberMenu(LogView member, LogTabGroup group)
@@ -222,15 +210,15 @@ public sealed partial class LogTabBar
 
         return
         [
-            MenuItem.SubMenu("Move to group", BuildMoveTargets(member, group.Id)),
-            MenuItem.Item("Remove from group", () => LogTableCommands.RemoveTabFromGroup(member.Id)),
+            MenuItem.SubMenu(Localizer["TabBar_Menu_MoveToGroup"].Value, BuildMoveTargets(member, group.Id)),
+            MenuItem.Item(Localizer["TabBar_Menu_RemoveFromGroup"].Value, () => LogTableCommands.RemoveTabFromGroup(member.Id)),
             MenuItem.Separator(),
-            DangerItem("Close", () => CloseLog(member)),
+            DangerItem(Localizer["TabBar_Menu_Close"].Value, () => CloseLog(member)),
             DangerItem(
-                "Close others in group",
+                Localizer["TabBar_Menu_CloseOthersInGroup"].Value,
                 () => LogTableCommands.CloseOthersInGroup(group.Id, member.Id),
                 isEnabled: canCloseOthersInGroup,
-                disabledReason: canCloseOthersInGroup ? null : "No other tabs in this group"),
+                disabledReason: canCloseOthersInGroup ? null : Localizer["TabBar_Menu_NoOtherTabsInGroupReason"].Value),
             CloseOtherTabsItem(member.Id),
         ];
     }
@@ -248,17 +236,17 @@ public sealed partial class LogTabBar
 
         if (items.Count > 0) { items.Add(MenuItem.Separator()); }
 
-        items.Add(MenuItem.Item("New group\u2026", () => PromptNewGroupAsync(tab)));
+        items.Add(MenuItem.Item(Localizer["TabBar_Menu_NewGroup"].Value, () => PromptNewGroupAsync(tab)));
 
         return items;
     }
 
     private IReadOnlyList<MenuItem> BuildStandaloneMenu(LogView tab) =>
     [
-        MenuItem.Item("New group from tab\u2026", () => PromptNewGroupAsync(tab)),
-        MenuItem.SubMenu("Move to group", BuildMoveTargets(tab, excludeGroupId: null)),
+        MenuItem.Item(Localizer["TabBar_Menu_NewGroupFromTab"].Value, () => PromptNewGroupAsync(tab)),
+        MenuItem.SubMenu(Localizer["TabBar_Menu_MoveToGroup"].Value, BuildMoveTargets(tab, excludeGroupId: null)),
         MenuItem.Separator(),
-        DangerItem("Close", () => CloseLog(tab)),
+        DangerItem(Localizer["TabBar_Menu_Close"].Value, () => CloseLog(tab)),
         CloseOtherTabsItem(tab.Id),
     ];
 
@@ -281,10 +269,10 @@ public sealed partial class LogTabBar
         bool canClose = CanCloseOtherTabs();
 
         return DangerItem(
-            "Close other tabs",
+            Localizer["TabBar_Menu_CloseOtherTabs"].Value,
             () => LogTableCommands.CloseAllButThis(tabId),
             isEnabled: canClose,
-            disabledReason: canClose ? null : "No other tabs to close");
+            disabledReason: canClose ? null : Localizer["TabBar_Menu_NoOtherTabsToCloseReason"].Value);
     }
 
     private async Task ConfirmCloseAllLogsAsync()
@@ -307,17 +295,26 @@ public sealed partial class LogTabBar
 
     private string GetTabName(LogTabBarPresentation presentation, LogView table)
     {
-        if (table.GroupId?.IsAll == true) { return "Combined"; }
+        if (table.GroupId?.IsAll == true) { return Localizer["TabBar_TabName_Combined"].Value; }
 
         if (table.IsCombined) { return table.LogName; }
 
         string tabName = table.LogPathType is LogPathType.File ?
             Path.GetFileNameWithoutExtension(table.FileName)!.Split("\\").Last() :
-            $"{table.LogName} - {table.ComputerName}";
+            Localizer["TabBar_TabName_Live", table.LogName, table.ComputerName].Value;
 
         if (table.IsLoading) { return tabName; }
 
-        return presentation.IsKnownEmpty(table.Id) ? $"(Empty) {tabName}" : tabName;
+        return presentation.IsKnownEmpty(table.Id) ? Localizer["TabBar_TabName_Empty", tabName].Value : tabName;
+    }
+
+    private string GetTabTooltip(LogView table)
+    {
+        if (table.IsCombined) { return string.Empty; }
+
+        return table.LogPathType == LogPathType.File ?
+            Localizer["TabBar_Tooltip_File", table.FileName ?? string.Empty, table.LogName, table.ComputerName].Value :
+            Localizer["TabBar_Tooltip_Live", table.LogName, table.ComputerName].Value;
     }
 
     private void OnCloseGroupKeyDown(KeyboardEventArgs e, LogTabGroup group)
@@ -370,10 +367,10 @@ public sealed partial class LogTabBar
     private async Task PromptNewGroupAsync(LogView tab)
     {
         string name = await AlertDialogService.DisplayPrompt(
-            "New group",
-            "Group name:",
+            Localizer["TabBar_Prompt_NewGroupTitle"].Value,
+            Localizer["TabBar_Prompt_GroupNameLabel"].Value,
             string.Empty,
-            candidate => string.IsNullOrWhiteSpace(candidate) ? "Group name is required." : null);
+            candidate => string.IsNullOrWhiteSpace(candidate) ? Localizer["TabBar_Prompt_GroupNameRequired"].Value : null);
 
         if (string.IsNullOrWhiteSpace(name)) { return; }
 
@@ -389,10 +386,10 @@ public sealed partial class LogTabBar
     private async Task PromptRenameAsync(LogTabGroup group)
     {
         string name = await AlertDialogService.DisplayPrompt(
-            "Rename group",
-            "Group name:",
+            Localizer["TabBar_Prompt_RenameGroupTitle"].Value,
+            Localizer["TabBar_Prompt_GroupNameLabel"].Value,
             group.Name,
-            candidate => string.IsNullOrWhiteSpace(candidate) ? "Group name is required." : null);
+            candidate => string.IsNullOrWhiteSpace(candidate) ? Localizer["TabBar_Prompt_GroupNameRequired"].Value : null);
 
         if (string.IsNullOrWhiteSpace(name)) { return; }
 

--- a/src/EventLogExpert.UI/LogTable/LogTableCellFilterLocalizer.cs
+++ b/src/EventLogExpert.UI/LogTable/LogTableCellFilterLocalizer.cs
@@ -1,0 +1,26 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Localization;
+using Microsoft.Extensions.Localization;
+
+namespace EventLogExpert.UI.LogTable;
+
+internal static class LogTableCellFilterLocalizer
+{
+    public static string Describe(
+        IStringLocalizer<SharedResource> localizer,
+        bool exclude,
+        bool isKeywords,
+        bool hasValue,
+        string columnLabel,
+        string value) => (exclude, isKeywords, hasValue) switch
+        {
+            (false, false, true) => localizer["CellFilter_IncludeWhereEquals", columnLabel, value],
+            (false, true, true) => localizer["CellFilter_IncludeWhereHas", columnLabel, value],
+            (true, false, true) => localizer["CellFilter_ExcludeWhereEquals", columnLabel, value],
+            (true, true, true) => localizer["CellFilter_ExcludeWhereHas", columnLabel, value],
+            (false, _, false) => localizer["CellFilter_IncludeWhereNoValue", columnLabel],
+            (true, _, false) => localizer["CellFilter_ExcludeWhereNoValue", columnLabel],
+        };
+}

--- a/src/EventLogExpert.UI/LogTable/LogTablePane.razor
+++ b/src/EventLogExpert.UI/LogTable/LogTablePane.razor
@@ -96,7 +96,7 @@
             </div>
         }
         <table aria-busy="@(IsGridBusy() ? "true" : null)"
-            aria-label="Event Log Table"
+            aria-label="@Localizer["Table_Aria"]"
             aria-multiselectable="true"
             aria-rowcount="@GetAriaRowCount()"
             id="eventTable"
@@ -130,7 +130,7 @@
                                 IconClass="bi bi-caret-up"
                                 OnClick="ToggleSorting"
                                 StopKeyDownPropagation="true"
-                                aria-label="Toggle sort direction"
+                                aria-label="@Localizer["Table_ToggleSortAria"]"
                                 data-rotate="@Presentation.Ordering.IsDescending.ToString().ToLower()" />
                         }
                     </th>
@@ -139,7 +139,7 @@
                 <th aria-colindex="@(_enabledColumns.Length + 1)"
                     class="description"
                     role="columnheader">
-                    @EventTableColumnFormatter.DescriptionColumnHeader
+                    @Localizer["Table_ColumnHeader_Description"]
                 </th>
             </tr>
             </thead>

--- a/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/LogTablePane.razor.cs
@@ -7,6 +7,7 @@ using EventLogExpert.Filtering.Common.Filtering;
 using EventLogExpert.Filtering.Compilation;
 using EventLogExpert.Filtering.Evaluation;
 using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Localization;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Runtime.Common.Clipboard;
 using EventLogExpert.Runtime.Common.Display;
@@ -23,6 +24,7 @@ using EventLogExpert.UI.Menu;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.Web.Virtualization;
+using Microsoft.Extensions.Localization;
 using Microsoft.JSInterop;
 using System.Collections.Immutable;
 
@@ -33,7 +35,6 @@ public sealed partial class LogTablePane
     private const int DefaultPageSize = 20;
     private const float EventRowHeightPixels = 22f;
     private const int MenuValueMaxLength = 40;
-    private const string NoCellValueReason = "No value in this cell to filter on";
 
     private static readonly IEventColumnView s_emptyView = LogTableState.EmptyView;
     private static readonly HashSet<int> s_warnedUnknownColors = [];
@@ -103,6 +104,8 @@ public sealed partial class LogTablePane
     [Inject] private DisplayIndicatorGate IndicatorGate { get; init; } = null!;
 
     [Inject] private IJSRuntime JSRuntime { get; init; } = null!;
+
+    [Inject] private IStringLocalizer<SharedResource> Localizer { get; init; } = null!;
 
     [Inject] private ILogTableCommands LogTableCommands { get; init; } = null!;
 
@@ -489,27 +492,27 @@ public sealed partial class LogTablePane
         if (CellFilterBuilder.TryGetDisplayValue(@event, property, out var value))
         {
             string shown = TruncateForMenu(value);
-            string verb = property is EventProperty.Keywords ? "has" : "=";
+            bool isKeywords = property is EventProperty.Keywords;
 
             items.Add(MenuItem.Item(
-                $"Include only where {columnLabel} {verb} '{shown}'",
+                LogTableCellFilterLocalizer.Describe(Localizer, exclude: false, isKeywords, hasValue: true, columnLabel, shown),
                 () => ApplySelectedFilter(@event, property, exclude: false)));
             items.Add(MenuItem.Item(
-                $"Exclude where {columnLabel} {verb} '{shown}'",
+                LogTableCellFilterLocalizer.Describe(Localizer, exclude: true, isKeywords, hasValue: true, columnLabel, shown),
                 () => ApplySelectedFilter(@event, property, exclude: true)));
         }
         else
         {
             items.Add(MenuItem.Item(
-                $"Include only where {columnLabel}",
+                LogTableCellFilterLocalizer.Describe(Localizer, exclude: false, isKeywords: false, hasValue: false, columnLabel, string.Empty),
                 () => { },
                 isEnabled: false,
-                disabledReason: NoCellValueReason));
+                disabledReason: Localizer["LogTable_NoCellValue"].Value));
             items.Add(MenuItem.Item(
-                $"Exclude where {columnLabel}",
+                LogTableCellFilterLocalizer.Describe(Localizer, exclude: true, isKeywords: false, hasValue: false, columnLabel, string.Empty),
                 () => { },
                 isEnabled: false,
-                disabledReason: NoCellValueReason));
+                disabledReason: Localizer["LogTable_NoCellValue"].Value));
         }
 
         items.Add(MenuItem.Separator());
@@ -658,14 +661,20 @@ public sealed partial class LogTablePane
         return count > 0 ? 0 : -1;
     }
 
-    private string GetDateColumnHeader() =>
-        EventTableColumnFormatter.GetColumnHeader(ColumnName.DateAndTime, Settings.TimeZoneInfo);
+    private string GetDateColumnHeader()
+    {
+        TimeZoneInfo timeZone = Settings.TimeZoneInfo;
+
+        return timeZone.Equals(TimeZoneInfo.Local) ?
+            Localizer["Table_ColumnHeader_DateAndTime"].Value :
+            Localizer["Table_ColumnHeader_DateAndTimeWithZone", timeZone.DisplayName.Split(' ').First()].Value;
+    }
 
     private string GetGroupName() => Presentation.Ordering.GroupBy?.ToFullString() ?? string.Empty;
 
     private string GetGroupValueText(EventGroup group)
     {
-        if (group.EventCount == 0) { return "(none)"; }
+        if (group.EventCount == 0) { return Localizer["LogTable_GroupValueNone"].Value; }
 
         var representative = _activeDisplayedEvents.GetDetailLean(_activeDisplayedEvents.LocatorAt(group.StartIndex));
 
@@ -673,7 +682,7 @@ public sealed partial class LogTablePane
             ColumnDescriptors.GetGroupText(representative, groupBy, new ColumnFormatContext(_timeZoneSettings)) :
             string.Empty;
 
-        return string.IsNullOrEmpty(value) ? "(none)" : value;
+        return string.IsNullOrEmpty(value) ? Localizer["LogTable_GroupValueNone"].Value : value;
     }
 
     private string? GetHighlight(DisplayRow row)
@@ -919,11 +928,11 @@ public sealed partial class LogTablePane
     private string? IndicatorSentence() =>
         _indicator.Sentence switch
         {
-            DisplayIndicatorKind.EmptyPending => "Loading events\u2026",
-            DisplayIndicatorKind.ReorderPending => "Reordering events\u2026",
+            DisplayIndicatorKind.EmptyPending => Localizer["Table_LoadingEvents"].Value,
+            DisplayIndicatorKind.ReorderPending => Localizer["Table_ReorderingEvents"].Value,
             DisplayIndicatorKind.Fault => Presentation.FaultCause is { Length: > 0 } cause ?
-                $"These events could not be prepared. {cause}" :
-                "These events could not be prepared.",
+                Localizer["Table_FaultPrefixWithCause", cause].Value :
+                Localizer["Table_FaultPrefix"].Value,
             _ => null
         };
 
@@ -1407,12 +1416,12 @@ public sealed partial class LogTablePane
                 isChecked: ordering.OrderBy.Equals(capturedColumn)));
         }
 
-        items.Add(MenuItem.SubMenu("Order By", orderItems));
+        items.Add(MenuItem.SubMenu(Localizer["LogTable_OrderBy"].Value, orderItems));
 
         var groupItems = new List<MenuItem>
         {
             MenuItem.Item(
-                "(none)",
+                Localizer["LogTable_GroupByNone"].Value,
                 () => { if (ordering.GroupBy is not null) { LogTableCommands.SetGroupBy(null); } },
                 isChecked: ordering.GroupBy is null)
         };
@@ -1426,11 +1435,11 @@ public sealed partial class LogTablePane
                 isChecked: ordering.GroupBy.Equals(capturedColumn)));
         }
 
-        items.Add(MenuItem.SubMenu("Group By", groupItems));
+        items.Add(MenuItem.SubMenu(Localizer["LogTable_GroupBy"].Value, groupItems));
 
         items.Add(MenuItem.Separator());
         items.Add(MenuItem.Item(
-            "Reset Column Defaults",
+            Localizer["LogTable_ResetColumnDefaults"].Value,
             () => LogTableCommands.ResetColumnDefaults()));
 
         return items;
@@ -1440,63 +1449,63 @@ public sealed partial class LogTablePane
     {
         return
         [
-            MenuItem.Item("Copy Selected", () => ClipboardService.CopySelectedEvent(EventCopyFormat.Default)),
-            MenuItem.Item("Copy Selected (Simple)", () => ClipboardService.CopySelectedEvent(EventCopyFormat.Simple)),
-            MenuItem.Item("Copy Selected (XML)", () => ClipboardService.CopySelectedEvent(EventCopyFormat.Xml)),
-            MenuItem.Item("Copy Selected (Full)", () => ClipboardService.CopySelectedEvent(EventCopyFormat.Full)),
+            MenuItem.Item(Localizer["Menu_Edit_CopySelected"].Value, () => ClipboardService.CopySelectedEvent(EventCopyFormat.Default)),
+            MenuItem.Item(Localizer["Menu_Edit_CopySelectedSimple"].Value, () => ClipboardService.CopySelectedEvent(EventCopyFormat.Simple)),
+            MenuItem.Item(Localizer["Menu_Edit_CopySelectedXml"].Value, () => ClipboardService.CopySelectedEvent(EventCopyFormat.Xml)),
+            MenuItem.Item(Localizer["Menu_Edit_CopySelectedFull"].Value, () => ClipboardService.CopySelectedEvent(EventCopyFormat.Full)),
             MenuItem.Separator(),
-            MenuItem.Item("Exclude Events Before", () =>
+            MenuItem.Item(Localizer["LogTable_ExcludeEventsBefore"].Value, () =>
                 FilterPaneCommands.SetFilterDateRange(
                     new DateFilter { Before = selectedEvent.TimeCreated })),
-            MenuItem.Item("Exclude Events After", () =>
+            MenuItem.Item(Localizer["LogTable_ExcludeEventsAfter"].Value, () =>
                 FilterPaneCommands.SetFilterDateRange(
                     new DateFilter { After = selectedEvent.TimeCreated })),
             MenuItem.Separator(),
             MenuItem.Item(
-                "Show Related by Activity ID",
+                Localizer["LogTable_ShowRelatedByActivityId"].Value,
                 () => FilterLensCommands.ShowRelatedByActivityId(selectedEvent.ActivityId, selectedEvent.OwningLog),
                 isEnabled: selectedEvent.ActivityId.HasValue,
-                disabledReason: selectedEvent.ActivityId.HasValue ? null : "This event has no Activity ID."),
+                disabledReason: selectedEvent.ActivityId.HasValue ? null : Localizer["LogTable_NoActivityIdReason"].Value),
             MenuItem.Item(
-                "Show Events Sharing Related Activity ID",
+                Localizer["LogTable_ShowSharingRelatedActivityId"].Value,
                 () => FilterLensCommands.ShowRelatedByRelatedActivityId(selectedEvent.RelatedActivityId, selectedEvent.OwningLog),
                 isEnabled: selectedEvent.RelatedActivityId.HasValue,
-                disabledReason: selectedEvent.RelatedActivityId.HasValue ? null : "This event has no Related Activity ID."),
+                disabledReason: selectedEvent.RelatedActivityId.HasValue ? null : Localizer["LogTable_NoRelatedActivityIdReason"].Value),
             MenuItem.Item(
-                "Show Parent Activity",
+                Localizer["LogTable_ShowParentActivity"].Value,
                 () => FilterLensCommands.ShowParentActivity(selectedEvent.RelatedActivityId, selectedEvent.OwningLog),
                 isEnabled: selectedEvent.RelatedActivityId.HasValue,
-                disabledReason: selectedEvent.RelatedActivityId.HasValue ? null : "This event has no Related Activity ID."),
+                disabledReason: selectedEvent.RelatedActivityId.HasValue ? null : Localizer["LogTable_NoRelatedActivityIdReason"].Value),
             MenuItem.SubMenu(
-                "Show Events Near This Time",
+                Localizer["LogTable_ShowEventsNearTime"].Value,
                 [
                     MenuItem.Item(
-                        "\u00b130 Seconds",
+                        Localizer["LogTable_NearTime_30Seconds"].Value,
                         () => FilterLensCommands.ShowEventsNearTime(
                             selectedEvent.TimeCreated, TimeSpan.FromSeconds(30), Settings.TimeZoneInfo, selectedEvent.OwningLog)),
                     MenuItem.Item(
-                        "\u00b11 Minute",
+                        Localizer["LogTable_NearTime_1Minute"].Value,
                         () => FilterLensCommands.ShowEventsNearTime(
                             selectedEvent.TimeCreated, TimeSpan.FromMinutes(1), Settings.TimeZoneInfo, selectedEvent.OwningLog)),
                     MenuItem.Item(
-                        "\u00b15 Minutes",
+                        Localizer["LogTable_NearTime_5Minutes"].Value,
                         () => FilterLensCommands.ShowEventsNearTime(
                             selectedEvent.TimeCreated, TimeSpan.FromMinutes(5), Settings.TimeZoneInfo, selectedEvent.OwningLog)),
                     MenuItem.Item(
-                        "\u00b115 Minutes",
+                        Localizer["LogTable_NearTime_15Minutes"].Value,
                         () => FilterLensCommands.ShowEventsNearTime(
                             selectedEvent.TimeCreated, TimeSpan.FromMinutes(15), Settings.TimeZoneInfo, selectedEvent.OwningLog)),
                     MenuItem.Item(
-                        "\u00b11 Hour",
+                        Localizer["LogTable_NearTime_1Hour"].Value,
                         () => FilterLensCommands.ShowEventsNearTime(
                             selectedEvent.TimeCreated, TimeSpan.FromHours(1), Settings.TimeZoneInfo, selectedEvent.OwningLog)),
                 ]),
             MenuItem.Separator(),
             MenuItem.SubMenu(
-                "More Fields",
+                Localizer["LogTable_MoreFields"].Value,
                 [
-                    MenuItem.SubMenu("Include", ShowEventFieldItems(selectedEvent, false)),
-                    MenuItem.SubMenu("Exclude", ShowEventFieldItems(selectedEvent, true)),
+                    MenuItem.SubMenu(Localizer["LogTable_Include"].Value, ShowEventFieldItems(selectedEvent, false)),
+                    MenuItem.SubMenu(Localizer["LogTable_Exclude"].Value, ShowEventFieldItems(selectedEvent, true)),
                 ]),
         ];
     }
@@ -1516,7 +1525,7 @@ public sealed partial class LogTablePane
                 property.ToFullString(),
                 () => ApplySelectedFilter(selectedEvent, capturedProperty, exclude),
                 isEnabled: hasValue,
-                disabledReason: hasValue ? null : NoCellValueReason));
+                disabledReason: hasValue ? null : Localizer["LogTable_NoCellValue"].Value));
         }
 
         return items;
@@ -1529,17 +1538,17 @@ public sealed partial class LogTablePane
         return
         [
             MenuItem.Item(
-                collapsedNow ? "Expand Group" : "Collapse Group",
+                collapsedNow ? Localizer["LogTable_ExpandGroup"].Value : Localizer["LogTable_CollapseGroup"].Value,
                 () => UserSetGroupCollapsed(group.Key, !collapsedNow)),
-            MenuItem.Item("Expand All Groups", () => LogTableCommands.SetAllGroupsCollapsed(false)),
-            MenuItem.Item("Collapse All Groups", () => LogTableCommands.SetAllGroupsCollapsed(true)),
+            MenuItem.Item(Localizer["Menu_View_ExpandAllGroups"].Value, () => LogTableCommands.SetAllGroupsCollapsed(false)),
+            MenuItem.Item(Localizer["Menu_View_CollapseAllGroups"].Value, () => LogTableCommands.SetAllGroupsCollapsed(true)),
             MenuItem.Separator(),
             MenuItem.Item(
-                "Group Descending",
+                Localizer["Menu_View_GroupDescending"].Value,
                 () => LogTableCommands.ToggleGroupSortDirection(),
                 isChecked: Presentation.Ordering.IsGroupDescending),
             MenuItem.Separator(),
-            MenuItem.Item("Select Group", () => SelectGroupByKey(group.Key)),
+            MenuItem.Item(Localizer["LogTable_SelectGroup"].Value, () => SelectGroupByKey(group.Key)),
         ];
     }
 

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Common/Clipboard/EventCopyFormatterCultureTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Common/Clipboard/EventCopyFormatterCultureTests.cs
@@ -15,14 +15,6 @@ using System.Globalization;
 
 namespace EventLogExpert.Runtime.Tests.Common.Clipboard;
 
-/// <summary>
-///     Pins the log-table copy path (<see cref="EventCopyFormatter" />, the highest-volume copy surface) as
-///     regional-culture-independent for its structural English: the Full-format <c>"Date: "</c> label and the Markdown
-///     <c>"Description"</c> header stay present under a foreign <see cref="CultureInfo.CurrentCulture" />. The Date VALUE
-///     is CurrentCulture-formatted by design (documented, deferred - <c>loc-copyexport-value-invariance</c>); only the
-///     label is pinned. UICulture localizer-independence is deferred to the copy-localization increment. Contrast culture
-///     fi-FI per <c>EventTableExporterCultureTests</c>.
-/// </summary>
 [Collection(CultureSensitiveCollection.Name)]
 public sealed class EventCopyFormatterCultureTests
 {
@@ -35,20 +27,19 @@ public sealed class EventCopyFormatterCultureTests
         ImmutableList.Create(ColumnName.Level, ColumnName.Source, ColumnName.EventId);
 
     [Fact]
-    public async Task FormatAsync_FullFormat_EmitsEnglishDateLabel_UnderForeignCulture() =>
-        Assert.Contains("Date: ", await FormatUnderContrastCultureAsync(EventCopyFormat.Full), StringComparison.Ordinal);
+    public async Task FormatAsync_FullFormat_RoutesCultureSensitiveDateThroughCopyText() =>
+        Assert.Contains("[[Date(26.8.2026 17.57.05)]]", await FormatUnderContrastCultureAsync(EventCopyFormat.Full), StringComparison.Ordinal);
 
     [Fact]
-    public async Task FormatAsync_MarkdownFormat_EmitsEnglishHeaderRow_UnderForeignCulture()
+    public async Task FormatAsync_MarkdownFormat_RoutesDescriptionHeaderThroughCopyText()
     {
         string result = await FormatUnderContrastCultureAsync(EventCopyFormat.Markdown);
 
-        // Markdown-specific: the pipe-table header with the hardcoded English "Description" column (EventCopyFormatter.cs:166).
-        // Asserting the full "| ... | Description |" row (not a bare "Description") ensures this cannot pass by matching the
-        // Full/line format, which emits no pipe table.
         Assert.StartsWith("|", result, StringComparison.Ordinal);
-        Assert.Contains("| Level | Source | Event ID | Description |", result, StringComparison.Ordinal);
+        Assert.Contains("| Level | Source | Event ID | [[MarkdownDescriptionHeader]] |", result, StringComparison.Ordinal);
     }
+
+    private static IEventCopyText CopyText() => new MarkerEventCopyText();
 
     private static SelectionEntry Entry(EventLocator locator) => new(locator, locator, null);
 
@@ -68,7 +59,7 @@ public sealed class EventCopyFormatterCultureTests
         detailResolver.TryResolve(locator, out Arg.Any<ResolvedEvent?>())
             .Returns(call => { call[1] = @event; return true; });
 
-        var formatter = new EventCopyFormatter(detailResolver, Substitute.For<IEventXmlResolver>());
+        var formatter = new EventCopyFormatter(detailResolver, Substitute.For<IEventXmlResolver>(), CopyText());
 
         return await RunUnderCultureAsync(
             CultureInfo.GetCultureInfo("fi-FI"),
@@ -93,5 +84,17 @@ public sealed class EventCopyFormatterCultureTests
             CultureInfo.CurrentCulture = priorCulture;
             CultureInfo.CurrentUICulture = priorUiCulture;
         }
+    }
+
+    private sealed class MarkerEventCopyText : IEventCopyText
+    {
+        public string MarkdownDescriptionHeader => "[[MarkdownDescriptionHeader]]";
+
+        public string FieldLine(EventCopyFullField field, string value) => field switch
+        {
+            EventCopyFullField.DescriptionHeader => "[[DescriptionHeader]]",
+            EventCopyFullField.EventXmlHeader => "[[EventXmlHeader]]",
+            _ => $"[[{field}({value})]]"
+        };
     }
 }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/Common/Clipboard/EventCopyFormatterTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/Common/Clipboard/EventCopyFormatterTests.cs
@@ -34,7 +34,7 @@ public sealed class EventCopyFormatterTests
         detailResolver.TryResolve(locator, out Arg.Any<ResolvedEvent?>())
             .Returns(call => { call[1] = Event(1, 4000, "ProviderA", "Alpha"); return true; });
 
-        var formatter = new EventCopyFormatter(detailResolver, Substitute.For<IEventXmlResolver>());
+        var formatter = new EventCopyFormatter(detailResolver, Substitute.For<IEventXmlResolver>(), CopyText());
 
         string result = await formatter.FormatAsync(
             Request([Entry(locator)], focus: null, EventCopyFormat.Default),
@@ -57,7 +57,7 @@ public sealed class EventCopyFormatterTests
         detailResolver.TryResolve(locatorA, out Arg.Any<ResolvedEvent?>())
             .Returns(call => { call[1] = eventA; return true; });
 
-        var formatter = new EventCopyFormatter(detailResolver, Substitute.For<IEventXmlResolver>());
+        var formatter = new EventCopyFormatter(detailResolver, Substitute.For<IEventXmlResolver>(), CopyText());
 
         string result = await formatter.FormatAsync(
             Request([Entry(locatorA), Entry(locatorB)], focus: null, EventCopyFormat.Simple),
@@ -74,7 +74,8 @@ public sealed class EventCopyFormatterTests
     {
         var formatter = new EventCopyFormatter(
             Substitute.For<IEventDetailResolver>(),
-            Substitute.For<IEventXmlResolver>());
+            Substitute.For<IEventXmlResolver>(),
+            CopyText());
 
         string result = await formatter.FormatAsync(
             Request([], focus: null, EventCopyFormat.Full),
@@ -92,7 +93,7 @@ public sealed class EventCopyFormatterTests
         detailResolver.TryResolve(focusLocator, out Arg.Any<ResolvedEvent?>())
             .Returns(call => { call[1] = Event(7, 6000, "FocusProvider", "FocusedDescription"); return true; });
 
-        var formatter = new EventCopyFormatter(detailResolver, Substitute.For<IEventXmlResolver>());
+        var formatter = new EventCopyFormatter(detailResolver, Substitute.For<IEventXmlResolver>(), CopyText());
 
         string result = await formatter.FormatAsync(
             Request([], Entry(focusLocator), EventCopyFormat.Simple),
@@ -122,20 +123,19 @@ public sealed class EventCopyFormatterTests
         detailResolver.TryResolve(locator, out Arg.Any<ResolvedEvent?>())
             .Returns(call => { call[1] = @event; return true; });
 
-        var formatter = new EventCopyFormatter(detailResolver, Substitute.For<IEventXmlResolver>());
+        var formatter = new EventCopyFormatter(detailResolver, Substitute.For<IEventXmlResolver>(), CopyText());
 
         string result = await formatter.FormatAsync(
             Request([Entry(locator)], focus: null, EventCopyFormat.Full),
             TestContext.Current.CancellationToken);
 
-        Assert.Contains(@"User: NT AUTHORITY\SYSTEM", result);
-        Assert.Contains("User SID: S-1-5-18", result);
+        Assert.Contains(@"[[User(NT AUTHORITY\SYSTEM)]]", result);
+        Assert.Contains("[[UserSid(S-1-5-18)]]", result);
     }
 
     [Fact]
     public async Task FormatAsync_FullFormat_OmitsUserSidWhenResolvedNameIsTheRawSid()
     {
-        // Raw-SID fallback: the resolved name already IS the SID, so a separate "User SID" line would just duplicate it.
         var locator = new EventLocator(s_logId, 0, 0);
         var @event = new ResolvedEvent("Application", LogPathType.Channel)
         {
@@ -153,14 +153,14 @@ public sealed class EventCopyFormatterTests
         detailResolver.TryResolve(locator, out Arg.Any<ResolvedEvent?>())
             .Returns(call => { call[1] = @event; return true; });
 
-        var formatter = new EventCopyFormatter(detailResolver, Substitute.For<IEventXmlResolver>());
+        var formatter = new EventCopyFormatter(detailResolver, Substitute.For<IEventXmlResolver>(), CopyText());
 
         string result = await formatter.FormatAsync(
             Request([Entry(locator)], focus: null, EventCopyFormat.Full),
             TestContext.Current.CancellationToken);
 
-        Assert.Contains("User: S-1-5-21-1-2-3-4", result);
-        Assert.DoesNotContain("User SID:", result);
+        Assert.Contains("[[User(S-1-5-21-1-2-3-4)]]", result);
+        Assert.DoesNotContain("[[UserSid(", result);
     }
 
     [Fact]
@@ -172,14 +172,14 @@ public sealed class EventCopyFormatterTests
         detailResolver.TryResolve(locator, out Arg.Any<ResolvedEvent?>())
             .Returns(call => { call[1] = Event(1, 4000, "ProviderA", "Alpha"); return true; });
 
-        var formatter = new EventCopyFormatter(detailResolver, Substitute.For<IEventXmlResolver>());
+        var formatter = new EventCopyFormatter(detailResolver, Substitute.For<IEventXmlResolver>(), CopyText());
 
         string result = await formatter.FormatAsync(
             Request([Entry(locator)], focus: null, EventCopyFormat.Markdown),
             TestContext.Current.CancellationToken);
 
         Assert.StartsWith("|", result);
-        Assert.Contains("Description", result);
+        Assert.Contains("[[MarkdownDescriptionHeader]]", result);
         Assert.Contains("---", result);
         Assert.Contains("ProviderA", result);
     }
@@ -200,7 +200,7 @@ public sealed class EventCopyFormatterTests
         xmlResolver.GetXmlAsync(eventA, Arg.Any<CancellationToken>()).Returns(new ValueTask<string>("<Event>AAA</Event>"));
         xmlResolver.GetXmlAsync(eventB, Arg.Any<CancellationToken>()).Returns(new ValueTask<string>("<Event>BBB</Event>"));
 
-        var formatter = new EventCopyFormatter(detailResolver, xmlResolver);
+        var formatter = new EventCopyFormatter(detailResolver, xmlResolver, CopyText());
 
         string result = await formatter.FormatAsync(
             Request([Entry(locatorA), Entry(locatorB)], focus: null, EventCopyFormat.Full),
@@ -228,7 +228,7 @@ public sealed class EventCopyFormatterTests
         detailResolver.TryResolve(locatorB, out Arg.Any<ResolvedEvent?>())
             .Returns(call => { call[1] = Event(2, 5000, "ProviderB", "Beta"); return true; });
 
-        var formatter = new EventCopyFormatter(detailResolver, Substitute.For<IEventXmlResolver>());
+        var formatter = new EventCopyFormatter(detailResolver, Substitute.For<IEventXmlResolver>(), CopyText());
 
         string result = await formatter.FormatAsync(
             Request([Entry(locatorA), Entry(locatorB)], focus: null, EventCopyFormat.Simple),
@@ -252,7 +252,7 @@ public sealed class EventCopyFormatterTests
         xmlResolver.GetXmlAsync(Arg.Any<ResolvedEvent>(), Arg.Any<CancellationToken>())
             .Returns(new ValueTask<string>("<Event><Data>payload</Data></Event>"));
 
-        var formatter = new EventCopyFormatter(detailResolver, xmlResolver);
+        var formatter = new EventCopyFormatter(detailResolver, xmlResolver, CopyText());
 
         string result = await formatter.FormatAsync(
             Request([Entry(locator)], focus: null, EventCopyFormat.Xml),
@@ -260,6 +260,8 @@ public sealed class EventCopyFormatterTests
 
         Assert.Contains("payload", result);
     }
+
+    private static IEventCopyText CopyText() => new MarkerEventCopyText();
 
     private static SelectionEntry Entry(EventLocator locator) => new(locator, locator, null);
 
@@ -279,4 +281,16 @@ public sealed class EventCopyFormatterTests
         SelectionEntry? focus,
         EventCopyFormat format) =>
         new(selection, focus, s_columns, s_order, format, TimeZoneInfo.Utc);
+
+    private sealed class MarkerEventCopyText : IEventCopyText
+    {
+        public string MarkdownDescriptionHeader => "[[MarkdownDescriptionHeader]]";
+
+        public string FieldLine(EventCopyFullField field, string value) => field switch
+        {
+            EventCopyFullField.DescriptionHeader => "[[DescriptionHeader]]",
+            EventCopyFullField.EventXmlHeader => "[[EventXmlHeader]]",
+            _ => $"[[{field}({value})]]"
+        };
+    }
 }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/DependencyInjection/RuntimeServiceCollectionExtensionsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/DependencyInjection/RuntimeServiceCollectionExtensionsTests.cs
@@ -11,6 +11,7 @@ using EventLogExpert.Runtime.Alerts;
 using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.Runtime.Banner;
 using EventLogExpert.Runtime.Common.AppTitle;
+using EventLogExpert.Runtime.Common.Clipboard;
 using EventLogExpert.Runtime.Common.Files;
 using EventLogExpert.Runtime.Common.Identity;
 using EventLogExpert.Runtime.Common.Restart;
@@ -226,6 +227,7 @@ public sealed class RuntimeServiceCollectionExtensionsTests
         services.AddSingleton(Substitute.For<IDispatcher>());
         services.AddSingleton(Substitute.For<IAlertDialogService>());
         services.AddSingleton(Substitute.For<IApplicationRestartService>());
+        services.AddSingleton(Substitute.For<IEventCopyText>());
         services.AddSingleton(Substitute.For<ISettingsPreferencesProvider>());
         services.AddSingleton(Substitute.For<IDatabasePreferencesProvider>());
         services.AddSingleton(Substitute.For<IProviderDatabaseMaintenance>());
@@ -376,6 +378,7 @@ public sealed class RuntimeServiceCollectionExtensionsTests
         services.AddSingleton(Substitute.For<IDispatcher>());
         services.AddSingleton(Substitute.For<IAlertDialogService>());
         services.AddSingleton(Substitute.For<IApplicationRestartService>());
+        services.AddSingleton(Substitute.For<IEventCopyText>());
         services.AddSingleton(preferences ?? Substitute.For<ISettingsPreferencesProvider>());
         services.AddSingleton(Substitute.For<IDatabasePreferencesProvider>());
         services.AddSingleton(Substitute.For<IProviderDatabaseMaintenance>());

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTabBarTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTabBarTests.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using Bunit;
+using EventLogExpert.Eventing.Common.Channels;
 using EventLogExpert.Eventing.Common.EventLogs;
 using EventLogExpert.Localization;
 using EventLogExpert.Logging.Abstractions;
@@ -10,6 +11,7 @@ using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.Runtime.LogTable;
 using EventLogExpert.UI.LogTable;
 using EventLogExpert.UI.Menu;
+using EventLogExpert.UI.Tests.TestUtils;
 using Fluxor;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
@@ -83,7 +85,7 @@ public sealed class LogTabBarTests : BunitContext
         Services.AddSingleton(_queries);
         Services.AddSingleton(_source);
         Services.AddSingleton(_traceLogger);
-        Services.AddEventLogLocalization();
+        Services.AddSingleton<IStringLocalizer<SharedResource>>(new MarkerLocalizer());
     }
 
     private IStringLocalizer<SharedResource> Localizer =>
@@ -136,6 +138,28 @@ public sealed class LogTabBarTests : BunitContext
     }
 
     [Fact]
+    public void AriaLabelsAndTitles_RouteThroughMarkerLocalizer()
+    {
+        var (collapsedState, _, _, _, _) = GroupedState(collapsed: true, activeIsMember1: false);
+        _logTableState.Value.Returns(collapsedState);
+        var collapsedCut = Render<LogTabBar>();
+
+        Assert.Equal(Localizer["TabBar_ExpandGroupAria"].Value, collapsedCut.Find("button.chevron").GetAttribute("aria-label"));
+        Assert.Equal(Localizer["TabBar_ExpandGroupAria"].Value, collapsedCut.Find("button.chevron").GetAttribute("title"));
+
+        var (expandedState, _, _, _, _) = GroupedState(collapsed: false, activeIsMember1: false);
+        _logTableState.Value.Returns(expandedState);
+        var expandedCut = Render<LogTabBar>();
+
+        Assert.Equal(Localizer["TabBar_CollapseGroupAria"].Value, expandedCut.Find("button.chevron").GetAttribute("aria-label"));
+        Assert.Equal(Localizer["TabBar_CollapseGroupAria"].Value, expandedCut.Find("button.chevron").GetAttribute("title"));
+        Assert.Equal(Localizer["TabBar_CloseGroup"].Value, expandedCut.Find(".group-header > i.bi-x").GetAttribute("aria-label"));
+        Assert.Equal(Localizer["TabBar_CloseGroup"].Value, expandedCut.Find(".group-header > i.bi-x").GetAttribute("title"));
+        Assert.Equal(Localizer["TabBar_CloseLogAria"].Value, expandedCut.Find(".tab.member > i.bi-x").GetAttribute("aria-label"));
+        Assert.Equal(Localizer["TabBar_CloseLogAria"].Value, expandedCut.Find(".tab.member > i.bi-x").GetAttribute("title"));
+    }
+
+    [Fact]
     public void ChevronClick_DispatchesSetTabGroupCollapsed()
     {
         var (state, groupId, _, _, _) = GroupedState(collapsed: false, activeIsMember1: false);
@@ -174,7 +198,7 @@ public sealed class LogTabBarTests : BunitContext
 
         var item = FindItem(menu, "Close other tabs");
         Assert.False(item.IsEnabled);
-        Assert.Equal("No other tabs to close", item.DisabledReason);
+        Assert.Equal(Localizer["TabBar_Menu_NoOtherTabsToCloseReason"].Value, item.DisabledReason);
     }
 
     [Fact]
@@ -187,7 +211,7 @@ public sealed class LogTabBarTests : BunitContext
 
         var item = FindItem(menu, "Close others in group");
         Assert.False(item.IsEnabled);
-        Assert.Equal("No other tabs in this group", item.DisabledReason);
+        Assert.Equal(Localizer["TabBar_Menu_NoOtherTabsInGroupReason"].Value, item.DisabledReason);
     }
 
     [Fact]
@@ -246,7 +270,7 @@ public sealed class LogTabBarTests : BunitContext
 
         var cut = Render<LogTabBar>();
 
-        Assert.Contains("Combined", cut.Markup);
+        Assert.Contains(Localizer["TabBar_TabName_Combined"].Value, cut.Markup);
     }
 
     [Fact]
@@ -345,12 +369,31 @@ public sealed class LogTabBarTests : BunitContext
     }
 
     [Fact]
+    public async Task GroupHeader_Expand_DispatchesSetTabGroupCollapsed()
+    {
+        var (state, groupId, _, _, _) = GroupedState(collapsed: true, activeIsMember1: false);
+        _logTableState.Value.Returns(state);
+        var cut = Render<LogTabBar>();
+        var menu = OpenContextMenu(cut, ".group-header");
+
+        Assert.Contains(menu, item => item.Label == Localizer["TabBar_Menu_Expand"].Value);
+        await InvokeMenuItemAsync(cut, FindItem(menu, "Expand"));
+
+        _logTableCommands.Received(1).SetTabGroupCollapsed(groupId, false);
+    }
+
+    [Fact]
     public async Task GroupHeader_Rename_PromptThenDispatches()
     {
         var (state, groupId, _, _, _) = GroupedState(collapsed: false, activeIsMember1: false);
         _logTableState.Value.Returns(state);
+        Func<string, string?>? validator = null;
         _alertDialogService
-            .DisplayPrompt("Rename group", Arg.Any<string>(), "MyGroup", Arg.Any<Func<string, string?>?>())
+            .DisplayPrompt(
+                Localizer["TabBar_Prompt_RenameGroupTitle"].Value,
+                Localizer["TabBar_Prompt_GroupNameLabel"].Value,
+                "MyGroup",
+                Arg.Do<Func<string, string?>?>(callback => validator = callback))
             .Returns("Renamed");
         var cut = Render<LogTabBar>();
         var menu = OpenContextMenu(cut, ".group-header");
@@ -358,6 +401,9 @@ public sealed class LogTabBarTests : BunitContext
         await InvokeMenuItemAsync(cut, FindItem(menu, "Rename\u2026"));
 
         _logTableCommands.Received(1).RenameGroup(groupId, "Renamed");
+        Assert.NotNull(validator);
+        Assert.Equal(Localizer["TabBar_Prompt_GroupNameRequired"].Value, validator(" "));
+        Assert.Null(validator("Renamed"));
     }
 
     [Fact]
@@ -366,7 +412,7 @@ public sealed class LogTabBarTests : BunitContext
         var (state, _, _, _, _) = GroupedState(collapsed: false, activeIsMember1: false);
         _logTableState.Value.Returns(state);
         _alertDialogService
-            .DisplayPrompt("Rename group", Arg.Any<string>(), "MyGroup", Arg.Any<Func<string, string?>?>())
+            .DisplayPrompt(Localizer["TabBar_Prompt_RenameGroupTitle"].Value, Localizer["TabBar_Prompt_GroupNameLabel"].Value, "MyGroup", Arg.Any<Func<string, string?>?>())
             .Returns("Renamed");
         var cut = Render<LogTabBar>();
         var menu = OpenContextMenu(cut, ".group-header");
@@ -388,7 +434,7 @@ public sealed class LogTabBarTests : BunitContext
         var menu = OpenContextMenu(cut, ".group-header");
 
         var labels = menu.Select(item => item.Label).ToList();
-        Assert.Equal(["Rename\u2026", "Collapse", string.Empty, "Close group"], labels);
+        Assert.Equal([Localizer["TabBar_Menu_Rename"].Value, Localizer["TabBar_Menu_Collapse"].Value, string.Empty, Localizer["TabBar_CloseGroup"].Value], labels);
     }
 
     [Fact]
@@ -401,8 +447,26 @@ public sealed class LogTabBarTests : BunitContext
 
         var cut = Render<LogTabBar>();
 
-        Assert.Contains("(Empty) Alpha", cut.Markup);
-        Assert.DoesNotContain("(Empty) Beta", cut.Markup);
+        Assert.Contains("[[TabBar_TabName_Empty(", cut.Markup);
+        Assert.DoesNotContain("Beta)]]", cut.Markup);
+    }
+
+    [Fact]
+    public void LoadingSpinner_RoutesAriaLabelThroughMarkerLocalizer()
+    {
+        var alpha = EventLogId.Create();
+        var beta = EventLogId.Create();
+        _logTableState.Value.Returns(new LogTableState
+        {
+            ActiveEventLogId = alpha,
+            EventTables = ImmutableList.Create(
+                new LogView(alpha) { LogName = "Alpha", IsLoading = true },
+                new LogView(beta) { LogName = "Beta" })
+        });
+
+        var cut = Render<LogTabBar>();
+
+        Assert.Equal(Localizer["TabBar_LoadingAria"].Value, cut.Find("i.loader-spin").GetAttribute("aria-label"));
     }
 
     [Fact]
@@ -436,14 +500,14 @@ public sealed class LogTabBarTests : BunitContext
         var (state, _, _, member1, _) = GroupedState(collapsed: false, activeIsMember1: false);
         _logTableState.Value.Returns(state);
         _alertDialogService
-            .DisplayPrompt("New group", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Func<string, string?>?>())
+            .DisplayPrompt(Localizer["TabBar_Prompt_NewGroupTitle"].Value, Localizer["TabBar_Prompt_GroupNameLabel"].Value, Arg.Any<string>(), Arg.Any<Func<string, string?>?>())
             .Returns("Split");
         var cut = Render<LogTabBar>();
         var menu = OpenContextMenu(cut, ".tab.member");
 
         var moveTo = FindItem(menu, "Move to group");
         Assert.NotNull(moveTo.Children);
-        Assert.Equal(["New group\u2026"], moveTo.Children!.Select(item => item.Label).ToList());
+        Assert.Equal([Localizer["TabBar_Menu_NewGroup"].Value], moveTo.Children!.Select(item => item.Label).ToList());
 
         await InvokeMenuItemAsync(cut, FindItem(moveTo.Children!, "New group\u2026"));
 
@@ -474,7 +538,7 @@ public sealed class LogTabBarTests : BunitContext
 
         var labels = menu.Select(item => item.Label).ToList();
         Assert.Equal(
-            ["Move to group", "Remove from group", string.Empty, "Close", "Close others in group", "Close other tabs"],
+            [Localizer["TabBar_Menu_MoveToGroup"].Value, Localizer["TabBar_Menu_RemoveFromGroup"].Value, string.Empty, Localizer["TabBar_Menu_Close"].Value, Localizer["TabBar_Menu_CloseOthersInGroup"].Value, Localizer["TabBar_Menu_CloseOtherTabs"].Value],
             labels);
     }
 
@@ -488,7 +552,7 @@ public sealed class LogTabBarTests : BunitContext
 
         var cut = Render<LogTabBar>();
 
-        Assert.DoesNotContain("(Empty)", cut.Markup);
+        Assert.DoesNotContain("[[TabBar_TabName_Empty", cut.Markup);
     }
 
     [Fact]
@@ -498,11 +562,11 @@ public sealed class LogTabBarTests : BunitContext
         var beta = EventLogId.Create();
         _logTableState.Value.Returns(TwoTabState(alpha, beta));
         var cut = Render<LogTabBar>();
-        Assert.DoesNotContain("(Empty) Alpha", cut.Markup);
+        Assert.DoesNotContain(Localizer["TabBar_TabName_Empty", "Alpha"].Value, cut.Markup);
 
         await RaisePresenceChange(cut, Presence((alpha, false), (beta, true)));
 
-        Assert.Contains("(Empty) Alpha", cut.Markup);
+        Assert.Contains("[[TabBar_TabName_Empty(", cut.Markup);
     }
 
     [Fact]
@@ -538,7 +602,7 @@ public sealed class LogTabBarTests : BunitContext
         var beta = EventLogId.Create();
         _logTableState.Value.Returns(TwoTabState(alpha, beta));
         _alertDialogService
-            .DisplayPrompt("New group", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Func<string, string?>?>())
+            .DisplayPrompt(Localizer["TabBar_Prompt_NewGroupTitle"].Value, Localizer["TabBar_Prompt_GroupNameLabel"].Value, Arg.Any<string>(), Arg.Any<Func<string, string?>?>())
             .Returns("   ");
         var cut = Render<LogTabBar>();
         var menu = OpenContextMenu(cut, ".tab");
@@ -597,8 +661,13 @@ public sealed class LogTabBarTests : BunitContext
         var alpha = EventLogId.Create();
         var beta = EventLogId.Create();
         _logTableState.Value.Returns(TwoTabState(alpha, beta));
+        Func<string, string?>? validator = null;
         _alertDialogService
-            .DisplayPrompt("New group", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Func<string, string?>?>())
+            .DisplayPrompt(
+                Localizer["TabBar_Prompt_NewGroupTitle"].Value,
+                Localizer["TabBar_Prompt_GroupNameLabel"].Value,
+                Arg.Any<string>(),
+                Arg.Do<Func<string, string?>?>(callback => validator = callback))
             .Returns("Diagnostics");
         var cut = Render<LogTabBar>();
         var menu = OpenContextMenu(cut, ".tab");
@@ -606,6 +675,9 @@ public sealed class LogTabBarTests : BunitContext
         await InvokeMenuItemAsync(cut, FindItem(menu, "New group from tab\u2026"));
 
         _logTableCommands.Received(1).NewGroupFromTab(alpha, "Diagnostics");
+        Assert.NotNull(validator);
+        Assert.Equal(Localizer["TabBar_Prompt_GroupNameRequired"].Value, validator(" "));
+        Assert.Null(validator("Diagnostics"));
     }
 
     [Fact]
@@ -615,7 +687,7 @@ public sealed class LogTabBarTests : BunitContext
         var beta = EventLogId.Create();
         _logTableState.Value.Returns(TwoTabState(alpha, beta));
         _alertDialogService
-            .DisplayPrompt("New group", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Func<string, string?>?>())
+            .DisplayPrompt(Localizer["TabBar_Prompt_NewGroupTitle"].Value, Localizer["TabBar_Prompt_GroupNameLabel"].Value, Arg.Any<string>(), Arg.Any<Func<string, string?>?>())
             .Returns("Diagnostics");
         var cut = Render<LogTabBar>();
         var menu = OpenContextMenu(cut, ".tab");
@@ -638,7 +710,39 @@ public sealed class LogTabBarTests : BunitContext
         var menu = OpenContextMenu(cut, ".tab");
 
         var labels = menu.Select(item => item.Label).ToList();
-        Assert.Equal(["New group from tab\u2026", "Move to group", string.Empty, "Close", "Close other tabs"], labels);
+        Assert.Equal([Localizer["TabBar_Menu_NewGroupFromTab"].Value, Localizer["TabBar_Menu_MoveToGroup"].Value, string.Empty, Localizer["TabBar_Menu_Close"].Value, Localizer["TabBar_Menu_CloseOtherTabs"].Value], labels);
+    }
+
+    [Fact]
+    public void TabTitlesAndLiveNames_RouteArgumentsThroughMarkerLocalizer()
+    {
+        var fileId = EventLogId.Create();
+        var liveId = EventLogId.Create();
+        _logTableState.Value.Returns(new LogTableState
+        {
+            ActiveEventLogId = fileId,
+            EventTables = ImmutableList.Create(
+                new LogView(fileId)
+                {
+                    FileName = @"C:\logs\Application.evtx",
+                    LogName = "Application",
+                    ComputerName = "FILEHOST",
+                    LogPathType = LogPathType.File
+                },
+                new LogView(liveId)
+                {
+                    LogName = "System",
+                    ComputerName = "LIVEHOST",
+                    LogPathType = LogPathType.Channel
+                })
+        });
+
+        var cut = Render<LogTabBar>();
+        var tabs = cut.FindAll(".tab");
+
+        Assert.Equal(Localizer["TabBar_Tooltip_File", @"C:\logs\Application.evtx", "Application", "FILEHOST"].Value, tabs[0].GetAttribute("title"));
+        Assert.Equal(Localizer["TabBar_Tooltip_Live", "System", "LIVEHOST"].Value, tabs[1].GetAttribute("title"));
+        Assert.Contains(Localizer["TabBar_TabName_Live", "System", "LIVEHOST"].Value, tabs[1].TextContent);
     }
 
     private static LogTableState AllLogsState(EventLogId allLogsId, EventLogId logId, string logName) =>
@@ -649,9 +753,6 @@ public sealed class LogTabBarTests : BunitContext
                 new LogView(allLogsId) { GroupId = LogTabGroupId.AllLogs },
                 new LogView(logId) { LogName = logName })
         };
-
-    private static MenuItem FindItem(IEnumerable<MenuItem> items, string label) =>
-        items.First(item => item.Label == label);
 
     private static (LogTableState State, LogTabGroupId GroupId, EventLogId Standalone) GroupPlusStandaloneState()
     {
@@ -761,8 +862,27 @@ public sealed class LogTabBarTests : BunitContext
                 new LogView(beta) { LogName = "Beta" })
         };
 
+    private MenuItem FindItem(IEnumerable<MenuItem> items, string label) =>
+        items.First(item => item.Label == LocalizedMenuLabel(label));
+
     private async Task InvokeMenuItemAsync(IRenderedComponent<LogTabBar> cut, MenuItem item) =>
         await cut.InvokeAsync(() => item.OnClickAsync!());
+
+    private string LocalizedMenuLabel(string label) => label switch
+    {
+        "Close all logs" => Localizer["TabBar_Menu_CloseAllLogs"].Value,
+        "Close" => Localizer["TabBar_Menu_Close"].Value,
+        "Close other tabs" => Localizer["TabBar_Menu_CloseOtherTabs"].Value,
+        "Close others in group" => Localizer["TabBar_Menu_CloseOthersInGroup"].Value,
+        "Expand" => Localizer["TabBar_Menu_Expand"].Value,
+        "Collapse" => Localizer["TabBar_Menu_Collapse"].Value,
+        "Move to group" => Localizer["TabBar_Menu_MoveToGroup"].Value,
+        "New group from tab\u2026" => Localizer["TabBar_Menu_NewGroupFromTab"].Value,
+        "New group\u2026" => Localizer["TabBar_Menu_NewGroup"].Value,
+        "Remove from group" => Localizer["TabBar_Menu_RemoveFromGroup"].Value,
+        "Rename\u2026" => Localizer["TabBar_Menu_Rename"].Value,
+        _ => label
+    };
 
     private IReadOnlyList<MenuItem> OpenContextMenu(IRenderedComponent<LogTabBar> cut, string selector)
     {

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTableLocalizerWiringTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTableLocalizerWiringTests.cs
@@ -1,0 +1,195 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Eventing.Resolvers;
+using EventLogExpert.Runtime.Common.Clipboard;
+using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.Runtime.Settings;
+using EventLogExpert.UI.LogTable;
+using EventLogExpert.UI.Tests.TestUtils;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using System.Reflection;
+using System.Xml.Linq;
+
+namespace EventLogExpert.UI.Tests.LogTable;
+
+public sealed class LogTableLocalizerWiringTests
+{
+    private readonly MarkerLocalizer _localizer = new();
+
+    public static TheoryData<bool, bool, bool, string, string, string> CellFilterCases => new()
+    {
+        { false, false, true, "Event ID", "1000", "[[CellFilter_IncludeWhereEquals(Event ID|1000)]]" },
+        { false, true, true, "Keywords", "Audit", "[[CellFilter_IncludeWhereHas(Keywords|Audit)]]" },
+        { true, false, true, "Source", "Provider", "[[CellFilter_ExcludeWhereEquals(Source|Provider)]]" },
+        { true, true, true, "Keywords", "Audit", "[[CellFilter_ExcludeWhereHas(Keywords|Audit)]]" },
+        { false, false, false, "Source", string.Empty, "[[CellFilter_IncludeWhereNoValue(Source)]]" },
+        { true, true, false, "Keywords", string.Empty, "[[CellFilter_ExcludeWhereNoValue(Keywords)]]" },
+    };
+
+    public static TheoryData<EventCopyFullField, string> EventCopyFieldCases => new()
+    {
+        { EventCopyFullField.LogName, "[[Copy_Full_LogName(value)]]" },
+        { EventCopyFullField.Source, "[[Copy_Full_Source(value)]]" },
+        { EventCopyFullField.Date, "[[Copy_Full_Date(value)]]" },
+        { EventCopyFullField.EventId, "[[Copy_Full_EventId(value)]]" },
+        { EventCopyFullField.TaskCategory, "[[Copy_Full_TaskCategory(value)]]" },
+        { EventCopyFullField.Level, "[[Copy_Full_Level(value)]]" },
+        { EventCopyFullField.Keywords, "[[Copy_Full_Keywords(value)]]" },
+        { EventCopyFullField.User, "[[Copy_Full_User(value)]]" },
+        { EventCopyFullField.UserSid, "[[Copy_Full_UserSid(value)]]" },
+        { EventCopyFullField.Computer, "[[Copy_Full_Computer(value)]]" },
+        { EventCopyFullField.DescriptionHeader, "[[Copy_Full_DescriptionHeader]]" },
+        { EventCopyFullField.EventXmlHeader, "[[Copy_Full_EventXmlHeader]]" },
+    };
+
+    [Fact]
+    public void DateColumnHeader_RoutesBothTimeZoneBranchesThroughLocalizer()
+    {
+        var pane = new LogTablePane();
+        SetInjected(pane, "Localizer", _localizer);
+
+        var settings = Substitute.For<ISettingsService>();
+        settings.TimeZoneInfo.Returns(TimeZoneInfo.Local);
+        SetInjected(pane, "Settings", settings);
+        Assert.Equal("[[Table_ColumnHeader_DateAndTime]]", InvokeDateHeader(pane));
+
+        TimeZoneInfo alternateZone = TimeZoneInfo.CreateCustomTimeZone(
+            "l4-marker-zone",
+            TimeSpan.FromHours(3),
+            "Marker Zone Standard Time",
+            "Marker Zone Standard Time");
+        Assert.NotEqual(TimeZoneInfo.Local, alternateZone);
+        settings.TimeZoneInfo.Returns(alternateZone);
+        Assert.Equal($"[[Table_ColumnHeader_DateAndTimeWithZone({alternateZone.DisplayName.Split(' ')[0]})]]", InvokeDateHeader(pane));
+    }
+
+    [Fact]
+    public void EventCopyFormatterComposition_UsesUiEventCopyTextRegistration()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddEventLogRuntime();
+        services.AddEventLogLocalization();
+        services.AddEventLogUIServices();
+        services.AddSingleton(Substitute.For<IEventDetailResolver>());
+        services.AddSingleton(Substitute.For<IEventXmlResolver>());
+
+        using var provider = services.BuildServiceProvider();
+
+        Assert.IsType<EventCopyText>(provider.GetRequiredService<IEventCopyText>());
+        Assert.NotNull(provider.GetRequiredService<IEventCopyFormatter>());
+    }
+
+    [Fact]
+    public void EventCopyFullField_CasesCoverEveryEnumMember()
+    {
+        EventCopyFullField[] tested = [EventCopyFullField.LogName, EventCopyFullField.Source, EventCopyFullField.Date, EventCopyFullField.EventId, EventCopyFullField.TaskCategory, EventCopyFullField.Level, EventCopyFullField.Keywords, EventCopyFullField.User, EventCopyFullField.UserSid, EventCopyFullField.Computer, EventCopyFullField.DescriptionHeader, EventCopyFullField.EventXmlHeader];
+        tested = [.. tested.Order()];
+        var defined = Enum.GetValues<EventCopyFullField>().Order().ToArray();
+
+        Assert.Equal(defined, tested);
+    }
+
+    [Fact]
+    public void EventCopyText_FieldLine_IgnoresHeadingValues()
+    {
+        EventCopyText text = new(_localizer);
+
+        Assert.Equal("[[Copy_Full_DescriptionHeader]]", text.FieldLine(EventCopyFullField.DescriptionHeader, "ignored"));
+        Assert.Equal("[[Copy_Full_EventXmlHeader]]", text.FieldLine(EventCopyFullField.EventXmlHeader, "ignored"));
+    }
+
+    [Theory]
+    [MemberData(nameof(EventCopyFieldCases))]
+    public void EventCopyText_FieldLine_MapsEveryFieldToLiteralKey(EventCopyFullField field, string expected)
+    {
+        EventCopyText text = new(_localizer);
+
+        Assert.Equal(expected, text.FieldLine(field, "value"));
+    }
+
+    [Fact]
+    public void EventCopyText_HeadingResources_HaveNoPlaceholderOrTrailingWhitespace()
+    {
+        var values = LoadSharedResourceData()
+            .Where(data => data.Attribute("name")?.Value is "Copy_Full_DescriptionHeader" or "Copy_Full_EventXmlHeader")
+            .ToDictionary(data => data.Attribute("name")!.Value, data => data.Element("value")!.Value);
+
+        Assert.Equal(2, values.Count);
+        foreach (string value in values.Values)
+        {
+            Assert.DoesNotContain("{0}", value, StringComparison.Ordinal);
+            Assert.Equal(value.TrimEnd(), value);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(CellFilterCases))]
+    public void LogTableCellFilterLocalizer_ChoosesWholeStringTemplate(bool exclude, bool isKeywords, bool hasValue, string column, string value, string expected)
+    {
+        string actual = LogTableCellFilterLocalizer.Describe(_localizer, exclude, isKeywords, hasValue, column, value);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void TabBarResources_UseRealLineFeedsAndEllipsisCharacters()
+    {
+        var values = LoadSharedResourceData()
+            .Where(data => data.Attribute("name")?.Value is
+                "TabBar_Tooltip_File" or
+                "TabBar_Tooltip_Live" or
+                "TabBar_Menu_Rename" or
+                "TabBar_Menu_NewGroup" or
+                "TabBar_Menu_NewGroupFromTab" or
+                "Table_LoadingEvents" or
+                "Table_ReorderingEvents")
+            .ToDictionary(data => data.Attribute("name")!.Value, data => data.Element("value")!.Value);
+
+        Assert.Equal(2, values["TabBar_Tooltip_File"].Count(character => character == '\n'));
+        Assert.Equal(1, values["TabBar_Tooltip_Live"].Count(character => character == '\n'));
+        Assert.DoesNotContain(@"\n", values["TabBar_Tooltip_File"], StringComparison.Ordinal);
+        Assert.DoesNotContain(@"\n", values["TabBar_Tooltip_Live"], StringComparison.Ordinal);
+
+        foreach (var key in new[] { "TabBar_Menu_Rename", "TabBar_Menu_NewGroup", "TabBar_Menu_NewGroupFromTab", "Table_LoadingEvents", "Table_ReorderingEvents" })
+        {
+            Assert.Contains('…', values[key]);
+            Assert.DoesNotContain("...", values[key], StringComparison.Ordinal);
+        }
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        DirectoryInfo? directory = new(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "EventLogExpert.slnx")))
+        {
+            directory = directory.Parent;
+        }
+
+        Assert.NotNull(directory);
+        return directory.FullName;
+    }
+
+    private static string InvokeDateHeader(LogTablePane pane)
+    {
+        var method = typeof(LogTablePane).GetMethod("GetDateColumnHeader", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        return Assert.IsType<string>(method.Invoke(pane, []));
+    }
+
+    private static IEnumerable<XElement> LoadSharedResourceData()
+    {
+        string root = FindRepositoryRoot();
+        string path = Path.Combine(root, "src", "EventLogExpert.Localization", "Resources", "SharedResource.resx");
+        return XDocument.Load(path).Root!.Elements("data");
+    }
+
+    private static void SetInjected<TValue>(LogTablePane pane, string name, TValue value)
+    {
+        var property = typeof(LogTablePane).GetProperty(name, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(property);
+        property.SetValue(pane, value);
+    }
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneGroupingTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneGroupingTests.cs
@@ -6,6 +6,7 @@ using EventLogExpert.Eventing.Common.Channels;
 using EventLogExpert.Eventing.Common.EventLogs;
 using EventLogExpert.Eventing.Common.Events;
 using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Localization;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.Runtime.FilterPane;
 using EventLogExpert.Runtime.LogTable;
@@ -18,6 +19,7 @@ using Fluxor;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.Web.Virtualization;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using NSubstitute;
 using System.Collections.Immutable;
 using System.Globalization;
@@ -62,6 +64,7 @@ public sealed class LogTablePaneGroupingTests : CultureSensitiveBunitContext
         _selectedEvents.Current.Returns(ImmutableList<SelectionEntry>.Empty);
 
         Services.AddLogTablePaneDependencies();
+        Services.AddSingleton<IStringLocalizer<SharedResource>>(new MarkerLocalizer());
         Services.AddImmediateCpuWorkScheduler();
         Services.AddSingleton(_columnDefaults);
         Services.AddSingleton(_eventLogCommands);
@@ -236,7 +239,7 @@ public sealed class LogTablePaneGroupingTests : CultureSensitiveBunitContext
         var cut = RenderGrouped(Collapsed(), Event(1, "Alpha"));
         cut.Find("tr.group-header-row").TriggerEvent("oncontextmenu", new MouseEventArgs { Button = 2 });
 
-        await items!.First(m => m.Label == "Collapse All Groups").OnClickAsync!();
+        await items!.First(m => m.Label == "[[Menu_View_CollapseAllGroups]]").OnClickAsync!();
 
         _logTableCommands.Received(1).SetAllGroupsCollapsed(true);
     }
@@ -254,7 +257,7 @@ public sealed class LogTablePaneGroupingTests : CultureSensitiveBunitContext
         var cut = RenderGrouped(Collapsed(), Event(1, "Alpha"), Event(2, "Alpha"), Event(3, "Beta"));
         cut.Find("tr.group-header-row").TriggerEvent("oncontextmenu", new MouseEventArgs { Button = 2 });
 
-        await items!.First(item => item.Label == "Select Group").OnClickAsync!();
+        await items!.First(item => item.Label == "[[LogTable_SelectGroup]]").OnClickAsync!();
 
         _eventLogCommands.Received(1).SetSelectedEvents(
             Arg.Is<IReadOnlyCollection<SelectionEntry>>(c => c != null && c.Count == 2),
@@ -509,10 +512,10 @@ public sealed class LogTablePaneGroupingTests : CultureSensitiveBunitContext
         cut.Find("tr.group-header-row").TriggerEvent("oncontextmenu", new MouseEventArgs { Button = 2 });
 
         Assert.NotNull(items);
-        Assert.Contains(items!, m => m.Label == "Expand All Groups");
-        Assert.Contains(items!, m => m.Label == "Collapse All Groups");
-        Assert.Contains(items!, m => m.Label == "Group Descending");
-        Assert.Contains(items!, m => m.Label == "Select Group");
+        Assert.Contains(items!, m => m.Label == "[[Menu_View_ExpandAllGroups]]");
+        Assert.Contains(items!, m => m.Label == "[[Menu_View_CollapseAllGroups]]");
+        Assert.Contains(items!, m => m.Label == "[[Menu_View_GroupDescending]]");
+        Assert.Contains(items!, m => m.Label == "[[LogTable_SelectGroup]]");
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneIndicatorTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneIndicatorTests.cs
@@ -6,6 +6,7 @@ using EventLogExpert.Eventing.Common.Channels;
 using EventLogExpert.Eventing.Common.EventLogs;
 using EventLogExpert.Eventing.Common.Events;
 using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Localization;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.Runtime.FilterPane;
 using EventLogExpert.Runtime.LogTable;
@@ -15,6 +16,7 @@ using EventLogExpert.UI.Menu;
 using EventLogExpert.UI.Tests.TestUtils;
 using Fluxor;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using NSubstitute;
 using System.Collections.Immutable;
 using System.Globalization;
@@ -55,6 +57,7 @@ public sealed class LogTablePaneIndicatorTests : CultureSensitiveBunitContext
         _selectedEvents.Current.Returns(ImmutableList<SelectionEntry>.Empty);
 
         Services.AddLogTablePaneDependencies();
+        Services.AddSingleton<IStringLocalizer<SharedResource>>(new MarkerLocalizer());
         Services.AddImmediateCpuWorkScheduler();
         Services.AddSingleton(_columnDefaults);
         Services.AddSingleton(_eventLogCommands);
@@ -74,6 +77,20 @@ public sealed class LogTablePaneIndicatorTests : CultureSensitiveBunitContext
     }
 
     [Fact]
+    public void AFailedViewWithoutCause_RoutesNoCauseFaultPrefixThroughLocalizer()
+    {
+        SetCommittedState();
+
+        _viewSource.Current.Returns(Presentation(PresentationState.Faulted, rows: 0, revision: 1, faultCause: null));
+
+        var cut = Render<LogTablePane>();
+
+        _delay.Elapse();
+
+        cut.WaitForAssertion(() => Assert.Contains("[[Table_FaultPrefix]]", cut.Markup));
+    }
+
+    [Fact]
     public void AFailedView_SaysSo_AndSaysWhy()
     {
         SetCommittedState();
@@ -86,9 +103,22 @@ public sealed class LogTablePaneIndicatorTests : CultureSensitiveBunitContext
 
         cut.WaitForAssertion(() =>
         {
-            Assert.Contains("could not be prepared", cut.Markup);
-            Assert.Contains("bad predicate", cut.Markup);
+            Assert.Contains("[[Table_FaultPrefixWithCause(InvalidOperationException: bad predicate)]]", cut.Markup);
         });
+    }
+
+    [Fact]
+    public void AStaleReorderingView_RoutesReorderingTextThroughLocalizer()
+    {
+        SetCommittedState();
+
+        _viewSource.Current.Returns(Presentation(PresentationState.Updating, rows: 1, revision: 1, orderingIsStale: true));
+
+        var cut = Render<LogTablePane>();
+
+        _delay.Elapse();
+
+        cut.WaitForAssertion(() => Assert.Contains("[[Table_ReorderingEvents]]", cut.Markup));
     }
 
     [Fact]
@@ -102,7 +132,7 @@ public sealed class LogTablePaneIndicatorTests : CultureSensitiveBunitContext
 
         _delay.Elapse();
 
-        cut.WaitForAssertion(() => Assert.Contains("Loading events", cut.Markup));
+        cut.WaitForAssertion(() => Assert.Contains("[[Table_LoadingEvents]]", cut.Markup));
     }
 
     [Fact]
@@ -114,7 +144,7 @@ public sealed class LogTablePaneIndicatorTests : CultureSensitiveBunitContext
 
         var cut = Render<LogTablePane>();
 
-        Assert.DoesNotContain("could not be prepared", cut.Markup);
+        Assert.DoesNotContain("[[Table_FaultPrefixWithCause", cut.Markup);
     }
 
     [Fact]
@@ -140,14 +170,20 @@ public sealed class LogTablePaneIndicatorTests : CultureSensitiveBunitContext
             LogName = LogName
         };
 
-    private OrderedViewPresentation Presentation(PresentationState state, int rows, long revision) =>
+    private OrderedViewPresentation Presentation(
+        PresentationState state,
+        int rows,
+        long revision,
+        string? faultCause = "InvalidOperationException: bad predicate",
+        bool orderingIsStale = false) =>
         new(
             DisplayViewTestFactory.Identity([.. Enumerable.Range(1, rows).Select(index => Event(index))]),
             _logId,
             default,
             state,
             revision,
-            FaultCause: state == PresentationState.Faulted ? "InvalidOperationException: bad predicate" : null);
+            FaultCause: state == PresentationState.Faulted ? faultCause : null,
+            OrderingIsStale: orderingIsStale);
 
     private void SetCommittedState() =>
         _logTableState.Value.Returns(new LogTableState

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneLocalizationTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTablePaneLocalizationTests.cs
@@ -1,0 +1,239 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using EventLogExpert.Eventing.Common.Channels;
+using EventLogExpert.Eventing.Common.EventLogs;
+using EventLogExpert.Eventing.Common.Events;
+using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Localization;
+using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.FilterPane;
+using EventLogExpert.Runtime.LogTable;
+using EventLogExpert.Runtime.Settings;
+using EventLogExpert.UI.LogTable;
+using EventLogExpert.UI.Menu;
+using EventLogExpert.UI.Tests.TestUtils;
+using Fluxor;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using NSubstitute;
+using System.Collections.Immutable;
+using System.Globalization;
+
+namespace EventLogExpert.UI.Tests.LogTable;
+
+[Collection(CultureSensitiveCollection.Name)]
+public sealed class LogTablePaneLocalizationTests : CultureSensitiveBunitContext
+{
+    private const string LogName = "Application";
+
+    private readonly ILogTableColumnDefaultsProvider _columnDefaults = Substitute.For<ILogTableColumnDefaultsProvider>();
+    private readonly IEventLogCommands _eventLogCommands = Substitute.For<IEventLogCommands>();
+    private readonly EventLogId _logId = EventLogId.Create();
+    private readonly ILogTableCommands _logTableCommands = Substitute.For<ILogTableCommands>();
+    private readonly IState<LogTableState> _logTableState = Substitute.For<IState<LogTableState>>();
+    private readonly IMenuService _menuService = Substitute.For<IMenuService>();
+    private readonly IEventFocusSource _selectedEvent = Substitute.For<IEventFocusSource>();
+    private readonly ISettingsService _settings = Substitute.For<ISettingsService>();
+    private readonly IOrderedViewSource _viewSource = Substitute.For<IOrderedViewSource>();
+
+    private IReadOnlyList<MenuItem>? _capturedMenu;
+    private OrderedViewPresentation? _presentation;
+    private long _presentationRevision;
+
+    public LogTablePaneLocalizationTests()
+    {
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        JSInterop.SetupModule("./_content/EventLogExpert.UI/LogTable/LogTablePane.razor.js");
+
+        _columnDefaults.ColumnOrder.Returns(ImmutableList.Create(ColumnName.Source, ColumnName.DateAndTime));
+        _selectedEvent.Current.Returns((SelectionEntry?)null);
+        _settings.TimeZoneInfo.Returns(TimeZoneInfo.Local);
+        _viewSource.Current.Returns(_ => _presentation);
+        _menuService
+            .When(menu => menu.OpenAt(
+                Arg.Any<double>(),
+                Arg.Any<double>(),
+                Arg.Any<IReadOnlyList<MenuItem>>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>()))
+            .Do(call => _capturedMenu = call.ArgAt<IReadOnlyList<MenuItem>>(2));
+
+        Services.AddLogTablePaneDependencies();
+        Services.AddSingleton<IStringLocalizer<SharedResource>>(new MarkerLocalizer());
+        Services.AddImmediateCpuWorkScheduler();
+        Services.AddSingleton(_columnDefaults);
+        Services.AddSingleton(_eventLogCommands);
+        var filterPaneState = Substitute.For<IState<FilterPaneState>>();
+        filterPaneState.Value.Returns(new FilterPaneState());
+        Services.AddSingleton(filterPaneState);
+        var highlightSelector = Substitute.For<IHighlightSelector>();
+        highlightSelector.Select(Arg.Any<ImmutableList<SavedFilter>>()).Returns([]);
+        highlightSelector.ComputeHighlightKey(Arg.Any<ImmutableList<SavedFilter>>()).Returns(0);
+        Services.AddSingleton(highlightSelector);
+        Services.AddSingleton(_logTableState);
+        Services.AddSingleton(_selectedEvent);
+        var eventSelection = Substitute.For<IEventSelectionSource>();
+        eventSelection.Current.Returns(ImmutableList<SelectionEntry>.Empty);
+        Services.AddSingleton(eventSelection);
+        Services.AddSingleton(_settings);
+        Services.AddSingleton(_logTableCommands);
+        Services.AddSingleton(_menuService);
+        Services.AddSingleton(_viewSource);
+        Services.AddFluxor(options => options.ScanAssemblies(typeof(LogTablePane).Assembly));
+    }
+
+    [Fact]
+    public void ColumnMenu_RoutesEveryChromeItemThroughMarkerLocalizer()
+    {
+        var cut = RenderTable(groupBy: null, ImmutableHashSet<string>.Empty, orderBy: ColumnName.Source, Event(1, "Alpha"));
+
+        OpenMenu(cut, "thead");
+
+        AssertMenuContains("[[LogTable_OrderBy]]");
+        AssertMenuContains("[[LogTable_GroupBy]]");
+        AssertMenuContains("[[LogTable_GroupByNone]]", ChildrenOf("[[LogTable_GroupBy]]"));
+        AssertMenuContains("[[LogTable_ResetColumnDefaults]]");
+    }
+
+    [Fact]
+    public void EventContextMenu_RoutesEveryEventActionThroughMarkerLocalizer()
+    {
+        var @event = Event(1, "Alpha");
+        var cut = RenderTable(groupBy: null, ImmutableHashSet<string>.Empty, orderBy: ColumnName.Source, @event);
+        _selectedEvent.Current.Returns(Focus(@event, 0));
+
+        OpenMenu(cut, "tbody");
+
+        AssertMenuContains("[[Menu_Edit_CopySelected]]");
+        AssertMenuContains("[[Menu_Edit_CopySelectedSimple]]");
+        AssertMenuContains("[[Menu_Edit_CopySelectedXml]]");
+        AssertMenuContains("[[Menu_Edit_CopySelectedFull]]");
+        AssertMenuContains("[[LogTable_ExcludeEventsBefore]]");
+        AssertMenuContains("[[LogTable_ExcludeEventsAfter]]");
+        AssertMenuContains("[[LogTable_ShowRelatedByActivityId]]");
+        AssertMenuContains("[[LogTable_ShowSharingRelatedActivityId]]");
+        AssertMenuContains("[[LogTable_ShowParentActivity]]");
+        Assert.Contains(_capturedMenu!, item => item.DisabledReason == "[[LogTable_NoActivityIdReason]]");
+        Assert.Contains(_capturedMenu!, item => item.DisabledReason == "[[LogTable_NoRelatedActivityIdReason]]");
+
+        var nearTime = ChildrenOf("[[LogTable_ShowEventsNearTime]]");
+        AssertMenuContains("[[LogTable_NearTime_30Seconds]]", nearTime);
+        AssertMenuContains("[[LogTable_NearTime_1Minute]]", nearTime);
+        AssertMenuContains("[[LogTable_NearTime_5Minutes]]", nearTime);
+        AssertMenuContains("[[LogTable_NearTime_15Minutes]]", nearTime);
+        AssertMenuContains("[[LogTable_NearTime_1Hour]]", nearTime);
+
+        var moreFields = ChildrenOf("[[LogTable_MoreFields]]");
+        AssertMenuContains("[[LogTable_Include]]", moreFields);
+        AssertMenuContains("[[LogTable_Exclude]]", moreFields);
+        Assert.Contains(moreFields.SelectMany(item => item.Children ?? []), item => item.DisabledReason == "[[LogTable_NoCellValue]]");
+    }
+
+    [Fact]
+    public void GroupContextMenu_RoutesEveryGroupActionThroughMarkerLocalizer()
+    {
+        var expanded = RenderTable(ColumnName.Source, ImmutableHashSet<string>.Empty, orderBy: ColumnName.Source, Event(1, "Alpha"));
+        OpenMenu(expanded, "tr.group-header-row");
+
+        AssertMenuContains("[[LogTable_CollapseGroup]]");
+        AssertMenuContains("[[Menu_View_ExpandAllGroups]]");
+        AssertMenuContains("[[Menu_View_CollapseAllGroups]]");
+        AssertMenuContains("[[Menu_View_GroupDescending]]");
+        AssertMenuContains("[[LogTable_SelectGroup]]");
+
+        var collapsed = RenderTable(ColumnName.Source, ImmutableHashSet.Create(StringComparer.Ordinal, "Alpha"), orderBy: ColumnName.Source, Event(1, "Alpha"));
+        OpenMenu(collapsed, "tr.group-header-row");
+
+        AssertMenuContains("[[LogTable_ExpandGroup]]");
+    }
+
+    [Fact]
+    public void GroupHeader_WhenGroupValueIsEmpty_RoutesPlaceholderThroughMarkerLocalizer()
+    {
+        var cut = RenderTable(ColumnName.Source, ImmutableHashSet<string>.Empty, orderBy: ColumnName.Source, Event(1, string.Empty));
+
+        Assert.Contains("[[LogTable_GroupValueNone]]", cut.Find("tr.group-header-row").TextContent);
+    }
+
+    [Fact]
+    public void TableDom_RoutesAriaSortAndDescriptionHeaderThroughMarkerLocalizer()
+    {
+        var cut = RenderTable(groupBy: null, ImmutableHashSet<string>.Empty, orderBy: ColumnName.Source, Event(1, "Alpha"));
+
+        Assert.Equal("[[Table_Aria]]", cut.Find("table#eventTable").GetAttribute("aria-label"));
+        Assert.Equal("[[Table_ToggleSortAria]]", cut.Find("button.menu-toggle").GetAttribute("aria-label"));
+        Assert.Contains("[[Table_ColumnHeader_Description]]", cut.Find("th.description").TextContent);
+    }
+
+    private static void AssertMenuContains(string label, IReadOnlyList<MenuItem> items) =>
+        Assert.Contains(items, item => item.Label == label);
+
+    private static ResolvedEvent Event(int id, string source) =>
+        new(LogName, LogPathType.Channel)
+        {
+            Id = id,
+            RecordId = id,
+            Source = source,
+            TimeCreated = new DateTime(2024, 1, 1, 0, 0, id, DateTimeKind.Utc),
+            Description = $"event {id}"
+        };
+
+    private void AssertMenuContains(string label) => AssertMenuContains(label, _capturedMenu!);
+
+    private IReadOnlyList<MenuItem> ChildrenOf(string label)
+    {
+        var item = _capturedMenu!.First(item => item.Label == label);
+        Assert.NotNull(item.Children);
+        return item.Children!;
+    }
+
+    private SelectionEntry Focus(ResolvedEvent evt, int physicalIndex)
+    {
+        var handle = new EventLocator(_logId, 0, physicalIndex);
+        ValueKey.TryCreate(evt, out var reloadKey);
+        return new SelectionEntry(handle, handle, reloadKey);
+    }
+
+    private void OpenMenu(IRenderedComponent<LogTablePane> cut, string selector)
+    {
+        _capturedMenu = null;
+        cut.Find(selector).TriggerEvent("oncontextmenu", new MouseEventArgs());
+        Assert.NotNull(_capturedMenu);
+    }
+
+    private IRenderedComponent<LogTablePane> RenderTable(
+        ColumnName? groupBy,
+        ImmutableHashSet<string> collapsed,
+        ColumnName? orderBy,
+        params ResolvedEvent[] events)
+    {
+        _presentation = DisplayViewTestFactory.Presentation(
+            _logId,
+            events,
+            orderBy,
+            isDescending: false,
+            groupBy,
+            groupCollapseOverrides: collapsed,
+            revision: ++_presentationRevision);
+
+        _logTableState.Value.Returns(new LogTableState
+        {
+            ActiveEventLogId = _logId,
+            EventTables = ImmutableList.Create(new LogView(_logId) { LogName = LogName }),
+            Columns = ImmutableDictionary<ColumnName, bool>.Empty
+                .Add(ColumnName.Source, true)
+                .Add(ColumnName.DateAndTime, true),
+            ColumnOrder = ImmutableList.Create(ColumnName.Source, ColumnName.DateAndTime),
+            OrderBy = orderBy,
+            GroupBy = groupBy,
+            GroupCollapseOverrides = collapsed
+        });
+
+        return Render<LogTablePane>();
+    }
+}


### PR DESCRIPTION
Localizes the **Log Table + tab bar + context menu** UI to `IStringLocalizer<SharedResource>` (roadmap increment **L4**), under a strict byte-identical en-US contract.

> **Stacked on #711** (`jschick/a11y-ct-aug26`). Base is the a11y branch, not `main`, to absorb the LogTable/resx overlap once. Rebase onto `main` after #711 merges.

## What changed
- **~40 UI-B strings** across `LogTablePane`/`LogTabBar`: table aria (`Table_Aria`, `Table_ToggleSortAria`), both Date-header zone branches, the right-click **context menu** (cell-filter whole-string templates, near-time ±N presets, group ops, `Order By`/`Group By`/`Reset Column Defaults`, disabled reasons), and the **tab bar** (context menus, tooltips, `Combined`/`(Empty)` tab-names, `New group`/`Rename` prompts).
- **Typed copy-label eviction** — `EventCopyFormatter` (Runtime) no longer authors display English: a **host-supplied `IEventCopyText`** port (Runtime interface, UI-localized impl, no Runtime English) supplies the "Copy (Full)" body via whole-line templates.
- **7 existing `Menu_*` keys reused** (byte-identical); 80 net-new additive resx keys (0 existing values changed).
- **Integration with #711**: resolved the `<table>` aria conflict and localized #711's newly-added tab-bar `title` tooltips (reusing L4 keys) so the tab bar is fully localized.

## Verification
- Release build **0W/0E**; full Unit suite **7,993 / 0 / 0** (stacked on #711).
- Byte-identical en-US; tests assert behavior (MarkerLocalizer routing / DOM receipts / structural), not UI copy.
- Design panel **4/4 DESIGN_READY**; post-code panel **6/6 LGTM**.

## Recorded residuals (by design)
- `ColumnName`/`EventProperty` display (`.ToFullString()`) → **L13**.
- CSV/JSON export headers stay invariant (data-interchange) → **L6**.
