### PR TITLE
Add keyboard-and-hover tooltips for icon-only buttons and fix contrast and zoom-reflow accessibility issues

### DIFF
--- a/src/EventLogExpert.UI/Dashboard/ScenarioDetail.razor.css
+++ b/src/EventLogExpert.UI/Dashboard/ScenarioDetail.razor.css
@@ -157,7 +157,7 @@
     flex: 0 0 auto;
     width: 0.85rem;
     height: 0.85rem;
-    border: 1px solid var(--border-divider);
+    border: 1px solid var(--text-secondary);
     border-radius: 3px;
     background-color: var(--hl-bg);
 }

--- a/src/EventLogExpert.UI/DatabaseTools/DatabaseToolsLogView.razor.css
+++ b/src/EventLogExpert.UI/DatabaseTools/DatabaseToolsLogView.razor.css
@@ -4,7 +4,10 @@
     flex: 1 1 0;
     min-width: 0;
     max-width: 100%;
-    min-height: 0;
+    /* Floor height so extreme text zoom (which squeezes this flex column) can't collapse the output
+       to zero and clip its toolbar (Copy / Export / Run / Jump to latest)
+       Normal layouts are already far taller, so this only engages under heavy zoom. */
+    min-height: 7rem;
     border: 1px solid var(--clr-statusbar);
     border-radius: 4px;
     background: var(--background-dark);

--- a/src/EventLogExpert.UI/DatabaseTools/DatabaseToolsLogView.razor.css
+++ b/src/EventLogExpert.UI/DatabaseTools/DatabaseToolsLogView.razor.css
@@ -4,15 +4,16 @@
     flex: 1 1 0;
     min-width: 0;
     max-width: 100%;
-    /* Floor height so extreme text zoom (which squeezes this flex column) can't collapse the output
-       to zero and clip its toolbar (Copy / Export / Run / Jump to latest)
-       Normal layouts are already far taller, so this only engages under heavy zoom. */
-    min-height: 7rem;
+    /* Size to at least the toolbar's own (possibly multi-row) height so heavy text zoom can't squeeze the
+       container below the toolbar and clip its actions; the log view (its own overflow, down to a one-row
+       floor) absorbs the remaining squeeze and scrolls. overflow stays visible on purpose - an
+       overflow:hidden flex item reports a zero automatic minimum and would let the toolbar be clipped
+       again - so the toolbar and log view carry the rounded corners instead. */
+    min-height: auto;
     border: 1px solid var(--clr-statusbar);
     border-radius: 4px;
     background: var(--background-dark);
     color: var(--text-primary);
-    overflow: hidden;
 }
 
 .database-tools-log-toolbar {
@@ -23,6 +24,7 @@
     padding: 4px 8px;
     background: var(--background-darkgray);
     border-bottom: 1px solid var(--clr-statusbar);
+    border-radius: 4px 4px 0 0;
     flex: 0 0 auto;
 }
 
@@ -94,9 +96,13 @@
 
 .database-tools-log-view {
     flex: 1 1 0;
-    min-height: 0;
+    /* Keep at least one log row (plus padding) visible so a heavy-zoom squeeze - which grows the container
+       to fit the toolbar - can't collapse the log / empty-state area to zero; content beyond this scrolls,
+       and the .db-tab wrapper scrolls when the toolbar plus this floor exceed the dialog. */
+    min-height: 2.5rem;
     overflow-y: auto;
     overflow-x: hidden;
+    border-radius: 0 0 4px 4px;
     padding: 6px 8px;
     font-family: Consolas, 'Courier New', monospace;
     font-size: 0.85em;

--- a/src/EventLogExpert.UI/DatabaseTools/DatabaseToolsLogView.razor.css
+++ b/src/EventLogExpert.UI/DatabaseTools/DatabaseToolsLogView.razor.css
@@ -39,10 +39,14 @@
 
 .toolbar-trailing {
     display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
     align-items: center;
     gap: 6px;
     margin-left: auto;
-    flex: 0 0 auto;
+    min-width: 0;
+    max-width: 100%;
+    flex: 0 1 auto;
 }
 
 .database-tools-log-toolbar .entry-count {

--- a/src/EventLogExpert.UI/DatabaseTools/DatabaseToolsModal.razor.css
+++ b/src/EventLogExpert.UI/DatabaseTools/DatabaseToolsModal.razor.css
@@ -155,6 +155,13 @@
     .db-tabs-container ::deep .db-tab-form .direction-row {
         grid-column: 1;
     }
+
+    /* Under narrow width / high text zoom the stacked form + floored output can exceed the tab
+       height; let the tab scroll so the form fields and output controls stay reachable instead of
+       being clipped */
+    .db-tabs-container ::deep .db-tab {
+        overflow-y: auto;
+    }
 }
 
 /* Narrow reflow (WCAG 1.4.10): below the width where the 200px sidebar and the tab panel can both

--- a/src/EventLogExpert.UI/FilterPane/FilterPane.razor
+++ b/src/EventLogExpert.UI/FilterPane/FilterPane.razor
@@ -61,7 +61,7 @@
             OnClick="SaveFiltersAsFilterSetAsync"
             aria-describedby="@(HasSavableFilters ? null : "save-filters-empty-hint")"
             aria-label="@Localizer["FilterPane_SaveAsFilterSet_Aria"]"
-            title="@(HasSavableFilters ? Localizer["FilterPane_SaveAsFilterSet_TitleEnabled"] : Localizer["FilterPane_SaveAsFilterSet_TitleDisabled"])" />
+            data-tooltip="@(HasSavableFilters ? Localizer["FilterPane_SaveAsFilterSet_TitleEnabled"] : Localizer["FilterPane_SaveAsFilterSet_TitleDisabled"])" />
 
         <Button Disabled="@(!HasClearableFilters)"
             IconClass="bi bi-trash"
@@ -69,13 +69,13 @@
             OnClick="ClearAllFiltersAsync"
             aria-describedby="@(HasClearableFilters ? null : "clear-filters-empty-hint")"
             aria-label="@Localizer["FilterPane_ClearAll_Aria"]"
-            title="@(HasClearableFilters ? Localizer["FilterPane_ClearAll_TitleEnabled"] : Localizer["FilterPane_ClearAll_TitleDisabled"])" />
+            data-tooltip="@(HasClearableFilters ? Localizer["FilterPane_ClearAll_TitleEnabled"] : Localizer["FilterPane_ClearAll_TitleDisabled"])" />
 
         <Button IconClass="bi bi-bookmarks"
             IconOnly
             OnClick="OpenFilterLibraryAsync"
             aria-label="@Localizer["FilterPane_OpenLibrary_Aria"]"
-            title="@Localizer["FilterPane_OpenLibrary_Title"]" />
+            data-tooltip="@Localizer["FilterPane_OpenLibrary_Title"]" />
 
         @if (ScenarioAuthoringEnabled)
         {
@@ -87,7 +87,7 @@
                 OnClick="CopyScenarioJsonAsync"
                 aria-describedby="@(hasEnabledFilters ? null : "scenario-export-empty-hint")"
                 aria-label="@Localizer["FilterPane_CopyScenarioJson_Aria"]"
-                title="@Localizer["FilterPane_CopyScenarioJson_Title"]" />
+                data-tooltip="@Localizer["FilterPane_CopyScenarioJson_Title"]" />
 
             <Button Disabled="@(!hasEnabledFilters)"
                 IconClass="bi bi-filetype-json"
@@ -95,7 +95,7 @@
                 OnClick="SaveScenarioJsonAsync"
                 aria-describedby="@(hasEnabledFilters ? null : "scenario-export-empty-hint")"
                 aria-label="@Localizer["FilterPane_SaveScenarioJson_Aria"]"
-                title="@Localizer["FilterPane_SaveScenarioJson_Title"]" />
+                data-tooltip="@Localizer["FilterPane_SaveScenarioJson_Title"]" />
 
             <span class="visually-hidden" id="scenario-export-empty-hint">
                 @Localizer["FilterPane_ScenarioExport_HintDisabled"]
@@ -117,7 +117,7 @@
                 OnClick="ToggleMenu"
                 aria-label="@(_isFilterListVisible ? Localizer["FilterPane_FilterList_ExpandedAria"] : Localizer["FilterPane_FilterList_CollapsedAria"])"
                 data-rotate="@MenuState"
-                title="@(_isFilterListVisible ? Localizer["FilterPane_FilterList_ExpandedAria"] : Localizer["FilterPane_FilterList_CollapsedAria"])" />
+                data-tooltip="@(_isFilterListVisible ? Localizer["FilterPane_FilterList_ExpandedAria"] : Localizer["FilterPane_FilterList_CollapsedAria"])" />
         }
     </div>
 </div>

--- a/src/EventLogExpert.UI/FilterPane/FilterPane.razor
+++ b/src/EventLogExpert.UI/FilterPane/FilterPane.razor
@@ -61,7 +61,8 @@
             OnClick="SaveFiltersAsFilterSetAsync"
             aria-describedby="@(HasSavableFilters ? null : "save-filters-empty-hint")"
             aria-label="@Localizer["FilterPane_SaveAsFilterSet_Aria"]"
-            data-tooltip="@(HasSavableFilters ? Localizer["FilterPane_SaveAsFilterSet_TitleEnabled"] : Localizer["FilterPane_SaveAsFilterSet_TitleDisabled"])" />
+            data-tooltip="@(HasSavableFilters ? Localizer["FilterPane_SaveAsFilterSet_TitleEnabled"] : null)"
+            title="@(HasSavableFilters ? null : Localizer["FilterPane_SaveAsFilterSet_TitleDisabled"])" />
 
         <Button Disabled="@(!HasClearableFilters)"
             IconClass="bi bi-trash"
@@ -69,7 +70,8 @@
             OnClick="ClearAllFiltersAsync"
             aria-describedby="@(HasClearableFilters ? null : "clear-filters-empty-hint")"
             aria-label="@Localizer["FilterPane_ClearAll_Aria"]"
-            data-tooltip="@(HasClearableFilters ? Localizer["FilterPane_ClearAll_TitleEnabled"] : Localizer["FilterPane_ClearAll_TitleDisabled"])" />
+            data-tooltip="@(HasClearableFilters ? Localizer["FilterPane_ClearAll_TitleEnabled"] : null)"
+            title="@(HasClearableFilters ? null : Localizer["FilterPane_ClearAll_TitleDisabled"])" />
 
         <Button IconClass="bi bi-bookmarks"
             IconOnly
@@ -87,7 +89,8 @@
                 OnClick="CopyScenarioJsonAsync"
                 aria-describedby="@(hasEnabledFilters ? null : "scenario-export-empty-hint")"
                 aria-label="@Localizer["FilterPane_CopyScenarioJson_Aria"]"
-                data-tooltip="@Localizer["FilterPane_CopyScenarioJson_Title"]" />
+                data-tooltip="@(hasEnabledFilters ? Localizer["FilterPane_CopyScenarioJson_Title"] : null)"
+                title="@(hasEnabledFilters ? null : Localizer["FilterPane_CopyScenarioJson_Title"])" />
 
             <Button Disabled="@(!hasEnabledFilters)"
                 IconClass="bi bi-filetype-json"
@@ -95,7 +98,8 @@
                 OnClick="SaveScenarioJsonAsync"
                 aria-describedby="@(hasEnabledFilters ? null : "scenario-export-empty-hint")"
                 aria-label="@Localizer["FilterPane_SaveScenarioJson_Aria"]"
-                data-tooltip="@Localizer["FilterPane_SaveScenarioJson_Title"]" />
+                data-tooltip="@(hasEnabledFilters ? Localizer["FilterPane_SaveScenarioJson_Title"] : null)"
+                title="@(hasEnabledFilters ? null : Localizer["FilterPane_SaveScenarioJson_Title"])" />
 
             <span class="visually-hidden" id="scenario-export-empty-hint">
                 @Localizer["FilterPane_ScenarioExport_HintDisabled"]

--- a/src/EventLogExpert.UI/Layout/MainLayout.razor.cs
+++ b/src/EventLogExpert.UI/Layout/MainLayout.razor.cs
@@ -14,6 +14,7 @@ public sealed partial class MainLayout : IAsyncDisposable
 {
     private bool _disposed;
     private Task<IJSObjectReference>? _focusRingModuleLoad;
+    private Task<IJSObjectReference>? _focusTooltipModuleLoad;
     private Task<IJSObjectReference>? _themeModuleLoad;
 
     [Inject] private IAppTitleService AppTitleService { get; init; } = null!;
@@ -62,6 +63,21 @@ public sealed partial class MainLayout : IAsyncDisposable
 
             _focusRingModuleLoad = null;
         }
+
+        if (_focusTooltipModuleLoad is not null)
+        {
+            try
+            {
+                var module = await _focusTooltipModuleLoad;
+                await module.DisposeAsync();
+            }
+            catch (JSDisconnectedException) { }
+            catch (JSException) { }
+            catch (ObjectDisposedException) { }
+            catch (TaskCanceledException) { }
+
+            _focusTooltipModuleLoad = null;
+        }
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -71,6 +87,7 @@ public sealed partial class MainLayout : IAsyncDisposable
             await ApplyThemeAsync();
             await KeyboardShortcutService.EnsureRegisteredAsync(JSRuntime);
             await RegisterKeyboardFocusRingAsync();
+            await RegisterFocusTooltipAsync();
         }
 
         await base.OnAfterRenderAsync(firstRender);
@@ -90,7 +107,9 @@ public sealed partial class MainLayout : IAsyncDisposable
     {
         if (_disposed) { return; }
 
-        var load = _themeModuleLoad ??= JSRuntime.InvokeAsync<IJSObjectReference>("import", "./_content/EventLogExpert.UI/Layout/MainLayout.razor.js").AsTask();
+        var load = _themeModuleLoad ??= JSRuntime
+            .InvokeAsync<IJSObjectReference>("import", "./_content/EventLogExpert.UI/Layout/MainLayout.razor.js")
+            .AsTask();
 
         try
         {
@@ -112,6 +131,28 @@ public sealed partial class MainLayout : IAsyncDisposable
     }
 
     private void OnThemeChanged() => _ = InvokeAsync(ApplyThemeAsync);
+
+    private async Task RegisterFocusTooltipAsync()
+    {
+        if (_disposed) { return; }
+
+        var load = _focusTooltipModuleLoad ??= JSRuntime.InvokeAsync<IJSObjectReference>(
+            "import",
+            "./_content/EventLogExpert.UI/Common/focusTooltip.js").AsTask();
+
+        try
+        {
+            var module = await load;
+            await module.InvokeVoidAsync("registerFocusTooltip");
+        }
+        catch (Exception ex) when (ex is JSDisconnectedException or JSException or ObjectDisposedException or TaskCanceledException)
+        {
+            if (!load.IsCompletedSuccessfully && ReferenceEquals(_focusTooltipModuleLoad, load))
+            {
+                _focusTooltipModuleLoad = null;
+            }
+        }
+    }
 
     private async Task RegisterKeyboardFocusRingAsync()
     {

--- a/src/EventLogExpert.UI/Update/ReleaseNotesModal.razor.css
+++ b/src/EventLogExpert.UI/Update/ReleaseNotesModal.razor.css
@@ -4,38 +4,38 @@
     overflow-wrap: anywhere;
 }
 
-.release-notes-content h1 {
+.release-notes-content ::deep h1 {
     font-size: 1.4rem;
     margin: 0 0 1rem 0;
     padding-bottom: 0.5rem;
     border-bottom: 1px solid var(--clr-statusbar);
 }
 
-.release-notes-content h2 {
+.release-notes-content ::deep h2 {
     font-size: 1.2rem;
     margin: 1.25rem 0 0.5rem 0;
     color: var(--clr-lightblue);
 }
 
-.release-notes-content h3 {
+.release-notes-content ::deep h3 {
     font-size: 1.05rem;
     margin: 1rem 0 0.4rem 0;
 }
 
-.release-notes-content ul {
+.release-notes-content ::deep ul {
     margin: 0.25rem 0 0.75rem 0;
     padding-left: 1.5rem;
 }
 
-.release-notes-content li {
+.release-notes-content ::deep li {
     margin-bottom: 0.25rem;
 }
 
-.release-notes-content p {
+.release-notes-content ::deep p {
     margin: 0.5rem 0;
 }
 
-.release-notes-content code {
+.release-notes-content ::deep code {
     padding: 0.1rem 0.3rem;
     background-color: var(--clr-statusbar);
     color: var(--text-on-statusbar);

--- a/src/EventLogExpert.UI/wwwroot/Common/focusTooltip.js
+++ b/src/EventLogExpert.UI/wwwroot/Common/focusTooltip.js
@@ -42,8 +42,13 @@ function ensureTip() {
 
     // Let the pointer move onto the bubble to read it without it vanishing (WCAG 1.4.13 hoverable). Leaving
     // the bubble re-derives the hovered control from where the pointer went (back onto a control, or nothing).
-    tip.addEventListener("mouseenter", () => { pointerOverTip = true; cancelHide(); cancelHoverEnd(); });
-    tip.addEventListener("mouseleave", (e) => {
+    // Touch has no hover and its tap-compatibility events would pin the bubble open, so only mouse/pen count.
+    tip.addEventListener("pointerenter", (e) => {
+        if (e.pointerType === "touch") { return; }
+        pointerOverTip = true; cancelHide(); cancelHoverEnd();
+    });
+    tip.addEventListener("pointerleave", (e) => {
+        if (e.pointerType === "touch") { return; }
         pointerOverTip = false;
         hoveredAnchor = e.relatedTarget?.closest?.("[data-tooltip]") ?? null;
         update();
@@ -82,7 +87,7 @@ function scheduleHoverEnd() {
     // Keep showing the just-left hovered control through the bridge delay so the pointer can still reach its
     // tooltip; without this, when another control holds keyboard focus, activeAnchor() would fall back to the
     // focused control the instant the pointer leaves and the hovered control's tooltip could never be hovered
-    // (WCAG 1.4.13 hoverable). Reaching the bubble (pointerOverTip) or another control (mouseover) cancels it.
+    // (WCAG 1.4.13 hoverable). Reaching the bubble (pointerOverTip) or another control (pointerover) cancels it.
     cancelHoverEnd();
     hoverEndTimer = setTimeout(() => {
         hoverEndTimer = 0;
@@ -195,7 +200,11 @@ export function registerFocusTooltip() {
         }
     }, true);
 
-    document.addEventListener("mouseover", (e) => {
+    document.addEventListener("pointerover", (e) => {
+        // Ignore touch: it has no hover, and a tap's compatibility events would open the tooltip during
+        // activation and leave it lingering (touch delivers no reliable pointerout on lift). Mouse and pen
+        // keep hover support (pointerType is "mouse", "pen", or "touch").
+        if (e.pointerType === "touch") { return; }
         const anchor = e.target.closest?.("[data-tooltip]");
         // Ignore movement WITHIN the same control (e.g. the button <-> its icon child): a genuine enter
         // comes from outside the anchor, so relatedTarget is not already inside it. Without this guard an
@@ -204,9 +213,10 @@ export function registerFocusTooltip() {
         if (anchor && !anchor.contains(e.relatedTarget)) { cancelHoverEnd(); hoveredAnchor = anchor; update(); }
     }, true);
 
-    document.addEventListener("mouseout", (e) => {
+    document.addEventListener("pointerout", (e) => {
+        if (e.pointerType === "touch") { return; }
         // Left the hovered control - but not when moving between its children or onto the bubble (the bubble's
-        // own mouseleave handles that handoff). Defer clearing it through the bridge delay so its tooltip stays
+        // own pointerleave handles that handoff). Defer clearing it through the bridge delay so its tooltip stays
         // reachable even when another control holds keyboard focus (which activeAnchor() would otherwise fall
         // back to immediately).
         if (hoveredAnchor

--- a/src/EventLogExpert.UI/wwwroot/Common/focusTooltip.js
+++ b/src/EventLogExpert.UI/wwwroot/Common/focusTooltip.js
@@ -95,10 +95,17 @@ function scheduleHoverEnd() {
 
 function position(anchor, element) {
     const rect = anchor.getBoundingClientRect();
-    const gap = 4;
+    // The bubble sits flush against the control (no gap) so the pointer path from control to bubble is
+    // continuous and staying hovered is not pointer-speed-dependent (WCAG 1.4.13): a gap would leave a
+    // non-hit-testable strip that a slow crossing could dwell in past the hover-end delay, losing the bubble.
+    // Measure with fractional (sub-pixel) geometry and leave the trigger-facing edge unrounded so the two
+    // border-boxes share an exact coordinate at every device-pixel ratio; rounding it would reopen a
+    // sub-pixel seam (or a click-stealing overlap) at fractional zoom levels such as WCAG's 400%.
+    const gap = 0;
     const margin = 4;
-    const width = element.offsetWidth;
-    const height = element.offsetHeight;
+    const tipRect = element.getBoundingClientRect();
+    const width = tipRect.width;
+    const height = tipRect.height;
     const viewportWidth = document.documentElement.clientWidth;
     const viewportHeight = document.documentElement.clientHeight;
 
@@ -108,12 +115,13 @@ function position(anchor, element) {
         top = rect.top - gap - height;
     }
 
-    // Align the tooltip's right edge to the control's, then clamp into the viewport.
+    // Align the tooltip's right edge to the control's, then clamp into the viewport. The horizontal edge has
+    // no flush neighbor, so it stays pixel-snapped to keep the label text crisp.
     let left = rect.right - width;
     left = Math.max(margin, Math.min(left, viewportWidth - margin - width));
 
     element.style.left = `${Math.round(left)}px`;
-    element.style.top = `${Math.round(top)}px`;
+    element.style.top = `${top}px`;
 }
 
 function reposition() {

--- a/src/EventLogExpert.UI/wwwroot/Common/focusTooltip.js
+++ b/src/EventLogExpert.UI/wwwroot/Common/focusTooltip.js
@@ -163,8 +163,19 @@ export function registerFocusTooltip() {
     registered = true;
 
     document.addEventListener("focusin", (e) => {
-        focusedAnchor = e.target.closest?.("[data-tooltip]") ?? null;
+        const anchor = e.target.closest?.("[data-tooltip]");
+        // Only KEYBOARD focus should surface the tooltip. A pointer click also focuses the control, and that
+        // focus would otherwise leave the bubble stuck open after the pointer moved away. :focus-visible is
+        // the browser's keyboard-focus signal, which is keyboard-only for these buttons in WebView2.
+        focusedAnchor = anchor && anchor.matches(":focus-visible") ? anchor : null;
         update();
+    }, true);
+
+    document.addEventListener("pointerdown", () => {
+        // A pointer interaction supersedes a keyboard-focus tooltip: pointer users are governed by hover
+        // alone, so a control that was tabbed to and then clicked doesn't keep its bubble after the pointer
+        // leaves.
+        if (focusedAnchor) { focusedAnchor = null; update(); }
     }, true);
 
     document.addEventListener("focusout", (e) => {

--- a/src/EventLogExpert.UI/wwwroot/Common/focusTooltip.js
+++ b/src/EventLogExpert.UI/wwwroot/Common/focusTooltip.js
@@ -1,0 +1,212 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT License.
+
+// A single shared, position:fixed tooltip that surfaces an icon-only control's label on BOTH keyboard
+// focus and pointer hover. The native `title` attribute only appears on mouse hover, leaving keyboard
+// users with no visible label. A CSS ::after bubble can't stand in because these
+// controls live inside overflow-clipping scroll panes (e.g. the filter pane, which is overflow:auto and,
+// when the filter list is collapsed, only header-height): a bubble anchored to the button would be clipped
+// by the pane. One fixed-position element appended to <body> escapes every ancestor clip.
+//
+// Opt in with data-tooltip="text" on the control. The accessible NAME still comes from the control's own
+// aria-label, so this element is a purely visual aid and is intentionally NOT wired via aria-describedby
+// (that would double-announce). Escape dismisses it, it stays visible while the pointer is over the control
+// or the bubble (so a pointer user can read it), and scroll/resize reposition it while its trigger is active
+// and drop it otherwise so it never drifts away stale (WCAG 1.4.13 dismissable / hoverable / persistent).
+// One idempotent registration wires delegated, capture-phase listeners for the whole app.
+
+let registered = false;
+let tip = null;
+// Keyboard focus and pointer hover are tracked separately because they can rest on DIFFERENT controls at
+// once (e.g. tab to A, then hover B): the hovered control wins the display while hovered, and leaving it
+// restores the still-focused control's tooltip instead of dropping it (WCAG 1.4.13 persistent).
+let focusedAnchor = null;
+let hoveredAnchor = null;
+let pointerOverTip = false;
+let hideTimer = 0;
+let hoverEndTimer = 0;
+let attributeObserver = null;
+
+// The control whose tooltip should show right now: a hovered control takes precedence, falling back to the
+// focused control.
+function activeAnchor() { return hoveredAnchor || focusedAnchor; }
+
+function ensureTip() {
+    if (tip) { return tip; }
+
+    tip = document.createElement("div");
+    tip.className = "focus-tooltip";
+    tip.setAttribute("role", "tooltip");
+    tip.hidden = true;
+
+    // Let the pointer move onto the bubble to read it without it vanishing (WCAG 1.4.13 hoverable). Leaving
+    // the bubble re-derives the hovered control from where the pointer went (back onto a control, or nothing).
+    tip.addEventListener("mouseenter", () => { pointerOverTip = true; cancelHide(); cancelHoverEnd(); });
+    tip.addEventListener("mouseleave", (e) => {
+        pointerOverTip = false;
+        hoveredAnchor = e.relatedTarget?.closest?.("[data-tooltip]") ?? null;
+        update();
+    });
+
+    document.body.appendChild(tip);
+
+    return tip;
+}
+
+function cancelHide() {
+    if (hideTimer) {
+        clearTimeout(hideTimer);
+        hideTimer = 0;
+    }
+}
+
+function scheduleHide() {
+    // Delay the hide so the pointer can bridge the small gap between the control and the bubble without it
+    // vanishing, and so a focus<->hover handoff doesn't flicker.
+    cancelHide();
+    hideTimer = setTimeout(() => {
+        hideTimer = 0;
+        if (!activeAnchor() && !pointerOverTip) { hide(); }
+    }, 120);
+}
+
+function cancelHoverEnd() {
+    if (hoverEndTimer) {
+        clearTimeout(hoverEndTimer);
+        hoverEndTimer = 0;
+    }
+}
+
+function scheduleHoverEnd() {
+    // Keep showing the just-left hovered control through the bridge delay so the pointer can still reach its
+    // tooltip; without this, when another control holds keyboard focus, activeAnchor() would fall back to the
+    // focused control the instant the pointer leaves and the hovered control's tooltip could never be hovered
+    // (WCAG 1.4.13 hoverable). Reaching the bubble (pointerOverTip) or another control (mouseover) cancels it.
+    cancelHoverEnd();
+    hoverEndTimer = setTimeout(() => {
+        hoverEndTimer = 0;
+        if (!pointerOverTip) {
+            hoveredAnchor = null;
+            update();
+        }
+    }, 120);
+}
+
+function position(anchor, element) {
+    const rect = anchor.getBoundingClientRect();
+    const gap = 4;
+    const margin = 4;
+    const width = element.offsetWidth;
+    const height = element.offsetHeight;
+    const viewportWidth = document.documentElement.clientWidth;
+    const viewportHeight = document.documentElement.clientHeight;
+
+    // Prefer below the control; flip above only when there is no room below but there is above.
+    let top = rect.bottom + gap;
+    if (top + height > viewportHeight - margin && rect.top - gap - height >= margin) {
+        top = rect.top - gap - height;
+    }
+
+    // Align the tooltip's right edge to the control's, then clamp into the viewport.
+    let left = rect.right - width;
+    left = Math.max(margin, Math.min(left, viewportWidth - margin - width));
+
+    element.style.left = `${Math.round(left)}px`;
+    element.style.top = `${Math.round(top)}px`;
+}
+
+function reposition() {
+    const anchor = activeAnchor();
+    if (anchor && tip && !tip.hidden) { position(anchor, tip); }
+}
+
+// Re-render the tooltip for whichever control is currently active, or begin hiding it when none is. Called
+// on every focus/hover change (and by the attribute observer) so the bubble always reflects current state.
+function update() {
+    const anchor = activeAnchor();
+
+    if (!anchor) {
+        if (!pointerOverTip) { scheduleHide(); }
+        return;
+    }
+
+    const text = anchor.getAttribute("data-tooltip");
+    if (!text) { hide(); return; }
+
+    cancelHide();
+
+    const element = ensureTip();
+    element.textContent = text;
+    element.hidden = false;
+    position(anchor, element);
+
+    // The control can rewrite its own data-tooltip in place while it stays focused / hovered (e.g. the
+    // filter-list collapse toggle flips Expanded<->Collapsed on Enter), which dispatches neither a focus nor
+    // a mouse event - watch the attribute so the visible bubble tracks the current state.
+    attributeObserver ??= new MutationObserver(update);
+    attributeObserver.disconnect();
+    attributeObserver.observe(anchor, { attributes: true, attributeFilter: ["data-tooltip"] });
+}
+
+function hide() {
+    cancelHide();
+    cancelHoverEnd();
+    if (attributeObserver) { attributeObserver.disconnect(); }
+    focusedAnchor = null;
+    hoveredAnchor = null;
+    pointerOverTip = false;
+    if (tip) { tip.hidden = true; }
+}
+
+export function registerFocusTooltip() {
+    if (registered) { return; }
+    registered = true;
+
+    document.addEventListener("focusin", (e) => {
+        focusedAnchor = e.target.closest?.("[data-tooltip]") ?? null;
+        update();
+    }, true);
+
+    document.addEventListener("focusout", (e) => {
+        // Focus left this control; focusin resets focusedAnchor synchronously if it lands on another anchor.
+        if (focusedAnchor && e.target.closest?.("[data-tooltip]") === focusedAnchor) {
+            focusedAnchor = null;
+            update();
+        }
+    }, true);
+
+    document.addEventListener("mouseover", (e) => {
+        const anchor = e.target.closest?.("[data-tooltip]");
+        if (anchor) { cancelHoverEnd(); hoveredAnchor = anchor; update(); }
+    }, true);
+
+    document.addEventListener("mouseout", (e) => {
+        // Left the hovered control - but not when moving between its children or onto the bubble (the bubble's
+        // own mouseleave handles that handoff). Defer clearing it through the bridge delay so its tooltip stays
+        // reachable even when another control holds keyboard focus (which activeAnchor() would otherwise fall
+        // back to immediately).
+        if (hoveredAnchor
+            && e.target.closest?.("[data-tooltip]") === hoveredAnchor
+            && e.relatedTarget !== tip
+            && !hoveredAnchor.contains(e.relatedTarget)) {
+            scheduleHoverEnd();
+        }
+    }, true);
+
+    document.addEventListener("keydown", (e) => {
+        // Dismiss on Escape without moving focus (WCAG 1.4.13); no stopPropagation so a host modal still gets it.
+        if (e.key === "Escape" && tip && !tip.hidden) { hide(); }
+    }, true);
+
+    // Keep the pinned bubble aligned with its control while a trigger is active; only drop it once nothing is
+    // focused/hovered, so a still-focused tooltip stays put (WCAG 1.4.13 persistent).
+    document.addEventListener("scroll", () => {
+        if (!tip || tip.hidden) { return; }
+        if (activeAnchor() || pointerOverTip) { reposition(); } else { hide(); }
+    }, true);
+
+    window.addEventListener("resize", () => {
+        if (!tip || tip.hidden) { return; }
+        if (activeAnchor() || pointerOverTip) { reposition(); } else { hide(); }
+    });
+}

--- a/src/EventLogExpert.UI/wwwroot/Common/focusTooltip.js
+++ b/src/EventLogExpert.UI/wwwroot/Common/focusTooltip.js
@@ -26,6 +26,7 @@ let pointerOverTip = false;
 let hideTimer = 0;
 let hoverEndTimer = 0;
 let attributeObserver = null;
+let escapeConsumed = false;
 
 // The control whose tooltip should show right now: a hovered control takes precedence, falling back to the
 // focused control.
@@ -188,7 +189,11 @@ export function registerFocusTooltip() {
 
     document.addEventListener("mouseover", (e) => {
         const anchor = e.target.closest?.("[data-tooltip]");
-        if (anchor) { cancelHoverEnd(); hoveredAnchor = anchor; update(); }
+        // Ignore movement WITHIN the same control (e.g. the button <-> its icon child): a genuine enter
+        // comes from outside the anchor, so relatedTarget is not already inside it. Without this guard an
+        // Escape dismissal would reopen on the next internal transition even though the pointer never left
+        // the trigger (WCAG 1.4.13 dismissable).
+        if (anchor && !anchor.contains(e.relatedTarget)) { cancelHoverEnd(); hoveredAnchor = anchor; update(); }
     }, true);
 
     document.addEventListener("mouseout", (e) => {
@@ -205,9 +210,31 @@ export function registerFocusTooltip() {
     }, true);
 
     document.addEventListener("keydown", (e) => {
-        // Dismiss on Escape without moving focus (WCAG 1.4.13); no stopPropagation so a host modal still gets it.
-        if (e.key === "Escape" && tip && !tip.hidden) { hide(); }
+        if (e.key !== "Escape") { return; }
+
+        // Dismiss on Escape without moving focus (WCAG 1.4.13). Consume the key while a tooltip is visible so
+        // the dismissal is standalone - for a control inside a dialog, an unconsumed Escape would also run the
+        // host's cancel and close it. Keep consuming the auto-repeat keydowns from the SAME held press (the
+        // tooltip is already hidden after the first) via the latch, so a held Escape can't fall through and
+        // close the host too. The latch clears on keyup, so a fresh Escape press reaches the host as usual.
+        if (tip && !tip.hidden) {
+            hide();
+            escapeConsumed = true;
+        }
+
+        if (escapeConsumed) {
+            e.stopPropagation();
+            e.preventDefault();
+        }
     }, true);
+
+    document.addEventListener("keyup", (e) => {
+        if (e.key === "Escape") { escapeConsumed = false; }
+    }, true);
+
+    // Also clear the latch if focus leaves the window mid-hold (e.g. Alt+Tab while Escape is held), since the
+    // matching keyup may then be delivered elsewhere and never seen here.
+    window.addEventListener("blur", () => { escapeConsumed = false; });
 
     // Keep the pinned bubble aligned with its control while a trigger is active; only drop it once nothing is
     // focused/hovered, so a still-focused tooltip stays put (WCAG 1.4.13 persistent).

--- a/src/EventLogExpert.UI/wwwroot/app.css
+++ b/src/EventLogExpert.UI/wwwroot/app.css
@@ -235,6 +235,29 @@ input[type="search"]:focus-visible,
 
 ::placeholder { color: var(--clr-placeholder); }
 
+/* Shared visual tooltip surfaced on keyboard focus AND pointer hover for icon-only controls that opt in
+   with data-tooltip="..." (native `title` shows on mouse hover only). The element is
+   position:fixed and appended to <body> by focusTooltip.js so it escapes the overflow clip of scroll panes
+   such as the filter pane (a CSS ::after bubble anchored to the button would be clipped there). Its left/top
+   are set inline from the control's viewport rect; the accessible name stays on the control's aria-label. */
+.focus-tooltip {
+    position: fixed;
+    z-index: var(--z-menu-overlay);
+
+    max-width: 15rem;
+    padding: 2px 6px;
+
+    background-color: var(--background-darkgray);
+    color: var(--text-primary);
+    border: 1px solid var(--border-divider);
+    border-radius: 3px;
+    box-shadow: var(--shadow-menu);
+
+    font-size: var(--font-size-sm);
+}
+
+.focus-tooltip[hidden] { display: none; }
+
 html, body {
     height: 100%;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe WPC', 'Segoe UI', 'HelveticaNeue-Light', 'Ubuntu', 'Droid Sans', sans-serif;

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterPane/FilterPaneLocalizerWiringTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterPane/FilterPaneLocalizerWiringTests.cs
@@ -236,11 +236,11 @@ public sealed class FilterPaneLocalizerWiringTests : BunitContext
         Assert.Contains("[[FilterPane_Action_ApplyFilterSet]]", component.Markup);
         Assert.Contains("[[FilterPane_Action_ApplyScenario]]", component.Markup);
         Assert.Contains("[[FilterPane_ActiveFilters(1)]]", component.Markup);
-        Assert.Equal("[[FilterPane_SaveAsFilterSet_Aria]]", component.Find("button[title='[[FilterPane_SaveAsFilterSet_TitleEnabled]]']").GetAttribute("aria-label"));
-        Assert.Equal("[[FilterPane_ClearAll_Aria]]", component.Find("button[title='[[FilterPane_ClearAll_TitleEnabled]]']").GetAttribute("aria-label"));
-        Assert.Equal("[[FilterPane_OpenLibrary_Aria]]", component.Find("button[title='[[FilterPane_OpenLibrary_Title]]']").GetAttribute("aria-label"));
-        Assert.Equal("[[FilterPane_CopyScenarioJson_Aria]]", component.Find("button[title='[[FilterPane_CopyScenarioJson_Title]]']").GetAttribute("aria-label"));
-        Assert.Equal("[[FilterPane_SaveScenarioJson_Aria]]", component.Find("button[title='[[FilterPane_SaveScenarioJson_Title]]']").GetAttribute("aria-label"));
+        Assert.Equal("[[FilterPane_SaveAsFilterSet_Aria]]", component.Find("button[data-tooltip='[[FilterPane_SaveAsFilterSet_TitleEnabled]]']").GetAttribute("aria-label"));
+        Assert.Equal("[[FilterPane_ClearAll_Aria]]", component.Find("button[data-tooltip='[[FilterPane_ClearAll_TitleEnabled]]']").GetAttribute("aria-label"));
+        Assert.Equal("[[FilterPane_OpenLibrary_Aria]]", component.Find("button[data-tooltip='[[FilterPane_OpenLibrary_Title]]']").GetAttribute("aria-label"));
+        Assert.Equal("[[FilterPane_CopyScenarioJson_Aria]]", component.Find("button[data-tooltip='[[FilterPane_CopyScenarioJson_Title]]']").GetAttribute("aria-label"));
+        Assert.Equal("[[FilterPane_SaveScenarioJson_Aria]]", component.Find("button[data-tooltip='[[FilterPane_SaveScenarioJson_Title]]']").GetAttribute("aria-label"));
         Assert.Contains("[[FilterPane_ScenarioExport_HintDisabled]]", component.Markup);
         Assert.Contains("[[FilterPane_SaveFilterSet_HintDisabled]]", component.Markup);
         Assert.Contains("[[FilterPane_ClearFilters_HintDisabled]]", component.Markup);
@@ -252,9 +252,9 @@ public sealed class FilterPaneLocalizerWiringTests : BunitContext
         var component = Render<UI.FilterPane.FilterPane>();
 
         Assert.True(component.Find("button[aria-label='[[FilterPane_SaveAsFilterSet_Aria]]']").HasAttribute("disabled"));
-        Assert.Equal("[[FilterPane_SaveAsFilterSet_TitleDisabled]]", component.Find("button[aria-label='[[FilterPane_SaveAsFilterSet_Aria]]']").GetAttribute("title"));
+        Assert.Equal("[[FilterPane_SaveAsFilterSet_TitleDisabled]]", component.Find("button[aria-label='[[FilterPane_SaveAsFilterSet_Aria]]']").GetAttribute("data-tooltip"));
         Assert.True(component.Find("button[aria-label='[[FilterPane_ClearAll_Aria]]']").HasAttribute("disabled"));
-        Assert.Equal("[[FilterPane_ClearAll_TitleDisabled]]", component.Find("button[aria-label='[[FilterPane_ClearAll_Aria]]']").GetAttribute("title"));
+        Assert.Equal("[[FilterPane_ClearAll_TitleDisabled]]", component.Find("button[aria-label='[[FilterPane_ClearAll_Aria]]']").GetAttribute("data-tooltip"));
 
         _dateFilter = new DateFilter { IsEnabled = false };
         _filteredDateRange.Changed += Raise.Event<Action>();
@@ -263,14 +263,14 @@ public sealed class FilterPaneLocalizerWiringTests : BunitContext
         Assert.True(component.Find("button[aria-label='[[FilterPane_SaveAsFilterSet_Aria]]']").HasAttribute("disabled"));
         Assert.Equal("save-filters-empty-hint", component.Find("button[aria-label='[[FilterPane_SaveAsFilterSet_Aria]]']").GetAttribute("aria-describedby"));
         Assert.False(component.Find("button[aria-label='[[FilterPane_ClearAll_Aria]]']").HasAttribute("disabled"));
-        Assert.Equal("[[FilterPane_ClearAll_TitleEnabled]]", component.Find("button[aria-label='[[FilterPane_ClearAll_Aria]]']").GetAttribute("title"));
+        Assert.Equal("[[FilterPane_ClearAll_TitleEnabled]]", component.Find("button[aria-label='[[FilterPane_ClearAll_Aria]]']").GetAttribute("data-tooltip"));
 
         _filters = [SavedFilter.TryCreate("Level == 4")! with { IsEnabled = true }];
         _activeFilters.Changed += Raise.Event<Action>();
         component.Render();
 
         Assert.False(component.Find("button[aria-label='[[FilterPane_SaveAsFilterSet_Aria]]']").HasAttribute("disabled"));
-        Assert.Equal("[[FilterPane_SaveAsFilterSet_TitleEnabled]]", component.Find("button[aria-label='[[FilterPane_SaveAsFilterSet_Aria]]']").GetAttribute("title"));
+        Assert.Equal("[[FilterPane_SaveAsFilterSet_TitleEnabled]]", component.Find("button[aria-label='[[FilterPane_SaveAsFilterSet_Aria]]']").GetAttribute("data-tooltip"));
     }
 
     [Fact]

--- a/tests/Unit/EventLogExpert.UI.Tests/FilterPane/FilterPaneLocalizerWiringTests.cs
+++ b/tests/Unit/EventLogExpert.UI.Tests/FilterPane/FilterPaneLocalizerWiringTests.cs
@@ -252,9 +252,10 @@ public sealed class FilterPaneLocalizerWiringTests : BunitContext
         var component = Render<UI.FilterPane.FilterPane>();
 
         Assert.True(component.Find("button[aria-label='[[FilterPane_SaveAsFilterSet_Aria]]']").HasAttribute("disabled"));
-        Assert.Equal("[[FilterPane_SaveAsFilterSet_TitleDisabled]]", component.Find("button[aria-label='[[FilterPane_SaveAsFilterSet_Aria]]']").GetAttribute("data-tooltip"));
+        Assert.Equal("[[FilterPane_SaveAsFilterSet_TitleDisabled]]", component.Find("button[aria-label='[[FilterPane_SaveAsFilterSet_Aria]]']").GetAttribute("title"));
+        Assert.False(component.Find("button[aria-label='[[FilterPane_SaveAsFilterSet_Aria]]']").HasAttribute("data-tooltip"));
         Assert.True(component.Find("button[aria-label='[[FilterPane_ClearAll_Aria]]']").HasAttribute("disabled"));
-        Assert.Equal("[[FilterPane_ClearAll_TitleDisabled]]", component.Find("button[aria-label='[[FilterPane_ClearAll_Aria]]']").GetAttribute("data-tooltip"));
+        Assert.Equal("[[FilterPane_ClearAll_TitleDisabled]]", component.Find("button[aria-label='[[FilterPane_ClearAll_Aria]]']").GetAttribute("title"));
 
         _dateFilter = new DateFilter { IsEnabled = false };
         _filteredDateRange.Changed += Raise.Event<Action>();
@@ -271,6 +272,7 @@ public sealed class FilterPaneLocalizerWiringTests : BunitContext
 
         Assert.False(component.Find("button[aria-label='[[FilterPane_SaveAsFilterSet_Aria]]']").HasAttribute("disabled"));
         Assert.Equal("[[FilterPane_SaveAsFilterSet_TitleEnabled]]", component.Find("button[aria-label='[[FilterPane_SaveAsFilterSet_Aria]]']").GetAttribute("data-tooltip"));
+        Assert.False(component.Find("button[aria-label='[[FilterPane_SaveAsFilterSet_Aria]]']").HasAttribute("title"));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Accessibility improvements across icon-only controls, dialog contrast, and the database-tools modal under high text zoom / reflow.

### Icon-only button labels on keyboard focus
- New shared `focusTooltip.js`: a single `position: fixed` tooltip appended to `<body>` that surfaces a control's `data-tooltip` label on **both keyboard focus and pointer hover**. Native `title` only appears on mouse hover, so keyboard users previously saw no visible label. A fixed-position element escapes the overflow clip of scroll panes (e.g. the filter pane) that a CSS `::after` bubble cannot.
- Meets WCAG 1.4.13 (dismissable via Escape, hoverable, persistent), handles simultaneous focus+hover on different controls, and refreshes when a control rewrites its label in place. Registered once in `MainLayout`, mirroring the existing keyboard-focus-ring module.
- The filter-pane icon buttons (save / clear / library / scenario JSON, collapse toggle) now carry `data-tooltip`; their `aria-label` remains the accessible name.

### Contrast
- **Scenario color swatch:** the near-invisible divider border is replaced with a `--text-secondary` border so the swatch boundary clears the 3:1 non-text-contrast bar in every theme.
- **Release notes:** the inline `code` styling now reaches the Markdown-rendered body via `::deep` (Blazor scoped CSS didn't apply to the injected `MarkupString`), replacing the low-contrast browser-default color with the intended readable chip.

### Database-tools zoom / reflow (best-effort — needs on-device verification)
- The output log container keeps a minimum height so heavy text zoom can't collapse it and clip its Copy / Export / Run controls.
- At narrow reflow widths the tab scrolls so stacked form fields and output controls stay reachable.

## Validation
- MAUI head build: **0 warnings / 0 errors**.
- UI unit tests: **1973 / 1973 passing**.
- The zoom/reflow items are render-dependent and could not be visually verified in this environment; they need an on-device retest.
