### PR TITLE
Accessibility and UI polish: tab bar, focus rings, close icons, dropdowns, dialogs

### DIFF
--- a/src/EventLogExpert.Localization/Resources/SharedResource.resx
+++ b/src/EventLogExpert.Localization/Resources/SharedResource.resx
@@ -1395,11 +1395,35 @@
   <data name="FilterLens_ActiveLensesAria" xml:space="preserve">
     <value>Active filter lenses</value>
   </data>
-  <data name="FilterLens_KeepAria" xml:space="preserve">
-    <value>Keep lens as filter: {0}</value>
+  <data name="FilterLens_SaveAria" xml:space="preserve">
+    <value>Save lens as filter: {0}</value>
   </data>
   <data name="FilterLens_RemoveAria" xml:space="preserve">
     <value>Remove lens: {0}</value>
+  </data>
+  <data name="FilterLens_SaveAll" xml:space="preserve">
+    <value>Save all</value>
+  </data>
+  <data name="FilterLens_SaveAsGroup" xml:space="preserve">
+    <value>Save as group</value>
+  </data>
+  <data name="FilterLens_SaveAsGroup_DisabledTitle" xml:space="preserve">
+    <value>Add a value lens to save as a group (time-window lenses can't be grouped)</value>
+  </data>
+  <data name="FilterLens_SaveAsGroup_PromptTitle" xml:space="preserve">
+    <value>Save as group</value>
+  </data>
+  <data name="FilterLens_SaveAsGroup_PromptMessage" xml:space="preserve">
+    <value>What would you like to name this group?</value>
+  </data>
+  <data name="FilterLens_SaveAsGroup_DefaultName" xml:space="preserve">
+    <value>New Group</value>
+  </data>
+  <data name="FilterLens_SavedAllAnnouncement" xml:space="preserve">
+    <value>Saved all lenses as filters</value>
+  </data>
+  <data name="FilterLens_SavedAsGroupAnnouncement" xml:space="preserve">
+    <value>Saved lenses as group: {0}</value>
   </data>
   <!-- Filter editor chrome, dialogs, actions, and predicate summaries. -->
   <data name="FilterEditor_ModeLabel" xml:space="preserve">

--- a/src/EventLogExpert.Localization/Resources/SharedResource.resx
+++ b/src/EventLogExpert.Localization/Resources/SharedResource.resx
@@ -1924,12 +1924,6 @@
   <data name="Copy_Markdown_DescriptionHeader" xml:space="preserve">
     <value>Description</value>
   </data>
-  <data name="TabBar_ExpandGroupAria" xml:space="preserve">
-    <value>Expand group</value>
-  </data>
-  <data name="TabBar_CollapseGroupAria" xml:space="preserve">
-    <value>Collapse group</value>
-  </data>
   <data name="TabBar_CloseGroup" xml:space="preserve">
     <value>Close group</value>
   </data>

--- a/src/EventLogExpert.Localization/Resources/SharedResource.resx
+++ b/src/EventLogExpert.Localization/Resources/SharedResource.resx
@@ -1528,6 +1528,10 @@
     <value>Cancel</value>
     <comment>Cancel button label for the save-as-group prompt.</comment>
   </data>
+  <data name="FilterLens_SaveAsGroup_NameRequired" xml:space="preserve">
+    <value>Group name is required.</value>
+    <comment>Validation message shown when the save-as-group prompt name is left blank.</comment>
+  </data>
   <data name="FilterLens_SavedAllAnnouncement" xml:space="preserve">
     <value>Saved all lenses as filters</value>
   </data>

--- a/src/EventLogExpert.Localization/Resources/SharedResource.resx
+++ b/src/EventLogExpert.Localization/Resources/SharedResource.resx
@@ -1516,6 +1516,18 @@
   <data name="FilterLens_SaveAsGroup_DefaultName" xml:space="preserve">
     <value>New Group</value>
   </data>
+  <data name="FilterLens_SaveAsGroup_Save" xml:space="preserve">
+    <value>Save</value>
+    <comment>Primary button label for saving the active lenses as a group without clearing them.</comment>
+  </data>
+  <data name="FilterLens_SaveAsGroup_SaveAndClear" xml:space="preserve">
+    <value>Save and clear</value>
+    <comment>Secondary button label for saving the active lenses as a group and then clearing the active lens stack.</comment>
+  </data>
+  <data name="FilterLens_SaveAsGroup_Cancel" xml:space="preserve">
+    <value>Cancel</value>
+    <comment>Cancel button label for the save-as-group prompt.</comment>
+  </data>
   <data name="FilterLens_SavedAllAnnouncement" xml:space="preserve">
     <value>Saved all lenses as filters</value>
   </data>

--- a/src/EventLogExpert.Runtime/Alerts/IAlertDialogService.cs
+++ b/src/EventLogExpert.Runtime/Alerts/IAlertDialogService.cs
@@ -11,6 +11,15 @@ public interface IAlertDialogService
 
     Task<string> DisplayPrompt(string title, string message, string initialValue, Func<string, string?>? validate);
 
+    Task<PromptOutcome> DisplayPromptWithSecondary(
+        string title,
+        string message,
+        string initialValue,
+        string primaryLabel,
+        string secondaryLabel,
+        string cancelLabel,
+        Func<string, string?>? validate = null);
+
     Task ShowAlert(string title, string message, string cancel);
 
     Task ShowAlert(string title, string message, string cancel, AlertPresentation presentation);

--- a/src/EventLogExpert.Runtime/Alerts/PromptOutcome.cs
+++ b/src/EventLogExpert.Runtime/Alerts/PromptOutcome.cs
@@ -1,0 +1,13 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.Alerts;
+
+public enum PromptChoice
+{
+    Cancel,
+    Primary,
+    Secondary,
+}
+
+public readonly record struct PromptOutcome(PromptChoice Choice, string Value);

--- a/src/EventLogExpert.Runtime/Alerts/PromptOutcome.cs
+++ b/src/EventLogExpert.Runtime/Alerts/PromptOutcome.cs
@@ -10,4 +10,4 @@ public enum PromptChoice
     Secondary,
 }
 
-public readonly record struct PromptOutcome(PromptChoice Choice, string Value);
+public readonly record struct PromptOutcome(PromptChoice Choice, string? Value);

--- a/src/EventLogExpert.Runtime/Announcement/Announcement.cs
+++ b/src/EventLogExpert.Runtime/Announcement/Announcement.cs
@@ -12,4 +12,8 @@ public abstract record Announcement
     public sealed record Text(string Message) : Announcement;
 
     public sealed record LensKept(FilterLensLabel Label) : Announcement;
+
+    public sealed record LensGroupSaved(string Name) : Announcement;
+
+    public sealed record LensesSavedAll : Announcement;
 }

--- a/src/EventLogExpert.Runtime/Announcement/AnnouncementService.cs
+++ b/src/EventLogExpert.Runtime/Announcement/AnnouncementService.cs
@@ -34,12 +34,21 @@ public sealed class AnnouncementService : IAnnouncementService
         Publish(new Announcement.Text(message));
     }
 
+    public void AnnounceLensGroupSaved(string name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+
+        Publish(new Announcement.LensGroupSaved(name));
+    }
+
     public void AnnounceLensKept(FilterLensLabel label)
     {
         ArgumentNullException.ThrowIfNull(label);
 
         Publish(new Announcement.LensKept(label));
     }
+
+    public void AnnounceLensesSavedAll() => Publish(new Announcement.LensesSavedAll());
 
     private void Publish(Announcement payload)
     {

--- a/src/EventLogExpert.Runtime/Announcement/IAnnouncementService.cs
+++ b/src/EventLogExpert.Runtime/Announcement/IAnnouncementService.cs
@@ -13,5 +13,9 @@ public interface IAnnouncementService
 
     void Announce(string message);
 
+    void AnnounceLensGroupSaved(string name);
+
     void AnnounceLensKept(FilterLensLabel label);
+
+    void AnnounceLensesSavedAll();
 }

--- a/src/EventLogExpert.Runtime/FilterLenses/CommitPromotedLensesAction.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/CommitPromotedLensesAction.cs
@@ -1,0 +1,15 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+using EventLogExpert.Filtering.Evaluation;
+using EventLogExpert.Filtering.Persistence;
+using System.Collections.Immutable;
+
+namespace EventLogExpert.Runtime.FilterLenses;
+
+internal sealed record CommitPromotedLensesAction(ImmutableList<PromotedLensCommit> Commits);
+
+internal sealed record PromotedLensCommit(
+    FilterLensId Id,
+    ImmutableList<SavedFilter> Filters,
+    DateFilter? Window);

--- a/src/EventLogExpert.Runtime/FilterLenses/Effects.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/Effects.cs
@@ -1,10 +1,13 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Filtering.Persistence;
 using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.Runtime.EventLog;
+using EventLogExpert.Runtime.FilterLibrary;
 using EventLogExpert.Runtime.FilterPane;
 using Fluxor;
+using System.Collections.Immutable;
 
 namespace EventLogExpert.Runtime.FilterLenses;
 
@@ -57,22 +60,26 @@ internal sealed class Effects(
     {
         var lens = _lensState.Value.Lenses.FirstOrDefault(candidate => candidate.Id == action.Id);
 
-        if (lens is null) { return Task.CompletedTask; }
-
-        // Persist the lens's natural promote form (a positive include for keep-only lenses), falling back to the
-        // transient exclude-of-complement for hide lenses, whose exclude form is already the natural one.
-        var filters = lens.PromoteFilters.IsEmpty ? lens.ExcludeFilters : lens.PromoteFilters;
-
         // An absent (already removed) or degenerate (nothing to keep) lens neither announces nor commits. The factory
         // never produces a degenerate lens; this is a defensive gate.
-        if (filters.IsEmpty && lens.Window is not { IsEnabled: true })
-        {
-            return Task.CompletedTask;
-        }
+        if (lens is null || !IsPromotable(lens)) { return Task.CompletedTask; }
 
         _announcementService.AnnounceLensKept(lens.Label);
 
-        dispatcher.Dispatch(new CommitPromotedLensAction(lens.Id, filters, lens.Window));
+        dispatcher.Dispatch(new CommitPromotedLensAction(lens.Id, PromoteForm(lens), lens.Window));
+
+        return Task.CompletedTask;
+    }
+
+    [EffectMethod(typeof(PromoteAllFilterLensesAction))]
+    public Task HandlePromoteAll(IDispatcher dispatcher)
+    {
+        foreach (var lens in _lensState.Value.Lenses)
+        {
+            if (lens.ExcludeFilters.IsEmpty && lens.Window is not { IsEnabled: true }) { continue; }
+
+            dispatcher.Dispatch(new CommitPromotedLensAction(lens.Id, lens.ExcludeFilters, lens.Window));
+        }
 
         return Task.CompletedTask;
     }
@@ -85,6 +92,26 @@ internal sealed class Effects(
 
     [EffectMethod]
     public Task HandleRemoveForLog(RemoveLensesForLogAction action, IDispatcher dispatcher) => Reapply(dispatcher);
+
+    [EffectMethod]
+    public Task HandleSaveLensesAsGroup(SaveLensesAsGroupAction action, IDispatcher dispatcher)
+    {
+        if (string.IsNullOrWhiteSpace(action.Name)) { return Task.CompletedTask; }
+
+        var filters = _lensState.Value.Lenses.SelectMany(lens => lens.ExcludeFilters).ToImmutableList();
+
+        if (filters.IsEmpty) { return Task.CompletedTask; }
+
+        dispatcher.Dispatch(new SaveFilterSetAction(action.Name, filters));
+
+        return Task.CompletedTask;
+    }
+
+    private static bool IsPromotable(FilterLens lens) =>
+        !PromoteForm(lens).IsEmpty || lens.Window is { IsEnabled: true };
+
+    private static ImmutableList<SavedFilter> PromoteForm(FilterLens lens) =>
+        lens.PromoteFilters.IsEmpty ? lens.ExcludeFilters : lens.PromoteFilters;
 
     private Task Reapply(IDispatcher dispatcher)
     {

--- a/src/EventLogExpert.Runtime/FilterLenses/Effects.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/Effects.cs
@@ -74,12 +74,19 @@ internal sealed class Effects(
     [EffectMethod(typeof(PromoteAllFilterLensesAction))]
     public Task HandlePromoteAll(IDispatcher dispatcher)
     {
+        var promoted = 0;
+
         foreach (var lens in _lensState.Value.Lenses)
         {
             if (lens.ExcludeFilters.IsEmpty && lens.Window is not { IsEnabled: true }) { continue; }
 
             dispatcher.Dispatch(new CommitPromotedLensAction(lens.Id, lens.ExcludeFilters, lens.Window));
+            promoted++;
         }
+
+        // Announce from the effect (not the breadcrumb) so it reflects what was actually committed, and stays
+        // silent when nothing was promotable. This is an in-memory commit, so unlike SaveAsGroup it cannot fail.
+        if (promoted > 0) { _announcementService.AnnounceLensesSavedAll(); }
 
         return Task.CompletedTask;
     }
@@ -94,6 +101,17 @@ internal sealed class Effects(
     public Task HandleRemoveForLog(RemoveLensesForLogAction action, IDispatcher dispatcher) => Reapply(dispatcher);
 
     [EffectMethod]
+    public Task HandleSaveFilterSetSucceeded(SaveFilterSetSucceededAction action, IDispatcher dispatcher)
+    {
+        if (action.Origin == SaveFilterSetOrigin.Lens)
+        {
+            _announcementService.AnnounceLensGroupSaved(action.Name);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    [EffectMethod]
     public Task HandleSaveLensesAsGroup(SaveLensesAsGroupAction action, IDispatcher dispatcher)
     {
         if (string.IsNullOrWhiteSpace(action.Name)) { return Task.CompletedTask; }
@@ -102,7 +120,9 @@ internal sealed class Effects(
 
         if (filters.IsEmpty) { return Task.CompletedTask; }
 
-        dispatcher.Dispatch(new SaveFilterSetAction(action.Name, filters));
+        // Tag the save as lens-originated. The terminal SaveFilterSetSucceededAction is announced (below) only
+        // for this origin, and only after the write actually succeeds; failure surfaces via the error banner.
+        dispatcher.Dispatch(new SaveFilterSetAction(action.Name, filters, SaveFilterSetOrigin.Lens));
 
         return Task.CompletedTask;
     }

--- a/src/EventLogExpert.Runtime/FilterLenses/Effects.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/Effects.cs
@@ -129,7 +129,10 @@ internal sealed class Effects(
         if (string.IsNullOrWhiteSpace(action.Name)) { return Task.CompletedTask; }
 
         var lenses = _lensState.Value.Lenses;
-        var filters = lenses.SelectMany(lens => lens.ExcludeFilters).ToImmutableList();
+        var filters = lenses
+            .SelectMany(lens => lens.ExcludeFilters)
+            .DistinctBy(filter => (filter.ComparisonText.ToLowerInvariant(), filter.Mode, filter.IsExcluded))
+            .ToImmutableList();
 
         if (filters.IsEmpty) { return Task.CompletedTask; }
 

--- a/src/EventLogExpert.Runtime/FilterLenses/Effects.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/Effects.cs
@@ -129,9 +129,10 @@ internal sealed class Effects(
         if (string.IsNullOrWhiteSpace(action.Name)) { return Task.CompletedTask; }
 
         var lenses = _lensState.Value.Lenses;
+
         var filters = lenses
             .SelectMany(lens => lens.ExcludeFilters)
-            .DistinctBy(filter => (filter.ComparisonText.ToLowerInvariant(), filter.Mode, filter.IsExcluded))
+            .DistinctBy(filter => (filter.ComparisonText, filter.Mode, filter.IsExcluded))
             .ToImmutableList();
 
         if (filters.IsEmpty) { return Task.CompletedTask; }

--- a/src/EventLogExpert.Runtime/FilterLenses/Effects.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/Effects.cs
@@ -102,11 +102,22 @@ internal sealed class Effects(
     public Task HandleRemoveForLog(RemoveLensesForLogAction action, IDispatcher dispatcher) => Reapply(dispatcher);
 
     [EffectMethod]
+    public Task HandleRemoveLenses(RemoveFilterLensesAction action, IDispatcher dispatcher) => Reapply(dispatcher);
+
+    [EffectMethod]
     public Task HandleSaveFilterSetSucceeded(SaveFilterSetSucceededAction action, IDispatcher dispatcher)
     {
         if (action.Origin == SaveFilterSetOrigin.Lens)
         {
             _announcementService.AnnounceLensGroupSaved(action.Name);
+        }
+
+        // Save-and-clear removes only the lenses that were actually saved (captured before the persist began), so any
+        // lens the user added while the write was in flight survives. The removal rides the confirmed-persist signal,
+        // so a failed save never removes anything.
+        if (action.LensesToClearOnSuccess is { Count: > 0 } lensesToClear)
+        {
+            dispatcher.Dispatch(new RemoveFilterLensesAction(lensesToClear));
         }
 
         return Task.CompletedTask;
@@ -117,13 +128,17 @@ internal sealed class Effects(
     {
         if (string.IsNullOrWhiteSpace(action.Name)) { return Task.CompletedTask; }
 
-        var filters = _lensState.Value.Lenses.SelectMany(lens => lens.ExcludeFilters).ToImmutableList();
+        var lenses = _lensState.Value.Lenses;
+        var filters = lenses.SelectMany(lens => lens.ExcludeFilters).ToImmutableList();
 
         if (filters.IsEmpty) { return Task.CompletedTask; }
 
-        // Tag the save as lens-originated. The terminal SaveFilterSetSucceededAction is announced (below) only
-        // for this origin, and only after the write actually succeeds; failure surfaces via the error banner.
-        dispatcher.Dispatch(new SaveFilterSetAction(action.Name, filters, SaveFilterSetOrigin.Lens));
+        // For save-and-clear, capture the ids of exactly the lenses being saved. The terminal
+        // SaveFilterSetSucceededAction removes only those - and only after the write succeeds - so a lens added while
+        // the persist is in flight survives, and a failed save (surfaced via the error banner) discards nothing.
+        var lensesToClearOnSuccess = action.ClearAfterSave ? lenses.Select(lens => lens.Id).ToImmutableList() : null;
+
+        dispatcher.Dispatch(new SaveFilterSetAction(action.Name, filters, SaveFilterSetOrigin.Lens, lensesToClearOnSuccess));
 
         return Task.CompletedTask;
     }

--- a/src/EventLogExpert.Runtime/FilterLenses/Effects.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/Effects.cs
@@ -128,19 +128,18 @@ internal sealed class Effects(
     {
         if (string.IsNullOrWhiteSpace(action.Name)) { return Task.CompletedTask; }
 
-        var lenses = _lensState.Value.Lenses;
+        var contributingLenses = _lensState.Value.Lenses.Where(lens => !lens.ExcludeFilters.IsEmpty).ToImmutableList();
 
-        var filters = lenses
+        var filters = contributingLenses
             .SelectMany(lens => lens.ExcludeFilters)
             .DistinctBy(filter => (filter.ComparisonText, filter.Mode, filter.IsExcluded))
             .ToImmutableList();
 
         if (filters.IsEmpty) { return Task.CompletedTask; }
 
-        // For save-and-clear, capture the ids of exactly the lenses being saved. The terminal
-        // SaveFilterSetSucceededAction removes only those - and only after the write succeeds - so a lens added while
-        // the persist is in flight survives, and a failed save (surfaced via the error banner) discards nothing.
-        var lensesToClearOnSuccess = action.ClearAfterSave ? lenses.Select(lens => lens.Id).ToImmutableList() : null;
+        var lensesToClearOnSuccess = action.ClearAfterSave ?
+            contributingLenses.Select(lens => lens.Id).ToImmutableList() :
+            null;
 
         dispatcher.Dispatch(new SaveFilterSetAction(action.Name, filters, SaveFilterSetOrigin.Lens, lensesToClearOnSuccess));
 

--- a/src/EventLogExpert.Runtime/FilterLenses/Effects.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/Effects.cs
@@ -130,9 +130,12 @@ internal sealed class Effects(
 
         var contributingLenses = _lensState.Value.Lenses.Where(lens => !lens.ExcludeFilters.IsEmpty).ToImmutableList();
 
+        // Dedupe by the same case-insensitive (ComparisonText, Mode, IsExcluded) identity the library apply path uses
+        // (ReduceMergeFilters / the FilterLibrary store dedup), so the saved group round-trips faithfully - applying it
+        // never silently drops a case-variant the save kept.
         var filters = contributingLenses
             .SelectMany(lens => lens.ExcludeFilters)
-            .DistinctBy(filter => (filter.ComparisonText, filter.Mode, filter.IsExcluded))
+            .DistinctBy(filter => (filter.ComparisonText.ToLowerInvariant(), filter.Mode, filter.IsExcluded))
             .ToImmutableList();
 
         if (filters.IsEmpty) { return Task.CompletedTask; }

--- a/src/EventLogExpert.Runtime/FilterLenses/Effects.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/Effects.cs
@@ -74,19 +74,20 @@ internal sealed class Effects(
     [EffectMethod(typeof(PromoteAllFilterLensesAction))]
     public Task HandlePromoteAll(IDispatcher dispatcher)
     {
-        var promoted = 0;
+        var commits = ImmutableList.CreateBuilder<PromotedLensCommit>();
 
         foreach (var lens in _lensState.Value.Lenses)
         {
             if (lens.ExcludeFilters.IsEmpty && lens.Window is not { IsEnabled: true }) { continue; }
 
-            dispatcher.Dispatch(new CommitPromotedLensAction(lens.Id, lens.ExcludeFilters, lens.Window));
-            promoted++;
+            commits.Add(new PromotedLensCommit(lens.Id, lens.ExcludeFilters, lens.Window));
         }
 
-        // Announce from the effect (not the breadcrumb) so it reflects what was actually committed, and stays
-        // silent when nothing was promotable. This is an in-memory commit, so unlike SaveAsGroup it cannot fail.
-        if (promoted > 0) { _announcementService.AnnounceLensesSavedAll(); }
+        if (commits.Count == 0) { return Task.CompletedTask; }
+
+        dispatcher.Dispatch(new CommitPromotedLensesAction(commits.ToImmutable()));
+
+        _announcementService.AnnounceLensesSavedAll();
 
         return Task.CompletedTask;
     }

--- a/src/EventLogExpert.Runtime/FilterLenses/FilterLensCommands.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/FilterLensCommands.cs
@@ -25,9 +25,13 @@ internal sealed class FilterLensCommands(IDispatcher dispatcher) : IFilterLensCo
     public void IncludeValue(EventProperty property, string value, string? originLog = null) =>
         PushLens(FilterLensFactory.ForIncludedValue(property, value, originLog));
 
+    public void PromoteAllLenses() => _dispatcher.Dispatch(new PromoteAllFilterLensesAction());
+
     public void PromoteLens(FilterLensId id) => _dispatcher.Dispatch(new PromoteFilterLensAction(id));
 
     public void RemoveLens(FilterLensId id) => _dispatcher.Dispatch(new RemoveFilterLensAction(id));
+
+    public void SaveLensesAsGroup(string name) => _dispatcher.Dispatch(new SaveLensesAsGroupAction(name));
 
     public void ShowEventsNearTime(DateTime timeCreated, TimeSpan radius, TimeZoneInfo displayZone, string? originLog = null) =>
         PushLens(FilterLensFactory.ForTimeWindow(timeCreated, radius, displayZone, originLog));

--- a/src/EventLogExpert.Runtime/FilterLenses/FilterLensCommands.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/FilterLensCommands.cs
@@ -31,7 +31,8 @@ internal sealed class FilterLensCommands(IDispatcher dispatcher) : IFilterLensCo
 
     public void RemoveLens(FilterLensId id) => _dispatcher.Dispatch(new RemoveFilterLensAction(id));
 
-    public void SaveLensesAsGroup(string name) => _dispatcher.Dispatch(new SaveLensesAsGroupAction(name));
+    public void SaveLensesAsGroup(string name, bool clearAfterSave = false) =>
+        _dispatcher.Dispatch(new SaveLensesAsGroupAction(name, clearAfterSave));
 
     public void ShowEventsNearTime(DateTime timeCreated, TimeSpan radius, TimeZoneInfo displayZone, string? originLog = null) =>
         PushLens(FilterLensFactory.ForTimeWindow(timeCreated, radius, displayZone, originLog));

--- a/src/EventLogExpert.Runtime/FilterLenses/FilterLensSource.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/FilterLensSource.cs
@@ -15,7 +15,7 @@ internal sealed class FilterLensSource(
     : ObservableStateSourceBase<FilterLensState, ImmutableList<FilterLensSummary>>(
             state,
             logger,
-            static state => [.. state.Lenses.Select(lens => new FilterLensSummary(lens.Id, lens.Label))],
+            static state => [.. state.Lenses.Select(lens => new FilterLensSummary(lens.Id, lens.Label, lens.Kind))],
             static (next, current) => next.SequenceEqual(current)),
         IFilterLensSource
 {

--- a/src/EventLogExpert.Runtime/FilterLenses/IFilterLensCommands.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/IFilterLensCommands.cs
@@ -17,9 +17,13 @@ public interface IFilterLensCommands
 
     void IncludeValue(EventProperty property, string value, string? originLog = null);
 
+    void PromoteAllLenses();
+
     void PromoteLens(FilterLensId id);
 
     void RemoveLens(FilterLensId id);
+
+    void SaveLensesAsGroup(string name);
 
     void ShowEventsNearTime(DateTime timeCreated, TimeSpan radius, TimeZoneInfo displayZone, string? originLog = null);
 

--- a/src/EventLogExpert.Runtime/FilterLenses/IFilterLensCommands.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/IFilterLensCommands.cs
@@ -23,7 +23,7 @@ public interface IFilterLensCommands
 
     void RemoveLens(FilterLensId id);
 
-    void SaveLensesAsGroup(string name);
+    void SaveLensesAsGroup(string name, bool clearAfterSave = false);
 
     void ShowEventsNearTime(DateTime timeCreated, TimeSpan radius, TimeZoneInfo displayZone, string? originLog = null);
 

--- a/src/EventLogExpert.Runtime/FilterLenses/PromoteAllFilterLensesAction.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/PromoteAllFilterLensesAction.cs
@@ -3,4 +3,4 @@
 
 namespace EventLogExpert.Runtime.FilterLenses;
 
-public sealed record FilterLensSummary(FilterLensId Id, FilterLensLabel Label, LensKind Kind = LensKind.Property);
+internal sealed record PromoteAllFilterLensesAction;

--- a/src/EventLogExpert.Runtime/FilterLenses/Reducers.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/Reducers.cs
@@ -20,6 +20,17 @@ internal sealed class Reducers
     }
 
     [ReducerMethod]
+    public static FilterLensState ReduceCommitPromotedLenses(FilterLensState state, CommitPromotedLensesAction action)
+    {
+        if (action.Commits.IsEmpty) { return state; }
+
+        var promotedIds = action.Commits.Select(commit => commit.Id).ToHashSet();
+        var updated = state.Lenses.RemoveAll(lens => promotedIds.Contains(lens.Id));
+
+        return updated.Count == state.Lenses.Count ? state : state with { Lenses = updated };
+    }
+
+    [ReducerMethod]
     public static FilterLensState ReducePush(FilterLensState state, PushFilterLensAction action) =>
         state with { Lenses = state.Lenses.Add(action.Lens) };
 

--- a/src/EventLogExpert.Runtime/FilterLenses/Reducers.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/Reducers.cs
@@ -50,4 +50,15 @@ internal sealed class Reducers
 
         return updated.Count == state.Lenses.Count ? state : state with { Lenses = updated };
     }
+
+    [ReducerMethod]
+    public static FilterLensState ReduceRemoveLenses(FilterLensState state, RemoveFilterLensesAction action)
+    {
+        if (action.Ids.IsEmpty) { return state; }
+
+        var ids = action.Ids.ToHashSet();
+        var updated = state.Lenses.RemoveAll(lens => ids.Contains(lens.Id));
+
+        return updated.Count == state.Lenses.Count ? state : state with { Lenses = updated };
+    }
 }

--- a/src/EventLogExpert.Runtime/FilterLenses/RemoveFilterLensesAction.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/RemoveFilterLensesAction.cs
@@ -1,6 +1,8 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using System.Collections.Immutable;
+
 namespace EventLogExpert.Runtime.FilterLenses;
 
-internal sealed record SaveLensesAsGroupAction(string Name, bool ClearAfterSave = false);
+internal sealed record RemoveFilterLensesAction(ImmutableList<FilterLensId> Ids);

--- a/src/EventLogExpert.Runtime/FilterLenses/SaveLensesAsGroupAction.cs
+++ b/src/EventLogExpert.Runtime/FilterLenses/SaveLensesAsGroupAction.cs
@@ -3,4 +3,4 @@
 
 namespace EventLogExpert.Runtime.FilterLenses;
 
-public sealed record FilterLensSummary(FilterLensId Id, FilterLensLabel Label, LensKind Kind = LensKind.Property);
+internal sealed record SaveLensesAsGroupAction(string Name);

--- a/src/EventLogExpert.Runtime/FilterLibrary/Effects.cs
+++ b/src/EventLogExpert.Runtime/FilterLibrary/Effects.cs
@@ -4,6 +4,7 @@
 using EventLogExpert.Filtering.Persistence;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Runtime.Announcement;
+using EventLogExpert.Runtime.Banner;
 using EventLogExpert.Runtime.FilterPane;
 using Fluxor;
 using System.Collections.Immutable;
@@ -17,6 +18,7 @@ internal sealed class Effects(
     ILegacyFilterMigrator legacyMigrator,
     IBackslashNameMigrator backslashMigrator,
     IAnnouncementService announcementService,
+    IErrorBannerService errorBannerService,
     ITraceLogger logger,
     TagBulkUpdateFailedNotifier tagBulkUpdateFailedNotifier)
 {
@@ -469,9 +471,9 @@ internal sealed class Effects(
     }
 
     [EffectMethod]
-    public Task HandleSaveFilterSet(SaveFilterSetAction action, IDispatcher dispatcher)
+    public async Task HandleSaveFilterSet(SaveFilterSetAction action, IDispatcher dispatcher)
     {
-        if (string.IsNullOrWhiteSpace(action.Name) || action.Filters.IsEmpty) { return Task.CompletedTask; }
+        if (string.IsNullOrWhiteSpace(action.Name) || action.Filters.IsEmpty) { return; }
 
         var created = new LibraryEntryFilterSet
         {
@@ -481,7 +483,18 @@ internal sealed class Effects(
             Origin = LibraryEntryOrigin.UserSaved,
         };
 
-        return PersistAddAsync(created, dispatcher);
+        if (await PersistAddAsync(created, dispatcher).ConfigureAwait(false))
+        {
+            dispatcher.Dispatch(new SaveFilterSetSucceededAction(created.Name, action.Origin));
+
+            return;
+        }
+
+        // The write failed and was already logged in PersistAddAsync. Surface it visibly: the error banner is
+        // role="alert", so it also reaches screen readers - do not also announce, or it would be spoken twice.
+        errorBannerService.ReportError(
+            "Couldn't save filter set",
+            $"'{created.Name}' couldn't be saved to the filter library.");
     }
 
     [EffectMethod]
@@ -827,7 +840,7 @@ internal sealed class Effects(
         IDispatcher dispatcher) =>
         DispatchUpdateWithLatestSnapshot(id, mutate, dispatcher, state.Value.Entries);
 
-    private async Task PersistAddAsync(LibraryEntry entry, IDispatcher dispatcher)
+    private async Task<bool> PersistAddAsync(LibraryEntry entry, IDispatcher dispatcher)
     {
         await _writeGate.WaitAsync().ConfigureAwait(false);
 
@@ -838,10 +851,12 @@ internal sealed class Effects(
             {
                 logger.Warning($"FilterLibrary Add failed for {entry.Id}. {ex.Message}");
 
-                return;
+                return false;
             }
 
             dispatcher.Dispatch(new AddLibraryEntrySuccessAction(entry));
+
+            return true;
         }
         finally
         {

--- a/src/EventLogExpert.Runtime/FilterLibrary/Effects.cs
+++ b/src/EventLogExpert.Runtime/FilterLibrary/Effects.cs
@@ -485,7 +485,7 @@ internal sealed class Effects(
 
         if (await PersistAddAsync(created, dispatcher).ConfigureAwait(false))
         {
-            dispatcher.Dispatch(new SaveFilterSetSucceededAction(created.Name, action.Origin));
+            dispatcher.Dispatch(new SaveFilterSetSucceededAction(created.Name, action.Origin, action.LensesToClearOnSuccess));
 
             return;
         }

--- a/src/EventLogExpert.Runtime/FilterLibrary/SaveFilterSetAction.cs
+++ b/src/EventLogExpert.Runtime/FilterLibrary/SaveFilterSetAction.cs
@@ -6,4 +6,14 @@ using System.Collections.Immutable;
 
 namespace EventLogExpert.Runtime.FilterLibrary;
 
-internal sealed record SaveFilterSetAction(string Name, ImmutableList<SavedFilter> Filters);
+// Identifies who initiated a filter-set save so the terminal outcome can be routed back to that initiator.
+internal enum SaveFilterSetOrigin
+{
+    Library,
+    Lens,
+}
+
+internal sealed record SaveFilterSetAction(
+    string Name,
+    ImmutableList<SavedFilter> Filters,
+    SaveFilterSetOrigin Origin = SaveFilterSetOrigin.Library);

--- a/src/EventLogExpert.Runtime/FilterLibrary/SaveFilterSetAction.cs
+++ b/src/EventLogExpert.Runtime/FilterLibrary/SaveFilterSetAction.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Filtering.Persistence;
+using EventLogExpert.Runtime.FilterLenses;
 using System.Collections.Immutable;
 
 namespace EventLogExpert.Runtime.FilterLibrary;
@@ -16,4 +17,5 @@ internal enum SaveFilterSetOrigin
 internal sealed record SaveFilterSetAction(
     string Name,
     ImmutableList<SavedFilter> Filters,
-    SaveFilterSetOrigin Origin = SaveFilterSetOrigin.Library);
+    SaveFilterSetOrigin Origin = SaveFilterSetOrigin.Library,
+    ImmutableList<FilterLensId>? LensesToClearOnSuccess = null);

--- a/src/EventLogExpert.Runtime/FilterLibrary/SaveFilterSetSucceededAction.cs
+++ b/src/EventLogExpert.Runtime/FilterLibrary/SaveFilterSetSucceededAction.cs
@@ -1,6 +1,12 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Runtime.FilterLenses;
+using System.Collections.Immutable;
+
 namespace EventLogExpert.Runtime.FilterLibrary;
 
-internal sealed record SaveFilterSetSucceededAction(string Name, SaveFilterSetOrigin Origin);
+internal sealed record SaveFilterSetSucceededAction(
+    string Name,
+    SaveFilterSetOrigin Origin,
+    ImmutableList<FilterLensId>? LensesToClearOnSuccess = null);

--- a/src/EventLogExpert.Runtime/FilterLibrary/SaveFilterSetSucceededAction.cs
+++ b/src/EventLogExpert.Runtime/FilterLibrary/SaveFilterSetSucceededAction.cs
@@ -1,0 +1,6 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+namespace EventLogExpert.Runtime.FilterLibrary;
+
+internal sealed record SaveFilterSetSucceededAction(string Name, SaveFilterSetOrigin Origin);

--- a/src/EventLogExpert.Runtime/FilterPane/Effects.cs
+++ b/src/EventLogExpert.Runtime/FilterPane/Effects.cs
@@ -79,6 +79,21 @@ internal sealed class Effects
         return Task.CompletedTask;
     }
 
+    [EffectMethod]
+    public Task HandleCommitPromotedLenses(CommitPromotedLensesAction action, IDispatcher dispatcher)
+    {
+        dispatcher.Dispatch(new ApplyFilterAction(BuildCandidate(_filterPaneState.Value)));
+
+        if (action.Commits.Any(commit => commit.Window is { IsEnabled: true }))
+        {
+            _setFilterDateRangeSucceededNotifier.Raise();
+        }
+
+        _filterPromotedNotifier.Raise();
+
+        return Task.CompletedTask;
+    }
+
     [EffectMethod(typeof(MergeFiltersAction))]
     public Task HandleMergeFilters(IDispatcher dispatcher)
     {

--- a/src/EventLogExpert.Runtime/FilterPane/Reducers.cs
+++ b/src/EventLogExpert.Runtime/FilterPane/Reducers.cs
@@ -21,43 +21,39 @@ internal sealed class Reducers
     [ReducerMethod]
     public static FilterPaneState ReduceCommitPromoted(FilterPaneState state, CommitPromotedLensAction action)
     {
+        var filters = MergePromotedFilters(state.Filters, action.Filters);
+
+        var date = action.Window is { IsEnabled: true } window ?
+            EffectiveFilterBuilder.IntersectWindow(state.FilteredDateRange, window) :
+            state.FilteredDateRange;
+
+        return ReferenceEquals(filters, state.Filters) && date == state.FilteredDateRange ?
+            state :
+            state with { Filters = filters, FilteredDateRange = date };
+    }
+
+    [ReducerMethod]
+    public static FilterPaneState ReduceCommitPromotedLenses(FilterPaneState state, CommitPromotedLensesAction action)
+    {
         var filters = state.Filters;
+        var date = state.FilteredDateRange;
 
-        foreach (var promoted in action.Filters)
+        // Fold every lens into the SAME running accumulators so batch == the sequential single-lens result: a filter
+        // added for one lens deduplicates the next lens's identical filter, and each enabled window intersects
+        // cumulatively (order-independent - dedup keys are exact and IntersectWindow is min/max of bounds).
+        foreach (var commit in action.Commits)
         {
-            // Match only a USABLE (compiled) equivalent, ordinal-exact so case-variant values stay distinct predicates
-            // (filter string equality is ordinal, unlike the lowercased library MRU in ReduceMergeFilters). A dead
-            // (uncompiled) ordinal match narrows nothing, so it is passed over and the working filter is added below.
-            var existingIndex = filters.FindIndex(filter =>
-                string.Equals(filter.ComparisonText, promoted.ComparisonText, StringComparison.Ordinal) &&
-                filter.Mode == promoted.Mode &&
-                filter.IsExcluded == promoted.IsExcluded &&
-                filter.Compiled is not null);
+            filters = MergePromotedFilters(filters, commit.Filters);
 
-            if (existingIndex >= 0)
+            if (commit.Window is { IsEnabled: true } window)
             {
-                var existing = filters[existingIndex];
-
-                // Re-enable a disabled equivalent in place so the promoted narrowing stays active; an already-enabled
-                // equivalent needs no change. Either way, no duplicate row.
-                if (!existing.IsEnabled)
-                {
-                    filters = filters.SetItem(existingIndex, existing with { IsEnabled = true });
-                }
-
-                continue;
+                date = EffectiveFilterBuilder.IntersectWindow(date, window);
             }
-
-            filters = filters.Add(promoted with { Id = FilterId.Create(), IsEnabled = promoted.Compiled is not null });
         }
 
-        var date = action.Window is { IsEnabled: true } window
-            ? EffectiveFilterBuilder.IntersectWindow(state.FilteredDateRange, window)
-            : state.FilteredDateRange;
-
-        return ReferenceEquals(filters, state.Filters) && date == state.FilteredDateRange
-            ? state
-            : state with { Filters = filters, FilteredDateRange = date };
+        return ReferenceEquals(filters, state.Filters) && date == state.FilteredDateRange ?
+            state :
+            state with { Filters = filters, FilteredDateRange = date };
     }
 
     [ReducerMethod]
@@ -163,6 +159,43 @@ internal sealed class Reducers
     [ReducerMethod(typeof(ToggleIsEnabledAction))]
     public static FilterPaneState ReduceToggleIsEnabled(FilterPaneState state) =>
         state with { IsEnabled = !state.IsEnabled };
+
+    // Folds one lens's promoted filters into the RUNNING list (not a fresh read of state.Filters, so a batch dedups
+    // across lenses): re-enable a disabled compiled-equivalent in place, leave a live one, else append a fresh copy.
+    private static ImmutableList<SavedFilter> MergePromotedFilters(
+        ImmutableList<SavedFilter> running,
+        ImmutableList<SavedFilter> promotedFilters)
+    {
+        foreach (var promoted in promotedFilters)
+        {
+            // Match only a USABLE (compiled) equivalent, ordinal-exact so case-variant values stay distinct predicates
+            // (filter string equality is ordinal, unlike the lowercased library MRU in ReduceMergeFilters). A dead
+            // (uncompiled) ordinal match narrows nothing, so it is passed over and the working filter is added below.
+            var existingIndex = running.FindIndex(filter =>
+                string.Equals(filter.ComparisonText, promoted.ComparisonText, StringComparison.Ordinal) &&
+                filter.Mode == promoted.Mode &&
+                filter.IsExcluded == promoted.IsExcluded &&
+                filter.Compiled is not null);
+
+            if (existingIndex >= 0)
+            {
+                var existing = running[existingIndex];
+
+                // Re-enable a disabled equivalent in place so the promoted narrowing stays active; an already-enabled
+                // equivalent needs no change. Either way, no duplicate row.
+                if (!existing.IsEnabled)
+                {
+                    running = running.SetItem(existingIndex, existing with { IsEnabled = true });
+                }
+
+                continue;
+            }
+
+            running = running.Add(promoted with { Id = FilterId.Create(), IsEnabled = promoted.Compiled is not null });
+        }
+
+        return running;
+    }
 
     private static FilterPaneState UpdateFilterById(
         FilterPaneState state,

--- a/src/EventLogExpert.UI/Alerts/AlertDialogService.cs
+++ b/src/EventLogExpert.UI/Alerts/AlertDialogService.cs
@@ -14,7 +14,9 @@ public sealed class AlertDialogService(
     IErrorBannerService errorBannerService,
     IInfoBannerService infoBannerService,
     Func<IReadOnlyDictionary<string, object?>, Task<bool>> openStandaloneAlert,
-    Func<IReadOnlyDictionary<string, object?>, Task<string>> openStandalonePrompt) : IAlertDialogService
+    Func<IReadOnlyDictionary<string, object?>, Task<string>> openStandalonePrompt,
+    Func<IReadOnlyDictionary<string, object?>, Task<PromptOutcome>>? openStandalonePromptWithSecondary = null)
+    : IAlertDialogService
 {
     private readonly IErrorBannerService _errorBannerService = errorBannerService;
     private readonly IInfoBannerService _infoBannerService = infoBannerService;
@@ -23,6 +25,8 @@ public sealed class AlertDialogService(
     private readonly Func<IReadOnlyDictionary<string, object?>, Task<bool>> _openStandaloneAlert = openStandaloneAlert;
     private readonly Func<IReadOnlyDictionary<string, object?>, Task<string>> _openStandalonePrompt =
         openStandalonePrompt;
+    private readonly Func<IReadOnlyDictionary<string, object?>, Task<PromptOutcome>> _openStandalonePromptWithSecondary =
+        openStandalonePromptWithSecondary ?? (_ => Task.FromResult(new PromptOutcome(PromptChoice.Cancel, string.Empty)));
 
     public Task<string> DisplayPrompt(string title, string message) => DisplayPromptCore(title, message, null, null);
 
@@ -31,6 +35,16 @@ public sealed class AlertDialogService(
 
     public Task<string> DisplayPrompt(string title, string message, string initialValue, Func<string, string?>? validate) =>
         DisplayPromptCore(title, message, initialValue, validate);
+
+    public Task<PromptOutcome> DisplayPromptWithSecondary(
+        string title,
+        string message,
+        string initialValue,
+        string primaryLabel,
+        string secondaryLabel,
+        string cancelLabel,
+        Func<string, string?>? validate = null) =>
+        DisplayPromptWithSecondaryCore(title, message, initialValue, primaryLabel, secondaryLabel, cancelLabel, validate);
 
     public Task ShowAlert(string title, string message, string cancel) =>
         ShowAlert(title, message, cancel, AlertPresentation.Auto);
@@ -94,6 +108,55 @@ public sealed class AlertDialogService(
             catch (TaskCanceledException)
             {
                 return string.Empty;
+            }
+        });
+
+    private Task<PromptOutcome> DisplayPromptWithSecondaryCore(
+        string title,
+        string message,
+        string initialValue,
+        string primaryLabel,
+        string secondaryLabel,
+        string cancelLabel,
+        Func<string, string?>? validate) =>
+        InvokeOnMainThreadAsync(async () =>
+        {
+            if (!_modalCoordinator.TryGetInlineAlertHost(out var host))
+            {
+                return await _openStandalonePromptWithSecondary(new Dictionary<string, object?>
+                {
+                    ["Title"] = title,
+                    ["Message"] = message,
+                    ["InitialValue"] = initialValue,
+                    ["Validate"] = validate,
+                    ["PrimaryLabel"] = primaryLabel,
+                    ["SecondaryActionLabel"] = secondaryLabel,
+                    ["CancelLabel"] = cancelLabel,
+                });
+            }
+
+            try
+            {
+                InlineAlertResult result = await host.ShowInlineAlertAsync(
+                    new InlineAlertRequest(title, message, primaryLabel, cancelLabel, true, initialValue)
+                    {
+                        SecondaryActionLabel = secondaryLabel,
+                        Validate = validate,
+                    },
+                    CancellationToken.None);
+
+                if (result.Accepted)
+                {
+                    return new PromptOutcome(PromptChoice.Primary, result.PromptValue ?? string.Empty);
+                }
+
+                return result.SecondaryChosen ?
+                    new PromptOutcome(PromptChoice.Secondary, result.PromptValue ?? string.Empty) :
+                    new PromptOutcome(PromptChoice.Cancel, string.Empty);
+            }
+            catch (TaskCanceledException)
+            {
+                return new PromptOutcome(PromptChoice.Cancel, string.Empty);
             }
         });
 

--- a/src/EventLogExpert.UI/Alerts/PromptModal.razor
+++ b/src/EventLogExpert.UI/Alerts/PromptModal.razor
@@ -12,18 +12,19 @@
     OnCancel="OnCancelAsync"
     OnDialogClosedByUser="HandleDialogClosedByUserAsync"
     OnInlineAlertResolved="HandleInlineAlertResolvedAsync"
-    @ref="ChromeRef"
-    Title="@Title">
+    Title="@Title"
+    @ref="ChromeRef">
     <ChildContent>
         <label class="prompt-modal-label" for="@_inputId">@Message</label>
         <TextInput AriaDescribedBy="@(ValidationError is not null ? _errorId : null)"
             AriaInvalid="@(ValidationError is not null)"
             CssClass="input dialog-input"
             Id="@_inputId"
-            @ref="_input"
+            OnEnter="HandleAcceptClickedAsync"
             UpdateOnInput="true"
             Value="@_value"
-            ValueChanged="HandleValueChanged" />
+            ValueChanged="HandleValueChanged"
+            @ref="_input" />
 
         @if (ValidationError is not null)
         {

--- a/src/EventLogExpert.UI/Alerts/PromptModal.razor
+++ b/src/EventLogExpert.UI/Alerts/PromptModal.razor
@@ -1,9 +1,10 @@
-@inherits ModalBase<string>
+@using EventLogExpert.Runtime.Alerts
+@inherits ModalBase<PromptOutcome>
 
 <ModalChrome AcceptDisabled="@(ValidationError is not null)"
-    AcceptLabel="OK"
+    AcceptLabel="@PrimaryLabel"
     AriaLabel="@AriaLabelText"
-    CancelLabel="Cancel"
+    CancelLabel="@CancelLabel"
     Footer="FooterPreset.AcceptCancel"
     InlineAlert="@CurrentInlineAlert"
     MaxWidth="min(34rem, calc(100vw - 2rem))"
@@ -12,6 +13,9 @@
     OnCancel="OnCancelAsync"
     OnDialogClosedByUser="HandleDialogClosedByUserAsync"
     OnInlineAlertResolved="HandleInlineAlertResolvedAsync"
+    OnSecondaryAction="HandleSecondaryActionClickedAsync"
+    SecondaryActionDisabled="@(ValidationError is not null)"
+    SecondaryActionLabel="@SecondaryActionLabel"
     Title="@Title"
     @ref="ChromeRef">
     <ChildContent>

--- a/src/EventLogExpert.UI/Alerts/PromptModal.razor.cs
+++ b/src/EventLogExpert.UI/Alerts/PromptModal.razor.cs
@@ -1,6 +1,7 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using EventLogExpert.Runtime.Alerts;
 using EventLogExpert.UI.Common;
 using EventLogExpert.UI.Inputs;
 using EventLogExpert.UI.Modal;
@@ -8,12 +9,7 @@ using Microsoft.AspNetCore.Components;
 
 namespace EventLogExpert.UI.Alerts;
 
-/// <summary>
-///     Standalone prompt modal used by <c>AlertDialogService</c> when no host modal is active. Returns the input
-///     value on Accept, or <see cref="string.Empty" /> on Cancel/Esc to match the existing
-///     <c>IAlertDialogService.DisplayPrompt</c> non-null contract.
-/// </summary>
-public sealed partial class PromptModal : ModalBase<string>
+public sealed partial class PromptModal : ModalBase<PromptOutcome>
 {
     private readonly string _errorId = ComponentId.NewUnique("prompt-modal-validation").Value;
     private readonly string _inputId = ComponentId.NewUnique("prompt-modal-input").Value;
@@ -22,9 +18,15 @@ public sealed partial class PromptModal : ModalBase<string>
     private TextInput? _input;
     private string _value = string.Empty;
 
+    [Parameter] public string CancelLabel { get; set; } = "Cancel";
+
     [Parameter] public string InitialValue { get; set; } = string.Empty;
 
     [Parameter] public string Message { get; set; } = string.Empty;
+
+    [Parameter] public string PrimaryLabel { get; set; } = "OK";
+
+    [Parameter] public string? SecondaryActionLabel { get; set; }
 
     [Parameter] public string Title { get; set; } = string.Empty;
 
@@ -53,7 +55,7 @@ public sealed partial class PromptModal : ModalBase<string>
         await base.OnAfterRenderAsync(firstRender);
     }
 
-    protected override Task OnCancelAsync() => CompleteAsync(string.Empty);
+    protected override Task OnCancelAsync() => CompleteAsync(new PromptOutcome(PromptChoice.Cancel, string.Empty));
 
     protected override void OnInitialized()
     {
@@ -61,8 +63,14 @@ public sealed partial class PromptModal : ModalBase<string>
         base.OnInitialized();
     }
 
+    private Task CompleteIfValidAsync(PromptChoice choice) =>
+        ValidationError is not null ? Task.CompletedTask : CompleteAsync(new PromptOutcome(choice, _value));
+
     private Task HandleAcceptClickedAsync() =>
-        ValidationError is not null ? Task.CompletedTask : CompleteAsync(_value);
+        CompleteIfValidAsync(PromptChoice.Primary);
+
+    private Task HandleSecondaryActionClickedAsync() =>
+        CompleteIfValidAsync(PromptChoice.Secondary);
 
     private void HandleValueChanged(string value) => _value = value;
 }

--- a/src/EventLogExpert.UI/Announcement/AnnouncerHost.razor.cs
+++ b/src/EventLogExpert.UI/Announcement/AnnouncerHost.razor.cs
@@ -36,6 +36,10 @@ public sealed partial class AnnouncerHost : ComponentBase, IDisposable
             AnnouncementPayload.Text(var message) => message,
             AnnouncementPayload.LensKept(var label) =>
                 Localizer["FilterLens_KeptAnnouncement", FilterLensLabelFormatter.Format(Localizer, label)].Value,
+            AnnouncementPayload.LensGroupSaved(var name) =>
+                Localizer["FilterLens_SavedAsGroupAnnouncement", name].Value,
+            AnnouncementPayload.LensesSavedAll _ =>
+                Localizer["FilterLens_SavedAllAnnouncement"].Value,
             _ => throw new ArgumentOutOfRangeException(nameof(current.Payload), current.Payload, null)
         };
 

--- a/src/EventLogExpert.UI/Banner/AttentionBanner.razor
+++ b/src/EventLogExpert.UI/Banner/AttentionBanner.razor
@@ -7,8 +7,8 @@
         Open Databases
     </Button>
 
-    <Button aria-label="Dismiss attention banner"
-        CssClass="banner-dismiss"
-        IconClass="bi bi-x"
-        OnClick="OnDismissAttention" />
+    <Button CssClass="banner-dismiss"
+        IconClass="bi bi-x-circle"
+        OnClick="OnDismissAttention"
+        aria-label="Dismiss attention banner" />
 </aside>

--- a/src/EventLogExpert.UI/Banner/ErrorBanner.razor
+++ b/src/EventLogExpert.UI/Banner/ErrorBanner.razor
@@ -11,8 +11,8 @@
         </Button>
     }
 
-    <Button aria-label="Dismiss error banner"
-        CssClass="banner-dismiss"
-        IconClass="bi bi-x"
-        OnClick="OnDismissError" />
+    <Button CssClass="banner-dismiss"
+        IconClass="bi bi-x-circle"
+        OnClick="OnDismissError"
+        aria-label="Dismiss error banner" />
 </aside>

--- a/src/EventLogExpert.UI/Banner/InfoBanner.razor
+++ b/src/EventLogExpert.UI/Banner/InfoBanner.razor
@@ -3,8 +3,8 @@
 
     @CycleNav
 
-    <Button aria-label="Dismiss banner"
-        CssClass="banner-dismiss"
-        IconClass="bi bi-x"
-        OnClick="OnDismissInfo" />
+    <Button CssClass="banner-dismiss"
+        IconClass="bi bi-x-circle"
+        OnClick="OnDismissInfo"
+        aria-label="Dismiss banner" />
 </aside>

--- a/src/EventLogExpert.UI/DatabaseTools/DatabaseToolsLogView.razor
+++ b/src/EventLogExpert.UI/DatabaseTools/DatabaseToolsLogView.razor
@@ -7,7 +7,7 @@
             <div class="toolbar-leading">@ToolbarLeadingContent</div>
         }
 
-        <span class="entry-count">@Entries.Count @(Entries.Count == 1 ? "entry" : "entries")</span>
+        <span class="entry-count vcenter-text">@Entries.Count @(Entries.Count == 1 ? "entry" : "entries")</span>
 
         <span aria-atomic="true" aria-live="@OutcomeChipAriaLive" role="@OutcomeChipRole">
             @if (Outcome is not null)

--- a/src/EventLogExpert.UI/DatabaseTools/DatabaseToolsLogView.razor.css
+++ b/src/EventLogExpert.UI/DatabaseTools/DatabaseToolsLogView.razor.css
@@ -43,9 +43,6 @@
 }
 
 .database-tools-log-toolbar .entry-count {
-    display: inline-flex;
-    align-items: center;
-    line-height: 1;
     padding-left: 6px;
     font-size: 0.85em;
     color: var(--text-secondary);

--- a/src/EventLogExpert.UI/DebugLog/DebugLogFilterRow.razor
+++ b/src/EventLogExpert.UI/DebugLog/DebugLogFilterRow.razor
@@ -25,6 +25,7 @@
         </ValueSelect>
 
         <ComparisonOperatorSelect AriaLabel="Filter operator"
+            CssClass="input filter-dropdown"
             MatchMode="draft.MatchMode"
             OnChanged="OnOperatorChanged"
             Operator="draft.Operator"

--- a/src/EventLogExpert.UI/DebugLog/DebugLogModal.razor
+++ b/src/EventLogExpert.UI/DebugLog/DebugLogModal.razor
@@ -19,7 +19,6 @@
                 <DebugLogFilterRow Applied="row.Applied"
                     AvailableCategories="CategoryFilterOptions()"
                     Draft="row.Editing"
-                    @key="row.Id"
                     OnCancel="@(() => CancelEditing(row))"
                     OnChanged="OnEditorChanged"
                     OnEdit="@(() => StartEditing(row))"
@@ -27,29 +26,30 @@
                     OnExcludeToggled="@(() => ToggleExclude(row))"
                     OnRemove="@(() => RemoveFilter(row))"
                     OnSave="@(() => SaveFilter(row))"
+                    @key="row.Id"
                     @ref="_editorRefs[row.Id]" />
             }
 
-            <Button aria-label="Add filter"
-                CssClass="debug-log-add-filter"
+            <Button CssClass="debug-log-add-filter"
                 IconClass="bi bi-plus-circle"
                 OnClick="AddFilter"
+                aria-label="Add filter"
                 @ref="_addButton"
                 title="Add filter">
                 Add Filter
             </Button>
 
-            <Button aria-label="Clear all filters"
-                CssClass="debug-log-clear-filters"
+            <Button CssClass="debug-log-clear-filters"
                 Disabled="@(_rows.Count == 0)"
                 IconClass="bi bi-x-circle"
                 OnClick="ClearFilters"
+                aria-label="Clear all filters"
                 title="Clear all filters">
                 Clear Filters
             </Button>
         </div>
         <div aria-busy="@(_hasLoaded ? "false" : "true")" aria-label="Debug log entries" class="debug-log-viewport" role="region" tabindex="0">
-            <Virtualize Context="line" Items="_displayed" ItemSize="@RowHeightPx" OverscanCount="20">
+            <Virtualize Context="line" ItemSize="@RowHeightPx" Items="_displayed" OverscanCount="20">
                 <ItemContent>
                     <div class="debug-log-row" title="@line">@line</div>
                 </ItemContent>
@@ -74,7 +74,7 @@
                     Copy
                 </Button>
             </div>
-            <span aria-atomic="true" aria-live="polite" class="debug-log-footer-counter" role="status">
+            <span aria-atomic="true" aria-live="polite" class="debug-log-footer-counter vcenter-text" role="status">
                 @($"{_filteredEntryCount:N0} of {_entries.Count:N0} {(_entries.Count == 1 ? "entry" : "entries")}")
             </span>
             <div class="debug-log-footer-actions debug-log-footer-right">

--- a/src/EventLogExpert.UI/DetailsPane/DetailsPane.razor.css
+++ b/src/EventLogExpert.UI/DetailsPane/DetailsPane.razor.css
@@ -5,7 +5,7 @@
     flex: 0 0 auto;
     height: var(--details-pane-height, 30%);
     min-height: 20%;
-    margin: 0 5px;
+    margin: 0;
     border-top: solid var(--background-darkgray);
     overflow: hidden;
 
@@ -338,6 +338,7 @@
 .details-correlation-tab {
     flex: 1 1 auto;
     min-height: 0;
+    padding: 0 0.85rem;
     overflow-x: hidden;
     overflow-y: auto;
 }

--- a/src/EventLogExpert.UI/FilterEditor/Comparison/ComparisonOperatorSelect.razor.cs
+++ b/src/EventLogExpert.UI/FilterEditor/Comparison/ComparisonOperatorSelect.razor.cs
@@ -32,7 +32,7 @@ public sealed partial class ComparisonOperatorSelect
 
     [Parameter] public string? AriaLabelledBy { get; set; }
 
-    [Parameter] public string CssClass { get; set; } = "input filter-dropdown";
+    [Parameter] public string CssClass { get; set; } = "input filter-operator-select";
 
     [Parameter] public MatchMode MatchMode { get; set; }
 

--- a/src/EventLogExpert.UI/FilterEditor/Comparison/FilterComparisonEditor.razor
+++ b/src/EventLogExpert.UI/FilterEditor/Comparison/FilterComparisonEditor.razor
@@ -1,6 +1,6 @@
 <ValueSelect AriaLabel="@(PropertyAriaLabelledBy is null ? Localizer["FilterEditor_PropertyLabel"].Value : null)"
     AriaLabelledBy="@PropertyAriaLabelledBy"
-    CssClass="input filter-dropdown"
+    CssClass="input filter-property-select"
     T="EventProperty"
     ToStringFunc="@(x => FilterLensLabelFormatter.PropertyName(Localizer, x))"
     @bind-Value="PropertyBinding">

--- a/src/EventLogExpert.UI/FilterEditor/Editing/FilterEditPanel.razor.css
+++ b/src/EventLogExpert.UI/FilterEditor/Editing/FilterEditPanel.razor.css
@@ -68,7 +68,13 @@
    muted gray = included. Uses aria-pressed for SR + visible color cue. */
 .filter-edit-panel-content ::deep .filter-exclude-toggle {
     color: var(--text-secondary);
-    transition: color 0.1s ease-in-out;
+    transition: color 0.1s ease-in-out, background-color 0.1s ease-in-out;
+}
+
+/* Neutral background-shift on hover so the affordance is visible in the muted "include" (gray)
+   state, not only the red "exclude" state where a color-tinted hover happened to show. */
+.filter-edit-panel-content ::deep .filter-exclude-toggle:hover:not(:disabled) {
+    background: var(--menu-hover-overlay);
 }
 
 .filter-edit-panel-content ::deep .filter-exclude-toggle[data-excluded="true"] {

--- a/src/EventLogExpert.UI/FilterEditor/Editing/FilterEditPanel.razor.css
+++ b/src/EventLogExpert.UI/FilterEditor/Editing/FilterEditPanel.razor.css
@@ -101,7 +101,7 @@
     border-color: var(--text-secondary);
 }
 
-.color-picker-wrapper[data-filter-excluded="true"] ::deep input.color-dropdown:focus:not([data-pointer-focus]) {
+:root[data-modality="keyboard"] .color-picker-wrapper[data-filter-excluded="true"] ::deep input.color-dropdown:focus {
     outline: 1px solid var(--toggle-accent);
     outline-offset: 2px;
 }

--- a/src/EventLogExpert.UI/FilterEditor/Editing/FilterPredicateEditor.razor.css
+++ b/src/EventLogExpert.UI/FilterEditor/Editing/FilterPredicateEditor.razor.css
@@ -158,11 +158,15 @@
     }
 }
 
-/* Compact dropdowns inside the editing chip. */
-.filter-predicate-editing ::deep .input.filter-dropdown {
-    width: 100px;
+/* Done/Remove icon buttons share the same neutral background-shift hover as the other filter
+   icon buttons; the icon color (accent/red) still carries state. :not(:disabled) leaves the
+   Done button inert while the predicate is incomplete. */
+.filter-predicate-editing ::deep .button.icon-button:hover:not(:disabled) {
+    background: var(--menu-hover-overlay);
 }
 
+/* Compact dropdowns inside the editing chip. The property/operator selects size to their
+   longest option globally (app.css); only the value select needs a context-tuned width here. */
 .filter-predicate-editing ::deep .input.filter-value-dropdown,
 .filter-predicate-editing ::deep .input.filter-description {
     width: 240px;

--- a/src/EventLogExpert.UI/FilterEditor/Editing/FilterPredicateList.razor.css
+++ b/src/EventLogExpert.UI/FilterEditor/Editing/FilterPredicateList.razor.css
@@ -19,8 +19,13 @@
 
 .filter-predicate-list ::deep .add-filter-predicate-button {
     color: var(--text-secondary);
+    transition: color 0.1s ease-in-out, background-color 0.1s ease-in-out;
 }
 
-.filter-predicate-list ::deep .add-filter-predicate-button:hover {
+/* Enabled-state hover: keep the color cue and add the shared neutral background-shift so the
+   button reads as interactive. The Add button is disabled while any predicate is incomplete
+   (CanAddPredicate), and :not(:disabled) keeps the disabled state inert (no hover, no pointer). */
+.filter-predicate-list ::deep .add-filter-predicate-button:hover:not(:disabled) {
     color: var(--clr-lightblue);
+    background: var(--menu-hover-overlay);
 }

--- a/src/EventLogExpert.UI/FilterEditor/FilterEditorCore.razor.css
+++ b/src/EventLogExpert.UI/FilterEditor/FilterEditorCore.razor.css
@@ -16,10 +16,6 @@
     gap: 0.25rem;
 }
 
-.filter-row-structured ::deep .input.filter-dropdown {
-    width: 100px;
-}
-
 .filter-row-structured ::deep .input.filter-value-dropdown,
 .filter-row-structured ::deep .input.filter-description {
     width: 280px;

--- a/src/EventLogExpert.UI/FilterEditor/Rows/FilterRowHeader.razor.css
+++ b/src/EventLogExpert.UI/FilterEditor/Rows/FilterRowHeader.razor.css
@@ -19,7 +19,13 @@
    not color). */
 .filter-row-header ::deep .filter-exclude-toggle {
     color: var(--text-secondary);
-    transition: color 0.1s ease-in-out;
+    transition: color 0.1s ease-in-out, background-color 0.1s ease-in-out;
+}
+
+/* Neutral background-shift on hover so the affordance is visible in the muted "include" (gray)
+   state, not only the red "exclude" state where a color-tinted hover happened to show. */
+.filter-row-header ::deep .filter-exclude-toggle:hover:not(:disabled) {
+    background: var(--menu-hover-overlay);
 }
 
 .filter-row-header ::deep .filter-exclude-toggle[data-excluded="true"] {

--- a/src/EventLogExpert.UI/FilterLenses/LensBreadcrumb.razor
+++ b/src/EventLogExpert.UI/FilterLenses/LensBreadcrumb.razor
@@ -21,11 +21,11 @@
             var label = FilterLensLabelFormatter.Format(Localizer, lens.Label);
             <span class="lens-chip">
                 <span class="lens-chip-label" title="@label">@label</span>
-                <button aria-label="@Localizer["FilterLens_KeepAria", label].Value"
+                <button aria-label="@Localizer["FilterLens_SaveAria", label].Value"
                     class="lens-chip-keep"
                     @onclick="@(() => Commands.PromoteLens(lensId))"
                     type="button">
-                    <i aria-hidden="true" class="bi bi-pin-angle"></i>
+                    <i aria-hidden="true" class="bi bi-floppy"></i>
                 </button>
                 <button aria-label="@Localizer["FilterLens_RemoveAria", label].Value"
                     class="lens-chip-remove"
@@ -36,6 +36,14 @@
             </span>
         }
 
+        <button class="lens-action" @onclick="SaveAll" type="button">@Localizer["FilterLens_SaveAll"]</button>
+        <button class="lens-action"
+            disabled="@(!CanSaveAsGroup)"
+            @onclick="SaveAsGroupAsync"
+            title="@(CanSaveAsGroup ? null : Localizer["FilterLens_SaveAsGroup_DisabledTitle"].Value)"
+            type="button">
+            @Localizer["FilterLens_SaveAsGroup"]
+        </button>
         <button class="lens-clear" @onclick="Commands.ClearLenses" type="button">@Localizer["FilterLens_ClearAll"]</button>
     </div>
 }

--- a/src/EventLogExpert.UI/FilterLenses/LensBreadcrumb.razor
+++ b/src/EventLogExpert.UI/FilterLenses/LensBreadcrumb.razor
@@ -37,13 +37,18 @@
         }
 
         <button class="lens-action" @onclick="SaveAll" type="button">@Localizer["FilterLens_SaveAll"]</button>
-        <button class="lens-action"
-            disabled="@(!CanSaveAsGroup)"
+        <button aria-describedby="@SaveAsGroupHintRef"
+            aria-disabled="@SaveAsGroupAriaDisabled"
+            class="lens-action"
             @onclick="SaveAsGroupAsync"
             title="@(CanSaveAsGroup ? null : Localizer["FilterLens_SaveAsGroup_DisabledTitle"].Value)"
             type="button">
             @Localizer["FilterLens_SaveAsGroup"]
         </button>
+        @if (!CanSaveAsGroup)
+        {
+            <span class="visually-hidden" id="@_saveAsGroupHintId">@Localizer["FilterLens_SaveAsGroup_DisabledTitle"].Value</span>
+        }
         <button class="lens-clear" @onclick="Commands.ClearLenses" type="button">@Localizer["FilterLens_ClearAll"]</button>
     </div>
 }

--- a/src/EventLogExpert.UI/FilterLenses/LensBreadcrumb.razor.cs
+++ b/src/EventLogExpert.UI/FilterLenses/LensBreadcrumb.razor.cs
@@ -2,6 +2,8 @@
 // // Licensed under the MIT License.
 
 using EventLogExpert.Localization;
+using EventLogExpert.Runtime.Alerts;
+using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.Runtime.FilterLenses;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
@@ -11,6 +13,12 @@ namespace EventLogExpert.UI.FilterLenses;
 
 public sealed partial class LensBreadcrumb
 {
+    [Inject] private IAlertDialogService AlertDialogService { get; init; } = null!;
+
+    [Inject] private IAnnouncementService AnnouncementService { get; init; } = null!;
+
+    private bool CanSaveAsGroup => LensSource.Lenses.Any(lens => lens.Kind == LensKind.Property);
+
     [Inject] private IFilterLensCommands Commands { get; init; } = null!;
 
     [Inject] private IFilterLensSource LensSource { get; init; } = null!;
@@ -33,5 +41,28 @@ public sealed partial class LensBreadcrumb
         {
             Commands.RemoveLens(lenses[^1].Id);
         }
+    }
+
+    private void SaveAll()
+    {
+        Commands.PromoteAllLenses();
+        AnnouncementService.Announce(Localizer["FilterLens_SavedAllAnnouncement"]);
+    }
+
+    private async Task SaveAsGroupAsync()
+    {
+        if (!CanSaveAsGroup) { return; }
+
+        var name = await AlertDialogService.DisplayPrompt(
+            Localizer["FilterLens_SaveAsGroup_PromptTitle"],
+            Localizer["FilterLens_SaveAsGroup_PromptMessage"],
+            Localizer["FilterLens_SaveAsGroup_DefaultName"]);
+
+        if (string.IsNullOrWhiteSpace(name)) { return; }
+
+        var trimmed = name.Trim();
+
+        Commands.SaveLensesAsGroup(trimmed);
+        AnnouncementService.Announce(Localizer["FilterLens_SavedAsGroupAnnouncement", trimmed]);
     }
 }

--- a/src/EventLogExpert.UI/FilterLenses/LensBreadcrumb.razor.cs
+++ b/src/EventLogExpert.UI/FilterLenses/LensBreadcrumb.razor.cs
@@ -3,7 +3,6 @@
 
 using EventLogExpert.Localization;
 using EventLogExpert.Runtime.Alerts;
-using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.Runtime.FilterLenses;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
@@ -14,8 +13,6 @@ namespace EventLogExpert.UI.FilterLenses;
 public sealed partial class LensBreadcrumb
 {
     [Inject] private IAlertDialogService AlertDialogService { get; init; } = null!;
-
-    [Inject] private IAnnouncementService AnnouncementService { get; init; } = null!;
 
     private bool CanSaveAsGroup => LensSource.Lenses.Any(lens => lens.Kind == LensKind.Property);
 
@@ -43,11 +40,7 @@ public sealed partial class LensBreadcrumb
         }
     }
 
-    private void SaveAll()
-    {
-        Commands.PromoteAllLenses();
-        AnnouncementService.Announce(Localizer["FilterLens_SavedAllAnnouncement"]);
-    }
+    private void SaveAll() => Commands.PromoteAllLenses();
 
     private async Task SaveAsGroupAsync()
     {
@@ -60,9 +53,6 @@ public sealed partial class LensBreadcrumb
 
         if (string.IsNullOrWhiteSpace(name)) { return; }
 
-        var trimmed = name.Trim();
-
-        Commands.SaveLensesAsGroup(trimmed);
-        AnnouncementService.Announce(Localizer["FilterLens_SavedAsGroupAnnouncement", trimmed]);
+        Commands.SaveLensesAsGroup(name.Trim());
     }
 }

--- a/src/EventLogExpert.UI/FilterLenses/LensBreadcrumb.razor.cs
+++ b/src/EventLogExpert.UI/FilterLenses/LensBreadcrumb.razor.cs
@@ -12,6 +12,11 @@ namespace EventLogExpert.UI.FilterLenses;
 
 public sealed partial class LensBreadcrumb
 {
+    // "Save as group" stays keyboard-focusable while unavailable (aria-disabled instead of the native
+    // disabled attribute, which drops focusability), so screen-reader users can reach it and hear the
+    // reason via aria-describedby. The click/keyboard handler still guards the action (SaveAsGroupAsync).
+    private readonly string _saveAsGroupHintId = $"lens-save-as-group-hint-{Guid.NewGuid():N}";
+
     [Inject] private IAlertDialogService AlertDialogService { get; init; } = null!;
 
     private bool CanSaveAsGroup => LensSource.Lenses.Any(lens => lens.Kind == LensKind.Property);
@@ -21,6 +26,10 @@ public sealed partial class LensBreadcrumb
     [Inject] private IFilterLensSource LensSource { get; init; } = null!;
 
     [Inject] private IStringLocalizer<SharedResource> Localizer { get; init; } = null!;
+
+    private string SaveAsGroupAriaDisabled => CanSaveAsGroup ? "false" : "true";
+
+    private string? SaveAsGroupHintRef => CanSaveAsGroup ? null : _saveAsGroupHintId;
 
     protected override void OnInitialized()
     {

--- a/src/EventLogExpert.UI/FilterLenses/LensBreadcrumb.razor.cs
+++ b/src/EventLogExpert.UI/FilterLenses/LensBreadcrumb.razor.cs
@@ -55,13 +55,20 @@ public sealed partial class LensBreadcrumb
     {
         if (!CanSaveAsGroup) { return; }
 
-        var name = await AlertDialogService.DisplayPrompt(
+        PromptOutcome outcome = await AlertDialogService.DisplayPromptWithSecondary(
             Localizer["FilterLens_SaveAsGroup_PromptTitle"],
             Localizer["FilterLens_SaveAsGroup_PromptMessage"],
-            Localizer["FilterLens_SaveAsGroup_DefaultName"]);
+            Localizer["FilterLens_SaveAsGroup_DefaultName"],
+            Localizer["FilterLens_SaveAsGroup_Save"],
+            Localizer["FilterLens_SaveAsGroup_SaveAndClear"],
+            Localizer["FilterLens_SaveAsGroup_Cancel"]);
 
-        if (string.IsNullOrWhiteSpace(name)) { return; }
+        if (outcome.Choice == PromptChoice.Cancel || string.IsNullOrWhiteSpace(outcome.Value)) { return; }
 
-        Commands.SaveLensesAsGroup(name.Trim());
+        string name = outcome.Value.Trim();
+
+        // Save and clear (Secondary) defers the clear to the persist-success effect, so a failed save leaves the active
+        // lenses intact instead of discarding them.
+        Commands.SaveLensesAsGroup(name, clearAfterSave: outcome.Choice == PromptChoice.Secondary);
     }
 }

--- a/src/EventLogExpert.UI/FilterLenses/LensBreadcrumb.razor.cs
+++ b/src/EventLogExpert.UI/FilterLenses/LensBreadcrumb.razor.cs
@@ -61,7 +61,8 @@ public sealed partial class LensBreadcrumb
             Localizer["FilterLens_SaveAsGroup_DefaultName"],
             Localizer["FilterLens_SaveAsGroup_Save"],
             Localizer["FilterLens_SaveAsGroup_SaveAndClear"],
-            Localizer["FilterLens_SaveAsGroup_Cancel"]);
+            Localizer["FilterLens_SaveAsGroup_Cancel"],
+            candidate => string.IsNullOrWhiteSpace(candidate) ? Localizer["FilterLens_SaveAsGroup_NameRequired"].Value : null);
 
         if (outcome.Choice == PromptChoice.Cancel || string.IsNullOrWhiteSpace(outcome.Value)) { return; }
 

--- a/src/EventLogExpert.UI/FilterLenses/LensBreadcrumb.razor.css
+++ b/src/EventLogExpert.UI/FilterLenses/LensBreadcrumb.razor.css
@@ -33,7 +33,8 @@
 
 .lens-chip-keep,
 .lens-chip-remove,
-.lens-clear {
+.lens-clear,
+.lens-action {
     background: transparent;
     border: none;
     cursor: pointer;
@@ -45,6 +46,24 @@
 .lens-clear {
     color: var(--clr-lightblue);
     font-size: 0.85em;
+}
+
+.lens-action {
+    color: var(--clr-lightblue);
+    font-size: 0.85em;
+}
+
+/* Non-destructive actions use the shared neutral background-shift on hover (not the red that Clear
+   all / chip-remove use), matching the app's standardized icon-button hover. */
+.lens-action:hover:not(:disabled) {
+    background: var(--menu-hover-overlay);
+    border-radius: 3px;
+}
+
+.lens-action:disabled {
+    color: var(--text-secondary);
+    cursor: default;
+    opacity: 0.6;
 }
 
 .lens-chip-keep:hover {
@@ -59,6 +78,7 @@
 .lens-breadcrumb:focus-visible,
 .lens-chip-keep:focus-visible,
 .lens-chip-remove:focus-visible,
-.lens-clear:focus-visible {
+.lens-clear:focus-visible,
+.lens-action:focus-visible {
     outline: 1px solid var(--toggle-accent);
 }

--- a/src/EventLogExpert.UI/FilterLenses/LensBreadcrumb.razor.css
+++ b/src/EventLogExpert.UI/FilterLenses/LensBreadcrumb.razor.css
@@ -55,12 +55,12 @@
 
 /* Non-destructive actions use the shared neutral background-shift on hover (not the red that Clear
    all / chip-remove use), matching the app's standardized icon-button hover. */
-.lens-action:hover:not(:disabled) {
+.lens-action:hover:not([aria-disabled="true"]) {
     background: var(--menu-hover-overlay);
     border-radius: 3px;
 }
 
-.lens-action:disabled {
+.lens-action[aria-disabled="true"] {
     color: var(--text-secondary);
     cursor: default;
     opacity: 0.6;
@@ -81,4 +81,16 @@
 .lens-clear:focus-visible,
 .lens-action:focus-visible {
     outline: 1px solid var(--toggle-accent);
+}
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
 }

--- a/src/EventLogExpert.UI/FilterLibrary/LibraryEntryRow.razor
+++ b/src/EventLogExpert.UI/FilterLibrary/LibraryEntryRow.razor
@@ -4,13 +4,13 @@
 
         @if (Entry is LibraryEntryFilterSet)
         {
-            <Button aria-controls="@_filterEditorRegionId"
-                aria-expanded="@(_isExpanded ? "true" : "false")"
-                aria-label="@($"Filters for {Entry.Name}")"
-                CssClass="library-entry-expand-toggle"
+            <Button CssClass="library-entry-expand-toggle"
                 IconClass="@(_isExpanded ? "bi bi-chevron-down" : "bi bi-chevron-right")"
                 IconOnly
-                OnClick="ToggleExpand" />
+                OnClick="ToggleExpand"
+                aria-controls="@_filterEditorRegionId"
+                aria-expanded="@(_isExpanded ? "true" : "false")"
+                aria-label="@($"Filters for {Entry.Name}")" />
         }
 
         <div class="library-entry-name">
@@ -49,56 +49,56 @@
                             var tag = Entry.Tags[i];
                             <span class="library-entry-tag-chip" role="listitem">
                                 <span class="library-entry-tag-chip-label">@tag</span>
-                                <ChromelessButton aria-label="@($"Remove tag {tag}")"
-                                    CssClass="library-entry-tag-chip-remove"
-                                    IconClass="bi bi-x"
+                                <ChromelessButton CssClass="library-entry-tag-chip-remove"
+                                    IconClass="bi bi-x-circle"
                                     OnClick="@(() => OnRemoveTagAsync(tag))"
-                                    StopPropagation="true" />
+                                    StopPropagation="true"
+                                    aria-label="@($"Remove tag {tag}")" />
                             </span>
                         }
                     </div>
 
                     @if (inlineHidden > 0)
                     {
-                        <Button aria-label="@($"Show all {Entry.Tags.Count} tags")"
-                            CssClass="library-entry-tag-chip-more"
+                        <Button CssClass="library-entry-tag-chip-more"
                             OnClick="ToggleEditTagsMode"
+                            aria-label="@($"Show all {Entry.Tags.Count} tags")"
                             title="@string.Join(", ", Entry.Tags.Skip(inlineVisible))">
                             +@inlineHidden more
                         </Button>
                     }
                 }
-                <Button aria-label="@(Entry.Tags.Count == 0 ? $"Add tags to {Entry.Name}" : $"Edit tags for {Entry.Name}")"
-                    CssClass="library-entry-tag-add-inline"
+                <Button CssClass="library-entry-tag-add-inline"
                     IconClass="bi bi-plus-circle"
                     IconOnly
                     OnClick="ToggleEditTagsMode"
+                    aria-label="@(Entry.Tags.Count == 0 ? $"Add tags to {Entry.Name}" : $"Edit tags for {Entry.Name}")"
                     title="@(Entry.Tags.Count == 0 ? "Add tags" : "Edit tags")" />
             </div>
         }
 
-        <PrimaryButton aria-label="@($"Apply {Entry.Name} additively to current filters")"
-            IconClass="bi bi-plus-circle"
-            OnClick="OnApplyAsync">
+        <PrimaryButton IconClass="bi bi-plus-circle"
+            OnClick="OnApplyAsync"
+            aria-label="@($"Apply {Entry.Name} additively to current filters")">
             Apply
         </PrimaryButton>
 
         @if (IsFavoritable)
         {
-            <WarningButton aria-label="@FavoriteAriaLabel"
-                aria-pressed="@(Entry.IsFavorite ? "true" : "false")"
-                IconClass="@FavoriteIconClass"
+            <WarningButton IconClass="@FavoriteIconClass"
                 IconOnly
                 OnClick="OnToggleFavoriteAsync"
+                aria-label="@FavoriteAriaLabel"
+                aria-pressed="@(Entry.IsFavorite ? "true" : "false")"
                 title="@FavoriteTitle" />
         }
 
-        <Button aria-expanded="@(IsMoreMenuOpen ? "true" : "false")"
-            aria-haspopup="menu"
-            aria-label="@($"More actions for {Entry.Name}")"
-            IconClass="bi bi-three-dots-vertical"
+        <Button IconClass="bi bi-three-dots-vertical"
             IconOnly
             OnClick="ToggleMoreMenuAsync"
+            aria-expanded="@(IsMoreMenuOpen ? "true" : "false")"
+            aria-haspopup="menu"
+            aria-label="@($"More actions for {Entry.Name}")"
             @ref="_moreMenuButton"
             title="More actions" />
     </div>
@@ -111,11 +111,11 @@
                 Value="@Entry.Tags"
                 ValueChanged="@OnTagsChangedAsync" />
 
-            <Button aria-label="Done editing tags"
-                CssClass="library-entry-tags-done"
+            <Button CssClass="library-entry-tags-done"
                 IconClass="bi bi-check2"
                 IconOnly
                 OnClick="ToggleEditTagsMode"
+                aria-label="Done editing tags"
                 title="Done" />
         </div>
     }

--- a/src/EventLogExpert.UI/FilterLibrary/TagManagementPanel.razor
+++ b/src/EventLogExpert.UI/FilterLibrary/TagManagementPanel.razor
@@ -35,24 +35,24 @@
 
                     @if (_mergeTargetTag is not null)
                     {
-                        <WarningButton aria-label="@($"Merge tag {tag} into {_mergeTargetTag}, affects {count} entries")"
-                            IconClass="bi bi-union"
-                            OnClick="ConfirmMergeAsync">
+                        <WarningButton IconClass="bi bi-union"
+                            OnClick="ConfirmMergeAsync"
+                            aria-label="@($"Merge tag {tag} into {_mergeTargetTag}, affects {count} entries")">
                             Merge into '@_mergeTargetTag'
                         </WarningButton>
                     }
                     else
                     {
-                        <PrimaryButton aria-label="@($"Save renamed tag {tag}")"
-                            IconClass="bi bi-check2"
+                        <PrimaryButton IconClass="bi bi-check2"
                             IconOnly
-                            OnClick="ConfirmRenameAsync" />
+                            OnClick="ConfirmRenameAsync"
+                            aria-label="@($"Save renamed tag {tag}")" />
                     }
 
-                    <Button aria-label="Cancel rename"
-                        IconClass="bi bi-x"
+                    <Button IconClass="bi bi-x-circle"
                         IconOnly
-                        OnClick="CancelEdit" />
+                        OnClick="CancelEdit"
+                        aria-label="Cancel rename" />
                 }
                 else if (_deleteConfirmTag == tag)
                 {
@@ -60,31 +60,31 @@
                     <span class="library-tag-management-row-count">(@count)</span>
                     <span class="library-tag-management-row-confirm">Remove from @count entries?</span>
 
-                    <DangerButton aria-label="@($"Confirm delete tag {tag}")"
-                        IconClass="bi bi-check2"
+                    <DangerButton IconClass="bi bi-check2"
                         IconOnly
-                        OnClick="ConfirmDeleteAsync" />
+                        OnClick="ConfirmDeleteAsync"
+                        aria-label="@($"Confirm delete tag {tag}")" />
 
-                    <Button aria-label="Cancel delete"
-                        IconClass="bi bi-x"
+                    <Button IconClass="bi bi-x-circle"
                         IconOnly
-                        OnClick="CancelDelete" />
+                        OnClick="CancelDelete"
+                        aria-label="Cancel delete" />
                 }
                 else
                 {
                     <span class="library-tag-management-row-name">@tag</span>
                     <span class="library-tag-management-row-count">(@count)</span>
 
-                    <Button aria-label="@($"Rename tag {tag}")"
-                        IconClass="bi bi-pencil"
+                    <Button IconClass="bi bi-pencil"
                         IconOnly
                         OnClick="@(() => BeginRename(tag))"
+                        aria-label="@($"Rename tag {tag}")"
                         title="Rename" />
 
-                    <DangerButton aria-label="@($"Delete tag {tag}")"
-                        IconClass="bi bi-trash"
+                    <DangerButton IconClass="bi bi-trash"
                         IconOnly
                         OnClick="@(() => BeginDelete(tag))"
+                        aria-label="@($"Delete tag {tag}")"
                         title="Delete" />
                 }
             </div>

--- a/src/EventLogExpert.UI/FilterPane/FilterPane.razor.css
+++ b/src/EventLogExpert.UI/FilterPane/FilterPane.razor.css
@@ -3,7 +3,7 @@
     flex-direction: column;
     flex: 0 0 auto;
 
-    margin: 0 5px;
+    padding: 0 5px;
 
     max-height: 30%;
     overflow-x: hidden;

--- a/src/EventLogExpert.UI/Inputs/OptionSelect.razor.css
+++ b/src/EventLogExpert.UI/Inputs/OptionSelect.razor.css
@@ -38,8 +38,13 @@
     min-width: 4rem;
 }
 
+.option-select label:first-of-type {
+    border-radius: .25rem 0 0 .25rem;
+}
+
 .option-select label:last-of-type {
     border-right: 1px solid var(--border-divider);
+    border-radius: 0 .25rem .25rem 0;
 }
 
 /* Do not change font-weight on selected state -- bold text causes the label to

--- a/src/EventLogExpert.UI/Inputs/TagPicker.razor
+++ b/src/EventLogExpert.UI/Inputs/TagPicker.razor
@@ -7,10 +7,10 @@
 
             <span class="tag-picker-chip" role="listitem">
                 <span class="tag-picker-chip-label">@tag</span>
-                <ChromelessButton aria-label="@($"Remove {tag}")"
-                    CssClass="tag-picker-chip-remove"
-                    IconClass="bi bi-x"
-                    OnClick="@(() => RemoveTagAsync(index))" />
+                <ChromelessButton CssClass="tag-picker-chip-remove"
+                    IconClass="bi bi-x-circle"
+                    OnClick="@(() => RemoveTagAsync(index))"
+                    aria-label="@($"Remove {tag}")" />
             </span>
         }
 

--- a/src/EventLogExpert.UI/Inputs/TextInput.razor
+++ b/src/EventLogExpert.UI/Inputs/TextInput.razor
@@ -7,6 +7,7 @@
     @attributes="_valueChangeBinding"
     class="@CssClass"
     id="@Id"
+    @onkeydown="HandleKeyDownAsync"
     @ref="_element"
     type="text"
     value="@Value" />

--- a/src/EventLogExpert.UI/Inputs/TextInput.razor.cs
+++ b/src/EventLogExpert.UI/Inputs/TextInput.razor.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace EventLogExpert.UI.Inputs;
 
@@ -13,6 +14,8 @@ public partial class TextInput : InputComponent<string>
     [Parameter] public bool AriaInvalid { get; set; }
 
     [Parameter] public string? Id { get; set; }
+
+    [Parameter] public EventCallback OnEnter { get; set; }
 
     [Parameter] public bool UpdateOnInput { get; set; }
 
@@ -32,6 +35,11 @@ public partial class TextInput : InputComponent<string>
 
         base.OnParametersSet();
     }
+
+    private Task HandleKeyDownAsync(KeyboardEventArgs args) =>
+        // Skip the Enter that commits an IME composition candidate (Chromium reports IsComposing on it) so a
+        // composition commit does not prematurely confirm the dialog.
+        args is { Key: "Enter", IsComposing: false } && OnEnter.HasDelegate ? OnEnter.InvokeAsync() : Task.CompletedTask;
 
     private async Task UpdateValue(ChangeEventArgs args)
     {

--- a/src/EventLogExpert.UI/Inputs/ValueSelect.razor.css
+++ b/src/EventLogExpert.UI/Inputs/ValueSelect.razor.css
@@ -4,21 +4,7 @@
 
     & > .input { margin: 0; }
 
-    /* The readonly combobox input matches :focus-visible on a mouse click in Chromium, which would
-       ring the box on click. Opt out of the global ring and paint a keyboard-only one instead:
-       ValueSelect.razor.js sets data-pointer-focus on mousedown (cleared on keydown/blur), so a Tab
-       arrival has no marker and rings while a click does not. Mouse movement never changes the
-       marker, so a Tab ring persists. The resting bottom border is a separate cue and is untouched. */
-    & > .input:focus-visible { outline: none; }
-
-    & > .input:focus:not([data-pointer-focus]) {
-        outline: var(--focus-ring-width) solid var(--focus-ring-color);
-        outline-offset: var(--focus-ring-offset);
-    }
-
-    /* The color swatch paints its own 1px border, so push its keyboard ring outside that border to
-       stay visible instead of overpainting it in the same color. */
-    & > .input.color-dropdown:focus:not([data-pointer-focus]) {
+    :root[data-modality="keyboard"] & > .input.color-dropdown:focus {
         outline-offset: 2px;
     }
 }

--- a/src/EventLogExpert.UI/Inputs/ValueSelect.razor.js
+++ b/src/EventLogExpert.UI/Inputs/ValueSelect.razor.js
@@ -1,45 +1,10 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
-// A <label for="..."> click focuses the associated input WITHOUT dispatching mousedown on the input,
-// so the per-input pointer marker below would miss it and the combobox would wrongly show its
-// keyboard ring on a mouse click. One document-level pointerdown listener (registered once) marks the
-// ValueSelect input a label points at, so label clicks are correctly treated as pointer focus.
-let labelPointerListenerRegistered = false;
-
-function ensureLabelPointerListener() {
-    if (labelPointerListenerRegistered) { return; }
-    labelPointerListenerRegistered = true;
-
-    document.addEventListener("pointerdown", (e) => {
-        const label = e.target && e.target.closest ? e.target.closest("label[for]") : null;
-        if (!label) { return; }
-
-        const target = document.getElementById(label.getAttribute("for"));
-        // Skip disabled targets: they cannot take focus, so the input's own focus/keydown/blur would
-        // never clear the marker, and it would wrongly suppress the keyboard ring once re-enabled.
-        if (target && !target.disabled && target.closest(".dropdown-input")) {
-            target.setAttribute("data-pointer-focus", "");
-        }
-    }, true);
-
-    // A pointerdown marker only holds meaning if that pointer interaction actually delivers focus to the
-    // input. If it does not (press then drag off the label), the marker would go stale and suppress the
-    // ring on a later Tab arrival. Any keydown means the user switched to the keyboard, so clear every
-    // lingering marker; the focused input then matches the keyboard-only :focus ring again.
-    document.addEventListener("keydown", () => {
-        document.querySelectorAll(".dropdown-input [data-pointer-focus]").forEach((el) => {
-            el.removeAttribute("data-pointer-focus");
-        });
-    }, true);
-}
-
 export function registerDropdown(root, dotNetRef) {
     const dropdown = root.getElementsByClassName("dropdown-list")[0];
     const input = root.getElementsByTagName("input")[0];
     const controller = new AbortController();
-
-    ensureLabelPointerListener();
 
     const closeDropdown = (e, force = false) => {
         const target = e.currentTarget.parentNode;
@@ -91,20 +56,13 @@ export function registerDropdown(root, dotNetRef) {
     };
 
     input.addEventListener("mousedown", (e) => {
-        // Mark pointer-originated focus so the keyboard-only ring (ValueSelect.razor.css) stays off on
-        // click. mousedown fires before focus, so the marker is set before :focus matches; it is
-        // cleared on keydown/blur.
-        input.setAttribute("data-pointer-focus", "");
-
+        // Keep the document click-away handler from closing the list, then toggle it.
         e.stopPropagation();
 
         toggle(e);
     }, { signal: controller.signal });
 
     input.addEventListener("keydown", (e) => {
-        // Keyboard use: allow the keyboard-only focus ring to appear.
-        input.removeAttribute("data-pointer-focus");
-
         // Arrow keys drive dropdown navigation and Enter opens/commits the dropdown, so suppress the
         // browser defaults here: caret-move/scroll for arrows, and Enter submitting an enclosing form
         // (e.g. a select nested in an EditForm). Space opens a select-only (readonly) list, so cancel
@@ -118,7 +76,6 @@ export function registerDropdown(root, dotNetRef) {
     }, { signal: controller.signal });
 
     input.addEventListener("blur", (e) => {
-        input.removeAttribute("data-pointer-focus");
         closeDropdown(e);
     }, { signal: controller.signal });
     dropdown.addEventListener("blur", (e) => closeDropdown(e), { signal: controller.signal });

--- a/src/EventLogExpert.UI/Layout/MainLayout.razor.cs
+++ b/src/EventLogExpert.UI/Layout/MainLayout.razor.cs
@@ -12,6 +12,10 @@ namespace EventLogExpert.UI.Layout;
 
 public sealed partial class MainLayout : IAsyncDisposable
 {
+    private bool _disposed;
+    private Task<IJSObjectReference>? _focusRingModuleLoad;
+    private Task<IJSObjectReference>? _themeModuleLoad;
+
     [Inject] private IAppTitleService AppTitleService { get; init; } = null!;
 
     [Inject] private IJSRuntime JSRuntime { get; init; } = null!;
@@ -21,9 +25,6 @@ public sealed partial class MainLayout : IAsyncDisposable
     [Inject] private ISettingsService Settings { get; init; } = null!;
 
     [Inject] private IUpdateService UpdateService { get; init; } = null!;
-
-    private Task<IJSObjectReference>? _themeModuleLoad;
-    private bool _disposed;
 
     public async ValueTask DisposeAsync()
     {
@@ -46,6 +47,21 @@ public sealed partial class MainLayout : IAsyncDisposable
 
             _themeModuleLoad = null;
         }
+
+        if (_focusRingModuleLoad is not null)
+        {
+            try
+            {
+                var module = await _focusRingModuleLoad;
+                await module.DisposeAsync();
+            }
+            catch (JSDisconnectedException) { }
+            catch (JSException) { }
+            catch (ObjectDisposedException) { }
+            catch (TaskCanceledException) { }
+
+            _focusRingModuleLoad = null;
+        }
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -54,6 +70,7 @@ public sealed partial class MainLayout : IAsyncDisposable
         {
             await ApplyThemeAsync();
             await KeyboardShortcutService.EnsureRegisteredAsync(JSRuntime);
+            await RegisterKeyboardFocusRingAsync();
         }
 
         await base.OnAfterRenderAsync(firstRender);
@@ -95,4 +112,26 @@ public sealed partial class MainLayout : IAsyncDisposable
     }
 
     private void OnThemeChanged() => _ = InvokeAsync(ApplyThemeAsync);
+
+    private async Task RegisterKeyboardFocusRingAsync()
+    {
+        if (_disposed) { return; }
+
+        var load = _focusRingModuleLoad ??= JSRuntime.InvokeAsync<IJSObjectReference>(
+            "import",
+            "./_content/EventLogExpert.UI/Common/keyboardFocusRing.js").AsTask();
+
+        try
+        {
+            var module = await load;
+            await module.InvokeVoidAsync("registerKeyboardFocusRing");
+        }
+        catch (Exception ex) when (ex is JSDisconnectedException or JSException or ObjectDisposedException or TaskCanceledException)
+        {
+            if (!load.IsCompletedSuccessfully && ReferenceEquals(_focusRingModuleLoad, load))
+            {
+                _focusRingModuleLoad = null;
+            }
+        }
+    }
 }

--- a/src/EventLogExpert.UI/LogTable/Find/FindBar.razor
+++ b/src/EventLogExpert.UI/LogTable/Find/FindBar.razor
@@ -45,7 +45,7 @@
             class="find-close"
             @onclick="OnClose"
             type="button">
-            <i aria-hidden="true" class="bi bi-x-lg"></i>
+            <i aria-hidden="true" class="bi bi-x-circle"></i>
         </button>
     </div>
     @if (_optionsOpen)

--- a/src/EventLogExpert.UI/LogTable/Histogram/HistogramPane.razor.css
+++ b/src/EventLogExpert.UI/LogTable/Histogram/HistogramPane.razor.css
@@ -239,21 +239,21 @@
     vector-effect: non-scaling-stroke;
 }
 
-.histogram-cat-0 { fill: light-dark(#0072b2, #56b4e9); }
+.histogram-cat-0 { fill: var(--cat-color-0); }
 
-.histogram-cat-1 { fill: light-dark(#b66d00, #e69f00); }
+.histogram-cat-1 { fill: var(--cat-color-1); }
 
-.histogram-cat-2 { fill: light-dark(#007a5a, #009e73); }
+.histogram-cat-2 { fill: var(--cat-color-2); }
 
-.histogram-cat-3 { fill: light-dark(#a64f82, #cc79a7); }
+.histogram-cat-3 { fill: var(--cat-color-3); }
 
-.histogram-cat-4 { fill: light-dark(#6f5aa8, #8e7cc3); }
+.histogram-cat-4 { fill: var(--cat-color-4); }
 
-.histogram-cat-5 { fill: light-dark(#8f6a00, #f0e442); }
+.histogram-cat-5 { fill: var(--cat-color-5); }
 
-.histogram-cat-6 { fill: light-dark(#8a3f00, #d55e00); }
+.histogram-cat-6 { fill: var(--cat-color-6); }
 
-.histogram-cat-7 { fill: light-dark(#007983, #00a6b8); }
+.histogram-cat-7 { fill: var(--cat-color-7); }
 
 .histogram-cat-other { fill: var(--text-secondary); }
 

--- a/src/EventLogExpert.UI/LogTable/Histogram/HistogramPane.razor.css
+++ b/src/EventLogExpert.UI/LogTable/Histogram/HistogramPane.razor.css
@@ -4,7 +4,7 @@
     flex-direction: column;
     flex: 0 0 auto;
     min-height: 170px;
-    margin: 0 5px;
+    padding: 0 5px;
     border-bottom: solid var(--background-darkgray);
     overflow: hidden;
     user-select: none;

--- a/src/EventLogExpert.UI/LogTable/LogTabBar.razor
+++ b/src/EventLogExpert.UI/LogTable/LogTabBar.razor
@@ -17,7 +17,7 @@
         {
             if (row is AllLogsRow allLogs)
             {
-                <div class="@GetActiveTab(presentation, allLogs.Header)" @oncontextmenu="OpenAllLogsMenu"
+                <div class="@GetActiveTab(presentation, allLogs.Header) all-logs" @oncontextmenu="OpenAllLogsMenu"
                     @oncontextmenu:preventDefault="true"
                     @oncontextmenu:stopPropagation="true"
                     title="@GetTabTooltip(allLogs.Header)">
@@ -31,27 +31,20 @@
             }
             else if (row is GroupRow group)
             {
-                <div class="tab-group">
+                <div class="tab-group" style="--group-color: var(--cat-color-@(GetGroupColorIndex(group.Group.Id)));">
                     <div class="@GetActiveTab(presentation, group.Header) group-header" @oncontextmenu="args => OpenGroupHeaderMenu(args, group.Group)"
                         @oncontextmenu:preventDefault="true"
                         @oncontextmenu:stopPropagation="true"
                         title="@GetTabTooltip(group.Header)">
-                        <button aria-expanded="@(group.Group.IsCollapsed ? "false" : "true")"
-                            aria-label="@(group.Group.IsCollapsed ? Localizer["TabBar_ExpandGroupAria"] : Localizer["TabBar_CollapseGroupAria"])"
-                            class="chevron"
-                            @onclick="() => ToggleCollapse(group.Group)"
-                            title="@(group.Group.IsCollapsed ? Localizer["TabBar_ExpandGroupAria"] : Localizer["TabBar_CollapseGroupAria"])"
-                            type="button">
-                            <i class="bi bi-chevron-@(group.Group.IsCollapsed ? "down" : "right")"></i>
-                        </button>
-                        <span @onkeydown="e => OnTabKeyDown(e, group.Header)"
-                            @onmousedown="e => OnTabMouseDown(e, group.Header)"
+                        <span aria-expanded="@(presentation.ActiveTabId == group.Header.Id ? (group.Group.IsCollapsed ? "false" : "true") : null)"
+                            @onclick="() => ActivateOrToggleGroup(group)"
+                            @onkeydown="e => OnGroupHeaderKeyDown(e, group)"
                             role="button"
                             tabindex="0">
                             @GetTabName(presentation, group.Header)
                         </span>
                         <i aria-label="@Localizer["TabBar_CloseGroup"]"
-                            class="bi bi-x"
+                            class="bi bi-x-circle"
                             @onclick="() => CloseGroup(group.Group)"
                             @onkeydown="e => OnCloseGroupKeyDown(e, group.Group)"
                             role="button"
@@ -78,7 +71,7 @@
                                 @GetTabName(presentation, member)
                             </span>
                             <i aria-label="@Localizer["TabBar_CloseLogAria"]"
-                                class="bi bi-x"
+                                class="bi bi-x-circle"
                                 @onkeydown="e => OnCloseLogKeyDown(e, member)"
                                 @onmousedown="e => OnCloseLogMouseDown(e, member)"
                                 role="button"
@@ -108,7 +101,7 @@
                         @GetTabName(presentation, standalone.Tab)
                     </span>
                     <i aria-label="@Localizer["TabBar_CloseLogAria"]"
-                        class="bi bi-x"
+                        class="bi bi-x-circle"
                         @onkeydown="e => OnCloseLogKeyDown(e, standalone.Tab)"
                         @onmousedown="e => OnCloseLogMouseDown(e, standalone.Tab)"
                         role="button"

--- a/src/EventLogExpert.UI/LogTable/LogTabBar.razor
+++ b/src/EventLogExpert.UI/LogTable/LogTabBar.razor
@@ -36,13 +36,12 @@
                         @oncontextmenu:preventDefault="true"
                         @oncontextmenu:stopPropagation="true"
                         title="@GetTabTooltip(group.Header)">
-                        <span aria-expanded="@(presentation.ActiveTabId == group.Header.Id ? (group.Group.IsCollapsed ? "false" : "true") : null)"
+                        <button aria-expanded="@(presentation.ActiveTabId == group.Header.Id ? (group.Group.IsCollapsed ? "false" : "true") : null)"
+                            class="group-header-label"
                             @onclick="() => ActivateOrToggleGroup(group)"
-                            @onkeydown="e => OnGroupHeaderKeyDown(e, group)"
-                            role="button"
-                            tabindex="0">
+                            type="button">
                             @GetTabName(presentation, group.Header)
-                        </span>
+                        </button>
                         <i aria-label="@Localizer["TabBar_CloseGroup"]"
                             class="bi bi-x-circle"
                             @onclick="() => CloseGroup(group.Group)"

--- a/src/EventLogExpert.UI/LogTable/LogTabBar.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/LogTabBar.razor.cs
@@ -20,6 +20,9 @@ namespace EventLogExpert.UI.LogTable;
 
 public sealed partial class LogTabBar
 {
+    // Number of --cat-color-N palette entries defined in app.css; a group's palette slot wraps within this range.
+    private const int CategoricalPaletteSize = 8;
+
     private IJSObjectReference? _logTabBarModule;
     private ElementReference _logTabBarRootRef;
     private LogTabBarPresentation? _renderedPresentation;
@@ -184,10 +187,27 @@ public sealed partial class LogTabBar
         string? disabledReason = null) =>
         MenuItem.Item(label, onClickAsync, isEnabled: isEnabled, isDanger: true, disabledReason: disabledReason);
 
+    private static int GetGroupColorIndex(LogTabGroupId id) =>
+        // Stable, deterministic palette slot from the group's GUID so the color survives re-renders (and
+        // persisted layouts) without storing it. (& 0x7FFFFFFF keeps the modulo operand non-negative.)
+        (id.Value.GetHashCode() & 0x7FFFFFFF) % CategoricalPaletteSize;
+
     private static IReadOnlyList<LogView> VisibleMembers(LogTabBarPresentation presentation, GroupRow row) =>
         row.Group.IsCollapsed ?
             [.. row.Members.Where(member => member.Id == presentation.ActiveTabId)] :
             row.Members;
+
+    private void ActivateOrToggleGroup(GroupRow row)
+    {
+        if (Source.Current.ActiveTabId == row.Header.Id)
+        {
+            ToggleCollapse(row.Group);
+
+            return;
+        }
+
+        SetActiveLog(row.Header);
+    }
 
     private IReadOnlyList<MenuItem> BuildAllLogsMenu() =>
     [
@@ -336,6 +356,13 @@ public sealed partial class LogTabBar
         if (e.Button != 0) { return; }
 
         CloseLog(table);
+    }
+
+    private void OnGroupHeaderKeyDown(KeyboardEventArgs e, GroupRow row)
+    {
+        if (e.Key != "Enter" && e.Key != " ") { return; }
+
+        ActivateOrToggleGroup(row);
     }
 
     private void OnTabKeyDown(KeyboardEventArgs e, LogView table)

--- a/src/EventLogExpert.UI/LogTable/LogTabBar.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/LogTabBar.razor.cs
@@ -358,13 +358,6 @@ public sealed partial class LogTabBar
         CloseLog(table);
     }
 
-    private void OnGroupHeaderKeyDown(KeyboardEventArgs e, GroupRow row)
-    {
-        if (e.Repeat || (e.Key != "Enter" && e.Key != " ")) { return; }
-
-        ActivateOrToggleGroup(row);
-    }
-
     private void OnTabKeyDown(KeyboardEventArgs e, LogView table)
     {
         if (e.Repeat || (e.Key != "Enter" && e.Key != " ")) { return; }

--- a/src/EventLogExpert.UI/LogTable/LogTabBar.razor.cs
+++ b/src/EventLogExpert.UI/LogTable/LogTabBar.razor.cs
@@ -339,14 +339,14 @@ public sealed partial class LogTabBar
 
     private void OnCloseGroupKeyDown(KeyboardEventArgs e, LogTabGroup group)
     {
-        if (e.Key != "Enter" && e.Key != " ") { return; }
+        if (e.Repeat || (e.Key != "Enter" && e.Key != " ")) { return; }
 
         CloseGroup(group);
     }
 
     private void OnCloseLogKeyDown(KeyboardEventArgs e, LogView table)
     {
-        if (e.Key != "Enter" && e.Key != " ") { return; }
+        if (e.Repeat || (e.Key != "Enter" && e.Key != " ")) { return; }
 
         CloseLog(table);
     }
@@ -360,14 +360,14 @@ public sealed partial class LogTabBar
 
     private void OnGroupHeaderKeyDown(KeyboardEventArgs e, GroupRow row)
     {
-        if (e.Key != "Enter" && e.Key != " ") { return; }
+        if (e.Repeat || (e.Key != "Enter" && e.Key != " ")) { return; }
 
         ActivateOrToggleGroup(row);
     }
 
     private void OnTabKeyDown(KeyboardEventArgs e, LogView table)
     {
-        if (e.Key != "Enter" && e.Key != " ") { return; }
+        if (e.Repeat || (e.Key != "Enter" && e.Key != " ")) { return; }
 
         SetActiveLog(table);
     }

--- a/src/EventLogExpert.UI/LogTable/LogTabBar.razor.css
+++ b/src/EventLogExpert.UI/LogTable/LogTabBar.razor.css
@@ -3,99 +3,125 @@
     margin: 0 5px;
     height: 33px;
     overflow: hidden;
+    background: var(--background-dark);
 }
 
 .tab-row {
     display: flex;
     align-items: flex-end;
+    height: 100%;
 }
 
 .tab-group {
     display: inline-flex;
     align-items: flex-end;
+    height: 100%;
 }
 
 .tab {
+    /* --tab-inline-pad frames the label on the left and the close glyph on the right by the same amount.
+       The close button carries its own --close-btn-pad of internal white space (like the app's icon
+       buttons); a tab that has a close button trims that much off its right padding (see the
+       .tab:not(.all-logs) rule) so the glyph still lands --tab-inline-pad from the edge. */
+    --tab-inline-pad: 10px;
+    --close-btn-pad: 4px;
+
     position: relative;
-    top: 2px;
+    display: flex;
+    /* Anchor content to the bottom edge so the label + close button stay fixed when the tab grows upward. */
+    align-items: flex-end;
+    gap: 4px;
+
+    box-sizing: border-box;
+    height: 27px;
 
     flex: 0 1 auto;
-    min-width: 120px;
+    min-width: 90px;
     max-width: 240px;
     margin: 0 1px 0 0;
-    padding: 4px 22px;
+    padding: 0 var(--tab-inline-pad) 3px;
+    border-top: 3px solid transparent;
     border-radius: 3px 3px 0 0;
 
-    text-align: center;
-
     background: var(--background-darkgray);
-    transition: background-color 0.1s ease-in-out, padding 0.1s ease-in-out;
+    transition: height 0.1s ease-in-out, background-color 0.1s ease-in-out, border-color 0.1s ease-in-out;
 
     cursor: pointer;
 
+    /* The tab-row is bottom-aligned, so increasing the height raises only the tab's TOP edge - the bottom,
+       and the bottom-anchored label, stay fixed. The tab pops up like a real tab (the beveled step) and the
+       blue top border appears, all without the text drifting (no sponginess). */
     &:hover,
     &.active {
-        padding-top: 6px;
-        border-top: 2px solid var(--clr-lightblue);
+        height: 31px;
+        border-top-color: var(--clr-lightblue);
+    }
+
+    & > span {
+        flex: 1 1 auto;
+        min-width: 0;
+        text-align: left;
     }
 
     & > i {
-        position: absolute;
-        right: 3px;
-        top: 4px;
-
-        width: 1.5em;
-        border: 1px solid transparent;
+        flex: 0 0 auto;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        /* Internal white space gives the hover pill breathing room; no fixed width, so the button hugs its
+           glyph plus this padding. height:1lh matches the label's line box, so the tab's bottom-alignment
+           lands the glyph on the label's vertical center (the base font is 10pt, so a fixed 22px box would
+           sit well above the text). */
+        padding: 0 var(--close-btn-pad);
+        height: 1lh;
         border-radius: 3px;
 
         color: var(--text-secondary);
+        font-size: 1rem;
 
-        &:hover {
-            border-color: var(--clr-lightblue);
-            color: var(--clr-lightblue);
+        opacity: 0;
+        transition: opacity 0.1s ease-in-out, color 0.1s ease-in-out, background-color 0.1s ease-in-out;
+
+        /* Neutralize Bootstrap Icons' baseline shift so the glyph sits at the geometric center (the same fix
+           .button.icon-button uses). */
+        &::before {
+            vertical-align: 0;
+            line-height: 0;
         }
 
+        &:hover,
         &:focus-visible {
-            border-color: var(--clr-lightblue);
+            background: var(--menu-hover-overlay);
             color: var(--clr-lightblue);
         }
     }
 
     &:hover > i,
-    &.active > i {
-        color: var(--clr-lightblue);
+    &.active > i,
+    & > i:focus-visible {
+        opacity: 1;
     }
+}
+
+/* The Combined tab has no close button, so size it to its label with equal left/right padding rather than
+   the shared min-width. Every tab still starts its text at the same left offset (the shared padding). */
+.all-logs {
+    min-width: auto;
+}
+
+/* A tab with a close button trims its right padding by the button's own white space, so the close glyph
+   sits the same distance from the right edge as the label sits from the left. (Combined has no close
+   button, so it keeps the symmetric padding above.) */
+.tab:not(.all-logs) {
+    padding-right: calc(var(--tab-inline-pad) - var(--close-btn-pad));
 }
 
 .tab-group > .tab {
-    box-shadow: inset 0 2px 0 0 var(--clr-lightgray);
-}
-
-.group-header > .chevron {
-    position: absolute;
-    z-index: 1;
-    top: 0;
-    bottom: 0;
-    left: 0;
-
-    display: flex;
-    align-items: center;
-    justify-content: center;
-
-    width: 20px;
-    padding: 0;
-    border: none;
-
-    color: inherit;
-
-    background: transparent;
-
-    cursor: pointer;
-
-    &:hover,
-    &:focus-visible {
-        color: var(--clr-lightblue);
-    }
+    /* The colored top border marks which tabs belong to a group (per-group hue via --group-color, set
+       inline on .tab-group from the shared categorical palette). It takes the place of the blue active
+       border on grouped tabs - the pop-up height alone signals which grouped tab is active, so we never
+       stack two colors on one tab. */
+    border-top-color: var(--group-color, var(--clr-lightgray));
 }
 
 span {

--- a/src/EventLogExpert.UI/LogTable/LogTabBar.razor.css
+++ b/src/EventLogExpert.UI/LogTable/LogTabBar.razor.css
@@ -1,6 +1,6 @@
 .log-tab-bar {
     flex: 0 0 auto;
-    margin: 0 5px;
+    padding: 0 5px;
     height: 33px;
     overflow: hidden;
     background: var(--background-dark);

--- a/src/EventLogExpert.UI/LogTable/LogTabBar.razor.css
+++ b/src/EventLogExpert.UI/LogTable/LogTabBar.razor.css
@@ -132,3 +132,27 @@ span {
     text-overflow: ellipsis;
     white-space: nowrap;
 }
+
+/* The group header is a real <button> so Enter/Space match native button semantics - Space activates it once
+   without also scrolling the tab row - while these rules strip the native chrome so it still presents as the
+   flex-filling tab label (mirrors the .tab > span label styling above). */
+.group-header > .group-header-label {
+    flex: 1 1 auto;
+    min-width: 0;
+    box-sizing: border-box;
+
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    text-align: left;
+    user-select: none;
+
+    margin: 0;
+    padding: 0;
+    border: 0;
+    background: none;
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+}

--- a/src/EventLogExpert.UI/LogTable/LogTabBar.razor.js
+++ b/src/EventLogExpert.UI/LogTable/LogTabBar.razor.js
@@ -10,6 +10,10 @@ export function registerLogTabBarEvents() {
 }
 
 function registerLogTabBarScroller(logTabBar) {
+    // A press only becomes a drag-scroll after moving past this many pixels, so pointer jitter during a
+    // click does not latch scrolling and suppress the click that activates/toggles a tab.
+    const DRAG_THRESHOLD_PX = 5;
+
     let canDrag, isScrolling = false;
     let startPos, currentPos;
 
@@ -22,6 +26,9 @@ function registerLogTabBarScroller(logTabBar) {
         if (e.button !== 0) { return; }
 
         canDrag = true;
+        // Reset the latch at the start of every press so a previous drag that ended outside the bar (its
+        // mouseup never ran here) can't leave isScrolling stuck true and suppress this press's click.
+        isScrolling = false;
 
         startPos = e.pageX - logTabBar.offsetLeft;
         currentPos = logTabBar.scrollLeft;
@@ -48,13 +55,15 @@ function registerLogTabBarScroller(logTabBar) {
     logTabBar.addEventListener("mousemove", (e) => {
         if (!canDrag) { return; }
 
+        const offset = e.pageX - logTabBar.offsetLeft;
+        const pos = offset - startPos;
+
+        if (!isScrolling && Math.abs(pos) < DRAG_THRESHOLD_PX) { return; }
+
         isScrolling = true;
 
         e.preventDefault();
 
-        const offset = e.pageX - logTabBar.offsetLeft;
-        const pos = offset - startPos;
-        
         logTabBar.scrollLeft = currentPos - pos;
     });
 

--- a/src/EventLogExpert.UI/LogTable/LogTabBar.razor.js
+++ b/src/EventLogExpert.UI/LogTable/LogTabBar.razor.js
@@ -40,9 +40,21 @@ function registerLogTabBarScroller(logTabBar) {
         const tabs = logTabBar.getElementsByClassName("tab");
 
         if (isScrolling) {
-            for (let i = 0; i < tabs.length; i++) {
-                tabs[i].addEventListener("click", preventClick);
+            // Suppress only the drag's own trailing click, then drop the listeners on the next task. Blazor routes
+            // activation through a document-level click listener, so a lingering suppressor would also swallow the
+            // browser click synthesized by Enter/Space on the native group-header button (which has no mouseup to
+            // clear it), breaking the first keyboard activation after a drag-scroll.
+            const scrolledTabs = Array.from(tabs);
+
+            for (let i = 0; i < scrolledTabs.length; i++) {
+                scrolledTabs[i].addEventListener("click", preventClick);
             }
+
+            setTimeout(() => {
+                for (let i = 0; i < scrolledTabs.length; i++) {
+                    scrolledTabs[i].removeEventListener("click", preventClick);
+                }
+            }, 0);
         } else {
             for (let i = 0; i < tabs.length; i++) {
                 tabs[i].removeEventListener("click", preventClick);

--- a/src/EventLogExpert.UI/LogTable/Stats/StatsPane.razor.css
+++ b/src/EventLogExpert.UI/LogTable/Stats/StatsPane.razor.css
@@ -15,8 +15,7 @@
     flex: 0 0 auto;
     container: stats-pane / inline-size;
     height: 100%;
-    margin: 0 5px;
-    padding: 2px 0 4px;
+    padding: 2px 5px 4px;
     border-top: solid var(--background-darkgray);
     overflow: hidden;
     color: var(--text-secondary);

--- a/src/EventLogExpert.UI/Modal/ModalChrome.razor
+++ b/src/EventLogExpert.UI/Modal/ModalChrome.razor
@@ -25,7 +25,7 @@
                     <Button aria-label="@EffectiveCloseButtonAriaLabel"
                         CssClass="dialog-close"
                         Disabled="@HasInlineAlert"
-                        IconClass="bi bi-x"
+                        IconClass="bi bi-x-circle"
                         OnClick="HandleCloseButtonAsync" />
                 }
             </header>
@@ -137,6 +137,7 @@
                     AriaInvalid="@(ValidationError is not null)"
                     AriaLabelledBy="@_inlineAlertMessageId"
                     CssClass="input dialog-input"
+                    OnEnter="HandleInlineAlertAcceptOnEnterAsync"
                     @ref="_inlineAlertInput"
                     UpdateOnInput="true"
                     Value="@_inlineAlertPromptValue"

--- a/src/EventLogExpert.UI/Modal/ModalChrome.razor
+++ b/src/EventLogExpert.UI/Modal/ModalChrome.razor
@@ -101,6 +101,14 @@
                         @EffectiveAcceptLabel
                     </PrimaryButton>
 
+                    @if (!string.IsNullOrEmpty(SecondaryActionLabel))
+                    {
+                        <Button Disabled="@(HasInlineAlert || FooterDisabled || SecondaryActionDisabled)"
+                            OnClick="HandleSecondaryActionAsync">
+                            @SecondaryActionLabel
+                        </Button>
+                    }
+
                     <Button Disabled="@(HasInlineAlert || FooterDisabled)"
                         OnClick="HandleCancelButtonAsync">
                         @EffectiveCancelLabel
@@ -165,7 +173,8 @@
                 }
                 @if (!string.IsNullOrEmpty(InlineAlert.SecondaryActionLabel))
                 {
-                    <Button OnClick="HandleInlineAlertSecondaryAsync">
+                    <Button Disabled="@(ValidationError is not null)"
+                        OnClick="HandleInlineAlertSecondaryAsync">
                         @InlineAlert.SecondaryActionLabel
                     </Button>
                 }

--- a/src/EventLogExpert.UI/Modal/ModalChrome.razor.cs
+++ b/src/EventLogExpert.UI/Modal/ModalChrome.razor.cs
@@ -309,6 +309,13 @@ public sealed partial class ModalChrome : ComponentBase, IAsyncDisposable
         await OnInlineAlertResolved.InvokeAsync(new InlineAlertResult(true, promptValue));
     }
 
+    // Enter in the prompt input confirms, but only when there is an accept action and no validation error -
+    // mirroring the guard the accept button applies via its disabled state.
+    private Task HandleInlineAlertAcceptOnEnterAsync() =>
+        !string.IsNullOrEmpty(InlineAlert?.AcceptLabel) && ValidationError is null ?
+            HandleInlineAlertAcceptAsync() :
+            Task.CompletedTask;
+
     private Task HandleInlineAlertCancelAsync() =>
         OnInlineAlertResolved.InvokeAsync(new InlineAlertResult(false, null));
 

--- a/src/EventLogExpert.UI/Modal/ModalChrome.razor.cs
+++ b/src/EventLogExpert.UI/Modal/ModalChrome.razor.cs
@@ -86,7 +86,13 @@ public sealed partial class ModalChrome : ComponentBase, IAsyncDisposable
 
     [Parameter] public EventCallback OnSave { get; set; }
 
+    [Parameter] public EventCallback OnSecondaryAction { get; set; }
+
     [Parameter] public string? SaveLabel { get; set; }
+
+    [Parameter] public bool SecondaryActionDisabled { get; set; }
+
+    [Parameter] public string? SecondaryActionLabel { get; set; }
 
     [Parameter] public bool ShowCloseButton { get; set; }
 
@@ -325,12 +331,16 @@ public sealed partial class ModalChrome : ComponentBase, IAsyncDisposable
     {
         if (InlineAlert is null) { return; }
 
+        if (ValidationError is not null) { return; }
+
         string? promptValue = InlineAlert.IsPrompt ? _inlineAlertPromptValue : null;
 
         await OnInlineAlertResolved.InvokeAsync(new InlineAlertResult(false, promptValue) { SecondaryChosen = true });
     }
 
     private Task HandleSaveAsync() => OnSave.InvokeAsync();
+
+    private Task HandleSecondaryActionAsync() => OnSecondaryAction.InvokeAsync();
 
     private void ResetInlineAlertPromptValueIfChanged()
     {

--- a/src/EventLogExpert.UI/wwwroot/Common/keyboardFocusRing.js
+++ b/src/EventLogExpert.UI/wwwroot/Common/keyboardFocusRing.js
@@ -1,0 +1,105 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+// Tracks the current input modality on <html data-modality="keyboard|pointer"> so CSS can keep the focus
+// ring keyboard-only for the controls where the browser's native :focus-visible is unreliable: editable /
+// search inputs (Chromium matches :focus-visible on a plain mouse click) and elements the chrome autofocuses
+// on open (Chromium matches :focus-visible on an autofocused <dialog> button opened by pointer - crbug
+// 469468111). Those selectors gate their ring on :root[data-modality="keyboard"]; every other control keeps
+// native :focus-visible, which is already keyboard-only in WebView2.
+//
+// The attribute lives on the root and is only flipped by real input events, so it persists across the async
+// gap between the opening click/keypress and a modal's deferred programmatic focus - which a per-element
+// marker cannot, because programmatic focus dispatches no pointer event on the target. Capture-phase
+// listeners run before any component can stopPropagation. The default is keyboard - seeded statically on
+// <html data-modality> in index.html and re-asserted here as a fallback - so focus placed before the first
+// input event (app load, assistive tech), or if this module ever fails to load, still shows a ring
+// (WCAG 2.4.7) instead of silently dropping it app-wide. One idempotent registration wires the listeners
+// for the whole app.
+
+// Lone modifier keydowns are not navigation. AltGraph is included because Windows AltGr dispatches its own
+// keydown (key "AltGraph") right before the printable character, which would otherwise flip modality mid-word
+// on non-US layouts.
+const MODIFIER_KEYS = new Set(["Shift", "Control", "Alt", "Meta", "AltGraph"]);
+const TEXT_ENTRY_INPUT_TYPES = new Set(["text", "search", "url", "tel", "email", "password", "number"]);
+// Caret / edit keys that, like a printable character, edit the field's text rather than navigate away from
+// it. ArrowUp / ArrowDown are intentionally excluded: this app has no multiline text inputs, so they never
+// move a caret here - they page combobox options (ValueSelect / TagPicker), which is navigation that should
+// ring. Every other key in a text box (Enter, Escape, F6, Tab, a Ctrl/Alt shortcut) is likewise a command.
+const EDIT_KEYS = new Set(["Backspace", "Delete", "ArrowLeft", "ArrowRight", "Home", "End"]);
+let registered = false;
+
+// True for controls where a keystroke edits text (not navigation), so the caret - not a focus ring - is the
+// right focus cue. Readonly/disabled fields (e.g. the select-only value-select) are excluded: there a key is
+// navigation and should ring. Tab is handled by the caller as the one navigation key that still counts here.
+function isTextEntry(element) {
+    if (!element) { return false; }
+    if (element.isContentEditable) { return true; }
+    if (element.tagName === "TEXTAREA") { return !element.readOnly && !element.disabled; }
+    if (element.tagName === "INPUT") {
+        return TEXT_ENTRY_INPUT_TYPES.has(element.type) && !element.readOnly && !element.disabled;
+    }
+
+    return false;
+}
+
+export function registerKeyboardFocusRing() {
+    if (registered) { return; }
+    registered = true;
+
+    const root = document.documentElement;
+    // The control a just-clicked <label> forwards to, so the click handler can tell that browser-synthesised
+    // detail-0 click apart from a real keyboard / assistive-tech activation.
+    let forwardedClickTarget = null;
+
+    const setModality = (modality) => {
+        if (root.getAttribute("data-modality") !== modality) {
+            root.setAttribute("data-modality", modality);
+        }
+    };
+
+    if (!root.hasAttribute("data-modality")) { setModality("keyboard"); }
+
+    document.addEventListener("keydown", (e) => {
+        // A lone modifier, or a text-composition keystroke - an IME keydown (including the first one, reported
+        // as key "Process" before isComposing flips true) or a dead key (key "Dead", the accent in a dead-key
+        // + vowel sequence) - is not a navigation intent, so it must not flip a mouse session into keyboard
+        // mode.
+        if (e.isComposing || e.key === "Process" || e.key === "Dead" || MODIFIER_KEYS.has(e.key)) { return; }
+
+        // Plain typing or caret editing inside a text box is not navigation - the blinking caret already
+        // shows focus - so it must not reveal the ring on a field the user clicked into. A command keystroke
+        // there (Tab, Enter, Escape, F6, a Ctrl/Alt/Meta shortcut) still moves or acts on focus, so it flips;
+        // every other control (buttons, menus, readonly selects) flips on any key. AltGr is reported as
+        // Ctrl+Alt on non-US layouts but produces printable characters, so it counts as typing, not a command.
+        const isAltGr = e.getModifierState("AltGraph");
+        const hasCommandModifier = !isAltGr && (e.ctrlKey || e.altKey || e.metaKey);
+        const isPlainTyping = !hasCommandModifier && (e.key.length === 1 || EDIT_KEYS.has(e.key));
+        if (isPlainTyping && isTextEntry(e.target)) { return; }
+
+        setModality("keyboard");
+    }, true);
+
+    document.addEventListener("pointerdown", () => {
+        forwardedClickTarget = null;
+        setModality("pointer");
+    }, true);
+
+    // Tell a genuine keyboard / assistive-tech activation (a trusted detail-0 click with no pointer behind
+    // it) apart from a <label>-forwarded mouse click: clicking a <label> bound to a control makes the browser
+    // dispatch a detail-0 click on that control right after the label's own detail>0 click. Only the former
+    // is keyboard use; the latter must not flip a mouse session to keyboard and ring the control.
+    document.addEventListener("click", (e) => {
+        if (!e.isTrusted) { return; }
+
+        if (e.detail > 0) {
+            const label = e.target.closest?.("label");
+            forwardedClickTarget = label ? label.control : null;
+            return;
+        }
+
+        const isForwardedLabelClick = e.target === forwardedClickTarget;
+        forwardedClickTarget = null;
+        if (!isForwardedLabelClick) { setModality("keyboard"); }
+    }, true);
+}

--- a/src/EventLogExpert.UI/wwwroot/Common/keyboardFocusRing.js
+++ b/src/EventLogExpert.UI/wwwroot/Common/keyboardFocusRing.js
@@ -94,12 +94,14 @@ export function registerKeyboardFocusRing() {
         if (!e.isTrusted) { return; }
 
         if (e.detail > 0) {
-            // Only remember an ENABLED forwarded control. The browser never dispatches the synthesised detail-0
-            // click to a disabled control, so remembering one would leave a stale target: once that control is
-            // later enabled and activated by assistive tech (a trusted detail-0 click), the stale match would
-            // misread it as a label-forwarded mouse click and wrongly suppress its focus ring.
+            // Only remember an ENABLED forwarded control that the click did NOT land on directly. The browser
+            // synthesises the detail-0 forwarded click only when the label itself (not the nested control) was clicked,
+            // and never to a disabled control - so remembering either case would strand a stale target that a later
+            // trusted detail-0 assistive-tech activation would misread as a label-forwarded mouse click and wrongly
+            // suppress its focus ring.
             const forwardedControl = e.target.closest?.("label")?.control;
-            forwardedClickTarget = forwardedControl && !forwardedControl.disabled ? forwardedControl : null;
+            forwardedClickTarget =
+                forwardedControl && forwardedControl !== e.target && !forwardedControl.disabled ? forwardedControl : null;
             return;
         }
 

--- a/src/EventLogExpert.UI/wwwroot/Common/keyboardFocusRing.js
+++ b/src/EventLogExpert.UI/wwwroot/Common/keyboardFocusRing.js
@@ -17,10 +17,11 @@
 // (WCAG 2.4.7) instead of silently dropping it app-wide. One idempotent registration wires the listeners
 // for the whole app.
 
-// Lone modifier keydowns are not navigation. AltGraph is included because Windows AltGr dispatches its own
-// keydown (key "AltGraph") right before the printable character, which would otherwise flip modality mid-word
-// on non-US layouts.
-const MODIFIER_KEYS = new Set(["Shift", "Control", "Alt", "Meta", "AltGraph"]);
+// Lone modifier and lock keydowns are not navigation. AltGraph is included because Windows AltGr dispatches
+// its own keydown (key "AltGraph") right before the printable character, which would otherwise flip modality
+// mid-word on non-US layouts. CapsLock / NumLock / ScrollLock move no focus either, so toggling one after a
+// mouse click must not flip to keyboard mode and paint a ring on a control focus never moved to.
+const MODIFIER_KEYS = new Set(["Shift", "Control", "Alt", "Meta", "AltGraph", "CapsLock", "NumLock", "ScrollLock"]);
 const TEXT_ENTRY_INPUT_TYPES = new Set(["text", "search", "url", "tel", "email", "password", "number"]);
 // Caret / edit keys that, like a printable character, edit the field's text rather than navigate away from
 // it. ArrowUp / ArrowDown are intentionally excluded: this app has no multiline text inputs, so they never
@@ -93,8 +94,12 @@ export function registerKeyboardFocusRing() {
         if (!e.isTrusted) { return; }
 
         if (e.detail > 0) {
-            const label = e.target.closest?.("label");
-            forwardedClickTarget = label ? label.control : null;
+            // Only remember an ENABLED forwarded control. The browser never dispatches the synthesised detail-0
+            // click to a disabled control, so remembering one would leave a stale target: once that control is
+            // later enabled and activated by assistive tech (a trusted detail-0 click), the stale match would
+            // misread it as a label-forwarded mouse click and wrongly suppress its focus ring.
+            const forwardedControl = e.target.closest?.("label")?.control;
+            forwardedClickTarget = forwardedControl && !forwardedControl.disabled ? forwardedControl : null;
             return;
         }
 

--- a/src/EventLogExpert.UI/wwwroot/app.css
+++ b/src/EventLogExpert.UI/wwwroot/app.css
@@ -339,6 +339,16 @@ a { color: var(--clr-lightblue); }
 
 .indent { margin-left: 1rem; }
 
+/* Vertically center reduced-font-size (sub-1em) single-line text that shares a flex/grid row with
+   taller controls (buttons/icons/inputs). inline-flex + align-items:center centers the glyph box,
+   and line-height:1 removes the asymmetric leading that otherwise makes small text sit visibly low
+   (the same fix DatabaseToolsLogView applies to its log rows). Use only on single-line labels. */
+.vcenter-text {
+    display: inline-flex;
+    align-items: center;
+    line-height: 1;
+}
+
 .input {
     background: none;
     border: none;
@@ -366,6 +376,14 @@ input[type="text"].input.dialog-input { padding: .25rem 0; }
 .input.filter-dropdown { width: 160px; }
 
 .input.filter-mode-dropdown { width: 90px; }
+
+/* Property/operator selects size to their longest option (property: "Related Activity ID";
+   operator: "Contains None") so no option is clipped and the width never shifts when the
+   selection changes. text-align:center (from .input) leaves symmetric whitespace on shorter
+   values. The value select (the last control) keeps its own wider, context-tuned width. */
+.input.filter-property-select { width: 21ch; }
+
+.input.filter-operator-select { width: 15ch; }
 
 .input.timezone-dropdown { width: 420px; }
 

--- a/src/EventLogExpert.UI/wwwroot/app.css
+++ b/src/EventLogExpert.UI/wwwroot/app.css
@@ -35,6 +35,17 @@
 
     --toggle-accent: light-dark(#0A4C8C, #6FB2F5);
 
+    /* Categorical palette (Okabe-Ito, colorblind-safe), theme-aware. Single source shared by the event
+       histogram category bars and the tab-group indicator lines so both draw the same set of hues. */
+    --cat-color-0: light-dark(#0072b2, #56b4e9);
+    --cat-color-1: light-dark(#b66d00, #e69f00);
+    --cat-color-2: light-dark(#007a5a, #009e73);
+    --cat-color-3: light-dark(#a64f82, #cc79a7);
+    --cat-color-4: light-dark(#6f5aa8, #8e7cc3);
+    --cat-color-5: light-dark(#8f6a00, #f0e442);
+    --cat-color-6: light-dark(#8a3f00, #d55e00);
+    --cat-color-7: light-dark(#007983, #00a6b8);
+
     /* Recessed surface used for content wells (e.g. the trash strip exposed
        behind a database row when it slides aside). Always darker than
        --background-dark in both schemes so the well reads as cut into the
@@ -186,6 +197,22 @@
 }
 
 :focus-visible {
+    outline: var(--focus-ring-width) solid var(--focus-ring-color);
+    outline-offset: var(--focus-ring-offset);
+}
+
+/* Text boxes, the value-select input, and elements the chrome autofocuses on open keep the focus ring
+   KEYBOARD-ONLY. Chromium matches :focus-visible on a mouse click for text/search fields, and on an
+   autofocused <dialog> button opened by pointer (crbug 469468111), so opt those out and paint the ring only
+   while the root input modality is keyboard. keyboardFocusRing.js tracks data-modality (registered once by
+   MainLayout). Every other control relies on native :focus-visible, already keyboard-only in WebView2. */
+input[type="text"]:focus-visible,
+input[type="search"]:focus-visible,
+[autofocus]:focus-visible { outline: none; }
+
+:root[data-modality="keyboard"] input[type="text"]:focus,
+:root[data-modality="keyboard"] input[type="search"]:focus,
+:root[data-modality="keyboard"] [autofocus]:focus {
     outline: var(--focus-ring-width) solid var(--focus-ring-color);
     outline-offset: var(--focus-ring-offset);
 }

--- a/src/EventLogExpert/DependencyInjection/MauiProgramExtensions.cs
+++ b/src/EventLogExpert/DependencyInjection/MauiProgramExtensions.cs
@@ -75,10 +75,19 @@ internal static class MauiProgramExtensions
                     },
                     async parameters =>
                     {
-                        ModalOpenResult<string> result = await modalCoordinator.PushAsync<PromptModal, string>(
+                        ModalOpenResult<PromptOutcome> result = await modalCoordinator.PushAsync<PromptModal, PromptOutcome>(
                             parameters as IDictionary<string, object?> ?? new Dictionary<string, object?>(parameters));
 
-                        return result.WasOpened ? result.Result ?? string.Empty : string.Empty;
+                        return result.WasOpened ? result.Result.Value ?? string.Empty : string.Empty;
+                    },
+                    async parameters =>
+                    {
+                        ModalOpenResult<PromptOutcome> result = await modalCoordinator.PushAsync<PromptModal, PromptOutcome>(
+                            parameters as IDictionary<string, object?> ?? new Dictionary<string, object?>(parameters));
+
+                        return result.WasOpened ?
+                            result.Result with { Value = result.Result.Value ?? string.Empty } :
+                            new PromptOutcome(PromptChoice.Cancel, string.Empty);
                     });
             });
 

--- a/src/EventLogExpert/wwwroot/index.html
+++ b/src/EventLogExpert/wwwroot/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-modality="keyboard">
 <head>
     <meta charset="utf-8" />
     <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" name="viewport" />

--- a/tests/Integration/EventLogExpert.Runtime.IntegrationTests/FilterLibrary/FilterLibraryMigrationIntegrationTests.cs
+++ b/tests/Integration/EventLogExpert.Runtime.IntegrationTests/FilterLibrary/FilterLibraryMigrationIntegrationTests.cs
@@ -4,6 +4,7 @@
 using EventLogExpert.Filtering.Persistence;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Runtime.Announcement;
+using EventLogExpert.Runtime.Banner;
 using EventLogExpert.Runtime.FilterLibrary;
 using EventLogExpert.Runtime.FilterPane;
 using Fluxor;
@@ -233,7 +234,7 @@ public sealed class FilterLibraryMigrationIntegrationTests : IDisposable
 
         backslashMigrator ??= Substitute.For<IBackslashNameMigrator>();
 
-        return new Effects(store, libraryState, paneState, migrator, backslashMigrator, Substitute.For<IAnnouncementService>(), Substitute.For<ITraceLogger>(), new TagBulkUpdateFailedNotifier(Substitute.For<ITraceLogger>()));
+        return new Effects(store, libraryState, paneState, migrator, backslashMigrator, Substitute.For<IAnnouncementService>(), Substitute.For<IErrorBannerService>(), Substitute.For<ITraceLogger>(), new TagBulkUpdateFailedNotifier(Substitute.For<ITraceLogger>()));
     }
 
     private string CreateTempDatabasePath()

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensCommandsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensCommandsTests.cs
@@ -83,6 +83,16 @@ public sealed class FilterLensCommandsTests
     }
 
     [Fact]
+    public void PromoteAllLenses_DispatchesPromoteAll()
+    {
+        var dispatcher = Substitute.For<IDispatcher>();
+
+        new FilterLensCommands(dispatcher).PromoteAllLenses();
+
+        dispatcher.Received(1).Dispatch(Arg.Any<PromoteAllFilterLensesAction>());
+    }
+
+    [Fact]
     public void RemoveLens_DispatchesRemove()
     {
         var dispatcher = Substitute.For<IDispatcher>();
@@ -92,6 +102,17 @@ public sealed class FilterLensCommandsTests
 
         dispatcher.Received(1).Dispatch(Arg.Is<RemoveFilterLensAction>(action =>
             action != null && action.Id == id));
+    }
+
+    [Fact]
+    public void SaveLensesAsGroup_DispatchesSaveAsGroupWithName()
+    {
+        var dispatcher = Substitute.For<IDispatcher>();
+
+        new FilterLensCommands(dispatcher).SaveLensesAsGroup("My Group");
+
+        dispatcher.Received(1).Dispatch(Arg.Is<SaveLensesAsGroupAction>(action =>
+            action != null && action.Name == "My Group"));
     }
 
     [Theory]

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensCommandsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensCommandsTests.cs
@@ -112,7 +112,18 @@ public sealed class FilterLensCommandsTests
         new FilterLensCommands(dispatcher).SaveLensesAsGroup("My Group");
 
         dispatcher.Received(1).Dispatch(Arg.Is<SaveLensesAsGroupAction>(action =>
-            action != null && action.Name == "My Group"));
+            action != null && action.Name == "My Group" && !action.ClearAfterSave));
+    }
+
+    [Fact]
+    public void SaveLensesAsGroup_WithClearAfterSave_DispatchesSaveAsGroupWithClearFlag()
+    {
+        var dispatcher = Substitute.For<IDispatcher>();
+
+        new FilterLensCommands(dispatcher).SaveLensesAsGroup("My Group", clearAfterSave: true);
+
+        dispatcher.Received(1).Dispatch(Arg.Is<SaveLensesAsGroupAction>(action =>
+            action != null && action.Name == "My Group" && action.ClearAfterSave));
     }
 
     [Theory]

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensEffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensEffectsTests.cs
@@ -6,6 +6,7 @@ using EventLogExpert.Filtering.Persistence;
 using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.Runtime.EventLog;
 using EventLogExpert.Runtime.FilterLenses;
+using EventLogExpert.Runtime.FilterLibrary;
 using EventLogExpert.Runtime.FilterPane;
 using Fluxor;
 using NSubstitute;
@@ -57,6 +58,56 @@ public sealed class FilterLensEffectsTests
         await effects.HandleLogClosedByUser(new LogClosedByUserAction(EventLogId.Create(), "LogB"), dispatcher);
 
         dispatcher.DidNotReceive().Dispatch(Arg.Any<RemoveLensesForLogAction>());
+    }
+
+    [Fact]
+    public async Task HandlePromoteAll_CommitsEveryPromotableLens_WithoutAnnouncing()
+    {
+        var keep = FilterLensFactory.ForActivityId(Guid.NewGuid())!;
+        var time = FilterLensFactory.ForTimeWindow(DateTime.UtcNow, TimeSpan.FromMinutes(5), TimeZoneInfo.Utc);
+        var (effects, dispatcher, announcer) =
+            CreateEffectsWithAnnouncer(new FilterLensState { Lenses = [keep, time] }, new FilterPaneState());
+
+        await effects.HandlePromoteAll(dispatcher);
+
+        // One commit per lens; the breadcrumb announces once at the UI layer, so the effect itself stays silent.
+        dispatcher.Received(1).Dispatch(Arg.Is<CommitPromotedLensAction>(action => action != null && action.Id == keep.Id));
+        dispatcher.Received(1).Dispatch(Arg.Is<CommitPromotedLensAction>(action => action != null && action.Id == time.Id));
+        announcer.DidNotReceive().AnnounceLensKept(Arg.Any<FilterLensLabel>());
+    }
+
+    [Fact]
+    public async Task HandlePromoteAll_CommitsExcludeCriteria_NotPositiveIncludes()
+    {
+        // A keep lens must promote via its AND-narrowing exclude-of-complement (which intersects with sibling lenses),
+        // not its positive PromoteForm include (which would OR into a union across multiple promoted lenses).
+        var keep = FilterLensFactory.ForActivityId(Guid.NewGuid())!;
+        var (effects, dispatcher) = CreateEffects(new FilterLensState { Lenses = [keep] }, new FilterPaneState());
+
+        await effects.HandlePromoteAll(dispatcher);
+
+        dispatcher.Received(1).Dispatch(Arg.Is<CommitPromotedLensAction>(action =>
+            action != null && action.Id == keep.Id &&
+            action.Filters.Count == keep.ExcludeFilters.Count && action.Filters.All(filter => filter.IsExcluded)));
+    }
+
+    [Fact]
+    public async Task HandlePromoteAll_SkipsNonPromotableLens()
+    {
+        var real = FilterLensFactory.ForActivityId(Guid.NewGuid())!;
+        var degenerate = new FilterLens
+        {
+            Label = new FilterLensLabel.PropertyComparison(EventProperty.Source, IsEqual: true, "empty"),
+            Kind = LensKind.Property,
+            ExcludeFilters = []
+        };
+        var (effects, dispatcher) =
+            CreateEffects(new FilterLensState { Lenses = [real, degenerate] }, new FilterPaneState());
+
+        await effects.HandlePromoteAll(dispatcher);
+
+        dispatcher.Received(1).Dispatch(Arg.Is<CommitPromotedLensAction>(action => action != null && action.Id == real.Id));
+        dispatcher.DidNotReceive().Dispatch(Arg.Is<CommitPromotedLensAction>(action => action != null && action.Id == degenerate.Id));
     }
 
     [Fact]
@@ -163,6 +214,69 @@ public sealed class FilterLensEffectsTests
         dispatcher.DidNotReceive().Dispatch(Arg.Any<SetFilterAction>());
         Assert.Single(paneState.Filters);
         Assert.False(paneState.Filters[0].IsExcluded);
+    }
+
+    [Fact]
+    public async Task HandleSaveLensesAsGroup_BlankName_DoesNothing()
+    {
+        var keep = FilterLensFactory.ForActivityId(Guid.NewGuid())!;
+        var (effects, dispatcher) = CreateEffects(new FilterLensState { Lenses = [keep] }, new FilterPaneState());
+
+        await effects.HandleSaveLensesAsGroup(new SaveLensesAsGroupAction("   "), dispatcher);
+
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<SaveFilterSetAction>());
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<RemoveFilterLensAction>());
+    }
+
+    [Fact]
+    public async Task HandleSaveLensesAsGroup_MixedStack_SavesOnlyValueLensAndLeavesAllLensesActive()
+    {
+        var keep = FilterLensFactory.ForActivityId(Guid.NewGuid())!;
+        var time = FilterLensFactory.ForTimeWindow(DateTime.UtcNow, TimeSpan.FromMinutes(5), TimeZoneInfo.Utc);
+        var (effects, dispatcher) =
+            CreateEffects(new FilterLensState { Lenses = [keep, time] }, new FilterPaneState());
+
+        await effects.HandleSaveLensesAsGroup(new SaveLensesAsGroupAction("My Group"), dispatcher);
+
+        // Only the value lens contributes to the saved set (the time-window lens carries no SavedFilters). All lenses
+        // are left active so the user keeps the current view.
+        dispatcher.Received(1).Dispatch(Arg.Is<SaveFilterSetAction>(action => action != null && action.Filters.Count == 1));
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<RemoveFilterLensAction>());
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<ClearFilterLensesAction>());
+    }
+
+    [Fact]
+    public async Task HandleSaveLensesAsGroup_OnlyTimeWindowLenses_DoesNothing()
+    {
+        var time = FilterLensFactory.ForTimeWindow(DateTime.UtcNow, TimeSpan.FromMinutes(5), TimeZoneInfo.Utc);
+        var (effects, dispatcher) = CreateEffects(new FilterLensState { Lenses = [time] }, new FilterPaneState());
+
+        await effects.HandleSaveLensesAsGroup(new SaveLensesAsGroupAction("My Group"), dispatcher);
+
+        // A time-window lens carries no SavedFilters, so there is nothing to persist and it stays active.
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<SaveFilterSetAction>());
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<RemoveFilterLensAction>());
+    }
+
+    [Fact]
+    public async Task HandleSaveLensesAsGroup_ValueLenses_SavesIntersectionAndLeavesLensesActive()
+    {
+        var keep = FilterLensFactory.ForActivityId(Guid.NewGuid())!;
+        var hide = FilterLensFactory.ForExcludedValue(EventProperty.Source, "Contoso")!;
+        var (effects, dispatcher) =
+            CreateEffects(new FilterLensState { Lenses = [keep, hide] }, new FilterPaneState());
+
+        await effects.HandleSaveLensesAsGroup(new SaveLensesAsGroupAction("My Group"), dispatcher);
+
+        // Both lenses contribute their AND-narrowing EXCLUDE criteria - NOT positive includes, which would OR into a
+        // union broader than the intersected lens stack the user sees.
+        dispatcher.Received(1).Dispatch(Arg.Is<SaveFilterSetAction>(action =>
+            action != null && action.Name == "My Group" &&
+            action.Filters.Count == 2 && action.Filters.All(filter => filter.IsExcluded)));
+
+        // The lenses stay active after saving (matching the other save-to-filter-set flows); nothing is cleared.
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<RemoveFilterLensAction>());
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<ClearFilterLensesAction>());
     }
 
     private static SavedFilter Compile(string text) =>

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensEffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensEffectsTests.cs
@@ -340,11 +340,28 @@ public sealed class FilterLensEffectsTests
     }
 
     [Fact]
+    public async Task HandleSaveLensesAsGroup_DedupesCaseVariantFiltersToMatchLibraryApply()
+    {
+        // The saved group is applied via the case-insensitive library merge (ReduceMergeFilters), so the save dedupes
+        // case-variant values ("Contoso" / "CONTOSO") into one predicate too - saving both would not round-trip, as the
+        // apply path would collapse them and broaden the result.
+        var lower = FilterLensFactory.ForExcludedValue(EventProperty.Source, "Contoso")!;
+        var upper = FilterLensFactory.ForExcludedValue(EventProperty.Source, "CONTOSO")!;
+        var (effects, dispatcher) =
+            CreateEffects(new FilterLensState { Lenses = [lower, upper] }, new FilterPaneState());
+
+        await effects.HandleSaveLensesAsGroup(new SaveLensesAsGroupAction("My Group"), dispatcher);
+
+        dispatcher.Received(1).Dispatch(Arg.Is<SaveFilterSetAction>(action =>
+            action != null && action.Filters.Count == 1 && action.Filters.All(filter => filter.IsExcluded)));
+    }
+
+    [Fact]
     public async Task HandleSaveLensesAsGroup_DeduplicatesFiltersWithIdenticalContent()
     {
         // Distinct lenses can carry byte-identical exclude criteria (the reducer supports same-content, distinct-id
-        // lenses). The saved set dedupes by the ordinal-exact (ComparisonText, Mode, IsExcluded) identity (matching
-        // MergePromotedFilters) so it never persists duplicate rows.
+        // lenses). The saved set dedupes by the same case-insensitive (ComparisonText, Mode, IsExcluded) identity the
+        // library apply uses, so it never persists duplicate rows.
         var first = FilterLensFactory.ForExcludedValue(EventProperty.Source, "Contoso")!;
         var second = FilterLensFactory.ForExcludedValue(EventProperty.Source, "Contoso")!;
         var (effects, dispatcher) =
@@ -354,22 +371,6 @@ public sealed class FilterLensEffectsTests
 
         dispatcher.Received(1).Dispatch(Arg.Is<SaveFilterSetAction>(action =>
             action != null && action.Filters.Count == 1 && action.Filters[0].IsExcluded));
-    }
-
-    [Fact]
-    public async Task HandleSaveLensesAsGroup_KeepsCaseVariantFiltersAsDistinctPredicates()
-    {
-        // Dedup is ordinal-exact (like MergePromotedFilters), so case-variant values stay distinct predicates -
-        // collapsing them case-insensitively would drop an exclusion and broaden the saved group when reapplied.
-        var lower = FilterLensFactory.ForExcludedValue(EventProperty.Source, "Contoso")!;
-        var upper = FilterLensFactory.ForExcludedValue(EventProperty.Source, "CONTOSO")!;
-        var (effects, dispatcher) =
-            CreateEffects(new FilterLensState { Lenses = [lower, upper] }, new FilterPaneState());
-
-        await effects.HandleSaveLensesAsGroup(new SaveLensesAsGroupAction("My Group"), dispatcher);
-
-        dispatcher.Received(1).Dispatch(Arg.Is<SaveFilterSetAction>(action =>
-            action != null && action.Filters.Count == 2 && action.Filters.All(filter => filter.IsExcluded)));
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensEffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensEffectsTests.cs
@@ -70,10 +70,13 @@ public sealed class FilterLensEffectsTests
 
         await effects.HandlePromoteAll(dispatcher);
 
-        // One commit per lens, plus a single "saved all" announcement from the effect so it reflects what was
-        // actually committed. No per-lens "kept" announcement for the bulk action.
-        dispatcher.Received(1).Dispatch(Arg.Is<CommitPromotedLensAction>(action => action != null && action.Id == keep.Id));
-        dispatcher.Received(1).Dispatch(Arg.Is<CommitPromotedLensAction>(action => action != null && action.Id == time.Id));
+        // One batch commit for the whole "Save all" (both lenses in a single action, not one action per lens), plus a
+        // single "saved all" announcement. No per-lens singular commit and no per-lens "kept" announcement.
+        dispatcher.Received(1).Dispatch(Arg.Is<CommitPromotedLensesAction>(action =>
+            action != null && action.Commits.Count == 2 &&
+            action.Commits.Any(commit => commit.Id == keep.Id) &&
+            action.Commits.Any(commit => commit.Id == time.Id)));
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<CommitPromotedLensAction>());
         announcer.Received(1).AnnounceLensesSavedAll();
         announcer.DidNotReceive().AnnounceLensKept(Arg.Any<FilterLensLabel>());
     }
@@ -88,9 +91,10 @@ public sealed class FilterLensEffectsTests
 
         await effects.HandlePromoteAll(dispatcher);
 
-        dispatcher.Received(1).Dispatch(Arg.Is<CommitPromotedLensAction>(action =>
-            action != null && action.Id == keep.Id &&
-            action.Filters.Count == keep.ExcludeFilters.Count && action.Filters.All(filter => filter.IsExcluded)));
+        dispatcher.Received(1).Dispatch(Arg.Is<CommitPromotedLensesAction>(action =>
+            action != null && action.Commits.Count == 1 && action.Commits[0].Id == keep.Id &&
+            action.Commits[0].Filters.Count == keep.ExcludeFilters.Count &&
+            action.Commits[0].Filters.All(filter => filter.IsExcluded)));
     }
 
     [Fact]
@@ -107,7 +111,7 @@ public sealed class FilterLensEffectsTests
 
         await effects.HandlePromoteAll(dispatcher);
 
-        dispatcher.DidNotReceive().Dispatch(Arg.Any<CommitPromotedLensAction>());
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<CommitPromotedLensesAction>());
         announcer.DidNotReceive().AnnounceLensesSavedAll();
     }
 
@@ -126,8 +130,9 @@ public sealed class FilterLensEffectsTests
 
         await effects.HandlePromoteAll(dispatcher);
 
-        dispatcher.Received(1).Dispatch(Arg.Is<CommitPromotedLensAction>(action => action != null && action.Id == real.Id));
-        dispatcher.DidNotReceive().Dispatch(Arg.Is<CommitPromotedLensAction>(action => action != null && action.Id == degenerate.Id));
+        dispatcher.Received(1).Dispatch(Arg.Is<CommitPromotedLensesAction>(action =>
+            action != null && action.Commits.Count == 1 && action.Commits[0].Id == real.Id));
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<CommitPromotedLensAction>());
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensEffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensEffectsTests.cs
@@ -322,6 +322,23 @@ public sealed class FilterLensEffectsTests
     }
 
     [Fact]
+    public async Task HandleSaveLensesAsGroup_DeduplicatesFiltersWithIdenticalContent()
+    {
+        // Distinct lenses can carry identical exclude criteria (the reducer supports same-content, distinct-id
+        // lenses). The saved set must dedupe by (ComparisonText, Mode, IsExcluded) so it never persists duplicate
+        // rows, matching the FilterPane/store invariant.
+        var first = FilterLensFactory.ForExcludedValue(EventProperty.Source, "Contoso")!;
+        var second = FilterLensFactory.ForExcludedValue(EventProperty.Source, "Contoso")!;
+        var (effects, dispatcher) =
+            CreateEffects(new FilterLensState { Lenses = [first, second] }, new FilterPaneState());
+
+        await effects.HandleSaveLensesAsGroup(new SaveLensesAsGroupAction("My Group"), dispatcher);
+
+        dispatcher.Received(1).Dispatch(Arg.Is<SaveFilterSetAction>(action =>
+            action != null && action.Filters.Count == 1 && action.Filters[0].IsExcluded));
+    }
+
+    [Fact]
     public async Task HandleSaveLensesAsGroup_MixedStack_SavesOnlyValueLensAndLeavesAllLensesActive()
     {
         var keep = FilterLensFactory.ForActivityId(Guid.NewGuid())!;

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensEffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensEffectsTests.cs
@@ -61,7 +61,7 @@ public sealed class FilterLensEffectsTests
     }
 
     [Fact]
-    public async Task HandlePromoteAll_CommitsEveryPromotableLens_WithoutAnnouncing()
+    public async Task HandlePromoteAll_CommitsEveryPromotableLens_AndAnnouncesOnce()
     {
         var keep = FilterLensFactory.ForActivityId(Guid.NewGuid())!;
         var time = FilterLensFactory.ForTimeWindow(DateTime.UtcNow, TimeSpan.FromMinutes(5), TimeZoneInfo.Utc);
@@ -70,9 +70,11 @@ public sealed class FilterLensEffectsTests
 
         await effects.HandlePromoteAll(dispatcher);
 
-        // One commit per lens; the breadcrumb announces once at the UI layer, so the effect itself stays silent.
+        // One commit per lens, plus a single "saved all" announcement from the effect so it reflects what was
+        // actually committed. No per-lens "kept" announcement for the bulk action.
         dispatcher.Received(1).Dispatch(Arg.Is<CommitPromotedLensAction>(action => action != null && action.Id == keep.Id));
         dispatcher.Received(1).Dispatch(Arg.Is<CommitPromotedLensAction>(action => action != null && action.Id == time.Id));
+        announcer.Received(1).AnnounceLensesSavedAll();
         announcer.DidNotReceive().AnnounceLensKept(Arg.Any<FilterLensLabel>());
     }
 
@@ -89,6 +91,24 @@ public sealed class FilterLensEffectsTests
         dispatcher.Received(1).Dispatch(Arg.Is<CommitPromotedLensAction>(action =>
             action != null && action.Id == keep.Id &&
             action.Filters.Count == keep.ExcludeFilters.Count && action.Filters.All(filter => filter.IsExcluded)));
+    }
+
+    [Fact]
+    public async Task HandlePromoteAll_NoPromotableLenses_DoesNotAnnounceOrCommit()
+    {
+        var degenerate = new FilterLens
+        {
+            Label = new FilterLensLabel.PropertyComparison(EventProperty.Source, IsEqual: true, "empty"),
+            Kind = LensKind.Property,
+            ExcludeFilters = []
+        };
+        var (effects, dispatcher, announcer) =
+            CreateEffectsWithAnnouncer(new FilterLensState { Lenses = [degenerate] }, new FilterPaneState());
+
+        await effects.HandlePromoteAll(dispatcher);
+
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<CommitPromotedLensAction>());
+        announcer.DidNotReceive().AnnounceLensesSavedAll();
     }
 
     [Fact]
@@ -217,6 +237,30 @@ public sealed class FilterLensEffectsTests
     }
 
     [Fact]
+    public async Task HandleSaveFilterSetSucceeded_LensOrigin_AnnouncesGroupSaved()
+    {
+        var (effects, dispatcher, announcer) =
+            CreateEffectsWithAnnouncer(new FilterLensState(), new FilterPaneState());
+
+        await effects.HandleSaveFilterSetSucceeded(
+            new SaveFilterSetSucceededAction("My Group", SaveFilterSetOrigin.Lens), dispatcher);
+
+        announcer.Received(1).AnnounceLensGroupSaved("My Group");
+    }
+
+    [Fact]
+    public async Task HandleSaveFilterSetSucceeded_LibraryOrigin_DoesNotAnnounce()
+    {
+        var (effects, dispatcher, announcer) =
+            CreateEffectsWithAnnouncer(new FilterLensState(), new FilterPaneState());
+
+        await effects.HandleSaveFilterSetSucceeded(
+            new SaveFilterSetSucceededAction("Pane Preset", SaveFilterSetOrigin.Library), dispatcher);
+
+        announcer.DidNotReceive().AnnounceLensGroupSaved(Arg.Any<string>());
+    }
+
+    [Fact]
     public async Task HandleSaveLensesAsGroup_BlankName_DoesNothing()
     {
         var keep = FilterLensFactory.ForActivityId(Guid.NewGuid())!;
@@ -271,7 +315,7 @@ public sealed class FilterLensEffectsTests
         // Both lenses contribute their AND-narrowing EXCLUDE criteria - NOT positive includes, which would OR into a
         // union broader than the intersected lens stack the user sees.
         dispatcher.Received(1).Dispatch(Arg.Is<SaveFilterSetAction>(action =>
-            action != null && action.Name == "My Group" &&
+            action != null && action.Name == "My Group" && action.Origin == SaveFilterSetOrigin.Lens &&
             action.Filters.Count == 2 && action.Filters.All(filter => filter.IsExcluded)));
 
         // The lenses stay active after saving (matching the other save-to-filter-set flows); nothing is cleared.

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensEffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensEffectsTests.cs
@@ -322,6 +322,24 @@ public sealed class FilterLensEffectsTests
     }
 
     [Fact]
+    public async Task HandleSaveLensesAsGroup_ClearAfterSave_MixedStack_ClearsOnlyContributingLenses()
+    {
+        // A time-window lens contributes no filter (the UI says it can't be grouped), so save-and-clear must remove
+        // only the contributing value lens and leave the non-groupable time-window lens active.
+        var value = FilterLensFactory.ForExcludedValue(EventProperty.Source, "Contoso")!;
+        var time = FilterLensFactory.ForTimeWindow(DateTime.UtcNow, TimeSpan.FromMinutes(5), TimeZoneInfo.Utc);
+        var (effects, dispatcher) =
+            CreateEffects(new FilterLensState { Lenses = [value, time] }, new FilterPaneState());
+
+        await effects.HandleSaveLensesAsGroup(new SaveLensesAsGroupAction("My Group", ClearAfterSave: true), dispatcher);
+
+        dispatcher.Received(1).Dispatch(Arg.Is<SaveFilterSetAction>(action =>
+            action != null && action.Filters.Count == 1 &&
+            action.LensesToClearOnSuccess != null && action.LensesToClearOnSuccess.Count == 1 &&
+            action.LensesToClearOnSuccess.Contains(value.Id) && !action.LensesToClearOnSuccess.Contains(time.Id)));
+    }
+
+    [Fact]
     public async Task HandleSaveLensesAsGroup_DeduplicatesFiltersWithIdenticalContent()
     {
         // Distinct lenses can carry byte-identical exclude criteria (the reducer supports same-content, distinct-id

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensEffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensEffectsTests.cs
@@ -324,9 +324,9 @@ public sealed class FilterLensEffectsTests
     [Fact]
     public async Task HandleSaveLensesAsGroup_DeduplicatesFiltersWithIdenticalContent()
     {
-        // Distinct lenses can carry identical exclude criteria (the reducer supports same-content, distinct-id
-        // lenses). The saved set must dedupe by (ComparisonText, Mode, IsExcluded) so it never persists duplicate
-        // rows, matching the FilterPane/store invariant.
+        // Distinct lenses can carry byte-identical exclude criteria (the reducer supports same-content, distinct-id
+        // lenses). The saved set dedupes by the ordinal-exact (ComparisonText, Mode, IsExcluded) identity (matching
+        // MergePromotedFilters) so it never persists duplicate rows.
         var first = FilterLensFactory.ForExcludedValue(EventProperty.Source, "Contoso")!;
         var second = FilterLensFactory.ForExcludedValue(EventProperty.Source, "Contoso")!;
         var (effects, dispatcher) =
@@ -336,6 +336,22 @@ public sealed class FilterLensEffectsTests
 
         dispatcher.Received(1).Dispatch(Arg.Is<SaveFilterSetAction>(action =>
             action != null && action.Filters.Count == 1 && action.Filters[0].IsExcluded));
+    }
+
+    [Fact]
+    public async Task HandleSaveLensesAsGroup_KeepsCaseVariantFiltersAsDistinctPredicates()
+    {
+        // Dedup is ordinal-exact (like MergePromotedFilters), so case-variant values stay distinct predicates -
+        // collapsing them case-insensitively would drop an exclusion and broaden the saved group when reapplied.
+        var lower = FilterLensFactory.ForExcludedValue(EventProperty.Source, "Contoso")!;
+        var upper = FilterLensFactory.ForExcludedValue(EventProperty.Source, "CONTOSO")!;
+        var (effects, dispatcher) =
+            CreateEffects(new FilterLensState { Lenses = [lower, upper] }, new FilterPaneState());
+
+        await effects.HandleSaveLensesAsGroup(new SaveLensesAsGroupAction("My Group"), dispatcher);
+
+        dispatcher.Received(1).Dispatch(Arg.Is<SaveFilterSetAction>(action =>
+            action != null && action.Filters.Count == 2 && action.Filters.All(filter => filter.IsExcluded)));
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensEffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensEffectsTests.cs
@@ -251,6 +251,9 @@ public sealed class FilterLensEffectsTests
             new SaveFilterSetSucceededAction("My Group", SaveFilterSetOrigin.Lens), dispatcher);
 
         announcer.Received(1).AnnounceLensGroupSaved("My Group");
+
+        // A plain lens save carries no lenses-to-clear, so the stack stays active - only save-and-clear removes lenses.
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<RemoveFilterLensesAction>());
     }
 
     [Fact]
@@ -266,6 +269,24 @@ public sealed class FilterLensEffectsTests
     }
 
     [Fact]
+    public async Task HandleSaveFilterSetSucceeded_WithLensesToClear_AnnouncesAndRemovesSavedLenses()
+    {
+        var savedA = FilterLensId.Create();
+        var savedB = FilterLensId.Create();
+        var (effects, dispatcher, announcer) =
+            CreateEffectsWithAnnouncer(new FilterLensState(), new FilterPaneState());
+
+        await effects.HandleSaveFilterSetSucceeded(
+            new SaveFilterSetSucceededAction("My Group", SaveFilterSetOrigin.Lens, [savedA, savedB]), dispatcher);
+
+        // The removal rides the confirmed-persist signal and targets exactly the saved lenses; a failed save never
+        // dispatches SaveFilterSetSucceededAction and so removes nothing.
+        announcer.Received(1).AnnounceLensGroupSaved("My Group");
+        dispatcher.Received(1).Dispatch(Arg.Is<RemoveFilterLensesAction>(action =>
+            action != null && action.Ids.Count == 2 && action.Ids.Contains(savedA) && action.Ids.Contains(savedB)));
+    }
+
+    [Fact]
     public async Task HandleSaveLensesAsGroup_BlankName_DoesNothing()
     {
         var keep = FilterLensFactory.ForActivityId(Guid.NewGuid())!;
@@ -275,6 +296,29 @@ public sealed class FilterLensEffectsTests
 
         dispatcher.DidNotReceive().Dispatch(Arg.Any<SaveFilterSetAction>());
         dispatcher.DidNotReceive().Dispatch(Arg.Any<RemoveFilterLensAction>());
+    }
+
+    [Fact]
+    public async Task HandleSaveLensesAsGroup_ClearAfterSave_CarriesSavedLensIdsForDeferredRemoval()
+    {
+        var keep = FilterLensFactory.ForActivityId(Guid.NewGuid())!;
+        var hide = FilterLensFactory.ForExcludedValue(EventProperty.Source, "Contoso")!;
+        var (effects, dispatcher) =
+            CreateEffects(new FilterLensState { Lenses = [keep, hide] }, new FilterPaneState());
+
+        await effects.HandleSaveLensesAsGroup(new SaveLensesAsGroupAction("My Group", ClearAfterSave: true), dispatcher);
+
+        // Save-and-clear tags the save with the ids of exactly the lenses being saved; the removal is deferred to the
+        // persist-success effect. The save effect itself must not remove anything up front (that would discard the
+        // lenses even if the save fails).
+        dispatcher.Received(1).Dispatch(Arg.Is<SaveFilterSetAction>(action =>
+            action != null && action.Name == "My Group" && action.Origin == SaveFilterSetOrigin.Lens &&
+            action.LensesToClearOnSuccess != null && action.LensesToClearOnSuccess.Count == 2 &&
+            action.LensesToClearOnSuccess.Contains(keep.Id) && action.LensesToClearOnSuccess.Contains(hide.Id) &&
+            action.Filters.Count == 2 && action.Filters.All(filter => filter.IsExcluded)));
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<RemoveFilterLensAction>());
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<RemoveFilterLensesAction>());
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<ClearFilterLensesAction>());
     }
 
     [Fact]
@@ -321,11 +365,12 @@ public sealed class FilterLensEffectsTests
         // union broader than the intersected lens stack the user sees.
         dispatcher.Received(1).Dispatch(Arg.Is<SaveFilterSetAction>(action =>
             action != null && action.Name == "My Group" && action.Origin == SaveFilterSetOrigin.Lens &&
+            action.LensesToClearOnSuccess == null &&
             action.Filters.Count == 2 && action.Filters.All(filter => filter.IsExcluded)));
 
-        // The lenses stay active after saving (matching the other save-to-filter-set flows); nothing is cleared.
+        // A plain save carries no lenses-to-clear and stays active (matching the other save-to-filter-set flows).
         dispatcher.DidNotReceive().Dispatch(Arg.Any<RemoveFilterLensAction>());
-        dispatcher.DidNotReceive().Dispatch(Arg.Any<ClearFilterLensesAction>());
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<RemoveFilterLensesAction>());
     }
 
     private static SavedFilter Compile(string text) =>

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensReducerTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensReducerTests.cs
@@ -129,6 +129,32 @@ public sealed class FilterLensReducerTests
     }
 
     [Fact]
+    public void RemoveLenses_EmptyIds_ReturnsSameStateInstance()
+    {
+        var state = new FilterLensState { Lenses = [Lens("a")] };
+
+        var result = Reducers.ReduceRemoveLenses(state, new RemoveFilterLensesAction([]));
+
+        Assert.Same(state, result);
+    }
+
+    [Fact]
+    public void RemoveLenses_RemovesOnlySpecifiedLenses_LeavingOthers()
+    {
+        var saved1 = Lens("saved1");
+        var saved2 = Lens("saved2");
+        var addedDuringSave = Lens("added");
+        var state = new FilterLensState { Lenses = [saved1, saved2, addedDuringSave] };
+
+        // Mirrors save-and-clear: only the saved lenses are removed on persist success; a lens the user added while the
+        // save was in flight (addedDuringSave) is preserved.
+        var result = Reducers.ReduceRemoveLenses(state, new RemoveFilterLensesAction([saved1.Id, saved2.Id]));
+
+        Assert.Single(result.Lenses);
+        Assert.Same(addedDuringSave, result.Lenses[0]);
+    }
+
+    [Fact]
     public void Remove_DuplicateContentLenses_RemovesOnlyTargetedInstance()
     {
         var first = Lens("duplicate");

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensReducerTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensReducerTests.cs
@@ -28,6 +28,46 @@ public sealed class FilterLensReducerTests
     }
 
     [Fact]
+    public void CommitPromotedLenses_EmptyBatch_ReturnsSameStateInstance()
+    {
+        var state = new FilterLensState { Lenses = [Lens("a")] };
+
+        var result = Reducers.ReduceCommitPromotedLenses(state, new CommitPromotedLensesAction([]));
+
+        Assert.Same(state, result);
+    }
+
+    [Fact]
+    public void CommitPromotedLenses_NoMatch_ReturnsSameStateInstance()
+    {
+        var state = new FilterLensState { Lenses = [Lens("a")] };
+
+        var result = Reducers.ReduceCommitPromotedLenses(
+            state,
+            new CommitPromotedLensesAction([new PromotedLensCommit(Lens("other").Id, [], null)]));
+
+        Assert.Same(state, result);
+    }
+
+    [Fact]
+    public void CommitPromotedLenses_RemovesEveryCommittedLens_KeepsOthers()
+    {
+        var a = Lens("a");
+        var b = Lens("b");
+        var c = Lens("c");
+        var state = new FilterLensState { Lenses = [a, b, c] };
+
+        var result = Reducers.ReduceCommitPromotedLenses(
+            state,
+            new CommitPromotedLensesAction(
+                [new PromotedLensCommit(a.Id, [], null), new PromotedLensCommit(c.Id, [], null)]));
+
+        // Only the committed lenses (a, c) are dropped; the skipped lens (b) survives.
+        Assert.Single(result.Lenses);
+        Assert.Same(b, result.Lenses[0]);
+    }
+
+    [Fact]
     public void CommitPromoted_RemovesLensById()
     {
         var a = Lens("a");

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensSourceTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLenses/FilterLensSourceTests.cs
@@ -78,6 +78,19 @@ public sealed class FilterLensSourceTests
     }
 
     [Fact]
+    public void Lenses_ProjectTheLensKind_SoTimeWindowLensesAreNotTreatedAsValueLenses()
+    {
+        // Guards the FilterLensSummary.Kind projection: if it were dropped, a time-window lens would default to
+        // Property and wrongly enable "Save as group" (which a filter set cannot store a date window for).
+        var time = FilterLensFactory.ForTimeWindow(DateTime.UtcNow, TimeSpan.FromMinutes(5), TimeZoneInfo.Utc);
+        var harness = new Harness(time);
+
+        var summary = Assert.Single(harness.Source.Lenses);
+
+        Assert.Equal(LensKind.TimeWindow, summary.Kind);
+    }
+
+    [Fact]
     public void Lenses_SummarizeTheActiveLenses()
     {
         var first = Lens("First");

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLibrary/FilterLibraryEffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLibrary/FilterLibraryEffectsTests.cs
@@ -5,6 +5,7 @@ using EventLogExpert.Filtering.Persistence;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.Runtime.Banner;
+using EventLogExpert.Runtime.FilterLenses;
 using EventLogExpert.Runtime.FilterLibrary;
 using EventLogExpert.Runtime.FilterPane;
 using Fluxor;
@@ -1689,6 +1690,25 @@ public sealed class FilterLibraryEffectsTests
 
         await store.DidNotReceive().AddAsync(Arg.Any<LibraryEntry>(), Arg.Any<CancellationToken>());
         dispatcher.DidNotReceive().Dispatch(Arg.Any<AddLibraryEntrySuccessAction>());
+    }
+
+    [Fact]
+    public async Task HandleSaveFilterSet_WithLensesToClearOnSuccess_ForwardsThemToSucceeded()
+    {
+        var filter = SavedFilter.TryCreate("Level == 4");
+        Assert.NotNull(filter);
+        var lensA = FilterLensId.Create();
+        var lensB = FilterLensId.Create();
+        var (effects, _, dispatcher, _, _) = CreateEffects();
+
+        await effects.HandleSaveFilterSet(
+            new SaveFilterSetAction("My Group", [filter], SaveFilterSetOrigin.Lens, [lensA, lensB]), dispatcher);
+
+        // The saved-lens ids ride opaquely through the FilterLibrary save so the FilterLenses success handler can
+        // remove exactly the saved lenses once the write is confirmed persisted.
+        dispatcher.Received(1).Dispatch(Arg.Is<SaveFilterSetSucceededAction>(a =>
+            a != null && a.LensesToClearOnSuccess != null && a.LensesToClearOnSuccess.Count == 2 &&
+            a.LensesToClearOnSuccess.Contains(lensA) && a.LensesToClearOnSuccess.Contains(lensB)));
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterLibrary/FilterLibraryEffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterLibrary/FilterLibraryEffectsTests.cs
@@ -4,10 +4,12 @@
 using EventLogExpert.Filtering.Persistence;
 using EventLogExpert.Logging.Abstractions;
 using EventLogExpert.Runtime.Announcement;
+using EventLogExpert.Runtime.Banner;
 using EventLogExpert.Runtime.FilterLibrary;
 using EventLogExpert.Runtime.FilterPane;
 using Fluxor;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using System.Collections.Immutable;
 using Effects = EventLogExpert.Runtime.FilterLibrary.Effects;
 
@@ -1643,6 +1645,40 @@ public sealed class FilterLibraryEffectsTests
     }
 
     [Fact]
+    public async Task HandleSaveFilterSet_LensOrigin_Succeeds_DispatchesSucceededWithOrigin()
+    {
+        var filter = SavedFilter.TryCreate("Level == 4");
+        Assert.NotNull(filter);
+        var (effects, _, dispatcher, _, _) = CreateEffects();
+
+        await effects.HandleSaveFilterSet(
+            new SaveFilterSetAction("My Group", [filter], SaveFilterSetOrigin.Lens), dispatcher);
+
+        dispatcher.Received(1).Dispatch(Arg.Is<AddLibraryEntrySuccessAction>(a => a != null));
+        dispatcher.Received(1).Dispatch(Arg.Is<SaveFilterSetSucceededAction>(a =>
+            a != null && a.Name == "My Group" && a.Origin == SaveFilterSetOrigin.Lens));
+    }
+
+    [Fact]
+    public async Task HandleSaveFilterSet_StoreThrows_ReportsErrorBanner_AndDoesNotDispatchSucceeded()
+    {
+        var filter = SavedFilter.TryCreate("Level == 4");
+        Assert.NotNull(filter);
+        var store = Substitute.For<IFilterLibraryStore>();
+        store.AddAsync(Arg.Any<LibraryEntry>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("disk full"));
+        var errorBanner = Substitute.For<IErrorBannerService>();
+        var (effects, _, dispatcher, _, _, _) = CreateEffectsWithMigrator(store: store, errorBannerService: errorBanner);
+
+        await effects.HandleSaveFilterSet(
+            new SaveFilterSetAction("My Group", [filter], SaveFilterSetOrigin.Lens), dispatcher);
+
+        errorBanner.Received(1).ReportError(Arg.Any<string>(), Arg.Any<string>());
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<SaveFilterSetSucceededAction>());
+        dispatcher.DidNotReceive().Dispatch(Arg.Any<AddLibraryEntrySuccessAction>());
+    }
+
+    [Fact]
     public async Task HandleSaveFilterSet_WhitespaceName_IsNoOp()
     {
         var filter = SavedFilter.TryCreate("Level == 4");
@@ -1889,13 +1925,15 @@ public sealed class FilterLibraryEffectsTests
     private static (Effects effects, IFilterLibraryStore store, IDispatcher dispatcher, IState<FilterLibraryState> stateMock, ITraceLogger logger) CreateEffects(
         FilterLibraryState? state = null,
         FilterPaneState? paneState = null,
-        IAnnouncementService? announcementService = null)
+        IAnnouncementService? announcementService = null,
+        IErrorBannerService? errorBannerService = null)
     {
         var (effects, store, dispatcher, stateMock, _, logger) = CreateEffectsWithMigrator(
             migrator: null,
             state: state,
             paneState: paneState,
-            announcementService: announcementService);
+            announcementService: announcementService,
+            errorBannerService: errorBannerService);
 
         return (effects, store, dispatcher, stateMock, logger);
     }
@@ -1906,7 +1944,8 @@ public sealed class FilterLibraryEffectsTests
         FilterPaneState? paneState = null,
         IFilterLibraryStore? store = null,
         IBackslashNameMigrator? backslashMigrator = null,
-        IAnnouncementService? announcementService = null)
+        IAnnouncementService? announcementService = null,
+        IErrorBannerService? errorBannerService = null)
     {
         var storeWasSupplied = store is not null;
         store ??= Substitute.For<IFilterLibraryStore>();
@@ -1937,10 +1976,11 @@ public sealed class FilterLibraryEffectsTests
 
         backslashMigrator ??= Substitute.For<IBackslashNameMigrator>();
         announcementService ??= Substitute.For<IAnnouncementService>();
+        errorBannerService ??= Substitute.For<IErrorBannerService>();
 
         var logger = Substitute.For<ITraceLogger>();
         var dispatcher = Substitute.For<IDispatcher>();
-        var effects = new Effects(store, stateMock, paneStateMock, migrator, backslashMigrator, announcementService, logger, new TagBulkUpdateFailedNotifier(Substitute.For<ITraceLogger>()));
+        var effects = new Effects(store, stateMock, paneStateMock, migrator, backslashMigrator, announcementService, errorBannerService, logger, new TagBulkUpdateFailedNotifier(Substitute.For<ITraceLogger>()));
 
         return (effects, store, dispatcher, stateMock, migrator, logger);
     }

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterPane/EffectsTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterPane/EffectsTests.cs
@@ -124,6 +124,55 @@ public sealed class EffectsTests
     }
 
     [Fact]
+    public async Task HandleCommitPromotedLenses_AnyWindowCommit_RaisesDateResyncOnce()
+    {
+        // One resync for the batch even though only one commit carries an enabled window; still one promote + one apply.
+        var window = new DateFilter
+        {
+            After = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            Before = new DateTime(2024, 1, 2, 0, 0, 0, DateTimeKind.Utc),
+            IsEnabled = true
+        };
+        var (effects, dispatcher, promotedRaised, dateResyncRaised) = CreateCommitPromotedEffects(
+            new FilterPaneState { FilteredDateRange = window },
+            appliedFilter: new Filter(null, []));
+
+        await effects.HandleCommitPromotedLenses(
+            new CommitPromotedLensesAction(
+                [
+                    new PromotedLensCommit(FilterLensId.Create(), [], null),
+                    new PromotedLensCommit(FilterLensId.Create(), [], window)
+                ]),
+            dispatcher);
+
+        Assert.Equal(1, dateResyncRaised());
+        Assert.Equal(1, promotedRaised());
+        dispatcher.Received(1).Dispatch(Arg.Any<ApplyFilterAction>());
+    }
+
+    [Fact]
+    public async Task HandleCommitPromotedLenses_MultipleCommits_AppliesOnceUnconditionally_RaisesPromotedOnce()
+    {
+        // The whole batch applies the filter exactly ONCE (not once per commit) and raises FilterPromoted once. The
+        // empty candidate equals the empty applied filter, so the apply must be unconditional to land last and win.
+        var (effects, dispatcher, promotedRaised, dateResyncRaised) = CreateCommitPromotedEffects(
+            new FilterPaneState(),
+            appliedFilter: new Filter(null, []));
+
+        await effects.HandleCommitPromotedLenses(
+            new CommitPromotedLensesAction(
+                [
+                    new PromotedLensCommit(FilterLensId.Create(), [], null),
+                    new PromotedLensCommit(FilterLensId.Create(), [], null)
+                ]),
+            dispatcher);
+
+        dispatcher.Received(1).Dispatch(Arg.Any<ApplyFilterAction>());
+        Assert.Equal(1, promotedRaised());
+        Assert.Equal(0, dateResyncRaised());
+    }
+
+    [Fact]
     public async Task HandleCommitPromoted_AppliesEvenWhenFilteringUnchanged()
     {
         // The empty candidate equals the empty applied filter, so the guarded path would suppress. The unconditional

--- a/tests/Unit/EventLogExpert.Runtime.Tests/FilterPane/FilterPaneStoreTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/FilterPane/FilterPaneStoreTests.cs
@@ -230,6 +230,69 @@ public sealed class FilterPaneReducerTests
     }
 
     [Fact]
+    public void ReduceCommitPromotedLenses_DuplicateAcrossCommits_AddsSingleRow()
+    {
+        // The batch folds over the RUNNING list, so the second commit's identical exclude dedups against the row the
+        // first commit just added: "Save all" of two lenses carrying the same filter yields ONE row, not two.
+        var state = new FilterPaneState();
+
+        var result = Reducers.ReduceCommitPromotedLenses(
+            state,
+            new CommitPromotedLensesAction(
+                [
+                    new PromotedLensCommit(FilterLensId.Create(), [PromotedExclude("Source != \"foo\"")], null),
+                    new PromotedLensCommit(FilterLensId.Create(), [PromotedExclude("Source != \"foo\"")], null)
+                ]));
+
+        Assert.Single(result.Filters);
+        Assert.True(result.Filters[0].IsExcluded);
+        Assert.True(result.Filters[0].IsEnabled);
+    }
+
+    [Fact]
+    public void ReduceCommitPromotedLenses_EmptyBatch_ReturnsSameStateInstance()
+    {
+        var state = new FilterPaneState { Filters = [PromotedExclude("Source != \"foo\"")] };
+
+        var result = Reducers.ReduceCommitPromotedLenses(state, new CommitPromotedLensesAction([]));
+
+        Assert.Same(state, result);
+    }
+
+    [Fact]
+    public void ReduceCommitPromotedLenses_MultipleWindows_IntersectsAllCumulatively()
+    {
+        // Every enabled window intersects cumulatively. Narrow is committed FIRST and wide LAST: if only the last
+        // window were applied the range would widen to the wide bounds, so asserting the narrow bounds proves the fold.
+        var narrow = new DateFilter
+        {
+            After = new DateTime(2024, 1, 3, 0, 0, 0, DateTimeKind.Utc),
+            Before = new DateTime(2024, 1, 5, 0, 0, 0, DateTimeKind.Utc),
+            IsEnabled = true
+        };
+        var wide = new DateFilter
+        {
+            After = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            Before = new DateTime(2024, 1, 10, 0, 0, 0, DateTimeKind.Utc),
+            IsEnabled = true
+        };
+        var state = new FilterPaneState();
+
+        var result = Reducers.ReduceCommitPromotedLenses(
+            state,
+            new CommitPromotedLensesAction(
+                [
+                    new PromotedLensCommit(FilterLensId.Create(), [], narrow),
+                    new PromotedLensCommit(FilterLensId.Create(), [], wide)
+                ]));
+
+        Assert.NotNull(result.FilteredDateRange);
+        Assert.True(result.FilteredDateRange.IsEnabled);
+        Assert.Equal(narrow.After, result.FilteredDateRange.After);
+        Assert.Equal(narrow.Before, result.FilteredDateRange.Before);
+    }
+
+    [Fact]
     public void ReduceCommitPromoted_CaseVariantValue_TreatedAsDistinct()
     {
         // Ordinal-exact dedup: the lens preserves the EXACT predicate it matched, so a case-variant value is a

--- a/tests/Unit/EventLogExpert.UI.Tests/Alerts/AlertDialogServiceTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Alerts/AlertDialogServiceTests.cs
@@ -13,6 +13,160 @@ namespace EventLogExpert.UI.Tests.Alerts;
 public sealed class ModalAlertDialogServiceTests
 {
     [Fact]
+    public async Task DisplayPromptWithSecondary_WhenActiveHostAccepts_ShouldReturnPrimaryChoice()
+    {
+        var host = Substitute.For<IInlineAlertHost>();
+        host.ShowInlineAlertAsync(Arg.Any<InlineAlertRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new InlineAlertResult(true, "group")));
+
+        var coordinator = Substitute.For<IModalCoordinator>();
+        coordinator.TryGetInlineAlertHost(out Arg.Any<IInlineAlertHost?>()).Returns(call =>
+        {
+            call[0] = host;
+            return true;
+        });
+
+        Func<string, string?> validate = value => string.IsNullOrWhiteSpace(value) ? "Required." : null;
+        var sut = new AlertDialogService(
+            coordinator,
+            PassthroughMainThread(),
+            Substitute.For<IErrorBannerService>(),
+            Substitute.For<IInfoBannerService>(),
+            _ => Task.FromResult(false),
+            _ => Task.FromResult(string.Empty));
+
+        PromptOutcome result = await sut.DisplayPromptWithSecondary(
+            "Save as group",
+            "Group name",
+            "New Group",
+            "Save",
+            "Save and clear",
+            "Cancel",
+            validate);
+
+        Assert.Equal(new PromptOutcome(PromptChoice.Primary, "group"), result);
+        await host.Received(1).ShowInlineAlertAsync(
+            Arg.Is<InlineAlertRequest>(request =>
+                request != null &&
+                request.Title == "Save as group" &&
+                request.Message == "Group name" &&
+                request.PromptInitialValue == "New Group" &&
+                request.AcceptLabel == "Save" &&
+                request.SecondaryActionLabel == "Save and clear" &&
+                request.CancelLabel == "Cancel" &&
+                request.IsPrompt &&
+                ReferenceEquals(request.Validate, validate)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DisplayPromptWithSecondary_WhenActiveHostCancels_ShouldReturnCancelChoice()
+    {
+        var host = Substitute.For<IInlineAlertHost>();
+        host.ShowInlineAlertAsync(Arg.Any<InlineAlertRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new InlineAlertResult(false, "ignored")));
+
+        var coordinator = Substitute.For<IModalCoordinator>();
+        coordinator.TryGetInlineAlertHost(out Arg.Any<IInlineAlertHost?>()).Returns(call =>
+        {
+            call[0] = host;
+            return true;
+        });
+
+        var sut = new AlertDialogService(
+            coordinator,
+            PassthroughMainThread(),
+            Substitute.For<IErrorBannerService>(),
+            Substitute.For<IInfoBannerService>(),
+            _ => Task.FromResult(false),
+            _ => Task.FromResult(string.Empty));
+
+        PromptOutcome result = await sut.DisplayPromptWithSecondary(
+            "Save as group",
+            "Group name",
+            "New Group",
+            "Save",
+            "Save and clear",
+            "Cancel");
+
+        Assert.Equal(new PromptOutcome(PromptChoice.Cancel, string.Empty), result);
+    }
+
+    [Fact]
+    public async Task DisplayPromptWithSecondary_WhenActiveHostChoosesSecondary_ShouldReturnSecondaryChoice()
+    {
+        var host = Substitute.For<IInlineAlertHost>();
+        host.ShowInlineAlertAsync(Arg.Any<InlineAlertRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new InlineAlertResult(false, "group") { SecondaryChosen = true }));
+
+        var coordinator = Substitute.For<IModalCoordinator>();
+        coordinator.TryGetInlineAlertHost(out Arg.Any<IInlineAlertHost?>()).Returns(call =>
+        {
+            call[0] = host;
+            return true;
+        });
+
+        var sut = new AlertDialogService(
+            coordinator,
+            PassthroughMainThread(),
+            Substitute.For<IErrorBannerService>(),
+            Substitute.For<IInfoBannerService>(),
+            _ => Task.FromResult(false),
+            _ => Task.FromResult(string.Empty));
+
+        PromptOutcome result = await sut.DisplayPromptWithSecondary(
+            "Save as group",
+            "Group name",
+            "New Group",
+            "Save",
+            "Save and clear",
+            "Cancel");
+
+        Assert.Equal(new PromptOutcome(PromptChoice.Secondary, "group"), result);
+    }
+
+    [Fact]
+    public async Task DisplayPromptWithSecondary_WhenNoActiveHost_ShouldCallStandalonePromptOpener()
+    {
+        var coordinator = Substitute.For<IModalCoordinator>();
+        coordinator.TryGetInlineAlertHost(out Arg.Any<IInlineAlertHost?>()).Returns(false);
+
+        IReadOnlyDictionary<string, object?>? capturedPrompt = null;
+        Func<string, string?> validate = value => string.IsNullOrWhiteSpace(value) ? "Required." : null;
+        var sut = new AlertDialogService(
+            coordinator,
+            PassthroughMainThread(),
+            Substitute.For<IErrorBannerService>(),
+            Substitute.For<IInfoBannerService>(),
+            _ => Task.FromResult(false),
+            _ => Task.FromResult(string.Empty),
+            parameters =>
+            {
+                capturedPrompt = parameters;
+                return Task.FromResult(new PromptOutcome(PromptChoice.Secondary, "group"));
+            });
+
+        PromptOutcome result = await sut.DisplayPromptWithSecondary(
+            "Save as group",
+            "Group name",
+            "New Group",
+            "Save",
+            "Save and clear",
+            "Cancel",
+            validate);
+
+        Assert.Equal(new PromptOutcome(PromptChoice.Secondary, "group"), result);
+        Assert.NotNull(capturedPrompt);
+        Assert.Equal("Save as group", capturedPrompt!["Title"]);
+        Assert.Equal("Group name", capturedPrompt["Message"]);
+        Assert.Equal("New Group", capturedPrompt["InitialValue"]);
+        Assert.Equal("Save", capturedPrompt["PrimaryLabel"]);
+        Assert.Equal("Save and clear", capturedPrompt["SecondaryActionLabel"]);
+        Assert.Equal("Cancel", capturedPrompt["CancelLabel"]);
+        Assert.Same(validate, capturedPrompt["Validate"]);
+    }
+
+    [Fact]
     public async Task DisplayPrompt_WhenActiveHost_ShouldRouteInlineAndReturnTypedValue()
     {
         var host = Substitute.For<IInlineAlertHost>();
@@ -114,29 +268,6 @@ public sealed class ModalAlertDialogServiceTests
 
         Assert.NotNull(capturedPrompt);
         Assert.Same(validate, capturedPrompt!["Validate"]);
-    }
-
-    [Fact]
-    public async Task ShowAlert_ShouldMarshalThroughMainThreadService()
-    {
-        var coordinator = Substitute.For<IModalCoordinator>();
-        coordinator.TryGetInlineAlertHost(out Arg.Any<IInlineAlertHost?>()).Returns(false);
-
-        var mainThread = Substitute.For<IMainThreadService>();
-        mainThread.InvokeOnMainThreadAsync(Arg.Any<Func<Task>>())
-            .Returns(call => call.ArgAt<Func<Task>>(0)());
-
-        var sut = new AlertDialogService(
-            coordinator,
-            mainThread,
-            Substitute.For<IErrorBannerService>(),
-            Substitute.For<IInfoBannerService>(),
-            _ => Task.FromResult(true),
-            _ => Task.FromResult(string.Empty));
-
-        await sut.ShowAlert("t", "m", "c");
-
-        await mainThread.Received(1).InvokeOnMainThreadAsync(Arg.Any<Func<Task>>());
     }
 
     [Fact]
@@ -411,6 +542,29 @@ public sealed class ModalAlertDialogServiceTests
         var result = await sut.ShowAlert("Confirm", "Sure?", "Yes", "No");
 
         Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ShowAlert_ShouldMarshalThroughMainThreadService()
+    {
+        var coordinator = Substitute.For<IModalCoordinator>();
+        coordinator.TryGetInlineAlertHost(out Arg.Any<IInlineAlertHost?>()).Returns(false);
+
+        var mainThread = Substitute.For<IMainThreadService>();
+        mainThread.InvokeOnMainThreadAsync(Arg.Any<Func<Task>>())
+            .Returns(call => call.ArgAt<Func<Task>>(0)());
+
+        var sut = new AlertDialogService(
+            coordinator,
+            mainThread,
+            Substitute.For<IErrorBannerService>(),
+            Substitute.For<IInfoBannerService>(),
+            _ => Task.FromResult(true),
+            _ => Task.FromResult(string.Empty));
+
+        await sut.ShowAlert("t", "m", "c");
+
+        await mainThread.Received(1).InvokeOnMainThreadAsync(Arg.Any<Func<Task>>());
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.UI.Tests/Alerts/PromptModalTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Alerts/PromptModalTests.cs
@@ -2,6 +2,7 @@
 // // Licensed under the MIT License.
 
 using Bunit;
+using EventLogExpert.Runtime.Alerts;
 using EventLogExpert.UI.Alerts;
 using EventLogExpert.UI.Modal;
 using EventLogExpert.UI.Tests.TestUtils;
@@ -36,7 +37,9 @@ public sealed class PromptModalTests : BunitContext
         component.Find("input").Input("renamed value");
         component.Find(".footer-group .button-green").Click();
 
-        _modalService.Received(1).Complete(Arg.Any<ModalId>(), "renamed value");
+        _modalService.Received(1).Complete(
+            Arg.Any<ModalId>(),
+            new PromptOutcome(PromptChoice.Primary, "renamed value"));
     }
 
     [Fact]
@@ -90,6 +93,36 @@ public sealed class PromptModalTests : BunitContext
     }
 
     [Fact]
+    public void Render_WithSecondaryActionLabel_RendersSecondaryButtonAndCompletesWithSecondaryChoice()
+    {
+        var component = Render<PromptModal>(parameters => parameters
+            .Add(p => p.Title, "Rename")
+            .Add(p => p.Message, "New name:")
+            .Add(p => p.PrimaryLabel, "Save")
+            .Add(p => p.SecondaryActionLabel, "Save and clear")
+            .Add(p => p.CancelLabel, "Cancel"));
+
+        component.Find("input").Input("group name");
+        component.FindAll(".footer-group button").Single(button => button.TextContent.Trim() == "Save and clear").Click();
+
+        _modalService.Received(1).Complete(
+            Arg.Any<ModalId>(),
+            new PromptOutcome(PromptChoice.Secondary, "group name"));
+    }
+
+    [Fact]
+    public void Render_WithoutSecondaryActionLabel_RendersNoSecondaryButton()
+    {
+        var component = Render<PromptModal>(parameters => parameters
+            .Add(p => p.Title, "Rename")
+            .Add(p => p.Message, "New name:"));
+
+        Assert.DoesNotContain(
+            component.FindAll(".footer-group button"),
+            button => button.TextContent.Trim() == "Save and clear");
+    }
+
+    [Fact]
     public void Validation_AcceptingInvalidValue_DoesNotComplete()
     {
         Func<string, string?> validate = value =>
@@ -102,7 +135,7 @@ public sealed class PromptModalTests : BunitContext
 
         component.FindAll(".footer-group button")[0].Click();
 
-        _modalService.DidNotReceive().Complete(Arg.Any<ModalId>(), Arg.Any<string>());
+        _modalService.DidNotReceive().Complete(Arg.Any<ModalId>(), Arg.Any<PromptOutcome>());
     }
 
     [Fact]
@@ -158,6 +191,8 @@ public sealed class PromptModalTests : BunitContext
 
         component.FindAll(".footer-group button")[0].Click();
 
-        _modalService.Received(1).Complete(Arg.Any<ModalId>(), "valid name");
+        _modalService.Received(1).Complete(
+            Arg.Any<ModalId>(),
+            new PromptOutcome(PromptChoice.Primary, "valid name"));
     }
 }

--- a/tests/Unit/EventLogExpert.UI.Tests/Announcement/AnnouncerHostTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Announcement/AnnouncerHostTests.cs
@@ -40,6 +40,20 @@ public sealed class AnnouncerHostTests : BunitContext
     }
 
     [Fact]
+    public void AnnouncerHost_LensGroupSaved_RoutesThroughLocalizer()
+    {
+        // The structured LensGroupSaved payload must have a switch arm (the default arm throws), and it localizes
+        // the "saved as group" wording with the group name at render time.
+        _announcementService.Current.Returns(new CurrentAnnouncement(new AnnouncementPayload.LensGroupSaved("My Group"), 1));
+
+        var component = Render<AnnouncerHost>();
+
+        var text = component.Find("#app-announcer").TextContent;
+        Assert.Contains("[[FilterLens_SavedAsGroupAnnouncement(", text);
+        Assert.Contains("My Group", text);
+    }
+
+    [Fact]
     public void AnnouncerHost_LensKeptReannounced_RoutesThroughLocalizerAndMutatesText()
     {
         // The structured LensKept payload localizes the "kept as filter" wording at render time (MarkerLocalizer echoes
@@ -61,6 +75,18 @@ public sealed class AnnouncerHostTests : BunitContext
 
         Assert.NotEqual(first, second);
         Assert.Contains("[[FilterLens_KeptAnnouncement(", second);
+    }
+
+    [Fact]
+    public void AnnouncerHost_LensesSavedAll_RoutesThroughLocalizer()
+    {
+        // The structured LensesSavedAll payload must have a switch arm (the default arm throws) and localizes the
+        // "saved all" wording.
+        _announcementService.Current.Returns(new CurrentAnnouncement(new AnnouncementPayload.LensesSavedAll(), 1));
+
+        var component = Render<AnnouncerHost>();
+
+        Assert.Contains("[[FilterLens_SavedAllAnnouncement", component.Find("#app-announcer").TextContent);
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterLenses/LensBreadcrumbLocalizerWiringTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterLenses/LensBreadcrumbLocalizerWiringTests.cs
@@ -5,6 +5,8 @@ using Bunit;
 using EventLogExpert.Eventing.Common.Events;
 using EventLogExpert.Filtering.Common.Filtering;
 using EventLogExpert.Localization;
+using EventLogExpert.Runtime.Alerts;
+using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.Runtime.FilterLenses;
 using EventLogExpert.UI.FilterLenses;
 using EventLogExpert.UI.Tests.TestUtils;
@@ -32,6 +34,8 @@ public sealed class LensBreadcrumbLocalizerWiringTests : BunitContext
         _source.Lenses.Returns(ImmutableList<FilterLensSummary>.Empty);
         Services.AddSingleton(_commands);
         Services.AddSingleton(_source);
+        Services.AddSingleton(Substitute.For<IAlertDialogService>());
+        Services.AddSingleton(Substitute.For<IAnnouncementService>());
         Services.AddSingleton<IStringLocalizer<SharedResource>>(new MarkerLocalizer());
     }
 
@@ -52,7 +56,7 @@ public sealed class LensBreadcrumbLocalizerWiringTests : BunitContext
         Assert.Contains("[[FilterLens_Property_ActivityId]] = abc", cut.Find(".lens-chip-label").TextContent);
 
         Assert.Equal(
-            "[[FilterLens_KeepAria([[FilterLens_Property_ActivityId]] = abc)]]",
+            "[[FilterLens_SaveAria([[FilterLens_Property_ActivityId]] = abc)]]",
             cut.Find(".lens-chip-keep").GetAttribute("aria-label"));
         Assert.Equal(
             "[[FilterLens_RemoveAria([[FilterLens_Property_ActivityId]] = abc)]]",

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterLenses/LensBreadcrumbTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterLenses/LensBreadcrumbTests.cs
@@ -1,12 +1,17 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
+using AngleSharp.Dom;
 using Bunit;
 using EventLogExpert.Filtering.Common.Filtering;
+using EventLogExpert.Localization;
+using EventLogExpert.Runtime.Alerts;
+using EventLogExpert.Runtime.Announcement;
 using EventLogExpert.Runtime.FilterLenses;
 using EventLogExpert.UI.FilterLenses;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using NSubstitute;
 using System.Collections.Immutable;
 
@@ -14,6 +19,9 @@ namespace EventLogExpert.UI.Tests.FilterLenses;
 
 public sealed class LensBreadcrumbTests : BunitContext
 {
+    private readonly IAlertDialogService _alertDialog = Substitute.For<IAlertDialogService>();
+
+    private readonly IAnnouncementService _announcements = Substitute.For<IAnnouncementService>();
     private readonly IFilterLensCommands _commands = Substitute.For<IFilterLensCommands>();
 
     private readonly IFilterLensSource _source = Substitute.For<IFilterLensSource>();
@@ -24,8 +32,13 @@ public sealed class LensBreadcrumbTests : BunitContext
         _source.Lenses.Returns(ImmutableList<FilterLensSummary>.Empty);
         Services.AddSingleton(_commands);
         Services.AddSingleton(_source);
+        Services.AddSingleton(_alertDialog);
+        Services.AddSingleton(_announcements);
         Services.AddEventLogLocalization();
     }
+
+    private IStringLocalizer<SharedResource> Localizer =>
+        Services.GetRequiredService<IStringLocalizer<SharedResource>>();
 
     [Fact]
     public void Changed_ReRendersTheBreadcrumb()
@@ -74,7 +87,7 @@ public sealed class LensBreadcrumbTests : BunitContext
         var cut = Render<LensBreadcrumb>();
 
         var keep = cut.Find(".lens-chip-keep");
-        Assert.Equal("Keep lens as filter: Activity ID = abc", keep.GetAttribute("aria-label"));
+        Assert.Equal("Save lens as filter: Activity ID = abc", keep.GetAttribute("aria-label"));
 
         keep.Click();
 
@@ -92,6 +105,46 @@ public sealed class LensBreadcrumbTests : BunitContext
     }
 
     [Fact]
+    public void SaveAllButton_PromotesAllLenses_AndAnnounces()
+    {
+        _source.Lenses.Returns(ImmutableList.Create(Summary("a"), Summary("b")));
+
+        var cut = Render<LensBreadcrumb>();
+
+        SaveActionButton(cut, Localizer["FilterLens_SaveAll"].Value).Click();
+
+        _commands.Received(1).PromoteAllLenses();
+        _announcements.Received(1).Announce(Localizer["FilterLens_SavedAllAnnouncement"].Value);
+    }
+
+    [Fact]
+    public void SaveAsGroupButton_WithOnlyTimeWindowLenses_IsDisabled()
+    {
+        _source.Lenses.Returns(ImmutableList.Create(TimeSummary()));
+
+        var cut = Render<LensBreadcrumb>();
+
+        Assert.True(SaveActionButton(cut, Localizer["FilterLens_SaveAsGroup"].Value).HasAttribute("disabled"));
+    }
+
+    [Fact]
+    public async Task SaveAsGroupButton_WithValueLens_PromptsAndSavesGroup()
+    {
+        _source.Lenses.Returns(ImmutableList.Create(Summary("a")));
+        _alertDialog.DisplayPrompt(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>()).Returns("My Group");
+
+        var cut = Render<LensBreadcrumb>();
+
+        var button = SaveActionButton(cut, Localizer["FilterLens_SaveAsGroup"].Value);
+        Assert.False(button.HasAttribute("disabled"));
+
+        await button.ClickAsync(new MouseEventArgs());
+
+        _commands.Received(1).SaveLensesAsGroup("My Group");
+        _announcements.Received(1).Announce(Localizer["FilterLens_SavedAsGroupAnnouncement", "My Group"].Value);
+    }
+
+    [Fact]
     public void WithLens_RendersLabel_AndRemoveButtonDispatchesRemoveLens()
     {
         var lens = Summary("abc");
@@ -106,6 +159,12 @@ public sealed class LensBreadcrumbTests : BunitContext
         _commands.Received(1).RemoveLens(lens.Id);
     }
 
+    private static IElement SaveActionButton(IRenderedComponent<LensBreadcrumb> cut, string text) =>
+        cut.FindAll(".lens-action").Single(button => button.TextContent.Trim() == text);
+
     private static FilterLensSummary Summary(string value) =>
         new(FilterLensId.Create(), new FilterLensLabel.PropertyComparison(EventProperty.ActivityId, IsEqual: true, value));
+
+    private static FilterLensSummary TimeSummary() =>
+        new(FilterLensId.Create(), new FilterLensLabel.TimeWindow(DateTime.Now, TimeSpan.FromHours(1)), LensKind.TimeWindow);
 }

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterLenses/LensBreadcrumbTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterLenses/LensBreadcrumbTests.cs
@@ -119,6 +119,32 @@ public sealed class LensBreadcrumbTests : BunitContext
     }
 
     [Fact]
+    public async Task SaveAsGroupButton_SuppliesWhitespaceRejectingValidatorToPrompt()
+    {
+        // Without a validator, clearing the name and pressing save closes the dialog and the outcome is silently
+        // discarded. The prompt must reject blank names (keeping itself open) like the tab-group prompts do.
+        Func<string, string?>? capturedValidator = null;
+        _source.Lenses.Returns(ImmutableList.Create(Summary("a")));
+        _alertDialog.DisplayPromptWithSecondary(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Do<Func<string, string?>?>(validator => capturedValidator = validator))
+            .Returns(new PromptOutcome(PromptChoice.Cancel, string.Empty));
+
+        var cut = Render<LensBreadcrumb>();
+
+        await SaveActionButton(cut, Localizer["FilterLens_SaveAsGroup"].Value).ClickAsync(new MouseEventArgs());
+
+        Assert.NotNull(capturedValidator);
+        Assert.False(string.IsNullOrEmpty(capturedValidator!("   ")));
+        Assert.Null(capturedValidator!("Valid name"));
+    }
+
+    [Fact]
     public async Task SaveAsGroupButton_WhenAriaDisabled_ActivationIsNoOp()
     {
         // aria-disabled (unlike the native disabled attribute) does NOT block activation in the browser, so the
@@ -137,7 +163,8 @@ public sealed class LensBreadcrumbTests : BunitContext
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<string>());
+            Arg.Any<string>(),
+            Arg.Any<Func<string, string?>?>());
         _commands.DidNotReceive().SaveLensesAsGroup(Arg.Any<string>(), Arg.Any<bool>());
     }
 
@@ -151,7 +178,8 @@ public sealed class LensBreadcrumbTests : BunitContext
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Any<string>())
+                Arg.Any<string>(),
+                Arg.Any<Func<string, string?>?>())
             .Returns(new PromptOutcome(PromptChoice.Cancel, string.Empty));
 
         var cut = Render<LensBreadcrumb>();
@@ -174,7 +202,8 @@ public sealed class LensBreadcrumbTests : BunitContext
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Any<string>())
+                Arg.Any<string>(),
+                Arg.Any<Func<string, string?>?>())
             .Returns(default(PromptOutcome));
 
         var cut = Render<LensBreadcrumb>();
@@ -190,12 +219,13 @@ public sealed class LensBreadcrumbTests : BunitContext
     {
         _source.Lenses.Returns(ImmutableList.Create(Summary("a")));
         _alertDialog.DisplayPromptWithSecondary(
-                Localizer["FilterLens_SaveAsGroup_PromptTitle"].Value,
-                Localizer["FilterLens_SaveAsGroup_PromptMessage"].Value,
-                Localizer["FilterLens_SaveAsGroup_DefaultName"].Value,
-                Localizer["FilterLens_SaveAsGroup_Save"].Value,
-                Localizer["FilterLens_SaveAsGroup_SaveAndClear"].Value,
-                Localizer["FilterLens_SaveAsGroup_Cancel"].Value)
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<Func<string, string?>?>())
             .Returns(new PromptOutcome(PromptChoice.Primary, "My Group"));
 
         var cut = Render<LensBreadcrumb>();
@@ -225,7 +255,8 @@ public sealed class LensBreadcrumbTests : BunitContext
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Any<string>())
+                Arg.Any<string>(),
+                Arg.Any<Func<string, string?>?>())
             .Returns(new PromptOutcome(PromptChoice.Secondary, "My Group"));
 
         var cut = Render<LensBreadcrumb>();

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterLenses/LensBreadcrumbTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterLenses/LensBreadcrumbTests.cs
@@ -20,10 +20,8 @@ namespace EventLogExpert.UI.Tests.FilterLenses;
 public sealed class LensBreadcrumbTests : BunitContext
 {
     private readonly IAlertDialogService _alertDialog = Substitute.For<IAlertDialogService>();
-
     private readonly IAnnouncementService _announcements = Substitute.For<IAnnouncementService>();
     private readonly IFilterLensCommands _commands = Substitute.For<IFilterLensCommands>();
-
     private readonly IFilterLensSource _source = Substitute.For<IFilterLensSource>();
 
     public LensBreadcrumbTests()
@@ -105,7 +103,7 @@ public sealed class LensBreadcrumbTests : BunitContext
     }
 
     [Fact]
-    public void SaveAllButton_PromotesAllLenses_AndAnnounces()
+    public void SaveAllButton_PromotesAllLenses()
     {
         _source.Lenses.Returns(ImmutableList.Create(Summary("a"), Summary("b")));
 
@@ -114,7 +112,10 @@ public sealed class LensBreadcrumbTests : BunitContext
         SaveActionButton(cut, Localizer["FilterLens_SaveAll"].Value).Click();
 
         _commands.Received(1).PromoteAllLenses();
-        _announcements.Received(1).Announce(Localizer["FilterLens_SavedAllAnnouncement"].Value);
+
+        // The "saved all" announcement now originates from the promote effect (after the commit), not the
+        // breadcrumb, so the breadcrumb must not announce anything itself.
+        _announcements.DidNotReceive().Announce(Arg.Any<string>());
     }
 
     [Fact]
@@ -141,7 +142,10 @@ public sealed class LensBreadcrumbTests : BunitContext
         await button.ClickAsync(new MouseEventArgs());
 
         _commands.Received(1).SaveLensesAsGroup("My Group");
-        _announcements.Received(1).Announce(Localizer["FilterLens_SavedAsGroupAnnouncement", "My Group"].Value);
+
+        // Success is announced from the lens effect only after the write actually persists (failure surfaces via
+        // the error banner), so the breadcrumb no longer announces optimistically on click.
+        _announcements.DidNotReceive().Announce(Arg.Any<string>());
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterLenses/LensBreadcrumbTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterLenses/LensBreadcrumbTests.cs
@@ -119,13 +119,41 @@ public sealed class LensBreadcrumbTests : BunitContext
     }
 
     [Fact]
-    public void SaveAsGroupButton_WithOnlyTimeWindowLenses_IsDisabled()
+    public async Task SaveAsGroupButton_WhenAriaDisabled_ActivationIsNoOp()
+    {
+        // aria-disabled (unlike the native disabled attribute) does NOT block activation in the browser, so the
+        // SaveAsGroupAsync guard is now the sole protection. Lock it in: activating the unavailable button must not
+        // prompt or save.
+        _source.Lenses.Returns(ImmutableList.Create(TimeSummary()));
+
+        var cut = Render<LensBreadcrumb>();
+        var button = SaveActionButton(cut, Localizer["FilterLens_SaveAsGroup"].Value);
+
+        await button.ClickAsync(new MouseEventArgs());
+
+        await _alertDialog.DidNotReceive().DisplayPrompt(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>());
+        _commands.DidNotReceive().SaveLensesAsGroup(Arg.Any<string>());
+    }
+
+    [Fact]
+    public void SaveAsGroupButton_WithOnlyTimeWindowLenses_IsAriaDisabled_WithAccessibleReason()
     {
         _source.Lenses.Returns(ImmutableList.Create(TimeSummary()));
 
         var cut = Render<LensBreadcrumb>();
 
-        Assert.True(SaveActionButton(cut, Localizer["FilterLens_SaveAsGroup"].Value).HasAttribute("disabled"));
+        var button = SaveActionButton(cut, Localizer["FilterLens_SaveAsGroup"].Value);
+
+        // Unavailable via aria-disabled, NOT the native disabled attribute (which would drop keyboard focus), so a
+        // screen-reader user can still reach the button and hear why it is unavailable.
+        Assert.Equal("true", button.GetAttribute("aria-disabled"));
+        Assert.False(button.HasAttribute("disabled"));
+
+        // The reason is exposed as a real accessible description (aria-describedby -> visually-hidden text), not just
+        // a title tooltip that assistive tech does not reliably announce.
+        var hintId = button.GetAttribute("aria-describedby");
+        Assert.False(string.IsNullOrEmpty(hintId));
+        Assert.Equal(Localizer["FilterLens_SaveAsGroup_DisabledTitle"].Value, cut.Find($"#{hintId}").TextContent.Trim());
     }
 
     [Fact]
@@ -138,6 +166,8 @@ public sealed class LensBreadcrumbTests : BunitContext
 
         var button = SaveActionButton(cut, Localizer["FilterLens_SaveAsGroup"].Value);
         Assert.False(button.HasAttribute("disabled"));
+        Assert.Equal("false", button.GetAttribute("aria-disabled"));
+        Assert.False(button.HasAttribute("aria-describedby"));
 
         await button.ClickAsync(new MouseEventArgs());
 

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterLenses/LensBreadcrumbTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterLenses/LensBreadcrumbTests.cs
@@ -131,8 +131,111 @@ public sealed class LensBreadcrumbTests : BunitContext
 
         await button.ClickAsync(new MouseEventArgs());
 
-        await _alertDialog.DidNotReceive().DisplayPrompt(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>());
-        _commands.DidNotReceive().SaveLensesAsGroup(Arg.Any<string>());
+        await _alertDialog.DidNotReceive().DisplayPromptWithSecondary(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>());
+        _commands.DidNotReceive().SaveLensesAsGroup(Arg.Any<string>(), Arg.Any<bool>());
+    }
+
+    [Fact]
+    public async Task SaveAsGroupButton_WhenPromptReturnsCancel_DoesNotSaveOrClear()
+    {
+        _source.Lenses.Returns(ImmutableList.Create(Summary("a")));
+        _alertDialog.DisplayPromptWithSecondary(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>())
+            .Returns(new PromptOutcome(PromptChoice.Cancel, string.Empty));
+
+        var cut = Render<LensBreadcrumb>();
+
+        await SaveActionButton(cut, Localizer["FilterLens_SaveAsGroup"].Value).ClickAsync(new MouseEventArgs());
+
+        _commands.DidNotReceive().SaveLensesAsGroup(Arg.Any<string>(), Arg.Any<bool>());
+        _commands.DidNotReceive().ClearLenses();
+    }
+
+    [Fact]
+    public async Task SaveAsGroupButton_WhenPromptReturnsDefaultOutcome_DoesNotSaveOrClear()
+    {
+        // A forced modal close or host teardown completes the standalone prompt with default(PromptOutcome),
+        // whose Value is null. The breadcrumb must treat it as a cancel and never dereference the null name.
+        _source.Lenses.Returns(ImmutableList.Create(Summary("a")));
+        _alertDialog.DisplayPromptWithSecondary(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>())
+            .Returns(default(PromptOutcome));
+
+        var cut = Render<LensBreadcrumb>();
+
+        await SaveActionButton(cut, Localizer["FilterLens_SaveAsGroup"].Value).ClickAsync(new MouseEventArgs());
+
+        _commands.DidNotReceive().SaveLensesAsGroup(Arg.Any<string>(), Arg.Any<bool>());
+        _commands.DidNotReceive().ClearLenses();
+    }
+
+    [Fact]
+    public async Task SaveAsGroupButton_WhenPromptReturnsPrimary_SavesGroupWithoutClearing()
+    {
+        _source.Lenses.Returns(ImmutableList.Create(Summary("a")));
+        _alertDialog.DisplayPromptWithSecondary(
+                Localizer["FilterLens_SaveAsGroup_PromptTitle"].Value,
+                Localizer["FilterLens_SaveAsGroup_PromptMessage"].Value,
+                Localizer["FilterLens_SaveAsGroup_DefaultName"].Value,
+                Localizer["FilterLens_SaveAsGroup_Save"].Value,
+                Localizer["FilterLens_SaveAsGroup_SaveAndClear"].Value,
+                Localizer["FilterLens_SaveAsGroup_Cancel"].Value)
+            .Returns(new PromptOutcome(PromptChoice.Primary, "My Group"));
+
+        var cut = Render<LensBreadcrumb>();
+
+        var button = SaveActionButton(cut, Localizer["FilterLens_SaveAsGroup"].Value);
+        Assert.False(button.HasAttribute("disabled"));
+        Assert.Equal("false", button.GetAttribute("aria-disabled"));
+        Assert.False(button.HasAttribute("aria-describedby"));
+
+        await button.ClickAsync(new MouseEventArgs());
+
+        _commands.Received(1).SaveLensesAsGroup("My Group", clearAfterSave: false);
+        _commands.DidNotReceive().ClearLenses();
+
+        // Success is announced from the lens effect only after the write actually persists (failure surfaces via
+        // the error banner), so the breadcrumb no longer announces optimistically on click.
+        _announcements.DidNotReceive().Announce(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task SaveAsGroupButton_WhenPromptReturnsSecondary_SavesGroupWithClearAfterSave()
+    {
+        _source.Lenses.Returns(ImmutableList.Create(Summary("a")));
+        _alertDialog.DisplayPromptWithSecondary(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>())
+            .Returns(new PromptOutcome(PromptChoice.Secondary, "My Group"));
+
+        var cut = Render<LensBreadcrumb>();
+
+        await SaveActionButton(cut, Localizer["FilterLens_SaveAsGroup"].Value).ClickAsync(new MouseEventArgs());
+
+        // Save and clear defers the clear to the persist-success effect, so the breadcrumb itself never calls
+        // ClearLenses directly - it flags the save with clearAfterSave: true.
+        _commands.Received(1).SaveLensesAsGroup("My Group", clearAfterSave: true);
+        _commands.DidNotReceive().ClearLenses();
     }
 
     [Fact]
@@ -154,28 +257,6 @@ public sealed class LensBreadcrumbTests : BunitContext
         var hintId = button.GetAttribute("aria-describedby");
         Assert.False(string.IsNullOrEmpty(hintId));
         Assert.Equal(Localizer["FilterLens_SaveAsGroup_DisabledTitle"].Value, cut.Find($"#{hintId}").TextContent.Trim());
-    }
-
-    [Fact]
-    public async Task SaveAsGroupButton_WithValueLens_PromptsAndSavesGroup()
-    {
-        _source.Lenses.Returns(ImmutableList.Create(Summary("a")));
-        _alertDialog.DisplayPrompt(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>()).Returns("My Group");
-
-        var cut = Render<LensBreadcrumb>();
-
-        var button = SaveActionButton(cut, Localizer["FilterLens_SaveAsGroup"].Value);
-        Assert.False(button.HasAttribute("disabled"));
-        Assert.Equal("false", button.GetAttribute("aria-disabled"));
-        Assert.False(button.HasAttribute("aria-describedby"));
-
-        await button.ClickAsync(new MouseEventArgs());
-
-        _commands.Received(1).SaveLensesAsGroup("My Group");
-
-        // Success is announced from the lens effect only after the write actually persists (failure surfaces via
-        // the error banner), so the breadcrumb no longer announces optimistically on click.
-        _announcements.DidNotReceive().Announce(Arg.Any<string>());
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.UI.Tests/Inputs/TextInputTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/Inputs/TextInputTests.cs
@@ -3,6 +3,7 @@
 
 using Bunit;
 using EventLogExpert.UI.Inputs;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace EventLogExpert.UI.Tests.Inputs;
 
@@ -20,6 +21,48 @@ public sealed class TextInputTests : BunitContext
         component.Find("input").Change("committed");
 
         Assert.Equal("committed", captured);
+    }
+
+    [Fact]
+    public void KeyDown_EnterWhileComposing_DoesNotInvokeOnEnter()
+    {
+        var invoked = false;
+
+        var component = Render<TextInput>(parameters => parameters
+            .Add(p => p.Value, string.Empty)
+            .Add(p => p.OnEnter, () => { invoked = true; }));
+
+        component.Find("input").KeyDown(new KeyboardEventArgs { Key = "Enter", IsComposing = true });
+
+        Assert.False(invoked);
+    }
+
+    [Fact]
+    public void KeyDown_Enter_InvokesOnEnter()
+    {
+        var invoked = false;
+
+        var component = Render<TextInput>(parameters => parameters
+            .Add(p => p.Value, string.Empty)
+            .Add(p => p.OnEnter, () => { invoked = true; }));
+
+        component.Find("input").KeyDown(new KeyboardEventArgs { Key = "Enter" });
+
+        Assert.True(invoked);
+    }
+
+    [Fact]
+    public void KeyDown_NonEnterKey_DoesNotInvokeOnEnter()
+    {
+        var invoked = false;
+
+        var component = Render<TextInput>(parameters => parameters
+            .Add(p => p.Value, string.Empty)
+            .Add(p => p.OnEnter, () => { invoked = true; }));
+
+        component.Find("input").KeyDown(new KeyboardEventArgs { Key = "a" });
+
+        Assert.False(invoked);
     }
 
     [Fact]
@@ -67,17 +110,6 @@ public sealed class TextInputTests : BunitContext
     }
 
     [Fact]
-    public void Render_AriaLabelledBy_AppliedToInput()
-    {
-        var component = Render<TextInput>(parameters => parameters
-            .Add(p => p.Value, string.Empty)
-            .Add(p => p.AriaLabelledBy, "external-label-id"));
-
-        var input = component.Find("input[type='text']");
-        Assert.Equal("external-label-id", input.GetAttribute("aria-labelledby"));
-    }
-
-    [Fact]
     public void Render_AriaLabelledByAndAriaLabel_SuppressesAriaLabel()
     {
         var component = Render<TextInput>(parameters => parameters
@@ -87,6 +119,17 @@ public sealed class TextInputTests : BunitContext
 
         var input = component.Find("input[type='text']");
         Assert.False(input.HasAttribute("aria-label"));
+        Assert.Equal("external-label-id", input.GetAttribute("aria-labelledby"));
+    }
+
+    [Fact]
+    public void Render_AriaLabelledBy_AppliedToInput()
+    {
+        var component = Render<TextInput>(parameters => parameters
+            .Add(p => p.Value, string.Empty)
+            .Add(p => p.AriaLabelledBy, "external-label-id"));
+
+        var input = component.Find("input[type='text']");
         Assert.Equal("external-label-id", input.GetAttribute("aria-labelledby"));
     }
 

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTabBarTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTabBarTests.cs
@@ -92,6 +92,21 @@ public sealed class LogTabBarTests : BunitContext
         Services.GetRequiredService<IStringLocalizer<SharedResource>>();
 
     [Fact]
+    public void ActiveGroupHeaderName_Click_TogglesCollapse()
+    {
+        // With the chevron removed, clicking an already-active group header toggles its collapse state. The
+        // toggle is on click (not mousedown) so a drag-scroll of the tab strip started on the header does not
+        // collapse the group.
+        var (state, groupId, _, _, _) = GroupedState(collapsed: false, activeIsMember1: false);
+        _logTableState.Value.Returns(state);
+        var cut = Render<LogTabBar>();
+
+        cut.Find(".group-header > span").Click();
+
+        _logTableCommands.Received(1).SetTabGroupCollapsed(groupId, true);
+    }
+
+    [Fact]
     public async Task ActiveTabChange_Rerenders()
     {
         var alpha = EventLogId.Create();
@@ -140,35 +155,14 @@ public sealed class LogTabBarTests : BunitContext
     [Fact]
     public void AriaLabelsAndTitles_RouteThroughMarkerLocalizer()
     {
-        var (collapsedState, _, _, _, _) = GroupedState(collapsed: true, activeIsMember1: false);
-        _logTableState.Value.Returns(collapsedState);
-        var collapsedCut = Render<LogTabBar>();
-
-        Assert.Equal(Localizer["TabBar_ExpandGroupAria"].Value, collapsedCut.Find("button.chevron").GetAttribute("aria-label"));
-        Assert.Equal(Localizer["TabBar_ExpandGroupAria"].Value, collapsedCut.Find("button.chevron").GetAttribute("title"));
-
         var (expandedState, _, _, _, _) = GroupedState(collapsed: false, activeIsMember1: false);
         _logTableState.Value.Returns(expandedState);
         var expandedCut = Render<LogTabBar>();
 
-        Assert.Equal(Localizer["TabBar_CollapseGroupAria"].Value, expandedCut.Find("button.chevron").GetAttribute("aria-label"));
-        Assert.Equal(Localizer["TabBar_CollapseGroupAria"].Value, expandedCut.Find("button.chevron").GetAttribute("title"));
-        Assert.Equal(Localizer["TabBar_CloseGroup"].Value, expandedCut.Find(".group-header > i.bi-x").GetAttribute("aria-label"));
-        Assert.Equal(Localizer["TabBar_CloseGroup"].Value, expandedCut.Find(".group-header > i.bi-x").GetAttribute("title"));
-        Assert.Equal(Localizer["TabBar_CloseLogAria"].Value, expandedCut.Find(".tab.member > i.bi-x").GetAttribute("aria-label"));
-        Assert.Equal(Localizer["TabBar_CloseLogAria"].Value, expandedCut.Find(".tab.member > i.bi-x").GetAttribute("title"));
-    }
-
-    [Fact]
-    public void ChevronClick_DispatchesSetTabGroupCollapsed()
-    {
-        var (state, groupId, _, _, _) = GroupedState(collapsed: false, activeIsMember1: false);
-        _logTableState.Value.Returns(state);
-        var cut = Render<LogTabBar>();
-
-        cut.Find("button.chevron").Click();
-
-        _logTableCommands.Received(1).SetTabGroupCollapsed(groupId, true);
+        Assert.Equal(Localizer["TabBar_CloseGroup"].Value, expandedCut.Find(".group-header > i.bi-x-circle").GetAttribute("aria-label"));
+        Assert.Equal(Localizer["TabBar_CloseGroup"].Value, expandedCut.Find(".group-header > i.bi-x-circle").GetAttribute("title"));
+        Assert.Equal(Localizer["TabBar_CloseLogAria"].Value, expandedCut.Find(".tab.member > i.bi-x-circle").GetAttribute("aria-label"));
+        Assert.Equal(Localizer["TabBar_CloseLogAria"].Value, expandedCut.Find(".tab.member > i.bi-x-circle").GetAttribute("title"));
     }
 
     [Fact]
@@ -232,6 +226,17 @@ public sealed class LogTabBarTests : BunitContext
     }
 
     [Fact]
+    public void CollapsedGroup_HeaderAriaExpandedFalse()
+    {
+        var (state, _, _, _, _) = GroupedState(collapsed: true, activeIsMember1: false);
+        _logTableState.Value.Returns(state);
+
+        var cut = Render<LogTabBar>();
+
+        Assert.Equal("false", cut.Find(".group-header > span").GetAttribute("aria-expanded"));
+    }
+
+    [Fact]
     public void CollapsedGroup_HidesInactiveMembers()
     {
         var (state, _, _, _, _) = GroupedState(collapsed: true, activeIsMember1: true);
@@ -241,17 +246,6 @@ public sealed class LogTabBarTests : BunitContext
 
         Assert.Contains("Alpha", cut.Markup);
         Assert.DoesNotContain("Beta", cut.Markup);
-    }
-
-    [Fact]
-    public void CollapsedGroup_RendersDownChevron()
-    {
-        var (state, _, _, _, _) = GroupedState(collapsed: true, activeIsMember1: false);
-        _logTableState.Value.Returns(state);
-
-        var cut = Render<LogTabBar>();
-
-        Assert.Contains("bi-chevron-down", cut.Markup);
     }
 
     [Fact]
@@ -295,6 +289,17 @@ public sealed class LogTabBarTests : BunitContext
     }
 
     [Fact]
+    public void ExpandedGroup_HeaderAriaExpandedTrue()
+    {
+        var (state, _, _, _, _) = GroupedState(collapsed: false, activeIsMember1: false);
+        _logTableState.Value.Returns(state);
+
+        var cut = Render<LogTabBar>();
+
+        Assert.Equal("true", cut.Find(".group-header > span").GetAttribute("aria-expanded"));
+    }
+
+    [Fact]
     public void ExpandedGroup_RendersHeaderNameAndMembers()
     {
         var (state, _, _, _, _) = GroupedState(collapsed: false, activeIsMember1: false);
@@ -305,17 +310,6 @@ public sealed class LogTabBarTests : BunitContext
         Assert.Contains("MyGroup", cut.Markup);
         Assert.Contains("Alpha", cut.Markup);
         Assert.Contains("Beta", cut.Markup);
-    }
-
-    [Fact]
-    public void ExpandedGroup_RendersRightChevron()
-    {
-        var (state, _, _, _, _) = GroupedState(collapsed: false, activeIsMember1: false);
-        _logTableState.Value.Returns(state);
-
-        var cut = Render<LogTabBar>();
-
-        Assert.Contains("bi-chevron-right", cut.Markup);
     }
 
     [Fact]
@@ -338,19 +332,20 @@ public sealed class LogTabBarTests : BunitContext
         _logTableState.Value.Returns(state);
         var cut = Render<LogTabBar>();
 
-        cut.Find(".group-header > i.bi-x").Click();
+        cut.Find(".group-header > i.bi-x-circle").Click();
 
         _logTableCommands.Received(1).CloseGroup(groupId);
     }
 
     [Fact]
-    public void GroupHeaderName_MouseDown_DispatchesSetActiveTable()
+    public void GroupHeaderName_Click_DispatchesSetActiveTable()
     {
-        var (state, _, headerId, _, _) = GroupedState(collapsed: false, activeIsMember1: false);
+        // Member1 is active (not the header), so clicking the header activates the group's combined view.
+        var (state, _, headerId, _, _) = GroupedState(collapsed: false, activeIsMember1: true);
         _logTableState.Value.Returns(state);
         var cut = Render<LogTabBar>();
 
-        cut.Find(".group-header > span").MouseDown();
+        cut.Find(".group-header > span").Click();
 
         _logTableCommands.Received(1).SetActiveTable(headerId);
     }
@@ -590,7 +585,7 @@ public sealed class LogTabBarTests : BunitContext
         _logTableState.Value.Returns(TwoTabState(alpha, beta));
         var cut = Render<LogTabBar>();
 
-        cut.Find(".tab > i.bi-x").MouseDown(new MouseEventArgs { Button = 2 });
+        cut.Find(".tab > i.bi-x-circle").MouseDown(new MouseEventArgs { Button = 2 });
 
         _eventLogCommands.DidNotReceive().CloseLog(Arg.Any<EventLogId>(), Arg.Any<string>());
     }

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTabBarTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTabBarTests.cs
@@ -107,6 +107,31 @@ public sealed class LogTabBarTests : BunitContext
     }
 
     [Fact]
+    public void ActiveGroupHeaderName_RepeatSpaceKeyDown_DoesNotToggle()
+    {
+        // Holding Space (key auto-repeat) must not toggle the group over and over; the handler ignores e.Repeat.
+        var (state, groupId, _, _, _) = GroupedState(collapsed: false, activeIsMember1: false);
+        _logTableState.Value.Returns(state);
+        var cut = Render<LogTabBar>();
+
+        cut.Find(".group-header > span").KeyDown(new KeyboardEventArgs { Key = " ", Repeat = true });
+
+        _logTableCommands.DidNotReceive().SetTabGroupCollapsed(groupId, true);
+    }
+
+    [Fact]
+    public void ActiveGroupHeaderName_SpaceKeyDown_TogglesCollapse()
+    {
+        var (state, groupId, _, _, _) = GroupedState(collapsed: false, activeIsMember1: false);
+        _logTableState.Value.Returns(state);
+        var cut = Render<LogTabBar>();
+
+        cut.Find(".group-header > span").KeyDown(new KeyboardEventArgs { Key = " " });
+
+        _logTableCommands.Received(1).SetTabGroupCollapsed(groupId, true);
+    }
+
+    [Fact]
     public async Task ActiveTabChange_Rerenders()
     {
         var alpha = EventLogId.Create();

--- a/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTabBarTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/LogTable/LogTabBarTests.cs
@@ -96,39 +96,30 @@ public sealed class LogTabBarTests : BunitContext
     {
         // With the chevron removed, clicking an already-active group header toggles its collapse state. The
         // toggle is on click (not mousedown) so a drag-scroll of the tab strip started on the header does not
-        // collapse the group.
+        // collapse the group. The header is a native <button>, so Enter/Space also activate it via onclick
+        // without scrolling the tab row.
         var (state, groupId, _, _, _) = GroupedState(collapsed: false, activeIsMember1: false);
         _logTableState.Value.Returns(state);
         var cut = Render<LogTabBar>();
 
-        cut.Find(".group-header > span").Click();
+        cut.Find(".group-header > button").Click();
 
         _logTableCommands.Received(1).SetTabGroupCollapsed(groupId, true);
     }
 
     [Fact]
-    public void ActiveGroupHeaderName_RepeatSpaceKeyDown_DoesNotToggle()
+    public void ActiveGroupHeader_RendersAsNativeButton_ForKeyboardSemantics()
     {
-        // Holding Space (key auto-repeat) must not toggle the group over and over; the handler ignores e.Repeat.
-        var (state, groupId, _, _, _) = GroupedState(collapsed: false, activeIsMember1: false);
+        // The header is a native <button> (not a span[role=button]) so the browser provides correct Enter/Space
+        // activation - Space activates it once without also scrolling the tab row.
+        var (state, _, _, _, _) = GroupedState(collapsed: false, activeIsMember1: false);
         _logTableState.Value.Returns(state);
         var cut = Render<LogTabBar>();
 
-        cut.Find(".group-header > span").KeyDown(new KeyboardEventArgs { Key = " ", Repeat = true });
+        var header = cut.Find(".group-header > button.group-header-label");
 
-        _logTableCommands.DidNotReceive().SetTabGroupCollapsed(groupId, true);
-    }
-
-    [Fact]
-    public void ActiveGroupHeaderName_SpaceKeyDown_TogglesCollapse()
-    {
-        var (state, groupId, _, _, _) = GroupedState(collapsed: false, activeIsMember1: false);
-        _logTableState.Value.Returns(state);
-        var cut = Render<LogTabBar>();
-
-        cut.Find(".group-header > span").KeyDown(new KeyboardEventArgs { Key = " " });
-
-        _logTableCommands.Received(1).SetTabGroupCollapsed(groupId, true);
+        Assert.Equal("BUTTON", header.TagName);
+        Assert.Equal("button", header.GetAttribute("type"));
     }
 
     [Fact]
@@ -258,7 +249,7 @@ public sealed class LogTabBarTests : BunitContext
 
         var cut = Render<LogTabBar>();
 
-        Assert.Equal("false", cut.Find(".group-header > span").GetAttribute("aria-expanded"));
+        Assert.Equal("false", cut.Find(".group-header > button").GetAttribute("aria-expanded"));
     }
 
     [Fact]
@@ -321,7 +312,7 @@ public sealed class LogTabBarTests : BunitContext
 
         var cut = Render<LogTabBar>();
 
-        Assert.Equal("true", cut.Find(".group-header > span").GetAttribute("aria-expanded"));
+        Assert.Equal("true", cut.Find(".group-header > button").GetAttribute("aria-expanded"));
     }
 
     [Fact]
@@ -370,7 +361,7 @@ public sealed class LogTabBarTests : BunitContext
         _logTableState.Value.Returns(state);
         var cut = Render<LogTabBar>();
 
-        cut.Find(".group-header > span").Click();
+        cut.Find(".group-header > button").Click();
 
         _logTableCommands.Received(1).SetActiveTable(headerId);
     }


### PR DESCRIPTION
## Summary

Accessibility and visual-consistency pass across the log viewer and shared inputs, following the accessibility review (AB#1344). Two commits on the branch:

**Filter dropdowns, icon-button hover, sub-1em text, lens save (7574702a)**
- Sized filter dropdowns to their longest option
- Unified icon-button hover (background shift, consistent across the app)
- Centered sub-1em text via a shared utility
- Added Save all / Save as group with a save icon on the lens breadcrumb

**Tab bar, focus rings, close icons, dialogs (47acaaba)**
- Log tab groups: per-group colored top border from a shared categorical palette; Edge-style activate-then-toggle group headers (removed the chevron; toggle fires on click-release, so a drag-scroll started on a header no longer collapses it)
- Standardized every close/dismiss control to `bi-x-circle` app-wide
- Keyboard-only focus-ring modality: a root `data-modality` tracker so text inputs, value selects, and autofocused dialog controls show the focus ring only under keyboard use (WCAG 2.4.7), with a static fallback so the ring never silently drops
- OptionSelect rounded outer corners to match buttons
- Enter-to-confirm in the input prompt and inline-alert dialogs (IME-composition-safe)

## Testing
- `dotnet build` clean (0 warnings / 0 errors)
- Full UI unit suite: **1922 / 1922 passing**

## Review
Ran a 5-model pre-commit review panel (4 rounds to unanimous sign-off), which drove fixes for: IME Enter premature-confirm, exact `<label>`-forwarded-click detection for the focus ring, AltGr / dead-key / combobox-arrow handling, and the group-header drag-scroll-collapse bug.

## Caveat
The keyboard-focus-ring modality and the group-header drag-suppression are WebView2-runtime (JS event-model) behaviors, validated by Blazor event-delegation semantics and the repo's existing reliance on the same mechanism, but **not** exercised by the bUnit suite (which invokes `@onclick` directly and does not run the drag-scroller JS). Worth a manual smoke-test in the running app.
