### PR TITLE
Localize the banner components

### DIFF
--- a/src/EventLogExpert.Localization/Resources/SharedResource.resx
+++ b/src/EventLogExpert.Localization/Resources/SharedResource.resx
@@ -225,6 +225,103 @@
     <value>Alert</value>
     <comment>Accessible name for a titleless inline alert.</comment>
   </data>
+  <!-- Banner components: chrome, fallback errors, and progress text. -->
+  <data name="Banner_Attention_DismissAria" xml:space="preserve">
+    <value>Dismiss attention banner</value>
+    <comment>Accessible label for the attention banner dismiss button.</comment>
+  </data>
+  <data name="Banner_Attention_ErrorTitle" xml:space="preserve">
+    <value>Databases</value>
+    <comment>Title used when the attention banner posts a fallback database error.</comment>
+  </data>
+  <data name="Banner_Attention_Many" xml:space="preserve">
+    <value>{0} databases need attention. Open Databases to enable or remove them.</value>
+    <comment>Attention banner message for multiple databases. {0} is a raw database count.</comment>
+  </data>
+  <data name="Banner_Attention_One" xml:space="preserve">
+    <value>{0} database needs attention. Open Databases to enable or remove them.</value>
+    <comment>Attention banner message for one database. {0} is the raw database count.</comment>
+  </data>
+  <data name="Banner_Attention_OpenDatabases" xml:space="preserve">
+    <value>Open Databases</value>
+    <comment>Button text that opens the database tools from the attention banner.</comment>
+  </data>
+  <data name="Banner_Attention_OpenFailed" xml:space="preserve">
+    <value>Failed to open databases; try again from the menu.</value>
+    <comment>Fallback error message when the database tools action returns unsuccessful with no detail.</comment>
+  </data>
+  <data name="Banner_Attention_OpenFailedDetail" xml:space="preserve">
+    <value>Failed to open databases: {0}</value>
+    <comment>Fallback error message when opening database tools throws. {0} is the exception message.</comment>
+  </data>
+  <data name="Banner_Critical_Copied" xml:space="preserve">
+    <value>Copied</value>
+    <comment>Temporary status chip shown after copying critical-error details.</comment>
+  </data>
+  <data name="Banner_Critical_CopyDetails" xml:space="preserve">
+    <value>Copy details</value>
+    <comment>Button text for copying critical-error details.</comment>
+  </data>
+  <data name="Banner_Critical_RecoveryFailed" xml:space="preserve">
+    <value>Recovery failed: {0}</value>
+    <comment>Critical banner recovery failure subtitle. {0} is the exception message.</comment>
+  </data>
+  <data name="Banner_Critical_Relaunch" xml:space="preserve">
+    <value>Relaunch</value>
+    <comment>Button text for restarting the app after a critical error.</comment>
+  </data>
+  <data name="Banner_Critical_Reload" xml:space="preserve">
+    <value>Reload</value>
+    <comment>Button text for retrying recovery after a critical error.</comment>
+  </data>
+  <data name="Banner_Critical_RestartFailed" xml:space="preserve">
+    <value>Restart failed; please close and reopen manually.</value>
+    <comment>Critical banner subtitle shown when app relaunch fails.</comment>
+  </data>
+  <data name="Banner_Critical_Unexpected" xml:space="preserve">
+    <value>An unexpected error occurred: {0}: {1}</value>
+    <comment>Critical banner headline. {0} is the exception type name; {1} is the exception message.</comment>
+  </data>
+  <data name="Banner_Error_DismissAria" xml:space="preserve">
+    <value>Dismiss error banner</value>
+    <comment>Accessible label for the error banner dismiss button.</comment>
+  </data>
+  <data name="Banner_Info_DismissAria" xml:space="preserve">
+    <value>Dismiss banner</value>
+    <comment>Accessible label for the info or warning banner dismiss button.</comment>
+  </data>
+  <data name="Banner_Nav_NextAria" xml:space="preserve">
+    <value>Next banner</value>
+    <comment>Accessible label for the banner carousel next button.</comment>
+  </data>
+  <data name="Banner_Nav_PreviousAria" xml:space="preserve">
+    <value>Previous banner</value>
+    <comment>Accessible label for the banner carousel previous button.</comment>
+  </data>
+  <data name="Banner_Pagination" xml:space="preserve">
+    <value>{0} of {1}</value>
+    <comment>Banner carousel page count. {0} is the displayed banner index; {1} is the total banner count.</comment>
+  </data>
+  <data name="Banner_Upgrade_InProgress" xml:space="preserve">
+    <value>Upgrading database {0} of {1}: {2} - {3}</value>
+    <comment>Upgrade progress banner message. {0} is current batch position; {1} is batch size; {2} is database name; {3} is the raw upgrade phase.</comment>
+  </data>
+  <data name="Banner_Upgrade_Preparing_Many" xml:space="preserve">
+    <value>Preparing upgrade of {0} databases…</value>
+    <comment>Upgrade progress preparing message for multiple databases. {0} is the raw database count.</comment>
+  </data>
+  <data name="Banner_Upgrade_Preparing_One" xml:space="preserve">
+    <value>Preparing upgrade of {0} database…</value>
+    <comment>Upgrade progress preparing message for one database. {0} is the raw database count.</comment>
+  </data>
+  <data name="Banner_Upgrade_QueuedBatches_Many" xml:space="preserve">
+    <value>(+{0} batches queued)</value>
+    <comment>Upgrade progress subtitle for multiple queued batches. {0} is the raw queued-batch count.</comment>
+  </data>
+  <data name="Banner_Upgrade_QueuedBatches_One" xml:space="preserve">
+    <value>(+{0} batch queued)</value>
+    <comment>Upgrade progress subtitle for one queued batch. {0} is the raw queued-batch count.</comment>
+  </data>
   <!-- Dashboard (empty-state welcome screen): masthead + Quick Launch. -->
   <data name="Dashboard_Lead" xml:space="preserve">
     <value>Open a log to get started, or jump straight into a common investigation.</value>
@@ -1504,10 +1601,10 @@
     <comment>{0} is the filter expression text authored by the user or loaded from the library.</comment>
   </data>
   <data name="FilterEditor_ExcludeToggle_TitleExcluded" xml:space="preserve">
-    <value>Excluded — click to include</value>
+    <value>Excluded - click to include</value>
   </data>
   <data name="FilterEditor_ExcludeToggle_TitleIncluded" xml:space="preserve">
-    <value>Included — click to exclude</value>
+    <value>Included - click to exclude</value>
   </data>
   <data name="FilterEditor_RowHeader_NoFilterSpecified" xml:space="preserve">
     <value>No Filter Specified</value>

--- a/src/EventLogExpert.UI/Banner/AttentionBanner.razor
+++ b/src/EventLogExpert.UI/Banner/AttentionBanner.razor
@@ -1,13 +1,13 @@
 <aside class="banner banner-attention" role="alert">
-    <span class="banner-message">@AttentionCount @DatabasesLabel @NeedsLabel attention. Open Databases to enable or remove them.</span>
+    <span class="banner-message">@LocalizedCount.OneOrManyRaw(Localizer, AttentionCount, "Banner_Attention_One", "Banner_Attention_Many")</span>
 
     @CycleNav
 
     <Button CssClass="banner-action" OnClick="OnOpenDatabasesClickedAsync">
-        Open Databases
+        @Localizer["Banner_Attention_OpenDatabases"]
     </Button>
 
-    <Button aria-label="Dismiss attention banner"
+    <Button aria-label='@Localizer["Banner_Attention_DismissAria"]'
         CssClass="banner-dismiss"
         IconClass="bi bi-x"
         OnClick="OnDismissAttention" />

--- a/src/EventLogExpert.UI/Banner/AttentionBanner.razor.cs
+++ b/src/EventLogExpert.UI/Banner/AttentionBanner.razor.cs
@@ -1,10 +1,12 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Localization;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Runtime.Banner;
 using EventLogExpert.Runtime.Menu;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
 using Microsoft.JSInterop;
 
 namespace EventLogExpert.UI.Banner;
@@ -19,13 +21,11 @@ public sealed partial class AttentionBanner : ComponentBase
 
     [Inject] private IAttentionBannerService AttentionBannerService { get; init; } = null!;
 
-    private string DatabasesLabel => AttentionCount == 1 ? "database" : "databases";
-
     [Inject] private IErrorBannerService ErrorBannerService { get; init; } = null!;
 
-    [Inject] private IMenuActionService MenuActionService { get; init; } = null!;
+    [Inject] private IStringLocalizer<SharedResource> Localizer { get; init; } = null!;
 
-    private string NeedsLabel => AttentionCount == 1 ? "needs" : "need";
+    [Inject] private IMenuActionService MenuActionService { get; init; } = null!;
 
     [Inject] private ITraceLogger TraceLogger { get; init; } = null!;
 
@@ -55,8 +55,8 @@ public sealed partial class AttentionBanner : ComponentBase
                 $"{nameof(AttentionBanner)}.{nameof(OnOpenDatabasesClickedAsync)}: open databases threw: {ex}");
 
             BannerId errorId = ErrorBannerService.ReportError(
-                "Databases",
-                $"Failed to open databases: {ex.Message}");
+                Localizer["Banner_Attention_ErrorTitle"],
+                Localizer["Banner_Attention_OpenFailedDetail", ex.Message]);
             await OnFallbackErrorPosted.InvokeAsync(new BannerCycleItem(BannerView.Error, 0, errorId));
 
             return;
@@ -68,8 +68,8 @@ public sealed partial class AttentionBanner : ComponentBase
                 $"{nameof(AttentionBanner)}.{nameof(OnOpenDatabasesClickedAsync)}: open databases returned false");
 
             BannerId errorId = ErrorBannerService.ReportError(
-                "Databases",
-                "Failed to open databases; try again from the menu.");
+                Localizer["Banner_Attention_ErrorTitle"],
+                Localizer["Banner_Attention_OpenFailed"]);
             await OnFallbackErrorPosted.InvokeAsync(new BannerCycleItem(BannerView.Error, 0, errorId));
         }
     }

--- a/src/EventLogExpert.UI/Banner/BannerHost.razor
+++ b/src/EventLogExpert.UI/Banner/BannerHost.razor
@@ -17,15 +17,15 @@
     RenderFragment cycleNav = @<text>
                                    @if (showCyclePagination)
                                    {
-                                       <span class="banner-pagination">@(displayedIndex + 1) of @items.Count</span>
+                                       <span class="banner-pagination">@Localizer["Banner_Pagination", displayedIndex + 1, items.Count]</span>
 
-                                       <Button aria-label="Previous banner"
+                                       <Button aria-label='@Localizer["Banner_Nav_PreviousAria"]'
                                            CssClass="banner-cycle-prev"
                                            Disabled="@(displayedIndex == 0)"
                                            IconClass="bi bi-chevron-left"
                                            OnClick="CycleState.MovePrev" />
 
-                                       <Button aria-label="Next banner"
+                                       <Button aria-label='@Localizer["Banner_Nav_NextAria"]'
                                            CssClass="banner-cycle-next"
                                            Disabled="@(displayedIndex == items.Count - 1)"
                                            IconClass="bi bi-chevron-right"

--- a/src/EventLogExpert.UI/Banner/BannerHost.razor.cs
+++ b/src/EventLogExpert.UI/Banner/BannerHost.razor.cs
@@ -1,8 +1,10 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Localization;
 using EventLogExpert.Runtime.Banner;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
 
 namespace EventLogExpert.UI.Banner;
 
@@ -21,6 +23,8 @@ public sealed partial class BannerHost : ComponentBase, IDisposable
     [Inject] private IExportProgressBannerService ExportProgressBannerService { get; init; } = null!;
 
     [Inject] private IInfoBannerService InfoBannerService { get; init; } = null!;
+
+    [Inject] private IStringLocalizer<SharedResource> Localizer { get; init; } = null!;
 
     [Inject] private IProgressBannerService ProgressBannerService { get; init; } = null!;
 

--- a/src/EventLogExpert.UI/Banner/CriticalBanner.razor
+++ b/src/EventLogExpert.UI/Banner/CriticalBanner.razor
@@ -1,28 +1,28 @@
 <aside class="banner banner-critical" role="alert">
-    <span class="banner-message">An unexpected error occurred: @Critical.GetType().Name: @Critical.Message</span>
+    <span class="banner-message">@Localizer["Banner_Critical_Unexpected", Critical.GetType().Name, Critical.Message]</span>
 
     <div class="banner-actions">
         <Button IconClass="bi bi-arrow-clockwise" OnClick="OnReloadClickedAsync" @ref="_reloadButton">
-            Reload
+            @Localizer["Banner_Critical_Reload"]
         </Button>
         <Button IconClass="bi bi-power" OnClick="OnRelaunchClickedAsync">
-            Relaunch
+            @Localizer["Banner_Critical_Relaunch"]
         </Button>
         <Button IconClass="bi bi-clipboard" OnClick="() => OnCopyDetailsClickedAsync(Critical)">
-            Copy details
+            @Localizer["Banner_Critical_CopyDetails"]
         </Button>
     </div>
 
     <div class="banner-feedback" role="status">
         @if (_showCopiedFeedback)
         {
-            <span class="banner-chip">Copied</span>
+            <span class="banner-chip">@Localizer["Banner_Critical_Copied"]</span>
         }
-        @if (!string.IsNullOrEmpty(_recoveryFailureMessage))
+        @if (_recoveryFailed)
         {
             <span class="banner-subtitle">@_recoveryFailureMessage</span>
         }
-        @if (!string.IsNullOrEmpty(_restartFailureMessage))
+        @if (_restartFailed)
         {
             <span class="banner-subtitle">@_restartFailureMessage</span>
         }

--- a/src/EventLogExpert.UI/Banner/CriticalBanner.razor.cs
+++ b/src/EventLogExpert.UI/Banner/CriticalBanner.razor.cs
@@ -1,6 +1,7 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Localization;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Runtime.Banner;
 using EventLogExpert.Runtime.Common.Clipboard;
@@ -8,6 +9,7 @@ using EventLogExpert.Runtime.Common.Restart;
 using EventLogExpert.UI.Focus;
 using EventLogExpert.UI.Inputs;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
 
 namespace EventLogExpert.UI.Banner;
 
@@ -16,8 +18,10 @@ public sealed partial class CriticalBanner : ComponentBase, IDisposable
     private static readonly TimeSpan s_copiedFeedbackDuration = TimeSpan.FromSeconds(2);
 
     private CancellationTokenSource? _copiedFeedbackCts;
+    private bool _recoveryFailed;
     private string? _recoveryFailureMessage;
     private Button? _reloadButton;
+    private bool _restartFailed;
     private string? _restartFailureMessage;
     private bool _showCopiedFeedback;
 
@@ -28,6 +32,8 @@ public sealed partial class CriticalBanner : ComponentBase, IDisposable
     [Inject] private IClipboardService ClipboardService { get; init; } = null!;
 
     [Inject] private ICriticalErrorService CriticalErrorService { get; init; } = null!;
+
+    [Inject] private IStringLocalizer<SharedResource> Localizer { get; init; } = null!;
 
     [Inject] private ITraceLogger TraceLogger { get; init; } = null!;
 
@@ -81,21 +87,26 @@ public sealed partial class CriticalBanner : ComponentBase, IDisposable
 
     private async Task OnRelaunchClickedAsync()
     {
+        _recoveryFailed = false;
         _recoveryFailureMessage = null;
+        _restartFailed = false;
         _restartFailureMessage = null;
 
         bool success = await ApplicationRestartService.TryRestartAsync();
 
         if (!success)
         {
-            _restartFailureMessage = "Restart failed; please close and reopen manually.";
+            _restartFailed = true;
+            _restartFailureMessage = Localizer["Banner_Critical_RestartFailed"];
             StateHasChanged();
         }
     }
 
     private async Task OnReloadClickedAsync()
     {
+        _recoveryFailed = false;
         _recoveryFailureMessage = null;
+        _restartFailed = false;
         _restartFailureMessage = null;
 
         try
@@ -104,7 +115,8 @@ public sealed partial class CriticalBanner : ComponentBase, IDisposable
         }
         catch (Exception ex)
         {
-            _recoveryFailureMessage = $"Recovery failed: {ex.Message}";
+            _recoveryFailed = true;
+            _recoveryFailureMessage = Localizer["Banner_Critical_RecoveryFailed", ex.Message];
 
             TraceLogger.Error($"{nameof(CriticalBanner)}.{nameof(OnReloadClickedAsync)}: recovery threw: {ex}");
 

--- a/src/EventLogExpert.UI/Banner/ErrorBanner.razor
+++ b/src/EventLogExpert.UI/Banner/ErrorBanner.razor
@@ -11,7 +11,7 @@
         </Button>
     }
 
-    <Button aria-label="Dismiss error banner"
+    <Button aria-label='@Localizer["Banner_Error_DismissAria"]'
         CssClass="banner-dismiss"
         IconClass="bi bi-x"
         OnClick="OnDismissError" />

--- a/src/EventLogExpert.UI/Banner/ErrorBanner.razor.cs
+++ b/src/EventLogExpert.UI/Banner/ErrorBanner.razor.cs
@@ -1,9 +1,11 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Localization;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Runtime.Banner;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
 
 namespace EventLogExpert.UI.Banner;
 
@@ -14,6 +16,8 @@ public sealed partial class ErrorBanner : ComponentBase
     [Parameter] public ErrorBannerEntry Entry { get; set; } = null!;
 
     [Inject] private IErrorBannerService ErrorBannerService { get; init; } = null!;
+
+    [Inject] private IStringLocalizer<SharedResource> Localizer { get; init; } = null!;
 
     [Inject] private ITraceLogger TraceLogger { get; init; } = null!;
 

--- a/src/EventLogExpert.UI/Banner/ExportProgressBanner.razor
+++ b/src/EventLogExpert.UI/Banner/ExportProgressBanner.razor
@@ -7,6 +7,6 @@
 
     <Button CssClass="banner-action"
         OnClick="() => OnCancelExportClickedAsync(Export)">
-        Cancel
+        @Localizer["Modal_Cancel"]
     </Button>
 </aside>

--- a/src/EventLogExpert.UI/Banner/ExportProgressBanner.razor.cs
+++ b/src/EventLogExpert.UI/Banner/ExportProgressBanner.razor.cs
@@ -1,9 +1,11 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Localization;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Runtime.Banner;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
 
 namespace EventLogExpert.UI.Banner;
 
@@ -12,6 +14,8 @@ public sealed partial class ExportProgressBanner : ComponentBase
     [Parameter] public RenderFragment? CycleNav { get; set; }
 
     [Parameter] public ExportProgressEntry Export { get; set; } = null!;
+
+    [Inject] private IStringLocalizer<SharedResource> Localizer { get; init; } = null!;
 
     [Inject] private ITraceLogger TraceLogger { get; init; } = null!;
 

--- a/src/EventLogExpert.UI/Banner/InfoBanner.razor
+++ b/src/EventLogExpert.UI/Banner/InfoBanner.razor
@@ -3,7 +3,7 @@
 
     @CycleNav
 
-    <Button aria-label="Dismiss banner"
+    <Button aria-label='@Localizer["Banner_Info_DismissAria"]'
         CssClass="banner-dismiss"
         IconClass="bi bi-x"
         OnClick="OnDismissInfo" />

--- a/src/EventLogExpert.UI/Banner/InfoBanner.razor.cs
+++ b/src/EventLogExpert.UI/Banner/InfoBanner.razor.cs
@@ -1,8 +1,10 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Localization;
 using EventLogExpert.Runtime.Banner;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
 
 namespace EventLogExpert.UI.Banner;
 
@@ -13,6 +15,8 @@ public sealed partial class InfoBanner : ComponentBase
     [Parameter] public BannerInfoEntry Entry { get; set; } = null!;
 
     [Inject] private IInfoBannerService InfoBannerService { get; init; } = null!;
+
+    [Inject] private IStringLocalizer<SharedResource> Localizer { get; init; } = null!;
 
     private string SeverityClass => Entry.Severity == BannerSeverity.Warning ? "banner-warning" : "banner-info";
 

--- a/src/EventLogExpert.UI/Banner/UpgradeProgressBanner.razor
+++ b/src/EventLogExpert.UI/Banner/UpgradeProgressBanner.razor
@@ -3,22 +3,22 @@
 
     @if (string.IsNullOrEmpty(Progress.CurrentEntryName))
     {
-        <span class="banner-message">Preparing upgrade of @Progress.CurrentBatchSize @(Progress.CurrentBatchSize == 1 ? "database" : "databases")&hellip;</span>
+        <span class="banner-message">@LocalizedCount.OneOrManyRaw(Localizer, Progress.CurrentBatchSize, "Banner_Upgrade_Preparing_One", "Banner_Upgrade_Preparing_Many")</span>
     }
     else
     {
-        <span class="banner-message">Upgrading database @Progress.CurrentBatchPosition of @Progress.CurrentBatchSize: @Progress.CurrentEntryName &mdash; @Progress.CurrentPhase</span>
+        <span class="banner-message">@Localizer["Banner_Upgrade_InProgress", Progress.CurrentBatchPosition, Progress.CurrentBatchSize, Progress.CurrentEntryName, Progress.CurrentPhase]</span>
     }
 
     @if (Progress.QueuedBatchesAfter > 0)
     {
-        <span class="banner-subtitle">(+@Progress.QueuedBatchesAfter @(Progress.QueuedBatchesAfter == 1 ? "batch" : "batches") queued)</span>
+        <span class="banner-subtitle">@LocalizedCount.OneOrManyRaw(Localizer, Progress.QueuedBatchesAfter, "Banner_Upgrade_QueuedBatches_One", "Banner_Upgrade_QueuedBatches_Many")</span>
     }
 
     @CycleNav
 
     <Button CssClass="banner-action"
         OnClick="() => OnCancelUpgradeClickedAsync(Progress)">
-        Cancel
+        @Localizer["Modal_Cancel"]
     </Button>
 </aside>

--- a/src/EventLogExpert.UI/Banner/UpgradeProgressBanner.razor.cs
+++ b/src/EventLogExpert.UI/Banner/UpgradeProgressBanner.razor.cs
@@ -1,9 +1,11 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Localization;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Runtime.Banner;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
 
 namespace EventLogExpert.UI.Banner;
 
@@ -12,6 +14,8 @@ public sealed partial class UpgradeProgressBanner : ComponentBase
     [Parameter] public RenderFragment? CycleNav { get; set; }
 
     [Parameter] public BannerProgressEntry Progress { get; set; } = null!;
+
+    [Inject] private IStringLocalizer<SharedResource> Localizer { get; init; } = null!;
 
     [Inject] private ITraceLogger TraceLogger { get; init; } = null!;
 

--- a/src/EventLogExpert.UI/Common/LocalizedCount.cs
+++ b/src/EventLogExpert.UI/Common/LocalizedCount.cs
@@ -11,4 +11,7 @@ internal static class LocalizedCount
 {
     internal static string OneOrMany(IStringLocalizer<SharedResource> localizer, int count, string oneKey, string manyKey) =>
         localizer[count == 1 ? oneKey : manyKey, TallyFormatter.Count(count)];
+
+    internal static string OneOrManyRaw(IStringLocalizer<SharedResource> localizer, int count, string oneKey, string manyKey) =>
+        localizer[count == 1 ? oneKey : manyKey, count];
 }

--- a/tests/Unit/EventLogExpert.UI.Tests/Banner/AttentionBannerTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Banner/AttentionBannerTests.cs
@@ -2,14 +2,17 @@
 // // Licensed under the MIT License.
 
 using Bunit;
+using EventLogExpert.Localization;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Logging.Abstractions.Handlers;
 using EventLogExpert.Runtime.Banner;
 using EventLogExpert.Runtime.Menu;
 using EventLogExpert.UI.Banner;
+using EventLogExpert.UI.Tests.TestUtils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using Microsoft.JSInterop;
 using NSubstitute;
 
@@ -27,6 +30,7 @@ public sealed class AttentionBannerTests : BunitContext
         Services.AddSingleton(_attentionBannerService);
         Services.AddSingleton(_errorBannerService);
         Services.AddSingleton(_menuActionService);
+        Services.AddSingleton<IStringLocalizer<SharedResource>>(new MarkerLocalizer());
         Services.AddSingleton(_traceLogger);
 
         JSInterop.Mode = JSRuntimeMode.Loose;
@@ -76,7 +80,7 @@ public sealed class AttentionBannerTests : BunitContext
 
         _attentionBannerService.Received(1).DismissAttention();
         _errorBannerService.Received(1)
-            .ReportError("Databases", Arg.Is<string>(s => s != null && s.Contains("Failed to open databases")));
+            .ReportError("[[Banner_Attention_ErrorTitle]]", "[[Banner_Attention_OpenFailed]]");
         Assert.NotNull(captured);
         Assert.Equal(BannerView.Error, captured.View);
     }
@@ -113,7 +117,7 @@ public sealed class AttentionBannerTests : BunitContext
 
         _attentionBannerService.Received(1).DismissAttention();
         _errorBannerService.Received(1)
-            .ReportError("Databases", Arg.Is<string>(s => s != null && s.Contains("modal boom")));
+            .ReportError("[[Banner_Attention_ErrorTitle]]", "[[Banner_Attention_OpenFailedDetail(modal boom)]]");
         _traceLogger.Received(1).Error(Arg.Is<ErrorLogHandler>(h =>
             h.ToString().Contains(nameof(AttentionBanner)) && h.ToString().Contains("modal boom")));
         Assert.NotNull(captured);
@@ -126,8 +130,8 @@ public sealed class AttentionBannerTests : BunitContext
         var component = RenderAttentionBanner(2);
 
         var banner = component.Find("aside.banner-attention");
-        Assert.Contains("2 databases need attention", banner.TextContent);
-        Assert.Equal("Open Databases", component.Find("aside.banner-attention button.banner-action").TextContent.Trim());
+        Assert.Contains("[[Banner_Attention_Many(2)]]", banner.TextContent);
+        Assert.Equal("[[Banner_Attention_OpenDatabases]]", component.Find("aside.banner-attention button.banner-action").TextContent.Trim());
         Assert.Single(component.FindAll("aside.banner-attention button.banner-dismiss"));
     }
 
@@ -137,9 +141,8 @@ public sealed class AttentionBannerTests : BunitContext
         var component = RenderAttentionBanner(1);
 
         var banner = component.Find("aside.banner-attention");
-        Assert.Contains("1 database needs attention", banner.TextContent);
-        Assert.DoesNotContain("databases", banner.TextContent);
-        Assert.DoesNotContain("database need ", banner.TextContent);
+        Assert.Contains("[[Banner_Attention_One(1)]]", banner.TextContent);
+        Assert.DoesNotContain("[[Banner_Attention_Many", banner.TextContent);
     }
 
     private IRenderedComponent<AttentionBanner> RenderAttentionBanner(

--- a/tests/Unit/EventLogExpert.UI.Tests/Banner/BannerHostTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Banner/BannerHostTests.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using Bunit;
+using EventLogExpert.Localization;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Runtime.Banner;
 using EventLogExpert.Runtime.Common.Clipboard;
@@ -14,6 +15,7 @@ using EventLogExpert.UI.Modal;
 using EventLogExpert.UI.Tests.TestUtils;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using NSubstitute;
 
 namespace EventLogExpert.UI.Tests.Banner;
@@ -52,6 +54,7 @@ public sealed class BannerHostTests : BunitContext
         Services.AddSingleton(_menuActionService);
         Services.AddSingleton(_modalCoordinator);
         Services.AddSingleton(_traceLogger);
+        Services.AddSingleton<IStringLocalizer<SharedResource>>(new MarkerLocalizer());
 
         JSInterop.Mode = JSRuntimeMode.Loose;
     }
@@ -113,7 +116,7 @@ public sealed class BannerHostTests : BunitContext
 
         var banner = component.Find("aside.banner-error");
         var pagination = component.Find("aside.banner-error .banner-pagination");
-        Assert.Equal("1 of 2", pagination.TextContent.Trim());
+        Assert.Equal("[[Banner_Pagination(1|2)]]", pagination.TextContent.Trim());
         Assert.Contains("Err: msg", banner.TextContent);
     }
 
@@ -128,31 +131,31 @@ public sealed class BannerHostTests : BunitContext
         var component = Render<BannerHost>();
 
         Assert.Contains("First: first message", component.Find("aside.banner-info").TextContent);
-        Assert.Equal("1 of 3", component.Find(".banner-pagination").TextContent.Trim());
+        Assert.Equal("[[Banner_Pagination(1|3)]]", component.Find(".banner-pagination").TextContent.Trim());
 
         await component.Find("button.banner-cycle-next").ClickAsync(new MouseEventArgs());
 
         Assert.Contains("Second: second message", component.Find("aside.banner-info").TextContent);
         Assert.DoesNotContain("First", component.Find("aside.banner-info").TextContent);
-        Assert.Equal("2 of 3", component.Find(".banner-pagination").TextContent.Trim());
+        Assert.Equal("[[Banner_Pagination(2|3)]]", component.Find(".banner-pagination").TextContent.Trim());
 
         await component.Find("button.banner-cycle-next").ClickAsync(new MouseEventArgs());
 
         Assert.Contains("Third: third message", component.Find("aside.banner-info").TextContent);
         Assert.DoesNotContain("Second", component.Find("aside.banner-info").TextContent);
-        Assert.Equal("3 of 3", component.Find(".banner-pagination").TextContent.Trim());
+        Assert.Equal("[[Banner_Pagination(3|3)]]", component.Find(".banner-pagination").TextContent.Trim());
 
         await component.Find("button.banner-cycle-prev").ClickAsync(new MouseEventArgs());
 
         Assert.Contains("Second: second message", component.Find("aside.banner-info").TextContent);
         Assert.DoesNotContain("Third", component.Find("aside.banner-info").TextContent);
-        Assert.Equal("2 of 3", component.Find(".banner-pagination").TextContent.Trim());
+        Assert.Equal("[[Banner_Pagination(2|3)]]", component.Find(".banner-pagination").TextContent.Trim());
 
         await component.Find("button.banner-cycle-prev").ClickAsync(new MouseEventArgs());
 
         Assert.Contains("First: first message", component.Find("aside.banner-info").TextContent);
         Assert.DoesNotContain("Second", component.Find("aside.banner-info").TextContent);
-        Assert.Equal("1 of 3", component.Find(".banner-pagination").TextContent.Trim());
+        Assert.Equal("[[Banner_Pagination(1|3)]]", component.Find(".banner-pagination").TextContent.Trim());
     }
 
     [Fact]
@@ -170,7 +173,7 @@ public sealed class BannerHostTests : BunitContext
 
         await next.ClickAsync(new MouseEventArgs());
 
-        Assert.Equal("2 of 2", component.Find(".banner-pagination").TextContent.Trim());
+        Assert.Equal("[[Banner_Pagination(2|2)]]", component.Find(".banner-pagination").TextContent.Trim());
         Assert.Single(component.FindAll("aside.banner-attention"));
     }
 
@@ -185,7 +188,7 @@ public sealed class BannerHostTests : BunitContext
         await component.Find("button.banner-cycle-next").ClickAsync(new MouseEventArgs());
 
         var pagination = component.Find(".banner-pagination");
-        Assert.Equal("2 of 2", pagination.TextContent.Trim());
+        Assert.Equal("[[Banner_Pagination(2|2)]]", pagination.TextContent.Trim());
         Assert.Single(component.FindAll("aside.banner-attention"));
         Assert.Empty(component.FindAll("aside.banner-error"));
     }
@@ -203,7 +206,7 @@ public sealed class BannerHostTests : BunitContext
 
         await prev.ClickAsync(new MouseEventArgs());
 
-        Assert.Equal("1 of 2", component.Find(".banner-pagination").TextContent.Trim());
+        Assert.Equal("[[Banner_Pagination(1|2)]]", component.Find(".banner-pagination").TextContent.Trim());
         Assert.Single(component.FindAll("aside.banner-error"));
     }
 
@@ -218,7 +221,7 @@ public sealed class BannerHostTests : BunitContext
         var component = Render<BannerHost>();
         await component.Find("button.banner-cycle-next").ClickAsync(new MouseEventArgs());
         Assert.Contains("Second: second message", component.Find("aside.banner-error").TextContent);
-        Assert.Equal("2 of 3", component.Find(".banner-pagination").TextContent.Trim());
+        Assert.Equal("[[Banner_Pagination(2|3)]]", component.Find(".banner-pagination").TextContent.Trim());
 
         _errorBannerService.ErrorBanners.Returns([e1, e2]);
         _errorBannerService.StateChanged += Raise.Event<Action>();
@@ -226,7 +229,7 @@ public sealed class BannerHostTests : BunitContext
         component.WaitForState(() =>
         {
             var pages = component.FindAll(".banner-pagination");
-            return pages.Count > 0 && pages[0].TextContent.Trim() == "1 of 2";
+            return pages.Count > 0 && pages[0].TextContent.Trim() == "[[Banner_Pagination(1|2)]]";
         });
 
         Assert.Contains("Second: second message", component.Find("aside.banner-error").TextContent);
@@ -273,7 +276,7 @@ public sealed class BannerHostTests : BunitContext
         Assert.DoesNotContain("Second", banner.TextContent);
 
         var pagination = component.Find("aside.banner-error .banner-pagination");
-        Assert.Equal("1 of 2", pagination.TextContent.Trim());
+        Assert.Equal("[[Banner_Pagination(1|2)]]", pagination.TextContent.Trim());
     }
 
     [Fact]
@@ -291,15 +294,15 @@ public sealed class BannerHostTests : BunitContext
         var newErrorId = BannerId.Create();
         var newError = new ErrorBannerEntry(
             newErrorId,
-            "Databases",
-            "Failed to open databases; try again from the menu.",
+            "[[Banner_Attention_ErrorTitle]]",
+            "[[Banner_Attention_OpenFailed]]",
             null,
             null,
             DateTime.UtcNow);
 
         _attentionBannerService.AttentionEntries.Returns([attention]);
         _menuActionService.OpenDatabaseToolsAsync().Returns(Task.FromResult(false));
-        _errorBannerService.ReportError("Databases", Arg.Any<string>())
+        _errorBannerService.ReportError("[[Banner_Attention_ErrorTitle]]", "[[Banner_Attention_OpenFailed]]")
             .Returns(_ =>
             {
                 _errorBannerService.ErrorBanners.Returns([newError]);
@@ -315,7 +318,7 @@ public sealed class BannerHostTests : BunitContext
         component.WaitForState(() => component.FindAll("aside.banner-error").Count > 0);
 
         var errorBanner = component.Find("aside.banner-error");
-        Assert.Contains("Failed to open databases; try again from the menu.", errorBanner.TextContent);
+        Assert.Contains("[[Banner_Attention_OpenFailed]]", errorBanner.TextContent);
         Assert.Empty(component.FindAll("aside.banner-attention"));
     }
 
@@ -350,6 +353,18 @@ public sealed class BannerHostTests : BunitContext
     }
 
     [Fact]
+    public void Render_AsInsideModalLocation_WithNoModalActive_RendersNothing()
+    {
+        _attentionBannerService.AttentionEntries.Returns([BuildDatabaseEntry("a.db")]);
+        _modalCoordinator.ActiveSession.Returns((ModalSession?)null);
+
+        var component = Render<BannerHost>(parameters => parameters
+            .Add(p => p.Location, BannerHostLocation.InsideModal));
+
+        Assert.Empty(component.FindAll("aside.banner-attention"));
+    }
+
+    [Fact]
     public void Render_AsInsideModal_WithDatabaseToolsModalActive_OmitsAttentionBanner_RendersOtherBanners()
     {
         var errorEntry = new ErrorBannerEntry(
@@ -381,18 +396,6 @@ public sealed class BannerHostTests : BunitContext
             .Add(p => p.Location, BannerHostLocation.InsideModal));
 
         Assert.Single(component.FindAll("aside.banner-attention"));
-    }
-
-    [Fact]
-    public void Render_AsInsideModalLocation_WithNoModalActive_RendersNothing()
-    {
-        _attentionBannerService.AttentionEntries.Returns([BuildDatabaseEntry("a.db")]);
-        _modalCoordinator.ActiveSession.Returns((ModalSession?)null);
-
-        var component = Render<BannerHost>(parameters => parameters
-            .Add(p => p.Location, BannerHostLocation.InsideModal));
-
-        Assert.Empty(component.FindAll("aside.banner-attention"));
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.UI.Tests/Banner/BannerLocalizationTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Banner/BannerLocalizationTests.cs
@@ -1,0 +1,345 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using Bunit;
+using EventLogExpert.Localization;
+using EventLogExpert.Logging.Abstractions;
+using EventLogExpert.Runtime.Banner;
+using EventLogExpert.Runtime.Common.Clipboard;
+using EventLogExpert.Runtime.Common.Restart;
+using EventLogExpert.Runtime.Database.Upgrade;
+using EventLogExpert.Runtime.Menu;
+using EventLogExpert.UI.Banner;
+using EventLogExpert.UI.Common;
+using EventLogExpert.UI.Modal;
+using EventLogExpert.UI.Tests.TestUtils;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using NSubstitute;
+
+namespace EventLogExpert.UI.Tests.Banner;
+
+public sealed class BannerLocalizationTests : BunitContext
+{
+    private static readonly DateTime s_createdUtc = new(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+
+    private readonly IApplicationRestartService _applicationRestartService = Substitute.For<IApplicationRestartService>();
+    private readonly IAttentionBannerService _attentionBannerService;
+    private readonly IClipboardService _clipboardService = Substitute.For<IClipboardService>();
+    private readonly ICriticalErrorService _criticalErrorService;
+    private readonly IErrorBannerService _errorBannerService;
+    private readonly IExportProgressBannerService _exportProgressBannerService;
+    private readonly IInfoBannerService _infoBannerService;
+    private readonly IMenuActionService _menuActionService = Substitute.For<IMenuActionService>();
+    private readonly IModalCoordinator _modalCoordinator = Substitute.For<IModalCoordinator>();
+    private readonly IProgressBannerService _progressBannerService;
+    private readonly ITraceLogger _traceLogger = Substitute.For<ITraceLogger>();
+
+    public BannerLocalizationTests()
+    {
+        Services.AddBannerSubstitutes(
+            out _attentionBannerService,
+            out _progressBannerService,
+            out _exportProgressBannerService,
+            out _criticalErrorService,
+            out _errorBannerService,
+            out _infoBannerService);
+        Services.AddSingleton<IBannerCycleStateService, BannerCycleStateService>();
+        Services.AddSingleton<IStringLocalizer<SharedResource>>(new MarkerLocalizer());
+        Services.AddSingleton(_applicationRestartService);
+        Services.AddSingleton(_clipboardService);
+        Services.AddSingleton(_menuActionService);
+        Services.AddSingleton(_modalCoordinator);
+        Services.AddSingleton(_traceLogger);
+
+        _attentionBannerService.AttentionEntries.Returns([]);
+        _attentionBannerService.AttentionDismissed.Returns(false);
+        _criticalErrorService.CurrentCritical.Returns((Exception?)null);
+        _errorBannerService.ErrorBanners.Returns([]);
+        _exportProgressBannerService.CurrentExport.Returns((ExportProgressEntry?)null);
+        _infoBannerService.InfoBanners.Returns([]);
+        _modalCoordinator.ActiveSession.Returns((ModalSession?)null);
+        _progressBannerService.BackgroundProgress.Returns((BannerProgressEntry?)null);
+        JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    [Fact]
+    public void AttentionBanner_RoutesOneAndManyMessagesAndChromeThroughLocalizer()
+    {
+        var one = Render<AttentionBanner>(parameters => parameters.Add(component => component.AttentionCount, 1));
+        var many = Render<AttentionBanner>(parameters => parameters.Add(component => component.AttentionCount, 2));
+
+        Assert.Equal("[[Banner_Attention_One(1)]]", one.Find(".banner-message").TextContent.Trim());
+        Assert.Equal("[[Banner_Attention_Many(2)]]", many.Find(".banner-message").TextContent.Trim());
+        Assert.Equal("[[Banner_Attention_OpenDatabases]]", many.Find("button.banner-action").TextContent.Trim());
+        Assert.Equal("[[Banner_Attention_DismissAria]]", many.Find("button.banner-dismiss").GetAttribute("aria-label"));
+    }
+
+    [Fact]
+    public async Task AttentionBanner_WhenOpenReturnsFalse_PostsLocalizedFallbackError()
+    {
+        BannerId errorId = BannerId.Create();
+        BannerCycleItem? postedItem = null;
+        _menuActionService.OpenDatabaseToolsAsync().Returns(Task.FromResult(false));
+        _errorBannerService.ReportError("[[Banner_Attention_ErrorTitle]]", "[[Banner_Attention_OpenFailed]]")
+            .Returns(errorId);
+
+        var component = Render<AttentionBanner>(parameters => parameters
+            .Add(banner => banner.AttentionCount, 1)
+            .Add(
+                banner => banner.OnFallbackErrorPosted,
+                EventCallback.Factory.Create<BannerCycleItem>(this, item => postedItem = item)));
+
+        await component.Find("button.banner-action").ClickAsync(new MouseEventArgs());
+
+        _errorBannerService.Received(1)
+            .ReportError("[[Banner_Attention_ErrorTitle]]", "[[Banner_Attention_OpenFailed]]");
+        Assert.NotNull(postedItem);
+        Assert.Equal(new BannerCycleItem(BannerView.Error, 0, errorId), postedItem);
+    }
+
+    [Fact]
+    public async Task AttentionBanner_WhenOpenThrows_PostsLocalizedDetailedFallbackError()
+    {
+        BannerId errorId = BannerId.Create();
+        BannerCycleItem? postedItem = null;
+        _menuActionService.OpenDatabaseToolsAsync()
+            .Returns(Task.FromException<bool>(new InvalidOperationException("modal boom")));
+        _errorBannerService.ReportError("[[Banner_Attention_ErrorTitle]]", "[[Banner_Attention_OpenFailedDetail(modal boom)]]")
+            .Returns(errorId);
+
+        var component = Render<AttentionBanner>(parameters => parameters
+            .Add(banner => banner.AttentionCount, 1)
+            .Add(
+                banner => banner.OnFallbackErrorPosted,
+                EventCallback.Factory.Create<BannerCycleItem>(this, item => postedItem = item)));
+
+        await component.Find("button.banner-action").ClickAsync(new MouseEventArgs());
+
+        _errorBannerService.Received(1)
+            .ReportError("[[Banner_Attention_ErrorTitle]]", "[[Banner_Attention_OpenFailedDetail(modal boom)]]");
+        Assert.NotNull(postedItem);
+        Assert.Equal(new BannerCycleItem(BannerView.Error, 0, errorId), postedItem);
+    }
+
+    [Fact]
+    public void BannerHost_RoutesPaginationAndNavigationAriaThroughLocalizer()
+    {
+        _errorBannerService.ErrorBanners.Returns([
+            new ErrorBannerEntry(BannerId.Create(), "First", "Message", null, null, s_createdUtc),
+            new ErrorBannerEntry(BannerId.Create(), "Second", "Message", null, null, s_createdUtc)
+        ]);
+
+        var component = Render<BannerHost>();
+
+        Assert.Equal("[[Banner_Pagination(1|2)]]", component.Find(".banner-pagination").TextContent.Trim());
+        var previous = component.Find("button.banner-cycle-prev");
+        var next = component.Find("button.banner-cycle-next");
+        Assert.Equal("[[Banner_Nav_PreviousAria]]", previous.GetAttribute("aria-label"));
+        Assert.Equal("[[Banner_Nav_NextAria]]", next.GetAttribute("aria-label"));
+        Assert.True(previous.HasAttribute("disabled"));
+        Assert.False(next.HasAttribute("disabled"));
+
+        next.Click();
+
+        Assert.Equal("[[Banner_Pagination(2|2)]]", component.Find(".banner-pagination").TextContent.Trim());
+        Assert.False(component.Find("button.banner-cycle-prev").HasAttribute("disabled"));
+        Assert.True(component.Find("button.banner-cycle-next").HasAttribute("disabled"));
+    }
+
+    [Fact]
+    public async Task CriticalBanner_RoutesTemplateButtonsChipAndFailureSubtitlesThroughLocalizer()
+    {
+        var critical = new InvalidOperationException("kaboom");
+        _applicationRestartService.TryRestartAsync().Returns(Task.FromResult(false));
+        _criticalErrorService.TryRecoverAsync()
+            .Returns(Task.FromException(new InvalidOperationException("recovery failed")));
+
+        var component = Render<CriticalBanner>(parameters => parameters.Add(banner => banner.Critical, critical));
+
+        Assert.Equal(
+            "[[Banner_Critical_Unexpected(InvalidOperationException|kaboom)]]",
+            component.Find(".banner-message").TextContent.Trim());
+        var buttons = component.FindAll(".banner-actions button");
+        Assert.Equal("[[Banner_Critical_Reload]]", buttons[0].TextContent.Trim());
+        Assert.Equal("[[Banner_Critical_Relaunch]]", buttons[1].TextContent.Trim());
+        Assert.Equal("[[Banner_Critical_CopyDetails]]", buttons[2].TextContent.Trim());
+
+        buttons[2].Click();
+        Assert.Equal("[[Banner_Critical_Copied]]", component.Find(".banner-chip").TextContent.Trim());
+
+        await buttons[1].ClickAsync(new MouseEventArgs());
+        Assert.Contains("[[Banner_Critical_RestartFailed]]", component.Markup, StringComparison.Ordinal);
+
+        await buttons[0].ClickAsync(new MouseEventArgs());
+        Assert.Contains("[[Banner_Critical_RecoveryFailed(recovery failed)]]", component.Markup, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CriticalBanner_WhenRelaunchRetrySucceeds_ClearsRestartFailureSubtitle()
+    {
+        var critical = new InvalidOperationException("kaboom");
+        _applicationRestartService.TryRestartAsync().Returns(Task.FromResult(false), Task.FromResult(true));
+        var component = Render<CriticalBanner>(parameters => parameters.Add(banner => banner.Critical, critical));
+        var relaunchButton = component.FindAll(".banner-actions button")[1];
+
+        await relaunchButton.ClickAsync(new MouseEventArgs());
+        Assert.Single(component.FindAll(".banner-subtitle"));
+
+        await relaunchButton.ClickAsync(new MouseEventArgs());
+
+        Assert.Empty(component.FindAll(".banner-subtitle"));
+    }
+
+    [Fact]
+    public async Task CriticalBanner_WhenReloadRetrySucceeds_ClearsRecoveryFailureSubtitle()
+    {
+        var critical = new InvalidOperationException("kaboom");
+        _criticalErrorService.TryRecoverAsync()
+            .Returns(Task.FromException(new InvalidOperationException("recovery failed")), Task.CompletedTask);
+        var component = Render<CriticalBanner>(parameters => parameters.Add(banner => banner.Critical, critical));
+        var reloadButton = component.FindAll(".banner-actions button")[0];
+
+        await reloadButton.ClickAsync(new MouseEventArgs());
+        Assert.Single(component.FindAll(".banner-subtitle"));
+
+        await reloadButton.ClickAsync(new MouseEventArgs());
+
+        Assert.Empty(component.FindAll(".banner-subtitle"));
+    }
+
+    [Fact]
+    public void DeferredContentSurfaces_RenderRawDataWithoutMarkerWrapping()
+    {
+        var error = Render<ErrorBanner>(parameters => parameters.Add(
+            banner => banner.Entry,
+            new ErrorBannerEntry(BannerId.Create(), "Database", "Recovery required", "Resolve", () => Task.CompletedTask, s_createdUtc)));
+        var info = Render<InfoBanner>(parameters => parameters.Add(
+            banner => banner.Entry,
+            new BannerInfoEntry(BannerId.Create(), "Notice", "Heads up", BannerSeverity.Info, s_createdUtc)));
+        var export = Render<ExportProgressBanner>(parameters => parameters.Add(
+            banner => banner.Export,
+            new ExportProgressEntry("Export raw message", () => { })));
+
+        Assert.Equal("Database: Recovery required", error.Find(".banner-message").TextContent.Trim());
+        Assert.DoesNotContain("[[", error.Find(".banner-message").TextContent, StringComparison.Ordinal);
+        Assert.Equal("Resolve", error.Find("button.banner-action").TextContent.Trim());
+        Assert.DoesNotContain("[[", error.Find("button.banner-action").TextContent, StringComparison.Ordinal);
+        Assert.Equal("Notice: Heads up", info.Find(".banner-message").TextContent.Trim());
+        Assert.DoesNotContain("[[", info.Find(".banner-message").TextContent, StringComparison.Ordinal);
+        Assert.Equal("Export raw message", export.Find(".banner-message").TextContent.Trim());
+        Assert.DoesNotContain("[[", export.Find(".banner-message").TextContent, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ErrorAndInfoBanners_RouteDismissAriaOnlyThroughLocalizer()
+    {
+        var error = new ErrorBannerEntry(BannerId.Create(), "Raw title", "Raw message", null, null, s_createdUtc);
+        var info = new BannerInfoEntry(BannerId.Create(), "Raw info", "Raw details", BannerSeverity.Info, s_createdUtc);
+
+        var errorComponent = Render<ErrorBanner>(parameters => parameters.Add(banner => banner.Entry, error));
+        var infoComponent = Render<InfoBanner>(parameters => parameters.Add(banner => banner.Entry, info));
+
+        Assert.Equal("Raw title: Raw message", errorComponent.Find(".banner-message").TextContent.Trim());
+        Assert.Equal("[[Banner_Error_DismissAria]]", errorComponent.Find("button.banner-dismiss").GetAttribute("aria-label"));
+        Assert.Equal("Raw info: Raw details", infoComponent.Find(".banner-message").TextContent.Trim());
+        Assert.Equal("[[Banner_Info_DismissAria]]", infoComponent.Find("button.banner-dismiss").GetAttribute("aria-label"));
+    }
+
+    [Fact]
+    public void ExportProgressBanner_RoutesCancelOnlyThroughLocalizer()
+    {
+        var component = Render<ExportProgressBanner>(parameters => parameters.Add(
+            banner => banner.Export,
+            new ExportProgressEntry("Export raw message", () => { })));
+
+        Assert.Equal("Export raw message", component.Find(".banner-message").TextContent.Trim());
+        Assert.Equal("[[Modal_Cancel]]", component.Find("button.banner-action").TextContent.Trim());
+    }
+
+    [Fact]
+    public void RawCountSites_PassUngroupedIntegersToLocalizer()
+    {
+        var localizer = new MarkerLocalizer();
+
+        Assert.Equal(
+            "[[Banner_Attention_Many(1000)]]",
+            LocalizedCount.OneOrManyRaw(localizer, 1000, "Banner_Attention_One", "Banner_Attention_Many"));
+        Assert.Equal(
+            "[[Banner_Attention_Many(1000)]]",
+            Render<AttentionBanner>(parameters => parameters.Add(banner => banner.AttentionCount, 1000))
+                .Find(".banner-message").TextContent.Trim());
+        Assert.Equal(
+            "[[Banner_Upgrade_Preparing_Many(1000)]]",
+            Render<UpgradeProgressBanner>(parameters => parameters.Add(
+                    banner => banner.Progress,
+                    CreateUpgradeProgress(position: 0, size: 1000, entryName: string.Empty, queuedBatches: 0)))
+                .Find(".banner-message").TextContent.Trim());
+        Assert.Equal(
+            "[[Banner_Upgrade_InProgress(1000|1001|db.evtx|BackingUp)]]",
+            Render<UpgradeProgressBanner>(parameters => parameters.Add(
+                    banner => banner.Progress,
+                    CreateUpgradeProgress(position: 1000, size: 1001, entryName: "db.evtx", queuedBatches: 0)))
+                .Find(".banner-message").TextContent.Trim());
+        Assert.Equal(
+            "[[Banner_Upgrade_QueuedBatches_Many(1000)]]",
+            Render<UpgradeProgressBanner>(parameters => parameters.Add(
+                    banner => banner.Progress,
+                    CreateUpgradeProgress(position: 1, size: 1, entryName: "db.evtx", queuedBatches: 1000)))
+                .Find(".banner-subtitle").TextContent.Trim());
+
+        ErrorBannerEntry[] errorEntries = CreateErrorEntries(1000);
+        _errorBannerService.ErrorBanners.Returns(errorEntries);
+        var host = Render<BannerHost>();
+
+        Assert.Equal("[[Banner_Pagination(1|1000)]]", host.Find(".banner-pagination").TextContent.Trim());
+        Services.GetRequiredService<IBannerCycleStateService>()
+            .RegisterFallbackError(new BannerCycleItem(BannerView.Error, 999, errorEntries[999].Id));
+
+        host.WaitForAssertion(() =>
+            Assert.Equal("[[Banner_Pagination(1000|1000)]]", host.Find(".banner-pagination").TextContent.Trim()));
+    }
+
+    [Fact]
+    public void UpgradeProgressBanner_RoutesPreparingInProgressQueuedAndCancelThroughLocalizer()
+    {
+        var preparingOne = Render<UpgradeProgressBanner>(parameters => parameters.Add(
+            banner => banner.Progress,
+            CreateUpgradeProgress(position: 0, size: 1, entryName: string.Empty, queuedBatches: 0)));
+        var preparingMany = Render<UpgradeProgressBanner>(parameters => parameters.Add(
+            banner => banner.Progress,
+            CreateUpgradeProgress(position: 0, size: 2, entryName: string.Empty, queuedBatches: 0)));
+        var inProgress = Render<UpgradeProgressBanner>(parameters => parameters.Add(
+            banner => banner.Progress,
+            CreateUpgradeProgress(position: 2, size: 5, entryName: "db.evtx", queuedBatches: 1)));
+        var queuedMany = Render<UpgradeProgressBanner>(parameters => parameters.Add(
+            banner => banner.Progress,
+            CreateUpgradeProgress(position: 2, size: 5, entryName: "db.evtx", queuedBatches: 2)));
+
+        Assert.Equal("[[Banner_Upgrade_Preparing_One(1)]]", preparingOne.Find(".banner-message").TextContent.Trim());
+        Assert.Empty(preparingOne.FindAll(".banner-subtitle"));
+        Assert.Equal("[[Banner_Upgrade_Preparing_Many(2)]]", preparingMany.Find(".banner-message").TextContent.Trim());
+        Assert.Equal("[[Banner_Upgrade_InProgress(2|5|db.evtx|BackingUp)]]", inProgress.Find(".banner-message").TextContent.Trim());
+        Assert.Equal("[[Banner_Upgrade_QueuedBatches_One(1)]]", inProgress.Find(".banner-subtitle").TextContent.Trim());
+        Assert.Equal("[[Banner_Upgrade_QueuedBatches_Many(2)]]", queuedMany.Find(".banner-subtitle").TextContent.Trim());
+        Assert.Equal("[[Modal_Cancel]]", inProgress.Find("button.banner-action").TextContent.Trim());
+    }
+
+    private static ErrorBannerEntry[] CreateErrorEntries(int count) =>
+        Enumerable.Range(1, count)
+            .Select(index => new ErrorBannerEntry(BannerId.Create(), $"Title {index}", "Message", null, null, s_createdUtc))
+            .ToArray();
+
+    private static BannerProgressEntry CreateUpgradeProgress(int position, int size, string entryName, int queuedBatches) =>
+        new(
+            UpgradeBatchId.Create(),
+            UpgradeProgressScope.Background,
+            position,
+            size,
+            entryName,
+            UpgradePhase.BackingUp,
+            queuedBatches,
+            () => { });
+}

--- a/tests/Unit/EventLogExpert.UI.Tests/Banner/CriticalBannerTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Banner/CriticalBannerTests.cs
@@ -2,13 +2,16 @@
 // // Licensed under the MIT License.
 
 using Bunit;
+using EventLogExpert.Localization;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Runtime.Banner;
 using EventLogExpert.Runtime.Common.Clipboard;
 using EventLogExpert.Runtime.Common.Restart;
 using EventLogExpert.UI.Banner;
+using EventLogExpert.UI.Tests.TestUtils;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using NSubstitute;
 
 namespace EventLogExpert.UI.Tests.Banner;
@@ -27,6 +30,7 @@ public sealed class CriticalBannerTests : BunitContext
         Services.AddSingleton(_applicationRestartService);
         Services.AddSingleton(_clipboardService);
         Services.AddSingleton(_traceLogger);
+        Services.AddSingleton<IStringLocalizer<SharedResource>>(new MarkerLocalizer());
 
         JSInterop.Mode = JSRuntimeMode.Loose;
     }
@@ -41,7 +45,7 @@ public sealed class CriticalBannerTests : BunitContext
 
         // Sync Click() returns at the handler's first real async point (the 2s Task.Delay) with
         // the chip rendered; ClickAsync would block for the full delay until the chip clears.
-        component.Find("aside.banner-critical .banner-actions button:contains('Copy details')").Click();
+        component.FindAll("aside.banner-critical .banner-actions button")[2].Click();
 
         await _clipboardService.Received(1)
             .CopyTextAsync(Arg.Is<string>(s => s != null && s.Contains("InvalidOperationException") && s.Contains("kaboom")));
@@ -57,11 +61,10 @@ public sealed class CriticalBannerTests : BunitContext
         _criticalErrorService.TryRecoverAsync().Returns(Task.FromException(new InvalidOperationException("recovery failed")));
 
         var component = Render<CriticalBanner>(p => p.Add(c => c.Critical, critical));
-        await component.Find("aside.banner-critical .banner-actions button:contains('Reload')").ClickAsync(new MouseEventArgs());
+        await component.FindAll("aside.banner-critical .banner-actions button")[0].ClickAsync(new MouseEventArgs());
 
         var subtitle = component.Find("aside.banner-critical .banner-feedback .banner-subtitle");
-        Assert.Contains("Recovery failed", subtitle.TextContent);
-        Assert.Contains("recovery failed", subtitle.TextContent);
+        Assert.Contains("[[Banner_Critical_RecoveryFailed(recovery failed)]]", subtitle.TextContent);
     }
 
     [Fact]
@@ -72,7 +75,7 @@ public sealed class CriticalBannerTests : BunitContext
         _applicationRestartService.TryRestartAsync().Returns(true);
 
         var component = Render<CriticalBanner>(p => p.Add(c => c.Critical, critical));
-        await component.Find("aside.banner-critical .banner-actions button:contains('Relaunch')").ClickAsync(new MouseEventArgs());
+        await component.FindAll("aside.banner-critical .banner-actions button")[1].ClickAsync(new MouseEventArgs());
 
         await _applicationRestartService.Received(1).TryRestartAsync();
     }
@@ -85,10 +88,10 @@ public sealed class CriticalBannerTests : BunitContext
         _applicationRestartService.TryRestartAsync().Returns(false);
 
         var component = Render<CriticalBanner>(p => p.Add(c => c.Critical, critical));
-        await component.Find("aside.banner-critical .banner-actions button:contains('Relaunch')").ClickAsync(new MouseEventArgs());
+        await component.FindAll("aside.banner-critical .banner-actions button")[1].ClickAsync(new MouseEventArgs());
 
         var subtitle = component.Find("aside.banner-critical .banner-feedback .banner-subtitle");
-        Assert.Contains("Restart failed", subtitle.TextContent);
+        Assert.Contains("[[Banner_Critical_RestartFailed]]", subtitle.TextContent);
     }
 
     [Fact]
@@ -99,7 +102,7 @@ public sealed class CriticalBannerTests : BunitContext
         _criticalErrorService.TryRecoverAsync().Returns(Task.CompletedTask);
 
         var component = Render<CriticalBanner>(p => p.Add(c => c.Critical, critical));
-        await component.Find("aside.banner-critical .banner-actions button:contains('Reload')").ClickAsync(new MouseEventArgs());
+        await component.FindAll("aside.banner-critical .banner-actions button")[0].ClickAsync(new MouseEventArgs());
 
         await _criticalErrorService.Received(1).TryRecoverAsync();
     }
@@ -113,13 +116,12 @@ public sealed class CriticalBannerTests : BunitContext
         var component = Render<CriticalBanner>(p => p.Add(c => c.Critical, critical));
 
         var banner = component.Find("aside.banner-critical");
-        Assert.Contains("InvalidOperationException", banner.TextContent);
-        Assert.Contains("kaboom", banner.TextContent);
+        Assert.Contains("[[Banner_Critical_Unexpected(InvalidOperationException|kaboom)]]", banner.TextContent);
 
         var buttons = component.FindAll("aside.banner-critical .banner-actions button");
         Assert.Equal(3, buttons.Count);
-        Assert.Contains("Reload", buttons[0].TextContent);
-        Assert.Contains("Relaunch", buttons[1].TextContent);
-        Assert.Contains("Copy details", buttons[2].TextContent);
+        Assert.Contains("[[Banner_Critical_Reload]]", buttons[0].TextContent);
+        Assert.Contains("[[Banner_Critical_Relaunch]]", buttons[1].TextContent);
+        Assert.Contains("[[Banner_Critical_CopyDetails]]", buttons[2].TextContent);
     }
 }

--- a/tests/Unit/EventLogExpert.UI.Tests/Banner/ErrorBannerTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Banner/ErrorBannerTests.cs
@@ -2,12 +2,15 @@
 // // Licensed under the MIT License.
 
 using Bunit;
+using EventLogExpert.Localization;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Logging.Abstractions.Handlers;
 using EventLogExpert.Runtime.Banner;
 using EventLogExpert.UI.Banner;
+using EventLogExpert.UI.Tests.TestUtils;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using NSubstitute;
 
 namespace EventLogExpert.UI.Tests.Banner;
@@ -21,6 +24,7 @@ public sealed class ErrorBannerTests : BunitContext
     {
         Services.AddSingleton(_errorBannerService);
         Services.AddSingleton(_traceLogger);
+        Services.AddSingleton<IStringLocalizer<SharedResource>>(new MarkerLocalizer());
 
         JSInterop.Mode = JSRuntimeMode.Loose;
     }

--- a/tests/Unit/EventLogExpert.UI.Tests/Banner/InfoBannerTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Banner/InfoBannerTests.cs
@@ -2,10 +2,13 @@
 // // Licensed under the MIT License.
 
 using Bunit;
+using EventLogExpert.Localization;
 using EventLogExpert.Runtime.Banner;
 using EventLogExpert.UI.Banner;
+using EventLogExpert.UI.Tests.TestUtils;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using NSubstitute;
 
 namespace EventLogExpert.UI.Tests.Banner;
@@ -17,6 +20,7 @@ public sealed class InfoBannerTests : BunitContext
     public InfoBannerTests()
     {
         Services.AddSingleton(_infoBannerService);
+        Services.AddSingleton<IStringLocalizer<SharedResource>>(new MarkerLocalizer());
 
         JSInterop.Mode = JSRuntimeMode.Loose;
     }

--- a/tests/Unit/EventLogExpert.UI.Tests/Banner/UpgradeProgressBannerTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Banner/UpgradeProgressBannerTests.cs
@@ -2,13 +2,16 @@
 // // Licensed under the MIT License.
 
 using Bunit;
+using EventLogExpert.Localization;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Logging.Abstractions.Handlers;
 using EventLogExpert.Runtime.Banner;
 using EventLogExpert.Runtime.Database.Upgrade;
 using EventLogExpert.UI.Banner;
+using EventLogExpert.UI.Tests.TestUtils;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using NSubstitute;
 
 namespace EventLogExpert.UI.Tests.Banner;
@@ -20,6 +23,7 @@ public sealed class UpgradeProgressBannerTests : BunitContext
     public UpgradeProgressBannerTests()
     {
         Services.AddSingleton(_traceLogger);
+        Services.AddSingleton<IStringLocalizer<SharedResource>>(new MarkerLocalizer());
 
         JSInterop.Mode = JSRuntimeMode.Loose;
     }
@@ -85,8 +89,8 @@ public sealed class UpgradeProgressBannerTests : BunitContext
         var component = Render<UpgradeProgressBanner>(p => p.Add(c => c.Progress, entry));
 
         var banner = component.Find("aside.banner-upgrade-progress");
-        Assert.Contains("Preparing upgrade of 3 databases", banner.TextContent);
-        Assert.DoesNotContain("Upgrading database 0", banner.TextContent);
+        Assert.Contains("[[Banner_Upgrade_Preparing_Many(3)]]", banner.TextContent);
+        Assert.DoesNotContain("[[Banner_Upgrade_InProgress(0", banner.TextContent);
     }
 
     [Fact]
@@ -105,10 +109,8 @@ public sealed class UpgradeProgressBannerTests : BunitContext
         var component = Render<UpgradeProgressBanner>(p => p.Add(c => c.Progress, entry));
 
         var banner = component.Find("aside.banner-upgrade-progress");
-        Assert.Contains("Upgrading database 2 of 5", banner.TextContent);
-        Assert.Contains("MyDb.evtx", banner.TextContent);
-        Assert.Contains("MigratingSchema", banner.TextContent);
-        Assert.Equal("Cancel", component.Find("aside.banner-upgrade-progress button.banner-action").TextContent.Trim());
+        Assert.Contains("[[Banner_Upgrade_InProgress(2|5|MyDb.evtx|MigratingSchema)]]", banner.TextContent);
+        Assert.Equal("[[Modal_Cancel]]", component.Find("aside.banner-upgrade-progress button.banner-action").TextContent.Trim());
         Assert.Single(component.FindAll("aside.banner-upgrade-progress .banner-spinner"));
     }
 
@@ -128,6 +130,6 @@ public sealed class UpgradeProgressBannerTests : BunitContext
         var component = Render<UpgradeProgressBanner>(p => p.Add(c => c.Progress, entry));
 
         var subtitle = component.Find("aside.banner-upgrade-progress .banner-subtitle");
-        Assert.Contains("+3 batches queued", subtitle.TextContent);
+        Assert.Contains("[[Banner_Upgrade_QueuedBatches_Many(3)]]", subtitle.TextContent);
     }
 }

--- a/tests/Unit/EventLogExpert.UI.Tests/Localization/LocalizationInfraTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Localization/LocalizationInfraTests.cs
@@ -112,7 +112,7 @@ public sealed class LocalizationInfraTests
             RegexOptions.Compiled);
         var keyLiteralPattern = new Regex(@"""([A-Za-z0-9_]+)""", RegexOptions.Compiled);
         var oneOrManyPattern = new Regex(
-            @"OneOrMany\([^;{}]*?""([A-Za-z0-9_]+)""\s*,\s*""([A-Za-z0-9_]+)""\s*\)",
+            @"OneOrMany(?:Raw)?\([^;{}]*?""([A-Za-z0-9_]+)""\s*,\s*""([A-Za-z0-9_]+)""\s*\)",
             RegexOptions.Compiled);
 
         var sources = LocalizationSourceScan.EnumerateProductionSource()
@@ -176,6 +176,49 @@ public sealed class LocalizationInfraTests
 
         Assert.True(result.ResourceNotFound);
         Assert.Equal("FindBar_ThisKeyDoesNotExist", result.Value);
+    }
+
+    [Fact]
+    public void NeutralBannerValues_HaveExpectedPlaceholderArity()
+    {
+        var neutralValues = ResxValues();
+        (string Key, int Arity)[] expected =
+        [
+            ("Banner_Attention_DismissAria", 0),
+            ("Banner_Attention_ErrorTitle", 0),
+            ("Banner_Attention_Many", 1),
+            ("Banner_Attention_One", 1),
+            ("Banner_Attention_OpenDatabases", 0),
+            ("Banner_Attention_OpenFailed", 0),
+            ("Banner_Attention_OpenFailedDetail", 1),
+            ("Banner_Critical_Copied", 0),
+            ("Banner_Critical_CopyDetails", 0),
+            ("Banner_Critical_RecoveryFailed", 1),
+            ("Banner_Critical_Relaunch", 0),
+            ("Banner_Critical_Reload", 0),
+            ("Banner_Critical_RestartFailed", 0),
+            ("Banner_Critical_Unexpected", 2),
+            ("Banner_Error_DismissAria", 0),
+            ("Banner_Info_DismissAria", 0),
+            ("Banner_Nav_NextAria", 0),
+            ("Banner_Nav_PreviousAria", 0),
+            ("Banner_Pagination", 2),
+            ("Banner_Upgrade_InProgress", 4),
+            ("Banner_Upgrade_Preparing_Many", 1),
+            ("Banner_Upgrade_Preparing_One", 1),
+            ("Banner_Upgrade_QueuedBatches_Many", 1),
+            ("Banner_Upgrade_QueuedBatches_One", 1)
+        ];
+
+        foreach ((string key, int arity) in expected)
+        {
+            Assert.True(neutralValues.TryGetValue(key, out string? value), $"Missing neutral RESX value for {key}.");
+            Assert.Equal(arity, PlaceholderArity(value));
+        }
+
+        Assert.Equal(
+            expected.Select(entry => entry.Key).OrderBy(key => key, StringComparer.Ordinal),
+            neutralValues.Keys.Where(key => key.StartsWith("Banner_", StringComparison.Ordinal)).OrderBy(key => key, StringComparer.Ordinal));
     }
 
     [Fact]
@@ -550,6 +593,15 @@ public sealed class LocalizationInfraTests
             .AddEventLogLocalization()
             .BuildServiceProvider()
             .GetRequiredService<IStringLocalizer<SharedResource>>();
+
+    private static int PlaceholderArity(string value)
+    {
+        var indexes = Regex.Matches(value, @"\{(\d+)\}")
+            .Select(match => int.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture))
+            .ToList();
+
+        return indexes.Count == 0 ? 0 : indexes.Max() + 1;
+    }
 
     private static IReadOnlyList<string> ResxKeys() =>
         XDocument.Load(LocalizationSourceScan.ResxPath)


### PR DESCRIPTION
## Summary

Localizes the 7 Banner components (Attention, Critical, Error, Info, Upgrade/Export progress, and `BannerHost`) to 24 new `Banner_*` resource keys via `IStringLocalizer<SharedResource>`, plus a §3.14 em-dash sweep. **Byte-identical en-US** except the 3 sanctioned em-dash to hyphen changes.

This is **part 1 of 2** of the banner-localization increment. Part 2 (a follow-on PR) retypes the banner notification-service contract to typed outcomes (`BannerMessage` + a UI `BannerContentLocalizer`) and evicts the Runtime-authored banner-message English (Export / DatabaseOps / FilterLibrary / empty-log / recovery). This PR makes **no contract change**: `ErrorBanner`/`InfoBanner` still render `@Entry.Title: @Entry.Message` and `ExportProgressBanner` still renders `@Export.Message` verbatim (deferred to part 2).

## Changes

- **24 new `Banner_*` keys** in `SharedResource.resx` (additive; each with a translator `<comment>`). `AttentionBanner` localizes its own `ReportError` strings inline, so the string-based `IErrorBannerService` API is unchanged.
- **Em-dash sweep (§3.14):** `Banner_Upgrade_InProgress` uses ` - `; the 2 pre-existing `FilterEditor_ExcludeToggle_Title*` values change `—` to `-`. These are the only deliberate en-US text changes.
- `LocalizedCount.OneOrManyRaw` (raw-count, no group separator — preserves byte-identity for the banner counts) + the forward key-existence guard widened to track it.
- `CriticalBanner` failure-subtitle visibility decoupled onto reset-on-entry flags, so an empty translation no longer hides the subtitle and a successful retry clears a prior failure.
- New behavioral `BannerLocalizationTests` (MarkerLocalizer key-routing, ≥1000 raw-count wiring, retry-clears-subtitle, deferred-content pass-through) + fixture migrations + a placeholder-arity guard.

## Verification

- Solution build **0 warnings / 0 errors**; full Unit suite **8006 / 0 / 0**.
- Byte-identical en-US except the 3 em-dash to hyphen changes; `SharedResource.resx` additive apart from the 2 swept values; real U+2026 ellipsis preserved, zero U+2014/U+2013 in `Banner_*`.
