### PR TITLE
Deflake the DisplayIndicator gate/state tests

### DIFF
--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/DisplayIndicatorGateTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/DisplayIndicatorGateTests.cs
@@ -1,20 +1,13 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
-using EventLogExpert.Eventing.Common.Channels;
-using EventLogExpert.Eventing.Common.EventLogs;
-using EventLogExpert.Eventing.Common.Events;
 using EventLogExpert.Runtime.LogTable;
-using EventLogExpert.Runtime.Tests.TestUtils;
-using System.Diagnostics;
 using static EventLogExpert.Runtime.Tests.LogTable.TestSupport.DisplayIndicatorTestFactory;
 
 namespace EventLogExpert.Runtime.Tests.LogTable;
 
 public sealed class DisplayIndicatorGateTests
 {
-    private static readonly TimeSpan s_testTimeout = TimeSpan.FromSeconds(5);
-
     [Fact]
     public void AFaultLandingMidSort_ReArms_BecauseItIsADifferentKindEvenThoughSomethingWasAlreadyOwed()
     {
@@ -45,7 +38,7 @@ public sealed class DisplayIndicatorGateTests
         Assert.Single(delay.Requested);
 
         delay.Elapse();
-        WaitUntil(() => gate.IsFiredFor(DisplayIndicatorKind.EmptyPending, 7));
+        Assert.True(gate.IsFiredFor(DisplayIndicatorKind.EmptyPending, 7), "the onset must fire once its delay elapses");
     }
 
     [Fact]
@@ -159,18 +152,6 @@ public sealed class DisplayIndicatorGateTests
         Assert.Equal(TimeSpan.FromMilliseconds(200), Assert.Single(world.RequestedDelays));
     }
 
-    private static void WaitUntil(Func<bool> condition)
-    {
-        var deadline = Stopwatch.StartNew();
-
-        while (!condition())
-        {
-            Assert.True(deadline.Elapsed < s_testTimeout, "the gate never reached the expected state");
-
-            Thread.Sleep(1);
-        }
-    }
-
     private sealed class ControllableDelay
     {
         private readonly List<Pending> _pending = [];
@@ -180,7 +161,10 @@ public sealed class DisplayIndicatorGateTests
 
         public Task Delay(TimeSpan duration, CancellationToken token)
         {
-            var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            // Default (synchronous) continuations: completing this in Elapse() runs the gate's post-await onset
+            // logic inline on the caller, so a test can assert the fired state directly instead of polling for a
+            // thread-pool continuation (whose scheduling slipped past the old real-clock deadline under CI load).
+            var completion = new TaskCompletionSource();
 
             lock (_sync)
             {
@@ -193,6 +177,8 @@ public sealed class DisplayIndicatorGateTests
 
         public void Elapse()
         {
+            RequireInlineContinuations();
+
             foreach (var pending in Take())
             {
                 if (pending.Token.IsCancellationRequested)
@@ -208,7 +194,19 @@ public sealed class DisplayIndicatorGateTests
 
         public void ElapseIgnoringCancellation()
         {
+            RequireInlineContinuations();
+
             foreach (var pending in Take()) { pending.Completion.TrySetResult(); }
+        }
+
+        // Completing a delay's TaskCompletionSource (see Delay) only runs the awaiting gate continuation inline
+        // when the ambient host leaves no SynchronizationContext and the default TaskScheduler in place - which
+        // the xUnit v3 test host does. Assert it here so any future host change fails loudly at the point of
+        // reliance instead of silently reintroducing the timing flakiness this design replaced.
+        private static void RequireInlineContinuations()
+        {
+            Assert.Null(SynchronizationContext.Current);
+            Assert.Same(TaskScheduler.Default, TaskScheduler.Current);
         }
 
         private Pending[] Take()
@@ -242,8 +240,6 @@ public sealed class DisplayIndicatorGateTests
 
     private sealed class Gate : IDisposable
     {
-        private static readonly TimeSpan SettleWindow = TimeSpan.FromMilliseconds(100);
-
         private readonly ControllableDelay _delay = new();
         private readonly DisplayIndicatorGate _gate;
         private readonly FakeSource _source;
@@ -271,8 +267,6 @@ public sealed class DisplayIndicatorGateTests
 
             _delay.Elapse();
 
-            Thread.Sleep(SettleWindow);
-
             Assert.Equal(before, Announcements);
         }
 
@@ -281,10 +275,6 @@ public sealed class DisplayIndicatorGateTests
             int before = Announcements;
 
             _delay.ElapseIgnoringCancellation();
-
-            WaitUntil(() => Announcements >= before + expectedAnnouncements);
-
-            Thread.Sleep(SettleWindow);
 
             Assert.Equal(before + expectedAnnouncements, Announcements);
         }
@@ -295,7 +285,7 @@ public sealed class DisplayIndicatorGateTests
 
             _delay.Elapse();
 
-            WaitUntil(() => Announcements > before);
+            Assert.True(Announcements > before, "the onset must fire once its delay elapses");
         }
 
         public bool IsFired(DisplayIndicatorKind kind) => IsFired(kind, Revision);

--- a/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/DisplayIndicatorStateTests.cs
+++ b/tests/Unit/EventLogExpert.Runtime.Tests/LogTable/DisplayIndicatorStateTests.cs
@@ -1,20 +1,13 @@
 // // Copyright (c) Microsoft Corporation.
 // // Licensed under the MIT License.
 
-using EventLogExpert.Eventing.Common.Channels;
-using EventLogExpert.Eventing.Common.EventLogs;
-using EventLogExpert.Eventing.Common.Events;
 using EventLogExpert.Runtime.LogTable;
-using EventLogExpert.Runtime.Tests.TestUtils;
-using System.Diagnostics;
 using static EventLogExpert.Runtime.Tests.LogTable.TestSupport.DisplayIndicatorTestFactory;
 
 namespace EventLogExpert.Runtime.Tests.LogTable;
 
 public sealed class DisplayIndicatorStateTests
 {
-    private static readonly TimeSpan s_testTimeout = TimeSpan.FromSeconds(5);
-
     [Fact]
     public void AConditionBecomingWorthShowing_AsksForARender_BecauseNoPublicationSaysSo()
     {
@@ -26,7 +19,7 @@ public sealed class DisplayIndicatorStateTests
 
         surface.ElapseOnset();
 
-        WaitUntil(() => surface.RenderRequests > before);
+        Assert.True(surface.RenderRequests > before, "a condition becoming worth showing must ask for a render");
     }
 
     [Fact]
@@ -196,18 +189,6 @@ public sealed class DisplayIndicatorStateTests
         Assert.Equal(DisplayIndicatorKind.None, surface.Paint(DisplayIndicatorKind.None).Sentence);
     }
 
-    private static void WaitUntil(Func<bool> condition)
-    {
-        var deadline = Stopwatch.StartNew();
-
-        while (!condition())
-        {
-            Assert.True(deadline.Elapsed < s_testTimeout, "the surface never reached the expected state");
-
-            Thread.Sleep(1);
-        }
-    }
-
     private sealed class ControllableDelay
     {
         private readonly List<Pending> _pending = [];
@@ -217,7 +198,10 @@ public sealed class DisplayIndicatorStateTests
 
         public Task Delay(TimeSpan duration, CancellationToken token)
         {
-            var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            // Default (synchronous) continuations: completing this in Elapse() runs the awaiting onset/floor
+            // logic inline on the caller, so a test can assert the resulting state directly instead of polling for
+            // a thread-pool continuation (whose scheduling slipped past the old real-clock deadline under CI load).
+            var completion = new TaskCompletionSource();
 
             lock (_sync)
             {
@@ -230,6 +214,8 @@ public sealed class DisplayIndicatorStateTests
 
         public void Elapse()
         {
+            RequireInlineContinuations();
+
             Pending[] outstanding;
 
             lock (_sync)
@@ -250,6 +236,16 @@ public sealed class DisplayIndicatorStateTests
                     pending.Completion.TrySetResult();
                 }
             }
+        }
+
+        // Completing a delay's TaskCompletionSource (see Delay) only runs the awaiting onset/floor continuation
+        // inline when the ambient host leaves no SynchronizationContext and the default TaskScheduler in place -
+        // which the xUnit v3 test host does. Assert it here so any future host change fails loudly at the point
+        // of reliance instead of silently reintroducing the timing flakiness this design replaced.
+        private static void RequireInlineContinuations()
+        {
+            Assert.Null(SynchronizationContext.Current);
+            Assert.Same(TaskScheduler.Default, TaskScheduler.Current);
         }
 
         private sealed record Pending(TaskCompletionSource Completion, CancellationToken Token);
@@ -307,7 +303,7 @@ public sealed class DisplayIndicatorStateTests
 
             _floorDelay.Elapse();
 
-            WaitUntil(() => RenderRequests > before);
+            Assert.True(RenderRequests > before, "the floor's expiry must ask for the paint that ends it");
         }
 
         public void ElapseOnset()
@@ -322,7 +318,7 @@ public sealed class DisplayIndicatorStateTests
             {
                 _onsetDelay.Elapse();
 
-                WaitUntil(() => announced);
+                Assert.True(announced, "the onset must fire once its delay elapses");
             }
             finally { _gate.OnsetElapsed -= OnElapsed; }
         }


### PR DESCRIPTION
## Problem
`DisplayIndicatorGateTests.AGateBuiltOverAnAlreadyPendingDisplay_ArmsFromWhatIsAlreadyOnScreen` was the only test to fail intermittently across the last 100 CI runs (a ~5s timeout under load; passes locally). Its sibling `DisplayIndicatorStateTests` shares the identical pattern.

## Root cause
Both files' `ControllableDelay` completed its `TaskCompletionSource` with `RunContinuationsAsynchronously`, forcing the gate/state's fire-and-forget post-`await` continuation onto the thread pool. The tests then polled for it with a `Stopwatch` + `Thread.Sleep(1)` loop capped at a 5s deadline. Under CI load the continuation was scheduled later than 5s, so the poll timed out.

## Fix (test-only)
- Drop `RunContinuationsAsynchronously` so the fake delay uses default **synchronous** continuations: completing it in `Elapse()` runs the gate/state's post-`await` logic inline before `Elapse()` returns.
- Replace every `WaitUntil(...)` poll and `Thread.Sleep(SettleWindow)` settle-wait with a direct assertion (the exact-count assertions become stronger, not weaker).
- Add a `RequireInlineContinuations()` guard that asserts the host invariant (no `SynchronizationContext` + the default `TaskScheduler`) so any future test-host change fails loudly at the point of reliance instead of silently re-introducing the flake.

No production code changed.

## Verification
- Build 0/0; the DisplayIndicator subset (27 tests) is green across 10+ consecutive runs (~65ms, down from the settle-sleep versions); full `EventLogExpert.Runtime.Tests` is 2724/2724.